### PR TITLE
remove imports from tests/__init__.py

### DIFF
--- a/corehq/apps/fixtures/tests/__init__.py
+++ b/corehq/apps/fixtures/tests/__init__.py
@@ -1,4 +1,0 @@
-from .test_field_names import *
-from .test_dbaccessors import *
-from .test_fixture_data import *
-from .test_location_ownership import *


### PR DESCRIPTION
Thanks @czue. I found it's not just unnecessary, it also triple runs each test.
