### PR TITLE
Migrate new export toggle to old one

### DIFF
--- a/corehq/apps/export/management/commands/migrate_export_toggle.py
+++ b/corehq/apps/export/management/commands/migrate_export_toggle.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+
+from toggle.shortcuts import set_toggle
+
+from corehq.form_processor.utils import use_new_exports
+from corehq.apps.domain.models import Domain
+from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster
+from corehq import toggles
+
+
+class Command(BaseCommand):
+    help = "Migrates old exports to new ones"
+
+    def handle(self, *args, **options):
+        for doc in Domain.get_all(include_docs=False):
+            domain = doc['key']
+            if not use_new_exports(domain):
+                set_toggle(
+                    toggles.OLD_EXPORTS.slug,
+                    domain,
+                    True,
+                    namespace=toggles.NAMESPACE_DOMAIN
+                )
+                toggle_js_domain_cachebuster.clear(domain)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -845,6 +845,13 @@ NEW_EXPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+OLD_EXPORTS = StaticToggle(
+    'old_exports',
+    'Use old backend export infrastructure',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN]
+)
+
 TF_DOES_NOT_USE_SQLITE_BACKEND = StaticToggle(
     'not_tf_sql_backend',
     'Domains that do not use a SQLite backend for Touchforms',


### PR DESCRIPTION
@czue i'm going to commit this now, then run on all environments, then merge code that'll switch the new export toggle to this old export toggle. since the number of old exports is static, (unless i manually migrate a domain) we shouldn't have to worry about timing. killing build

cc: @mkangia 