### PR TITLE
reduce confusing and duplicated code

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -79,9 +79,7 @@ class DomainInvoiceFactory(object):
 
     @transaction.atomic
     def _ensure_full_coverage(self, subscriptions):
-        plan_version = DefaultProductPlan.get_default_plan(
-            edition=SoftwarePlanEdition.COMMUNITY
-        ).plan.get_version()
+        plan_version = DefaultProductPlan.get_default_plan_version()
         if not plan_version.feature_charges_exist_for_domain(self.domain):
             return
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -759,9 +759,7 @@ class DefaultProductPlan(models.Model):
     @classmethod
     def get_lowest_edition(cls, requested_privileges, return_plan=False):
         for edition in SoftwarePlanEdition.SELF_SERVICE_ORDER:
-            plan_version = cls.get_default_plan(
-                edition=edition
-            )
+            plan_version = cls.get_default_plan_version(edition)
             privileges = get_privileges(plan_version) - REPORT_BUILDER_ADD_ON_PRIVS
             if privileges.issuperset(requested_privileges):
                 return (plan_version if return_plan
@@ -959,7 +957,7 @@ class Subscriber(models.Model):
 
 
         if new_plan_version is None:
-            new_plan_version = DefaultProductPlan.get_default_plan()
+            new_plan_version = DefaultProductPlan.get_default_plan_version()
 
         if downgraded_privileges is None or upgraded_privileges is None:
             change_status_result = get_change_status(None, new_plan_version)
@@ -1609,7 +1607,7 @@ class Subscription(models.Model):
         subscriber = Subscriber.objects.safe_get(domain=domain.name)
         plan_version, subscription = cls._get_plan_by_subscriber(subscriber) if subscriber else (None, None)
         if plan_version is None:
-            plan_version = DefaultProductPlan.get_default_plan()
+            plan_version = DefaultProductPlan.get_default_plan_version()
         return plan_version, subscription
 
     @classmethod

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -744,7 +744,7 @@ class DefaultProductPlan(models.Model):
         app_label = 'accounting'
 
     @classmethod
-    def get_default_plan(cls, edition=None, is_trial=False):
+    def get_default_plan_version(cls, edition=None, is_trial=False):
         edition = edition or SoftwarePlanEdition.COMMUNITY
         try:
             default_product_plan = DefaultProductPlan.objects.select_related('plan').get(
@@ -1601,10 +1601,7 @@ class Subscription(models.Model):
         domain_obj = ensure_domain_instance(domain)
         if domain_obj is None:
             try:
-                plan_version = DefaultProductPlan.objects.get(
-                    edition=SoftwarePlanEdition.COMMUNITY,
-                    product_type=SoftwareProductType.COMMCARE,
-                ).plan.get_version()
+                plan_version = DefaultProductPlan.get_default_plan_version()
                 return plan_version, None
             except DefaultProductPlan.DoesNotExist:
                 raise ProductPlanNotFoundError

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -608,9 +608,7 @@ def assign_explicit_community_subscription(domain_name, start_date):
             entry_point=EntryPoint.SELF_STARTED,
         )[0],
         domain=domain_name,
-        plan_version=DefaultProductPlan.get_default_plan(
-            SoftwarePlanEdition.COMMUNITY
-        ).plan.get_version(),
+        plan_version=DefaultProductPlan.get_default_plan_version(),
         date_start=start_date,
         date_end=end_date,
         skip_invoicing_if_no_feature_charges=True,

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -121,11 +121,7 @@ def delete_all_accounts():
 
 @unit_testing_only
 def subscribable_plan(edition=SoftwarePlanEdition.STANDARD):
-    return DefaultProductPlan.objects.get(
-        edition=edition,
-        product_type=SoftwareProductType.COMMCARE,
-        is_trial=False
-    ).plan.get_version()
+    return DefaultProductPlan.get_default_plan_version(edition)
 
 
 @unit_testing_only
@@ -194,12 +190,9 @@ def arbitrary_commcare_users_for_domain(domain, num_users, is_active=True):
 
 @unit_testing_only
 def create_excess_community_users(domain):
-    community_plan = DefaultProductPlan.objects.get(
-        product_type=SoftwareProductType.COMMCARE,
-        edition=SoftwarePlanEdition.COMMUNITY
-    ).plan.get_version()
-    num_active_users = random.randint(community_plan.user_limit + 1,
-                                      community_plan.user_limit + 4)
+    community_plan_version = DefaultProductPlan.get_default_plan_version()
+    num_active_users = random.randint(community_plan_version.user_limit + 1,
+                                      community_plan_version.user_limit + 4)
     arbitrary_commcare_users_for_domain(domain.name, num_active_users)
     return num_active_users
 

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -302,10 +302,10 @@ class TestCreditTransfers(BaseAccountingTest):
         return transferred_credits
 
     def test_transfers(self):
-        advanced_plan = DefaultProductPlan.get_default_plan(
+        advanced_plan = DefaultProductPlan.get_default_plan_version(
             edition=SoftwarePlanEdition.ADVANCED
         )
-        standard_plan = DefaultProductPlan.get_default_plan(
+        standard_plan = DefaultProductPlan.get_default_plan_version(
             edition=SoftwarePlanEdition.STANDARD
         )
         first_sub = Subscription.new_domain_subscription(

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -22,7 +22,7 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
         self.account = BillingAccount.get_or_create_account_by_domain(
             domain=self.domain.name, created_by="TEST"
         )[0]
-        self.community = DefaultProductPlan.get_default_plan().plan.get_version()
+        self.community = DefaultProductPlan.get_default_plan_version()
         generator.arbitrary_commcare_users_for_domain(
             self.domain.name, self.community.user_limit + 1
         )

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -57,10 +57,7 @@ class BaseInvoiceTestCase(BaseAccountingTest):
             date_end=subscription_end_date,
         )
 
-        self.community_plan = DefaultProductPlan.objects.get(
-            product_type=SoftwareProductType.COMMCARE,
-            edition=SoftwarePlanEdition.COMMUNITY
-        ).plan.get_version()
+        self.community_plan = DefaultProductPlan.get_default_plan_version()
 
     def tearDown(self):
         CreditAdjustment.objects.all().delete()
@@ -158,11 +155,7 @@ class TestInvoice(BaseInvoiceTestCase):
     def test_date_due_not_set_small_invoice(self):
         """Date Due doesn't get set if the invoice is small"""
         Subscription.objects.all().delete()
-        plan = DefaultProductPlan.objects.get(
-            edition=SoftwarePlanEdition.STANDARD,
-            product_type=SoftwareProductType.COMMCARE,
-            is_trial=False
-        ).plan.get_version()
+        plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.STANDARD)
 
         subscription_length = 5  # months
         subscription_start_date = datetime.date(2016, 2, 23)
@@ -172,7 +165,7 @@ class TestInvoice(BaseInvoiceTestCase):
             self.domain,
             date_start=subscription_start_date,
             date_end=subscription_end_date,
-            plan_version=plan,
+            plan_version=plan_version,
         )
 
         invoice_date_small = utils.months_from_date(subscription.date_start, 1)
@@ -185,11 +178,7 @@ class TestInvoice(BaseInvoiceTestCase):
     def test_date_due_set_large_invoice(self):
         """Date Due only gets set for a large invoice (> $100)"""
         Subscription.objects.all().delete()
-        plan = DefaultProductPlan.objects.get(
-            edition=SoftwarePlanEdition.ADVANCED,
-            product_type=SoftwareProductType.COMMCARE,
-            is_trial=False
-        ).plan.get_version()
+        plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.ADVANCED)
 
         subscription_length = 5  # months
         subscription_start_date = datetime.date(2016, 2, 23)
