### PR TITLE
Explicitly specify archive filename

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -56,6 +56,12 @@ class _Writer(object):
 
         # Create and open a temp file
         assert self._path is None
+
+        if len(export_instances) == 1:
+            name = export_instances[0].name
+        else:
+            name = ''
+
         fd, self._path = tempfile.mkstemp()
         with os.fdopen(fd, 'wb') as file:
 
@@ -68,7 +74,7 @@ class _Writer(object):
                     for t in instance.selected_tables
                 ]
                 table_titles.update({t: t.label for t in instance.selected_tables})
-            self.writer.open(headers, file, table_titles=table_titles)
+            self.writer.open(headers, file, table_titles=table_titles, archive_basepath=name)
             yield
             self.writer.close()
 

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -18,6 +18,7 @@ class ZippedExportWriterTests(SimpleTestCase):
         self.path_mock.get_path.return_value = 'tmp'
 
         self.writer = ZippedExportWriter()
+        self.writer.archive_basepath = 'path'
         self.writer.tables = [self.path_mock]
         self.writer.file = Mock()
 

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import os
 from codecs import BOM_UTF8
 
 import StringIO
@@ -18,7 +19,7 @@ class ZippedExportWriterTests(SimpleTestCase):
         self.path_mock.get_path.return_value = 'tmp'
 
         self.writer = ZippedExportWriter()
-        self.writer.archive_basepath = 'path'
+        self.writer.archive_basepath = '✓path'
         self.writer.tables = [self.path_mock]
         self.writer.file = Mock()
 
@@ -30,13 +31,19 @@ class ZippedExportWriterTests(SimpleTestCase):
         mock_zip_file = self.MockZipFile.return_value
         self.writer.table_names = {0: u'ひらがな'}
         self.writer._write_final_result()
-        mock_zip_file.write.assert_called_with('tmp', 'ひらがな.csv')
+        mock_zip_file.write.assert_called_with(
+            'tmp',
+            os.path.join(self.writer.archive_basepath, 'ひらがな.csv')
+        )
 
     def test_zipped_export_writer_utf8(self):
         mock_zip_file = self.MockZipFile.return_value
         self.writer.table_names = {0: '\xe3\x81\xb2\xe3\x82\x89\xe3\x81\x8c\xe3\x81\xaa'}
         self.writer._write_final_result()
-        mock_zip_file.write.assert_called_with('tmp', 'ひらがな.csv')
+        mock_zip_file.write.assert_called_with(
+            'tmp',
+            os.path.join(self.writer.archive_basepath, 'ひらがな.csv')
+        )
 
 
 class CsvFileWriterTests(SimpleTestCase):

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -297,7 +297,7 @@ class ZippedExportWriter(OnDiskExportWriter):
         self.file.seek(0)
 
     def _get_archive_filename(self, name):
-        return os.path.join(self.archive_basepath, '{}{}'.format(name, self.table_file_extension))
+        return os.path.join(self.archive_basepath, u'{}{}'.format(name, self.table_file_extension))
 
 
 class CsvExportWriter(ZippedExportWriter):

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -143,7 +143,7 @@ class ExportWriter(object):
     max_table_name_size = 500
     target_app = 'Excel'  # Where does this writer export to? Export button to say "Export to Excel"
 
-    def open(self, header_table, file, max_column_size=2000, table_titles=None):
+    def open(self, header_table, file, max_column_size=2000, table_titles=None, archive_basepath=''):
         """
         Create any initial files, headings, etc necessary.
         """
@@ -153,6 +153,7 @@ class ExportWriter(object):
         self.max_column_size = max_column_size
         self._current_primary_id = 0
         self.file = file
+        self.archive_basepath = archive_basepath
 
         self._init()
         self.table_name_generator = UniqueHeaderGenerator(
@@ -291,9 +292,12 @@ class ZippedExportWriter(OnDiskExportWriter):
             if isinstance(name, unicode):
                 name = name.encode('utf-8')
             path = self.tables[index].get_path()
-            archive.write(path, "{}{}".format(name, self.table_file_extension))
+            archive.write(path, self._get_archive_filename(name))
         archive.close()
         self.file.seek(0)
+
+    def _get_archive_filename(self, name):
+        return os.path.join(self.archive_basepath, '{}{}'.format(name, self.table_file_extension))
 
 
 class CsvExportWriter(ZippedExportWriter):

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -297,7 +297,7 @@ class ZippedExportWriter(OnDiskExportWriter):
         self.file.seek(0)
 
     def _get_archive_filename(self, name):
-        return os.path.join(self.archive_basepath, u'{}{}'.format(name, self.table_file_extension))
+        return os.path.join(self.archive_basepath, '{}{}'.format(name, self.table_file_extension))
 
 
 class CsvExportWriter(ZippedExportWriter):


### PR DESCRIPTION
@czue @NoahCarnahan this'll ensure that when you unzip an export folder that has only one table it'll be unzipped into a folder with the export name. this prevents the `Forms (2134).csv` effect. this was something that had always annoyed me
<img width="486" alt="screen shot 2016-11-22 at 12 33 13 pm" src="https://cloud.githubusercontent.com/assets/918514/20534638/e72d544e-b0af-11e6-9acd-471b6d66060d.png">

fyi: @jessica-long