### PR TITLE
v0.1 of dump & reload tasks

### DIFF
--- a/corehq/apps/hqadmin/management/commands/dump_domain_data.py
+++ b/corehq/apps/hqadmin/management/commands/dump_domain_data.py
@@ -1,0 +1,140 @@
+from collections import OrderedDict
+
+from django.apps import apps
+from django.conf import settings
+from django.core import serializers
+from django.core.management.base import BaseCommand, CommandError
+from django.db import router
+
+from corehq.sql_db.config import partition_config
+
+app_labels = {
+    'locations.LocationType': 'domain',
+    'locations.SQLLocation': 'domain',
+    'form_processor.XFormInstanceSQL': 'domain'
+}
+
+
+class Command(BaseCommand):
+    help = "Dump a domain's data to disk."
+    args = '<domain>'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-e', '--exclude', dest='exclude', action='append', default=[],
+            help='An app_label or app_label.ModelName to exclude '
+                 '(use multiple --exclude to exclude multiple apps/models).')
+        parser.add_argument('--indent', default=None, dest='indent', type=int,
+                            help='Specifies the indent level to use when pretty-printing output.')
+        parser.add_argument('-o', '--output', default=None, dest='output',
+            help='Specifies file to which the output is written.')
+
+    def handle(self, domain, **options):
+        format = 'json'
+        indent = options.get('indent')
+        excludes = options.get('exclude')
+        output = options.get('output')
+        show_traceback = options.get('traceback')
+
+        _check_serialization_format(format)
+
+        excluded_apps, excluded_models = _get_excluded_apps_and_models(excludes)
+        app_list = _get_app_list(excluded_apps)
+
+        def get_objects():
+            # Collate the objects to be serialized.
+            for model in serializers.sort_dependencies(app_list.items()):
+                if model in excluded_models:
+                    continue
+
+                using = router.db_for_read(model)
+                if settings.USE_PARTITIONED_DATABASE and using == partition_config.get_proxy_db():
+                    using = partition_config.get_form_processing_dbs()
+                else:
+                    using = [using]
+
+                for db_alias in using:
+                    if not model._meta.proxy and router.allow_migrate_model(db_alias, model):
+                        objects = model._default_manager
+
+                        label = '{}.{}'.format(model._meta.app_label, model.__name__)
+                        filter_kwarg = app_labels[label]
+
+                        queryset = objects.using(db_alias) \
+                            .filter(**{filter_kwarg: domain}) \
+                            .order_by(model._meta.pk.name)
+
+                        for obj in queryset.iterator():
+                            yield obj
+
+        try:
+            self.stdout.ending = None
+            stream = open(output, 'w') if output else None
+            try:
+                serializers.serialize(format, get_objects(), indent=indent,
+                        use_natural_foreign_keys=False,
+                        use_natural_primary_keys=False,
+                        stream=stream or self.stdout)
+            finally:
+                if stream:
+                    stream.close()
+        except Exception as e:
+            if show_traceback:
+                raise
+            raise CommandError("Unable to serialize database: %s" % e)
+
+
+def _get_excluded_apps_and_models(excludes):
+    excluded_apps = set()
+    excluded_models = set()
+    for exclude in excludes:
+        if '.' in exclude:
+            try:
+                model = apps.get_model(exclude)
+            except LookupError:
+                raise CommandError('Unknown model in excludes: %s' % exclude)
+            excluded_models.add(model)
+        else:
+            try:
+                app_config = apps.get_app_config(exclude)
+            except LookupError:
+                raise CommandError('Unknown app in excludes: %s' % exclude)
+            excluded_apps.add(app_config)
+    return excluded_apps, excluded_models
+
+
+def _get_app_list(excluded_apps):
+    """
+    :return: OrderedDict((model, filter_kwarg), ...)
+    """
+    app_list = OrderedDict()
+    for label in app_labels:
+        app_label, model_label = label.split('.')
+        try:
+            app_config = apps.get_app_config(app_label)
+        except LookupError:
+            raise CommandError("Unknown application: %s" % app_label)
+        if app_config in excluded_apps:
+            continue
+        try:
+            model = app_config.get_model(model_label)
+        except LookupError:
+            raise CommandError("Unknown model: %s.%s" % (app_label, model_label))
+
+        app_list_value = app_list.setdefault(app_config, [])
+
+        if model not in app_list_value:
+            app_list_value.append(model)
+
+    return app_list
+
+
+def _check_serialization_format(format):
+    # Check that the serialization format exists; this is a shortcut to
+    # avoid collating all the objects and _then_ failing.
+    if format not in serializers.get_public_serializer_formats():
+        try:
+            serializers.get_serializer(format)
+        except serializers.SerializerDoesNotExist:
+            pass
+
+        raise CommandError("Unknown serialization format: %s" % format)

