### PR TITLE
sort multimedia by path

### DIFF
--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -106,7 +106,7 @@ class MediaSuiteGenerator(object):
             for lang in self.build_profile.langs:
                 media_list += self.app.media_language_map[lang].media_refs
             requested_media = set(media_list)
-        for path, m in self.app.multimedia_map.items():
+        for path, m in sorted(self.app.multimedia_map.items(), key=lambda item: item[0]):
             if filter_multimedia and m.form_media and path not in requested_media:
                 continue
             unchanged_path = path


### PR DESCRIPTION
Having the MM sorted prevents large changes in the app diff that come from different ordering.
@gcapalbo 