### PR TITLE
fix broken url reverse

### DIFF
--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -51,7 +51,7 @@ def back_to_main(request, domain, app_id=None, module_id=None, form_id=None,
         view_name = page
     else:
         view_name = {
-            1: 'view_app',
+            1: 'default_app',
             2: 'view_app',
             3: 'view_module',
             4: 'form_designer' if toggles.APP_MANAGER_V2.enabled(domain) else 'view_form',


### PR DESCRIPTION
fixes
```NoReverseMatch: Reverse for 'view_app' with arguments '(u'test-project-195',)' and keyword arguments '{}' not found. 1 pattern(s) tried: ['a/(?P<domain>[\\w\\.:-]+)/apps/view/(?P<app_id>[\\w-]+)/$']```

@millerdev 