### PR TITLE
extra case detail variables

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1865,6 +1865,9 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     persist_case_context = BooleanProperty()
     persistent_case_context_xml = StringProperty(default='case_name')
 
+    # Custom variables to add into the <variables /> node
+    custom_variables= StringProperty()
+
     # If True, use case tiles in the case list
     use_case_tiles = BooleanProperty()
     # If given, use this string for the case tile markup instead of the default temaplte

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1866,7 +1866,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     persistent_case_context_xml = StringProperty(default='case_name')
 
     # Custom variables to add into the <variables /> node
-    custom_variables= StringProperty()
+    custom_variables = StringProperty()
 
     # If True, use case tiles in the case list
     use_case_tiles = BooleanProperty()

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -924,6 +924,13 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 });
                 this.persistCaseContext = ko.observable(spec[this.columnKey].persist_case_context || false);
                 this.persistentCaseContextXML = ko.observable(spec[this.columnKey].persistent_case_context_xml|| 'case_name');
+                this.customVariablesViewModel = {
+                    enabled: COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_VARIABLES'),
+                    xml: ko.observable(spec[this.columnKey].custom_variables || ""),
+                };
+                this.customVariablesViewModel.xml.subscribe(function(){
+                    that.fireChange();
+                });
                 this.persistTileOnForms = ko.observable(spec[this.columnKey].persist_tile_on_forms || false);
                 this.enableTilePullDown = ko.observable(spec[this.columnKey].pull_down_tile || false);
                 this.allowsEmptyColumns = options.allowsEmptyColumns;
@@ -1156,6 +1163,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                     if (this.containsCustomXMLConfiguration){
                         data.custom_xml = this.config.customXMLViewModel.xml();
                     }
+                    data[this.columnKey + '_custom_variables'] = this.customVariablesViewModel.xml();
                     if (this.containsSearchConfiguration) {
                         data.search_properties = JSON.stringify(this.config.search.serialize());
                     }

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_detail.html
@@ -4,6 +4,10 @@
 {% include 'app_manager/v1/partials/case_list_missing_warning.html' %}
 
 <div data-bind="saveButton: longScreen.saveButton"></div>
+
+
+{% include 'app_manager/v1/partials/custom_detail_variables.html' with screen='longScreen'%}
+
 <legend>
     {% trans "Display Properties" %}
     <span class="hq-help-template"

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -17,6 +17,8 @@
     </div>
 </div>
 
+{% include 'app_manager/v1/partials/custom_detail_variables.html' with screen='shortScreen'%}
+
 <legend>
     {% trans "Display Properties" %}
 </legend>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/custom_detail_variables.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/custom_detail_variables.html
@@ -7,7 +7,9 @@
             <div class="col-sm-6">
                 <textarea class="form-control"
                           data-bind="value: xml"
-                          placeholder="<variable-name function='some(xpath_expression)'>">
+                          placeholder="<variable-name function='some(xpath_expression)' />"
+                          spellcheck="false"
+                >
                 </textarea>
             </div>
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/custom_detail_variables.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/custom_detail_variables.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<div data-bind="with: {{screen}}.customVariablesViewModel">
+    <div data-bind="visible: enabled">
+        <legend>{% trans "Custom Detail Variables" %}</legend>
+        <p>{% trans "Add custom variables to the variables node." %}</p>
+        <div class="row">
+            <div class="col-sm-6">
+                <textarea class="form-control"
+                          data-bind="value: xml"
+                          placeholder="<variable-name function='some(xpath_expression)'>">
+                </textarea>
+            </div>
+        </div>
+        <div class="spacer"></div>
+    </div>
+</div>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -763,3 +763,25 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         with self.assertRaises(SuiteValidationError):
             factory.app.create_suite()
+
+    def test_custom_variables(self):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('m0', 'case1')
+        short_custom_variables = "<variable function='true()' /><foo function='bar'/>"
+        long_custom_variables = "<bar function='true()' /><baz function='buzz'/>"
+        module.case_details.short.custom_variables = short_custom_variables
+        module.case_details.long.custom_variables = long_custom_variables
+        self.assertXmlPartialEqual(
+            u"""
+            <partial>
+                <variables>
+                    {short_variables}
+                </variables>
+                <variables>
+                    {long_variables}
+                </variables>
+            </partial>
+            """.format(short_variables=short_custom_variables, long_variables=long_custom_variables),
+            factory.app.create_suite(),
+            "detail/variables"
+        )

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -3,6 +3,7 @@ import os
 from collections import OrderedDict, namedtuple
 import json
 import logging
+from lxml import etree
 
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _, gettext_lazy
@@ -707,8 +708,21 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         detail.short.custom_xml = custom_xml
 
     if custom_variables['short'] is not None:
+        try:
+            etree.fromstring("<variables>{}</variables>".format(custom_variables['short']))
+        except etree.XMLSyntaxError as error:
+            return HttpResponseBadRequest(
+                "There was an issue with your custom variables: {}".format(error.message)
+            )
         detail.short.custom_variables = custom_variables['short']
+
     if custom_variables['long'] is not None:
+        try:
+            etree.fromstring("<variables>{}</variables>".format(custom_variables['long']))
+        except etree.XMLSyntaxError as error:
+            return HttpResponseBadRequest(
+                "There was an issue with your custom variables: {}".format(error.message)
+            )
         detail.long.custom_variables = custom_variables['long']
 
     if sort_elements is not None:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -660,6 +660,10 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     pull_down_tile = params.get("enableTilePullDown", None)
     case_list_lookup = params.get("case_list_lookup", None)
     search_properties = params.get("search_properties")
+    custom_variables = {
+        'short': params.get("short_custom_variables", None),
+        'long': params.get("long_custom_variables", None)
+    }
 
     app = get_app(domain, app_id)
     module = app.get_module(module_id)
@@ -701,6 +705,12 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         detail.short.filter = filter
     if custom_xml is not None:
         detail.short.custom_xml = custom_xml
+
+    if custom_variables['short'] is not None:
+        detail.short.custom_variables = custom_variables['short']
+    if custom_variables['long'] is not None:
+        detail.long.custom_variables = custom_variables['long']
+
     if sort_elements is not None:
         detail.short.sort_elements = []
         for sort_element in sort_elements:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -246,6 +246,13 @@ CASE_LIST_CUSTOM_XML = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+CASE_LIST_CUSTOM_VARIABLES = StaticToggle(
+    'case_list_custom_variables',
+    'Show text area for entering custom variables',
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN]
+)
+
 CASE_LIST_TILE = StaticToggle(
     'case_list_tile',
     'Allow configuration of case list tiles',


### PR DESCRIPTION
Adds a textbox to allow adding custom detail variables in case lists and case details.
@nickpell 
FYI @ctsims 
![screenshot from 2016-11-11 15-32-46](https://cloud.githubusercontent.com/assets/146896/20229394/2335ec88-a824-11e6-92f7-bdf9d2627c07.png)
