### PR TITLE
Signal to update inferred schema

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -11,6 +11,7 @@ from corehq.apps.es.domains import DomainES
 from corehq.apps.es import filters
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.export.signals import added_inferred_export_properties
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import UserTime, ServerTime
@@ -153,6 +154,13 @@ def _get_user_case_fields(commcare_user):
         'language': commcare_user.language or '',
         'phone_number': commcare_user.phone_number or ''
     })
+
+    added_inferred_export_properties.send(
+        'UserSave',
+        domain=commcare_user.domain,
+        case_type=USERCASE_TYPE,
+        properties=fields.keys()
+    )
     return fields
 
 

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -61,3 +61,5 @@ CASE_SCROLL_SIZE = 10000
 MISSING_VALUE = '---'
 # When a question has been answered, but is blank, this shoudl be the value
 EMPTY_VALUE = ''
+
+UNKNOWN_INFERRED_FROM = 'unknown'

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -121,7 +121,7 @@ class ExportItem(DocumentSchema):
     # True if this item was inferred from different actions in HQ (i.e. case upload)
     # False if the item was found in the application structure
     inferred = BooleanProperty(default=False)
-    inferred_from = SetProperty()
+    inferred_from = SetProperty(default=set)
 
     @classmethod
     def wrap(cls, data):
@@ -945,17 +945,17 @@ class InferredExportGroupSchema(ExportGroupSchema):
 
     def put_item(self, path, inferred_from=None):
         assert self.path == path[:len(self.path)], "ExportItem's path doesn't start with the table"
-
         item = self.get_item(path)
 
         if item:
+            item.inferred_from.add(inferred_from or UNKNOWN_INFERRED_FROM)
             return item
 
         item = ExportItem(
             path=path,
             label='.'.join(map(lambda node: node.name, path)),
             inferred=True,
-            inferred_from=set().add(inferred_from or UNKNOWN_INFERRED_FROM)
+            inferred_from=set([inferred_from or UNKNOWN_INFERRED_FROM])
         )
         self.items.append(item)
         return item

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1016,7 +1016,7 @@ class ExportDataSchema(Document):
     An object representing the things that can be exported for a particular
     form xmlns or case type. It contains a list of ExportGroupSchema.
     """
-    domain = StringProperty()
+    domain = StringProperty(required=True)
     created_on = DateTimeProperty(default=datetime.utcnow)
     group_schemas = SchemaListProperty(ExportGroupSchema)
     app_id = StringProperty()
@@ -1179,7 +1179,7 @@ class ExportDataSchema(Document):
 
 class FormExportDataSchema(ExportDataSchema):
 
-    xmlns = StringProperty()
+    xmlns = StringProperty(required=True)
     datatype_mapping = defaultdict(lambda: ScalarItem, {
         'MSelect': MultipleChoiceItem,
         'Geopoint': GeopointItem,
@@ -1331,7 +1331,7 @@ class FormExportDataSchema(ExportDataSchema):
 
 class CaseExportDataSchema(ExportDataSchema):
 
-    case_type = StringProperty()
+    case_type = StringProperty(required=True)
 
     @property
     def type(self):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1072,14 +1072,14 @@ class ExportDataSchema(Document):
 
             current_schema.record_update(app.copy_of or app._id, app.version)
 
+        inferred_schema = cls._get_inferred_schema(domain, identifier)
+        if inferred_schema:
+            current_schema = cls._merge_schemas(current_schema, inferred_schema)
+
         current_schema.domain = domain
         current_schema.app_id = app_id
         current_schema.version = DATA_SCHEMA_VERSION
         current_schema._set_identifier(identifier)
-
-        inferred_schema = current_schema._get_inferred_schema()
-        if inferred_schema:
-            current_schema = cls._merge_schemas(current_schema, inferred_schema)
 
         current_schema = cls._save_export_schema(
             current_schema,
@@ -1192,7 +1192,8 @@ class FormExportDataSchema(ExportDataSchema):
     def type(self):
         return FORM_EXPORT
 
-    def _get_inferred_schema(self):
+    @classmethod
+    def _get_inferred_schema(cls, domain, xmlns):
         return None
 
     def _set_identifier(self, form_xmlns):
@@ -1340,8 +1341,9 @@ class CaseExportDataSchema(ExportDataSchema):
     def _set_identifier(self, case_type):
         self.case_type = case_type
 
-    def _get_inferred_schema(self):
-        return get_inferred_schema(self.domain, self.case_type)
+    @classmethod
+    def _get_inferred_schema(cls, domain, case_type):
+        return get_inferred_schema(domain, case_type)
 
     @classmethod
     def _get_current_app_ids_for_domain(cls, domain):

--- a/corehq/apps/export/signals.py
+++ b/corehq/apps/export/signals.py
@@ -1,10 +1,10 @@
 from django import dispatch
 
 from .dbaccessors import get_inferred_schema
-from .models import MAIN_TABLE, PathNode
+from .models import MAIN_TABLE, PathNode, InferredSchema
 
 
-def add_inferred_export_properties(sender, domain, case_type, properties, **kwargs):
+def add_inferred_export_properties(sender, domain=None, case_type=None, properties=None, **kwargs):
     """
     Adds inferred properties to the inferred schema for a case type.
 
