### PR TITLE
Make sure exclude_source() does exclude source.

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -303,7 +303,9 @@ class ESQuery(object):
         if self._start is not None:
             self.es_query['from'] = self._start
         self.es_query['size'] = self._size if self._size is not None else SIZE_LIMIT
-        if self._source:
+        if self._exclude_source:
+            self.es_query['_source'] = False
+        elif self._source is not None:
             self.es_query['_source'] = self._source
         if self._aggregations:
             self.es_query['aggs'] = {

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -234,3 +234,30 @@ class TestESQuery(ElasticTestMixin, TestCase):
         query = HQESQuery('forms').date_histogram('by_day', 'date', 'day', '-01:00')
         self.checkQuery(query, json_output)
         self.checkQuery(query._clean_before_run(), expected_output)
+
+    def test_exclude_source(self):
+        json_output = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {
+                                "term": {
+                                    "domain.exact": "test-exclude"
+                                }
+                            },
+                            {
+                                "match_all": {}
+                            }
+                        ]
+                    },
+                    "query": {
+                        "match_all": {}
+                    }
+                }
+            },
+            "_source": False,
+            "size": SIZE_LIMIT,
+        }
+        query = HQESQuery('forms').domain('test-exclude').exclude_source()
+        self.checkQuery(query, json_output)


### PR DESCRIPTION
We hadn't been doing this at all.  And somewhat surprisingly, setting fields to [] causes ES to return *all* fields, so that hadn't been working at all either.  I expect this will be a dramatic ES speed up for anything that uses `.get_ids()`
@emord