### PR TITLE
Ensure displayOptions stick

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -131,7 +131,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.username = user.username;
     data.restoreAs = user.restoreAs;
     data.formplayerEnabled = true;
-    data.displayOptions = user.displayOptions;
+    data.displayOptions = $.extend(true, {}, user.displayOptions);
     data.onerror = function (resp) {
         showError(resp.human_readable_message || resp.message, $("#cloudcare-notifications"));
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -57,7 +57,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 "query_dictionary": params.queryDict,
                 "previewCommand": params.previewCommand,
                 "installReference": params.installReference,
-                "oneQuestionPerScreen": ko.utils.unwrapObservable(displayOptions.oneQuestionPerScreen),
+                "oneQuestionPerScreen": displayOptions.oneQuestionPerScreen,
             });
             options.url = formplayerUrl + '/navigate_menu';
 

--- a/corehq/apps/cloudcare/templates/formplayer/users.html
+++ b/corehq/apps/cloudcare/templates/formplayer/users.html
@@ -90,7 +90,7 @@
                 <th>{% trans "Date Registered" %}</th>
                 <td><%= user.dateRegistered %></td>
             </tr>
-        <% _.each(user.customFields, function(key, value) { %>
+        <% _.each(user.customFields, function(value, key) { %>
             <tr>
                 <th><%= key %></th>
                 <td><%= value %></td>


### PR DESCRIPTION
@biyeun @wpride surprisingly tricky bug. we were passing displayOptions by reference into form entry and then wrapping it into a ko model. the formplayer code wasn't aware of this and it caused some conditions to be evaluated incorrectly. this does a deep clone of displayOptions so we don't have this issue anymore. also fixes minor argument mistake

cc: @mkangia 