### PR TITLE
don't process queues and periodic tasks during data migration

### DIFF
--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -11,6 +11,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 
 from corehq.apps.data_interfaces.utils import add_cases_to_case_group, archive_forms_old, archive_or_restore_forms
+from corehq.toggles import DATA_MIGRATION
 from .interfaces import FormManagementMode, BulkFormManagementInterface
 from .dispatcher import EditDataInterfaceDispatcher
 from dimagi.utils.django.email import send_HTML_email
@@ -91,7 +92,8 @@ def run_case_update_rules(now=None):
                .distinct()
                .order_by('domain'))
     for domain in domains:
-        run_case_update_rules_for_domain.delay(domain, now)
+        if not DATA_MIGRATION.enabled(domain):
+            run_case_update_rules_for_domain.delay(domain, now)
 
 
 @task(queue='background_queue', acks_late=True, ignore_result=True)

--- a/corehq/apps/reminders/management/commands/run_reminder_queue.py
+++ b/corehq/apps/reminders/management/commands/run_reminder_queue.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+
+from corehq.toggles import DATA_MIGRATION
 from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.reminders.models import CaseReminder
 from corehq.apps.reminders.tasks import fire_reminder
@@ -33,6 +35,8 @@ class ReminderEnqueuingOperation(GenericEnqueuingOperation):
 
     def enqueue_item(self, _id):
         domain = get_reminder_domain(_id)
+        if DATA_MIGRATION.enabled(domain):
+            return
         fire_reminder.delay(_id, domain)
 
     def enqueue_directly(self, reminder):

--- a/corehq/apps/sms/management/commands/run_sms_queue.py
+++ b/corehq/apps/sms/management/commands/run_sms_queue.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+
+from corehq.toggles import DATA_MIGRATION
 from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.sms.models import QueuedSMS
 from corehq.apps.sms.tasks import process_sms
@@ -17,6 +19,8 @@ class SMSEnqueuingOperation(GenericEnqueuingOperation):
 
     def get_items_to_be_processed(self, utcnow):
         for sms in QueuedSMS.get_queued_sms():
+            if DATA_MIGRATION.enabled(sms.domain):
+                continue
             yield {
                 'id': sms.pk,
                 'key': json_format_datetime(sms.datetime_to_process),


### PR DESCRIPTION
I think this should be sufficient for the data migration. All other celery tasks / background jobs are only executed when data is changed and since we're making the domain 'read only' there shouldn't be any data changes.
@gcapalbo 