### PR TITLE
use new domain's name for creating subscription

### DIFF
--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -356,8 +356,7 @@ def copy_snapshot(request, snapshot):
                                                user=user)
                     if new_domain.commtrack_enabled:
                         new_domain.convert_to_commtrack()
-                    ensure_explicit_community_subscription(new_domain_name, date.today())
-
+                    ensure_explicit_community_subscription(new_domain.name, date.today())
                 except NameUnavailableException:
                     messages.error(request, _("A project by that name already exists"))
                     return HttpResponseRedirect(reverse(ProjectInformationView.urlname, args=[snapshot]))


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?236652#1234995

This failed to set a subscription if the requested domain's name was taken and it was saved as a different domain

@nickpell buddy @gcapalbo 
