### PR TITLE
hide unused case importer options

### DIFF
--- a/corehq/apps/case_importer_v1/templates/case_importer_v1/excel_config.html
+++ b/corehq/apps/case_importer_v1/templates/case_importer_v1/excel_config.html
@@ -129,7 +129,7 @@
             </div>
         </fieldset>
 
-        <fieldset>
+        <fieldset class="hide">
             <legend>
                 <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#" href="#advanced-options">
                     <i class="fa fa-angle-double-down"></i> {% trans "Advanced" %}

--- a/corehq/apps/case_importer_v1/templates/case_importer_v1/import_cases.html
+++ b/corehq/apps/case_importer_v1/templates/case_importer_v1/import_cases.html
@@ -25,7 +25,7 @@
                 </div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group hide">
                 <label class="control-label col-sm-3">
                     {% trans "File to Upload" %}
                 </label>


### PR DESCRIPTION
@sheelio and I suspect that no one uses either of these options intentionally and are harmful and confusing to everyone else, and as a half-measure before deleting the features entirely (which will be glorious), we're hiding them to see if anyone complains.

The two options being removed are

- Option to upload without headers (it them makes you map column numbers to case properties):
  <img width="335" alt="screen shot 2016-11-16 at 3 14 56 pm" src="https://cloud.githubusercontent.com/assets/137212/20364025/a470eb60-ac0f-11e6-8a52-ebd30acece9b.png">

- Option to have one row (case id, property name, property value) per property being uploaded instead of one row per case.
  <img width="624" alt="screen shot 2016-11-16 at 3 15 42 pm" src="https://cloud.githubusercontent.com/assets/137212/20364024/a470ed04-ac0f-11e6-96fe-98af32e83327.png">

They're basically both just ways to make the process of uploading even :poop:ier