### PR TITLE
Allow expanded columns to have transforms

### DIFF
--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -27,10 +27,10 @@ class UCRExpandDatabaseSubcolumn(DatabaseColumn):
     """
     A light wrapper around DatabaseColumn that stores the expand value that this DatabaseColumn is based on.
     """
-    def __init__(self, header, agg_column, expand_value, format_fn=None, slug=None, *args, **kwargs):
+    def __init__(self, header, agg_column, expand_value, *args, **kwargs):
         self.expand_value = expand_value
         super(UCRExpandDatabaseSubcolumn, self).__init__(
-            header, agg_column, format_fn=None, slug=None, *args, **kwargs
+            header, agg_column, *args, **kwargs
         )
 
 


### PR DESCRIPTION
@NoahCarnahan found this while refactoring. Comes from https://github.com/dimagi/commcare-hq/pull/12872 I don't think that this was intentional, but it doesn't allow expanded columns to have transforms.

buddies @nickpell @benrudolph 
