### PR TITLE
A fix for preview app and some tests

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -216,7 +216,7 @@ FormplayerFrontend.reqres.setHandler('getCurrentAppId', function() {
         user = FormplayerFrontend.request('currentUser'),
         appId;
 
-    appId = urlObject.appId
+    appId = urlObject.appId;
 
     if (appId) {
         return appId;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -191,6 +191,7 @@ FormplayerFrontend.on("start", function (options) {
         if (this.getCurrentRoute() === "") {
             if (options.phoneMode) {
                 appId = options.apps[0]['_id'];
+                user.previewAppId = appId;
 
                 FormplayerFrontend.trigger('setAppDisplayProperties', options.apps[0]);
                 FormplayerFrontend.trigger("app:singleApp", appId);
@@ -207,6 +208,25 @@ FormplayerFrontend.on("start", function (options) {
             false
         );
     }
+});
+
+FormplayerFrontend.reqres.setHandler('getCurrentAppId', function() {
+    // First attempt to grab app id from URL
+    var urlObject = Util.currentUrlToObject(),
+        user = FormplayerFrontend.request('currentUser'),
+        appId;
+
+    appId = urlObject.appId
+
+    if (appId) {
+        return appId;
+    }
+
+    // If it's not in the URL, then we are either on the home screen of formplayer
+    // and there is no app selected, or we are in preview mode.
+    appId = user.previewAppId;
+
+    return appId || null;
 });
 
 FormplayerFrontend.on('navigation:back', function() {
@@ -242,7 +262,8 @@ FormplayerFrontend.reqres.setHandler('restoreAsUser', function(domain, username)
  * navigates you to the main page.
  */
 FormplayerFrontend.on('clearRestoreAsUser', function() {
-    var user = FormplayerFrontend.request('currentUser');
+    var user = FormplayerFrontend.request('currentUser'),
+        appId;
     FormplayerFrontend.Utils.Users.clearRestoreAsUser(
         user.domain,
         user.username
@@ -253,7 +274,10 @@ FormplayerFrontend.on('clearRestoreAsUser', function() {
             model: user,
         })
     );
-    FormplayerFrontend.trigger('navigateHome');
+
+    appId = FormplayerFrontend.request('getCurrentAppId');
+
+    FormplayerFrontend.trigger('navigateHome', appId);
 });
 
 FormplayerFrontend.on("sync", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/session_middleware_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/session_middleware_spec.js
@@ -1,0 +1,30 @@
+/* global FormplayerFrontend */
+/* eslint-env mocha */
+
+describe('SessionMiddle', function() {
+    var Middleware = FormplayerFrontend.SessionNavigate.Middleware;
+
+    it('Should call middleware and apis with same arguments', function() {
+        var middlewareSpy = sinon.spy(),
+            result,
+            API = {
+                myRoute: sinon.spy(function(one, two, three) {
+                    return two;
+                }),
+            };
+
+        Middleware.middlewares = [middlewareSpy];
+
+        var WrappedApi = Middleware.apply(API);
+
+        result = WrappedApi.myRoute(1, 2, 3);
+
+        // Ensure middleware is called and called with route name
+        assert.isTrue(middlewareSpy.called);
+        assert.deepEqual(middlewareSpy.getCall(0).args, ['myRoute']);
+
+        // Ensure actual route is called with proper arguments and return value
+        assert.deepEqual(API.myRoute.getCall(0).args, [1, 2, 3]);
+        assert.equal(result, 2);
+    });
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/session_middleware_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/session_middleware_spec.js
@@ -9,7 +9,7 @@ describe('SessionMiddle', function() {
             result,
             API = {
                 myRoute: sinon.spy(function(one, two, three) {
-                    return two;
+                    return one + two + three;
                 }),
             };
 
@@ -25,6 +25,6 @@ describe('SessionMiddle', function() {
 
         // Ensure actual route is called with proper arguments and return value
         assert.deepEqual(API.myRoute.getCall(0).args, [1, 2, 3]);
-        assert.equal(result, 2);
+        assert.equal(result, 6);
     });
 });

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -10,6 +10,7 @@
 <script src="{% static 'cloudcare/js/formplayer/spec/hq.events_spec.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/spec/menu_list_test.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/spec/user_spec.js' %}"></script>
+<script src="{% static 'cloudcare/js/formplayer/spec/session_middleware_spec.js' %}"></script>
 {% endblock %}
 
 {% block fixtures %}


### PR DESCRIPTION
@wpride after removing your "auth as" in preview app, it would try and navigate you to `single_app/undefined` since an app id was never specified. made a function that should reliably get us the current app id as this difference between formplayer and preview has been pretty annoying. i also added a test for the session middlware. should make it clearer what it's doing too

cc: @emord @nickpell 