### PR TITLE
allow advanced shadow modules

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -207,7 +207,7 @@ def _get_shadow_module_view_context(app, module, lang=None):
         }
 
     return {
-        'modules': [get_mod_dict(m) for m in app.modules if m.module_type == 'basic'],
+        'modules': [get_mod_dict(m) for m in app.modules if m.module_type != 'shadow'],
         'excluded_form_ids': module.excluded_form_ids,
     }
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -207,7 +207,7 @@ def _get_shadow_module_view_context(app, module, lang=None):
         }
 
     return {
-        'modules': [get_mod_dict(m) for m in app.modules if m.module_type != 'shadow'],
+        'modules': [get_mod_dict(m) for m in app.modules if m.module_type in ['basic', 'advanced']],
         'excluded_form_ids': module.excluded_form_ids,
     }
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240834

I don't think there's a specific reason that shadow modules can't be advanced modules, it was just the most conservative design decision to make at the time. It's possible that there's some situation with advanced modules that won't work well with shadow modules...but I'm not concerned about this PR causing significant increased support, because when/if shadow modules misbehave, there's always the workaround "don't use shadow modules, make a full copy of the module you want to shadow."

@czue / @kaapstorm 