### PR TITLE
fix 500 when loading a case from a fixture on initial load

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -397,7 +397,7 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
                         fixture_tag: '',
                         fixture_variable: '',
                         case_property: '',
-                        auto_select: '',
+                        auto_select: false,
                         arbitrary_datum_id: '',
                         arbitrary_datum_function: '',
                     };


### PR DESCRIPTION
@emord when this is empty on initial load and you press save it errors with `BadValueError: u'' not of type <type 'bool'>`
