### PR TITLE
analytics for live preview A/B test

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4893,7 +4893,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     def save(self, response_json=None, increment_version=None, **params):
         if not self._rev and not domain_has_apps(self.domain):
             domain_has_apps.clear(self.domain)
-        user = view_utils.get_request().getattr('couch_user', None)
+        user = getattr(view_utils.get_request(), 'couch_user', None)
         if user and user.days_since_created == 0:
             track_workflow(user.get_email(), 'Saved the App Builder within first 24 hours')
         super(ApplicationBase, self).save(

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4893,8 +4893,8 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     def save(self, response_json=None, increment_version=None, **params):
         if not self._rev and not domain_has_apps(self.domain):
             domain_has_apps.clear(self.domain)
-        user = view_utils.get_request().couch_user
-        if user.days_since_created == 0:
+        user = view_utils.get_request().getattr('couch_user', None)
+        if user and user.days_since_created == 0:
             track_workflow(user.get_email(), 'Saved the App Builder within first 24 hours')
         super(ApplicationBase, self).save(
             response_json=response_json, increment_version=increment_version, **params)

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
@@ -56,6 +56,9 @@
                 onFormSave: function (data) {
                     var app_manager = hqImport('app_manager/js/app_manager.js')
                     app_manager.updateDOM(data.update);
+                    {% if request.couch_user.days_since_created == 0 %}
+                        analytics.workflow('Saved the Form Builder within first 24 hours');
+                    {% endif %}
                 },
                 {% if vellum_debug == "dev" %}
                 onReady: function () {
@@ -68,6 +71,11 @@
                     }
                     {% if request.guided_tour %}
                     form_tour_start();
+                    {% endif %}
+                    {% if request.couch_user.days_since_created == 0 %}
+                        $("#formdesigner").vellum("get").data.core.form.on("question-create", function() {
+                            analytics.workflow('Added question in Form Builder within first 24 hours');
+                        });
                     {% endif %}
                 },
                 {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -259,6 +259,9 @@
             $('#cloudcare-preview-url').click(function(e) {
                 ga_track_event('CloudCare', 'Click "Preview Form"');
                 analytics.workflow("Clicked Preview Form");
+                {% if request.couch_user.days_since_created == 0 %}
+                    analytics.workflow("Clicked Preview Form within first 24 hours");
+                {% endif %}
             });
         {% endif %}
         });

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -260,8 +260,8 @@
                 ga_track_event('CloudCare', 'Click "Preview Form"');
                 analytics.workflow("Clicked Preview Form");
                 {% if request.couch_user.days_since_created == 0 %}
-                    ga_track_event('CloudCare', 'Click "Preview Form" within first 24 hours');
-                    analytics.workflow("Clicked Preview Form within first 24 hours");
+                    ga_track_event('CloudCare', 'Clicked "Preview Form" within first 24 hours');
+                    analytics.workflow('Clicked "Preview Form" within first 24 hours');
                 {% endif %}
             });
         {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -260,6 +260,7 @@
                 ga_track_event('CloudCare', 'Click "Preview Form"');
                 analytics.workflow("Clicked Preview Form");
                 {% if request.couch_user.days_since_created == 0 %}
+                    ga_track_event('CloudCare', 'Click "Preview Form" within first 24 hours');
                     analytics.workflow("Clicked Preview Form within first 24 hours");
                 {% endif %}
             });

--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -30,6 +30,9 @@
         ga('set', 'dimension3', '{% if request.couch_user.is_commcare_user %}yes{% else %}no{% endif %}');
         ga('set', 'dimension4', '{% if domain %}{{ domain|escapejs }}{% else %}none{% endif %}');
         ga('set', 'dimension5', '{% if request.couch_user.has_built_app %}yes{% else %}no{% endif %}');
+        var daysOld = {{ request.couch_user.days_since_created }};
+        ga('set', 'dimension6', daysOld < 1 ? 'yes' : 'no');
+        ga('set', 'dimension7', daysOld >= 1 && daysOld < 7 ? 'yes' : 'no');
         ga('send', 'pageview');
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -887,6 +887,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         username = self.username.split("@")[0]
         return "%s <%s>" % (self.full_name, username) if self.full_name else username
 
+    @property
+    def days_since_created(self):
+        # Note this does not round, but returns the floor of days since creation
+        return (datetime.utcnow() - self.created_on).days
+
     formatted_name = full_name
     name = full_name
 


### PR DESCRIPTION
@amsagoff this does the following
- Adds `dimension6` and `dimension7` to google analytics: 6 is `yes` if it's the user's first 24 hours and 7 is `yes` if it's past the first 24 hours but within the first week. I'm assuming we can use this to track # visits to HQ within a new user's first day and first week. (Would be good if you or @krsdimagi can confirm this.)
- Adds a kiss event for form builder saves within the first 24 hours.
- Adds a kiss event each time a question is added in form builder in the first 24 hours.
- Adds a kiss and a google event for clicking `Preview Form` within the first 24 hours.

Did not add an event for app manager saves in general because there are quite a few pages in the ui where we save the app. They all go through `ApplicationBase.save` eventually, but by that point we no longer know who the user is.

@dannyroberts 