### PR TITLE
Don't fail hard if markdown doesn't exist

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -5,7 +5,7 @@
     <div class="gr">
         <fieldset class="gr-header">
             <legend>
-                <span class="caption" data-bind="html: caption_markdown() || caption()"></span>
+                <span class="caption" data-bind="html: ko.utils.unwrapObservable(caption_markdown) || caption()"></span>
                 <button class="btn btn-xs btn-danger del pull-right" href="#" data-bind="
                     visible: isRepetition,
                     click: deleteRepeat
@@ -225,7 +225,7 @@
             }
         ">
         <label class="caption control-label" data-bind="
-            html: caption_markdown() || caption(),
+            html: ko.utils.unwrapObservable(caption_markdown) || caption(),
             css: Formplayer.Const.LABEL_WIDTH
             "></label>
         <div class="widget-container controls" data-bind="css: Formplayer.Const.CONTROL_WIDTH">
@@ -260,7 +260,7 @@
     <div class="info panel panel-default">
         <div class="panel-body">
             <span class="ix" data-bind="text: ixInfo($data)">></span>
-            <span class="caption" data-bind="html: caption_markdown() || caption()"></span>
+            <span class="caption" data-bind="html: ko.utils.unwrapObservable(caption_markdown) || caption()"></span>
             <div class="widget-multimedia" data-bind="
                 template: { name: 'widget-multimedia-ko-template', data: $data }"
                 >


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?242129

@wpride this causes us not to fail hard when markdown doesn't exist (i think the root cause of that property not being inserted is something in old touchforms, didn't look too deeply since i'm trying not to touch that code)

cc: @mkangia 