### PR TITLE
Search only the base username

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -105,7 +105,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
             return ['%s*' % tokens.pop()] + tokens
 
     def user_es_query(self, query):
-        search_fields = ["first_name", "last_name", "username"]
+        search_fields = ["first_name", "last_name", "base_username"]
         return (UserES()
                 .domain(self.domain)
                 .search_string_query(query, default_fields=search_fields))


### PR DESCRIPTION
@sravfeyn @nhooper
The "username" field includes @domain.commcarehq.org, which makes for
some strange search results
This is basically the same change I made here: https://github.com/dimagi/commcare-hq/pull/12536
