### PR TITLE
Shadow module form selection: handle child modules

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/shadow-module-settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/shadow-module-settings.js
@@ -12,9 +12,13 @@ hqDefine('app_manager/js/shadow-module-settings.js', function () {
             self.selectedModule = ko.pureComputed(function () {
                 return _.findWhere(self.modules(), {uniqueId: self.selectedModuleId()});
             });
+            self.allForms = ko.pureComputed(function() {
+                return _.flatten(_.map(self.modules(), function(m) { return m.forms(); }));
+            });
+            self.includedFormIds = ko.observableArray();
             self.excludedFormIds = ko.pureComputed(function () {
-                var exclForms = _.filter(self.selectedModule().forms(), function (form) {
-                    return self.selectedModule().includedFormIds().indexOf(form.uniqueId) === -1;
+                var exclForms = _.filter(self.allForms(), function (form) {
+                    return self.includedFormIds().indexOf(form.uniqueId) === -1;
                 });
                 return _.map(exclForms, function (form) { return form.uniqueId; });
             });
@@ -23,7 +27,6 @@ hqDefine('app_manager/js/shadow-module-settings.js', function () {
                 this.uniqueId = uniqueId;
                 this.name = name;
                 this.forms = ko.observableArray();
-                this.includedFormIds = ko.observableArray();
             };
 
             var SourceModuleForm = function (uniqueId, name) {
@@ -41,7 +44,7 @@ hqDefine('app_manager/js/shadow-module-settings.js', function () {
                     var sourceModuleForm = new SourceModuleForm(form.unique_id, form.name);
                     sourceModule.forms.push(sourceModuleForm);
                     if (excludedFormIds.indexOf(form.unique_id) === -1) {
-                        sourceModule.includedFormIds.push(form.unique_id);
+                        self.includedFormIds.push(form.unique_id);
                     }
                 }
                 self.modules.push(sourceModule);

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -1,7 +1,6 @@
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import (ScheduleError, CaseXPathValidationError,
     UserCaseXPathValidationError)
-from corehq.apps.app_manager.models import ShadowModule
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
 from corehq.apps.app_manager.suite_xml.xml_models import Menu, Command, LocalizedMenu
 from corehq.apps.app_manager.util import (is_usercase_in_use, xpath_references_case,
@@ -80,6 +79,7 @@ class MenuContributor(SuiteContributorByModule):
             for menu in module.get_menus(supports_module_filter=supports_module_filter):
                 menus.append(menu)
         elif module.module_type != 'careplan':
+            from corehq.apps.app_manager.models import ShadowModule
             id_modules = [module]
             root_modules = []
 

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -14,7 +14,7 @@ from dimagi.utils.decorators.memoized import memoized
 class MenuContributor(SuiteContributorByModule):
 
     def get_module_contributions(self, module):
-        def get_commands():
+        def get_commands(excluded_form_ids):
             @memoized
             def module_uses_case():
                 return module.all_forms_require_a_case()
@@ -24,6 +24,9 @@ class MenuContributor(SuiteContributorByModule):
                 return is_usercase_in_use(self.app.domain)
 
             for form in module.get_suite_forms():
+                if form.unique_id in excluded_form_ids:
+                    continue
+
                 command = Command(id=id_strings.form_command(form, module))
 
                 if form.requires_case():
@@ -123,7 +126,12 @@ class MenuContributor(SuiteContributorByModule):
                         })
                         menu = Menu(**menu_kwargs)
 
-                    menu.commands.extend(get_commands())
+                    excluded_form_ids = []
+                    if root_module and root_module.doc_type == 'ShadowModule':
+                        excluded_form_ids = root_module.excluded_form_ids
+                    if id_module and id_module.doc_type == 'ShadowModule':
+                        excluded_form_ids = id_module.excluded_form_ids
+                    menu.commands.extend(get_commands(excluded_form_ids))
 
                     menus.append(menu)
 

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -1,6 +1,7 @@
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import (ScheduleError, CaseXPathValidationError,
     UserCaseXPathValidationError)
+from corehq.apps.app_manager.models import ShadowModule
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
 from corehq.apps.app_manager.suite_xml.xml_models import Menu, Command, LocalizedMenu
 from corehq.apps.app_manager.util import (is_usercase_in_use, xpath_references_case,

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -83,7 +83,7 @@ class MenuContributor(SuiteContributorByModule):
             root_modules = []
 
             shadow_modules = [m for m in self.app.get_modules()
-                              if m.doc_type == "ShadowModule" and m.source_module_id]
+                              if isinstance(m, ShadowModule) and m.source_module_id]
             put_in_root = getattr(module, 'put_in_root', False)
             if not put_in_root and getattr(module, 'root_module', False):
                 root_modules.append(module.root_module)
@@ -103,7 +103,7 @@ class MenuContributor(SuiteContributorByModule):
                     suffix = ""
                     if root_module:
                         menu_kwargs.update({'root': id_strings.menu_id(root_module)})
-                        suffix = id_strings.menu_id(root_module) if root_module.doc_type == 'ShadowModule' else ""
+                        suffix = id_strings.menu_id(root_module) if isinstance(root_module, ShadowModule) else ""
                     menu_kwargs.update({'id': id_strings.menu_id(id_module, suffix)})
 
                     if supports_module_filter:
@@ -127,9 +127,9 @@ class MenuContributor(SuiteContributorByModule):
                         menu = Menu(**menu_kwargs)
 
                     excluded_form_ids = []
-                    if root_module and root_module.doc_type == 'ShadowModule':
+                    if root_module and isinstance(root_module, ShadowModule):
                         excluded_form_ids = root_module.excluded_form_ids
-                    if id_module and id_module.doc_type == 'ShadowModule':
+                    if id_module and isinstance(id_module, ShadowModule):
                         excluded_form_ids = id_module.excluded_form_ids
                     menu.commands.extend(get_commands(excluded_form_ids))
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view.html
@@ -223,7 +223,7 @@
             <label>
                 <input name="incl_form_ids"
                        type="checkbox"
-                       data-bind="value: uniqueId, checked: $parent.selectedModule().includedFormIds"/>
+                       data-bind="value: uniqueId, checked: $parent.includedFormIds"/>
                 <span data-bind="text: name"></span>
             </label>
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/module_view_settings.html
@@ -28,11 +28,11 @@
                 </label>
                 <div class="col-sm-4"
                      data-bind="template: {name: 'module-forms-template',
-                                           foreach: selectedModule().forms()}"></div>
+                                           foreach: allForms()}"></div>
                 <div class="hidden">
                     <select name="excl_form_ids"
                             multiple="multiple"
-                            data-bind="options: selectedModule().forms,
+                            data-bind="options: allForms,
                                        optionsText: 'name',
                                        optionsValue: 'uniqueId',
                                        selectedOptions: excludedFormIds"></select>

--- a/corehq/apps/app_manager/tests/test_shadow_modules.py
+++ b/corehq/apps/app_manager/tests/test_shadow_modules.py
@@ -12,6 +12,7 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
         self.form1 = self.factory.new_form(self.basic_module)
         self.form1.xmlns = 'http://openrosa.org/formdesigner/secondform'
         self.shadow_module = self.factory.new_shadow_module('shadow_module', self.basic_module, with_form=False)
+        self.child_module, self.form2 = self.factory.new_basic_module('child_module', 'parrot', parent_module=self.basic_module)
 
     def test_all_forms_selected(self):
         expected = """
@@ -65,6 +66,303 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
             self.factory.app.create_suite(),
             "./menu[@id='m1']"
         )
+
+
+    def test_no_child_forms_selected(self):
+        self.shadow_module.excluded_form_ids = [self.form2.unique_id]
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="m0">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="m1">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="m2" root="m0">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="m2.m1" root="m1">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = True
+        self.shadow_module.put_in_root = False
+        self.child_module.put_in_root = False
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="m1">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="m2" root="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="m2.m1" root="m1">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = False
+        self.shadow_module.put_in_root = True
+        self.child_module.put_in_root = False
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="m0">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="m2" root="m0">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="m2.root" root="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = False
+        self.shadow_module.put_in_root = False
+        self.child_module.put_in_root = True
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="m0">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="m1">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="m0">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="m1">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = False
+        self.shadow_module.put_in_root = True
+        self.child_module.put_in_root = True
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="m0">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="m0">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = True
+        self.shadow_module.put_in_root = False
+        self.child_module.put_in_root = True
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="m1">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="m1">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = True
+        self.shadow_module.put_in_root = True
+        self.child_module.put_in_root = False
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="m2" root="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="m2.root" root="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
+        self.basic_module.put_in_root = True
+        self.shadow_module.put_in_root = True
+        self.child_module.put_in_root = True
+        self.assertXmlPartialEqual(
+            '''
+                <partial>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m0"/>
+                    </text>
+                    <command id="m0-f0"/>
+                    <command id="m0-f1"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m1"/>
+                    </text>
+                    <command id="m1-f0"/>
+                    <command id="m1-f1"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                    <command id="m2-f0"/>
+                  </menu>
+                  <menu id="root">
+                    <text>
+                      <locale id="modules.m2"/>
+                    </text>
+                  </menu>
+                </partial>
+            ''',
+            self.factory.app.create_suite(),
+            "./menu"
+        )
+
 
     def test_form_added(self):
         self.shadow_module.excluded_form_ids = [self.form0.unique_id]

--- a/corehq/apps/app_manager/tests/test_shadow_modules.py
+++ b/corehq/apps/app_manager/tests/test_shadow_modules.py
@@ -12,7 +12,8 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
         self.form1 = self.factory.new_form(self.basic_module)
         self.form1.xmlns = 'http://openrosa.org/formdesigner/secondform'
         self.shadow_module = self.factory.new_shadow_module('shadow_module', self.basic_module, with_form=False)
-        self.child_module, self.form2 = self.factory.new_basic_module('child_module', 'parrot', parent_module=self.basic_module)
+        self.child_module, self.form2 = self.factory.new_basic_module('child_module', 'parrot',
+                                                                      parent_module=self.basic_module)
 
     def test_all_forms_selected(self):
         expected = """
@@ -66,7 +67,6 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
             self.factory.app.create_suite(),
             "./menu[@id='m1']"
         )
-
 
     def test_no_child_forms_selected(self):
         self.shadow_module.excluded_form_ids = [self.form2.unique_id]


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240834

I got bogged down in the suite.xml changes, particularly how form exclusion works with menu mode, for quite some time, so I wrote tests for all of the variants of menu mode in an app with a parent module, a child module, and a shadow module which has the parent as its source.

@dannyroberts / @kaapstorm 