### PR TITLE
Don't populate ReportAppConfig description unless ReportConfiguration has one

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -555,7 +555,7 @@ def _new_report_module(request, domain, app, name, lang):
         ReportAppConfig(
             report_id=report._id,
             header={lang: report.title},
-            description={lang: report.description},
+            description={lang: report.description} if report.description else None,
         )
         for report in ReportConfiguration.by_domain(domain)
     ]


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?241475

The build error happens because the report config's `localized_description` is `{'en': None}` which breaks when creating the app's translation files: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/templatetags/xforms_extras.py#L36

@czue 