### PR TITLE
Fix SMS language dropdowns

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/supported-languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/supported-languages.html
@@ -27,11 +27,9 @@
                 <span data-bind="text: $root.languages.indexOf($data) + 1 + '.', visible: !isDefaultLang()"></span>
                 <span class="label label-info" data-bind="visible: isDefaultLang()">1. default</span>
             </td>
-            <td class="col-sm-1">
-                <span class="form-inline">
-                      <input class="short form-control"
-                             data-bind="langcode: langcode, valueUpdate: 'textchange', inputHandlers: {hasfocus: $root.seen}"/>
-                </span>
+            <td class="col-sm-3">
+                <input class="short form-control"
+                       data-bind="langcode: langcode, valueUpdate: 'textchange', inputHandlers: {hasfocus: $root.seen}"/>
             </td>
             <td class="col-sm-1">
                 <span data-bind="visible: originalLangcode() && originalLangcode() !== langcode()">

--- a/corehq/apps/sms/templates/sms/languages.html
+++ b/corehq/apps/sms/templates/sms/languages.html
@@ -53,7 +53,7 @@
         </div>
         <div class="tab-content">
             <div id="supported-languages" class="tab-pane active">
-                    {% include "app_manager/v1/partials/supported-languages.html" with hide_deploy_column=True %}
+                    {% include "app_manager/v1/partials/supported-languages.html" %}
             </div>
             <div id="translations-tab" class="tab-pane">
                 <div>

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1662,6 +1662,7 @@ class SMSLanguagesView(BaseMessagingSectionView):
     page_title = ugettext_noop("Languages")
 
     @use_jquery_ui
+    @use_select2
     @method_decorator(domain_admin_required)
     def dispatch(self, *args, **kwargs):
         return super(SMSLanguagesView, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
https://github.com/dimagi/langcodes/pull/8 means the SMS languages page needs to include select2.

@calellowitz / @gcapalbo 
