### PR TITLE
Limit include-able forms to the source module and its children

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/module_view_settings.html
@@ -28,11 +28,11 @@
                 </label>
                 <div class="col-sm-4"
                      data-bind="template: {name: 'module-forms-template',
-                                           foreach: allForms()}"></div>
+                                           foreach: sourceForms()}"></div>
                 <div class="hidden">
                     <select name="excl_form_ids"
                             multiple="multiple"
-                            data-bind="options: allForms,
+                            data-bind="options: sourceForms,
                                        optionsText: 'name',
                                        optionsValue: 'uniqueId',
                                        selectedOptions: excludedFormIds"></select>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -202,6 +202,7 @@ def _get_shadow_module_view_context(app, module, lang=None):
         return {
             'unique_id': mod.unique_id,
             'name': trans(mod.name, langs),
+            'root_module_id': mod.root_module_id,
             'forms': [{'unique_id': f.unique_id, 'name': trans(f.name, langs)} for f in mod.get_forms()]
         }
 


### PR DESCRIPTION
In https://github.com/dimagi/commcare-hq/pull/13896, I misunderstood exactly which modules were available in `shadow-module-settings.js` and ended up displaying all of the app's forms as options to exclude from the shadow module. The list of forms should include come from only the source module and any children of the source module.

@czue / @dannyroberts 