### PR TITLE
update Ops form to reduce confusion

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1899,7 +1899,6 @@ class AdjustBalanceForm(forms.Form):
             ('current', 'Add Credit of Current Balance: %s' %
                         get_money_str(self.invoice.balance)),
             ('credit', 'Add CREDIT of Custom Amount'),
-            ('debit', 'Add DEBIT of Custom Amount'),
         )
         self.fields['invoice_id'].initial = invoice.id
         self.helper = FormHelper()
@@ -1960,8 +1959,6 @@ class AdjustBalanceForm(forms.Form):
             return self.invoice.balance
         elif adjustment_type == 'credit':
             return Decimal(self.cleaned_data['custom_amount'])
-        elif adjustment_type == 'debit':
-            return -Decimal(self.cleaned_data['custom_amount'])
         else:
             raise ValidationError(_("Received invalid adjustment type: %s")
                                   % adjustment_type)

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1896,9 +1896,9 @@ class AdjustBalanceForm(forms.Form):
         self.invoice = invoice
         super(AdjustBalanceForm, self).__init__(*args, **kwargs)
         self.fields['adjustment_type'].choices = (
-            ('current', 'Add Credit of Current Balance: %s' %
+            ('current', 'Pay off Current Balance: %s' %
                         get_money_str(self.invoice.balance)),
-            ('credit', 'Add CREDIT of Custom Amount'),
+            ('credit', 'Pay off Custom Amount'),
         )
         self.fields['invoice_id'].initial = invoice.id
         self.helper = FormHelper()

--- a/corehq/apps/accounting/static/accounting/js/adjust-balance-modal.js
+++ b/corehq/apps/accounting/static/accounting/js/adjust-balance-modal.js
@@ -3,8 +3,7 @@ hqDefine('accounting/js/adjust-balance-modal.js', function () {
         var self = this;
         self.adjustmentType = ko.observable("current");
         self.showCustomAmount = ko.computed(function() {
-            return self.adjustmentType() === 'credit'  ||
-                self.adjustmentType() === 'debit';
+            return self.adjustmentType() === 'credit';
         }, self);
     };
     return {AdjustBalanceFormModel: AdjustBalanceFormModel};

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -97,32 +97,3 @@ class TestAdjustBalanceForm(BaseInvoiceTestCase):
             credit_line.balance
             for credit_line in CreditLine.get_credits_for_invoice(self.invoice)
         ))
-
-    def test_transfer_debit_without_credit(self):
-        original_credit_balance = 0
-        CreditLine.add_credit(
-            original_credit_balance,
-            account=self.subscription.account,
-            subscription=self.subscription,
-        )
-        original_balance = self.invoice.balance
-        adjustment_amount = random.randint(1, 5)
-
-        adjust_balance_form = AdjustBalanceForm(
-            self.invoice,
-            {
-                'adjustment_type': 'debit',
-                'custom_amount': adjustment_amount,
-                'method': CreditAdjustmentReason.TRANSFER,
-                'note': 'some text',
-                'invoice_id': self.invoice.id,
-            }
-        )
-        self.assertTrue(adjust_balance_form.is_valid())
-
-        adjust_balance_form.adjust_balance()
-        self.assertEqual(original_balance + adjustment_amount, self.invoice.balance)
-        self.assertEqual(original_credit_balance + adjustment_amount, sum(
-            credit_line.balance
-            for credit_line in CreditLine.get_credits_for_invoice(self.invoice)
-        ))


### PR DESCRIPTION
Removes "debit" option since we can just add negative credit.
Update text to clarify what this form does.

Motivated by http://manage.dimagi.com/default.asp?237443

@benrudolph 
