### PR TITLE
Convert case list & detail autocompletes to select2s

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -1,4 +1,4 @@
-/*globals $, _, uiElement, eventize, lcsMerge, COMMCAREHQ */
+/*globals $, _, uiElement, eventize, lcsMerge, COMMCAREHQ, DOMPurify */
 
 hqDefine('app_manager/js/detail-screen-config.js', function () {
     var module = {};

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -39,39 +39,44 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
          * Enable autocomplete on the given jquery element with the given autocomplete
          * options.
          * @param $elem
-         * @param options
+         * @param options: Array of strings.
          */
         setUpAutocomplete: function($elem, options){
-            $elem.$edit_view.autocomplete({
-                source: function (request, response) {
-                    var availableTags = _.map(options, function(value) {
-                        var label = value;
-                        if (module.CC_DETAIL_SCREEN.isAttachmentProperty(value)) {
-                            label = (
-                                '<i class="fa fa-paperclip"></i> ' +
-                                label.substring(label.indexOf(":") + 1)
-                            );
-                        }
-                        return {value: value, label: label};
-                    });
-                    response(
-                        $.ui.autocomplete.filter(availableTags, request.term)
-                    );
-                },
-                minLength: 0,
+            $elem.$edit_view.select2({
+                minimumInputLength: 0,
                 delay: 0,
-                select: function (event, ui) {
-                    $elem.val(ui.item.value);
-                    $elem.fire('change');
-                }
-            }).focus(function () {
-                $(this).autocomplete('search');
-            }).data("ui-autocomplete")._renderItem = function (ul, item) {
-                return $("<li></li>")
-                    .data("item.autocomplete", item)
-                    .append($("<a></a>").html(item.label))
-                    .appendTo(ul);
-            };
+                data: {
+                    results: _.map(options, function(o) {
+                        return {
+                            id: o,
+                            text: o,
+                        };
+                    }),
+                },
+                // Allow manually entered text in drop down, which is not supported by legacy select2.
+                createSearchChoice: function(term, data) {
+                    if (!_.find(data, function(d) { return d.text === term; })) {
+                        return {
+                            id: term,
+                            text: term,
+                        };
+                    }
+                },
+                escapeMarkup: function (m) { return DOMPurify.sanitize(m); },   // injection?
+                formatResult: function(result) {
+                    var formatted = result.id;
+                    if (module.CC_DETAIL_SCREEN.isAttachmentProperty(result.id)) {
+                        formatted = (
+                            '<i class="fa fa-paperclip"></i> ' +
+                            result.id.substring(result.id.indexOf(":") + 1)
+                        );
+                    }
+                    return DOMPurify.sanitize(formatted);
+                },
+            }).on('change', function() {
+                $elem.val($elem.$edit_view.value);
+                $elem.fire('change');
+            });
             return $elem;
         }
 

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -1,4 +1,4 @@
-/*globals $, _, uiElement, eventize, lcsMerge, COMMCAREHQ, DOMPurify */
+/*globals $, _, uiElement, eventize, COMMCAREHQ, DOMPurify */
 
 hqDefine('app_manager/js/detail-screen-config.js', function () {
     var module = {};

--- a/corehq/apps/style/static/style/less/_hq/forms.less
+++ b/corehq/apps/style/static/style/less/_hq/forms.less
@@ -94,8 +94,8 @@ legend .subtext {
   }
 }
 
-// Static width for select2 widgets, which otherwise grow too large on case management pages
-.app-manager-select2s(@width) {
+// Static width for select2 widgets, which otherwise grow too large on form view's case management tab
+.case-config-select2s(@width) {
     .select2-container {
         width: @width;
     }
@@ -107,13 +107,13 @@ legend .subtext {
     }
 }
 
-.appmanager-content {
+#case-config-ko {
     @select2Width: 210px;
 
-    .app-manager-select2s(@select2Width);
+    .case-config-select2s(@select2Width);
 
     .wide-select2s {
-        .app-manager-select2s(@select2Width * 1.5);
+        .case-config-select2s(@select2Width * 1.5);
     }
 }
 


### PR DESCRIPTION
Same rationale as https://github.com/dimagi/langcodes/pull/8

@dimagi/product are you cool with this new look? The only functionality change is that you can no longer blank out the value, but that would throw an error anyway.

<img width="1057" alt="screen shot 2016-10-24 at 1 48 17 pm" src="https://cloud.githubusercontent.com/assets/1486591/19657306/a6a652a6-99f1-11e6-84a2-a8a987eb1fea.png">

<img width="1055" alt="screen shot 2016-10-24 at 1 54 59 pm" src="https://cloud.githubusercontent.com/assets/1486591/19657309/aa9871fa-99f1-11e6-9e4a-40b1591a596a.png">

@calellowitz 
