### PR TITLE
query on correct field

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1370,7 +1370,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
 
                 # changing a plan overrides future subscriptions
                 future_subscriptions = Subscription.objects.filter(
-                    subscriber=self.domain,
+                    subscriber__domain=self.domain,
                     date_start__gt=datetime.date.today()
                 )
                 if future_subscriptions.count() > 0:


### PR DESCRIPTION
@emord @benrudolph 

Recommending merging before tests and deploying since the self-service subscription change workflow is broken.