### PR TITLE
Allow arbitrary xpath in default search properties

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -54,7 +54,7 @@ AMPLIFIES_NOT_SET = 'not_set'
 
 DEFAULT_MONTH_FILTER_PERIOD_LENGTH = 0
 
-CLAIM_DEFAULT_RELEVANT_CONDITION = "count(instance('casedb')/casedb/case[@case_id=instance('querysession')/session/data/case_id]) = 0"
+CLAIM_DEFAULT_RELEVANT_CONDITION = "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0"
 
 STOCK_QUESTION_TAG_NAMES = [
     'balance',

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -213,7 +213,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
 
     var searchViewModel = function (searchProperties, includeClosed, defaultProperties, lang, saveButton) {
         var self = this,
-            DEFAULT_CLAIM_RELEVANT= "count(instance('casedb')/casedb/case[@case_id=instance('querysession')/session/data/case_id]) = 0";
+            DEFAULT_CLAIM_RELEVANT= "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0";
 
         var SearchProperty = function (name, label) {
             var self = this;

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -219,12 +219,26 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
             var self = this;
             self.name = ko.observable(name);
             self.label = ko.observable(label);
+
+            self.name.subscribe(function () {
+                saveButton.fire('change');
+            });
+            self.label.subscribe(function () {
+                saveButton.fire('change');
+            });
         };
 
         var DefaultProperty = function (property, defaultValue) {
             var self = this;
             self.property = ko.observable(property);
             self.defaultValue = ko.observable(defaultValue);
+
+            self.property.subscribe(function () {
+                saveButton.fire('change');
+            });
+            self.defaultValue.subscribe(function () {
+                saveButton.fire('change');
+            });
         };
 
         self.relevant = ko.observable();
@@ -245,9 +259,6 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         } else {
             self.searchProperties.push(new SearchProperty('', ''));
         }
-        self.searchProperties.subscribe(function () {
-            saveButton.fire('change');
-        });
 
         self.addProperty = function () {
             self.searchProperties.push(new SearchProperty('', ''));
@@ -281,9 +292,6 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         } else {
             self.defaultProperties.push(new DefaultProperty('', ''));
         }
-        self.defaultProperties.subscribe(function () {
-            saveButton.fire('change');
-        });
         self.addDefaultProperty = function () {
             self.defaultProperties.push(new DefaultProperty('',''));
         };
@@ -323,10 +331,17 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 default_properties: self._getDefaultProperties(),
             };
         };
+
         self.includeClosed.subscribe(function () {
             saveButton.fire('change');
         });
         self.default_relevant.subscribe(function () {
+            saveButton.fire('change');
+        });
+        self.searchProperties.subscribe(function () {
+            saveButton.fire('change');
+        });
+        self.defaultProperties.subscribe(function () {
             saveButton.fire('change');
         });
     };

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -100,7 +100,7 @@ class RemoteRequestContributor(SuiteContributorByModule):
                                     ref="'{}'".format(module.search_config.include_closed)
                                 )
                             ] + [
-                                QueryData(key="'{}'".format(c.property), ref="'{}'".format(c.defaultValue))
+                                QueryData(key="{}".format(c.property), ref="{}".format(c.defaultValue))
                                 for c in module.search_config.default_properties
                             ]),
                             prompts=[

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -50,16 +50,16 @@ class RemoteRequestFactory(object):
 
     def _build_remote_request_post(self):
         return RemoteRequestPost(
-                url=absolute_reverse('claim_case', args=[self.domain]),
-                relevant=self.module.search_config.relevant,
-                data=[
-                    QueryData(
-                        key='case_id',
-                        ref=QuerySessionXPath('case_id').instance(),
-                        # e.g. instance('querysession')/session/data/case_id
-                    ),
-                ]
-            )
+            url=absolute_reverse('claim_case', args=[self.domain]),
+            relevant=self.module.search_config.relevant,
+            data=[
+                QueryData(
+                    key='case_id',
+                    ref=QuerySessionXPath('case_id').instance(),
+                    # e.g. instance('querysession')/session/data/case_id
+                ),
+            ]
+        )
 
     def _build_command(self):
         return Command(

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -56,7 +56,6 @@ class RemoteRequestFactory(object):
                 QueryData(
                     key='case_id',
                     ref=QuerySessionXPath('case_id').instance(),
-                    # e.g. instance('querysession')/session/data/case_id
                 ),
             ]
         )
