### PR TITLE
only show jad and jar download links if commcare version supports j2me

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/download_index.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/download_index.html
@@ -15,12 +15,14 @@
 {% block downloads %}
     <h2>Downloads</h2>
     <table class="table table-condensed">
+        {% if supports_j2me %}
         <tr>
             <td>{% url "download_jad" app.domain app.id as url %}<a href="{{ url }}">CommCare.jad</a></td>
         </tr>
         <tr>
             <td>{% url "download_jar" app.domain app.id as url %}<a href="{{ url }}">CommCare.jar</a></td>
         </tr>
+        {% endif %}
         <tr>
             <td>
                 <a href="#download_ccz" data-toggle="modal" onclick="download_application_zip()">CommCare.ccz</a>

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -346,6 +346,7 @@ def download_index(request, domain, app_id, template="app_manager/v1/download_in
     return render(request, template, {
         'app': request.app,
         'files': [{'name': f[0], 'source': f[1]} for f in files],
+        'supports_j2me': request.app.build_spec.supports_j2me(),
     })
 
 


### PR DESCRIPTION
@mkangia @nickpell 

http://manage.dimagi.com/default.asp?241068#1243490

looks like the downloads modal in deploy is already configured not to show download links

<img width="461" alt="screen shot 2016-11-10 at 3 39 16 pm" src="https://cloud.githubusercontent.com/assets/716573/20193529/59016270-a75c-11e6-8c90-a9078bd20285.png">
<img width="620" alt="screen shot 2016-11-10 at 3 39 33 pm" src="https://cloud.githubusercontent.com/assets/716573/20193530/5904e85a-a75c-11e6-98ba-83a05ad640ae.png">
