### PR TITLE
Don't migrate apps that are already migrated

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
     '''
 
     def handle(self, *args, **options):
-        app_query = AppES().is_build(False).term('vellum_case_management', True) \
+        app_query = AppES().is_build(False).term('vellum_case_management', False) \
                            .term('doc_type', 'Application').source(['domain', '_id'])
 
         hits = app_query.run().hits


### PR DESCRIPTION
Flipped this to true for local testing, forgot to flip it back...which makes the migration a lot less useful.

@emord 