### PR TITLE
Populate case list/detail select2 with current value

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -42,6 +42,9 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
          * @param options: Array of strings.
          */
         setUpAutocomplete: function($elem, options){
+            if (!_.contains(options, $elem.value)) {
+                options.unshift($elem.value);
+            }
             $elem.$edit_view.select2({
                 minimumInputLength: 0,
                 delay: 0,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?241998

Looks like this is the only one of the recent jquery autocomplete => select2 conversions that doesn't use the `typeahead` binding (which takes care of this at https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/style/static/style/ko/knockout_bindings.ko.js#L589-L594) and also stores a value that might not be in the given list of options.

@czue 