### PR TITLE
Fix Stock Rates page

### DIFF
--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -10,6 +10,7 @@ from casexml.apps.stock.models import StockTransaction
 from corehq.apps.commtrack.const import SUPPLY_POINT_CASE_TYPE
 from corehq.apps.commtrack.processing import plan_rebuild_stock_state, \
     rebuild_stock_state
+from corehq import toggles
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.exceptions import XFormNotFound
@@ -249,6 +250,10 @@ class StockLevelsView(BaseCommTrackManageView):
     urlname = 'stock_levels'
     page_title = ugettext_noop("Stock Levels")
     template_name = 'commtrack/manage/stock_levels.html'
+
+    @method_decorator(toggles.LOCATION_TYPE_STOCK_RATES.required_decorator())
+    def dispatch(self, *args, **kwargs):
+        return super(StockLevelsView, self).dispatch(*args, **kwargs)
 
     def get_existing_stock_levels(self):
         loc_types = LocationType.objects.by_domain(self.domain)

--- a/corehq/apps/style/templates/style/partials/form_list_form.html
+++ b/corehq/apps/style/templates/style/partials/form_list_form.html
@@ -107,7 +107,7 @@
                     .attr('name', 'child_form_data')
                     .attr('value', JSON.stringify(self.serialize()))
                     .appendTo(tableForm);
-                $("{% csrf_token %}").appendTo($form);
+                $("{% csrf_token %}").appendTo(tableForm);
                 tableForm.appendTo("body");
                 tableForm.submit();
             };

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -323,7 +323,6 @@ class SetupTab(UITab):
 
         if self.project.commtrack_enabled:
             commcare_supply_setup = [
-                # products
                 {
                     'title': ProductListView.page_title,
                     'url': reverse(ProductListView.urlname, args=[self.domain]),
@@ -342,7 +341,6 @@ class SetupTab(UITab):
                         },
                     ]
                 },
-                # programs
                 {
                     'title': ProgramListView.page_title,
                     'url': reverse(ProgramListView.urlname, args=[self.domain]),
@@ -357,27 +355,24 @@ class SetupTab(UITab):
                         },
                     ]
                 },
-                # sms
                 {
                     'title': SMSSettingsView.page_title,
                     'url': reverse(SMSSettingsView.urlname, args=[self.domain]),
                 },
-                # consumption
                 {
                     'title': DefaultConsumptionView.page_title,
                     'url': reverse(DefaultConsumptionView.urlname, args=[self.domain]),
                 },
-                # settings
                 {
                     'title': CommTrackSettingsView.page_title,
                     'url': reverse(CommTrackSettingsView.urlname, args=[self.domain]),
                 },
-                # stock levels
-                {
+            ]
+            if toggles.LOCATION_TYPE_STOCK_RATES.enabled(self.domain):
+                commcare_supply_setup.append({
                     'title': StockLevelsView.page_title,
                     'url': reverse(StockLevelsView.urlname, args=[self.domain]),
-                },
-            ]
+                })
             return [[_('CommCare Supply Setup'), commcare_supply_setup]]
 
 


### PR DESCRIPTION
@orangejenny @emord
http://manage.dimagi.com/default.asp?240981

Fix adding csrf token to page and protect the Stock Rates page from being accessed when the feature flag isn't enabled

It doesn't work (intentionally) unless the flag is enabled.  I think this is just an oversight that no one has noticed in two years...
This was written as a one-off for ewsghana with the intention that we may roll it in to product in the future.