### PR TITLE
partially supported SQL cloudcare API

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -200,7 +200,6 @@ def get_filtered_cases(domain, status, user_id=None, case_type=None,
     filters = dict((k, v) for k, v in (filters or {}).items() if v is not None)
     if should_use_sql_backend(domain):
         assert not footprint, "'footprint' not supported for SQL domains"
-        assert not filters, "'filters' not supported for SQL domains"
     helper = CaseAPIHelper(domain, status, case_type=case_type, ids_only=ids_only,
                            footprint=footprint, strip_history=strip_history,
                            filters=filters)

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -12,6 +12,7 @@ from casexml.apps.case.dbaccessors import get_open_case_ids_in_domain
 from casexml.apps.case.models import CommCareCase, CASE_STATUS_ALL, CASE_STATUS_CLOSED, CASE_STATUS_OPEN
 from casexml.apps.case.util import iter_cases
 from casexml.apps.phone.caselogic import get_footprint
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from dimagi.utils.couch.safe_index import safe_index
 from dimagi.utils.parsing import json_format_date
 from touchforms.formplayer.models import EntrySession
@@ -45,7 +46,8 @@ class CaseAPIResult(object):
     between an id-only representation and a full_blown one.
     """
 
-    def __init__(self, id=None, couch_doc=None, id_only=False, lite=True, sanitize=True):
+    def __init__(self, domain, id=None, couch_doc=None, id_only=False, lite=True, sanitize=True):
+        self.domain = domain
         self._id = id
         self._couch_doc = couch_doc
         self.id_only = id_only
@@ -61,13 +63,13 @@ class CaseAPIResult(object):
     @property
     def id(self):
         if self._id is None:
-            self._id = self._couch_doc['_id']
+            self._id = self._couch_doc['_id'] if isinstance(self._couch_doc, dict) else self._couch_doc.case_id
         return self._id
 
     @property
     def couch_doc(self):
         if self._couch_doc is None:
-            self._couch_doc = CommCareCase.get(self._id)
+            self._couch_doc = CaseAccessors(self.domain).get_case(self._id)
         return self._couch_doc
 
     @property
@@ -107,6 +109,7 @@ class CaseAPIHelper(object):
         self.footprint = footprint
         self.strip_history = strip_history
         self.filters = filters
+        self.case_accessors = CaseAccessors(self.domain)
 
     def _case_results(self, case_id_list):
         def _filter(res):
@@ -125,11 +128,10 @@ class CaseAPIHelper(object):
         if not self.ids_only or self.filters or self.footprint:
             # optimization hack - we know we'll need the full cases eventually
             # so just grab them now.
-            base_results = [CaseAPIResult(couch_doc=case, id_only=self.ids_only)
+            base_results = [CaseAPIResult(domain=self.domain, couch_doc=case, id_only=self.ids_only)
                             for case in iter_cases(case_id_list, self.strip_history, self.wrap)]
-
         else:
-            base_results = [CaseAPIResult(id=id, id_only=True) for id in case_id_list]
+            base_results = [CaseAPIResult(domain=self.domain, id=id, id_only=True) for id in case_id_list]
 
         if self.filters and not self.footprint:
             base_results = filter(_filter, base_results)
@@ -145,7 +147,7 @@ class CaseAPIHelper(object):
                             strip_history=self.strip_history,
                         ).values()
 
-        return [CaseAPIResult(couch_doc=case, id_only=self.ids_only) for case in case_list]
+        return [CaseAPIResult(domain=self.domain, couch_doc=case, id_only=self.ids_only) for case in case_list]
 
     def get_all(self):
         status = self.status or CASE_STATUS_ALL

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -181,9 +181,7 @@ class CaseAPIHelper(object):
             CASE_STATUS_ALL: None,
         }[self.status]
 
-        ids = get_case_ids_in_domain_by_owner(
-            self.domain, owner_id__in=owner_ids, closed=closed)
-
+        ids = self.case_accessors.get_case_ids_by_owners(owner_ids, closed=closed)
         return self._case_results(ids)
 
 

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -200,6 +200,9 @@ def get_filtered_cases(domain, status, user_id=None, case_type=None,
 
     # a filter value of None means don't filter
     filters = dict((k, v) for k, v in (filters or {}).items() if v is not None)
+    if should_use_sql_backend(domain):
+        assert not footprint, "'footprint' not supported for SQL domains"
+        assert not filters, "'filters' not supported for SQL domains"
     helper = CaseAPIHelper(domain, status, case_type=case_type, ids_only=ids_only,
                            footprint=footprint, strip_history=strip_history,
                            filters=filters)

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -232,22 +232,20 @@ class CaseAPITest(TestCase):
         self.assertEqual(self.expectedOpenByUserWithFootprint + self.expectedClosedByUserWithFootprint, len(list))
 
     def testCaseAPIResultJSON(self):
-        try:
-            case = CommCareCase()
-            # because of how setattr is overridden you have to set it to None in this wacky way
-            case._doc['type'] = None
-            case.save()
-            self.assertEqual(None, CommCareCase.get(case.case_id).type)
-            res_sanitized = CaseAPIResult(domain=TEST_DOMAIN, id=case.case_id, couch_doc=case, sanitize=True)
-            res_unsanitized = CaseAPIResult(domain=TEST_DOMAIN, id=case.case_id, couch_doc=case, sanitize=False)
+        case = CommCareCase()
+        # because of how setattr is overridden you have to set it to None in this wacky way
+        case._doc['type'] = None
+        case.save()
+        self.addCleanup(case.delete)
+        self.assertEqual(None, CommCareCase.get(case.case_id).type)
+        res_sanitized = CaseAPIResult(domain=TEST_DOMAIN, id=case.case_id, couch_doc=case, sanitize=True)
+        res_unsanitized = CaseAPIResult(domain=TEST_DOMAIN, id=case.case_id, couch_doc=case, sanitize=False)
 
-            json = res_sanitized.case_json
-            self.assertEqual(json['properties']['case_type'], '')
+        json = res_sanitized.case_json
+        self.assertEqual(json['properties']['case_type'], '')
 
-            json = res_unsanitized.case_json
-            self.assertEqual(json['properties']['case_type'], None)
-        finally:
-            case.delete()
+        json = res_unsanitized.case_json
+        self.assertEqual(json['properties']['case_type'], None)
 
     def testGetCasesCaching(self):
         user = self.users[0]

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -7,7 +7,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import post_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
 from corehq import toggles
 from corehq.apps.domain.shortcuts import create_domain
@@ -126,20 +126,24 @@ class CaseAPITest(TestCase):
     def expectedAll(self):
         return len(self.user_ids) * len(self.case_types) * 3
 
+    @run_with_all_backends
     def testGetAllOpen(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_OPEN)
         self.assertEqual(self.expectedOpen, len(list))
         self.assertListMatches(list, lambda c: not c['closed'])
 
+    @run_with_all_backends
     def testGetAllWithClosed(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL)
         self.assertEqual(self.expectedOpen + self.expectedClosed, len(list))
 
+    @run_with_all_backends
     def testGetAllOpenWithType(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_OPEN, case_type=self.test_type)
         self.assertEqual(self.expectedOpenByType, len(list))
         self.assertListMatches(list, lambda c: not c['closed'] and c['properties']['case_type'] == self.test_type)
 
+    @run_with_all_backends
     def testGetAllWithClosedAndType(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, case_type=self.test_type)
         self.assertEqual(self.expectedByType, len(list))

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -238,8 +238,8 @@ class CaseAPITest(TestCase):
             case._doc['type'] = None
             case.save()
             self.assertEqual(None, CommCareCase.get(case.case_id).type)
-            res_sanitized = CaseAPIResult(id=case.case_id, couch_doc=case, sanitize=True)
-            res_unsanitized = CaseAPIResult(id=case.case_id, couch_doc=case, sanitize=False)
+            res_sanitized = CaseAPIResult(domain=TEST_DOMAIN, id=case.case_id, couch_doc=case, sanitize=True)
+            res_unsanitized = CaseAPIResult(domain=TEST_DOMAIN, id=case.case_id, couch_doc=case, sanitize=False)
 
             json = res_sanitized.case_json
             self.assertEqual(json['properties']['case_type'], '')

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -150,16 +150,19 @@ class CaseAPITest(TestCase):
         self.assertEqual(self.expectedByType, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_type'] == self.test_type)
 
+    @run_with_all_backends
     def testGetOwnedOpen(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_OPEN, footprint=False)
         self.assertEqual(self.expectedOpenByUser, len(list))
         self.assertListMatches(list, lambda c: not c['closed'] and c['user_id'] == self.test_user_id)
 
+    @run_with_all_backends
     def testGetOwnedClosed(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_CLOSED, footprint=False)
         self.assertEqual(self.expectedClosedByUser, len(list))
         self.assertListMatches(list, lambda c: c['closed'] and c['user_id'] == self.test_user_id)
 
+    @run_with_all_backends
     def testGetOwnedBoth(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL, footprint=False)
         self.assertEqual(self.expectedByUser, len(list))

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -208,18 +208,21 @@ class CaseAPITest(TestCase):
         self.assertListMatches(list, lambda c: 'xform_ids' not in c._couch_doc)
         self.assertListMatches(list, lambda c: isinstance(c.to_json(), basestring))
 
+    @run_with_all_backends
     def testFiltersOnAll(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL,
                                   filters={"properties/case_name": _type_to_name(self.test_type)})
         self.assertEqual(self.expectedByType, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_name'] == _type_to_name(self.test_type))
 
+    @run_with_all_backends
     def testFiltersOnOwned(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL,
                                   filters={"properties/case_name": _type_to_name(self.test_type)})
         self.assertEqual(2, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_name'] == _type_to_name(self.test_type))
 
+    @run_with_all_backends
     def testFiltersWithoutFootprint(self):
         name = _type_to_name(_child_case_type(self.test_type))
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL,

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -8,7 +8,6 @@ from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import post_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
-from corehq.form_processor.utils.general import should_use_sql_backend
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
 from corehq import toggles
 from corehq.apps.domain.shortcuts import create_domain
@@ -194,16 +193,14 @@ class CaseAPITest(TestCase):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   ids_only=True)
         self.assertEqual(self.expectedAll, len(list))
-        if should_use_sql_backend(TEST_DOMAIN):
-            self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))
+        self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))
         self.assertListMatches(list, lambda c: isinstance(c.to_json(), basestring))
 
     def testGetAllIdsOnlyStripHistory(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   ids_only=True, strip_history=True)
         self.assertEqual(self.expectedAll, len(list))
-        if should_use_sql_backend(TEST_DOMAIN):
-            self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))
+        self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))
         self.assertListMatches(list, lambda c: 'actions' not in c._couch_doc)
         self.assertListMatches(list, lambda c: 'xform_ids' not in c._couch_doc)
         self.assertListMatches(list, lambda c: isinstance(c.to_json(), basestring))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -336,7 +336,7 @@ def get_cases(request, domain):
             usercase_id = CommCareUser.get_by_user_id(user_id).get_usercase_id()
             usercase = accessor.get_case(usercase_id) if usercase_id else None
             return json_response(map(
-                lambda case: CaseAPIResult(id=case['_id'], couch_doc=case, id_only=ids_only),
+                lambda case: CaseAPIResult(domain=domain, id=case['_id'], couch_doc=case, id_only=ids_only),
                 filter(None, [case, case.parent, usercase])
             ))
 
@@ -349,7 +349,7 @@ def get_cases(request, domain):
         # owned case list + footprint
         case = accessor.get_case(case_id)
         assert case.domain == domain
-        cases = [CaseAPIResult(id=case_id, couch_doc=case, id_only=ids_only)]
+        cases = [CaseAPIResult(domain=domain, id=case_id, couch_doc=case, id_only=ids_only)]
     else:
         filters = get_filters_from_request_params(request_params)
         status = api_closed_to_status(request_params.get('closed', 'false'))

--- a/corehq/ex-submodules/casexml/apps/phone/caselogic.py
+++ b/corehq/ex-submodules/casexml/apps/phone/caselogic.py
@@ -3,6 +3,7 @@ import logging
 from casexml.apps.case.dbaccessors import get_reverse_indices_json
 from casexml.apps.case.models import CommCareCase
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
+from corehq.form_processor.utils.general import should_use_sql_backend
 
 
 def get_related_cases(initial_cases, domain, strip_history=False, search_up=True):
@@ -12,6 +13,7 @@ def get_related_cases(initial_cases, domain, strip_history=False, search_up=True
     If search_up is True, all cases and their parent cases are returned.
     If search_up is False, all cases and their child cases are returned.
     """
+    assert not should_use_sql_backend(domain), "get_related_cases not supported for SQL domain"
     if not initial_cases:
         return {}
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -299,7 +299,7 @@ class CaseAccessors(object):
 
         returns a list of case_ids
         """
-        return self.db_accessor.get_case_ids_in_domain_by_owners(self.domain, owner_ids)
+        return self.db_accessor.get_case_ids_in_domain_by_owners(self.domain, owner_ids, closed=closed)
 
     def get_open_case_ids_for_owner(self, owner_id):
         return self.db_accessor.get_open_case_ids_for_owner(self.domain, owner_id)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?239090
@gcapalbo @emord 

This makes the cloudcare API support SQL domains provided it doesn't use `footprint`.
