### PR TITLE
refresh form properties list

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -1,4 +1,4 @@
-/*globals $, COMMCAREHQ, ko, _, alert_user*/
+/*globals $, COMMCAREHQ, ko, _*/
 
 hqDefine('app_manager/js/case-config-ui-2.js', function () {
     "use strict";
@@ -126,21 +126,7 @@ hqDefine('app_manager/js/case-config-ui-2.js', function () {
         };
 
         self.refreshQuestions = function(url, moduleId, formId, event){
-            var $el = $(event.currentTarget);
-            $el.find('i').addClass('fa-spin');
-            $.get(
-                url,
-                {module_id: moduleId, form_id: formId}
-            ).success(function(data){
-                $el.addClass('btn-success').removeClass('btn-danger');
-                self.questions(data);
-                $el.find('i').removeClass('fa-spin');
-            }).error(function(e){
-                $el.removeClass('btn-success').addClass('btn-danger');
-                $el.find('i').removeClass('fa-spin');
-                alert_user("Something went wrong refreshing your form properties. "
-                           + "Please refresh the page and try again", "danger");
-            });
+            return caseConfigUtils.refreshQuestions(self.questions,url, moduleId, formId, event);
         };
         self.getAnswers = function (condition) {
             return caseConfigUtils.getAnswers(self.questions(), condition);

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -1,4 +1,4 @@
-/*globals $, COMMCAREHQ, _, ko, alert_user*/
+/*globals $, COMMCAREHQ, _, ko */
 hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
     'use strict';
     var caseConfigUtils = hqImport('app_manager/js/case-config-utils.js');
@@ -143,21 +143,7 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
         };
 
         self.refreshQuestions = function(url, moduleId, formId, event){
-            var $el = $(event.currentTarget);
-            $el.find('i').addClass('fa-spin');
-            $.get(
-                url,
-                {module_id: moduleId, form_id: formId}
-            ).success(function(data){
-                $el.addClass('btn-success').removeClass('btn-danger');
-                self.questions(data);
-                $el.find('i').removeClass('fa-spin');
-            }).error(function(e){
-                $el.removeClass('btn-success').addClass('btn-danger');
-                $el.find('i').removeClass('fa-spin');
-                alert_user("Something went wrong refreshing your form properties. "
-                           + "Please refresh the page and try again", "danger");
-            });
+            return caseConfigUtils.refreshQuestions(self.questions,url, moduleId, formId, event);
         };
 
         self.getAnswers = function (condition) {

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -1,4 +1,4 @@
-/*globals $, COMMCAREHQ, _, ko, console*/
+/*globals $, COMMCAREHQ, _, ko, alert_user*/
 hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
     'use strict';
     var caseConfigUtils = hqImport('app_manager/js/case-config-utils.js');
@@ -15,7 +15,7 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
         var self = this;
 
         self.home = params.home;
-        self.questions = params.questions;
+        self.questions = ko.observable(params.questions);
         self.save_url = params.save_url;
         self.caseType = params.caseType;
         self.module_id = params.module_id;
@@ -54,7 +54,7 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
         });
 
         var questionScores = {};
-        _(self.questions).each(function (question, i) {
+        _(self.questions()).each(function (question, i) {
             questionScores[question.value] = i;
         });
         self.questionScores = questionScores;
@@ -123,7 +123,7 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
         };
 
         var questionMap = {};
-        _(self.questions).each(function (question) {
+        _(self.questions()).each(function (question) {
             questionMap[question.value] = question;
         });
         self.get_repeat_context = function(path) {
@@ -139,10 +139,29 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
         };
 
         self.getQuestions = function (filter, excludeHidden, includeRepeat) {
-            return caseConfigUtils.getQuestions(self.questions, filter, excludeHidden, includeRepeat);
+            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
         };
+
+        self.refreshQuestions = function(url, moduleId, formId, event){
+            var $el = $(event.currentTarget);
+            $el.find('i').addClass('fa-spin');
+            $.get(
+                url,
+                {module_id: moduleId, form_id: formId}
+            ).success(function(data){
+                $el.addClass('btn-success').removeClass('btn-danger');
+                self.questions(data);
+                $el.find('i').removeClass('fa-spin');
+            }).error(function(e){
+                $el.removeClass('btn-success').addClass('btn-danger');
+                $el.find('i').removeClass('fa-spin');
+                alert_user("Something went wrong refreshing your form properties. "
+                           + "Please refresh the page and try again", "danger");
+            });
+        };
+
         self.getAnswers = function (condition) {
-            return caseConfigUtils.getAnswers(self.questions, condition);
+            return caseConfigUtils.getAnswers(self.questions(), condition);
         };
 
         self.change = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-utils.js
@@ -1,3 +1,4 @@
+/* globals alert_user */
 hqDefine('app_manager/js/case-config-utils.js', function () {
     return {
         getQuestions: function (questions, filter, excludeHidden, includeRepeat, excludeTrigger) {
@@ -42,6 +43,23 @@ hqDefine('app_manager/js/case-config-utils.js', function () {
                 }
             }
             return options;
+        },
+        refreshQuestions: function(questions_observable, url, moduleId, formId, event){
+            var $el = $(event.currentTarget);
+            $el.find('i').addClass('fa-spin');
+            $.get(
+                url,
+                {module_id: moduleId, form_id: formId}
+            ).success(function(data){
+                $el.addClass('btn-success').removeClass('btn-danger');
+                questions_observable(data);
+                $el.find('i').removeClass('fa-spin');
+            }).error(function(e){
+                $el.removeClass('btn-success').addClass('btn-danger');
+                $el.find('i').removeClass('fa-spin');
+                alert_user("Something went wrong refreshing your form properties. "
+                           + "Please refresh the page and try again", "danger");
+            });
         },
         filteredSuggestedProperties: function (suggestedProperties, properties) {
             var used_properties = _.map(properties, function (x) {

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config.html
@@ -65,6 +65,7 @@
 
 <div id="case-config-ko">
     <div data-bind="saveButton: saveButton"></div>
+    <div data-bind="template: 'case-config:refresh-form-questions'"></div>
     <div data-bind="with: caseConfigViewModel">
         <div class="form-inline container-fluid">
             {% trans "This form " %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 
 {% include 'app_manager/v1/partials/case_config_shared.html' %}
 
@@ -65,7 +66,9 @@
 
 <div id="case-config-ko">
     <div data-bind="saveButton: saveButton"></div>
-    <div data-bind="template: 'case-config:refresh-form-questions'"></div>
+    {% if request|toggle_enabled:"REFRESH_CASE_MANAGEMENT" %}
+        <div data-bind="template: 'case-config:refresh-form-questions'"></div>
+    {% endif %}
     <div data-bind="with: caseConfigViewModel">
         <div class="form-inline container-fluid">
             {% trans "This form " %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_advanced.html
@@ -372,6 +372,7 @@
 
 <div id="case-config-ko">
     <div data-bind="saveButton: saveButton"></div>
+    <div data-bind="template: 'case-config:refresh-form-questions'"></div>
     <div data-bind="with: caseConfigViewModel">
         <div class="btn-group" data-bind="visible: actionOptions().length">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_advanced.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 
 {% include 'app_manager/v1/partials/case_config_shared.html' %}
 
@@ -372,7 +373,9 @@
 
 <div id="case-config-ko">
     <div data-bind="saveButton: saveButton"></div>
-    <div data-bind="template: 'case-config:refresh-form-questions'"></div>
+    {% if request|toggle_enabled:"REFRESH_CASE_MANAGEMENT" %}
+        <div data-bind="template: 'case-config:refresh-form-questions'"></div>
+    {% endif %}
     <div data-bind="with: caseConfigViewModel">
         <div class="btn-group" data-bind="visible: actionOptions().length">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_shared.html
@@ -135,10 +135,6 @@
 <script type="text/html" id="case-config:case-transaction:case-properties">
     <div class="panel-heading panel-title">
         {% trans "Save data to the following case properties" %}
-        <span class="btn btn-success refresh-form-questions"
-              data-bind="click: function(data, event){$root.refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{module.id}}', '{{form.id}}', event)}">
-            <i class="fa fa-refresh"></i>
-        </span>
     </div>
     <table class="table table-condensed" data-bind="visible: case_properties().length">
         <thead>
@@ -184,5 +180,14 @@
             <i class="fa fa-plus"></i>
             {% trans "Save properties" %}
         </a>
+    </div>
+</script>
+
+<script type="text/html" id="case-config:refresh-form-questions">
+    <div style="margin-right: 1em;"
+         class="btn btn-success refresh-form-questions pull-right"
+         data-bind="click: function(data, event){
+                    refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{module.id}}', '{{form.id}}', event)}">
+        <i class="fa fa-refresh"></i>
     </div>
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_shared.html
@@ -133,7 +133,13 @@
 </script>
 
 <script type="text/html" id="case-config:case-transaction:case-properties">
-    <div class="panel-heading panel-title">{% trans "Save data to the following case properties" %}</div>
+    <div class="panel-heading panel-title">
+        {% trans "Save data to the following case properties" %}
+        <span class="btn btn-success refresh-form-questions"
+              data-bind="click: function(data, event){$root.refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{module.id}}', '{{form.id}}', event)}">
+            <i class="fa fa-refresh"></i>
+        </span>
+    </div>
     <table class="table table-condensed" data-bind="visible: case_properties().length">
         <thead>
             <tr>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_shared.html
@@ -187,7 +187,9 @@
     <div style="margin-right: 1em;"
          class="btn btn-success refresh-form-questions pull-right"
          data-bind="click: function(data, event){
-                    refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{module.id}}', '{{form.id}}', event)}">
+                    refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{module.id}}', '{{form.id}}', event);
+                    analytics.usage('Refresh case management', 'Button Clicked');
+                    }">
         <i class="fa fa-refresh"></i>
     </div>
 </script>

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -21,7 +21,7 @@ from corehq.apps.app_manager.views import (
     edit_report_module, validate_module_for_build, commcare_profile, edit_commcare_profile, edit_commcare_settings,
     edit_app_langs, edit_app_attr, edit_app_ui_translations, get_app_ui_translations, rearrange, odk_qr_code,
     odk_media_qr_code, odk_install, short_url, short_odk_url, save_copy, revert_to_copy, delete_copy, list_apps,
-    direct_ccz, download_index, download_file, formdefs, release_manager,
+    direct_ccz, download_index, download_file, formdefs, release_manager, get_form_questions,
 )
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls
 from corehq.apps.hqmedia.urls import download_urls as media_download_urls
@@ -54,6 +54,7 @@ app_urls = [
     url(r'^modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/$',
         view_form, name='view_form'),
     url(r'^get_form_datums/$', get_form_datums, name='get_form_datums'),
+    url(r'^get_form_questions/$', get_form_questions, name='get_form_questions'),
     url(r'^modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/source/$',
         form_designer, name='form_source'),
     url(r'^summary/$', AppSummaryView.as_view(), name=AppSummaryView.urlname),

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -87,6 +87,7 @@ from corehq.apps.app_manager.views.forms import (
     undo_delete_form,
     view_form,
     xform_display,
+    get_form_questions,
 )
 from corehq.apps.app_manager.views.modules import (
     delete_module,

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -22,7 +22,7 @@ from corehq.apps.app_manager.views.notifications import notify_form_changed
 from corehq.apps.app_manager.views.schedules import get_schedule_context
 
 from corehq.apps.app_manager.views.utils import back_to_main, \
-    CASE_TYPE_CONFLICT_MSG
+    CASE_TYPE_CONFLICT_MSG, get_langs
 
 from corehq import toggles, privileges, feature_previews
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -399,15 +399,12 @@ def get_xform_source(request, domain, app_id, module_id, form_id):
 def get_form_questions(request, domain, app_id):
     module_id = request.GET.get('module_id')
     form_id = request.GET.get('form_id')
-    from corehq.apps.app_manager.views.utils import  get_langs
-
     try:
         app = get_app(domain, app_id)
         form = app.get_module(module_id).get_form(form_id)
         lang, langs = get_langs(request, app)
     except (ModuleNotFoundException, IndexError):
         raise Http404()
-    form.validate_form()
     xform_questions = form.get_questions(langs, include_triggers=True)
     return json_response(xform_questions)
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -395,7 +395,9 @@ def get_xform_source(request, domain, app_id, module_id, form_id):
         raise Http404()
     return _get_xform_source(request, app, form)
 
+
 @require_GET
+@require_can_edit_apps
 def get_form_questions(request, domain, app_id):
     module_id = request.GET.get('module_id')
     form_id = request.GET.get('form_id')
@@ -407,6 +409,7 @@ def get_form_questions(request, domain, app_id):
         raise Http404()
     xform_questions = form.get_questions(langs, include_triggers=True)
     return json_response(xform_questions)
+
 
 def get_form_view_context_and_template(request, domain, form, langs, messages=messages):
     xform_questions = []

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -395,6 +395,21 @@ def get_xform_source(request, domain, app_id, module_id, form_id):
         raise Http404()
     return _get_xform_source(request, app, form)
 
+@require_GET
+def get_form_questions(request, domain, app_id):
+    module_id = request.GET.get('module_id')
+    form_id = request.GET.get('form_id')
+    from corehq.apps.app_manager.views.utils import  get_langs
+
+    try:
+        app = get_app(domain, app_id)
+        form = app.get_module(module_id).get_form(form_id)
+        lang, langs = get_langs(request, app)
+    except (ModuleNotFoundException, IndexError):
+        raise Http404()
+    form.validate_form()
+    xform_questions = form.get_questions(langs, include_triggers=True)
+    return json_response(xform_questions)
 
 def get_form_view_context_and_template(request, domain, form, langs, messages=messages):
     xform_questions = []

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -928,6 +928,13 @@ DISABLE_COLUMN_LIMIT_IN_UCR = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+REFRESH_CASE_MANAGEMENT = StaticToggle(
+    'refresh_case_management',
+    'Show a button to refresh case management',
+    TAG_PREVIEW,
+    [NAMESPACE_USER, NAMESPACE_DOMAIN],
+)
+
 CLOUDCARE_LATEST_BUILD = StaticToggle(
     'use_latest_build_cloudcare',
     'Uses latest build for cloudcare instead of latest starred',


### PR DESCRIPTION
I'm surprised refreshing the module settings page every time you make a change to the app wasn't more annoying for people.
This adds a refresh button that fetches new questions from the form that you are editing, likely in another tab.
## Regular modules

![peek 2016-10-15 00-19](https://cloud.githubusercontent.com/assets/146896/19407426/151eac9e-9270-11e6-9db5-613042761a69.gif)
## Advanced modules (and conditionals)

![peek 2016-10-15 00-45](https://cloud.githubusercontent.com/assets/146896/19407461/c9824a7e-9270-11e6-907f-9cd46ab1f708.gif)

@dimagi/product, @orangejenny  what do you think?
cc: @millerdev 
