### PR TITLE
Hardware refresh button for app preview

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -13,6 +13,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
         APP_MANAGER_BODY: '#js-appmanager-body',
         PREVIEW_ACTION_TEXT_SHOW: '.js-preview-action-show',
         PREVIEW_ACTION_TEXT_HIDE: '.js-preview-action-hide',
+        BTN_REFRESH: '.js-preview-refresh',
     };
 
     module.EVENTS = {
@@ -119,7 +120,15 @@ hqDefine('app_manager/js/preview_app.js', function() {
         $(window).on(module.EVENTS.RESIZE, _resizeAppPreview);
         layoutController.utils.setBalancePreviewFn(_resizeAppPreview);
         $('.js-preview-back').click(_private.triggerPreviewEvent.bind(this, 'back'));
-        $('.js-preview-refresh').click(_private.triggerPreviewEvent.bind(this, 'refresh'));
+        $('.js-preview-refresh').click(function() {
+            $(module.SELECTORS.BTN_REFRESH).removeClass('app-out-of-date');
+            _private.triggerPreviewEvent('refresh');
+        });
+        $(document).ajaxComplete(function(e, xhr, options) {
+            if (/edit_form_attr/.test(options.url)) {
+                $(module.SELECTORS.BTN_REFRESH).addClass('app-out-of-date');
+            }
+        });
 
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -125,7 +125,9 @@ hqDefine('app_manager/js/preview_app.js', function() {
             _private.triggerPreviewEvent('refresh');
         });
         $(document).ajaxComplete(function(e, xhr, options) {
-            if (/edit_form_attr/.test(options.url)) {
+            if (/edit_form_attr/.test(options.url) ||
+                /edit_module_attr/.test(options.url) ||
+                /patch_xform/.test(options.url)) {
                 $(module.SELECTORS.BTN_REFRESH).addClass('app-out-of-date');
             }
         });

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -39,10 +39,18 @@ hqDefine('app_manager/js/preview_app.js', function() {
     };
 
     _private.navigateBack = function() {
+        _private.triggerPreviewEvent('back');
+    };
+
+    _private.refresh = function() {
+        _private.triggerPreviewEvent('refresh');
+    };
+
+    _private.triggerPreviewEvent = function(action) {
         var $appPreviewIframe = $(module.SELECTORS.PREVIEW_WINDOW_IFRAME),
             previewWindow = $appPreviewIframe[0].contentWindow;
         previewWindow.postMessage({
-            action: 'back',
+            action: action,
         }, window.location.origin);
     };
 
@@ -110,7 +118,8 @@ hqDefine('app_manager/js/preview_app.js', function() {
         };
         $(window).on(module.EVENTS.RESIZE, _resizeAppPreview);
         layoutController.utils.setBalancePreviewFn(_resizeAppPreview);
-        $('.js-preview-back').click(_private.navigateBack);
+        $('.js-preview-back').click(_private.triggerPreviewEvent.bind(this, 'back'));
+        $('.js-preview-refresh').click(_private.triggerPreviewEvent.bind(this, 'refresh'));
 
     };
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/preview_app.html
@@ -10,6 +10,9 @@
             <button type="button" class="btn btn-default btn-preview-back js-preview-back">
                 <i class="fa fa-arrow-left"></i>
             </button>
+            <button type="button" class="btn btn-default btn-preview-refresh js-preview-refresh">
+                <i class="fa fa-refresh"></i>
+            </button>
         </div>
     </div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/preview_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/preview_app.html
@@ -11,6 +11,9 @@
             <button type="button" class="btn btn-default btn-preview-back js-preview-back">
                 <i class="fa fa-arrow-left"></i>
             </button>
+            <button type="button" class="btn btn-default btn-preview-refresh js-preview-refresh">
+                <i class="fa fa-refresh"></i>
+            </button>
         </div>
     </div>
 </div>

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -327,18 +327,6 @@ FormplayerFrontend.on("sync", function () {
     $.ajax(options);
 });
 
-FormplayerFrontend.on('phone:back:hide', function() {
-    if (FormplayerFrontend.regions.phoneModeNavigation.currentView) {
-        FormplayerFrontend.regions.phoneModeNavigation.currentView.hideBackButton();
-    }
-});
-
-FormplayerFrontend.on('phone:back:show', function() {
-    if (FormplayerFrontend.regions.phoneModeNavigation.currentView) {
-        FormplayerFrontend.regions.phoneModeNavigation.currentView.showBackButton();
-    }
-});
-
 /**
  * retry
  *

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -211,6 +211,11 @@ FormplayerFrontend.on("start", function (options) {
             } else {
                 FormplayerFrontend.trigger("apps:list", options.apps);
             }
+            if (user.displayOptions.phoneMode) {
+                // Refresh on start of preview mode so it ensures we're on the latest app
+                // since app updates do not work.
+                FormplayerFrontend.trigger('refreshApplication', appId);
+            }
         }
     }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -381,6 +381,10 @@ FormplayerFrontend.on('clearProgress', function() {
 });
 
 
+FormplayerFrontend.on('setVersionInfo', function(versionInfo) {
+    $("#version-info").text(versionInfo || '');
+});
+
 /**
  * refreshApplication
  *

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq.events.js
@@ -16,7 +16,7 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
         // For Chrome, the origin property is in the event.originalEvent object
         var origin = event.origin || event.originalEvent.origin,
             data = event.data,
-            success = true;
+            appId;
 
         if (!origin.endsWith(this.allowedHost)) {
             throw new Error('Disallowed origin ' + origin);
@@ -33,10 +33,15 @@ FormplayerFrontend.module("HQ.Events", function(Events, FormplayerFrontend) {
         case Events.Actions.BACK:
             FormplayerFrontend.trigger('navigation:back');
             break;
+        case Events.Actions.REFRESH:
+            appId = FormplayerFrontend.request('getCurrentAppId');
+            FormplayerFrontend.trigger('refreshApplication', appId);
+            break;
         }
     };
 
     Events.Actions = {
         BACK: 'back',
+        REFRESH: 'refresh',
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/phone_navigation.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/phone_navigation.js
@@ -10,19 +10,8 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
     Views.PhoneNavigation = Marionette.ItemView.extend({
         className: 'formplayer-phone-navigation',
         template: '#formplayer-phone-navigation-template',
-        ui: {
-            reloadButton: '.formplayer-reload',
-        },
-        events: {
-            'click @ui.backButton': 'onBack',
-            'click @ui.reloadButton': 'onReload',
-        },
         initialize: function(options) {
             this.appId = options.appId;
-        },
-        onReload: function(e) {
-            e.preventDefault();
-            FormplayerFrontend.trigger('refreshApplication', this.appId);
         },
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/phone_navigation.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/phone_navigation.js
@@ -11,7 +11,6 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         className: 'formplayer-phone-navigation',
         template: '#formplayer-phone-navigation-template',
         ui: {
-            backButton: '.formplayer-back',
             reloadButton: '.formplayer-reload',
         },
         events: {
@@ -21,19 +20,9 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         initialize: function(options) {
             this.appId = options.appId;
         },
-        onBack: function(e) {
-            e.preventDefault();
-            window.history.back();
-        },
         onReload: function(e) {
             e.preventDefault();
             FormplayerFrontend.trigger('refreshApplication', this.appId);
-        },
-        hideBackButton: function() {
-            this.ui.backButton.hide();
-        },
-        showBackButton: function() {
-            this.ui.backButton.show();
         },
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -62,17 +62,13 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 FormplayerFrontend.regions.breadcrumb.empty();
             }
             if (menuResponse.appVersion) {
-                Menus.Controller.showAppVersion(menuResponse.appVersion);
+                FormplayerFrontend.trigger('setVersionInfo', menuResponse.appVersion);
             }
         },
 
         showPersistentCaseTile: function (persistentCaseTile) {
             var detailView = Menus.Controller.getCaseTile(persistentCaseTile);
             FormplayerFrontend.regions.persistentCaseTile.show(detailView.render());
-        },
-
-        showAppVersion: function (appVersion) {
-            $("#version-info").text(appVersion);
         },
 
         showBreadcrumbs: function (breadcrumbs) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -28,10 +28,14 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
     var clearFormMiddleware = function(name) {
         FormplayerFrontend.trigger("clearForm");
     };
+    var clearVersionInfo = function(name) {
+        FormplayerFrontend.trigger('setVersionInfo', '');
+    };
 
     SessionNavigate.Middleware.middlewares = [
         logRouteMiddleware,
         backButtonShowHideMiddleware,
         clearFormMiddleware,
+        clearVersionInfo,
     ];
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -15,13 +15,6 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
             return wrappedApi;
         },
     };
-    var backButtonShowHideMiddleware = function(name) {
-        if (name === 'singleApp') {
-            FormplayerFrontend.trigger('phone:back:hide');
-        } else {
-            FormplayerFrontend.trigger('phone:back:show');
-        }
-    };
     var logRouteMiddleware = function(name) {
         window.console.log('User navigated to ' + name);
     };
@@ -34,7 +27,6 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
 
     SessionNavigate.Middleware.middlewares = [
         logRouteMiddleware,
-        backButtonShowHideMiddleware,
         clearFormMiddleware,
         clearVersionInfo,
     ];

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq.events_spec.js
@@ -6,18 +6,22 @@ describe('HQ.Events', function() {
             Actions = FormplayerFrontend.HQ.Events.Actions,
             origin = 'myorigin',
             triggerSpy,
+            requestSpy,
             dummyEvent;
         beforeEach(function() {
             triggerSpy = sinon.spy();
+            requestSpy = sinon.spy();
             dummyEvent = {
                 origin: origin,
                 data: {},
             };
             sinon.stub(FormplayerFrontend, 'trigger', triggerSpy);
+            sinon.stub(FormplayerFrontend, 'request', requestSpy);
         });
 
         afterEach(function() {
             FormplayerFrontend.trigger.restore();
+            FormplayerFrontend.request.restore();
         });
 
         it('should allow the back action', function() {
@@ -25,6 +29,15 @@ describe('HQ.Events', function() {
             dummyEvent.data.action = Actions.BACK;
 
             receiver(dummyEvent);
+            assert.isTrue(triggerSpy.called);
+        });
+
+        it('should allow the refresh action', function() {
+            var receiver = new Receiver(origin);
+            dummyEvent.data.action = Actions.REFRESH;
+
+            receiver(dummyEvent);
+            assert.isTrue(requestSpy.called);
             assert.isTrue(triggerSpy.called);
         });
 

--- a/corehq/apps/cloudcare/templates/formplayer/navigation.html
+++ b/corehq/apps/cloudcare/templates/formplayer/navigation.html
@@ -1,9 +1,6 @@
 <script id="formplayer-phone-navigation-template" type="text/template">
   <div class="navbar navbar-default navbar-static-top navbar-formplayer">
     <div class="container">
-      <ul class="nav navbar-nav">
-        <li><a class="formplayer-back" href=""><i class="fa fa-chevron-left"></i></a></li>
-      </ul>
       <ul class="nav navbar-nav navbar-right">
         <li><a class="formplayer-reload" href=""><i class="fa fa-refresh"></i></a></li>
       </ul>

--- a/corehq/apps/cloudcare/templates/formplayer/navigation.html
+++ b/corehq/apps/cloudcare/templates/formplayer/navigation.html
@@ -1,9 +1,6 @@
 <script id="formplayer-phone-navigation-template" type="text/template">
   <div class="navbar navbar-default navbar-static-top navbar-formplayer">
     <div class="container">
-      <ul class="nav navbar-nav navbar-right">
-        <li><a class="formplayer-reload" href=""><i class="fa fa-refresh"></i></a></li>
-      </ul>
     </div>
   </div>
 </script>

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -160,6 +160,7 @@
             <div id="breadcrumb-region"></div>
             <div class="scrollable-container dragscroll">
               <div id="menu-region" class="content menu-content"></div>
+              <small id="version-info"></small>
             </div>
         </div>
         <div class="scrollable-container dragscroll form-scrollable-container">

--- a/corehq/apps/style/static/app_manager/less/preview_app-main.less
+++ b/corehq/apps/style/static/app_manager/less/preview_app-main.less
@@ -119,15 +119,20 @@ preview_app/less */
   top: -5px;
 }
 
-.btn-preview-refresh.app-out-of-date::after {
-  content: ' ';
-  background-color: red;
+.btn-preview-refresh::after {
+  content: '✔';
+  color: green;
   width: 10px;
   height: 10px;
   display: block;
   position: absolute;
   top: -3px;
   right: -3px;
+}
+
+.btn-preview-refresh.app-out-of-date::after {
+  content: ' ';
+  background-color: red;
   border-radius: 10px;
 }
 

--- a/corehq/apps/style/static/app_manager/less/preview_app-main.less
+++ b/corehq/apps/style/static/app_manager/less/preview_app-main.less
@@ -119,6 +119,18 @@ preview_app/less */
   top: -5px;
 }
 
+.btn-preview-refresh.app-out-of-date::after {
+  content: ' ';
+  background-color: red;
+  width: 10px;
+  height: 10px;
+  display: block;
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  border-radius: 10px;
+}
+
 .hardware-buttons {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
@biyeun @wpride this adds a hardware refresh button to app preview and takes care of a couple of small other items:

- Removes back and refresh button from phone navigation bar (now just a blue bar)
- Adds a hardware refresh button and adds a red dot when out of date
- shows version info on phone

styling is purposefully woeful:
<img width="295" alt="screen shot 2016-11-17 at 10 35 05 am" src="https://cloud.githubusercontent.com/assets/918514/20395736/ece4ddf0-acb1-11e6-929a-5b1169231e6e.png">
<img width="304" alt="screen shot 2016-11-17 at 10 33 09 am" src="https://cloud.githubusercontent.com/assets/918514/20395738/ece90b14-acb1-11e6-8e65-266d50610c20.png">
<img width="300" alt="screen shot 2016-11-17 at 10 33 18 am" src="https://cloud.githubusercontent.com/assets/918514/20395737/ece8133a-acb1-11e6-8de1-720c2d406c3d.png">


cc: @mkangia 

