### PR TITLE
Breadcrumbs for app preview

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -22,7 +22,6 @@ FormplayerFrontend.on("before:start", function () {
             loadingProgress: "#formplayer-progress-container",
             breadcrumb: "#breadcrumb-region",
             persistentCaseTile: "#persistent-case-tile",
-            phoneModeNavigation: '#phone-mode-navigation',
             restoreAsBanner: '#restore-as-region',
         },
     });
@@ -199,12 +198,6 @@ FormplayerFrontend.on("start", function (options) {
             appId = options.apps[0]['_id'];
         }
 
-        if (user.displayOptions.phoneMode && user.displayOptions.singleAppMode) {
-            FormplayerFrontend.regions.phoneModeNavigation.show(
-                new FormplayerFrontend.Layout.Views.PhoneNavigation({ appId: appId })
-            );
-            FormplayerFrontend.trigger('phone:back:hide');
-        }
         // will be the same for every domain. TODO: get domain/username/pass from django
         if (this.getCurrentRoute() === "") {
             if (user.displayOptions.singleAppMode) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -75,11 +75,15 @@ FormplayerFrontend.module("Apps.Views", function (Views, FormplayerFrontend, Bac
             this.appId = options.appId;
         },
         templateHelpers: function() {
+            var currentApp = FormplayerFrontend.request("appselect:getApp", this.appId),
+                appName;
+            appName = currentApp.get('name');
             return {
                 showIncompleteForms: function () {
                     return FormplayerFrontend
                         .request('getAppDisplayProperties')['cc-show-incomplete'] === 'yes';
                 },
+                appName: appName,
             };
         },
         startApp: function(e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -28,10 +28,8 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
         var maxHeight,
             maxHeightForm;
         maxHeight = ($(window).height() -
-            FormplayerFrontend.regions.phoneModeNavigation.$el.height() -
             FormplayerFrontend.regions.breadcrumb.$el.height());
-        maxHeightForm = ($(window).height() -
-            FormplayerFrontend.regions.phoneModeNavigation.$el.height());
+        maxHeightForm = $(window).height();
 
         $('.scrollable-container').css('max-height', maxHeight + 'px');
         $('.form-scrollable-container').css({

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -172,6 +172,5 @@
     {% include 'formplayer/query_view.html' %}
     {% include 'formplayer/confirmation_modal.html' %}
     {% include 'formplayer/progress.html' %}
-    {% include 'formplayer/navigation.html' %}
 
 {% endblock %}

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -142,7 +142,6 @@
         <section id="case-crumbs" style="width: 800px"></section>
         <section id="cases"></section>
         <div id="menu-container">
-            <div id="phone-mode-navigation"></div>
             <section id="formplayer-progress-container"></section>
             <div id="restore-as-region"></div>
             <div id="breadcrumb-region"></div>

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -35,6 +35,5 @@
     {% include 'formplayer/query_view.html' %}
     {% include 'formplayer/confirmation_modal.html' %}
     {% include 'formplayer/progress.html' %}
-    {% include 'formplayer/navigation.html' %}
 
 {% endblock %}

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -43,10 +43,10 @@
 </script>
 
 <script id="single-app-template" type="text/template">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-text"><%= appName %></li>
+  </ol>
   <div class="container container-appicons">
-    <div class="page-header page-header-apps">
-      <h1 class="page-title">{% trans "Application" %}</h1>
-    </div>
     <div class="row">
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-start-app appicon appicon-start">

--- a/corehq/apps/cloudcare/templates/formplayer/navigation.html
+++ b/corehq/apps/cloudcare/templates/formplayer/navigation.html
@@ -1,6 +1,0 @@
-<script id="formplayer-phone-navigation-template" type="text/template">
-  <div class="navbar navbar-default navbar-static-top navbar-formplayer">
-    <div class="container">
-    </div>
-  </div>
-</script>

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -153,7 +153,6 @@
         <section id="case-crumbs" style="width: 800px"></section>
         <section id="cases"></section>
         <div id="menu-container">
-            <div id="phone-mode-navigation"></div>
             <div id="formplayer-progress-container"></div>
             <section id="cloudcare-notifications" class="notifications-container"></section>
             <div id="restore-as-region"></div>

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -203,7 +203,6 @@
         {% include 'formplayer/case_list.html' %}
         {% include 'formplayer/menu_list.html' %}
         {% include 'formplayer/session_list.html' %}
-        {% include 'formplayer/navigation.html' %}
         {% include 'formplayer/confirmation_modal.html' %}
         {% include 'formplayer/users.html' %}
         {% include 'formplayer/progress.html' %}

--- a/corehq/apps/style/static/cloudcare/less/cloudcare/breadcrumbs.less
+++ b/corehq/apps/style/static/cloudcare/less/cloudcare/breadcrumbs.less
@@ -2,7 +2,7 @@
     cursor: pointer;
 }
 
-#breadcrumb-region .breadcrumb {
+.breadcrumb {
   background-color: @cc-brand-mid;
   color: white;
   .border-top-radius(0);

--- a/corehq/apps/style/static/cloudcare/less/cloudcare/breadcrumbs.less
+++ b/corehq/apps/style/static/cloudcare/less/cloudcare/breadcrumbs.less
@@ -2,3 +2,23 @@
     cursor: pointer;
 }
 
+#breadcrumb-region .breadcrumb {
+  background-color: @cc-brand-mid;
+  color: white;
+  .border-top-radius(0);
+  .border-bottom-radius(0);
+  .box-shadow(0 0 5px 2px rgba(0,0,0,.3));
+  border: none;
+
+  .breadcrumb-text {
+    &:before {
+      content: '\f054';
+      font-family: 'FontAwesome';
+    }
+  }
+  .breadcrumb-text:first-child {
+    &:before {
+      display: none;
+    }
+  }
+}

--- a/corehq/apps/style/static/cloudcare/less/formplayer/breadcrumbs.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer/breadcrumbs.less
@@ -1,4 +1,4 @@
-#breadcrumb-region ol.breadcrumb {
+ol.breadcrumb {
   font-size: 2rem;
   padding-top: 1rem;
   padding-bottom: 1rem;

--- a/corehq/apps/style/static/cloudcare/less/formplayer/breadcrumbs.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer/breadcrumbs.less
@@ -1,30 +1,15 @@
-
 #breadcrumb-region ol.breadcrumb {
-  background-color: @cc-brand-mid;
-  color: white;
-  .border-top-radius(0);
-  .border-bottom-radius(0);
   font-size: 2rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  .box-shadow(0 0 5px 2px rgba(0,0,0,.3));
-  border: none;
   margin-top: -1px;
-
   .breadcrumb-text {
     &:before {
-      content: '\f054';
-      font-family: 'FontAwesome';
       padding: 0 6px 0 12px;
       color: #cccccc;
       font-size: 12px;
       vertical-align: top;
       line-height: 28px;
-    }
-  }
-  .breadcrumb-text:first-child {
-    &:before {
-      display: none;
     }
   }
 }

--- a/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
@@ -1,21 +1,26 @@
 #breadcrumb-region .breadcrumb {
-  color: @cc-neutral-mid;
   text-transform: uppercase;
-  background-color: white;
   margin: 0;
   padding: 0 10px;
   line-height: 30px;
-  font-size: 10px;
-  font-weight: 600;
+  font-size: 11px;
 
   li {
     display: none;
     &:before {
-      display: none;
+      padding: 0;
+      color: white;
+      vertical-align: middle;
+      font-size: 8px;
+      padding: 0 4px;
     }
   }
+  li:first-child {
+    display: inline-block;
+    white-space: nowrap;
+  }
   li:last-child {
-    display: block;
+    display: inline-block;
     white-space: nowrap;
     text-overflow: ellipsis;
   }

--- a/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
@@ -1,4 +1,4 @@
-#breadcrumb-region .breadcrumb {
+.breadcrumb {
   text-transform: uppercase;
   margin: 0;
   padding: 0 10px;


### PR DESCRIPTION
@biyeun @wpride this completely removes PhoneNavigation and adds breadcrumbs to app preview:

<img width="500" alt="screen shot 2016-11-22 at 3 14 43 pm" src="https://cloud.githubusercontent.com/assets/918514/20540262/8e6c64be-b0c6-11e6-83f8-da6e7e773ce8.png">
<img width="495" alt="screen shot 2016-11-22 at 3 14 37 pm" src="https://cloud.githubusercontent.com/assets/918514/20540263/8e6f88ce-b0c6-11e6-8cf5-4074505128cb.png">

also B i don't see breadcrumbs for form entry i think we'll have to go back later to implement. this is a screenshot from prod:
<img width="295" alt="screen shot 2016-11-22 at 3 18 52 pm" src="https://cloud.githubusercontent.com/assets/918514/20540393/0fbdecfe-b0c7-11e6-951a-7ff27f60b6c5.png">

cc: @mkangia 
