### PR TITLE
Kill celery stale workers

### DIFF
--- a/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
+++ b/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
@@ -1,0 +1,33 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from celery import Celery
+from restkit import Resource
+
+from corehq.apps.hqadmin.utils import parse_celery_workers, parse_celery_pings
+
+
+class Command(BaseCommand):
+    help = "Kills stale celery workers"
+
+    def handle(self, *args, **options):
+        _kill_stale_workers()
+
+
+def _kill_stale_workers():
+    celery_monitoring = getattr(settings, 'CELERY_FLOWER_URL', None)
+    if celery_monitoring:
+        cresource = Resource(celery_monitoring, timeout=3)
+        t = cresource.get("api/workers", params_dict={'status': True}).body_string()
+        all_workers = json.loads(t)
+        expected_running, expected_stopped = parse_celery_workers(all_workers)
+
+        celery = Celery()
+        celery.config_from_object(settings)
+        worker_responses = celery.control.ping(timeout=10)
+        pings = parse_celery_pings(worker_responses)
+
+        for hostname in expected_stopped:
+            if hostname in pings:
+                celery.control.broadcast('shutdown, destination="{}"'.format(hostname))

--- a/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
+++ b/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
@@ -28,6 +28,5 @@ def _kill_stale_workers():
         worker_responses = celery.control.ping(timeout=10)
         pings = parse_celery_pings(worker_responses)
 
-        for hostname in expected_stopped:
-            if hostname in pings:
-                celery.control.broadcast('shutdown, destination="{}"'.format(hostname))
+        hosts_to_stop = filter(lambda hostname: hostname in pings, expected_stopped)
+        celery.control.broadcast('shutdown', destination=hosts_to_stop)

--- a/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
+++ b/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
@@ -29,4 +29,5 @@ def _kill_stale_workers():
         pings = parse_celery_pings(worker_responses)
 
         hosts_to_stop = filter(lambda hostname: hostname in pings, expected_stopped)
-        celery.control.broadcast('shutdown', destination=hosts_to_stop)
+        if hosts_to_stop:
+            celery.control.broadcast('shutdown', destination=hosts_to_stop)


### PR DESCRIPTION
@gcapalbo i spent some time digging into the stale worker issue on swiss and staging. some of the workers on swiss just didn't respond to SIGTERM for some reason. i couldn't find any trace of the signal in strace either. eventually gave up and decided that we should just have a job to take care of it. this is a management command to kill the stale workers. if it works out alright, i think it would then make sense to move it to a cron task. what do you think?

cc: @emord @nickpell 