@@ -70,9 +69,13 @@ class RemoteRequestFactory(object):
         )
 
     def _build_instances(self):
-        instances, unknown_instances = EntryInstances.get_all_instances(self.domain, [
-            datum.ref for datum in self._get_remote_request_query_datums()
-        ])
+        query_xpaths = [datum.ref for datum in self._get_remote_request_query_datums()]
+        claim_relevant_xpaths = [self.module.search_config.relevant]
+
+        instances, unknown_instances = EntryInstances.get_all_instances(
+            self.domain,
+            query_xpaths + claim_relevant_xpaths
+        )
         return list(instances)
 
     def _build_session(self):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -107,7 +107,7 @@ class RemoteRequestFactory(object):
         default_query_datums = [
             QueryData(
                 key='case_type',
-                ref="'{}'".format(self.module.case_type)
+                ref=u"'{}'".format(self.module.case_type)
             ),
             QueryData(
                 key='include_closed',
@@ -115,7 +115,7 @@ class RemoteRequestFactory(object):
             )
         ]
         extra_query_datums = [
-            QueryData(key="{}".format(c.property), ref="{}".format(c.defaultValue))
+            QueryData(key=u"{}".format(c.property), ref=u"{}".format(c.defaultValue))
             for c in self.module.search_config.default_properties
         ]
         return default_query_datums + extra_query_datums

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -4,7 +4,6 @@ from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Command,
     Display,
-    Instance,
     PushFrame,
     QueryData,
     QueryPrompt,
@@ -34,6 +33,111 @@ class QuerySessionXPath(InstanceXpath):
         return 'session/data/{}'.format(self)
 
 
+class RemoteRequestFactory(object):
+    def __init__(self, domain, app, module):
+        self.domain = domain
+        self.app = app
+        self.module = module
+
+    def build_remote_request(self):
+        return RemoteRequest(
+            post=self._build_remote_request_post(),
+            command=self._build_command(),
+            instances=self._build_instances(),
+            session=self._build_session(),
+            stack=self._build_stack(),
+        )
+
+    def _build_remote_request_post(self):
+        return RemoteRequestPost(
+                url=absolute_reverse('claim_case', args=[self.domain]),
+                relevant=self.module.search_config.relevant,
+                data=[
+                    QueryData(
+                        key='case_id',
+                        ref=QuerySessionXPath('case_id').instance(),
+                        # e.g. instance('querysession')/session/data/case_id
+                    ),
+                ]
+            )
+
+    def _build_command(self):
+        return Command(
+            id=id_strings.search_command(self.module),
+            display=Display(
+                text=Text(locale_id=id_strings.case_search_locale(self.module)),
+            ),
+        )
+
+    def _build_instances(self):
+        instances, unknown_instances = EntryInstances.get_all_instances(self.domain, [
+            datum.ref for datum in self._get_remote_request_query_datums()
+        ])
+        return list(instances)
+
+    def _build_session(self):
+        return RemoteRequestSession(
+            queries=self._build_remote_request_queries(),
+            data=self._build_remote_request_datums(),
+        )
+
+    def _build_remote_request_queries(self):
+        return [
+            RemoteRequestQuery(
+                url=absolute_reverse('remote_search', args=[self.app.domain]),
+                storage_instance=RESULTS_INSTANCE,
+                template='case',
+                data=self._get_remote_request_query_datums(),
+                prompts=self._build_query_prompts()
+            )
+        ]
+
+    def _build_remote_request_datums(self):
+        details_helper = DetailsHelper(self.app)
+        return [SessionDatum(
+            id='case_id',
+            nodeset=(CaseTypeXpath(self.module.case_type)
+                     .case(instance_name=RESULTS_INSTANCE)),
+            value='./@case_id',
+            detail_select=details_helper.get_detail_id_safe(self.module, 'case_short'),
+            detail_confirm=details_helper.get_detail_id_safe(self.module, 'case_long'),
+        )]
+
+    def _get_remote_request_query_datums(self):
+        default_query_datums = [
+            QueryData(
+                key='case_type',
+                ref="'{}'".format(self.module.case_type)
+            ),
+            QueryData(
+                key='include_closed',
+                ref="'{}'".format(self.module.search_config.include_closed)
+            )
+        ]
+        extra_query_datums = [
+            QueryData(key="{}".format(c.property), ref="{}".format(c.defaultValue))
+            for c in self.module.search_config.default_properties
+        ]
+        return default_query_datums + extra_query_datums
+
+    def _build_query_prompts(self):
+        return [
+            QueryPrompt(
+                key=p.name,
+                display=Display(
+                    text=Text(locale_id=id_strings.search_property_locale(self.module, p.name)),
+                ),
+            ) for p in self.module.search_config.properties
+        ]
+
+    def _build_stack(self):
+        stack = Stack()
+        frame = PushFrame()
+        frame.add_rewind(QuerySessionXPath('case_id').instance())
+        stack.add_frame(frame)
+        return stack
+
+
 class RemoteRequestContributor(SuiteContributorByModule):
     """
     Adds a remote-request node, which sets the URL and query details for
@@ -47,85 +151,7 @@ class RemoteRequestContributor(SuiteContributorByModule):
     .. _CommCare 2.0 Suite Definition: https://github.com/dimagi/commcare/wiki/Suite20#remote-request
 
     """
