### PR TITLE
change CommCare translations from atwho to select2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,8 +27,6 @@
     "select2": "4.0.0",
     "less": "1.7.3",
     "xpath": "dimagi/js-xpath#f4f0c78",
-    "At.js": "1.5.2",
-    "Caret.js": "0.2.2",
     "backbone": "0.9.1",
     "backbone-1.3.2": "backbone#1.3.2",
     "bootstrap-daterangepicker": "2.1.13",

--- a/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
@@ -3,15 +3,9 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% load compress %}
 
 {% block head %}{{ block.super }}
     {% include 'analytics/fullstory.html' %}
-{% endblock %}
-{% block stylesheets %}{{ block.super }}
-    {% compress css %}
-    <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
-    {% endcompress %}
 {% endblock %}
 {% block js %}{{ block.super }}
     <script src="{% static 'app_manager/js/commcaresettings.js' %}"></script>
@@ -30,8 +24,6 @@
     {{ block.super }}
     {% if app.get_doc_type == "Application" %}
         <script src="{% static 'translations/js/translations.js' %}"></script>
-        <script src="{% static 'Caret.js/dist/jquery.caret.min.js' %}"></script>
-        <script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
     {% endif %}
     {% if app %}
     <script>

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -23,7 +23,7 @@ var mk_translation_ui = function (spec) {
                     $(this).remove();
                     translation_ui.deleteTranslation(that.key.val());
                 }).css({cursor: 'pointer'}).attr('title', "Delete Translation");
-                
+
                 this.$add = $('<button class="btn btn-default"><i></i></button>').addClass(COMMCAREHQ.icons.ADD).click(function () {
                     // remove any trailing whitespace from the input box
                     that.key.val($.trim(that.key.val()));
@@ -53,46 +53,44 @@ var mk_translation_ui = function (spec) {
 
                 this.value.on('change', helperFunction);
 
-                var $input = this.value.ui.find('input');
-                var options = {
-                    at: "",
-                    maxLen: Infinity,
-                    suffix: "",
-                    tabSelectsMatch: false,
-                    callbacks: {
-                        filter: function(query, data, searchKey) {
-                            return _.filter(data, function(item) {
-                                return item.name.indexOf(query) !== -1;
-                            });
+                this.value.ui.find('input').select2({
+                    minimumInputLength: 0,
+                    delay: 100,
+                    allowClear: 1,
+                    placeholder: ' ',   // allowClear requires a placeholder
+                    initSelection: function(element, callback) {
+                        callback({
+                            id: element.val(),
+                            text: element.val(),
+                        });
+                    },
+                    createSearchChoice: function(term, data) {
+                        if (term !== "" && !_.find(data, function(d) { return d.text === term; })) {
+                            return {
+                                id: term,
+                                text: term,
+                            };
+                        }
+                    },
+                    ajax: {
+                        url: suggestionURL,
+                        data: function (term, page) {
+                            return {
+                                lang: translation_ui.lang,
+                                key: that.key.val(),
+                            };
                         },
-                        matcher: function(flag, subtext, should_startWithSpace) {
-                            return $input.val();
-                        },
-                        beforeInsert: function(value, $li) {
-                            helperFunction();
-
-                            // This and the inserted.atwho handler below ensure that the entire
-                            // input's value is replaced, regardless of where the cursor is
-                            $input.data("selected-value", value);
+                        results: function(data, page) {
+                            return {
+                                results: _.map(_.compact(data), function(item) {
+                                    return {
+                                        id: item,
+                                        text: item,
+                                    };
+                                }),
+                            };
                         },
                     },
-                };
-
-                $input.one('focus', function () {
-                    $.ajax({
-                        url: suggestionURL,
-                        data: {
-                            lang: translation_ui.lang,
-                            key: that.key.val(),
-                        },
-                        success: function (data) {
-                            options.data = data;
-                            $input.atwho(options).on("inserted.atwho", function(event, $li, otherEvent) {
-                                $input.val($input.data("selected-value")).change();
-                            });
-                            $input.atwho('run');
-                        },
-                    });
                 });
             };
             Translation.init = function (key, value) {


### PR DESCRIPTION
@emord bringing atwho into HQ didn't work out after all, because it requires Caret.js, which sometimes conflicts with the jQuery caret plugin HQ is already using. So, I'm changing https://github.com/dimagi/commcare-hq/pull/13731 to use select2 and pulling atwho out of HQ.

code buddy @dannyroberts 

<img width="633" alt="screen shot 2016-11-01 at 2 55 39 pm" src="https://cloud.githubusercontent.com/assets/1486591/19902995/5c53643e-a043-11e6-8031-f90379728b88.png">
