### PR TITLE
Fix worker activity times in spanish

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1302,7 +1302,9 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
 
         chart.set_axis_labels('x', [''] + [(str(h) + ':00') for h in range(24)] + [''])
         chart.set_axis_labels('x', [' ', _('Time ({timezone})').format(timezone=timezone), ' '])
-        chart.set_axis_labels('y', [''] + [day_names[n] for n in days] + [''])
+        # our google charts library doesn't support unicode
+        # TODO: replace with some in JS (d3?)
+        chart.set_axis_labels('y', [''] + [day_names[n].encode('ascii', 'replace') for n in days] + [''])
 
         chart.add_marker(1, 1.0, 'o', '333333', 25)
         return chart.get_url() + '&chds=-1,24,-1,7,0,20'


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?239466#1233470

bad solution, but the google chart library doesn't support unicode axis labels. Ideally we'd just use a JS library for reports, but I think that's out of the scope for interrupt.

buddy @czue  
