### PR TITLE
Add ability to force convert columns in migrate_exports command

### DIFF
--- a/corehq/apps/export/management/commands/migrate_exports.py
+++ b/corehq/apps/export/management/commands/migrate_exports.py
@@ -26,11 +26,19 @@ class Command(BaseCommand):
             type='int',
             help='Limits the number of domains migrated'
         ),
+        make_option(
+            '--force-convert-columns',
+            action='store_true',
+            dest='force_convert_columns',
+            default=False,
+            help='Force convert columns that were not found in the new schema'
+        ),
     )
 
     def handle(self, *args, **options):
         dryrun = options.pop('dryrun')
         limit = options.pop('limit')
+        force_convert_columns = options.pop('force_convert_columns')
         count = 0
 
         if dryrun:
@@ -44,7 +52,7 @@ class Command(BaseCommand):
 
             if not use_new_exports(domain):
                 try:
-                    metas = migrate_domain(domain, True)
+                    metas = migrate_domain(domain, dryrun=True, force_convert_columns=force_convert_columns)
                 except Exception:
                     print 'Migration raised an exception, skipping.'
                     traceback.print_exc()
@@ -67,7 +75,7 @@ class Command(BaseCommand):
                 if not dryrun:
                     print 'Migrating {}'.format(domain)
                     try:
-                        migrate_domain(domain, False)
+                        migrate_domain(domain, dryrun=False, force_convert_columns=force_convert_columns)
                     except Exception:
                         print 'Migration raised an exception, skipping.'
                         skipped_domains.append(domain)

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -529,7 +529,7 @@ def revert_migrate_domain(domain, dryrun=False):
         print 'Reverted export: {}'.format(reverted_export._id)
 
 
-def migrate_domain(domain, dryrun=False):
+def migrate_domain(domain, dryrun=False, force_convert_columns=False):
     from couchexport.models import SavedExportSchema
     export_count = stale_get_export_count(domain)
     metas = []
@@ -542,7 +542,8 @@ def migrate_domain(domain, dryrun=False):
                 _, migration_meta = convert_saved_export_to_export_instance(
                     domain,
                     SavedExportSchema.wrap(old_export),
-                    dryrun=dryrun
+                    dryrun=dryrun,
+                    force_convert_columns=force_convert_columns,
                 )
             except Exception, e:
                 print 'Failed parsing {}: {}'.format(old_export['_id'], e)


### PR DESCRIPTION
@czue @NoahCarnahan allows us to force convert columns in the migrate exports command

cc: @nickpell 
