### PR TITLE
Refactor UCR ES

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -253,6 +253,16 @@ class SumAggregation(Aggregation):
         }
 
 
+class MinAggregation(SumAggregation):
+    """
+    Bucket aggregation that returns the minumum value of a field
+
+    :param name: aggregation name
+    :param field: name of the field to min
+    """
+    type = "min"
+
+
 class MissingAggregation(Aggregation):
     """
     A field data based single bucket aggregation, that creates a bucket of all

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -3,6 +3,7 @@ from elasticsearch import NotFoundError
 from corehq.apps.userreports.util import get_table_name
 from corehq.apps.userreports.adapter import IndicatorAdapter
 from corehq.apps.es.es_query import HQESQuery
+from corehq.apps.es.aggregations import MissingAggregation
 from corehq.elastic import get_es_new, ESError
 from dimagi.utils.decorators.memoized import memoized
 from pillowtop.es_utils import INDEX_STANDARD_SETTINGS
@@ -101,9 +102,15 @@ class ESAlchemy(object):
         return self.es.count()
 
     def distinct_values(self, column, size):
+        missing_agg_name = column + '_missing'
         query = self.es.terms_aggregation(column, column, size=size).size(0)
+        query = query.aggregation(MissingAggregation(missing_agg_name, column))
         results = query.run()
-        return getattr(results.aggregations, column).keys
+        missing_result = getattr(results.aggregations, missing_agg_name).result
+        result = getattr(results.aggregations, column).keys
+        if missing_result['doc_count'] > 0:
+            result.append(None)
+        return result
 
 
 class IndicatorESAdapter(IndicatorAdapter):

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -102,6 +102,7 @@ class ESAlchemy(object):
         return self.es.count()
 
     def distinct_values(self, column, size):
+        # missing aggregation can be removed on upgrade to ES 2.0
         missing_agg_name = column + '_missing'
         query = self.es.terms_aggregation(column, column, size=size).size(0)
         query = query.aggregation(MissingAggregation(missing_agg_name, column))

--- a/corehq/apps/userreports/es/columns.py
+++ b/corehq/apps/userreports/es/columns.py
@@ -8,7 +8,7 @@ class UCRExpandEsDatabaseSubcolumn(UCRExpandDatabaseSubcolumn):
         self.aggregation = aggregation
         self.es_alias = es_alias
         self.ui_alias = ui_alias
-        super(UCRExpandEsDatabaseSubcolumn, self).__init__(header, *args, **kwargs)
+        super(UCRExpandEsDatabaseSubcolumn, self).__init__(header, slug=ui_alias, *args, **kwargs)
 
 
 def expand_column(report_column, distinct_values, lang):

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -206,10 +206,6 @@ class ConfigurableReportEsDataSource(ConfigurableReportSqlDataSource):
     def engine_id(self):
         raise NotImplementedError
 
-    def set_filter_values(self, filter_values):
-        # this does nothing here. it's only used in sql, but can't throw error yet
-        pass
-
     @property
     def keys(self):
         raise NotImplementedError

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -75,8 +75,12 @@ class ConfigurableReportEsDataSource(ConfigurableReportSqlDataSource):
         else:
             ret = self._get_query_results(start, limit)
 
-        for report_column in self.top_level_columns:
+        for report_column in self.top_level_db_columns:
             report_column.format_data(ret)
+
+        for computed_column in self.top_level_computed_columns:
+            for row in ret:
+                row[computed_column.column_id] = computed_column.wrapped_expression(row)
 
         return ret
 

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -17,11 +17,6 @@ from corehq.apps.userreports.util import get_table_name
 
 class ConfigurableReportEsDataSource(ConfigurableReportSqlDataSource):
     @property
-    def aggregation_columns(self):
-        # TODO add deferred filters to support mobile ucr
-        return self._aggregation_columns
-
-    @property
     def config(self):
         if self._config is None:
             self._config, _ = get_datasource_config(self._config_id, self.domain)

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -103,7 +103,8 @@ class ConfigurableReportEsDataSource(ConfigurableReportSqlDataSource):
                         else:
                             r[ui_col] = 0
                         counter += 1
-                r[report_column.column_id] = row[report_column.field]
+                else:
+                    r[report_column.column_id] = row[report_column.field]
             ret.append(r)
 
         return ret

--- a/corehq/apps/userreports/mixins.py
+++ b/corehq/apps/userreports/mixins.py
@@ -1,0 +1,99 @@
+from collections import OrderedDict
+
+from corehq.apps.userreports.models import DataSourceConfiguration, get_datasource_config
+from corehq.apps.userreports.reports.specs import ReportColumn, ExpressionColumn
+from corehq.apps.userreports.util import get_table_name
+
+
+class ConfigurableReportDataSourceMixin(object):
+    def __init__(self, domain, config_or_config_id, filters, aggregation_columns, columns, order_by):
+        self.lang = None
+        self.domain = domain
+        if isinstance(config_or_config_id, DataSourceConfiguration):
+            self._config = config_or_config_id
+            self._config_id = self._config._id
+        else:
+            assert isinstance(config_or_config_id, basestring)
+            self._config = None
+            self._config_id = config_or_config_id
+
+        self._filters = {f.slug: f for f in filters}
+        self._filter_values = {}
+        self._deferred_filters = {}
+        self._order_by = order_by
+        self._aggregation_columns = aggregation_columns
+        self._column_configs = OrderedDict()
+        for column in columns:
+            # should be caught in validation prior to reaching this
+            assert column.column_id not in self._column_configs, \
+                'Report {} in domain {} has more than one {} column defined!'.format(
+                    self._config_id, self.domain, column.column_id,
+                )
+            self._column_configs[column.column_id] = column
+
+    @property
+    def aggregation_columns(self):
+        return self._aggregation_columns + [
+            deferred_filter.field for deferred_filter in self._deferred_filters.values()
+            if deferred_filter.field not in self._aggregation_columns]
+
+    @property
+    def config(self):
+        if self._config is None:
+            self._config, _ = get_datasource_config(self._config_id, self.domain)
+        return self._config
+
+    @property
+    def top_level_columns(self):
+        """
+        This returns a list of BaseReportColumn objects that define the top-level columns
+        in the report. These top-level columns may resolve to more than one column in the
+        underlying query or report (e.g. percentage columns or expanded columns)
+        """
+        return self._column_configs.values()
+
+    @property
+    def inner_columns(self):
+        """
+        This returns a list of Column objects that are contained within the top_level_columns
+        above.
+        """
+        return [
+            inner_col for col in self.top_level_columns
+            for inner_col in col.get_column_config(self.config, self.lang).columns
+        ]
+
+    @property
+    def top_level_db_columns(self):
+        return [col for col in self.top_level_columns if isinstance(col, ReportColumn)]
+
+    @property
+    def top_level_computed_columns(self):
+        return [col for col in self.top_level_columns if isinstance(col, ExpressionColumn)]
+
+    @property
+    def table_name(self):
+        return get_table_name(self.domain, self.config.table_id)
+
+    def set_filter_values(self, filter_values):
+        for filter_slug, value in filter_values.items():
+            self._filter_values[filter_slug] = self._filters[filter_slug].create_filter_value(value)
+
+    def defer_filters(self, filter_slugs):
+        self._deferred_filters.update({
+            filter_slug: self._filters[filter_slug] for filter_slug in filter_slugs})
+
+    def set_order_by(self, columns):
+        self._order_by = columns
+
+    @property
+    def column_configs(self):
+        return [col.get_column_config(self.config, self.lang) for col in self.top_level_db_columns]
+
+    @property
+    def column_warnings(self):
+        return [w for conf in self.column_configs for w in conf.warnings]
+
+    @property
+    def has_total_row(self):
+        return any(column_config.calculate_total for column_config in self.top_level_db_columns)

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -287,7 +287,7 @@ class PreFilterValue(FilterValue):
         elif self._is_null():
             return filters.missing(self.filter.field)
         else:
-            terms = [v.value.lower() for v in self.value]
+            terms = [v.value for v in self.value]
             return filters.term(self.filter.field, terms)
 
 
@@ -331,7 +331,7 @@ class ChoiceListFilterValue(FilterValue):
             return None
         if self.is_null:
             return filters.missing(self.filter.field)
-        terms = [v.value.lower() for v in self.value]
+        terms = [v.value for v in self.value]
         return filters.term(self.filter.field, terms)
 
 

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -155,12 +155,12 @@ class ConfigurableReportSqlDataSource(SqlData):
             if deferred_filter.field not in fields]
 
     @property
-    def sql_column_configs(self):
+    def column_configs(self):
         return [col.get_column_config(self.config, self.lang) for col in self.top_level_db_columns]
 
     @property
     def column_warnings(self):
-        return [w for sql_conf in self.sql_column_configs for w in sql_conf.warnings]
+        return [w for conf in self.column_configs for w in conf.warnings]
 
     @memoized
     @method_decorator(catch_and_raise_exceptions)

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -79,6 +79,7 @@ class TestFieldColumn(SimpleTestCase):
 
 class ChoiceListColumnDbTest(TestCase):
 
+    @run_with_all_ucr_backends
     def test_column_uniqueness_when_truncated(self):
         problem_spec = {
             "display_name": "practicing_lessons",
@@ -108,6 +109,7 @@ class ChoiceListColumnDbTest(TestCase):
             'doc_type': 'CommCareCase',
             'long_column': 'duplicate_choice_1',
         })
+        adapter.refresh_table()
         # and query it back
         q = adapter.get_query_object()
         self.assertEqual(1, q.count())
@@ -195,6 +197,9 @@ class TestExpandedColumn(TestCase):
         report_config.save()
         self.addCleanup(report_config.delete)
         data_source = ReportFactory.from_spec(report_config)
+        adapter = get_indicator_adapter(data_source_config)
+        if build_data_source:
+            adapter.refresh_table()
 
         return data_source, data_source.top_level_columns[0]
 
@@ -253,6 +258,7 @@ class TestExpandedColumn(TestCase):
         self.assertListEqual(distinct_vals, [])
         self.assertFalse(too_many_values)
 
+    @run_with_all_ucr_backends
     def test_expansion(self):
         column = ReportColumnFactory.from_spec(dict(
             type="expanded",
@@ -267,6 +273,7 @@ class TestExpandedColumn(TestCase):
         self.assertEqual(type(cols[0].view), SumWhen)
         self.assertEqual(cols[1].view.whens, {'negative': 1})
 
+    @run_with_all_ucr_backends
     def test_none_in_values(self):
         """
         Confirm that expanded columns work when one of the distinct values is None.

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -322,6 +322,7 @@ class TestReportAggregation(ConfigurableReportTestMixin, TestCase):
             ]]
         )
 
