### PR TITLE
Move ES UCR interpretation to columns

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -263,6 +263,22 @@ class MinAggregation(SumAggregation):
     type = "min"
 
 
+class MaxAggregation(SumAggregation):
+    type = "max"
+
+
+class AvgAggregation(SumAggregation):
+    type = "avg"
+
+
+class ValueCountAggregation(SumAggregation):
+    type = "value_count"
+
+
+class CardinalityAggregation(SumAggregation):
+    type = "cardinality"
+
+
 class MissingAggregation(Aggregation):
     """
     A field data based single bucket aggregation, that creates a bucket of all

--- a/corehq/apps/userreports/es/columns.py
+++ b/corehq/apps/userreports/es/columns.py
@@ -24,7 +24,7 @@ class UCRExpandEsDatabaseSubcolumn(UCRExpandDatabaseSubcolumn):
             self.es_alias, filters.term(self.data_source_field, self.expand_value)
         )
 
-    def get_data(self, row):
+    def get_es_data(self, row):
         return row[self.es_alias]['doc_count']
 
 

--- a/corehq/apps/userreports/es/columns.py
+++ b/corehq/apps/userreports/es/columns.py
@@ -1,47 +1,31 @@
 from corehq.apps.es import filters
 from corehq.apps.es.aggregations import (
-    FilterAggregation, SumAggregation, MissingAggregation
+    FilterAggregation, MissingAggregation
 )
 from corehq.apps.userreports.columns import UCRExpandDatabaseSubcolumn
 
 
 class UCRExpandEsDatabaseSubcolumn(UCRExpandDatabaseSubcolumn):
-    def __init__(self, header, aggregation, ui_alias, *args, **kwargs):
-        self.aggregation = aggregation
+    def __init__(self, header, ui_alias, es_alias, expand_value, data_source_field, *args, **kwargs):
         self.ui_alias = ui_alias
-        super(UCRExpandEsDatabaseSubcolumn, self).__init__(header, slug=ui_alias, *args, **kwargs)
-
-
-class FilterAggregationColumn(object):
-    _aggregation = FilterAggregation
-
-    def __init__(self, report_column, value, es_alias=None):
-        self.report_column = report_column
-        self.value = value
-        self.es_alias = es_alias or report_column.column_id
+        self.data_source_field = data_source_field
+        self.es_alias = es_alias
+        super(UCRExpandEsDatabaseSubcolumn, self).__init__(
+            header, slug=ui_alias, expand_value=expand_value, *args, **kwargs
+        )
 
     @property
     def aggregation(self):
-        return self._aggregation(
-            self.es_alias, filters.term(self.report_column.field, self.value)
+        if self.expand_value is None:
+            return MissingAggregation(
+                self.es_alias, self.data_source_field
+            )
+        return FilterAggregation(
+            self.es_alias, filters.term(self.data_source_field, self.expand_value)
         )
 
     def get_data(self, row):
         return row[self.es_alias]['doc_count']
-
-
-class SumAggregationColumn(FilterAggregationColumn):
-    _aggregation = SumAggregation
-
-    @property
-    def aggregation(self):
-        return self._aggregation(
-            self.es_alias, self.report_column.field
-        )
-
-
-class MissingAggregationColumn(SumAggregationColumn):
-    _aggregation = MissingAggregation
 
 
 def expand_column(report_column, distinct_values, lang):
@@ -49,16 +33,12 @@ def expand_column(report_column, distinct_values, lang):
     for index, val in enumerate(distinct_values):
         es_alias = u"{}_dash_{}".format(report_column.column_id, index)
         ui_alias = u"{}-{}".format(report_column.column_id, index)
-        if val is None:
-            aggregation = MissingAggregationColumn(report_column, val, es_alias)
-        else:
-            aggregation = FilterAggregationColumn(report_column, val, es_alias)
-        # todo aggregation only supports # of matches
         columns.append(UCRExpandEsDatabaseSubcolumn(
             u"{}-{}".format(report_column.get_header(lang), val),
-            expand_value=val,
-            aggregation=aggregation,
             ui_alias=ui_alias,
+            es_alias=es_alias,
+            expand_value=val,
+            data_source_field=report_column.field,
             sortable=False,
             data_slug=u"{}-{}".format(report_column.column_id, index),
             format_fn=report_column.get_format_fn(),

--- a/corehq/apps/userreports/es/columns.py
+++ b/corehq/apps/userreports/es/columns.py
@@ -1,14 +1,47 @@
 from corehq.apps.es import filters
-from corehq.apps.es.aggregations import FilterAggregation
+from corehq.apps.es.aggregations import (
+    FilterAggregation, SumAggregation, MissingAggregation
+)
 from corehq.apps.userreports.columns import UCRExpandDatabaseSubcolumn
 
 
 class UCRExpandEsDatabaseSubcolumn(UCRExpandDatabaseSubcolumn):
-    def __init__(self, header, aggregation, es_alias, ui_alias, *args, **kwargs):
+    def __init__(self, header, aggregation, ui_alias, *args, **kwargs):
         self.aggregation = aggregation
-        self.es_alias = es_alias
         self.ui_alias = ui_alias
         super(UCRExpandEsDatabaseSubcolumn, self).__init__(header, slug=ui_alias, *args, **kwargs)
+
+
+class FilterAggregationColumn(object):
+    _aggregation = FilterAggregation
+
+    def __init__(self, report_column, value, es_alias=None):
+        self.report_column = report_column
+        self.value = value
+        self.es_alias = es_alias or report_column.column_id
+
+    @property
+    def aggregation(self):
+        return self._aggregation(
+            self.es_alias, filters.term(self.report_column.field, self.value)
+        )
+
+    def get_data(self, row):
+        return row[self.es_alias]['doc_count']
+
+
+class SumAggregationColumn(FilterAggregationColumn):
+    _aggregation = SumAggregation
+
+    @property
+    def aggregation(self):
+        return self._aggregation(
+            self.es_alias, self.report_column.field
+        )
+
+
+class MissingAggregationColumn(SumAggregationColumn):
+    _aggregation = MissingAggregation
 
 
 def expand_column(report_column, distinct_values, lang):
@@ -16,14 +49,15 @@ def expand_column(report_column, distinct_values, lang):
     for index, val in enumerate(distinct_values):
         es_alias = u"{}_dash_{}".format(report_column.column_id, index)
         ui_alias = u"{}-{}".format(report_column.column_id, index)
+        if val is None:
+            aggregation = MissingAggregationColumn(report_column, val, es_alias)
+        else:
+            aggregation = FilterAggregationColumn(report_column, val, es_alias)
         # todo aggregation only supports # of matches
         columns.append(UCRExpandEsDatabaseSubcolumn(
             u"{}-{}".format(report_column.get_header(lang), val),
             expand_value=val,
-            aggregation=FilterAggregation(
-                es_alias, filters.term(report_column.field, val)
-            ),
-            es_alias=es_alias,
+            aggregation=aggregation,
             ui_alias=ui_alias,
             sortable=False,
             data_slug=u"{}-{}".format(report_column.column_id, index),

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -116,7 +116,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
                 if report_column.type == 'expanded':
                     # todo aggregation only supports # of docs matching
                     for sub_col in get_expanded_column_config(self.config, report_column, 'en').columns:
-                        r[sub_col.ui_alias] = sub_col.aggregation.get_data(row)
+                        r[sub_col.ui_alias] = sub_col.get_data(row)
                 elif report_column.field == self.aggregation_columns[0]:
                     r[report_column.column_id] = row['key']
                 elif report_column.aggregation == 'sum':

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -73,7 +73,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
                 if report_column.type == 'expanded':
                     # todo aggregation only supports # of docs matching
                     counter = 0
-                    for sub_col in get_expanded_column_config(self.config, report_column, 'en').columns:
+                    for sub_col in get_expanded_column_config(self.config, report_column, self.lang).columns:
                         ui_col = report_column.column_id + "-" + str(counter)
                         # todo move interpretation of data into column config
                         if row[report_column.column_id] == sub_col.expand_value:

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -113,18 +113,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
         for row in hits:
             r = {}
             for report_column in self.top_level_columns:
-                if report_column.type == 'expanded':
-                    # todo aggregation only supports # of docs matching
-                    for sub_col in get_expanded_column_config(self.config, report_column, 'en').columns:
-                        r[sub_col.ui_alias] = sub_col.get_data(row)
-                elif report_column.field == self.aggregation_columns[0]:
-                    r[report_column.column_id] = row['key']
-                elif report_column.aggregation == 'sum':
-                    r[report_column.column_id] = int(row[report_column.column_id]['value'])
-                elif report_column.aggregation == 'min':
-                    r[report_column.column_id] = int(row[report_column.column_id]['value'])
-                else:
-                    r[report_column.column_id] = row[report_column.column_id]['doc_count']
+                r.update(report_column.get_es_data(row, self.config, self.lang))
             ret.append(r)
 
         return ret

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -144,8 +144,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
         aggregations = []
         for col in self.top_level_columns:
             if col.type == 'expanded':
-                for sub_col in get_expanded_column_config(self.config, col, 'en').columns:
-                    aggregations.append(sub_col.aggregation.aggregation)
+                aggregations.extend(col.aggregations(self.config, col))
             elif col.type == 'field':
                 # todo push this to the column
                 if col.aggregation == 'sum':

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -70,19 +70,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
         for row in hits:
             r = {}
             for report_column in self.top_level_db_columns:
-                if report_column.type == 'expanded':
-                    # todo aggregation only supports # of docs matching
-                    counter = 0
-                    for sub_col in get_expanded_column_config(self.config, report_column, self.lang).columns:
-                        ui_col = report_column.column_id + "-" + str(counter)
-                        # todo move interpretation of data into column config
-                        if row[report_column.column_id] == sub_col.expand_value:
-                            r[ui_col] = 1
-                        else:
-                            r[ui_col] = 0
-                        counter += 1
-                else:
-                    r[report_column.column_id] = row[report_column.field]
+                r.update(report_column.get_es_data(row, self.config, self.lang, from_aggregation=False))
             ret.append(r)
 
         return ret

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -143,14 +143,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
 
         aggregations = []
         for col in self.top_level_columns:
-            if col.type == 'expanded':
-                aggregations.extend(col.aggregations(self.config, col))
-            elif col.type == 'field':
-                # todo push this to the column
-                if col.aggregation == 'sum':
-                    aggregations.append(SumAggregation(col.column_id, col.field))
-                elif col.aggregation == 'min':
-                    aggregations.append(MinAggregation(col.column_id, col.field))
+            aggregations += col.aggregations(self.config, self.lang)
 
         for agg in aggregations:
             top_agg = top_agg.aggregation(agg)

--- a/corehq/apps/userreports/es/data_source.py
+++ b/corehq/apps/userreports/es/data_source.py
@@ -116,8 +116,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
                 if report_column.type == 'expanded':
                     # todo aggregation only supports # of docs matching
                     for sub_col in get_expanded_column_config(self.config, report_column, 'en').columns:
-                        # todo move interpretation of data into column config
-                        r[sub_col.ui_alias] = row[sub_col.es_alias]['doc_count']
+                        r[sub_col.ui_alias] = sub_col.aggregation.get_data(row)
                 elif report_column.field == self.aggregation_columns[0]:
                     r[report_column.column_id] = row['key']
                 elif report_column.aggregation == 'sum':
@@ -146,7 +145,7 @@ class ConfigurableReportEsDataSource(ConfigurableReportDataSourceMixin, ReportDa
         for col in self.top_level_columns:
             if col.type == 'expanded':
                 for sub_col in get_expanded_column_config(self.config, col, 'en').columns:
-                    aggregations.append(sub_col.aggregation)
+                    aggregations.append(sub_col.aggregation.aggregation)
             elif col.type == 'field':
                 # todo push this to the column
                 if col.aggregation == 'sum':

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -89,9 +89,15 @@ class BaseReportColumn(JsonObject):
         raise NotImplementedError('subclasses must override this')
 
     def aggregations(self, data_source_config, lang):
+        """
+        Returns a list of aggregations to be used in an ES query
+        """
         raise NotImplementedError('subclasses must override this')
 
     def get_es_data(self, row, data_source_config, lang):
+        """
+        Returns a dictionary of the data of this column from an ES query
+        """
         raise NotImplementedError('subclasses must override this')
 
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -56,6 +56,8 @@ ES_AGG_MAP = {
     'max': aggregations.MaxAggregation,
     'sum': aggregations.SumAggregation,
     'simple': lambda x, y: None,  # this is not an aggregation
+    # these can be implemented, but will need some python level interpretation
+    # should use date aggregation with a format and merge equal key_as_string
     # 'month': MonthColumn,
     # 'year': YearColumn,
 }

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -218,7 +218,7 @@ class ExpandedColumn(ReportColumn):
         return get_expanded_column_config(data_source_config, self, lang)
 
     def aggregations(self, data_source_config, lang):
-        return [c.aggregation.aggregation for c in self.get_column_config(data_source_config, lang).columns]
+        return [c.aggregation for c in self.get_column_config(data_source_config, lang).columns]
 
 
 class AggregateDateColumn(ReportColumn):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -196,6 +196,9 @@ class ExpandedColumn(ReportColumn):
     def get_column_config(self, data_source_config, lang):
         return get_expanded_column_config(data_source_config, self, lang)
 
+    def aggregations(self, data_source_config, lang):
+        return [c.aggregation.aggregation for c in self.get_column_config(data_source_config, lang).columns]
+
 
 class AggregateDateColumn(ReportColumn):
     """

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -241,21 +241,19 @@ class ExpandedColumn(ReportColumn):
 
     def get_es_data(self, row, data_source_config, lang, from_aggregation=True):
         sub_columns = self.get_column_config(data_source_config, lang).columns
-        r = {}
+        ret = {}
 
         if not from_aggregation:
-            counter = 0
-            for sub_col in sub_columns:
+            for counter, sub_col in enumerate(sub_columns):
                 ui_col = self.column_id + "-" + str(counter)
                 if row[self.column_id] == sub_col.expand_value:
-                    r[ui_col] = 1
+                    ret[ui_col] = 1
                 else:
-                    r[ui_col] = 0
-                counter += 1
+                    ret[ui_col] = 0
         else:
             for sub_col in sub_columns:
-                r[sub_col.ui_alias] = sub_col.get_es_data(row)
-        return r
+                ret[sub_col.ui_alias] = sub_col.get_es_data(row)
+        return ret
 
 
 class AggregateDateColumn(ReportColumn):


### PR DESCRIPTION
This simplifies ES `get_data` function quite a bit and makes it quite a bit more obvious what to do to add ES functionality to a report.

It also adds a small amount of functionality in supporting some more aggregation types

@proteusvacuum @dannyroberts 