### PR TITLE
Directly download restore xml

### DIFF
--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -472,6 +472,12 @@ class AdminRestoreView(TemplateView):
             response, _ = self._get_restore_response()
             return response
 
+        download = request.GET.get('download') == 'true'
+        if download:
+            response, _ = self._get_restore_response()
+            response['Content-Disposition'] = "attachment; filename={}-restore.xml".format(username)
+            return response
+
         return super(AdminRestoreView, self).get(request, *args, **kwargs)
 
     def _get_restore_response(self):


### PR DESCRIPTION
@NoahCarnahan 
Adds the ability to directly download a restore xml file (by adding `&download=true` to the url).

(FYI @phillipm this is useful for immediately saving restores to be used in the CLI)