+    # todo @run_with_all_ucr_backends
     def test_total_row(self):
         report_config = self._create_report(
             aggregation_columns=['indicator_col_id_first_name'],
@@ -370,6 +371,7 @@ class TestReportAggregation(ConfigurableReportTestMixin, TestCase):
             ]]
         )
 
+    # todo @run_with_all_ucr_backends
     def test_no_total_row(self):
         report_config = self._create_report(
             aggregation_columns=['indicator_col_id_first_name'],
@@ -417,6 +419,7 @@ class TestReportAggregation(ConfigurableReportTestMixin, TestCase):
             ]]
         )
 
+    # todo @run_with_all_ucr_backends
     def test_total_row_first_column_value(self):
         report_config = self._create_report(
             aggregation_columns=['indicator_col_id_first_name'],
@@ -465,6 +468,7 @@ class TestReportAggregation(ConfigurableReportTestMixin, TestCase):
             ]]
         )
 
+    # todo @run_with_all_ucr_backends
     def test_totaling_noninteger_column(self):
         report_config = self._create_report(
             aggregation_columns=['indicator_col_id_first_name'],
@@ -484,6 +488,7 @@ class TestReportAggregation(ConfigurableReportTestMixin, TestCase):
         with self.assertRaises(UserReportsError):
             view.export_table
 
+    # todo @run_with_all_ucr_backends
     def test_total_row_with_expanded_column(self):
         report_config = self._create_report(
             aggregation_columns=['indicator_col_id_first_name'],

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -371,7 +371,7 @@ class TestReportAggregation(ConfigurableReportTestMixin, TestCase):
             ]]
         )
 
