### PR TITLE
Add HQ reports to location-restricted whitelist

### DIFF
--- a/corehq/apps/locations/resources/v0_1.py
+++ b/corehq/apps/locations/resources/v0_1.py
@@ -9,7 +9,7 @@ from corehq.apps.api.util import get_object_or_not_exist
 from corehq.apps.api.resources import HqBaseResource
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.permissions import (
-    tastypie_location_safe, LOCATION_ACCESS_DENIED)
+    location_safe, LOCATION_ACCESS_DENIED)
 from corehq.apps.users.models import WebUser
 from corehq.util.quickcache import quickcache
 from dimagi.utils.decorators.memoized import memoized
@@ -46,7 +46,7 @@ def _user_locations_ids(user, project, only_editable):
         return viewable + editable
 
 
-@tastypie_location_safe
+@location_safe
 class LocationResource(HqBaseResource):
     type = "location"
     uuid = fields.CharField(attribute='location_id', readonly=True, unique=True)
@@ -100,7 +100,7 @@ class LocationResource(HqBaseResource):
         limit = 0
 
 
-@tastypie_location_safe
+@location_safe
 class InternalLocationResource(LocationResource):
 
     # using the default resource dispatch function to bypass our authorization for internal use

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -115,13 +115,13 @@ class BaseLocationView(BaseDomainView):
         return context
 
 
+@location_safe
 class LocationsListView(BaseLocationView):
     urlname = 'manage_locations'
     page_title = ugettext_noop("Organization Structure")
     template_name = 'locations/manage/locations.html'
 
     @use_jquery_ui
-    @location_safe
     @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, request, *args, **kwargs):
         return super(LocationsListView, self).dispatch(request, *args, **kwargs)
@@ -358,6 +358,7 @@ class LocationTypesView(BaseLocationView):
         return ordered_loc_types
 
 
+@location_safe
 class NewLocationView(BaseLocationView):
     urlname = 'create_location'
     page_title = ugettext_noop("New Location")
@@ -366,7 +367,6 @@ class NewLocationView(BaseLocationView):
     form_tab = 'basic'
 
     @use_multiselect
-    @location_safe
     def dispatch(self, request, *args, **kwargs):
         return super(NewLocationView, self).dispatch(request, *args, **kwargs)
 
@@ -522,12 +522,12 @@ def unarchive_location(request, domain, loc_id):
     })
 
 
+@location_safe
 class EditLocationView(NewLocationView):
     urlname = 'edit_location'
     page_title = ugettext_noop("Edit Location")
     creates_new_location = False
 
-    @location_safe
     @method_decorator(can_edit_location)
     def dispatch(self, request, *args, **kwargs):
         return super(EditLocationView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -166,6 +166,12 @@ class ReportDispatcher(View):
         else:
             raise Http404()
 
+    @classmethod
+    def as_view(cls, *args, **kwargs):
+        view = super(ReportDispatcher, cls).as_view(*args, **kwargs)
+        view.is_hq_report = True
+        return view
+
     @staticmethod
     def toggles_enabled(report_class, request):
         if not getattr(report_class, 'toggles', ()):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -105,6 +105,7 @@ def _can_edit_workers_location(web_user, mobile_worker):
     return user_can_access_location_id(mobile_worker.domain, web_user, loc_id)
 
 
+@location_safe
 class EditCommCareUserView(BaseEditUserView):
     urlname = "edit_commcare_user"
     user_update_form_class = UpdateCommCareUserInfoForm
@@ -118,7 +119,6 @@ class EditCommCareUserView(BaseEditUserView):
             return "users/edit_commcare_user.html"
 
     @use_multiselect
-    @location_safe
     @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, request, *args, **kwargs):
         return super(EditCommCareUserView, self).dispatch(request, *args, **kwargs)
@@ -547,6 +547,7 @@ def update_user_data(request, domain, couch_user_id):
     return HttpResponseRedirect(reverse(EditCommCareUserView.urlname, args=[domain, couch_user_id]))
 
 
+@location_safe
 class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
     template_name = 'users/mobile_workers.html'
     urlname = 'mobile_workers'
@@ -554,7 +555,6 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
     @use_select2
     @use_angular_js
-    @location_safe
     @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, *args, **kwargs):
         return super(MobileWorkerListView, self).dispatch(*args, **kwargs)

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -5,11 +5,13 @@ from corehq.tabs.exceptions import UrlPrefixFormatError, UrlPrefixFormatsSuggest
 from corehq.tabs.utils import sidebar_to_dropdown
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.django.cache import make_template_fragment_key
+from dimagi.utils.web import get_url_base
 from django.conf import settings
 
 
 def url_is_location_safe(url):
     from corehq.apps.locations.permissions import is_location_safe
+    url = url.split(get_url_base())[-1] if url else None
     try:
         match = resolve(url)
     except Resolver404:


### PR DESCRIPTION
@proteusvacuum

This PR adds support for HQ reports to the location-restricted whitelist and combines `@location_safe` decorators for simplicity.
This doesn't actually affect any live functionality, but this is currently a high-traffic area, and we have several things in motion that may want this.
