### PR TITLE
use minified knockout

### DIFF
--- a/corehq/apps/style/templates/style/includes/ko.html
+++ b/corehq/apps/style/templates/style/includes/ko.html
@@ -2,7 +2,7 @@
 {% load compress %}
 
 {% compress js %}
-<script src="{% static 'knockout/dist/knockout.debug.js' %}"></script>
+<script src="{% static 'knockout/dist/knockout.js' %}"></script>
 <script src="{% static 'style/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>
 <script src="{% static 'style/ko/global_handlers.ko.js' %}"></script>
 <script src="{% static 'style/ko/knockout_bindings.ko.js' %}"></script>


### PR DESCRIPTION
Noticed we're always including the debug version. It's not a major difference, since we minify, but the version minified by knockout is ~25% smaller.

@calellowitz 
