### PR TITLE
drop jQuery UI autocomplete

### DIFF
--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -167,8 +167,6 @@
             <script src="{% static 'jquery-ui/ui/position.js' %}"></script>
 
             <!-- Individual widgets and interactions -->
-            <script src="{% static 'jquery-ui/ui/menu.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/autocomplete.js' %}"></script>
             <script src="{% static 'jquery-ui/ui/button.js' %}"></script>
             <script src="{% static 'jquery-ui/ui/datepicker.js' %}"></script>
             <script src="{% static 'jquery-ui/ui/draggable.js' %}"></script>


### PR DESCRIPTION
depends on https://github.com/dimagi/commcare-hq/pull/13731, https://github.com/dimagi/commcare-hq/pull/13709, https://github.com/dimagi/commcare-hq/pull/13708, and https://github.com/dimagi/commcare-hq/pull/13697

@calellowitz 
