### PR TITLE
use explict imports for from django.conf.urls

### DIFF
--- a/corehq/apps/accounting/urls.py
+++ b/corehq/apps/accounting/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.accounting.dispatcher import AccountingAdminInterfaceDispatcher
 from corehq.apps.accounting.views import (
     AccountingSingleOptionResponseView,

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -8,7 +8,7 @@ from corehq.apps.commtrack.resources.v0_1 import ProductResource
 from corehq.apps.fixtures.resources.v0_1 import FixtureResource, InternalFixtureResource
 from corehq.apps.locations import resources as locations
 from corehq.apps.sms.resources import v0_5 as sms_v0_5
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 from django.http import HttpResponseNotFound
 from tastypie.api import Api
 

--- a/corehq/apps/builds/urls.py
+++ b/corehq/apps/builds/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from .views import EditMenuView
 
 urlpatterns = patterns('corehq.apps.builds.views',

--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 from corehq.apps.data_interfaces.dispatcher import DataInterfaceDispatcher, EditDataInterfaceDispatcher
 from corehq.apps.data_interfaces.views import (
     CaseGroupListView,

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -1,5 +1,5 @@
 import sys
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from django.contrib.auth.views import (
     password_reset, password_change, password_change_done, password_reset_done,
     password_reset_complete,

--- a/corehq/apps/dropbox/urls.py
+++ b/corehq/apps/dropbox/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from .views import DropboxAuthCallback, DropboxAuthInitiate
 

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.export.views import (
     CreateCustomFormExportView,
     CreateCustomCaseExportView,

--- a/corehq/apps/groups/urls.py
+++ b/corehq/apps/groups/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from corehq.apps.groups.views import (
     add_group, delete_group, undo_delete_group, restore_group, edit_group,

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.domain.utils import new_domain_re
 from corehq.apps.hqadmin.views import (

--- a/corehq/apps/hqcase/urls.py
+++ b/corehq/apps/hqcase/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from corehq.apps.hqcase.views import explode_cases
 

--- a/corehq/apps/hqmedia/urls.py
+++ b/corehq/apps/hqmedia/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.hqmedia.views import (
     DownloadMultimediaZip,
     BulkUploadMultimediaView,

--- a/corehq/apps/hqpillow_retry/urls.py
+++ b/corehq/apps/hqpillow_retry/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.hqpillow_retry.views import EditPillowError
 
 urlpatterns = patterns('corehq.apps.hqpillow_retry.views',

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 from corehq.apps.domain.views import PublicSMSRatesView
 from corehq.apps.settings.views import (
     TwoFactorProfileView, TwoFactorSetupView, TwoFactorSetupCompleteView,

--- a/corehq/apps/importer/urls.py
+++ b/corehq/apps/importer/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from corehq.apps.importer.views import (
     excel_commit,

--- a/corehq/apps/ivr/urls.py
+++ b/corehq/apps/ivr/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns
 
 urlpatterns = patterns("corehq.apps.ivr.views",
 )

--- a/corehq/apps/receiverwrapper/urls.py
+++ b/corehq/apps/receiverwrapper/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from corehq.apps.receiverwrapper.views import post, secure_post
 

--- a/corehq/apps/registration/urls.py
+++ b/corehq/apps/registration/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from corehq.apps.registration.views import (
     RegisterDomainView,

--- a/corehq/apps/reminders/urls.py
+++ b/corehq/apps/reminders/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.reminders.views import (
     CreateScheduledReminderView,
     EditScheduledReminderView,

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from .api import EmwfOptionsView
 from .case_list import CaseListFilterOptions

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from corehq.apps.reports.util import get_installed_custom_modules
 from corehq.apps.reports.dispatcher import (ProjectReportDispatcher, 

--- a/corehq/apps/settings/urls.py
+++ b/corehq/apps/settings/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 
 from corehq.apps.domain.urls import domain_settings
 from corehq.apps.cloudcare.urls import settings_urls as cloudcare_settings

--- a/corehq/apps/styleguide/examples/controls_demo/urls.py
+++ b/corehq/apps/styleguide/examples/controls_demo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.styleguide.examples.controls_demo.views import *
 from corehq.apps.styleguide.views.docs import (
     SelectControlFormExampleView,

--- a/corehq/apps/styleguide/examples/simple_crispy_form/urls.py
+++ b/corehq/apps/styleguide/examples/simple_crispy_form/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.styleguide.examples.simple_crispy_form.views import *
 from corehq.apps.styleguide.views.docs import (
     FormsSimpleCrispyFormExampleView,

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, patterns, url
+
 from corehq.apps.styleguide.views import (
     ClassBasedViewStyleGuideView,
     ColorsStyleGuide,

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.apps.toggle_ui.views import ToggleListView, ToggleEditView
 
 urlpatterns = patterns('toggle.views',

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from corehq.apps.domain.utils import grandfathered_domain_re
 from .views import (

--- a/corehq/messaging/ivrbackends/kookoo/urls.py
+++ b/corehq/messaging/ivrbackends/kookoo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('corehq.messaging.ivrbackends.kookoo.views',
     url(r'^ivr/?$', 'ivr', name='ivr'),

--- a/corehq/messaging/smsbackends/apposit/urls.py
+++ b/corehq/messaging/smsbackends/apposit/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.messaging.smsbackends.apposit.views import AppositIncomingView
 
 

--- a/corehq/messaging/smsbackends/grapevine/urls.py
+++ b/corehq/messaging/smsbackends/grapevine/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import include, patterns, url
 from .models import GrapevineResource
 
 gvi_resource = GrapevineResource()

--- a/corehq/messaging/smsbackends/megamobile/urls.py
+++ b/corehq/messaging/smsbackends/megamobile/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('corehq.messaging.smsbackends.megamobile.views',
     url(r'^sms/?$', 'sms_in', name='sms_in'),

--- a/corehq/messaging/smsbackends/smsgh/urls.py
+++ b/corehq/messaging/smsbackends/smsgh/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.messaging.smsbackends.smsgh.views import SMSGHIncomingView
 
 urlpatterns = patterns('corehq.messaging.smsbackends.smsgh.views',

--- a/corehq/messaging/smsbackends/tropo/urls.py
+++ b/corehq/messaging/smsbackends/tropo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('corehq.messaging.smsbackends.tropo.views',
     url(r'^sms/?$', 'sms_in', name='sms_in'),

--- a/corehq/messaging/smsbackends/twilio/urls.py
+++ b/corehq/messaging/smsbackends/twilio/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 from corehq.messaging.smsbackends.twilio.views import (TwilioIncomingSMSView,
     TwilioIncomingIVRView)
 

--- a/corehq/messaging/smsbackends/yo/urls.py
+++ b/corehq/messaging/smsbackends/yo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('corehq.messaging.smsbackends.yo.views',
     url(r'^sms/?$', 'sms_in', name='sms_in'),

--- a/custom/fri/urls.py
+++ b/custom/fri/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from custom.fri.views import upload_message_bank
 

--- a/custom/m4change/urls.py
+++ b/custom/m4change/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from custom.m4change.views import update_service_status
 

--- a/custom/uth/urls.py
+++ b/custom/uth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from custom.uth.views import vscan_upload, sonosite_upload, pending_exams
 


### PR DESCRIPTION
`patterns` is deprecated, so I want to make it explicit that we're using it (and easier for removal)
