### PR TITLE
Add SQL-backed document store for locations UCR

### DIFF
--- a/corehq/apps/change_feed/data_sources.py
+++ b/corehq/apps/change_feed/data_sources.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
+from corehq.apps.locations.document_store import ReadonlyLocationDocumentStore
 from corehq.apps.sms.document_stores import ReadonlySMSDocumentStore
 from corehq.form_processor.document_stores import (
     ReadonlyFormDocumentStore, ReadonlyCaseDocumentStore, ReadonlyLedgerV2DocumentStore,
@@ -15,6 +16,7 @@ CASE_SQL = 'case-sql'
 SMS = 'sms'
 LEDGER_V2 = 'ledger-v2'
 LEDGER_V1 = 'ledger-v1'
+LOCATION = 'location'
 
 
 def get_document_store(data_source_type, data_source_name, domain):
@@ -36,6 +38,8 @@ def get_document_store(data_source_type, data_source_name, domain):
         return ReadonlyLedgerV2DocumentStore(domain)
     elif data_source_type == LEDGER_V1:
         return LedgerV1DocumentStore(domain)
+    elif data_source_type == LOCATION:
+        return ReadonlyLocationDocumentStore(domain)
     else:
         raise UnknownDocumentStore(
             'getting document stores for backend {} is not supported!'.format(data_source_type)

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -19,6 +19,7 @@ LEDGER = 'ledger'
 COMMCARE_USER = 'commcare-user'
 GROUP = 'group'
 WEB_USER = 'web-user'
+LOCATION = 'location'
 
 
 ALL = (
@@ -34,6 +35,7 @@ ALL = (
     SMS,
     WEB_USER,
     APP,
+    LOCATION,
 )
 
 

--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -1,0 +1,45 @@
+"""
+This file contains stuff for publishing and reading changes for UCR.
+"""
+from pillowtop.dao.exceptions import DocumentNotFoundError
+from pillowtop.dao.interface import ReadOnlyDocumentStore
+from .models import SQLLocation
+from pillowtop.feed.interface import ChangeMeta
+
+from corehq.apps.change_feed import data_sources
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.producer import producer
+
+LOCATION_DOC_TYPE = "Location"
+
+
+class ReadonlyLocationDocumentStore(ReadOnlyDocumentStore):
+
+    def __init__(self, domain):
+        self.domain = domain
+        self.queryset = SQLLocation.active_objects.filter(domain=domain)
+
+    def get_document(self, doc_id):
+        try:
+            return self.queryset.get(location_id=doc_id).to_json()
+        except SQLLocation.DoesNotExist as e:
+            raise DocumentNotFoundError(e)
+
+    def iter_document_ids(self, last_id=None):
+        return iter(self.queryset.location_ids())
+
+    def iter_documents(self, ids):
+        for location in self.queryset.filter(location_id__in=ids):
+            yield location.to_json()
+
+
+def publish_location_saved(domain, location_id, is_deletion=False):
+    change_meta = ChangeMeta(
+        document_id=location_id,
+        data_source_type=data_sources.LOCATION,
+        data_source_name=data_sources.LOCATION,
+        document_type=LOCATION_DOC_TYPE,
+        domain=domain,
+        is_deletion=is_deletion,
+    )
+    producer.send_change(topics.LOCATION, change_meta)

--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -32,8 +32,8 @@ class ReadonlyLocationDocumentStore(ReadOnlyDocumentStore):
             yield location.to_json()
 
 
-def publish_location_saved(domain, location_id, is_deletion=False):
-    change_meta = ChangeMeta(
+def get_location_change_meta(domain, location_id, is_deletion=False):
+    return ChangeMeta(
         document_id=location_id,
         data_source_type='location',
         data_source_name='location',
@@ -41,4 +41,8 @@ def publish_location_saved(domain, location_id, is_deletion=False):
         domain=domain,
         is_deletion=is_deletion,
     )
+
+
+def publish_location_saved(domain, location_id, is_deletion=False):
+    change_meta = get_location_change_meta(domain, location_id, is_deletion)
     producer.send_change(topics.LOCATION, change_meta)

--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -32,8 +32,8 @@ class ReadonlyLocationDocumentStore(ReadOnlyDocumentStore):
             yield location.to_json()
 
 
-def get_location_change_meta(domain, location_id, is_deletion=False):
-    return ChangeMeta(
+def publish_location_saved(domain, location_id, is_deletion=False):
+    change_meta = ChangeMeta(
         document_id=location_id,
         data_source_type='location',
         data_source_name='location',
@@ -41,8 +41,4 @@ def get_location_change_meta(domain, location_id, is_deletion=False):
         domain=domain,
         is_deletion=is_deletion,
     )
-
-
-def publish_location_saved(domain, location_id, is_deletion=False):
-    change_meta = get_location_change_meta(domain, location_id, is_deletion)
     producer.send_change(topics.LOCATION, change_meta)

--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -6,7 +6,6 @@ from pillowtop.dao.interface import ReadOnlyDocumentStore
 from .models import SQLLocation
 from pillowtop.feed.interface import ChangeMeta
 
-from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.producer import producer
 
@@ -36,8 +35,8 @@ class ReadonlyLocationDocumentStore(ReadOnlyDocumentStore):
 def publish_location_saved(domain, location_id, is_deletion=False):
     change_meta = ChangeMeta(
         document_id=location_id,
-        data_source_type=data_sources.LOCATION,
-        data_source_name=data_sources.LOCATION,
+        data_source_type='location',
+        data_source_name='location',
         document_type=LOCATION_DOC_TYPE,
         domain=domain,
         is_deletion=is_deletion,

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -554,14 +554,12 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
         SQL ONLY FULL DELETE
         Delete this location and it's descendants.
         """
-        ids_to_delete = self.get_descendants(include_self=True).location_ids()
+        to_delete = self.get_descendants(include_self=True)
 
-        for loc_id in ids_to_delete:
-            loc = SQLLocation.objects.prefetch_related(
-                'location_type').get(location_id=loc_id)
+        for loc in to_delete:
             loc._sql_close_case_and_remove_users()
 
-        self.get_descendants(include_self=True).delete()
+        to_delete.delete()
 
     def _sql_close_case_and_remove_users(self):
         """

--- a/corehq/apps/userreports/document_stores.py
+++ b/corehq/apps/userreports/document_stores.py
@@ -1,7 +1,30 @@
+from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.document_stores import ReadonlyFormDocumentStore, ReadonlyCaseDocumentStore
 from corehq.form_processor.utils import should_use_sql_backend
 from corehq.util.couch import get_db_by_doc_type
 from pillowtop.dao.couch import CouchDocumentStore
+from pillowtop.dao.exceptions import DocumentNotFoundError
+from pillowtop.dao.interface import ReadOnlyDocumentStore
+
+
+class ReadonlyLocationDocumentStore(ReadOnlyDocumentStore):
+
+    def __init__(self, domain):
+        self.domain = domain
+        self.queryset = SQLLocation.objects.filter(domain=domain)
+
+    def get_document(self, doc_id):
+        try:
+            return self.queryset.get(location_id=doc_id).to_json()
+        except SQLLocation.DoesNotExist as e:
+            raise DocumentNotFoundError(e)
+
+    def iter_document_ids(self, last_id=None):
+        return iter(self.queryset.location_ids())
+
+    def iter_documents(self, ids):
+        for location in self.queryset.filter(location_id__in=ids):
+            yield location.to_json()
 
 
 def get_document_store(domain, doc_type):
@@ -10,6 +33,8 @@ def get_document_store(domain, doc_type):
         return ReadonlyFormDocumentStore(domain)
     elif use_sql and doc_type == 'CommCareCase':
         return ReadonlyCaseDocumentStore(domain)
+    elif doc_type == 'Location':
+        return ReadonlyLocationDocumentStore(domain)
     else:
         # all other types still live in couchdb
         return CouchDocumentStore(

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -180,7 +180,9 @@ class RelatedDocExpressionSpec(JsonObject):
     value_expression = DictProperty(required=True)
 
     def configure(self, doc_id_expression, value_expression):
-        if get_db_by_doc_type(self.related_doc_type) is None:
+        non_couch_doc_types = ('Location')
+        if (self.related_doc_type not in non_couch_doc_types
+                and get_db_by_doc_type(self.related_doc_type) is None):
             raise BadSpecError(u'Cannot determine database for document type {}!'.format(self.related_doc_type))
 
         self._doc_id_expression = doc_id_expression

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -1,5 +1,6 @@
 import json
 from simpleeval import InvalidExpression
+from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 from corehq.apps.userreports.document_stores import get_document_store
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -180,7 +181,7 @@ class RelatedDocExpressionSpec(JsonObject):
     value_expression = DictProperty(required=True)
 
     def configure(self, doc_id_expression, value_expression):
-        non_couch_doc_types = ('Location')
+        non_couch_doc_types = (LOCATION_DOC_TYPE,)
         if (self.related_doc_type not in non_couch_doc_types
                 and get_db_by_doc_type(self.related_doc_type) is None):
             raise BadSpecError(u'Cannot determine database for document type {}!'.format(self.related_doc_type))

--- a/corehq/apps/userreports/tests/test_location_data_source.py
+++ b/corehq/apps/userreports/tests/test_location_data_source.py
@@ -1,0 +1,105 @@
+import uuid
+from django.test import TestCase
+from pillowtop.feed.interface import Change
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.locations.document_store import get_location_change_meta
+from corehq.apps.locations.models import SQLLocation, LocationType
+from corehq.apps.locations.tests.util import delete_all_locations
+
+from corehq.apps.userreports.app_manager import _clean_table_name
+from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.pillow import get_kafka_ucr_pillow
+from corehq.apps.userreports.tasks import rebuild_indicators
+from corehq.apps.userreports.util import get_indicator_adapter
+
+
+class TestLocationDataSource(TestCase):
+    domain = "delos_corp"
+
+    def setUp(self):
+        delete_all_locations()
+        self.domain_obj = create_domain(self.domain)
+
+        self.region = LocationType.objects.create(domain=self.domain, name="region")
+        self.town = LocationType.objects.create(domain=self.domain, name="town", parent_type=self.region)
+
+        self.data_source_config = DataSourceConfiguration(
+            domain=self.domain,
+            display_name='Locations in Westworld',
+            referenced_doc_type='Location',
+            table_id=_clean_table_name(self.domain, str(uuid.uuid4().hex)),
+            configured_filter={},
+            configured_indicators=[{
+                "type": "expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "name"
+                },
+                "column_id": "location_name",
+                "display_name": "location_name",
+                "datatype": "string"
+            }],
+        )
+        self.data_source_config.validate()
+        self.data_source_config.save()
+
+        self.pillow = get_kafka_ucr_pillow()
+        self.pillow.bootstrap(configs=[self.data_source_config])
+
+    def tearDown(self):
+        self.domain_obj.delete()
+        delete_all_locations()
+        self.data_source_config.delete()
+
+    def _make_loc(self, name, location_type):
+        return SQLLocation.objects.create(
+            domain=self.domain, name=name, site_code=name, location_type=location_type)
+
+    @staticmethod
+    def location_to_change(location, is_deletion=False):
+        change_meta = get_location_change_meta(location.domain, location.location_id, is_deletion)
+        return Change(
+            id=location.location_id,
+            sequence_id='0',
+            deleted=is_deletion,
+            document=location.to_json(),
+            metadata=change_meta,
+        )
+
+    def assertDataSourceAccurate(self, expected_locations):
+        adapter = get_indicator_adapter(self.data_source_config)
+        query = adapter.get_query_object()
+        adapter.refresh_table()
+        data_source = query.all()
+        self.assertItemsEqual(
+            expected_locations,
+            [row[-1] for row in data_source]
+        )
+
+    def test_location_data_source(self):
+        self._make_loc("Westworld", self.region)
+        sweetwater = self._make_loc("Sweetwater", self.town)
+        las_mudas = self._make_loc("Las Mudas", self.town)
+
+        rebuild_indicators(self.data_source_config._id)
+
+        self.assertDataSourceAccurate(["Westworld", "Sweetwater", "Las Mudas"])
+
+        # Insert new location
+        blood_arroyo = self._make_loc("Blood Arroyo", self.town)
+        self.pillow.process_change(self.location_to_change(blood_arroyo))
+        self.assertDataSourceAccurate(["Westworld", "Sweetwater", "Las Mudas", "Blood Arroyo"])
+
+        # Change an existing location
+        sweetwater.name = "Pariah"
+        sweetwater.save()
+        self.pillow.process_change(self.location_to_change(sweetwater))
+        self.assertDataSourceAccurate(["Westworld", "Pariah", "Las Mudas", "Blood Arroyo"])
+
+        # Delete a location
+        change = self.location_to_change(las_mudas, is_deletion=True)
+        las_mudas.delete()
+        self.pillow.process_change(change)
+        # No actual change - deletions are not yet processed
+        self.assertDataSourceAccurate(["Westworld", "Pariah", "Las Mudas", "Blood Arroyo"])

--- a/corehq/apps/userreports/tests/test_location_data_source.py
+++ b/corehq/apps/userreports/tests/test_location_data_source.py
@@ -1,10 +1,8 @@
 import uuid
 from django.test import TestCase
 from kafka.common import KafkaUnavailableError
-from pillowtop.feed.interface import Change
 
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.locations.document_store import get_location_change_meta
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.util.test_utils import trap_extra_setup
@@ -81,7 +79,7 @@ class TestLocationDataSource(TestCase):
 
         # Insert new location
         since = self.pillow.get_change_feed().get_current_offsets()
-        blood_arroyo = self._make_loc("Blood Arroyo", self.town)
+        self._make_loc("Blood Arroyo", self.town)
 
         # Change an existing location
         sweetwater.name = "Pariah"

--- a/corehq/ex-submodules/pillowtop/dao/interface.py
+++ b/corehq/ex-submodules/pillowtop/dao/interface.py
@@ -20,7 +20,7 @@ class DocumentStore(object):
     def delete_document(self, doc_id):
         pass
 
-    def iter_document_ids(self):
+    def iter_document_ids(self, last_id=None):
         # todo: can convert to @abstractmethod once subclasses handle it
         raise NotImplementedError('this function not yet implemented')
 


### PR DESCRIPTION
@sravfeyn
@czue
Is this really all it takes to make UCR not need couch for locations?  I tested it locally and it works as expected on a forced rebuild, but I'm not sure if that gets docs in a different way than the steady-state process.  Marking as don't merge 'till I can get a conclusive answer on that.