### PR TITLE
short term fix for not including dashes

### DIFF
--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -423,7 +423,11 @@ class AbstractAttachment(DisabledDbMixin, models.Model, SaveStateMixin):
         try:
             blob = db.get(self.blob_id, self.blobdb_bucket())
         except (KeyError, NotFound, BadName):
-            raise AttachmentNotFound(self.name)
+            try:
+                # http://manage.dimagi.com/default.asp?239638
+                blob = db.get(self.blob_id, self.blobdb_bucket(True))
+            except (KeyError, NotFound, BadName):
+                raise AttachmentNotFound(self.name)
 
         if stream:
             return blob
@@ -440,12 +444,15 @@ class AbstractAttachment(DisabledDbMixin, models.Model, SaveStateMixin):
 
         return deleted
 
-    def blobdb_bucket(self):
+    def blobdb_bucket(self, remove_dashes=False):
         if self.blob_bucket is not None:
             return self.blob_bucket
         if self.attachment_id is None:
             raise AttachmentNotFound("cannot manipulate attachment on unidentified document")
-        return os.path.join(self._attachment_prefix, str(self.attachment_id))
+        attach_id = str(self.attachment_id)
+        if remove_dashes:
+            attach_id = attach_id.replace('-', '')
+        return os.path.join(self._attachment_prefix, attach_id)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
@millerdev buddy @czue http://manage.dimagi.com/default.asp?239638

This will solve the issue of not being able to retrieve already saved attachments, but I will need to look deeper to make sure this is consistent between all forms. Offlined with @millerdev and it seems that ideally we would always use without dashes as it saves RAM
