### PR TITLE
data migration flag

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -391,11 +391,11 @@ cls_require_previewer = cls_to_view(additional_decorator=require_previewer)
 
 
 def check_domain_migration(view_func):
-    def decorator(request, domain, *args, **kwargs):
+    def wrapped_view(request, domain, *args, **kwargs):
         if DATA_MIGRATION.enabled(domain):
             return HttpResponse('Service Temporarily Unavailable',
                                 content_type='text/plain', status=503)
-        else:
-            view_func.mobile_request = True
-            return view_func(request, domain, *args, **kwargs)
-    return decorator
+        return view_func(request, domain, *args, **kwargs)
+
+    wrapped_view.domain_migration_handled = True
+    return wraps(view_func)(wrapped_view)

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -396,5 +396,5 @@ def check_domain_migration(view_func):
             return HttpResponse('Service Temporarily Unavailable',
                                 content_type='text/plain', status=503)
         else:
-            return view_func(request, *args, **kwargs)
+            return view_func(request, domain, *args, **kwargs)
     return decorator

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -396,5 +396,6 @@ def check_domain_migration(view_func):
             return HttpResponse('Service Temporarily Unavailable',
                                 content_type='text/plain', status=503)
         else:
+            view_func.mobile_request = True
             return view_func(request, domain, *args, **kwargs)
     return decorator

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -1,9 +1,12 @@
 # Use modern Python
 from __future__ import unicode_literals, print_function, absolute_import
 
+from django.template.response import TemplateResponse
+
 # External imports
 from corehq.apps.accounting.exceptions import AccountingError
 from corehq.apps.accounting.models import Subscription
+from corehq.toggles import DATA_MIGRATION
 from django_prbac.models import Role
 
 
@@ -55,3 +58,21 @@ class DomainHistoryMiddleware(object):
         last_visited_domain = request.session.get('last_visited_domain')
         if last_visited_domain != request.domain:
             request.session['last_visited_domain'] = request.domain
