### PR TITLE
attachment followup

### DIFF
--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -426,7 +426,7 @@ class AbstractAttachment(DisabledDbMixin, models.Model, SaveStateMixin):
             if not self.blob_bucket and '-' in str(self.attachment_id):
                 try:
                     # http://manage.dimagi.com/default.asp?239638
-                    blob = db.get(self.blob_id, self.blobdb_bucket(True))
+                    blob = db.get(self.blob_id, self.blobdb_bucket(remove_dashes=False))
                 except (KeyError, NotFound, BadName):
                     raise AttachmentNotFound(self.name)
             else:
@@ -447,7 +447,7 @@ class AbstractAttachment(DisabledDbMixin, models.Model, SaveStateMixin):
 
         return deleted
 
-    def blobdb_bucket(self, remove_dashes=False):
+    def blobdb_bucket(self, remove_dashes=True):
         if self.blob_bucket is not None:
             return self.blob_bucket
         if self.attachment_id is None:


### PR DESCRIPTION
@millerdev buddy @gcapalbo 

following up https://github.com/dimagi/commcare-hq/pull/13618

https://github.com/dimagi/commcare-hq/pull/13060/commits/1c8bda82f5f0487cd149c5589457bf37cd65f65b @snopoke added a `blob_bucket` to attachments during work on couch -> sql migrate but we don't actually write it for new sql forms. This PR saves that bucket when the attachment is created so that we don't run into a similar issue again.

I will have a followup PR to migrate old attachments to save their `blob_bucket`