-
     def get_module_contributions(self, module):
         if module_offers_search(module):
-            domain = self.app.domain
-
-            details_helper = DetailsHelper(self.app)
-
-            remote_request = RemoteRequest(
-                post=RemoteRequestPost(
-                    url=absolute_reverse('claim_case', args=[domain]),
-                    relevant=module.search_config.relevant,
-                    data=[
-                        QueryData(
-                            key='case_id',
-                            ref=QuerySessionXPath('case_id').instance(),
-                            # e.g. instance('querysession')/session/data/case_id
-                        ),
-                    ]
-                ),
-
-                command=Command(
-                    id=id_strings.search_command(module),
-                    display=Display(
-                        text=Text(locale_id=id_strings.case_search_locale(module)),
-                    ),
-                ),
-                session=RemoteRequestSession(
-                    queries=[
-                        RemoteRequestQuery(
-                            url=absolute_reverse('remote_search', args=[domain]),
-                            storage_instance=RESULTS_INSTANCE,
-                            template='case',
-                            data=_get_query_data(module),
-                            prompts=[
-                                QueryPrompt(
-                                    key=p.name,
-                                    display=Display(
-                                        text=Text(locale_id=id_strings.search_property_locale(module, p.name)),
-                                    ),
-                                ) for p in module.search_config.properties
-                            ]
-                        )
-                    ],
-                    data=[SessionDatum(
-                        id='case_id',
-                        nodeset=(CaseTypeXpath(module.case_type)
-                                 .case(instance_name=RESULTS_INSTANCE)),
-                        value='./@case_id',
-                        detail_select=details_helper.get_detail_id_safe(module, 'case_short'),
-                        detail_confirm=details_helper.get_detail_id_safe(module, 'case_long'),
-                    )],
-                ),
-
-                stack=Stack(),
-            )
-            instances, unknown_instances = EntryInstances.get_all_instances(domain, [
-                datum.ref for datum in _get_query_data(module)
-            ])
-            remote_request.instances = list(instances)
-
-            frame = PushFrame()
-            frame.add_rewind(QuerySessionXPath('case_id').instance())
-            remote_request.stack.add_frame(frame)
-
-            return [remote_request]
+            return [RemoteRequestFactory(self.app.domain, self.app, module).build_remote_request()]
         return []
-
-
-def _get_query_data(module):
-    return ([
-        QueryData(
-            key='case_type',
-            ref="'{}'".format(module.case_type)
-        ),
-        QueryData(
-            key='include_closed',
-            ref="'{}'".format(module.search_config.include_closed)
-        )
-    ] + [
-        QueryData(key="{}".format(c.property), ref="{}".format(c.defaultValue))
-        for c in module.search_config.default_properties
-    ])

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -76,7 +76,8 @@ class RemoteRequestFactory(object):
             self.domain,
             query_xpaths + claim_relevant_xpaths
         )
