### PR TITLE
Replace CommCare translations autocomplete with atwho

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,8 @@
     "select2": "4.0.0",
     "less": "1.7.3",
     "xpath": "dimagi/js-xpath#f4f0c78",
+    "At.js": "1.5.2",
+    "Caret.js": "0.2.2",
     "backbone": "0.9.1",
     "backbone-1.3.2": "backbone#1.3.2",
     "bootstrap-daterangepicker": "2.1.13",

--- a/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
@@ -3,8 +3,15 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% load compress %}
+
 {% block head %}{{ block.super }}
     {% include 'analytics/fullstory.html' %}
+{% endblock %}
+{% block stylesheets %}{{ block.super }}
+    {% compress css %}
+    <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
+    {% endcompress %}
 {% endblock %}
 {% block js %}{{ block.super }}
     <script src="{% static 'app_manager/js/commcaresettings.js' %}"></script>
@@ -23,6 +30,8 @@
     {{ block.super }}
     {% if app.get_doc_type == "Application" %}
         <script src="{% static 'translations/js/translations.js' %}"></script>
+        <script src="{% static 'Caret.js/dist/jquery.caret.min.js' %}"></script>
+        <script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
     {% endif %}
     {% if app %}
     <script>

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -58,6 +58,7 @@ var mk_translation_ui = function (spec) {
                     at: "",
                     maxLen: Infinity,
                     suffix: "",
+                    tabSelectsMatch: false,
                     callbacks: {
                         filter: function(query, data, searchKey) {
                             return _.filter(data, function(item) {

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -83,7 +83,7 @@ var mk_translation_ui = function (spec) {
                         url: suggestionURL,
                         data: {
                             lang: translation_ui.lang,
-                            key: that.key.val()
+                            key: that.key.val(),
                         },
                         success: function (data) {
                             options.data = data;
@@ -92,7 +92,7 @@ var mk_translation_ui = function (spec) {
                                 $input.val($input.data("selected-value")).change();
                             });
                             $input.atwho('run');
-                        }
+                        },
                     });
                 });
             };

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -88,7 +88,6 @@ var mk_translation_ui = function (spec) {
                         success: function (data) {
                             options.data = data;
                             $input.atwho(options).on("inserted.atwho", function(event, $li, otherEvent) {
-                                $(this).find('.atwho-inserted').children().unwrap();
                                 $input.val($input.data("selected-value")).change();
                             });
                             $input.atwho('run');


### PR DESCRIPTION
Borrowing heavily from https://github.com/dimagi/Vellum/pull/440

Odds are good that the atwho inclusions & options will go somewhere more general later, but for the moment this is the only place they're being used.

<img width="1055" alt="screen shot 2016-10-24 at 3 19 16 pm" src="https://cloud.githubusercontent.com/assets/1486591/19660392/90c0799c-99fd-11e6-87e3-0b4b9c8b61b4.png">

@calellowitz / @emord 