--- a/corehq/apps/hqadmin/management/commands/dump_domain_data.py
+++ b/corehq/apps/hqadmin/management/commands/dump_domain_data.py
@@ -11,7 +11,9 @@ from corehq.sql_db.config import partition_config
 app_labels = {
     'locations.LocationType': 'domain',
     'locations.SQLLocation': 'domain',
-    'form_processor.XFormInstanceSQL': 'domain'
+    'form_processor.XFormInstanceSQL': 'domain',
+    'form_processor.XFormAttachmentSQL': 'form__domain',
+    'form_processor.XFormOperationSQL': 'form__domain',
 }
 
 

--- a/corehq/apps/hqadmin/management/commands/load_domain_data.py
+++ b/corehq/apps/hqadmin/management/commands/load_domain_data.py
@@ -1,0 +1,177 @@
+from __future__ import unicode_literals
+
+import gzip
+import json
+import os
+import warnings
+import zipfile
+from collections import defaultdict
+
+from django.apps import apps
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management.color import no_style
+from django.core.serializers.python import (
+    Deserializer as PythonDeserializer,
+)
+from django.db import (
+    DatabaseError, IntegrityError, connections, router,
+    transaction,
+)
+from django.utils.encoding import force_text
+
+from corehq.form_processor.backends.sql.dbaccessors import ShardAccessor
+from corehq.sql_db.config import partition_config
+
+
+partitioned_model_id_fields = {
+    'form_processor.XFormInstanceSQL': 'form_id',
+    'form_processor.XFormAttachmentSQL': 'form',
+    'form_processor.XFormOperationSQL': 'form',
+}
+
+
+class Command(BaseCommand):
+    help = 'Loads data from the give file into the database.'
+    args = '<dump file path>'
+
+    def handle(self, dump_file_path, **options):
+        self.verbosity = options.get('verbosity')
+
+        # Keep a count of the installed objects
+        self.loaded_object_count = 0
+        self.total_object_count = 0
+
+        self.compression_formats = {
+            None: (open, 'rb'),
+            'gz': (gzip.GzipFile, 'rb'),
+            'zip': (SingleZipReader, 'r'),
+        }
+
+        if not os.path.isfile(dump_file_path):
+            raise CommandError("Dump file not found: {}".format(dump_file_path))
+
+        self.load_data(dump_file_path)
+
+        if self.verbosity >= 1:
+            if self.total_object_count == self.loaded_object_count:
+                self.stdout.write("Installed %d object(s)" % self.loaded_object_count)
+            else:
+                self.stdout.write("Installed %d object(s) (of %d)" %
+                                  (self.loaded_object_count, self.total_object_count))
+
+    def load_data(self, dump_file_path):
+        """
+        Loads data from a given file.
+        """
+        cmp_fmt = self.get_compression_format(os.path.basename(dump_file_path))
+        open_method, mode = self.compression_formats[cmp_fmt]
+        dump_file = open_method(dump_file_path, mode)
+        try:
+            if self.verbosity >= 2:
+                self.stdout.write("Installing data from %s." % dump_file_path)
+
+            objects = json.load(dump_file)
+            for db_alias, objects_for_db in _group_objects_by_db(objects):
+                with transaction.atomic(using=db_alias):
+                    loaded_objects, num_objects = self.load_data_for_db(db_alias, objects)
+                self.loaded_object_count += loaded_objects
+                self.total_object_count += num_objects
+        except Exception as e:
+            if not isinstance(e, CommandError):
+                e.args = ("Problem installing data '%s': %s" % (dump_file_path, e),)
+            raise
+        finally:
+            dump_file.close()
+
+        # Warn if the file we loaded contains 0 objects.
+        if self.loaded_object_count == 0:
+            warnings.warn(
+                "No data found for '%s'. (File format may be "
+                "invalid.)" % dump_file_path,
+                RuntimeWarning
+            )
+
+    def load_data_for_db(self, db_alias, objects):
+        connection = connections[db_alias]
+
+        objects_count = 0
+        loaded_object_count = 0
+        models = set()
+        with connection.constraint_checks_disabled():
+            for obj in PythonDeserializer(objects, using=db_alias):
+                objects_count += 1
+                if router.allow_migrate_model(db_alias, obj.object.__class__):
+                    loaded_object_count += 1
+                    models.add(obj.object.__class__)
+                    try:
+                        obj.save(using=db_alias)
+                    except (DatabaseError, IntegrityError) as e:
+                        e.args = ("Could not load %(app_label)s.%(object_name)s(pk=%(pk)s): %(error_msg)s" % {
+                            'app_label': obj.object._meta.app_label,
+                            'object_name': obj.object._meta.object_name,
+                            'pk': obj.object.pk,
+                            'error_msg': force_text(e)
+                        },)
+                        raise
+
+        # Since we disabled constraint checks, we must manually check for
+        # any invalid keys that might have been added
+        table_names = [model._meta.db_table for model in models]
+        try:
+            connection.check_constraints(table_names=table_names)
+        except Exception as e:
+            e.args = ("Problem loading data: %s" % e,)
+            raise
+
+        # If we found even one object, we need to reset the database sequences.
+        if loaded_object_count > 0:
+            sequence_sql = connection.ops.sequence_reset_sql(no_style(), models)
+            if sequence_sql:
+                if self.verbosity >= 2:
+                    self.stdout.write("Resetting sequences\n")
+                with connection.cursor() as cursor:
+                    for line in sequence_sql:
+                        print line
+                        cursor.execute(line)
+        return loaded_object_count, objects_count
+
+    def get_compression_format(self, file_name):
+        parts = file_name.rsplit('.', 1)
+
+        if len(parts) > 1 and parts[-1] in self.compression_formats:
+            cmp_fmt = parts[-1]
+        else:
+            cmp_fmt = None
+
+        return cmp_fmt
+
+
+def _group_objects_by_db(objects):
+    objects_by_db = defaultdict(list)
+    for obj in objects:
+        app_label = obj['model']
+        model = apps.get_model(app_label)
+        db_alias = router.db_for_write(model)
+        if settings.USE_PARTITIONED_DATABASE and db_alias == partition_config.get_proxy_db():
+            doc_id = _get_doc_id(app_label, obj)
+            db_alias = ShardAccessor.get_database_for_doc(doc_id)
+
+        objects_by_db[db_alias].append(obj)
+    return objects_by_db.items()
+
+
+def _get_doc_id(app_label, model_json):
+    field = partitioned_model_id_fields[app_label]
+    return model_json[field]
+
+
+class SingleZipReader(zipfile.ZipFile):
+
+    def __init__(self, *args, **kwargs):
+        zipfile.ZipFile.__init__(self, *args, **kwargs)
+        if len(self.namelist()) != 1:
+            raise ValueError("Zip-compressed data file must contain one file.")
+
+    def read(self):
+        return zipfile.ZipFile.read(self, self.namelist()[0])

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -50,7 +50,7 @@ from corehq.form_processor.utils.sql import (
     case_index_adapter,
     case_attachment_adapter
 )
