### PR TITLE
Setting for app preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -59,7 +59,7 @@
     "DOMPurify": "0.8.3",
     "jquery-tiny-pubsub": "https://github.com/cowboy/jquery-tiny-pubsub.git#~0.7.0",
     "markdown-it": "7.0.1",
-    "bootstrap-switch": "~3.3.2"
+    "bootstrap-switch": "3.3.2"
   },
   "devDependencies": {
     "chai": "3.3.0",

--- a/bower.json
+++ b/bower.json
@@ -58,7 +58,8 @@
     "datetimepicker": "2.5.4",
     "DOMPurify": "0.8.3",
     "jquery-tiny-pubsub": "https://github.com/cowboy/jquery-tiny-pubsub.git#~0.7.0",
-    "markdown-it": "7.0.1"
+    "markdown-it": "7.0.1",
+    "bootstrap-switch": "~3.3.2"
   },
   "devDependencies": {
     "chai": "3.3.0",

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -9,6 +9,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
     module.SELECTORS = {
         BTN_TOGGLE_PREVIEW: '.js-preview-toggle',
         PREVIEW_WINDOW: '#js-appmanager-preview',
+        PREVIEW_WINDOW_IFRAME: '#js-appmanager-preview iframe',
         APP_MANAGER_BODY: '#js-appmanager-body',
         PREVIEW_ACTION_TEXT_SHOW: '.js-preview-action-show',
         PREVIEW_ACTION_TEXT_HIDE: '.js-preview-action-hide',
@@ -38,7 +39,8 @@ hqDefine('app_manager/js/preview_app.js', function() {
     };
 
     _private.navigateBack = function() {
-        var previewWindow = $appPreviewIframe[0].contentWindow;
+        var $appPreviewIframe = $(module.SELECTORS.PREVIEW_WINDOW.IFRAME),
+            previewWindow = $appPreviewIframe[0].contentWindow;
         previewWindow.postMessage({
             action: 'back',
         }, window.location.origin);

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -39,7 +39,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
     };
 
     _private.navigateBack = function() {
-        var $appPreviewIframe = $(module.SELECTORS.PREVIEW_WINDOW.IFRAME),
+        var $appPreviewIframe = $(module.SELECTORS.PREVIEW_WINDOW_IFRAME),
             previewWindow = $appPreviewIframe[0].contentWindow;
         previewWindow.postMessage({
             action: 'back',

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
@@ -10,15 +10,6 @@
             <button type="button" class="btn btn-default btn-preview-back js-preview-back">
                 <i class="fa fa-arrow-left"></i>
             </button>
-            <div class="dropup btn-hardware">
-                <button type="button" id="settings-dropup" data-toggle="dropdown" class="btn btn-default dropdown-toggle">
-                    <i class="fa fa-gear"></i>
-                </button>
-                <ul class="dropdown-menu">
-                    <li><a class="js-one-question-per-screen">abc</a>
-                    </li>
-                </ul>
-            </div>
         </div>
     </div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
@@ -1,18 +1,24 @@
 {% load hq_shared_tags %}
-
 <div id="js-appmanager-preview" class="preview-phone-wrapper">
-  <div class="preview-phone-container">
-    <button type="button" class="btn btn-default js-preview-toggle btn-preview-toggle">
-      <i class="fa fa-close"></i>
-    </button>
-    <iframe
-        class="preview-phone-window"
-        frameBorder="0"
-        scrolling="no"
-        src="{% url 'preview_app' request.domain app.get_id %}">
-    </iframe>
-    <button type="button" class="btn btn-default btn-preview-back js-preview-back">
-      <i class="fa fa-arrow-left"></i>
-    </button>
-  </div>
+    <div class="preview-phone-container">
+        <button type="button" class="btn btn-default js-preview-toggle btn-preview-toggle">
+            <i class="fa fa-close"></i>
+        </button>
+        <iframe class="preview-phone-window" frameBorder="0" scrolling="no" src="{% url 'preview_app' request.domain app.get_id %}">
+        </iframe>
+        <div class="hardware-buttons">
+            <button type="button" class="btn btn-default btn-preview-back js-preview-back">
+                <i class="fa fa-arrow-left"></i>
+            </button>
+            <div class="dropup btn-hardware">
+                <button type="button" id="settings-dropup" data-toggle="dropdown" class="btn btn-default dropdown-toggle">
+                    <i class="fa fa-gear"></i>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="js-one-question-per-screen">abc</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/preview_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/preview_app.html
@@ -1,19 +1,16 @@
 {% load hq_shared_tags %}
 
 <div id="js-appmanager-preview" class="preview-phone-wrapper">
-  <div class="preview-phone-container">
-    <button type="button" class="btn btn-default js-preview-toggle btn-preview-toggle">
-      <i class="fa fa-close"></i>
-    </button>
-    <iframe
-        class="preview-phone-window"
-        frameBorder="0"
-        scrolling="no"
-        src="{% url 'preview_app' request.domain app.get_id %}">
-    </iframe>
-{#    todo fix #}
-{#  <button type="button" class="btn btn-default btn-preview-back js-preview-back">#}
-{#    <i class="fa fa-arrow-left"></i>#}
-{#  </button>#}
-  </div>
+    <div class="preview-phone-container">
+        <button type="button" class="btn btn-default js-preview-toggle btn-preview-toggle">
+            <i class="fa fa-close"></i>
+        </button>
+        <iframe class="preview-phone-window" frameBorder="0" scrolling="no" src="{% url 'preview_app' request.domain app.get_id %}">
+        </iframe>
+        <div class="hardware-buttons">
+            <button type="button" class="btn btn-default btn-preview-back js-preview-back">
+                <i class="fa fa-arrow-left"></i>
+            </button>
+        </div>
+    </div>
 </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/preview_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/preview_app.html.diff.txt
@@ -1,15 +1,8 @@
 --- 
 +++ 
-@@ -11,8 +11,9 @@
-         scrolling="no"
-         src="{% url 'preview_app' request.domain app.get_id %}">
-     </iframe>
--    <button type="button" class="btn btn-default btn-preview-back js-preview-back">
--      <i class="fa fa-arrow-left"></i>
--    </button>
-+{#    todo fix #}
-+{#  <button type="button" class="btn btn-default btn-preview-back js-preview-back">#}
-+{#    <i class="fa fa-arrow-left"></i>#}
-+{#  </button>#}
-   </div>
- </div>
+@@ -1,4 +1,5 @@
+ {% load hq_shared_tags %}
++
+ <div id="js-appmanager-preview" class="preview-phone-wrapper">
+     <div class="preview-phone-container">
+         <button type="button" class="btn btn-default js-preview-toggle btn-preview-toggle">

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -601,7 +601,6 @@ Formplayer.Utils.answersEqual = function(answer1, answer2) {
 Formplayer.Utils.initialRender = function(formJSON, resourceMap, $div) {
     var form = new Form(formJSON),
         $debug = $('#cloudcare-debugger'),
-        $webformsNav = $('#webforms-nav'),
         cloudCareDebugger;
     Formplayer.resourceMap = resourceMap;
     ko.cleanNode($div[0]);
@@ -611,11 +610,6 @@ Formplayer.Utils.initialRender = function(formJSON, resourceMap, $div) {
         cloudCareDebugger = new Formplayer.ViewModels.CloudCareDebugger();
         ko.cleanNode($debug[0]);
         $debug.koApplyBindings(cloudCareDebugger);
-    }
-
-    if ($webformsNav.length) {
-        ko.cleanNode($webformsNav[0]);
-        $webformsNav.koApplyBindings(form);
     }
 
     return form;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -165,6 +165,7 @@ FormplayerFrontend.on('startForm', function (data) {
 
 FormplayerFrontend.on("start", function (options) {
     var user = FormplayerFrontend.request('currentUser'),
+        savedDisplayOptions,
         appId;
     user.username = options.username;
     user.language = options.language;
@@ -173,10 +174,16 @@ FormplayerFrontend.on("start", function (options) {
     user.formplayer_url = options.formplayer_url;
     user.debuggerEnabled = options.debuggerEnabled;
     user.restoreAs = FormplayerFrontend.request('restoreAsUser', user.domain, user.username);
-    user.displayOptions = {
+
+    savedDisplayOptions = _.pick(
+        Util.getSavedDisplayOptions(),
+        FormplayerFrontend.Constants.ALLOWED_SAVED_OPTIONS
+    );
+    console.log(savedDisplayOptions);
+    user.displayOptions = _.defaults(savedDisplayOptions, {
         phoneMode: options.phoneMode,
         oneQuestionPerScreen: options.oneQuestionPerScreen,
-    };
+    });
 
     FormplayerFrontend.request('gridPolyfillPath', options.gridPolyfillPath);
     if (Backbone.history) {
@@ -251,18 +258,6 @@ FormplayerFrontend.reqres.setHandler('restoreAsUser', function(domain, username)
         domain,
         username
     );
-});
-
-FormplayerFrontend.reqres.setHandler('setDisplayOptions', function(property, value) {
-    var user = FormplayerFrontend.request('currentUser');
-    user.displayOptions[property] = value;
-    return user.displayOptions;
-});
-
-FormplayerFrontend.reqres.setHandler('getDisplayOptions', function() {
-    var user = FormplayerFrontend.request('currentUser');
-    user.displayOptions[property] = value;
-    return user.displayOptions;
 });
 
 /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -179,7 +179,6 @@ FormplayerFrontend.on("start", function (options) {
         Util.getSavedDisplayOptions(),
         FormplayerFrontend.Constants.ALLOWED_SAVED_OPTIONS
     );
-    console.log(savedDisplayOptions);
     user.displayOptions = _.defaults(savedDisplayOptions, {
         phoneMode: options.phoneMode,
         oneQuestionPerScreen: options.oneQuestionPerScreen,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -172,7 +172,6 @@ FormplayerFrontend.on("start", function (options) {
     user.domain = options.domain;
     user.formplayer_url = options.formplayer_url;
     user.debuggerEnabled = options.debuggerEnabled;
-    user.phoneMode = options.phoneMode;
     user.restoreAs = FormplayerFrontend.request('restoreAsUser', user.domain, user.username);
     user.displayOptions = {
         phoneMode: options.phoneMode,
@@ -252,6 +251,18 @@ FormplayerFrontend.reqres.setHandler('restoreAsUser', function(domain, username)
         domain,
         username
     );
+});
+
+FormplayerFrontend.reqres.setHandler('setDisplayOptions', function(property, value) {
+    var user = FormplayerFrontend.request('currentUser');
+    user.displayOptions[property] = value;
+    return user.displayOptions;
+});
+
+FormplayerFrontend.reqres.setHandler('getDisplayOptions', function() {
+    var user = FormplayerFrontend.request('currentUser');
+    user.displayOptions[property] = value;
+    return user.displayOptions;
 });
 
 /**
@@ -408,7 +419,7 @@ FormplayerFrontend.on('navigateHome', function(appId) {
         currentUser = FormplayerFrontend.request('currentUser');
     urlObject.clearExceptApp();
     FormplayerFrontend.regions.breadcrumb.empty();
-    if (currentUser.phoneMode) {
+    if (currentUser.displayOptions.phoneMode) {
         FormplayerFrontend.navigate("/single_app/" + appId, { trigger: true });
     } else {
         FormplayerFrontend.navigate("/apps", { trigger: true });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -280,9 +280,7 @@ FormplayerFrontend.on('clearRestoreAsUser', function() {
         })
     );
 
-    appId = FormplayerFrontend.request('getCurrentAppId');
-
-    FormplayerFrontend.trigger('navigateHome', appId);
+    FormplayerFrontend.trigger('navigateHome');
 });
 
 FormplayerFrontend.on("sync", function () {
@@ -404,16 +402,18 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
         tfLoadingComplete(true);
     }).done(function() {
         tfLoadingComplete();
-        FormplayerFrontend.trigger('navigateHome', appId);
+        FormplayerFrontend.trigger('navigateHome');
     });
 });
 
-FormplayerFrontend.on('navigateHome', function(appId) {
+FormplayerFrontend.on('navigateHome', function() {
     var urlObject = Util.currentUrlToObject(),
+        appId,
         currentUser = FormplayerFrontend.request('currentUser');
     urlObject.clearExceptApp();
     FormplayerFrontend.regions.breadcrumb.empty();
     if (currentUser.displayOptions.phoneMode) {
+        appId = FormplayerFrontend.request('getCurrentAppId');
         FormplayerFrontend.navigate("/single_app/" + appId, { trigger: true });
     } else {
         FormplayerFrontend.navigate("/apps", { trigger: true });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/list_controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/list_controller.js
@@ -29,5 +29,9 @@ FormplayerFrontend.module("SessionNavigate.AppList", function(AppList, Formplaye
             FormplayerFrontend.regions.main.show(singleAppView);
             FormplayerFrontend.trigger('phone:back:hide');
         },
+        listSettings: function() {
+            var settingsView = new AppList.SettingsView();
+            FormplayerFrontend.regions.main.show(settingsView);
+        },
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/list_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/list_view.js
@@ -20,6 +20,7 @@ FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, Formplay
             'click .js-incomplete-sessions-item': 'incompleteSessionsClick',
             'click .js-sync-item': 'syncClick',
             'click .js-restore-as-item': 'onClickRestoreAs',
+            'click .js-settings': 'onClickSettings',
         },
         incompleteSessionsClick: function (e) {
             e.preventDefault();
@@ -33,6 +34,10 @@ FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, Formplay
             e.preventDefault();
             FormplayerFrontend.trigger("restore_as:list", this.appId);
         },
+        onClickSettings: function(e) {
+            e.preventDefault();
+            FormplayerFrontend.trigger("settings:list");
+        },
     };
 
     AppList.GridView = Marionette.CompositeView.extend({
@@ -44,6 +49,7 @@ FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, Formplay
         incompleteSessionsClick: _.extend(AppList.BaseAppView.incompleteSessionsClick),
         syncClick: _.extend(AppList.BaseAppView.syncClick),
         onClickRestoreAs: _.extend(AppList.BaseAppView.onClickRestoreAs),
+        onClickSettings: _.extend(AppList.BaseAppView.onClickSettings),
     });
 
     /**
@@ -63,6 +69,7 @@ FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, Formplay
         incompleteSessionsClick: _.extend(AppList.BaseAppView.incompleteSessionsClick),
         syncClick: _.extend(AppList.BaseAppView.syncClick),
         onClickRestoreAs: _.extend(AppList.BaseAppView.onClickRestoreAs),
+        onClickSettings: _.extend(AppList.BaseAppView.onClickSettings),
 
         initialize: function(options) {
             this.appId = options.appId;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/settings_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/settings_view.js
@@ -1,0 +1,29 @@
+/*global FormplayerFrontend */
+
+FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, FormplayerFrontend, Backbone, Marionette) {
+    AppList.SettingsView = Marionette.ItemView.extend({
+        ui: {
+            oneQuestionPerScreen: '.js-one-question-per-screen',
+            done: '.js-done',
+        },
+        events: {
+            'switchChange.bootstrapSwitch @ui.oneQuestionPerScreen': 'onChangeOneQuestionPerScreen',
+            'click @ui.done': 'onClickDone',
+        },
+        template: '#settings-template',
+        initialize: function() {
+            this.currentUser = FormplayerFrontend.request('currentUser');
+        },
+        onRender: function() {
+            this.ui.oneQuestionPerScreen.bootstrapSwitch(
+                this.currentUser.displayOptions.oneQuestionPerScreen
+            )
+        },
+        onChangeOneQuestionPerScreen: function(e, switchValue) {
+            this.currentUser.displayOptions.oneQuestionPerScreen = switchValue;
+        },
+        onClickDone: function() {
+            FormplayerFrontend.trigger('navigateHome');
+        },
+    });
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/settings_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/settings_view.js
@@ -1,4 +1,4 @@
-/*global FormplayerFrontend */
+/*global FormplayerFrontend, Util */
 
 FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, FormplayerFrontend, Backbone, Marionette) {
     AppList.SettingsView = Marionette.ItemView.extend({
@@ -18,7 +18,7 @@ FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, Formplay
             this.ui.oneQuestionPerScreen.bootstrapSwitch(
                 'state',
                 this.currentUser.displayOptions.oneQuestionPerScreen
-            )
+            );
         },
         onChangeOneQuestionPerScreen: function(e, switchValue) {
             this.currentUser.displayOptions.oneQuestionPerScreen = switchValue;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/settings_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/list/settings_view.js
@@ -16,11 +16,13 @@ FormplayerFrontend.module("SessionNavigate.AppList", function (AppList, Formplay
         },
         onRender: function() {
             this.ui.oneQuestionPerScreen.bootstrapSwitch(
+                'state',
                 this.currentUser.displayOptions.oneQuestionPerScreen
             )
         },
         onChangeOneQuestionPerScreen: function(e, switchValue) {
             this.currentUser.displayOptions.oneQuestionPerScreen = switchValue;
+            Util.saveDisplayOptions(this.currentUser.displayOptions);
         },
         onClickDone: function() {
             FormplayerFrontend.trigger('navigateHome');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/session_nav.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/session_nav.js
@@ -11,6 +11,7 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
             "restore_as/:page/:query": "listUsers",
             "restore_as/:page/": "listUsers",
             "restore_as": "listUsers",
+            "settings": "listSettings",
             ":session": "listMenus",  // Default route
         },
     });
@@ -43,6 +44,9 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
                 page = 1;
             }
             SessionNavigate.Users.Controller.listUsers(page, query);
+        },
+        listSettings: function() {
+            SessionNavigate.AppList.Controller.listSettings();
         },
         showDetail: function (model, detailTabIndex) {
             SessionNavigate.MenuList.Controller.showDetail(model, detailTabIndex);
@@ -151,6 +155,11 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
     FormplayerFrontend.on('restore_as:list', function() {
         FormplayerFrontend.navigate("/restore_as");
         API.listUsers();
+    });
+
+    FormplayerFrontend.on('settings:list', function() {
+        FormplayerFrontend.navigate("/settings");
+        API.listSettings();
     });
 
     FormplayerFrontend.on("menu:show:detail", function (model, detailTabIndex) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
@@ -77,22 +77,22 @@ Util.setCrossDomainAjaxOptions = function (options) {
 Util.saveDisplayOptions = function(displayOptions) {
     var displayOptionsKey = Util.getDisplayOptionsKey();
     localStorage.setItem(displayOptionsKey, JSON.stringify(displayOptions));
-}
+};
 
 Util.getSavedDisplayOptions = function() {
     var displayOptionsKey = Util.getDisplayOptionsKey();
     try {
         return JSON.parse(localStorage.getItem(displayOptionsKey));
     } catch (e) {
-        window.console.warn('Unabled to parse saved display options')
+        window.console.warn('Unabled to parse saved display options');
         return {};
     }
-}
+};
 
 Util.getDisplayOptionsKey = function() {
     var user = FormplayerFrontend.request('currentUser');
     return user.domain + ':' + user.username + ':' + 'displayOptions';
-}
+};
 
 Util.CloudcareUrl = function (options) {
     this.appId = options.appId;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
@@ -75,16 +75,23 @@ Util.setCrossDomainAjaxOptions = function (options) {
 };
 
 Util.saveDisplayOptions = function(displayOptions) {
-    localStorage.setItem('displayOptions', JSON.stringify(displayOptions));
+    var displayOptionsKey = Util.getDisplayOptionsKey();
+    localStorage.setItem(displayOptionsKey, JSON.stringify(displayOptions));
 }
 
 Util.getSavedDisplayOptions = function() {
+    var displayOptionsKey = Util.getDisplayOptionsKey();
     try {
-        return JSON.parse(localStorage.getItem('displayOptions'));
+        return JSON.parse(localStorage.getItem(displayOptionsKey));
     } catch (e) {
         window.console.warn('Unabled to parse saved display options')
         return {};
     }
+}
+
+Util.getDisplayOptionsKey = function() {
+    var user = FormplayerFrontend.request('currentUser');
+    return user.domain + ':' + user.username + ':' + 'displayOptions';
 }
 
 Util.CloudcareUrl = function (options) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
@@ -74,6 +74,19 @@ Util.setCrossDomainAjaxOptions = function (options) {
     options.contentType = "application/json;charset=UTF-8";
 };
 
+Util.saveDisplayOptions = function(displayOptions) {
+    localStorage.setItem('displayOptions', JSON.stringify(displayOptions));
+}
+
+Util.getSavedDisplayOptions = function() {
+    try {
+        return JSON.parse(localStorage.getItem('displayOptions'));
+    } catch (e) {
+        window.console.warn('Unabled to parse saved display options')
+        return {};
+    }
+}
+
 Util.CloudcareUrl = function (options) {
     this.appId = options.appId;
     this.sessionId = options.sessionId;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -1,0 +1,5 @@
+/*global FormplayerFrontend */
+
+FormplayerFrontend.Constants = {
+    ALLOWED_SAVED_OPTIONS: ['oneQuestionPerScreen'],
+};

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
@@ -16,14 +16,8 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
         // For Chrome, the origin property is in the event.originalEvent object
         var origin = event.origin || event.originalEvent.origin,
             data = event.data,
-            returnValue = null,
             success = true;
 
-        _.defaults(data, {
-            success: function() {},
-            error: function() {},
-            complete: function() {},
-        });
         if (!origin.endsWith(this.allowedHost)) {
             throw new Error('Disallowed origin ' + origin);
         }
@@ -35,20 +29,10 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
             throw new Error('Invalid action ' + data.action);
         }
 
-        try {
-            switch (data.action) {
-            case Events.Actions.BACK:
-                FormplayerFrontend.trigger('navigation:back');
-                break;
-            }
-        } catch (e) {
-            success = false;
-            data.error(event, data, returnValue);
-        } finally {
-            data.complete(event, data, returnValue);
-        }
-        if (success) {
-            data.success(event, data, returnValue);
+        switch (data.action) {
+        case Events.Actions.BACK:
+            FormplayerFrontend.trigger('navigation:back');
+            break;
         }
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
@@ -44,30 +44,5 @@ describe('HQ.Events', function() {
             dummyEvent.data.action = 'unknown';
             assert.throws(function() { receiver(dummyEvent); }, /Invalid action/);
         });
-
-        it('should call success on success', function() {
-            var receiver = new Receiver(origin);
-            dummyEvent.data.action = Actions.BACK;
-            dummyEvent.data.success = sinon.spy();
-            dummyEvent.data.complete = sinon.spy();
-
-            receiver(dummyEvent);
-            assert.isTrue(dummyEvent.data.success.called);
-            assert.isTrue(dummyEvent.data.complete.called);
-        });
-
-        it('should call error on error', function() {
-            var receiver = new Receiver(origin);
-            dummyEvent.data.action = Actions.BACK;
-            dummyEvent.data.error = sinon.spy();
-            dummyEvent.data.complete = sinon.spy();
-
-            FormplayerFrontend.trigger.restore();
-            sinon.stub(FormplayerFrontend, 'trigger', function() { throw new Error('Boom'); });
-
-            receiver(dummyEvent);
-            assert.isTrue(dummyEvent.data.error.called);
-            assert.isTrue(dummyEvent.data.complete.called);
-        });
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
@@ -1,0 +1,52 @@
+/* global FormplayerFrontend, Util */
+/* eslint-env mocha */
+
+describe('FormplayerFrontend Integration', function() {
+    describe('Start up', function() {
+        var options,
+            server;
+        beforeEach(function() {
+            server = sinon.useFakeXMLHttpRequest();
+            options = {
+                username: 'batman',
+                domain: 'domain',
+                apps: [],
+            };
+            sinon.stub(Backbone.history, 'start', sinon.spy());
+        });
+
+        afterEach(function() {
+            server.restore();
+            Backbone.history.start.restore();
+        });
+
+        it('should start the formplayer frontend app', function() {
+            FormplayerFrontend.start(options);
+
+            var user = FormplayerFrontend.request('currentUser');
+            assert.equal(user.username, options.username);
+            assert.equal(user.domain, options.domain);
+        });
+
+        it('should correctly restore display options', function() {
+            var newOptions = _.clone(options),
+                user;
+            newOptions.phoneMode = true;
+            newOptions.oneQuestionPerScreen = true;
+
+            FormplayerFrontend.start(newOptions);
+
+            user = FormplayerFrontend.request('currentUser');
+            Util.saveDisplayOptions(user.displayOptions);
+
+            // New session, but old options
+            FormplayerFrontend.start(options);
+            user = FormplayerFrontend.request('currentUser');
+
+            assert.deepEqual(user.displayOptions, {
+                phoneMode: undefined, // we don't store this option
+                oneQuestionPerScreen: true,
+            });
+        });
+    });
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
@@ -1,4 +1,4 @@
-/* global FormplayerFrontend, Util */
+/* global FormplayerFrontend, Util, Backbone */
 /* eslint-env mocha */
 
 describe('FormplayerFrontend Integration', function() {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/util_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/util_spec.js
@@ -1,0 +1,27 @@
+/* global Util */
+/* eslint-env mocha */
+
+describe('Util', function() {
+    describe('#displayOptions', function() {
+        beforeEach(function() {
+            sinon.stub(Util, 'getDisplayOptionsKey', function() { return 'mykey'; });
+            window.localStorage.clear();
+        });
+
+        afterEach(function() {
+            Util.getDisplayOptionsKey.restore();
+        });
+
+        it('should retrieve saved display options', function() {
+            var options = { option: 'yes' }
+            Util.saveDisplayOptions(options);
+            assert.deepEqual(Util.getSavedDisplayOptions(), options);
+        });
+
+        it('should not fail on bad json saved', function() {
+            localStorage.setItem(Util.getDisplayOptionsKey(), 'bad json');
+            assert.deepEqual(Util.getSavedDisplayOptions(), {});
+        });
+
+    });
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/util_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/util_spec.js
@@ -13,7 +13,7 @@ describe('Util', function() {
         });
 
         it('should retrieve saved display options', function() {
-            var options = { option: 'yes' }
+            var options = { option: 'yes' };
             Util.saveDisplayOptions(options);
             assert.deepEqual(Util.getSavedDisplayOptions(), options);
         });

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -42,6 +42,7 @@
               href="{% static 'datatables/media/css/jquery.dataTables.min.css' %}"/>
         <link rel="stylesheet" href="{% static 'cloudcare/css/webforms.css' %}">
         <link rel="stylesheet" href="{% static 'codemirror/lib/codemirror.css' %}"/>
+        <link rel="stylesheet" href="{% static 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css' %}"/>
     {% endcompress %}
 
   {% if less_debug %}
@@ -160,6 +161,7 @@
 
     {% include 'form_entry/templates.html' %}
     {% include 'formplayer/grid_view.html' %}
+    {% include 'formplayer/settings_view.html' %}
     {% include 'formplayer/case_detail.html' %}
     {% include 'formplayer/case_list.html' %}
     {% include 'formplayer/menu_list.html' %}

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -11,8 +11,28 @@
 <script src="{% static 'cloudcare/js/formplayer/spec/menu_list_test.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/spec/user_spec.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/spec/session_middleware_spec.js' %}"></script>
+<script src="{% static 'cloudcare/js/formplayer/spec/util_spec.js' %}"></script>
+<script src="{% static 'cloudcare/js/formplayer/spec/integration_spec.js' %}"></script>
 {% endblock %}
 
 {% block fixtures %}
-{% include "formplayer/case_list.html" %}
+    {% include "formplayer/case_list.html" %}
+
+    <div id="restore-as-region"></div>
+    <div id="breadcrumb-region"></div>
+    <div id="persistent-case-tile" class="container"></div>
+    <div id="menu-region" class="container"></div>
+
+    {% include 'form_entry/templates.html' %}
+    {% include 'formplayer/grid_view.html' %}
+    {% include 'formplayer/settings_view.html' %}
+    {% include 'formplayer/case_detail.html' %}
+    {% include 'formplayer/case_list.html' %}
+    {% include 'formplayer/menu_list.html' %}
+    {% include 'formplayer/users.html' %}
+    {% include 'formplayer/session_list.html' %}
+    {% include 'formplayer/query_view.html' %}
+    {% include 'formplayer/confirmation_modal.html' %}
+    {% include 'formplayer/progress.html' %}
+
 {% endblock %}

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -18,7 +18,7 @@
 </script>
 
 <script type="text/html" id="form-navigation-ko-template">
-  <h2 class="formnav-title" data-bind="text: title, visible: showInFormNavigation"></h2>
+  <h1 class="formnav-title page-header" data-bind="text: title, visible: showInFormNavigation"></h1>
   <div class="formnav-container" data-bind="visible: showInFormNavigation">
     <button type="button"
             class="btn btn-formnav"
@@ -56,6 +56,8 @@
       <div class="page-header" data-bind="visible: !showInFormNavigation()">
         <h1 class="title" data-bind="text: title"></h1>
       </div>
+      <div class="webforms-nav"
+           data-bind="template: { name: 'form-navigation-ko-template' }"></div>
 
       <div class="row">
         <div class="col-sm-12">

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -12,6 +12,7 @@
 <script src="{% static 'cloudcare/js/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/util/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/app.js' %}"></script>
+<script src="{% static 'cloudcare/js/formplayer/constants.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/hq.events.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/util/progress_view.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/models/user.js' %}"></script>

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -7,6 +7,7 @@
 <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
 <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
 <script src="{% static 'codemirror/mode/xml/xml.js' %}"></script>
+<script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.js' %}"></script>
 <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
 <script src="{% static 'cloudcare/js/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/util/util.js' %}"></script>
@@ -21,6 +22,7 @@
 <script src="{% static 'cloudcare/js/formplayer/entities/sessions.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/list/list_controller.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/list/list_view.js' %}"></script>
+<script src="{% static 'cloudcare/js/formplayer/apps/list/settings_view.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/menus/menu_view.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/menus/query_view.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/menus/menu_controller.js' %}"></script>

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -39,6 +39,14 @@
           </div>
         </div>
         {% endif %}
+        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
+          <div class="js-settings appicon appicon-settings">
+            <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
+            <div class="appicon-title">
+              <h3>{% trans "Settings" %}</h3>
+            </div>
+          </div>
+        </div>
     </div>
 </script>
 

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -39,14 +39,6 @@
           </div>
         </div>
         {% endif %}
-        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-          <div class="js-settings appicon appicon-settings">
-            <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
-            <div class="appicon-title">
-              <h3>{% trans "Settings" %}</h3>
-            </div>
-          </div>
-        </div>
     </div>
 </script>
 

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -83,6 +83,14 @@
           </div>
         </div>
         {% endif %}
+        <div class="grid-item col-xs-6 col-sm-4 formplayer-request">
+          <div class="js-settings appicon appicon-settings">
+            <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
+            <div class="appicon-title">
+              <h3>{% trans "Settings" %}</h3>
+            </div>
+          </div>
+        </div>
     </div>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -1,0 +1,23 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+
+<script type="text/template" id="settings-template">
+<div class="module-menu-container">
+    <div class="page-header menu-header">
+        <h1 class="page-title">{% trans "Settings" %}</h1>
+    </div>
+    <table class="table module-table">
+        <tbody>
+            <tr>
+                <th>Use one question per screen</th>
+                <td><input class="js-one-question-per-screen" type="checkbox" data-size="mini" /></td>
+            </tr>
+        </tbody>
+    </table>
+    <div class="page-footer">
+        <button class="btn btn-success js-done">
+            <i class="fa fa-check"></i>&nbsp;Done
+        </button>
+    </div>
+</div>
+</script>

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -30,7 +30,9 @@
   <body>
       <!-- HTML Fixtures -->
       <div id="mocha"></div>
+      <div id="mocha-fixtures" style="display:none">
       {% block fixtures %}{% endblock %}
+      </div>
       {% block mocha_tests %}{% endblock %}
       <script charset="utf-8">
 	// Only tests run in real browser, injected script run if options.run == true

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -154,7 +154,6 @@
         <div id="menu-container">
             <div id="phone-mode-navigation"></div>
             <div id="formplayer-progress-container"></div>
-            <div id="webforms-nav" class="webforms-nav" data-bind="template: { name: 'form-navigation-ko-template' }"></div>
             <section id="cloudcare-notifications" class="notifications-container"></section>
             <div id="restore-as-region"></div>
             <div id="breadcrumb-region"></div>

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -79,6 +79,8 @@
                   href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}" />
           {% endcompress %}
         {% endif %}
+        <link rel="stylesheet"
+              href="{% static 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css' %}"/>
         <link type="text/css"
               rel="stylesheet"
               media="screen"

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -191,6 +191,7 @@
         </script>
         {% include 'form_entry/templates.html' %}
         {% include 'formplayer/grid_view.html' %}
+        {% include 'formplayer/settings_view.html' %}
         {% include 'formplayer/case_detail.html' %}
         {% include 'formplayer/case_list.html' %}
         {% include 'formplayer/menu_list.html' %}

--- a/corehq/apps/style/static/app_manager/less/preview_app-main.less
+++ b/corehq/apps/style/static/app_manager/less/preview_app-main.less
@@ -118,3 +118,12 @@ preview_app/less */
   left: -5px;
   top: -5px;
 }
+
+.hardware-buttons {
+  position: absolute;
+  bottom: 0;
+
+  .btn-hardware {
+    display: inline-block;
+  }
+}

--- a/corehq/apps/style/static/cloudcare/less/cloudcare/appicon.less
+++ b/corehq/apps/style/static/cloudcare/less/cloudcare/appicon.less
@@ -126,6 +126,17 @@
   }
 }
 
+.appicon-settings {
+  background-color: @cc-neutral-low;
+  .appicon-icon {
+    color: @cc-neutral-hi;
+  }
+  &:hover {
+    background-color: darken(@cc-neutral-low, 5);
+    .appicon-icon { color: lighten(@cc-neutral-hi, 5); }
+  }
+}
+
 .appicon-default {
   background-color: white;
   color: lighten(@cc-text, 30);

--- a/corehq/apps/style/static/cloudcare/less/formplayer/content.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer/content.less
@@ -25,6 +25,10 @@ body {
   }
 }
 
+.page-footer {
+  padding: 14px 8px 7px;
+}
+
 .page-header-apps {
   padding-left: 2px;
 }

--- a/corehq/apps/style/static/preview_app/less/preview_app/form.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/form.less
@@ -18,6 +18,10 @@
   }
 }
 
+.page-footer {
+  padding: 14px 8px 7px;
+}
+
 .form-single-question {
   padding-top: 10px;
   min-height: 367px;

--- a/corehq/apps/style/static/preview_app/less/preview_app/formnav.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/formnav.less
@@ -1,5 +1,8 @@
 .webforms-nav {
   position: relative;
+
+  margin: -10px;
+  margin-bottom: 10px;
 }
 
 .formnav-title {


### PR DESCRIPTION
@biyeun @wpride Adds basic ability to turn on and off one question per screen. label because there are a few things i want to do first

- [x] write some tests
- [x] fix navigate for phone preview after selecting a setting
- [x] one question per screen for full screen mode

Here's what it currently looks like (looks a bit better in full screen mode):

<img width="298" alt="screen shot 2016-10-31 at 5 30 13 pm" src="https://cloud.githubusercontent.com/assets/918514/19872388/d3d8a4f6-9f8f-11e6-8c39-4bf9a6f4d20d.png">
<img width="298" alt="screen shot 2016-10-31 at 5 30 04 pm" src="https://cloud.githubusercontent.com/assets/918514/19872387/d3d79750-9f8f-11e6-97c8-2d549495cccb.png">

@biyeun one question per screen doesn't work in full screen mode because i think we conflate the `phoneMode` and `oneQuestionPerScreen` mode. will try and make a pass at getting OQPS to work in full screen mode:

<img width="1439" alt="screen shot 2016-10-31 at 5 30 56 pm" src="https://cloud.githubusercontent.com/assets/918514/19872423/fa9e780e-9f8f-11e6-8254-f279b212d776.png">