@@ -13,12 +13,20 @@ def add_inferred_export_properties(sender, domain, case_type, properties, **kwar
     :param: case_type
     :param: properties - An iterable of case properties to add to the inferred schema
     """
+
+    assert domain, 'Must have domain'
+    assert case_type, 'Must have case type'
     inferred_schema = get_inferred_schema(domain, case_type)
+    if not inferred_schema:
+        inferred_schema = InferredSchema(
+            domain=domain,
+            case_type=case_type,
+        )
     group_schema = inferred_schema.put_group_schema(MAIN_TABLE)
 
     for case_property in properties:
-        group_schema.put_item([PathNode(name=case_property)])
+        group_schema.put_item([PathNode(name=case_property)], inferred_from=sender)
     inferred_schema.save()
 
-added_inferred_export_properties = dispatch.Signal(providing_args=['properties'])
+added_inferred_export_properties = dispatch.Signal(providing_args=['domain', 'case_type', 'properties'])
 added_inferred_export_properties.connect(add_inferred_export_properties)

--- a/corehq/apps/export/signals.py
+++ b/corehq/apps/export/signals.py
@@ -1,0 +1,24 @@
+from django import dispatch
+
+from .dbaccessors import get_inferred_schema
+from .models import MAIN_TABLE, PathNode
+
+
+def add_inferred_export_properties(sender, domain, case_type, properties, **kwargs):
+    """
+    Adds inferred properties to the inferred schema for a case type.
+
+    :param: sender - The signal sender
+    :param: domain
+    :param: case_type
+    :param: properties - An iterable of case properties to add to the inferred schema
+    """
+    inferred_schema = get_inferred_schema(domain, case_type)
+    group_schema = inferred_schema.put_group_schema(MAIN_TABLE)
+
+    for case_property in properties:
+        group_schema.put_item([PathNode(name=case_property)])
+    inferred_schema.save()
+
+added_inferred_export_properties = dispatch.Signal(providing_args=['properties'])
+added_inferred_export_properties.connect(add_inferred_export_properties)

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -53,7 +53,7 @@ class TestExportDBAccessors(TestCase):
             domain=cls.domain,
             case_type='other',
         )
-        cls.case_schema_before = FormExportDataSchema(
+        cls.case_schema_before = CaseExportDataSchema(
             domain=cls.domain,
             case_type=cls.case_type,
             created_on=datetime.utcnow() - timedelta(1)

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -422,17 +422,33 @@ class TestMergingCaseExportDataSchema(SimpleTestCase, TestXmlMixin):
                     items=[ExportItem(
                         path=[PathNode(name='case_property')],
                         inferred=True,
+                        inferred_from=set(['One']),
                     )],
                     inferred=True,
                 )
             ]
         )
-        merged = ExportDataSchema._merge_schemas(schema, inferred_schema)
+        inferred_schema_two = CaseExportDataSchema(
+            domain='my-domain',
+            group_schemas=[
+                ExportGroupSchema(
+                    path=MAIN_TABLE,
+                    items=[ExportItem(
+                        path=[PathNode(name='case_property')],
+                        inferred=True,
+                        inferred_from=set(['Two']),
+                    )],
+                    inferred=True,
+                )
+            ]
+        )
+        merged = ExportDataSchema._merge_schemas(schema, inferred_schema, inferred_schema_two)
         self.assertEqual(len(merged.group_schemas), 1)
         self.assertTrue(merged.group_schemas[0].inferred)
         group_schema = merged.group_schemas[0]
         self.assertEqual(len(group_schema.items), 1)
         self.assertTrue(group_schema.items[0].inferred)
+        self.assertEqual(group_schema.items[0].inferred_from, set(['One', 'Two']))
 
 
 class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):

--- a/corehq/apps/export/tests/test_export_signals.py
+++ b/corehq/apps/export/tests/test_export_signals.py
@@ -43,4 +43,3 @@ class InferredSchemaSignalTest(TestCase):
             set(map(lambda item: item.path[0].name, group_schema.items)),
             set(['one', 'two', 'three'])
         )
-

--- a/corehq/apps/export/tests/test_export_signals.py
+++ b/corehq/apps/export/tests/test_export_signals.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from corehq.apps.export.signals import added_inferred_export_properties
+from corehq.apps.export.dbaccessors import get_inferred_schema
+
+
+class InferredSchemaSignalTest(TestCase):
+    domain = 'inferred-domain'
+    case_type = 'inferred'
+
+    def test_add_inferred_export_properties(self):
+        props = set(['one', 'two'])
+        added_inferred_export_properties.send(
+            'TestSend',
+            domain=self.domain,
+            case_type=self.case_type,
+            properties=props,
+        )
+
+        schema = get_inferred_schema(self.domain, self.case_type)
+        group_schema = schema.group_schemas[0]
+        self.assertEqual(set(map(lambda item: item.path[0].name, group_schema.items)), props)
+
+    def test_add_inferred_export_properties_saved_schema(self):
+        props = set(['one', 'two'])
+        props_two = set(['one', 'three'])
+        added_inferred_export_properties.send(
+            'TestSend',
+            domain=self.domain,
+            case_type=self.case_type,
+            properties=props,
+        )
+        added_inferred_export_properties.send(
+            'TestSend',
+            domain=self.domain,
+            case_type=self.case_type,
+            properties=props_two,
+        )
+
+        schema = get_inferred_schema(self.domain, self.case_type)
+        group_schema = schema.group_schemas[0]
+        self.assertEqual(
+            set(map(lambda item: item.path[0].name, group_schema.items)),
+            set(['one', 'two', 'three'])
+        )
+

--- a/corehq/apps/export/tests/test_inferred_schema.py
+++ b/corehq/apps/export/tests/test_inferred_schema.py
@@ -37,10 +37,16 @@ class InferredExportGroupSchemaTest(SimpleTestCase):
             path=[PathNode(name='random')]
         )
         item = group_schema.put_item(
-            [PathNode(name='random'), PathNode(name='inferred')]
+            [PathNode(name='random'), PathNode(name='inferred')],
+            inferred_from='Test',
+        )
+        item = group_schema.put_item(
+            [PathNode(name='random'), PathNode(name='inferred')],
+            inferred_from='TestTwo',
         )
         self.assertTrue(isinstance(item, ExportItem))
         self.assertTrue(item.inferred)
+        self.assertEqual(item.inferred_from, set(['Test', 'TestTwo']))
         self.assertEqual(len(group_schema.items), 1)
 
         # After putting same item, should not re-add group schema

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -295,7 +295,7 @@ def _create_column_from_inferred_schema(inferred_schema, new_table, old_column, 
     from .models import ExportColumn
 
     group_schema = inferred_schema.put_group_schema(new_table.path)
-    item = group_schema.put_item(column_path)
+    item = group_schema.put_item(column_path, inferred_from='Export Migration')
     return ExportColumn(
         item=item,
         label=old_column.display,


### PR DESCRIPTION
@NoahCarnahan @czue this adds a signal for the inferred schema to be updated. it also refactors the inferred schema generation a little and adds more database constraints on what can be saved to the schema. 🐟 or 🏠 

These properties were "inferred" from a user case save. kind of cool:
<img width="1552" alt="screen shot 2016-10-28 at 3 28 37 pm" src="https://cloud.githubusercontent.com/assets/918514/19820293/b6fdc214-9d26-11e6-932c-e1f0902ba16b.png">

cc: @emord @nickpell 
