### PR TITLE
Distinguish btwn raw view and no CodeMirror

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
@@ -16,7 +16,7 @@
         {% endcompress %}
 
         {# CodeMirror uses granular resources as a means of config #}
-        {% if not raw %}
+        {% if use_code_mirror %}
         <link rel="stylesheet" href="{% static 'codemirror/lib/codemirror.css' %}" />
         <link rel="stylesheet" href="{% static 'codemirror/addon/fold/foldgutter.css' %}"/>
         <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
@@ -83,11 +83,7 @@
                              title="Open in HQ" />
                     </a>
                     <a href="{% url 'doc_in_es' %}?id={{ doc_id }}" target="_blank" title="Search in ES"><i class="fa fa-search"></i></a>
-                    {% if raw %}
-                        <a href="{% url "raw_couch" %}?id={{ doc_id }}&db_name={{ selected_db }}" title="Enable CodeMirror"><i class="fa fa-code"></i></a>
-                    {% else %}
-                        <a href="{% url "raw_couch" %}?id={{ doc_id }}&db_name={{ selected_db }}&raw=true" title="Disable CodeMirror"><i class="fa fa-code"></i></a>
-                    {% endif %}
+                    <a href="{% url "raw_couch" %}?id={{ doc_id }}&db_name={{ selected_db }}&raw=true" title="Load raw json doc"><i class="fa fa-code"></i></a>
                     <div>
                         <h3>Raw Doc:</h3>
                         <pre id="couch-document">{{ doc }}</pre>
@@ -99,8 +95,8 @@
 
         <script>
             // don't break if offline (Also why I left it as a <pre/>)
-            var raw = {{ raw|JSON  }};
-            if (!raw && window.CodeMirror) {
+            var use_code_mirror = {{ use_code_mirror|JSON  }};
+            if (use_code_mirror && window.CodeMirror) {
                 var couchDocElement = document.getElementById('couch-document');
                 var myCodeMirror = CodeMirror(function(elt) {
                     couchDocElement.parentNode.replaceChild(elt, couchDocElement);

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -873,13 +873,20 @@ def raw_couch(request):
 def raw_doc(request):
     doc_id = request.GET.get("id")
     db_name = request.GET.get("db_name", None)
-    raw = request.GET.get("raw", False)
     if db_name and "__" in db_name:
         db_name = db_name.split("__")[-1]
     context = _lookup_id_in_database(doc_id, db_name) if doc_id else {}
     other_couch_dbs = sorted(filter(None, couch_config.all_dbs_by_slug.keys()))
     context['all_databases'] = ['commcarehq'] + other_couch_dbs + _SQL_DBS.keys()
-    context['raw'] = raw
+    context['use_code_mirror'] = request.GET.get('code_mirror', 'true').lower() == 'true'
+
+    if request.GET.get("raw", False):
+        if 'doc' in context:
+            return HttpResponse(context['doc'], content_type="application/json")
+        else:
+            return HttpResponse(json.dumps({"status": "missing"}),
+                                content_type="application/json", status=404)
+
     return render(request, "hqadmin/raw_couch.html", context)
 
 


### PR DESCRIPTION
From comments on https://github.com/dimagi/commcare-hq/pull/13868/files
@emord @czue

I think there IS a use-case for a totally raw json response, so this
adds that.  Additionally, it's useful to disable CodeMirror for really
large documents, where CodeMirror can be quite slow.  For that use-case,
I'd like to keep around the metadata, db statuses, and links, as
available on the normal page.