### PR TITLE
Formplayer post message api

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -52,7 +52,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
             previewWindow.postMessage({
                 action: 'back',
             }, window.location.origin);
-        }
+        };
 
         var _showAppPreview = function() {
             $('.preview-action-show').addClass('hide');

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -7,6 +7,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
     
     module.EVENTS = {
         RESIZE: 'previewApp.resize',
+        BACK: 'click .js-preview-back',
     };
 
     module.POSITION = {
@@ -26,6 +27,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
     ) {
 
         var $appPreview = $(previewWindowSelector);
+        var $appPreviewIframe = $(previewWindowSelector).find('iframe');
         var $appBody = $(appManagerBodySelector);
         var $togglePreviewBtn = $(previewToggleBtnSelector);
 
@@ -44,6 +46,13 @@ hqDefine('app_manager/js/preview_app.js', function() {
                 _hideAppPreview();
             }
         };
+
+        var _navigateBack = function() {
+            var previewWindow = $appPreviewIframe[0].contentWindow;
+            previewWindow.postMessage({
+                action: 'back',
+            }, window.location.origin);
+        }
 
         var _showAppPreview = function() {
             $('.preview-action-show').addClass('hide');
@@ -87,6 +96,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
         _resizeAppPreview();
         $(window).resize(_resizeAppPreview);
         $(window).on(module.EVENTS.RESIZE, _resizeAppPreview);
+        $(document).on(module.EVENTS.BACK, _navigateBack);
 
     };
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
@@ -11,4 +11,7 @@
   <button type="button" class="btn btn-default btn-preview-close">
     <i class="fa fa-remove"></i>
   </button>
+  <button type="button" class="btn btn-default btn-preview-back js-preview-back">
+    <i class="fa fa-arrow-left"></i>
+  </button>
 </div>

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -204,7 +204,7 @@ FormplayerFrontend.on("start", function (options) {
 
 FormplayerFrontend.on('navigation:back', function() {
     var url = Backbone.history.getFragment();
-    if (url.startsWith('/single_app')) {
+    if (!url.startsWith('/single_app')) {
         window.history.back();
     }
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -192,6 +192,18 @@ FormplayerFrontend.on("start", function (options) {
             }
         }
     }
+
+    if (options.allowedOrigin) {
+        window.addEventListener(
+            "message",
+            new FormplayerFrontend.HQ.Events.Receiver(options.allowedOrigin),
+            false
+        );
+    }
+});
+
+FormplayerFrontend.on('navigation:back', function() {
+    window.history.back();
 });
 
 FormplayerFrontend.on('setAppDisplayProperties', function(app) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -203,7 +203,10 @@ FormplayerFrontend.on("start", function (options) {
 });
 
 FormplayerFrontend.on('navigation:back', function() {
-    window.history.back();
+    var url = Backbone.history.getFragment();
+    if (url.startsWith('/single_app')) {
+        window.history.back();
+    }
 });
 
 FormplayerFrontend.on('setAppDisplayProperties', function(app) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
@@ -1,0 +1,58 @@
+/*global FormplayerFrontend */
+
+/**
+ * hq.events.js
+ *
+ * This is framework for allowing messages from HQ
+ */
+FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
+
+    Events.Receiver = function(allowedOrigin) {
+        this.allowedOrigin = allowedOrigin;
+        return receiver.bind(this);
+    };
+
+    var receiver = function(event) {
+        // For Chrome, the origin property is in the event.originalEvent object
+        var origin = event.origin || event.originalEvent.origin,
+            data = event.data,
+            returnValue = null,
+            success = true;
+
+        _.defaults(data, {
+            success: function() {},
+            error: function() {},
+            complete: function() {},
+        });
+        if (origin !== this.allowedOrigin) {
+            throw new Error('Disallowed origin ' + origin);
+        }
+
+        if (!data.hasOwnProperty('action')) {
+            throw new Error('Message must have action property');
+        }
+        if (!_.contains(_.values(Actions), data.action)) {
+            throw new Error('Invalid action ' + data.action);
+        }
+
+        try {
+            switch (data.action) {
+                case Actions.BACK:
+                    FormplayerFrontend.trigger('navigation:back');
+                    break;
+            }
+        } catch (e) {
+            success = false;
+            data.error(event, data, returnValue);
+        } finally {
+            data.complete(event, data, returnValue);
+        }
+        if (success) {
+            data.success(event, data, returnValue);
+        }
+    };
+
+    Actions = {
+        BACK: 'back'
+    };
+})

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
@@ -31,13 +31,13 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
         if (!data.hasOwnProperty('action')) {
             throw new Error('Message must have action property');
         }
-        if (!_.contains(_.values(Actions), data.action)) {
+        if (!_.contains(_.values(Events.Actions), data.action)) {
             throw new Error('Invalid action ' + data.action);
         }
 
         try {
             switch (data.action) {
-                case Actions.BACK:
+                case Events.Actions.BACK:
                     FormplayerFrontend.trigger('navigation:back');
                     break;
             }
@@ -52,7 +52,7 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
         }
     };
 
-    Actions = {
+    Events.Actions = {
         BACK: 'back'
     };
 })

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
@@ -37,9 +37,9 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
 
         try {
             switch (data.action) {
-                case Events.Actions.BACK:
-                    FormplayerFrontend.trigger('navigation:back');
-                    break;
+            case Events.Actions.BACK:
+                FormplayerFrontend.trigger('navigation:back');
+                break;
             }
         } catch (e) {
             success = false;
@@ -53,6 +53,6 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
     };
 
     Events.Actions = {
-        BACK: 'back'
+        BACK: 'back',
     };
-})
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
@@ -11,7 +11,7 @@ describe('HQ.Events', function() {
             triggerSpy = sinon.spy();
             dummyEvent = {
                 origin: origin,
-                data: {}
+                data: {},
             };
             sinon.stub(FormplayerFrontend, 'trigger', triggerSpy);
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
@@ -1,0 +1,71 @@
+describe('HQ.Events', function() {
+    describe('Receiver', function() {
+        var Receiver = FormplayerFrontend.HQ.Events.Receiver,
+            Actions = FormplayerFrontend.HQ.Events.Actions,
+            origin = 'myorigin',
+            triggerSpy,
+            dummyEvent;
+        beforeEach(function() {
+            triggerSpy = sinon.spy();
+            dummyEvent = {
+                origin: origin,
+                data: {}
+            };
+            sinon.stub(FormplayerFrontend, 'trigger', triggerSpy);
+        });
+
+        afterEach(function() {
+            FormplayerFrontend.trigger.restore();
+        });
+
+        it('should allow the back action', function() {
+            var receiver = new Receiver(origin);
+            dummyEvent.data.action = Actions.BACK;
+
+            receiver(dummyEvent);
+            assert.isTrue(triggerSpy.called);
+        });
+
+        it('should not allow the wrong origin', function() {
+            var receiver = new Receiver('wrong-origin');
+            dummyEvent.data.action = Actions.BACK;
+            assert.throws(function() { receiver(dummyEvent); }, /Disallowed origin/);
+        });
+
+        it('should not allow no action', function() {
+            var receiver = new Receiver(origin);
+            assert.throws(function() { receiver(dummyEvent); }, /must have action/);
+        });
+
+        it('should not allow unknown action', function() {
+            var receiver = new Receiver(origin);
+            dummyEvent.data.action = 'unknown';
+            assert.throws(function() { receiver(dummyEvent); }, /Invalid action/);
+        });
+
+        it('should call success on success', function() {
+            var receiver = new Receiver(origin);
+            dummyEvent.data.action = Actions.BACK;
+            dummyEvent.data.success = sinon.spy();
+            dummyEvent.data.complete = sinon.spy();
+
+            receiver(dummyEvent);
+            assert.isTrue(dummyEvent.data.success.called);
+            assert.isTrue(dummyEvent.data.complete.called);
+        });
+
+        it('should call error on error', function() {
+            var receiver = new Receiver(origin);
+            dummyEvent.data.action = Actions.BACK;
+            dummyEvent.data.error = sinon.spy();
+            dummyEvent.data.complete = sinon.spy();
+
+            FormplayerFrontend.trigger.restore();
+            sinon.stub(FormplayerFrontend, 'trigger', function() { throw new Error('Boom'); });
+
+            receiver(dummyEvent);
+            assert.isTrue(dummyEvent.data.error.called);
+            assert.isTrue(dummyEvent.data.complete.called);
+        });
+    });
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
@@ -1,3 +1,5 @@
+/* global FormplayerFrontend */
+/* eslint-env mocha */
 describe('HQ.Events', function() {
     describe('Receiver', function() {
         var Receiver = FormplayerFrontend.HQ.Events.Receiver,

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -7,6 +7,7 @@
 {% endblock %}
 
 {% block mocha_tests %}
+<script src="{% static 'cloudcare/js/formplayer/spec/hq.events_spec.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/spec/menu_list_test.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -11,6 +11,7 @@
 <script src="{% static 'cloudcare/js/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/util/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/app.js' %}"></script>
+<script src="{% static 'cloudcare/js/formplayer/hq.events.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/util/progress_view.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/entities/cc_app.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/entities/menu.js' %}"></script>

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -180,6 +180,7 @@
                 formplayer_url: "{{ formplayer_url }}",
                 phoneMode: true,
                 oneQuestionPerScreen: true,
+                allowedOrigin: "{{ request.scheme }}://{{ request.get_host }}"
             });
             $('.dragscroll').on('scroll', function () {
               $('.form-control').blur();


### PR DESCRIPTION
@biyeun @wpride this provides us with a framework to send messages to app preview from HQ. right now the use case is for providing a back button that does not live inside of app preview. in the future we'll be able to do things like tell app preview when it's a version behind the version of the app loaded in the app manager or send cool signals from vellum to live preview. the API is pretty simple right now: `{ action: <action> }`. in the future though i'd imagine we'd have the ability to pass parameters etc. 

@biyeun this doesn't implement a styled back button as discussed. fine to merge, but should style it before we release. the button is in the very very bottom left corner haha

<img width="310" alt="screen shot 2016-10-26 at 5 22 19 pm" src="https://cloud.githubusercontent.com/assets/918514/19745695/c84b21c4-9ba0-11e6-9fe0-f9fe0a50f6fc.png">

cc: @nickpell @emord 
