### PR TITLE
Add New Expressions for Case History

### DIFF
--- a/custom/ucr_ext/expressions.py
+++ b/custom/ucr_ext/expressions.py
@@ -536,7 +536,7 @@ def get_last_case_property_update(spec, context):
                 }
             }
         },
-        'value_expression':{
+        'value_expression': {
             'type': 'property_path',
             'property_path': [
                 'updated_unknown_properties',

--- a/custom/ucr_ext/expressions.py
+++ b/custom/ucr_ext/expressions.py
@@ -56,6 +56,8 @@ class GetCaseFormsByDateSpec(JsonObject):
 
 class GetCaseHistoryByDateSpec(JsonObject):
     type = TypeProperty('ext_get_case_history_by_date')
+    xmlns_map = DefaultProperty(required=True)
+    case_id_expression = DefaultProperty(required=False)
     start_date = DefaultProperty(required=False)
     end_date = DefaultProperty(required=False)
     filter = DefaultProperty(required=False)
@@ -64,6 +66,8 @@ class GetCaseHistoryByDateSpec(JsonObject):
 class GetLastCasePropertyUpdateSpec(JsonObject):
     type = TypeProperty('ext_get_last_case_property_update')
     case_property = StringProperty(required=True)
+    xmlns_map = DefaultProperty(required=True)
+    case_id_expression = DefaultProperty(required=False)
     start_date = DefaultProperty(required=False)
     end_date = DefaultProperty(required=False)
     filter = DefaultProperty(required=False)
@@ -426,79 +430,64 @@ def get_case_forms_by_date(spec, context):
 def get_case_history_by_date(spec, context):
     GetCaseHistoryByDateSpec.wrap(spec)
 
+    form_map = {
+        'type': 'switch',
+        'switch_on': {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "xmlns"
+        },
+        'cases': spec['xmlns_map'],
+        'default': {
+            'type': 'property_name',
+            'property_name': 'no_exist'
+        }
+    }
+
     filters = []
-    if spec['start_date'] is not None:
-        start_date_filter = {
-            'operator': 'gte',
-            'expression': {
-                'datatype': 'integer',
-                'from_date_expression': spec['start_date'],
-                'type': 'diff_days',
-                'to_date_expression': {
-                    'datatype': 'date',
-                    'type': 'property_name',
-                    'property_name': 'date'
-                }
-            },
-            'type': 'boolean_expression',
-            'property_value': 0
-        }
-        filters.append(start_date_filter)
-    if spec['end_date'] is not None:
-        end_date_filter = {
-            'operator': 'gte',
-            'expression': {
-                'datatype': 'integer',
-                'from_date_expression': {
-                    'datatype': 'date',
-                    'type': 'property_name',
-                    'property_name': 'date'
+    filters.append(
+        {
+            'type': 'not',
+            'filter': {
+                'operator': 'in',
+                'type': 'boolean_expression',
+                'expression': {
+                    'type': 'identity',
                 },
-                'type': 'diff_days',
-                'to_date_expression': spec['end_date']
-            },
-            'type': 'boolean_expression',
-            'property_value': 0
+                'property_value': [
+                    "",
+                    None
+                ]
+            }
         }
-        filters.append(end_date_filter)
+    )
     if spec['filter'] is not None:
         filters.append(spec['filter'])
 
-    if len(filters) > 0:
-        spec = {
-            "type": "sort_items",
-            "sort_expression": {
-                'datatype': 'date',
-                'type': 'property_name',
-                'property_name': 'date'
-            },
+    spec = {
+        'type': 'filter_items',
+        'items_expression': {
+            'type': 'map_items',
             'items_expression': {
-                'filter_expression': {
-                    'type': 'and',
-                    'filters': filters
-                },
-                'type': 'filter_items',
-                'items_expression': {
-                    'datatype': 'array',
-                    'type': 'ext_root_property_name',
-                    'property_name': 'actions'
+                'type': 'ext_get_case_forms_by_date',
+                'case_id_expression': spec['case_id_expression'],
+                'start_date': spec['start_date'],
+                'end_date': spec['end_date'],
+            },
+            'map_expression': {
+                'type': 'nested',
+                'argument_expression': form_map,
+                'value_expression': {
+                    'type': 'property_name',
+                    'property_name': 'update'
                 }
             }
+        },
+        'filter_expression': {
+            'type': 'and',
+            'filters': filters
         }
-    else:
-        spec = {
-            'type': 'sort_items',
-            'sort_expression': {
-                'datatype': 'date',
-                'type': 'property_name',
-                'property_name': 'date'
-            },
-            'items_expression': {
-                'datatype': 'array',
-                'type': 'ext_root_property_name',
-                'property_name': 'actions'
-            }
-        }
+    }
     return ExpressionFactory.from_spec(spec, context)
 
 
@@ -513,20 +502,19 @@ def get_last_case_property_update(spec, context):
                 'type': 'filter_items',
                 'items_expression': {
                     'type': 'ext_get_case_history_by_date',
+                    'case_id_expression': spec['case_id_expression'],
                     'start_date': spec['start_date'],
                     'end_date': spec['end_date'],
                     'filter': spec['filter'],
+                    'xmlns_map': spec['xmlns_map']
                 },
                 'filter_expression': {
                     'filter': {
                         'operator': 'in',
                         'type': 'boolean_expression',
                         'expression': {
-                            'type': 'property_path',
-                            'property_path': [
-                                'updated_unknown_properties',
-                                spec['case_property'],
-                            ]
+                            'type': 'property_name',
+                            'property_name': spec['case_property'],
                         },
                         'property_value': [
                             None
@@ -537,11 +525,8 @@ def get_last_case_property_update(spec, context):
             }
         },
         'value_expression': {
-            'type': 'property_path',
-            'property_path': [
-                'updated_unknown_properties',
-                spec['case_property'],
-            ]
+            'type': 'property_name',
+            'property_name': spec['case_property'],
         }
     }
     return ExpressionFactory.from_spec(spec, context)

--- a/custom/ucr_ext/tests.py
+++ b/custom/ucr_ext/tests.py
@@ -512,6 +512,7 @@ class TestGetCaseHistoryExpressionTest(TestCase):
             )
         )
 
+
 class TestGetLastCasePropertyUpdateTest(TestCase):
     def test_no_update(self):
         case = {

--- a/custom/ucr_ext/tests.py
+++ b/custom/ucr_ext/tests.py
@@ -394,7 +394,7 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                 'case_type': 'test',
                 'create': True,
                 'date_opened': datetime(2015, 1, 10),
-                'date_modified': datetime(2015, 3, 10),
+                'date_modified': datetime(2015, 1, 10),
             },
         ))
         self._submit_form(form_date=datetime(2015, 1, 10), case_id=self.test_case_id,
@@ -407,33 +407,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                           case_path='b', xmlns="xmlns_b", foo="b")
         self._submit_form(form_date=datetime(2015, 3, 4), case_id=self.test_case_id,
                           case_path='c', xmlns="xmlns_c", foo="c")
-
-        self.xmlns_map = {
-            'xmlns_a': {
-                'type': 'property_path',
-                'property_path': [
-                    'form',
-                    'a',
-                    'case'
-                ]
-            },
-            'xmlns_b': {
-                'type': 'property_path',
-                'property_path': [
-                    'form',
-                    'b',
-                    'case'
-                ]
-            },
-            'xmlns_c': {
-                'type': 'property_path',
-                'property_path': [
-                    'form',
-                    'c',
-                    'case'
-                ]
-            },
-        }
 
     def tearDown(self):
         delete_all_xforms()
@@ -468,16 +441,15 @@ class TestGetCaseHistoryExpressionTest(TestCase):
             "type": "reduce_items",
             "aggregation_fn": "count",
             "items_expression": {
-                "type": "ext_get_case_history_by_date",
+                "type": "ext_get_case_history",
                 "case_id_expression": {
                     "type": "constant",
                     "constant": self.test_case_id
                 },
-                "xmlns_map": self.xmlns_map
             }
         })
         self.assertEqual(
-            5,
+            6,
             expression(
                 {"some_item": "item_value"},
                 context=EvaluationContext({"domain": self.domain}, 0),
@@ -494,13 +466,12 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                     "type": "constant",
                     "constant": self.test_case_id
                 },
-                "xmlns_map": self.xmlns_map,
                 "filter": {
                     "type": "boolean_expression",
                     "operator": "eq",
                     "expression": {
-                        "type": "property_name",
-                        "property_name": "foo"
+                        "type": "property_path",
+                        "property_path": ["update", "foo"]
                     },
                     "property_value": "a"
                 }
@@ -508,81 +479,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
         })
         self.assertEqual(
             2,
-            expression(
-                {"some_item": "item_value"},
-                context=EvaluationContext({"domain": self.domain}, 0),
-            )
-        )
-
-    def test_incorrect_map(self):
-        expression = ExpressionFactory.from_spec({
-            "type": "reduce_items",
-            "aggregation_fn": "count",
-            "items_expression": {
-                "type": "ext_get_case_history_by_date",
-                "case_id_expression": {
-                    "type": "constant",
-                    "constant": self.test_case_id
-                },
-                "xmlns_map": {
-                    'xmlns_a': {
-                        'type': 'property_path',
-                        'property_path': [
-                            'form',
-                            'n'
-                        ]
-                    }
-                },
-            }
-        })
-        self.assertEqual(
-            0,
-            expression(
-                {"some_item": "item_value"},
-                context=EvaluationContext({"domain": self.domain}, 0),
-            )
-        )
-
-    def test_partial_map(self):
-        expression = ExpressionFactory.from_spec({
-            "type": "reduce_items",
-            "aggregation_fn": "count",
-            "items_expression": {
-                "type": "ext_get_case_history_by_date",
-                "case_id_expression": {
-                    "type": "constant",
-                    "constant": self.test_case_id
-                },
-                "xmlns_map": {
-                    'xmlns_a': {
-                        'type': 'property_path',
-                        'property_path': [
-                            'form',
-                            'a',
-                            'case'
-                        ]
-                    },
-                    'xmlns_b': {
-                        'type': 'property_path',
-                        'property_path': [
-                            'form',
-                            'b',
-                            'case'
-                        ]
-                    },
-                    'xmlns_c': {
-                        'type': 'property_path',
-                        'property_path': [
-                            'form',
-                            'x',
-                            'case'
-                        ]
-                    },
-                },
-            }
-        })
-        self.assertEqual(
-            4,
             expression(
                 {"some_item": "item_value"},
                 context=EvaluationContext({"domain": self.domain}, 0),
@@ -602,7 +498,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                     "type": "constant",
                     "constant": self.test_case_id
                 },
-                'xmlns_map': self.xmlns_map,
                 "start_date": {
                     "type": "ext_root_property_name",
                     "property_name": "start_date",
@@ -636,7 +531,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                     "type": "constant",
                     "constant": self.test_case_id
                 },
-                'xmlns_map': self.xmlns_map,
                 "end_date": {
                     "type": "ext_root_property_name",
                     "property_name": "end_date",
@@ -645,7 +539,7 @@ class TestGetCaseHistoryExpressionTest(TestCase):
             }
         })
         self.assertEqual(
-            4,
+            5,
             expression(
                 {"some_item": "item_value"},
                 context=context,
@@ -659,7 +553,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                 "type": "constant",
                 "constant": self.test_case_id
             },
-            'xmlns_map': self.xmlns_map,
             "case_property": "bar",
         })
         self.assertEqual(
@@ -681,7 +574,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                 "constant": self.test_case_id
             },
             "case_property": "foo",
-            "xmlns_map": self.xmlns_map,
             "end_date": {
                 "type": "ext_root_property_name",
                 "property_name": "end_date",
@@ -707,7 +599,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                 "constant": self.test_case_id
             },
             "case_property": "foo",
-            "xmlns_map": self.xmlns_map,
             "end_date": {
                 "type": "ext_root_property_name",
                 "property_name": "end_date",
@@ -732,7 +623,6 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                 "type": "constant",
                 "constant": self.test_case_id
             },
-            "xmlns_map": self.xmlns_map,
             "case_property": "foo",
             "end_date": {
                 "type": "ext_root_property_name",
@@ -746,8 +636,11 @@ class TestGetCaseHistoryExpressionTest(TestCase):
                         "type": "boolean_expression",
                         "operator": "in",
                         "expression": {
-                            "type": "property_name",
-                            "property_name": "foo",
+                            "type": "property_path",
+                            "property_path": [
+                                "update",
+                                "foo",
+                            ]
                         },
                         "property_value": [
                             "",


### PR DESCRIPTION
This adds some additional UCR extension expressions for accessing the case history.  Its for something that Neal and I are testing ( not for use by most projects).  