### PR TITLE
Stop js error on inline edit widget

### DIFF
--- a/corehq/apps/style/static/style/ko/components/inline_edit.js
+++ b/corehq/apps/style/static/style/ko/components/inline_edit.js
@@ -141,7 +141,6 @@ hqDefine('style/ko/components/inline_edit.js', function() {
                             attr: {name: name, id: id, placeholder: placeholder, rows: rows, cols: cols},\
                             value: value,\
                             hasFocus: isEditing(),\
-                            event: {blur: blur},\
                         "></textarea>\
                     <!-- /ko -->\
                     <!-- ko if: nodeName === "input" -->\
@@ -149,7 +148,6 @@ hqDefine('style/ko/components/inline_edit.js', function() {
                             attr: {name: name, id: id, placeholder: placeholder, rows: rows, cols: cols},\
                             value: value,\
                             hasFocus: isEditing(),\
-                            event: {blur: blur},\
                         " />\
                     <!-- /ko -->\
                     <!-- ko if: lang -->\


### PR DESCRIPTION
Blur function was removed in https://github.com/dimagi/commcare-hq/pull/13342, so this widget now throws a harmless but annoying js error on blur.

@czue 