### PR TITLE
Use default url tag

### DIFF
--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -1,5 +1,4 @@
 {% extends 'fixtures/fixtures_base.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load i18n %}

--- a/corehq/apps/hqadmin/templates/hqadmin/loadtest.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/loadtest.html
@@ -1,5 +1,4 @@
 {% extends "hqadmin/hqadmin_base_report.html" %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load i18n %}
 

--- a/custom/m4change/templates/m4change/activateStatus.html
+++ b/custom/m4change/templates/m4change/activateStatus.html
@@ -1,5 +1,4 @@
 {% extends 'm4change/selectTemplate.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load i18n %}

--- a/custom/m4change/templates/m4change/approveStatus.html
+++ b/custom/m4change/templates/m4change/approveStatus.html
@@ -1,5 +1,4 @@
 {% extends 'm4change/selectTemplate.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load i18n %}

--- a/custom/m4change/templates/m4change/paidStatus.html
+++ b/custom/m4change/templates/m4change/paidStatus.html
@@ -1,5 +1,4 @@
 {% extends 'm4change/selectTemplate.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load i18n %}

--- a/custom/m4change/templates/m4change/report_content.html
+++ b/custom/m4change/templates/m4change/report_content.html
@@ -1,5 +1,4 @@
 {% extends 'reports/async/tabular.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load compress %}

--- a/custom/m4change/templates/m4change/reviewStatus.html
+++ b/custom/m4change/templates/m4change/reviewStatus.html
@@ -1,5 +1,4 @@
 {% extends 'm4change/selectTemplate.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load i18n %}

--- a/custom/m4change/templates/m4change/selectTemplate.html
+++ b/custom/m4change/templates/m4change/selectTemplate.html
@@ -1,5 +1,4 @@
 {% extends 'reports/async/tabular.html' %}
-{% load url from future %}
 {% load hq_shared_tags %}
 {% load report_tags %}
 {% load i18n %}

--- a/custom/succeed/templates/patient_error.html
+++ b/custom/succeed/templates/patient_error.html
@@ -1,5 +1,4 @@
 {% extends "base_patient.html" %}
-{% load url from future %}
 {% load i18n %}
 {% block patient-tab-container %}
     <h3>{{ error_message }}</h3>

--- a/custom/succeed/templates/patient_info.html
+++ b/custom/succeed/templates/patient_info.html
@@ -1,5 +1,4 @@
 {% extends "base_patient.html" %}
-{% load url from future %}
 {% load i18n %}
 {% block patient-tab-container %}
 

--- a/custom/succeed/templates/patient_interactions.html
+++ b/custom/succeed/templates/patient_interactions.html
@@ -1,5 +1,4 @@
 {% extends "base_patient.html" %}
-{% load url from future %}
 {% load i18n %}
 {% block patient-tab-container %}
     <div style="display: inline">

--- a/custom/succeed/templates/patient_status.html
+++ b/custom/succeed/templates/patient_status.html
@@ -1,5 +1,4 @@
 {% extends "base_patient.html" %}
-{% load url from future %}
 {% load i18n %}
 {% block patient-tab-container %}
     <a target="_blank" href="{{ disenroll_patient_url }}" class="btn btn-large btn-success" style="margin: 2%">{% trans "Disenroll Patient" %}</a>

--- a/custom/succeed/templates/patient_tasks.html
+++ b/custom/succeed/templates/patient_tasks.html
@@ -1,5 +1,4 @@
 {% extends "base_patient.html" %}
-{% load url from future %}
 {% load i18n %}
 {% block patient-tab-container %}
     <a target="_blank" href="{{ patient_task_list_url }}" class="btn btn-large btn-success" style="margin: 2%">{% trans "View All Tasks" %}</a>


### PR DESCRIPTION
@nickpell needed for django 1.9

```RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.```

buddies @dannyroberts @proteusvacuum 