### PR TITLE
Refer to media_files url with project id

### DIFF
--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -212,7 +212,7 @@
                 {% endif %}
                 {% if project.multimedia_included and project.has_media %}
                     <dd>
-                        <a class="btn btn-default" style="margin-top: .4em" href="{% url "media_files" project %}">{% trans "Browse Multimedia" %}</a>
+                        <a class="btn btn-default" style="margin-top: .4em" href="{% url "media_files" project.get_id %}">{% trans "Browse Multimedia" %}</a>
                     </dd>
                 {% endif %}
             </dl>
@@ -361,7 +361,7 @@
                 </p>
                 {% if project.multimedia_included and project.has_media %}
                 <p>
-                    {% trans "Please view the" %} <a target="_blank" href="{% url "media_files" project %}">{% trans "licenses for this app's media files" %}</a>
+                    {% trans "Please view the" %} <a target="_blank" href="{% url "media_files" project.get_id %}">{% trans "licenses for this app's media files" %}</a>
                 </p>
                 {% endif %}
             </div>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240620
Snapshots used to have names that matched ids, then with the implementation of `hr_name`, the ids were truncated to form the names, so they no longer match.  The issue at hand is that some references used names when they should have been using ids, but only recently is that an issue, and only for snapshots created after the `hr_name` change.

This the same issue seen here:
https://github.com/dimagi/commcare-hq/pull/13391/files

@emord