-from corehq.sql_db.config import PartitionConfig
+from corehq.sql_db.config import partition_config
 from corehq.sql_db.routers import db_for_read_write
 from corehq.util.test_utils import unit_testing_only
 from dimagi.utils.chunked import chunked
@@ -104,7 +104,7 @@ class ShardAccessor(object):
         :return: Dict of ``doc_id -> Django DB alias``
         """
         databases = {}
-        shard_map = PartitionConfig().get_django_shard_map()
+        shard_map = partition_config.get_django_shard_map()
         part_mask = len(shard_map) - 1
         for chunk in chunked(doc_ids, 100):
             hashes = ShardAccessor.hash_doc_ids_python(chunk)

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -141,7 +141,7 @@ class ShardAccessorTests(TestCase):
         tolerance = N * 0.05  # 5% tollerance
         diffs = [abs(even_split - count) for count in doc_count_per_db.values()]
         outliers = [diff for diff in diffs if diff > tolerance]
-        message = 'partitioning not within tollerance: tolerance={}, diffs={}'.format(tolerance, outliers)
+        message = 'partitioning not within tollerance: tolerance={}, diffs={}'.format(tolerance, diffs)
         self.assertEqual(len(outliers), 0, message)
 
     def test_hash_in_python(self):

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -114,7 +114,7 @@ class ShardAccessorTests(TestCase):
     def test_hash_doc_ids(self):
         N = 1001
         doc_ids = [str(i) for i in range(N)]
-        hashes = ShardAccessor.hash_doc_ids(doc_ids)
+        hashes = ShardAccessor.hash_doc_ids_sql(doc_ids)
         self.assertEquals(len(hashes), N)
         self.assertTrue(all(isinstance(hash_, int) for hash_ in hashes.values()))
 
@@ -139,7 +139,7 @@ class ShardAccessorTests(TestCase):
         N = 1024
         doc_ids = [str(i) for i in range(N)]
 
-        sql_hashes = ShardAccessor.hash_doc_ids(doc_ids)
+        sql_hashes = ShardAccessor.hash_doc_ids_sql(doc_ids)
 
         csiphash_hashes = ShardAccessor.hash_doc_ids_python(doc_ids)
         self.assertEquals(len(csiphash_hashes), N)

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -115,6 +115,9 @@ class ShardAccessorTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super(ShardAccessorTests, cls).setUpClass()
+        if not settings.USE_PARTITIONED_DATABASE:
+            # https://github.com/nose-devs/nose/issues/946
+            raise SkipTest('Only applicable if sharding is setup')
         partition_config.get_django_shard_map.reset_cache(partition_config)
         partition_config.get_shards.reset_cache(partition_config)
         partition_config._get_django_shards.reset_cache(partition_config)

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -127,7 +127,7 @@ class ShardAccessorTests(TestCase):
         self.assertTrue(all(isinstance(hash_, int) for hash_ in hashes.values()))
 
     def test_get_database_for_docs(self):
-        # test that sharding 1000 docs gives a distribution withing some tollerance
+        # test that sharding 1000 docs gives a distribution withing some tolerance
         # (bit of a vague test)
         N = 1000
         doc_ids = [str(i) for i in range(N)]
@@ -138,9 +138,11 @@ class ShardAccessorTests(TestCase):
 
         num_dbs = len(partition_config.get_form_processing_dbs())
         even_split = int(N / num_dbs)
-        tollerance = N * 0.05  # 5% tollerance
+        tolerance = N * 0.05  # 5% tollerance
         diffs = [abs(even_split - count) for count in doc_count_per_db.values()]
-        self.assertTrue(all(diff < tollerance for diff in diffs))
+        outliers = [diff for diff in diffs if diff > tolerance]
+        message = 'partitioning not within tollerance: tolerance={}, diffs={}'.format(tolerance, outliers)
+        self.assertEqual(len(outliers), 0, message)
 
     def test_hash_in_python(self):
         # test that python hashing matches with SQL hashing

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -114,10 +114,10 @@ class ShardAccessorTests(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(ShardAccessorTests, cls).tearDownClass()
         partition_config.get_django_shard_map.reset_cache(partition_config)
         partition_config.get_shards.reset_cache(partition_config)
         partition_config._get_django_shards.reset_cache(partition_config)
+        super(ShardAccessorTests, cls).tearDownClass()
 
     def test_hash_doc_ids(self):
         N = 1001

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -113,6 +113,13 @@ PARTITION_DATABASE_CONFIG = {
 class ShardAccessorTests(TestCase):
 
     @classmethod
+    def setUpClass(cls):
+        super(ShardAccessorTests, cls).setUpClass()
+        partition_config.get_django_shard_map.reset_cache(partition_config)
+        partition_config.get_shards.reset_cache(partition_config)
+        partition_config._get_django_shards.reset_cache(partition_config)
+
+    @classmethod
     def tearDownClass(cls):
         partition_config.get_django_shard_map.reset_cache(partition_config)
         partition_config.get_shards.reset_cache(partition_config)

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -111,6 +111,14 @@ PARTITION_DATABASE_CONFIG = {
 @override_settings(PARTITION_DATABASE_CONFIG=PARTITION_DATABASE_CONFIG, DATABASES=DATABASES, ALLOW_FORM_PROCESSING_QUERIES=True)
 @skipUnless(settings.USE_PARTITIONED_DATABASE, 'Only applicable if sharding is setup')
 class ShardAccessorTests(TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        super(ShardAccessorTests, cls).tearDownClass()
+        partition_config.get_django_shard_map.reset_cache(partition_config)
+        partition_config.get_shards.reset_cache(partition_config)
+        partition_config._get_django_shards.reset_cache(partition_config)
+
     def test_hash_doc_ids(self):
         N = 1001
         doc_ids = [str(i) for i in range(N)]
@@ -136,7 +144,7 @@ class ShardAccessorTests(TestCase):
 
     def test_hash_in_python(self):
         # test that python hashing matches with SQL hashing
-        N = 1024
+        N = 2048
         doc_ids = [str(i) for i in range(N)]
 
         sql_hashes = ShardAccessor.hash_doc_ids_sql(doc_ids)

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -17,7 +17,7 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface, P
 from corehq.form_processor.models import XFormInstanceSQL, CommCareCaseSQL, CaseTransaction, Attachment
 from corehq.form_processor.parsers.form import process_xform_xml
 from corehq.form_processor.utils.general import should_use_sql_backend
-from corehq.sql_db.config import PartitionConfig
+from corehq.sql_db.config import partition_config
 from corehq.util.test_utils import unit_testing_only, run_with_multiple_configs, RunConfig
 from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import safe_delete
@@ -171,7 +171,7 @@ run_with_all_backends = functools.partial(
 
 def _get_db_list_to_query():
     if settings.USE_PARTITIONED_DATABASE:
-        return PartitionConfig().get_form_processing_dbs()
+        return partition_config.get_form_processing_dbs()
     return [None]
 
 

--- a/corehq/sql_db/config.py
+++ b/corehq/sql_db/config.py
@@ -158,4 +158,11 @@ def get_shards_to_update(existing_shards, new_shards):
     return shards_to_update
 
 
-partition_config = PartitionConfig()
+def _get_config():
+    if settings.USE_PARTITIONED_DATABASE:
+        return PartitionConfig()
+    else:
+        return object()
+
+
+partition_config = _get_config()

--- a/corehq/sql_db/management/commands/configure_pl_proxy_cluster.py
+++ b/corehq/sql_db/management/commands/configure_pl_proxy_cluster.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand
 from django.db import connections
 
 from corehq.form_processor.utils.sql import fetchall_as_namedtuple
-from corehq.sql_db.config import PartitionConfig, parse_existing_shard, get_shards_to_update
+from corehq.sql_db.config import partition_config, parse_existing_shard, get_shards_to_update
 
 SHARD_OPTION_RX = re.compile('^p[\d+]')
 
@@ -68,8 +68,7 @@ def _is_shard_option(option):
 
 def _update_pl_proxy_cluster(existing_config, verbose):
     existing_shards = _get_current_shards(existing_config)
-    config = PartitionConfig()
-    new_shard_configs = config.get_shards()
+    new_shard_configs = partition_config.get_shards()
 
     shards_to_update = get_shards_to_update(existing_shards, new_shard_configs)
 
@@ -107,14 +106,13 @@ def _get_alter_server_sql(shards_to_update):
 
 
 def create_pl_proxy_cluster(verbose=False, drop_existing=False):
-    config = PartitionConfig()
-    proxy_db = config.get_proxy_db()
+    proxy_db = partition_config.get_proxy_db()
 
     if drop_existing:
         with connections[proxy_db].cursor() as cursor:
             cursor.execute(get_drop_server_sql())
 
-    config_sql = get_pl_proxy_server_config_sql(config.get_shards())
+    config_sql = get_pl_proxy_server_config_sql(partition_config.get_shards())
     user_mapping_sql = get_user_mapping_sql()
 
     if verbose:
@@ -132,7 +130,7 @@ def get_drop_server_sql():
 
 
 def _get_existing_cluster_config(cluster_name):
-    proxy_db = PartitionConfig().get_proxy_db()
+    proxy_db = partition_config.get_proxy_db()
     with connections[proxy_db].cursor() as cursor:
         cursor.execute('SELECT * from pg_foreign_server where srvname = %s', [cluster_name])
         results = list(fetchall_as_namedtuple(cursor))
@@ -152,7 +150,7 @@ def get_pl_proxy_server_config_sql(shards):
 
 
 def get_user_mapping_sql():
-    proxy_db = PartitionConfig().get_proxy_db()
+    proxy_db = partition_config.get_proxy_db()
     proxy_db_config = settings.DATABASES[proxy_db].copy()
     proxy_db_config['server_name'] = settings.PL_PROXY_CLUSTER_NAME
     return USER_MAPPING_TEMPLATE.format(**proxy_db_config)

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from .config import PartitionConfig
+from .config import partition_config
 
 PROXY_APP = 'sql_proxy_accessors'
 FORM_PROCESSOR_APP = 'form_processor'
@@ -34,7 +34,6 @@ def allow_migrate(db, app_label):
     if not settings.USE_PARTITIONED_DATABASE:
         return app_label != PROXY_APP
 
-    partition_config = PartitionConfig()
     if app_label == PROXY_APP:
         return db == partition_config.get_proxy_db()
     elif app_label == FORM_PROCESSOR_APP:
@@ -53,8 +52,7 @@ def db_for_read_write(model):
         return 'default'
 
     app_label = model._meta.app_label
-    config = PartitionConfig()
     if app_label == FORM_PROCESSOR_APP:
-        return config.get_proxy_db()
+        return partition_config.get_proxy_db()
     else:
-        return config.get_main_db()
+        return partition_config.get_main_db()

--- a/corehq/sql_proxy_accessors/migrations/0001_initial.py
+++ b/corehq/sql_proxy_accessors/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import migrations
 
-from corehq.sql_db.config import PartitionConfig
+from corehq.sql_db.config import partition_config
 from corehq.sql_db.management.commands.configure_pl_proxy_cluster import get_drop_server_sql, \
     get_pl_proxy_server_config_sql, get_user_mapping_sql
 from corehq.sql_db.operations import HqRunSQL, noop_migration, RawSQLMigration
@@ -20,7 +20,7 @@ def create_update_pl_proxy_config():
 
     drop_server_sql = get_drop_server_sql()
     sql_statements = [
-        get_pl_proxy_server_config_sql(PartitionConfig().get_shards()),
+        get_pl_proxy_server_config_sql(partition_config.get_shards()),
         get_user_mapping_sql()
     ]
 

--- a/corehq/util/doc_processor/sql.py
+++ b/corehq/util/doc_processor/sql.py
@@ -95,6 +95,4 @@ def _get_db_aliases_to_query():
     if not settings.USE_PARTITIONED_DATABASE:
         return [None]  # use the default database
     else:
-        from corehq.sql_db.config import PartitionConfig
-        partition_config = PartitionConfig()
         return partition_config.get_form_processing_dbs()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -90,3 +90,4 @@ laboratory==0.2.0
 ConcurrentLogHandler==0.9.1
 github3.py==1.0.0a4
 django-bulk-update==1.1.10
+csiphash==0.0.4


### PR DESCRIPTION
This PR includes:
- tools for re-sharding data (getting the shard for a doc_id)
- dump data command to dump a domains data to disk (based off [dumpdata](https://docs.djangoproject.com/en/1.10/ref/django-admin/#dumpdata))
  - currently only for a few SQL models
- load domains data from disk into the db (based off [loaddata](https://docs.djangoproject.com/en/1.10/ref/django-admin/#loaddata))
  - currently only for a few SQL models

@biyeun 
@dimagi/scale-team 