@@ -199,7 +188,7 @@ class TestInvoice(BaseInvoiceTestCase):
             self.domain,
             date_start=subscription_start_date,
             date_end=subscription_end_date,
-            plan_version=plan
+            plan_version=plan_version
         )
 
         invoice_date_large = utils.months_from_date(subscription.date_start, 3)
@@ -212,11 +201,7 @@ class TestInvoice(BaseInvoiceTestCase):
     def test_date_due_gets_set_autopay(self):
         """Date due always gets set for autopay """
         Subscription.objects.all().delete()
-        plan = DefaultProductPlan.objects.get(
-            edition=SoftwarePlanEdition.STANDARD,
-            product_type=SoftwareProductType.COMMCARE,
-            is_trial=False
-        ).plan.get_version()
+        plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.STANDARD)
 
         subscription_length = 4
         subscription_start_date = datetime.date(2016, 2, 23)
@@ -226,7 +211,7 @@ class TestInvoice(BaseInvoiceTestCase):
             self.domain,
             date_start=subscription_start_date,
             date_end=subscription_end_date,
-            plan_version=plan
+            plan_version=plan_version
         )
 
         autopay_subscription.account.update_autopay_user(self.billing_contact.username, self.domain)

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -130,11 +130,11 @@ class TestExplicitCommunitySubscriptions(TestCase):
 
     @property
     def _most_recently_created_community_plan_version(self):
