### PR TITLE
make case_importer_v1 infer types

### DIFF
--- a/corehq/apps/case_importer_v1/tasks.py
+++ b/corehq/apps/case_importer_v1/tasks.py
@@ -120,21 +120,9 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
             errors.add(ImportErrors.BlankExternalId, i + 1)
             continue
 
-        try:
-            fields_to_update = importer_util.populate_updated_fields(
-                config,
-                columns,
-                row,
-                spreadsheet.workbook.datemode
-            )
-            if not any(fields_to_update.values()):
-                # if the row was blank, just skip it, no errors
-                continue
-        except importer_util.InvalidDateException as e:
-            errors.add(ImportErrors.InvalidDate, i + 1, e.column)
-            continue
-        except importer_util.InvalidIntegerException as e:
-            errors.add(ImportErrors.InvalidInteger, i + 1, e.column)
+        fields_to_update = importer_util.populate_updated_fields(config, columns, row)
+        if not any(fields_to_update.values()):
+            # if the row was blank, just skip it, no errors
             continue
 
         external_id = fields_to_update.pop('external_id', None)

--- a/corehq/apps/case_importer_v1/templates/case_importer_v1/excel_fields.html
+++ b/corehq/apps/case_importer_v1/templates/case_importer_v1/excel_fields.html
@@ -152,7 +152,6 @@
                 <thead>
                     <th class="span1"></th>
                     <th>{% trans "Excel Field" %}</th>
-                    <th>{% trans "Data Type" %}</th>
                     <th></th>
                     <th>{% trans "Case Property" %}<button type="button" class="btn btn-primary btn-xs pull-right" id="autofill">{% trans "Auto Fill" %}</button></th>
                     <th></th>

--- a/corehq/apps/case_importer_v1/templates/case_importer_v1/partials/excel_field_row.html
+++ b/corehq/apps/case_importer_v1/templates/case_importer_v1/partials/excel_field_row.html
@@ -25,14 +25,6 @@
     </select>
 </td>
 
-<td class="col-sm-3">
-    <select class="form-control" name="type_field[]">
-        <option value="plain">{% trans "Plain" %}</option>
-        <option value="date">{% trans "Date" %}</option>
-        <option value="integer">{% trans "Integer" %}</option>
-    </select>
-</td>
-
 <td>
     <i class="fa fa-arrow-right"></i>
 </td>

--- a/corehq/apps/case_importer_v1/tests.py
+++ b/corehq/apps/case_importer_v1/tests.py
@@ -101,18 +101,16 @@ class ImporterTest(TestCase):
         super(ImporterTest, self).tearDown()
 
     def _config(self, col_names=None, search_column=None, case_type=None,
-                search_field='case_id', named_columns=False, create_new_cases=True, type_fields=None):
+                search_field='case_id', named_columns=False, create_new_cases=True):
         col_names = col_names or self.default_headers
         case_type = case_type or self.default_case_type
         search_column = search_column or col_names[0]
-        type_fields = type_fields if type_fields is not None else ['plain'] * len(col_names)
         return ImporterConfig(
             couch_user_id=self.couch_user._id,
             case_type=case_type,
             excel_fields=col_names,
             case_fields=[''] * len(col_names),
             custom_fields=col_names,
-            type_fields=type_fields,
             search_column=search_column,
             search_field=search_field,
             named_columns=named_columns,
@@ -426,19 +424,6 @@ class ImporterTest(TestCase):
         self.assertIn(error_message, res['errors'])
         error_column_name = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [5])
-
-    def _typeTest(self, type_fields, error_message):
-        config = self._config(self.default_headers, type_fields=type_fields)
-        file = ExcelFileFake(header_columns=self.default_headers, num_rows=3)
-        res = do_import(file, config, self.domain)
-        self.assertIn(self.default_headers[1], res['errors'][error_message])
-        self.assertEqual(res['errors'][error_message][self.default_headers[1]]['rows'], [1, 2, 3])
-
-    def testDateError(self):
-        self._typeTest(['plain', 'date', 'plain', 'plain'], ImportErrors.InvalidDate)
-
-    def testIntegerError(self):
-        self._typeTest(['plain', 'integer', 'plain', 'plain'], ImportErrors.InvalidInteger)
 
 
 class ImporterUtilsTest(SimpleTestCase):


### PR DESCRIPTION
Get rid of "Data Types" column and the need for users to specify property types. The data's already in the excel file, so let's just use that.

Before release:
- [ ] We'll have to update the docs [here](https://confluence.dimagi.com/display/commcarepublic/Mapping+Case+Properties+and+Completing+the+Import) as well