-    # todo @run_with_all_ucr_backends
+    @run_with_all_ucr_backends
     def test_no_total_row(self):
         report_config = self._create_report(
             aggregation_columns=['indicator_col_id_first_name'],

--- a/corehq/apps/userreports/tests/test_report_data.py
+++ b/corehq/apps/userreports/tests/test_report_data.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
 from corehq.apps.userreports.pillow import get_kafka_ucr_pillow
 from corehq.apps.userreports.reports.factory import ReportFactory
-from corehq.apps.userreports.tests.utils import doc_to_change
+from corehq.apps.userreports.tests.utils import doc_to_change, run_with_all_ucr_backends
 from corehq.apps.userreports.util import get_indicator_adapter
 
 
@@ -47,7 +47,8 @@ class ReportDataTest(TestCase):
         )
         self.data_source.validate()
         self.data_source.save()
-        get_indicator_adapter(self.data_source).rebuild_table()
+        self.adapter = get_indicator_adapter(self.data_source)
+        self.adapter.rebuild_table()
         self.addCleanup(self.data_source.delete)
 
         # initialize a report on the data
@@ -108,6 +109,7 @@ class ReportDataTest(TestCase):
     def _add_some_rows(self, count):
         rows = [ReportDataTestRow(uuid.uuid4().hex, i) for i in range(count)]
         self._add_rows(rows)
+        self.adapter.refresh_table()
         return rows
 
     def _add_rows(self, rows):
@@ -126,6 +128,7 @@ class ReportDataTest(TestCase):
         for row in rows:
             pillow.process_change(doc_to_change(_get_case(row)))
 
+    @run_with_all_ucr_backends
     def test_basic_query(self):
         # add a few rows to the data source
         rows = self._add_some_rows(3)
@@ -141,6 +144,7 @@ class ReportDataTest(TestCase):
             self.assertEqual(10, row['ten'])
             self.assertEqual(10 * row['number'], row['by_tens'])
 
+    @run_with_all_ucr_backends
     def test_limit(self):
         count = 5
         self._add_some_rows(count)
@@ -151,6 +155,7 @@ class ReportDataTest(TestCase):
         self.assertEqual(3, len(limited_data))
         self.assertEqual(original_data[:3], limited_data)
 
+    @run_with_all_ucr_backends
     def test_skip(self):
         count = 5
         self._add_some_rows(count)


### PR DESCRIPTION
less code, more tests, more features

The big change here is extracting the common code in report data sources to a common base class for both sql and es. Along the way I realized that all the code differences didn't necessarily need to be different, so ES now supports the new calculated condtions. I think it may also support mobile ucr, but to be honest haven't looked into it.

I was also able to add more tests and there are now very few db backed tests which aren't on both es and sql (just ones with total rows)

@czue you'll probably be the most familiar/interested

buddy @esoergel 