-        return DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.COMMUNITY)
+        return DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.COMMUNITY)
 
     @property
     def _random_plan_version(self):
-        return DefaultProductPlan.get_default_plan(
+        return DefaultProductPlan.get_default_plan_version(
             edition=random.choice(SoftwarePlanEdition.SELF_SERVICE_ORDER + [SoftwarePlanEdition.ENTERPRISE]),
         )
 

--- a/corehq/apps/accounting/tests/test_new_domain_subscription.py
+++ b/corehq/apps/accounting/tests/test_new_domain_subscription.py
@@ -33,8 +33,8 @@ class TestNewDomainSubscription(BaseAccountingTest):
             self.domain.name, created_by=self.admin_user.username)[0]
         self.account2 = BillingAccount.get_or_create_account_by_domain(
             self.domain2.name, created_by=self.admin_user.username)[0]
-        self.standard_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.STANDARD)
-        self.advanced_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
+        self.standard_plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.STANDARD)
+        self.advanced_plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
 
     def test_new_susbscription_in_future(self):
         """

--- a/corehq/apps/accounting/tests/test_renew_subscription.py
+++ b/corehq/apps/accounting/tests/test_renew_subscription.py
@@ -28,7 +28,7 @@ class TestRenewSubscriptions(BaseAccountingTest):
         self.account = BillingAccount.get_or_create_account_by_domain(
             self.domain.name, created_by=self.admin_user.username)[0]
 
-        self.standard_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.STANDARD)
+        self.standard_plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.STANDARD)
 
         today = datetime.date.today()
         yesterday = today + datetime.timedelta(days=-1)
@@ -60,7 +60,7 @@ class TestRenewSubscriptions(BaseAccountingTest):
 
     def test_change_plan_on_renewal(self):
         new_edition = SoftwarePlanEdition.ADVANCED
-        new_plan = DefaultProductPlan.get_default_plan(new_edition)
+        new_plan = DefaultProductPlan.get_default_plan_version(new_edition)
 
         self.renewed_subscription = self.subscription.renew_subscription(
             new_version=new_plan

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -69,7 +69,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
 
         self.account = BillingAccount.get_or_create_account_by_domain(
             self.domain.name,created_by=self.admin_user.username)[0]
-        self.advanced_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
+        self.advanced_plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
 
     def test_cancellation(self):
         subscription = Subscription.new_domain_subscription(

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -32,7 +32,7 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
 
         self.account = BillingAccount.get_or_create_account_by_domain(
             self.project.name, created_by=self.admin_user.username)[0]
-        self.advanced_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
+        self.advanced_plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
         self._init_pro_with_rb_plan_and_version()
 
     def _init_pro_with_rb_plan_and_version(self):

--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -11,7 +11,7 @@ class DomainSubscriptionMixin(object):
     def setup_subscription(cls, domain_name, software_plan):
         generator.instantiate_accounting()
 
-        plan = DefaultProductPlan.get_default_plan(edition=software_plan)
+        plan = DefaultProductPlan.get_default_plan_version(edition=software_plan)
         cls.account = BillingAccount.get_or_create_account_by_domain(
             domain_name, created_by="automated-test" + cls.__name__
         )[0]

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -546,8 +546,8 @@ class EditSoftwarePlanView(AccountingSectionView, AsyncHandlerMixin):
             'role_slug': plan_version.role.slug if plan_version else None,
         }
         if self.request.method == 'POST' and 'update_version' in self.request.POST:
-            return SoftwarePlanVersionForm(self.plan, self.plan.get_version(), self.request.POST, initial=initial)
-        return SoftwarePlanVersionForm(self.plan, self.plan.get_version(), initial=initial)
+            return SoftwarePlanVersionForm(self.plan, plan_version, self.request.POST, initial=initial)
+        return SoftwarePlanVersionForm(self.plan, plan_version, initial=initial)
 
     @property
     def page_context(self):

--- a/corehq/apps/analytics/tests/test_subscription_properties.py
+++ b/corehq/apps/analytics/tests/test_subscription_properties.py
@@ -42,7 +42,7 @@ class TestSubscriptionProperties(TestCase):
 
     @classmethod
     def _setup_subscription(cls, domain_name, software_plan):
-        plan = DefaultProductPlan.get_default_plan(edition=software_plan)
+        plan = DefaultProductPlan.get_default_plan_version(edition=software_plan)
         account = BillingAccount.get_or_create_account_by_domain(
             domain_name, created_by="automated-test" + cls.__name__
         )[0]

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -83,7 +83,7 @@ class FakeXFormES(object):
 
 def set_up_subscription(cls):
     cls.account = BillingAccount.get_or_create_account_by_domain(cls.domain.name, created_by="automated-test")[0]
-    plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
+    plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
     cls.subscription = Subscription.new_domain_subscription(cls.account, cls.domain.name, plan)
     cls.subscription.is_active = True
     cls.subscription.save()
@@ -1330,7 +1330,7 @@ class TestSingleSignOnResource(APIResourceTest):
         # have to set up subscription for the bad domain or it will fail on authorization
         new_account = BillingAccount.get_or_create_account_by_domain(wrong_domain.name,
                                                                      created_by="automated-test")[0]
-        plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
+        plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
         new_subscription = Subscription.new_domain_subscription(new_account, wrong_domain.name, plan)
         new_subscription.is_active = True
         new_subscription.save()

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1719,9 +1719,7 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
 
     @transaction.atomic
     def process_subscription_management(self):
-        enterprise_plan_version = DefaultProductPlan.get_default_plan(
-            SoftwarePlanEdition.ENTERPRISE
-        ).plan.get_version()
+        enterprise_plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.ENTERPRISE)
         if self.current_subscription:
             self.current_subscription.change_plan(
                 enterprise_plan_version,

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1805,7 +1805,7 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
 
     @transaction.atomic
     def process_subscription_management(self):
-        advanced_trial_plan_version = DefaultProductPlan.get_default_plan(
+        advanced_trial_plan_version = DefaultProductPlan.get_default_plan_version(
             edition=SoftwarePlanEdition.ADVANCED, is_trial=True,
         )
         if self.current_subscription:
@@ -1989,7 +1989,7 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                 "CommCare %s edition with privilege REPORT_BUILDER_5 was not found! Requires manual setup."
                 % edition
             )
-            new_plan_version = DefaultProductPlan.get_default_plan(
+            new_plan_version = DefaultProductPlan.get_default_plan_version(
                 edition=self.cleaned_data['software_plan_edition'],
             )
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1662,7 +1662,7 @@ class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin
     @property
     @memoized
     def next_plan_version(self):
-        plan_version = DefaultProductPlan.get_default_plan(self.new_edition)
+        plan_version = DefaultProductPlan.get_default_plan_version(self.new_edition)
         if plan_version is None:
             log_accounting_error(
                 "Could not find a matching renewable plan "

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1474,7 +1474,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
     @property
     @memoized
     def selected_plan_version(self):
-        return DefaultProductPlan.get_default_plan(self.edition).plan.get_version()
+        return DefaultProductPlan.get_default_plan_version(self.edition)
 
     @property
     def downgrade_messages(self):

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -235,7 +235,7 @@ You can view the %s here: %s""" % (
 # Only new-users are eligible for advanced trial
 def create_30_day_advanced_trial(domain_obj):
     # Create a 30 Day Trial subscription to the Advanced Plan
-    advanced_plan_version = DefaultProductPlan.get_default_plan(
+    advanced_plan_version = DefaultProductPlan.get_default_plan_version(
         edition=SoftwarePlanEdition.ADVANCED, is_trial=True
     )
     expiration_date = date.today() + timedelta(days=30)

--- a/corehq/apps/sms/tests/test_registration.py
+++ b/corehq/apps/sms/tests/test_registration.py
@@ -394,7 +394,7 @@ class RegistrationAPITestCase(TestCase):
         domain_obj = Domain(name=name, sms_mobile_worker_registration_enabled=True)
         domain_obj.save()
 
-        plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
+        plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
         account = BillingAccount.get_or_create_account_by_domain(
             name, created_by="automated-test-" + cls.__name__
         )[0]

--- a/corehq/apps/zapier/tests.py
+++ b/corehq/apps/zapier/tests.py
@@ -87,7 +87,7 @@ class TestZapierIntegration(TestCase):
         cls.domain = cls.domain_object.name
 
         account = BillingAccount.get_or_create_account_by_domain(cls.domain, created_by="automated-test")[0]
-        plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.STANDARD)
+        plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.STANDARD)
         subscription = Subscription.new_domain_subscription(account, cls.domain, plan)
         subscription.is_active = True
         subscription.save()

