### PR TITLE
Add case name to window title

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_details.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_details.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block title %}Case: {{ report.name }}{% endblock %}
+{% block title %}Case: {{ case.name }}{% endblock %}
 
 {% block head %} {{ block.super }}
     {% include "imports/proptable.html" %}


### PR DESCRIPTION
Getting really confused when I have lots of cases open in different tabs.

# Before 
![screenshot from 2016-11-17 17-12-16](https://cloud.githubusercontent.com/assets/146896/20410002/0c559c60-ace9-11e6-861c-8e83894b794a.png)
# After
(case name is "measurement")
![screenshot from 2016-11-17 17-12-25](https://cloud.githubusercontent.com/assets/146896/20410001/0c558de2-ace9-11e6-9adb-c412e77303e9.png)

@dannyroberts @emord 