### PR TITLE
Drop 'Show ' from app summary

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/ng_partials/form_summary_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/ng_partials/form_summary_view.html
@@ -67,19 +67,19 @@
                                 ng-click="showCalculations = !showCalculations"
                                 ng-class="{ 'active' : showCalculations }">
                             <i class="fa fa-calculator" ng-class="showCalculations ? 'hq-icon' : ''"></i>
-                            &nbsp;{% trans "Show Calculations" %}
+                            &nbsp;{% trans "Calculations" %}
                         </button>
                         <button type="button" class="btn btn-default"
                                 ng-click="showRelevance = !showRelevance"
                                 ng-class="{ 'active' : showRelevance }">
                             <i class="fa fa-code-fork" ng-class="showRelevance ? 'hq-icon' : ''"></i>
-                            &nbsp;{% trans "Show Display Conditions" %}
+                            &nbsp;{% trans "Display Conditions" %}
                         </button>
                         <button type="button" class="btn btn-default"
                                 ng-click="showComments = !showComments"
                                 ng-class="{ 'active': showComments }">
                             <i class="fa fa-quote-left" ng-class="showComments ? 'hq-icon' : ''"></i>
-                            &nbsp;{% trans "Show Comments" %}
+                            &nbsp;{% trans "Comments" %}
                         </button>
                     </div>
                     <a class="btn btn-primary" href="{{ formDownloadURL }}?lang={{ lang }}">


### PR DESCRIPTION
This button bar wraps on screens that are small but not *that* small (i.e., my laptop):
<img width="1044" alt="screen shot 2016-11-09 at 5 44 01 pm" src="https://cloud.githubusercontent.com/assets/1486591/20157676/41c6aee8-a6a4-11e6-8391-9902fe5b02c4.png">

Dropping "show" makes it less likely to wrap, and I don't think it takes anything away from understanding/meaning:
<img width="1092" alt="screen shot 2016-11-09 at 5 44 18 pm" src="https://cloud.githubusercontent.com/assets/1486591/20157695/5d42d94e-a6a4-11e6-9e00-fb490e995fbd.png">

@dannyroberts 