### PR TITLE
always reset reindexer if index doesn't exist

### DIFF
--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -214,6 +214,9 @@ class ResumableBulkElasticPillowReindexer(Reindexer):
         _clean_index(self.es, self.index_info)
 
     def reindex(self):
+        if not self.es.indices.exists(self.index_info.index):
+            self.reset = True  # if the index doesn't exist always reset the processing
+
         processor = BulkDocProcessor(
             self.doc_provider,
             self.doc_processor,


### PR DESCRIPTION
@gcapalbo 

This just makes it easier to reindex if you delete the index.