### PR TITLE
return None if case_id empty

### DIFF
--- a/corehq/apps/export/transforms.py
+++ b/corehq/apps/export/transforms.py
@@ -23,6 +23,8 @@ NULL_CACHE_VALUE = "___NULL_CACHE_VAL___"
 
 
 def _cached_case_id_to_case_name(case_id):
+    if not case_id:
+        return None
     key = 'case_id_to_case_name_cache_{id}'.format(id=case_id)
     ret = cache.get(key, NULL_CACHE_VALUE)
     if ret != NULL_CACHE_VALUE:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240377
@calellowitz 
@dannyroberts 

Was resulting in this ES query:

```
{
  "query": {
    "filtered": {
      "filter": {
        "and": [
          {
            "terms": {
              "_id": [
                null
              ]
            }
          },
          {
            "match_all": {}
          }
        ]
      },
      "query": {
        "match_all": {}
      }
    }
  },
  "_source": [
    "name"
  ],
  "size": 1000000
}   
```
