### PR TITLE
update checkpoints after 5 mins

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -155,7 +155,7 @@ class MultiTopicCheckpointEventHandler(PillowCheckpointEventHandler):
             checkpoint_doc.save()
 
     def fire_change_processed(self, change, context):
-        if context.changes_seen % self.checkpoint_frequency == 0 and context.do_set_checkpoint:
+        if self.should_update_checkpoint(context):
             updated_to = self.change_feed.get_current_checkpoint_offsets()
             self.checkpoint.update_to(json.dumps(updated_to))
 

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -93,7 +93,7 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
     def should_update_checkpoint(self, context):
         frequency_hit = context.changes_seen % self.checkpoint_frequency == 0
         time_hit = (datetime.utcnow() - self.last_update).total_seconds() >= self.max_checkpoint_delay
-        return context.do_set_checkpoint and frequency_hit or time_hit
+        return context.do_set_checkpoint and (frequency_hit or time_hit)
 
     def fire_change_processed(self, change, context):
         if self.should_update_checkpoint(context):

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -56,7 +56,7 @@ class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
 class ReadonlyLedgerV2DocumentStore(ReadOnlyDocumentStore):
 
     def __init__(self, domain):
-        assert should_use_sql_backend(domain), "Only SQL backend supported"
+        assert should_use_sql_backend(domain), "Only SQL backend supported: {}".format(domain)
         self.domain = domain
         self.ledger_accessors = LedgerAccessorSQL
         self.case_accessors = CaseAccessorSQL

--- a/testapps/test_pillowtop/utils.py
+++ b/testapps/test_pillowtop/utils.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.conf import settings
+from django.test.utils import override_settings
 
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.apps.change_feed.topics import get_topic_offset, get_multi_topic_offset
@@ -12,9 +13,8 @@ from pillowtop import get_pillow_by_name
 class process_kafka_changes(ContextDecorator):
     def __init__(self, pillow_name_or_instance):
         if isinstance(pillow_name_or_instance, basestring):
-            with real_pillow_settings():
+            with real_pillow_settings(), override_settings(PTOP_CHECKPOINT_DELAY_OVERRIDE=None):
                 self.pillow = get_pillow_by_name(pillow_name_or_instance, instantiate=True)
-
         else:
             self.pillow = pillow_name_or_instance
 


### PR DESCRIPTION
On envs that don't have a lot of changes the checkpoints can take a very long time to get updated. This still relies on a change coming through to trigger the update but will still reduce the time between updates.
@gcapalbo 