### PR TITLE
404 if trying to download a jad/jar when unsupported

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -271,6 +271,8 @@ def download_file(request, domain, app_id, path):
                 request.app.save()
                 return download_file(request, domain, app_id, path)
             elif path in ('CommCare.jad', 'CommCare.jar'):
+                if not request.app.build_spec.supports_j2me():
+                    raise Http404()
                 request.app.create_jadjar_from_build_files(save=True)
                 try:
                     request.app.save(increment_version=False)

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -190,6 +190,9 @@ class BuildSpec(DocumentSchema):
                 return item.label or self.get_label()
         return self.get_label()
 
+    def supports_j2me(self):
+        return self.get_menu_item_label() in CommCareBuildConfig.j2me_enabled_config_labels()
+
     def __str__(self):
         fmt = "{self.version}/"
         fmt += "latest" if self.latest else "{self.build_number}"


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240977

Also should hide the links to the jad/jar when not supported in a build (do later)

@millerdev 