-        return list(instances)
+        # sorted list to prevent intermittent test failures
+        return sorted(list(instances), key=lambda i: i.id)
 
     def _build_session(self):
         return RemoteRequestSession(

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_search_properties.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <legend>
-    {% trans "Searching" %}
+    {% trans "Case Search and Claim" %}
 </legend>
 
 <div data-bind="with: search">
@@ -23,73 +23,108 @@
     </script>
 
     <form>
-        <table class="table table-condensed">
-            <thead data-bind="visible: searchProperties().length > 0">
-                <tr>
-                    <th class="col-sm-5">{% trans "Property" %}</th>
-                    <th class="col-sm-6">{% trans "Display Text" %}</th>
-                    <th class="col-sm-1">&nbsp;</th>
-                </tr>
-            </thead>
-            <tbody data-bind="template: { name: 'property_template', foreach: searchProperties, as: 'property' }">
-            </tbody>
-        </table>
-        <p>
-            <button type="button"
-                    class="btn btn-default"
-                    data-bind="click: addProperty">
-                <i class="fa fa-plus"></i> {% trans "Add search property" %}
-            </button>
-        </p>
-        <div class="checkbox">
-            <label>
-                <input type="checkbox" data-bind="checked: includeClosed"> {% trans "Include closed cases" %}
-            </label>
-        </div>
-        <div class="form-group">
-            <label>
-                {% trans "Conditional claim condition" %}
-                <input type="text" data-bind="value: relevant" class="form-control" />
-            </label>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" data-bind="checked: default_relevant">
-                    {% trans "Don't claim already owned cases" %}
-                </label>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{% trans "Search Properties" %}</h4>
+            </div>
+            <div class="panel-body">
+                <p>{% trans "Search against the following case properties." %}</p>
+                <table class="table table-condensed">
+                    <thead data-bind="visible: searchProperties().length > 0">
+                        <tr>
+                            <th class="col-sm-5">{% trans "Case Property" %}</th>
+                            <th class="col-sm-6">{% trans "Display Text" %}</th>
+                            <th class="col-sm-1">&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="template: { name: 'property_template', foreach: searchProperties, as: 'property' }">
+                    </tbody>
+                </table>
+                <p>
+                    <button type="button"
+                            class="btn btn-default"
+                            data-bind="click: addProperty">
+                        <i class="fa fa-plus"></i> {% trans "Add search property" %}
+                    </button>
+                </p>
             </div>
         </div>
-        <label>{% trans "Default Search Properties" %}</label>
-        <p>{% trans "Filter based on a specific value of any case property" %}</p>
-        <table class="table table-condensed">
-            <thead data-bind="visible: defaultProperties().length > 0">
-                <tr>
-                    <th class="col-sm-5">{% trans "Key" %}</th>
-                    <th class="col-sm-6">{% trans "Value" %}</th>
-                    <th class="col-sm-1">&nbsp;</th>
-                </tr>
-            </thead>
-            <tbody data-bind="foreach: defaultProperties">
-            <tr>
-                <td class="col-sm-4">
-                    <input class="form-control" type="text" data-bind="value: property"/>
-                </td>
-                <td class="col-sm-6">
-                    <input class="form-control" type="text" data-bind="value: defaultValue"/>
-                </td>
-                <td class="col-sm-2">
-                    <i style="cursor: pointer;"
-                       data-bind="click: $parent.removeDefaultProperty,
-                                  css: COMMCAREHQ.icons.DELETE"></i>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <p>
-            <button type="button"
-                    class="btn btn-default"
-                    data-bind="click: addDefaultProperty">
-                <i class="fa fa-plus"></i> {% trans "Add default property" %}
-            </button>
-        </p>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{% trans "Default Search Properties" %}</h4>
+            </div>
+            <div class="panel-body">
+                <p>{% trans "Filter based on a specific value of any case property. These are applied to every search and are hidden from the user." %}</p>
+                <table class="table table-condensed">
+                    <thead data-bind="visible: defaultProperties().length > 0">
+                        <tr>
+                            <th class="col-sm-5">{% trans "Case Property" %}</th>
+                            <th class="col-sm-6">{% trans "Value (XPath expression)" %}</th>
+                            <th class="col-sm-1">&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: defaultProperties">
+                        <tr>
+                            <td class="col-sm-4">
+                                <input class="form-control" type="text" data-bind="value: property"/>
+                            </td>
+                            <td class="col-sm-6">
+                                <input
+                                    class="form-control"
+                                    type="text"
+                                    data-bind="value: defaultValue"
+                                    spellcheck="false"
+                                />
+                            </td>
+                            <td class="col-sm-2">
+                                <i style="cursor: pointer;"
+                                   data-bind="click: $parent.removeDefaultProperty,
+                                              css: COMMCAREHQ.icons.DELETE"></i>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>
+                    <button type="button"
+                            class="btn btn-default"
+                            data-bind="click: addDefaultProperty">
+                        <i class="fa fa-plus"></i> {% trans "Add default search property" %}
+                    </button>
+                </p>
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{% trans "Search and Claim Options" %}</h4>
+            </div>
+            <div class="panel-body">
+                <div class="form-group">
+                    <label for="claim-relevant-condition" >
+                        {% trans "Only claim cases that fulfill the following condition" %}
+                    </label>
+                    <input type="text"
+                           data-bind="value: relevant"
+                           class="form-control"
+                           id="claim-relevant-condition"
+                           spellcheck="false"
+                    />
+                </div>
+                <div class="form-group">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" data-bind="checked: default_relevant">
+                            {% trans "Don't claim cases already owned by the user" %}
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" data-bind="checked: includeClosed"> {% trans "Include closed cases in search results" %}
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_search_properties.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <legend>
-    {% trans "Searching" %}
+    {% trans "Case Search and Claim" %}
 </legend>
 
 <div data-bind="with: search">
@@ -23,73 +23,108 @@
     </script>
 
     <form>
-        <table class="table table-condensed">
-            <thead data-bind="visible: searchProperties().length > 0">
-                <tr>
-                    <th class="col-sm-5">{% trans "Property" %}</th>
-                    <th class="col-sm-6">{% trans "Display Text" %}</th>
-                    <th class="col-sm-1">&nbsp;</th>
-                </tr>
-            </thead>
-            <tbody data-bind="template: { name: 'property_template', foreach: searchProperties, as: 'property' }">
-            </tbody>
-        </table>
-        <p>
-            <button type="button"
-                    class="btn btn-default"
-                    data-bind="click: addProperty">
-                <i class="fa fa-plus"></i> {% trans "Add search property" %}
-            </button>
-        </p>
-        <div class="checkbox">
-            <label>
-                <input type="checkbox" data-bind="checked: includeClosed"> {% trans "Include closed cases" %}
-            </label>
-        </div>
-        <div class="form-group">
-            <label>
-                {% trans "Conditional claim condition" %}
-                <input type="text" data-bind="value: relevant" class="form-control" />
-            </label>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" data-bind="checked: default_relevant">
-                    {% trans "Don't claim already owned cases" %}
-                </label>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{% trans "Search Properties" %}</h4>
+            </div>
+            <div class="panel-body">
+                <p>{% trans "Search against the following case properties." %}</p>
+                <table class="table table-condensed">
+                    <thead data-bind="visible: searchProperties().length > 0">
+                        <tr>
+                            <th class="col-sm-5">{% trans "Case Property" %}</th>
+                            <th class="col-sm-6">{% trans "Display Text" %}</th>
+                            <th class="col-sm-1">&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="template: { name: 'property_template', foreach: searchProperties, as: 'property' }">
+                    </tbody>
+                </table>
+                <p>
+                    <button type="button"
+                            class="btn btn-default"
+                            data-bind="click: addProperty">
+                        <i class="fa fa-plus"></i> {% trans "Add search property" %}
+                    </button>
+                </p>
             </div>
         </div>
-        <label>{% trans "Default Search Properties" %}</label>
-        <p>{% trans "Filter based on a specific value of any case property" %}</p>
-        <table class="table table-condensed">
-            <thead data-bind="visible: defaultProperties().length > 0">
-                <tr>
-                    <th class="col-sm-5">{% trans "Key" %}</th>
-                    <th class="col-sm-6">{% trans "Value" %}</th>
-                    <th class="col-sm-1">&nbsp;</th>
-                </tr>
-            </thead>
-            <tbody data-bind="foreach: defaultProperties">
-            <tr>
-                <td class="col-sm-4">
-                    <input class="form-control" type="text" data-bind="value: property"/>
-                </td>
-                <td class="col-sm-6">
-                    <input class="form-control" type="text" data-bind="value: defaultValue"/>
-                </td>
-                <td class="col-sm-2">
-                    <i style="cursor: pointer;"
-                       data-bind="click: $parent.removeDefaultProperty,
-                                  css: COMMCAREHQ.icons.DELETE"></i>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <p>
-            <button type="button"
-                    class="btn btn-default"
-                    data-bind="click: addDefaultProperty">
-                <i class="fa fa-plus"></i> {% trans "Add default property" %}
-            </button>
-        </p>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{% trans "Default Search Properties" %}</h4>
+            </div>
+            <div class="panel-body">
+                <p>{% trans "Filter based on a specific value of any case property. These are applied to every search and are hidden from the user." %}</p>
+                <table class="table table-condensed">
+                    <thead data-bind="visible: defaultProperties().length > 0">
+                        <tr>
+                            <th class="col-sm-5">{% trans "Case Property" %}</th>
+                            <th class="col-sm-6">{% trans "Value (XPath expression)" %}</th>
+                            <th class="col-sm-1">&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: defaultProperties">
+                        <tr>
+                            <td class="col-sm-4">
+                                <input class="form-control" type="text" data-bind="value: property"/>
+                            </td>
+                            <td class="col-sm-6">
+                                <input
+                                    class="form-control"
+                                    type="text"
+                                    data-bind="value: defaultValue"
+                                    spellcheck="false"
+                                />
+                            </td>
+                            <td class="col-sm-2">
+                                <i style="cursor: pointer;"
+                                   data-bind="click: $parent.removeDefaultProperty,
+                                              css: COMMCAREHQ.icons.DELETE"></i>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>
+                    <button type="button"
+                            class="btn btn-default"
+                            data-bind="click: addDefaultProperty">
+                        <i class="fa fa-plus"></i> {% trans "Add default search property" %}
+                    </button>
+                </p>
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{% trans "Search and Claim Options" %}</h4>
+            </div>
+            <div class="panel-body">
+                <div class="form-group">
+                    <label for="claim-relevant-condition" >
+                        {% trans "Only claim cases that fulfill the following condition" %}
+                    </label>
+                    <input type="text"
+                           data-bind="value: relevant"
+                           class="form-control"
+                           id="claim-relevant-condition"
+                           spellcheck="false"
+                    />
+                </div>
+                <div class="form-group">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" data-bind="checked: default_relevant">
+                            {% trans "Don't claim cases already owned by the user" %}
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" data-bind="checked: includeClosed"> {% trans "Include closed cases in search results" %}
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
 </div>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -19,6 +19,7 @@
              template="case">
         <data key="case_type" ref="'case'"/>
         <data key="include_closed" ref="'False'"/>
+        <data key="name" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property"/>
         <prompt key="name">
           <display>
             <text>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -1,7 +1,7 @@
 <partial>
   <remote-request>
     <post url="https://www.example.com/a/test_domain/phone/claim-case/"
-          relevant="count(instance('casedb')/casedb/case[@case_id=instance('querysession')/session/data/case_id]) = 0">
+          relevant="instance('groups')/groups/group and count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">
       <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
     </post>
     <command id="search_command.m0">
@@ -11,9 +11,10 @@
         </text>
       </display>
     </command>
-    <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="locations" src="jr://fixture/commtrack:locations"/>
+    <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="groups" src="jr://fixture/user-groups"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/"
              storage-instance="results"

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -2,7 +2,7 @@
   <remote-request>
     <post url="https://www.example.com/a/test_domain/phone/claim-case/"
           relevant="count(instance('casedb')/casedb/case[@case_id=instance('querysession')/session/data/case_id]) = 0">
-      <data key="case_id" ref="instance('querysession')/session/data/case_id"/>
+      <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
     </post>
     <command id="search_command.m0">
       <display>
@@ -11,8 +11,9 @@
         </text>
       </display>
     </command>
-    <instance id="querysession" src="jr://instance/session"/>
     <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="locations" src="jr://fixture/commtrack:locations"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/"
              storage-instance="results"
@@ -20,6 +21,7 @@
         <data key="case_type" ref="'case'"/>
         <data key="include_closed" ref="'False'"/>
         <data key="name" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property"/>
+        <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
         <prompt key="name">
           <display>
             <text>
@@ -43,7 +45,7 @@
     </session>
     <stack>
       <push>
-        <rewind value="instance('querysession')/session/data/case_id"/>
+        <rewind value="instance('commcaresession')/session/data/case_id"/>
       </push>
     </stack>
   </remote-request>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -20,7 +20,7 @@
              template="case">
         <data key="case_type" ref="'case'"/>
         <data key="include_closed" ref="'False'"/>
-        <data key="name" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property"/>
+        <data key="&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;"/>
         <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
         <prompt key="name">
           <display>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -11,10 +11,10 @@
         </text>
       </display>
     </command>
-    <instance id="locations" src="jr://fixture/commtrack:locations"/>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="groups" src="jr://fixture/user-groups"/>
+    <instance id="locations" src="jr://fixture/commtrack:locations"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/"
              storage-instance="results"

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.test import SimpleTestCase
 from mock import patch
 
@@ -30,11 +31,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             ],
             default_properties=[
                 DefaultCaseSearchProperty(
-                    property='name',
+                    property=u'ɨŧsȺŧɍȺᵽ',
                     defaultValue=(
-                        "instance('casedb')/case"
-                        "[@case_id='instance('commcaresession')/session/data/case_id']"
-                        "/some_property")
+                        u"instance('casedb')/case"
+                        u"[@case_id='instance('commcaresession')/session/data/case_id']"
+                        u"/ɨŧsȺŧɍȺᵽ")
                 ),
                 DefaultCaseSearchProperty(
                     property='name',

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -31,7 +31,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             default_properties=[
                 DefaultCaseSearchProperty(
                     property='name',
-                    defaultValue="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property")
+                    defaultValue="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property"),
+                DefaultCaseSearchProperty(
+                    property='name',
+                    defaultValue="instance('locations')/locations/location[@id=123]/@type",
+                ),
             ],
         )
 

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -1,7 +1,13 @@
 from django.test import SimpleTestCase
 from mock import patch
 
