### PR TITLE
represent blank dimagi_contact in one way

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -336,8 +336,6 @@ class AccountFilterAsyncHandler(BaseSingleOptionFilterAsyncHandler):
 
         if self.action == 'dimagi_contact':
             query = query.exclude(
-                dimagi_contact=None
-            ).exclude(
                 dimagi_contact=''
             ).order_by('dimagi_contact')
             if self.search_string:

--- a/corehq/apps/accounting/migrations/0045_dimagi_contact_email_field.py
+++ b/corehq/apps/accounting/migrations/0045_dimagi_contact_email_field.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0044_subscription_skip_auto_downgrade'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='billingaccount',
+            name='auto_pay_user',
+            field=models.CharField(max_length=80, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='billingaccount',
+            name='dimagi_contact',
+            field=models.EmailField(default='', max_length=254, blank=True),
+            preserve_default=False,
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -320,7 +320,7 @@ class Currency(models.Model):
 
 DEFAULT_ACCOUNT_FORMAT = 'Account for Project %s'
 
-class BillingAccount(models.Model):
+class BillingAccount(ValidateModelMixin, models.Model):
     """
     The key model that links a Subscription to its financial source and methods of payment.
     """
@@ -335,7 +335,7 @@ class BillingAccount(models.Model):
     created_by = models.CharField(max_length=80)
     created_by_domain = models.CharField(max_length=256, null=True, blank=True)
     date_created = models.DateTimeField(auto_now_add=True)
-    dimagi_contact = models.CharField(max_length=80, null=True, blank=True)
+    dimagi_contact = models.EmailField(blank=True)
     currency = models.ForeignKey(Currency, on_delete=models.PROTECT)
     is_auto_invoiceable = models.BooleanField(default=False)
     date_confirmed_extra_charges = models.DateTimeField(null=True, blank=True)
@@ -350,7 +350,7 @@ class BillingAccount(models.Model):
         default=EntryPoint.NOT_SET,
         choices=EntryPoint.CHOICES,
     )
-    auto_pay_user = models.CharField(max_length=80, null=True)
+    auto_pay_user = models.CharField(max_length=80, null=True, blank=True)
     last_modified = models.DateTimeField(auto_now=True)
     last_payment_method = models.CharField(
         max_length=25,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -320,6 +320,7 @@ class Currency(models.Model):
 
 DEFAULT_ACCOUNT_FORMAT = 'Account for Project %s'
 
+
 class BillingAccount(ValidateModelMixin, models.Model):
     """
     The key model that links a Subscription to its financial source and methods of payment.

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -339,7 +339,7 @@ def send_subscription_reminder_emails_dimagi_contact(num_days):
                             .filter(is_active=True)
                             .filter(date_end=date_in_n_days)
                             .filter(do_not_email_reminder=False)
-                            .filter(account__dimagi_contact__isnull=False))
+                            .exclude(account__dimagi_contact=''))
     for subscription in ending_subscriptions:
         # only send reminder emails if the subscription isn't renewed
         if not subscription.is_renewed:
@@ -468,8 +468,10 @@ def weekly_digest():
             date_end__gte=today,
             is_active=True,
             is_trial=False,
-            account__dimagi_contact__isnull=True,
-        ))
+        ).exclude(
+            account__dimagi_contact='',
+        )
+    )
 
     if not ending_in_forty_days:
         log_accounting_info(

--- a/corehq/apps/accounting/tests/test_model_validation.py
+++ b/corehq/apps/accounting/tests/test_model_validation.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from django.core.exceptions import ValidationError
-from django.test import TransactionTestCase
 
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -27,6 +26,8 @@ class TestCreditAdjustmentValidation(BaseAccountingTest):
 
     def test_clean(self):
         account = BillingAccount.objects.create(
+            name='Test Account',
+            created_by='test@example.com',
             currency=generator.init_default_currency(),
         )
         subscription = Subscription.objects.create(


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240619

Resolve inconsistency between ```None``` and ```''``` for blank ```dimagi_contact``` according to django's convention: https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.Field.null