--- a/custom/ewsghana/utils.py
+++ b/custom/ewsghana/utils.py
@@ -143,7 +143,7 @@ def prepare_domain(domain_name):
         domain.name,
         created_by="automated-test",
     )[0]
-    plan = DefaultProductPlan.get_default_plan(
+    plan = DefaultProductPlan.get_default_plan_version(
         edition=SoftwarePlanEdition.ADVANCED
     )
     subscription = Subscription.new_domain_subscription(

--- a/custom/ilsgateway/tests/handlers/utils.py
+++ b/custom/ilsgateway/tests/handlers/utils.py
@@ -160,7 +160,7 @@ def prepare_domain(domain_name):
         domain.name,
         created_by="automated-test",
     )[0]
-    plan = DefaultProductPlan.get_default_plan(
+    plan = DefaultProductPlan.get_default_plan_version(
         edition=SoftwarePlanEdition.ADVANCED
     )
     commtrack = domain.commtrack_settings


### PR DESCRIPTION
get_default_plan actually returns a plan version, so let's rename the function to make it obvious.

and, let's stop recalculating the plan version from the returned plan version.

https://github.com/dimagi/commcare-hq/commit/cad9759c23b3871cef7f8e84cffa8586d2723abb is a random optimization I found

code buddy @benrudolph 

@calellowitz This affects https://github.com/dimagi/commcare-hq/pull/13671.  Sorry that every example suggests you have to do more work than you really need for getting the latest plan version.