+
+
+class DomainMigrationMiddleware(object):
+    """
+    Redirects web requests to a page explaining a data migration is occurring
+    """
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if hasattr(request, 'domain') and hasattr(request, 'couch_user'):
+            if getattr(view_func, 'mobile_request', False):
+                return None
+            if DATA_MIGRATION.enabled(request.domain):
+                return TemplateResponse(
+                    request=request,
+                    template='domain/data_migration_in_progress.html',
+                    status=503,
+                )
+        return None

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -67,7 +67,7 @@ class DomainMigrationMiddleware(object):
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if hasattr(request, 'domain') and hasattr(request, 'couch_user'):
-            if getattr(view_func, 'mobile_request', False):
+            if getattr(view_func, 'domain_migration_handled', False):
                 return None
             if DATA_MIGRATION.enabled(request.domain):
                 return TemplateResponse(

--- a/corehq/apps/domain/templates/domain/data_migration_in_progress.html
+++ b/corehq/apps/domain/templates/domain/data_migration_in_progress.html
@@ -1,0 +1,10 @@
+{% extends "style/base_page.html" %}
+{% load i18n future %}
+
+{% block page_content %}
+  <h1>{% block title %}{% trans "Domain Temporarily Unavailable" %}{% endblock %}</h1>
+
+  <p>{% blocktrans %}The page you requested is currently unavailable due to a
+  data migration. Please check back later.{% endblocktrans %}</p>
+
+{% endblock %}

--- a/corehq/apps/ota/tests/test_digest_restore.py
+++ b/corehq/apps/ota/tests/test_digest_restore.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from corehq.apps.domain.tests.test_utils import delete_all_domains
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.util.test_utils import flag_enabled
 
 
 class DigestOtaRestoreTest(TestCase):
@@ -48,6 +49,12 @@ class DigestOtaRestoreTest(TestCase):
         uri, client = self._set_restore_client(self.wrong_domain, self.web_user.username)
         resp = client.get(uri, follow=True)
         self.assertEqual(resp.status_code, 401)
+
+    @flag_enabled('DATA_MIGRATION')
+    def test_web_user_restore_during_migration(self):
+        uri, client = self._set_restore_client(self.domain, self.web_user.username)
+        resp = client.get(uri, follow=True)
+        self.assertEqual(resp.status_code, 503)
 
     def _set_restore_client(self, with_domain, auth_username):
         uri = reverse('ota_restore', args=[with_domain])

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -15,7 +15,9 @@ from corehq.const import OPENROSA_VERSION_MAP, OPENROSA_DEFAULT_VERSION
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.case_search.models import CaseSearchConfig
-from corehq.apps.domain.decorators import domain_admin_required, login_or_digest_or_basic_or_apikey
+from corehq.apps.domain.decorators import (
+    domain_admin_required, login_or_digest_or_basic_or_apikey, check_domain_migration
+)
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import DomainViewMixin, EditMyProjectSettingsView
 from corehq.apps.es.case_search import CaseSearchES, flatten_result
@@ -38,6 +40,7 @@ from .utils import demo_user_restore_response, get_restore_user, is_permitted_to
 @json_error
 @handle_401_response
 @login_or_digest_or_basic_or_apikey()
+@check_domain_migration
 def restore(request, domain, app_id=None):
     """
     We override restore because we have to supply our own
@@ -51,6 +54,7 @@ def restore(request, domain, app_id=None):
 
 @json_error
 @login_or_digest_or_basic_or_apikey()
+@check_domain_migration
 def search(request, domain):
     """
     Accepts search criteria as GET params, e.g. "https://www.commcarehq.org/a/domain/phone/search/?a=b&c=d"
@@ -99,6 +103,7 @@ def search(request, domain):
 @require_POST
 @json_error
 @login_or_digest_or_basic_or_apikey()
+@check_domain_migration
 def claim(request, domain):
     """
     Allows a user to claim a case that they don't own.

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -8,6 +8,7 @@ import os
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.util.test_utils import flag_enabled
 from dimagi.utils.post import tmpfile
 from couchforms.signals import successful_form_received
 
@@ -122,3 +123,11 @@ class SubmissionErrorTest(TestCase):
         self.assertIn(message, log.problem)
         with open(file) as f:
             self.assertEqual(f.read(), log.get_xml())
+
+    @run_with_all_backends
+    @flag_enabled('DATA_MIGRATION')
+    def test_data_migration(self):
+        file, res = self._submit('simple_form.xml')
+        self.assertEqual(503, res.status_code)
+        message = "Service Temporarily Unavailable"
+        self.assertIn(message, res.content)

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -6,7 +6,9 @@ from django.http import (
     HttpResponseForbidden,
 )
 from casexml.apps.case.xform import get_case_updates, is_device_report
-from corehq.apps.domain.decorators import login_or_digest_ex, login_or_basic_ex
+from corehq.apps.domain.decorators import (
+    check_domain_migration, login_or_digest_ex, login_or_basic_ex
+)
 from corehq.apps.receiverwrapper.auth import (
     AuthContext,
     WaivedAuthContext,
@@ -104,6 +106,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
 
 @csrf_exempt
 @require_POST
+@check_domain_migration
 def post(request, domain, app_id=None):
     try:
         if domain_requires_auth(domain):
@@ -215,6 +218,7 @@ def _secure_post_basic(request, domain, app_id=None):
 
 @csrf_exempt
 @require_POST
+@check_domain_migration
 def secure_post(request, domain, app_id=None):
     authtype_map = {
         'digest': _secure_post_digest,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -948,3 +948,10 @@ RESTORE_AS_CLOUDCARE = StaticToggle(
     TAG_PRODUCT_PATH,
     [NAMESPACE_USER, NAMESPACE_DOMAIN],
 )
+
+DATA_MIGRATION = StaticToggle(
+    'data_migration',
+    'Disable submissions and restores during a data migration',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN]
+)

--- a/settings.py
+++ b/settings.py
@@ -152,6 +152,7 @@ MIDDLEWARE_CLASSES = [
     'corehq.middleware.OpenRosaMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
+    'corehq.apps.domain.middleware.DomainMigrationMiddleware',
     'corehq.middleware.TimeoutMiddleware',
     'corehq.apps.domain.middleware.CCHQPRBACMiddleware',
     'corehq.apps.domain.middleware.DomainHistoryMiddleware',


### PR DESCRIPTION
@snopoke 

This sets the migration flag for a domain. Returns with 503 for mobile requests to restore, submission, search and claim. Everything displays a page that explains a data migration is in progress.

Tried to model this off of csrf:

https://docs.djangoproject.com/en/1.10/_modules/django/middleware/csrf/#CsrfViewMiddleware
https://docs.djangoproject.com/en/1.8/_modules/django/views/decorators/csrf/#csrf_exempt

buddy @esoergel 