### PR TITLE
Preview and single app modes

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -250,7 +250,7 @@
             };
 
             {% if request|toggle_enabled:"USE_FORMPLAYER_FRONTEND"%}
-                var cloudCareUrl = getFormplayerUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}");
+                var cloudCareUrl = getFormplayerUrl("{% url "formplayer_main" domain %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}");
             {% else %}
                 var cloudCareUrl = getCloudCareUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
             {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -250,7 +250,7 @@
             };
 
             {% if request|toggle_enabled:"USE_FORMPLAYER_FRONTEND"%}
-                var cloudCareUrl = getFormplayerUrl("{% url "formplayer_main" domain %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}");
+            var cloudCareUrl = getFormplayerUrl("{% url "formplayer_single_app" domain app.id %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}");
             {% else %}
                 var cloudCareUrl = getCloudCareUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
             {% endif %}

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -181,6 +181,7 @@ FormplayerFrontend.on("start", function (options) {
         FormplayerFrontend.Constants.ALLOWED_SAVED_OPTIONS
     );
     user.displayOptions = _.defaults(savedDisplayOptions, {
+        singleAppMode: options.singleAppMode,
         phoneMode: options.phoneMode,
         oneQuestionPerScreen: options.oneQuestionPerScreen,
     });
@@ -201,9 +202,8 @@ FormplayerFrontend.on("start", function (options) {
         }
         // will be the same for every domain. TODO: get domain/username/pass from django
         if (this.getCurrentRoute() === "") {
-            if (options.phoneMode) {
+            if (user.displayOptions.singleAppMode) {
                 appId = options.apps[0]['_id'];
-                user.previewAppId = appId;
 
                 FormplayerFrontend.trigger('setAppDisplayProperties', options.apps[0]);
                 FormplayerFrontend.trigger("app:singleApp", appId);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -419,7 +419,7 @@ FormplayerFrontend.on('navigateHome', function() {
         currentUser = FormplayerFrontend.request('currentUser');
     urlObject.clearExceptApp();
     FormplayerFrontend.regions.breadcrumb.empty();
-    if (currentUser.displayOptions.phoneMode) {
+    if (currentUser.displayOptions.singleAppMode) {
         appId = FormplayerFrontend.request('getCurrentAppId');
         FormplayerFrontend.navigate("/single_app/" + appId, { trigger: true });
     } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -193,6 +193,12 @@ FormplayerFrontend.on("start", function (options) {
                 model: user,
             })
         );
+        if (user.displayOptions.phoneMode) {
+            FormplayerFrontend.regions.phoneModeNavigation.show(
+                new FormplayerFrontend.Layout.Views.PhoneNavigation({ appId: appId })
+            );
+            FormplayerFrontend.trigger('phone:back:hide');
+        }
         // will be the same for every domain. TODO: get domain/username/pass from django
         if (this.getCurrentRoute() === "") {
             if (options.phoneMode) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -23,11 +23,7 @@ FormplayerFrontend.module("Apps", function(Apps, FormplayerFrontend, Backbone, M
             var singleAppView = new Apps.Views.SingleAppView({
                 appId: appId,
             });
-            FormplayerFrontend.regions.phoneModeNavigation.show(
-                new FormplayerFrontend.Layout.Views.PhoneNavigation({ appId: appId })
-            );
             FormplayerFrontend.regions.main.show(singleAppView);
-            FormplayerFrontend.trigger('phone:back:hide');
         },
         listSettings: function() {
             var settingsView = new FormplayerFrontend.Layout.Views.SettingsView();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -344,6 +344,12 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
         template: "#breadcrumb-list-template",
         childView: Views.BreadcrumbView,
         childViewContainer: "ol",
+        events: {
+            'click .js-home': 'onClickHome',
+        },
+        onClickHome: function() {
+            FormplayerFrontend.trigger('navigateHome');
+        },
     });
 
     Views.DetailView = Marionette.ItemView.extend({

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -23,7 +23,9 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
             FormplayerFrontend.Apps.Controller.listApps();
         },
         singleApp: function(appId) {
+            var user = FormplayerFrontend.request('currentUser');
             FormplayerFrontend.regions.breadcrumb.empty();
+            user.previewAppId = appId;
             FormplayerFrontend.Apps.Controller.singleApp(appId);
         },
         selectApp: function (appId) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
@@ -45,6 +45,7 @@ describe('FormplayerFrontend Integration', function() {
 
             assert.deepEqual(user.displayOptions, {
                 phoneMode: undefined, // we don't store this option
+                singleAppMode: undefined,
                 oneQuestionPerScreen: true,
             });
         });

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -93,13 +93,14 @@
             instanceViewerEnabled = true;
         {% endif %}
         var options = {
-            "apps": apps,
-            "language": language,
-            "username": username,
-            "domain": domain,
-            "formplayer_url": formplayer_url,
-            "gridPolyfillPath": "{% static 'css-grid-polyfill-binaries/css-polyfills.js' %}",
-            "debuggerEnabled": instanceViewerEnabled,
+            apps: apps,
+            language: language,
+            username: username,
+            domain: domain,
+            formplayer_url: formplayer_url,
+            gridPolyfillPath: "{% static 'css-grid-polyfill-binaries/css-polyfills.js' %}",
+            debuggerEnabled: instanceViewerEnabled,
+            singleAppMode: {{ single_app_mode|JSON }},
         };
         FormplayerFrontend.start(options);
         $(function () {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -24,7 +24,7 @@
 {% block navigation %}{{ block.super }}
   <div class="navbar navbar-inverse navbar-cloudcare navbar-static-top">
     <div class="container-fluid">
-      <a class="navbar-brand" href="{% url 'cloudcare_default' domain %}"><i class="fcc fcc-flower"></i> Web Apps</a>
+      <a class="navbar-brand" href="{{ home_url }}"><i class="fcc fcc-flower"></i> Web Apps</a>
       <ul class="nav navbar-nav navbar-right" >
         <li><a href="#" id="commcare-menu-toggle">{% trans 'Show Full Menu' %}</a></li>
       </ul>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -140,6 +140,7 @@
         <section id="case-crumbs" style="width: 800px"></section>
         <section id="cases"></section>
         <div id="menu-container">
+            <div id="phone-mode-navigation"></div>
             <section id="formplayer-progress-container"></section>
             <div id="restore-as-region"></div>
             <div id="breadcrumb-region"></div>
@@ -170,5 +171,6 @@
     {% include 'formplayer/query_view.html' %}
     {% include 'formplayer/confirmation_modal.html' %}
     {% include 'formplayer/progress.html' %}
+    {% include 'formplayer/navigation.html' %}
 
 {% endblock %}

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -19,6 +19,7 @@
     {% include "formplayer/case_list.html" %}
 
     <div id="restore-as-region"></div>
+    <div id="phone-mode-navigation"></div>
     <div id="breadcrumb-region"></div>
     <div id="persistent-case-tile" class="container"></div>
     <div id="menu-region" class="container"></div>
@@ -34,5 +35,6 @@
     {% include 'formplayer/query_view.html' %}
     {% include 'formplayer/confirmation_modal.html' %}
     {% include 'formplayer/progress.html' %}
+    {% include 'formplayer/navigation.html' %}
 
 {% endblock %}

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -45,7 +45,7 @@
 <script id="single-app-template" type="text/template">
   <div class="container container-appicons">
     <div class="row">
-        <div class="grid-item col-xs-6 col-sm-4 formplayer-request">
+        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-start-app appicon appicon-start">
             <i class="ff ff-start-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
             <i class="ff ff-start-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
@@ -65,7 +65,7 @@
           </div>
         </div>
         <% } %>
-        <div class="grid-item col-xs-6 col-sm-4 formplayer-request">
+        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-sync-item appicon appicon-sync">
             <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
             <div class="appicon-title">
@@ -74,7 +74,7 @@
           </div>
         </div>
         {% if request|toggle_enabled:'RESTORE_AS_CLOUDCARE' %}
-        <div class="grid-item col-xs-6 col-sm-4 formplayer-request">
+        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-restore-as-item appicon appicon-restore-as">
             <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
             <div class="appicon-title">
@@ -83,7 +83,7 @@
           </div>
         </div>
         {% endif %}
-        <div class="grid-item col-xs-6 col-sm-4 formplayer-request">
+        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-settings appicon appicon-settings">
             <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
             <div class="appicon-title">

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -44,6 +44,9 @@
 
 <script id="single-app-template" type="text/template">
   <div class="container container-appicons">
+    <div class="page-header page-header-apps">
+      <h1 class="page-title">{% trans "Application" %}</h1>
+    </div>
     <div class="row">
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-start-app appicon appicon-start">

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -58,5 +58,7 @@
 </script>
 
 <script type="text/template" id="breadcrumb-list-template">
-    <ol class="breadcrumb"></ol>
+    <ol class="breadcrumb">
+      <li class="js-home breadcrumb-text"><i class="fa fa-home"></i></li>
+    </ol>
 </script>

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -4,6 +4,7 @@ from corehq.apps.cloudcare.views import (
     EditCloudcareUserPermissionsView,
     CloudcareMain,
     ReadableQuestions,
+    FormplayerMain,
     form_context, get_cases, filter_cases, get_apps_api, get_app_api,
     get_fixtures, get_sessions, get_session_context, get_ledgers, render_form,
     sync_db_api, default,
@@ -12,6 +13,7 @@ from corehq.apps.cloudcare.views import (
 app_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^view/(?P<app_id>[\w-]+)/modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/context/$',
         form_context, name='cloudcare_form_context'),
+    url(r'^v2/$', FormplayerMain.as_view(), name=FormplayerMain.urlname),
     url(r'^(?P<urlPath>.*)$', CloudcareMain.as_view(), name='cloudcare_main'),
 )
 

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -5,6 +5,7 @@ from corehq.apps.cloudcare.views import (
     CloudcareMain,
     ReadableQuestions,
     FormplayerMain,
+    FormplayerMainPreview,
     form_context, get_cases, filter_cases, get_apps_api, get_app_api,
     get_fixtures, get_sessions, get_session_context, get_ledgers, render_form,
     sync_db_api, default,
@@ -14,6 +15,7 @@ app_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^view/(?P<app_id>[\w-]+)/modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/context/$',
         form_context, name='cloudcare_form_context'),
     url(r'^v2/$', FormplayerMain.as_view(), name=FormplayerMain.urlname),
+    url(r'^v2/preview/$', FormplayerMainPreview.as_view(), name=FormplayerMainPreview.urlname),
     url(r'^(?P<urlPath>.*)$', CloudcareMain.as_view(), name='cloudcare_main'),
 )
 

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -6,6 +6,7 @@ from corehq.apps.cloudcare.views import (
     ReadableQuestions,
     FormplayerMain,
     FormplayerMainPreview,
+    FormplayerPreviewSingleApp,
     form_context, get_cases, filter_cases, get_apps_api, get_app_api,
     get_fixtures, get_sessions, get_session_context, get_ledgers, render_form,
     sync_db_api, default,
@@ -16,6 +17,11 @@ app_urls = patterns('corehq.apps.cloudcare.views',
         form_context, name='cloudcare_form_context'),
     url(r'^v2/$', FormplayerMain.as_view(), name=FormplayerMain.urlname),
     url(r'^v2/preview/$', FormplayerMainPreview.as_view(), name=FormplayerMainPreview.urlname),
+    url(
+        r'^v2/preview/(?P<app_id>[\w-]+)/$',
+        FormplayerPreviewSingleApp.as_view(),
+        name=FormplayerPreviewSingleApp.urlname,
+    ),
     url(r'^(?P<urlPath>.*)$', CloudcareMain.as_view(), name='cloudcare_main'),
 )
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -284,6 +284,7 @@ class FormplayerMain(View):
             "username": request.user.username,
             "formplayer_url": settings.FORMPLAYER_URL,
             "single_app_mode": False,
+            "home_url": reverse(self.urlname, args=[domain]),
         }
         return render(request, "cloudcare/formplayer_home.html", context)
 
@@ -334,6 +335,7 @@ class FormplayerPreviewSingleApp(View):
             "username": request.user.username,
             "formplayer_url": settings.FORMPLAYER_URL,
             "single_app_mode": True,
+            "home_url": reverse(self.urlname, args=[domain, app_id]),
         }
         return render(request, "cloudcare/formplayer_home.html", context)
 

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -181,6 +181,7 @@
                 username: "{{ request.user.username  }}",
                 domain: "{{ request.domain }}",
                 formplayer_url: "{{ formplayer_url }}",
+                singleAppMode: true,
                 phoneMode: true,
                 oneQuestionPerScreen: true,
                 allowedHost: "{{ request.get_host }}",

--- a/corehq/apps/style/static/preview_app/less/preview_app/appicon.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/appicon.less
@@ -29,3 +29,6 @@
   }
 }
 
+.container-appicons .page-header-apps {
+  display: none;
+}

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -665,11 +665,17 @@ class ApplicationsTab(UITab):
 
 
 class CloudcareTab(UITab):
-    view = "corehq.apps.cloudcare.views.default"
-
     url_prefix_formats = ('/a/{domain}/cloudcare/',)
 
     ga_tracker = GaTracker('CloudCare', 'Click Cloud-Care top-level nav')
+
+    @property
+    def view(self):
+        from corehq.apps.cloudcare.views import FormplayerMain
+        if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+            return FormplayerMain.urlname
+        else:
+            return "corehq.apps.cloudcare.views.default"
 
     @property
     def title(self):


### PR DESCRIPTION
@wpride (and @czue you may be interested) this separates out the concerns of the different views of nimbus. before we would conflate phoneMode with singleAppMode. This straightens that all out, pulls formplayer main route into its own view and allows for 2 new views on nimbus.

1. Live Preview - Just the regular phone with the most recent app
2. Regular Nimbus - All apps at either the latest build or latest starred depending on a feature flag
`http://localhost:8000/a/aspace/cloudcare/apps/v2/`
3. [new] Preview Nimbus - All apps at the most current version of the app
`http://localhost:8000/a/aspace/cloudcare/apps/v2/preview/`
4. [new] Single App Preview Nimbus - One app at the most current version
`http://localhost:8000/a/aspace/cloudcare/apps/v2/preview/<app_id>/`
looks like this:
![screen shot 2016-11-03 at 11 33 50 pm](https://cloud.githubusercontent.com/assets/918514/19993701/ffd031ba-a21d-11e6-8c4c-86a230957483.png)

Aaand for a sneak preview at what I'm implementing next, I'm going to take the 4th option Single App Preview Nimbus, and allow people to "pop" out their Live Preview session. This'll make it easier for power users to use live preview in a bigger window. It could look something like this:

<img width="1412" alt="screen shot 2016-11-03 at 11 35 57 pm" src="https://cloud.githubusercontent.com/assets/918514/19993737/506c36e6-a21e-11e6-96fb-ef9b1fef9e5b.png">

(also added a home button to the breadcrumb bar)
🏠 there was a fair bit churn
cc: @NoahCarnahan 