-from corehq.apps.app_manager.models import Application, Module, CaseSearch, CaseSearchProperty
+from corehq.apps.app_manager.models import (
+    Application,
+    Module,
+    CaseSearch,
+    CaseSearchProperty,
+    DefaultCaseSearchProperty
+)
 from corehq.apps.app_manager.tests.util import TestXmlMixin, SuiteMixin
 
 
@@ -21,7 +27,12 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
-            ]
+            ],
+            default_properties=[
+                DefaultCaseSearchProperty(
+                    property='name',
+                    defaultValue="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property")
+            ],
         )
 
     def test_remote_request(self):

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -2,6 +2,7 @@
 from django.test import SimpleTestCase
 from mock import patch
 
+from corehq.apps.app_manager.const import CLAIM_DEFAULT_RELEVANT_CONDITION
 from corehq.apps.app_manager.models import (
     Application,
     Module,
@@ -29,6 +30,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
             ],
+            relevant="{} and {}".format("instance('groups')/groups/group", CLAIM_DEFAULT_RELEVANT_CONDITION),
             default_properties=[
                 DefaultCaseSearchProperty(
                     property=u'ɨŧsȺŧɍȺᵽ',

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -31,7 +31,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             default_properties=[
                 DefaultCaseSearchProperty(
                     property='name',
-                    defaultValue="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/some_property"),
+                    defaultValue=(
+                        "instance('casedb')/case"
+                        "[@case_id='instance('commcaresession')/session/data/case_id']"
+                        "/some_property")
+                ),
                 DefaultCaseSearchProperty(
                     property='name',
                     defaultValue="instance('locations')/locations/location[@id=123]/@type",


### PR DESCRIPTION
Don't wrap default search values in quotes, so generic XPath expressions are evaluated on mobile. Instances referenced in those XPaths are also added into the RemoteRequest. 

This is needed by `m2m` who want to have a default search property that automatically searches cases based on the user's location.

Did a bunch of refactoring and updating of the UI as it was pretty messy and somewhat broken, and I'm planning on doing more work here soon.

🐡 

@emord @dannyroberts 