### PR TITLE
Add ESQuery.get_ids() method

### DIFF
--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -237,4 +237,4 @@ class BulkFormManagementInterface(SubmitHistoryMixin, DataInterface, ProjectRepo
         # returns a list of form_ids
         # this is called using ReportDispatcher.dispatch(render_as='form_ids', ***) in
         # the bulk_form_management_async task
-        return self.es_query.exclude_source().run().doc_ids
+        return self.es_query.get_ids()

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -404,6 +404,10 @@ class ESQuery(object):
         """Performs a minimal query to get the count of matching documents"""
         return self.size(0).run().total
 
+    def get_ids(self):
+        """Performs a minimal query to get the ids of the matching documents"""
+        return self.exclude_source().run().doc_ids
+
 
 class ESQuerySet(object):
     """

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -18,10 +18,9 @@ of all unknown users, web users, and demo users on a domain.
     query = (user_es.UserES()
              .domain(self.domain)
              .OR(*user_filters)
-             .show_inactive()
-             .fields([]))
+             .show_inactive())
 
-    owner_ids = query.run().doc_ids
+    owner_ids = query.get_ids()
 """
 from copy import deepcopy
 from .es_query import HQESQuery

--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -401,7 +401,7 @@ def get_total_clients_data(domains, datespan, interval, datefield='opened_on'):
             .domain(domains)
             .filter({"ids": {"values": cases}})
             .opened_range(lt=datespan.startdate)
-            .size(0)).run().total
+            .count())
 
     return format_return_data(histo_data, cases_before_date, datespan)
 
@@ -437,7 +437,7 @@ def get_mobile_workers_data(domains, datespan, interval,
             .mobile_users()
             .show_inactive()
             .created(lt=datespan.startdate)
-            .size(0)).run().total
+            .count())
 
     return format_return_data(histo_data, users_before_date, datespan)
 
@@ -693,11 +693,7 @@ def get_users_all_stats(domains, datespan, interval,
         .run().aggregations.date.as_facet_result()
     )
 
-    users_before_date = len(
-        query
-        .created(lt=datespan.startdate)
-        .run().doc_ids
-    )
+    users_before_date = query.created(lt=datespan.startdate).count()
 
     return format_return_data(histo_data, users_before_date, datespan)
 

--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -155,7 +155,7 @@ def get_mobile_users(domains):
         .show_inactive()
         .mobile_users()
         .domain(domains)
-        .run().doc_ids
+        .get_ids()
     )
 
 
@@ -598,7 +598,7 @@ def get_domain_stats_data(domains, datespan, interval,
 
 def commtrack_form_submissions(domains, datespan, interval,
         datefield='received_on'):
-    mobile_workers = UserES().exclude_source().mobile_users().show_inactive().run().doc_ids
+    mobile_workers = UserES().mobile_users().show_inactive().get_ids()
 
     forms_after_date = (FormES()
             .domain(domains)
@@ -785,7 +785,7 @@ def get_user_ids(user_type_mobile):
         query = query.mobile_users()
     else:
         query = query.web_users()
-    return set(query.run().doc_ids)
+    return set(query.get_ids())
 
 
 def get_submitted_users():

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -359,12 +359,11 @@ class UsersAtLocationForm(MultipleSelectionForm):
     @property
     @memoized
     def users_at_location(self):
-        user_query = (UserES()
-                      .domain(self.domain_object.name)
-                      .mobile_users()
-                      .location(self.location.location_id)
-                      .fields([]))
-        return user_query.run().doc_ids
+        return (UserES()
+                .domain(self.domain_object.name)
+                .mobile_users()
+                .location(self.location.location_id)
+                .get_ids())
 
     def unassign_users(self, users):
         for doc in iter_docs(CommCareUser.get_db(), users):

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -95,12 +95,11 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             (demo, user_es.demo_users()),
         ] if include]
 
-        query = (user_es.UserES()
-                 .domain(self.domain)
-                 .OR(*user_filters)
-                 .show_inactive()
-                 .fields([]))
-        owner_ids = query.run().doc_ids
+        owner_ids = (user_es.UserES()
+                     .domain(self.domain)
+                     .OR(*user_filters)
+                     .show_inactive()
+                     .get_ids())
 
         if commtrack:
             owner_ids.append("commtrack-system")
@@ -144,14 +143,13 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         selected_reporting_group_users = list(set().union(*user_lists))
 
         # Get ids for each sharing group that contains a user from selected_reporting_group_users OR a user that was specifically selected
-        share_group_q = (HQESQuery(index="groups")
-                         .domain(self.domain)
-                         .doc_type("Group")
-                         .term("case_sharing", True)
-                         .term("users", (selected_reporting_group_users +
-                                         selected_user_ids))
-                         .fields([]))
-        sharing_group_ids = share_group_q.run().doc_ids
+        sharing_group_ids = (HQESQuery(index="groups")
+                             .domain(self.domain)
+                             .doc_type("Group")
+                             .term("case_sharing", True)
+                             .term("users", (selected_reporting_group_users +
+                                             selected_user_ids))
+                             .get_ids())
 
         owner_ids = list(set().union(
             special_owner_ids,


### PR DESCRIPTION
Note that many of these instances weren't excluding source, so they were retrieving full documents, then only using the ids.  This is a common enough use-case that it seems like it makes sense to abstract out, particularly to make sure we do it properly.

I also discovered that it looks like we're not actually excluding source when we say we do, so this is a moot point for now, but I'm working on a fix for that too (to be PR'd separately).  For now, just consider this API cleanup.
@emord