### PR TITLE
Debugger for nimbus!

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -1,3 +1,4 @@
+/* globals CodeMirror */
 var Formplayer = {
     Utils: {},
     Const: {},
@@ -421,14 +422,17 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     self.evalXPath = new Formplayer.ViewModels.EvaluateXPath();
     self.isMinimized = ko.observable(true);
     self.instanceXml = ko.observable('');
+    self.formattedQuestionsHtml = ko.observable('');
     self.toggleState = function() {
         self.isMinimized(!self.isMinimized());
     };
+
     $.unsubscribe('debugger.update');
-    $.subscribe('debugger.update', function(e, resp) {
-        if (resp.instanceXml) {
-            self.instanceXml(resp.instanceXml.output);
-        }
+    $.subscribe('debugger.update', function(e) {
+        $.publish('formplayer.' + Formplayer.Const.FORMATTED_QUESTIONS, function(resp) {
+            self.formattedQuestionsHtml(resp.formattedQuestions);
+            self.instanceXml(resp.instanceXml);
+        });
     });
 
     self.instanceXml.subscribe(function(newXml) {
@@ -451,7 +455,7 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     });
 
     // Called afterRender, ensures that the debugger takes the whole screen
-    self.adjustWidth = function(e) {
+    self.adjustWidth = function() {
         var $debug = $('#instance-xml-home'),
             $body = $('body');
 
@@ -569,6 +573,7 @@ Formplayer.Const = {
     DELETE_REPEAT: 'delete-repeat',
     SET_LANG: 'set-lang',
     SUBMIT: 'submit-all',
+    FORMATTED_QUESTIONS: 'formatted_questions',
 
     // Control values. See commcare/javarosa/src/main/java/org/javarosa/core/model/Constants.java
     CONTROL_UNTYPED: -1,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -420,9 +420,35 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
 
     self.evalXPath = new Formplayer.ViewModels.EvaluateXPath();
     self.isMinimized = ko.observable(true);
+    self.instanceXml = ko.observable('');
     self.toggleState = function() {
         self.isMinimized(!self.isMinimized());
     };
+    $.unsubscribe('debugger.update');
+    $.subscribe('debugger.update', function(e, resp) {
+        if (resp.instanceXml) {
+            self.instanceXml(resp.instanceXml.output);
+        }
+    });
+
+    self.instanceXml.subscribe(function(newXml) {
+        var $instanceTab = $('#debugger-xml-instance-tab'),
+            codeMirror;
+
+        codeMirror = CodeMirror(function(el) {
+            $('#xml-viewer-pretty').html(el);
+        }, {
+            value: newXml,
+            mode: 'xml',
+            viewportMargin: Infinity,
+            readOnly: true,
+            lineNumbers: true,
+        });
+        $instanceTab.off();
+        $instanceTab.on('shown.bs.tab', function() {
+            codeMirror.refresh();
+        });
+    });
 
     // Called afterRender, ensures that the debugger takes the whole screen
     self.adjustWidth = function(e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -471,11 +471,11 @@ Formplayer.ViewModels.EvaluateXPath = function() {
     self.evaluate = function(form) {
         var callback = function(result, status) {
             self.result(result);
-            self.success(status === "success");
+            self.success(status === "accepted");
         };
         $.publish('formplayer.' + Formplayer.Const.EVALUATE_XPATH, [self.xpath(), callback]);
     };
-}
+};
 
 /**
  * Used to compare if questions are equal to each other by looking at their index

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
@@ -1,3 +1,6 @@
+/* globals Formplayer, TaskQueue, WebFormSession */
+/* eslint-env mocha */
+
 describe('WebForm', function() {
 
     describe('TaskQueue', function() {
@@ -98,6 +101,19 @@ describe('WebForm', function() {
             $.unsubscribe();
         });
 
+        it('Should determine whether to update debugger', function() {
+            var sess = new WebFormSession(params);
+
+            sess.debuggerEnabled = false;
+            assert.isFalse(sess.shouldUpdateDebugger(Formplayer.Const.ANSWER));
+
+            sess.debuggerEnabled = true;
+            assert.isTrue(sess.shouldUpdateDebugger(Formplayer.Const.ANSWER));
+
+            sess.debuggerEnabled = true;
+            assert.isFalse(sess.shouldUpdateDebugger('bogus-action'));
+        });
+
         it('Should queue requests', function() {
             var sess = new WebFormSession(params);
             sess.serverRequest({}, sinon.spy(), false);
@@ -165,7 +181,7 @@ describe('WebForm', function() {
         it('Should handle error in callback', function() {
             var sess = new WebFormSession(params);
 
-            sess.handleSuccess({}, sinon.stub().throws());
+            sess.handleSuccess({}, 'action', sinon.stub().throws());
 
             assert.isTrue(sess.onerror.calledOnce);
         });
@@ -174,7 +190,7 @@ describe('WebForm', function() {
             var sess = new WebFormSession(params),
                 cb = sinon.stub();
 
-            sess.handleSuccess({ status: 'error' }, cb);
+            sess.handleSuccess({ status: 'error' }, 'action', cb);
 
             assert.isTrue(sess.onerror.calledOnce);
             assert.isFalse(cb.calledOnce);
@@ -189,7 +205,7 @@ describe('WebForm', function() {
 
         it('Should handle timeout error', function() {
             var sess = new WebFormSession(params);
-            sess.handleFailure({}, 'timeout');
+            sess.handleFailure({}, 'action', 'timeout');
 
             assert.isTrue(sess.onerror.calledOnce);
             assert.isTrue(sess.onerror.calledWith({

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -183,31 +183,6 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
     }
 };
 
-WebFormSession.prototype.displayInstanceXml = function(resp) {
-    var $instanceTab = $('#debugger-xml-instance-tab'),
-        self = this,
-        codeMirror;
-
-    if (!self.debuggerEnabled || !resp.instanceXml || !resp.instanceXml.output) {
-        return;
-    }
-
-    codeMirror = CodeMirror(function(el) {
-        $('#xml-viewer-pretty').html(el);
-    }, {
-        value: resp.instanceXml.output,
-        mode: 'xml',
-        viewportMargin: Infinity,
-        readOnly: true,
-        lineNumbers: true,
-    });
-
-    $instanceTab.off();
-    $instanceTab.on('shown.bs.tab', function() {
-        codeMirror.refresh();
-    });
-};
-
 /*
  * Handles a successful request to touchforms.
  * @param {Object} response - touchforms response object
@@ -226,7 +201,9 @@ WebFormSession.prototype.handleSuccess = function(resp, callback) {
 
         try {
             callback(resp);
-            self.displayInstanceXml(resp);
+            if (self.debuggerEnabled) {
+                $.publish('debugger.update', resp);
+            }
         } catch (err) {
             console.error(err);
             self.onerror({message: Formplayer.Utils.touchformsError(err)});
@@ -493,5 +470,7 @@ WebFormSession.prototype.renderFormXml = function (resp, $form) {
     var self = this;
     self.session_id = self.session_id || resp.session_id;
     self.form = Formplayer.Utils.initialRender(resp, self.resourceMap, $form);
-    self.displayInstanceXml(resp);
+    if (self.debuggerEnabled) {
+        $.publish('debugger.update', resp);
+    }
 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -202,7 +202,7 @@ WebFormSession.prototype.handleSuccess = function(resp, action, callback) {
         try {
             callback(resp);
             if (self.shouldUpdateDebugger(action)) {
-                $.publish('debugger.update', resp);
+                $.publish('debugger.update');
             }
         } catch (err) {
             console.error(err);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -201,7 +201,7 @@ WebFormSession.prototype.handleSuccess = function(resp, action, callback) {
 
         try {
             callback(resp);
-            if (self.debuggerEnabled) {
+            if (self.shouldUpdateDebugger(action)) {
                 $.publish('debugger.update', resp);
             }
         } catch (err) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -383,7 +383,6 @@ WebFormSession.prototype.getFormattedQuestions = function(callback) {
         function(resp) {
             callback(resp);
         });
-
 };
 
 WebFormSession.prototype.newRepeat = function(repeat) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -1,4 +1,4 @@
-/*global CodeMirror, Formplayer */
+/*global Formplayer */
 
 // IE compliance
 if (!Array.prototype.indexOf) {
@@ -378,11 +378,11 @@ WebFormSession.prototype.evaluateXPath = function(xpath, callback) {
 
 WebFormSession.prototype.getFormattedQuestions = function(callback) {
     this.serverRequest({
-            'action': Formplayer.Const.FORMATTED_QUESTIONS,
-        },
-        function(resp) {
-            callback(resp);
-        });
+        'action': Formplayer.Const.FORMATTED_QUESTIONS,
+    },
+    function(resp) {
+        callback(resp);
+    });
 };
 
 WebFormSession.prototype.newRepeat = function(repeat) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -84,6 +84,7 @@ FormplayerFrontend.reqres.setHandler('currentUser', function () {
 FormplayerFrontend.on('clearForm', function () {
     $('#webforms').html("");
     $('#webforms-nav').html("");
+    $('#cloudcare-debugger').html("");
 });
 
 FormplayerFrontend.reqres.setHandler('clearMenu', function () {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -153,7 +153,7 @@
                 <!-- tab content -->
                 <div class="tab-content debugger-content">
                     <div role="tabpanel" class="tab-pane active" id="debugger-form-data">
-                        <div id="question-viewer-pretty">{% trans "Answer a question to show data" %}</div>
+                        <div data-bind="html: formattedQuestionsHtml" id="question-viewer-pretty"></div>
                     </div>
                     <div role="tabpanel" class="tab-pane" id="debugger-xml-instance">
                         <div id="xml-viewer-pretty">{% trans "Answer a question to show data" %}</div>

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -376,4 +376,3 @@ class ReadableQuestionsAPITest(TestCase):
             )
         self.assertEqual(result.status_code, 200)
         self.assertIn('form_data', json.loads(result.content))
-

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -1,3 +1,4 @@
+from mock import patch
 import json
 import uuid
 
@@ -13,6 +14,7 @@ from corehq import toggles
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
+from corehq.apps.cloudcare.views import ReadableQuestions
 from corehq.apps.cloudcare.api import get_filtered_cases, CaseAPIResult, CASE_STATUS_OPEN, CASE_STATUS_ALL,\
     CASE_STATUS_CLOSED
 
@@ -329,3 +331,49 @@ def _create_case(user, type, close=False, **extras):
     case = CaseAccessors(TEST_DOMAIN).get_case(case_id)
     assert case.closed == close
     return case
+
+
+class ReadableQuestionsAPITest(TestCase):
+    """
+    Tests some of the Case API functions
+    """
+    domain = TEST_DOMAIN
+
+    @classmethod
+    def setUpClass(cls):
+        super(ReadableQuestionsAPITest, cls).setUpClass()
+        cls.project = create_domain(cls.domain)
+        cls.password = "****"
+        cls.username = format_username('reed', cls.domain)
+
+        cls.user = CommCareUser.create(
+            cls.domain,
+            cls.username,
+            cls.password
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super(ReadableQuestionsAPITest, cls).tearDownClass()
+        cls.user.delete()
+        cls.project.delete()
+
+    def test_readable_questions(self):
+        instanceXml = '''
+        <data>
+          <question1>ddd</question1>
+        </data>
+        '''
+        self.client.login(username=self.username, password=self.password)
+        with patch('corehq.apps.cloudcare.views.readable.get_questions', lambda x, y, z: []):
+            result = self.client.post(
+                reverse(ReadableQuestions.urlname, args=[self.domain]),
+                {
+                    'app_id': '123',
+                    'xmlns': 'abc',
+                    'instanceXml': instanceXml,
+                }
+            )
+        self.assertEqual(result.status_code, 200)
+        self.assertIn('form_data', json.loads(result.content))
+

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import patterns, url, include
 from corehq.apps.cloudcare.views import (
     EditCloudcareUserPermissionsView,
     CloudcareMain,
+    ReadableQuestions,
     form_context, get_cases, filter_cases, get_apps_api, get_app_api,
     get_fixtures, get_sessions, get_session_context, get_ledgers, render_form,
     sync_db_api, default,
@@ -29,6 +30,7 @@ api_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^sessions/(?P<session_id>[\w-]*)/$', get_session_context, name='cloudcare_get_session_context'),
     url(r'^ledgers/$', get_ledgers, name='cloudcare_get_ledgers'),
     url(r'^render_form/$', render_form, name='cloudcare_render_form'),
+    url(r'^readable_questions/$', ReadableQuestions.as_view(), name=ReadableQuestions.urlname),
     url(r'^sync_db/$', sync_db_api, name='cloudcare_sync_db'),
 )
 


### PR DESCRIPTION
@czue @wpride after many times of looking at this code and then just putting it off, this finally enables debugger for nimbus (and still supports old cloudcare debugger). it also clears the debugger when you leave the form. it requires this:  https://github.com/dimagi/formplayer/pull/167

the only "clean" way of doing this was to use the existing adapter and just route that call to HQ from formplayer instead of hitting HQ directly

cc: @NoahCarnahan 