### PR TITLE
Async restore progress bar enhancements

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -217,7 +217,7 @@ FormplayerFrontend.on("sync", function () {
         if (response.responseJSON.status === 'retry') {
             FormplayerFrontend.trigger('retry', response.responseJSON, function() {
                 $.ajax(options);
-            }, gettext('Please wait while we sync your user...'));
+            }, gettext('Waiting for server progress'));
         } else {
             FormplayerFrontend.trigger('clearProgress');
             tfSyncComplete(response.responseJSON.status === 'error');
@@ -244,7 +244,6 @@ FormplayerFrontend.on("sync", function () {
 FormplayerFrontend.on("retry", function(response, retryFn, progressMessage) {
 
     var progressView = FormplayerFrontend.regions.loadingProgress.currentView,
-        progress = response.total === 0 ? 0 : response.done / response.total,
         retryTimeout = response.retryAfter * 1000;
     progressMessage = progressMessage || gettext('Please wait...');
 
@@ -255,7 +254,7 @@ FormplayerFrontend.on("retry", function(response, retryFn, progressMessage) {
         FormplayerFrontend.regions.loadingProgress.show(progressView);
     }
 
-    progressView.setProgress(progress, retryTimeout);
+    progressView.setProgress(response.done, response.total, retryTimeout);
     setTimeout(retryFn, retryTimeout);
 });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/progress_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/progress_view.js
@@ -15,10 +15,16 @@ FormplayerFrontend.module("Utils.Views", function (Views, FormplayerFrontend, Ba
             };
         },
 
-        setProgress: function(progress, duration) {
+        setProgress: function(done, total, duration) {
+            var progress = total === 0 ? 0 : done / total;
             // Due to jQuery bug, can't use .animate() with % until jQuery 3.0
             $(this.el).find('.js-progress-bar').css('transition', duration + 'ms');
             $(this.el).find('.js-progress-bar').width(progress * 100 + '%');
+            if (total > 0) {
+                $(this.el).find('.js-subtext small').text(
+                    gettext('Completed: ') + done + '/' + total
+                );
+            }
         },
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/entities/menu.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/entities/menu.js
@@ -72,7 +72,7 @@ FormplayerFrontend.module("Entities", function (Entities, FormplayerFrontend, Ba
                     if (response.status === 'retry') {
                         FormplayerFrontend.trigger('retry', response, function() {
                             menus.fetch($.extend(true, {}, options));
-                        }, gettext('Please wait while we sync your user...'));
+                        }, gettext('Waiting for server progress'));
                     } else if (response.exception){
                         FormplayerFrontend.trigger(
                             'showError',

--- a/corehq/apps/cloudcare/templates/formplayer/progress.html
+++ b/corehq/apps/cloudcare/templates/formplayer/progress.html
@@ -1,7 +1,10 @@
 <script type="text/template" id="progress-view-template">
     <div id="formplayer-progress">
         <div class="progress-container">
-            <h1><%= progressMessage %></h1>
+            <div class="progress-title">
+                <h1><%= progressMessage %></h1>
+                <h2 class="subtext text-left js-subtext"><small></small></h2>
+            </div>
             <div class="progress">
                 <div
                     style="width: 0%"

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -151,6 +151,7 @@
         <section id="cases"></section>
         <div id="menu-container">
             <div id="phone-mode-navigation"></div>
+            <div id="formplayer-progress-container"></div>
             <div id="webforms-nav" class="webforms-nav" data-bind="template: { name: 'form-navigation-ko-template' }"></div>
             <section id="cloudcare-notifications" class="notifications-container"></section>
             <div id="breadcrumb-region"></div>
@@ -194,6 +195,7 @@
         {% include 'formplayer/session_list.html' %}
         {% include 'formplayer/navigation.html' %}
         {% include 'formplayer/confirmation_modal.html' %}
+        {% include 'formplayer/progress.html' %}
 
         {% include 'formplayer/dependencies.html' %}
         {% include "style/includes/ko.html" %}

--- a/corehq/apps/style/static/cloudcare/less/cloudcare/module.less
+++ b/corehq/apps/style/static/cloudcare/less/cloudcare/module.less
@@ -189,12 +189,6 @@
     font-size: 1.8rem;
   }
 }
-@media(max-width: 720px) {
-  .module-caselist-table-container {
-    width: 100%;
-    overflow-x: scroll;
-  }
-}
 
 #formplayer-progress {
   top: 0;
@@ -215,4 +209,37 @@
   margin: 0 auto;
   width: 80%;
   top: 50%;
+
+  // Centers container vertically
+  transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+
+  .progress-title {
+    display: inline-block;
+    h1 {
+      margin-bottom: 0px;
+    }
+    .subtext {
+      margin-top: 0px;
+    }
+    margin-bottom: 14px;
+  }
+}
+
+@media(max-width: 720px) {
+  .module-caselist-table-container {
+    width: 100%;
+    overflow-x: scroll;
+  }
+  #formplayer-progress .progress-container {
+    .progress-title {
+      h1, h2 {
+        font-size: 1.3em;
+      }
+      h1 {
+        margin-bottom: 4px;
+      }
+    }
+  }
 }

--- a/corehq/apps/style/static/cloudcare/less/cloudcare/module.less
+++ b/corehq/apps/style/static/cloudcare/less/cloudcare/module.less
@@ -227,7 +227,7 @@
   }
 }
 
-@media(max-width: 720px) {
+@media(max-width: @screen-sm-max) {
   .module-caselist-table-container {
     width: 100%;
     overflow-x: scroll;


### PR DESCRIPTION
@proteusvacuum 
![screen shot 2016-10-20 at 11 35 58 am](https://cloud.githubusercontent.com/assets/918514/19566883/d84f9302-96b9-11e6-9290-4d69a26acf56.png)

how about this? a lot of the notions that happen on the phone are fundamentally different in formplayer and make it very hard to replicate all the states. for example in formplayer, we attempt to do a restore on every request and do one if the restore isn't there. all this happens transparently to client so "communicating with the server" state is just the normal web request state. also at this time we have no hook into the progress that is made by formplayer in parsing the request, which i believe is "processing data from the server" state. definitely would be nice to have at some point, but right now it's less of an issue since a server is able to parse the xml much faster than a phone. will update to include when/if we get to that point

cc: @nickpell 
