### PR TITLE
Fixed bihar reports

### DIFF
--- a/custom/bihar/reports/supervisor.py
+++ b/custom/bihar/reports/supervisor.py
@@ -422,7 +422,8 @@ def default_nav_link(nav_report, i, report_cls):
 
 
 def get_awcc(group):
-    return group.metadata.get("awc-code") or _('no awcc')
+    metadata = group.metadata or {}
+    return metadata.get("awc-code") or _('no awcc')
 
 
 def url_and_params(urlbase, params):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?239583

One group from Bihar domain has metadata equal to `null`, that's why this line was failing.
