### PR TITLE
Make undeleting users easier

### DIFF
--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -50,6 +50,19 @@ def get_mobile_user_count(domain, include_inactive=True):
     ])
 
 
+def get_mobile_user_ids(domain, include_inactive=True):
+    return {
+        row['id']
+        for row in _get_all_user_rows(
+            domain,
+            include_web_users=False,
+            include_mobile_users=True,
+            include_inactive=include_inactive,
+            count_only=False
+        ) if row
+    }
+
+
 def _get_all_user_rows(domain, include_web_users=True, include_mobile_users=True,
                        include_inactive=True, count_only=False):
     from corehq.apps.users.models import CommCareUser, WebUser

--- a/corehq/apps/users/management/commands/deleted_users.py
+++ b/corehq/apps/users/management/commands/deleted_users.py
@@ -1,0 +1,41 @@
+"""
+List the IDs of deleted users for a given domain
+"""
+from optparse import make_option
+from django.core.management import BaseCommand
+from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_class
+from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
+from corehq.apps.users.dbaccessors.all_commcare_users import get_mobile_user_ids
+from corehq.apps.users.models import CommCareUser
+
+
+class Command(BaseCommand):
+    help = __doc__.strip()  # (The module's docstring)
+    args = 'domain'
+    option_list = (
+        make_option(
+            '--usernames',
+            action='store_true',
+            dest='with_usernames',
+            default=False,
+            help="Include usernames in the list of IDs"
+        ),
+    )
+
+    def handle(self, *args, **options):
+        domain = args[0]
+
+        mobile_users = get_mobile_user_ids(domain)
+        everyone = set(get_doc_ids_in_domain_by_class(domain, CommCareUser))
+        deleted = everyone - mobile_users
+        # See also corehq.apps.dump_reload.management.commands.print_domain_stats._get_couchdb_counts
+
+        id_ = None
+        for id_ in deleted:
+            if options['with_usernames']:
+                doc_info = get_doc_info_by_id(domain, id_)
+                print id_, doc_info.display
+            else:
+                print id_
+        if id_ is None:
+            print 'Domain "{}" has no deleted users'.format(domain)

--- a/corehq/apps/users/templates/users/deleted_mobile_workers.html
+++ b/corehq/apps/users/templates/users/deleted_mobile_workers.html
@@ -1,0 +1,21 @@
+{% extends "style/base_section.html" %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+
+{% block page_content %}
+<div class="form">
+    <fieldset>
+        <legend>{% trans 'Deleted Mobile Workers' %}</legend>
+
+        {% for user in deleted_mobile_workers %}
+        <div class="row">
+            <div class="col-sm-12">
+                <a href="{{ user.link }}">{{ user.display }}</a>
+            </div>
+        </div>
+        {% endfor %}
+    </fieldset>
+</div>
+
+{% endblock %}

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -2,23 +2,57 @@ from django.conf.urls import url
 
 from corehq.apps.domain.utils import grandfathered_domain_re
 from .views import (
-    DefaultProjectUserSettingsView, DomainRequestView, EditWebUserView,
-    ListWebUsersView, InviteWebUserView, change_password,
-    domain_accounts, delete_phone_number, make_phone_number_default, verify_phone_number, add_domain_membership,
-    remove_web_user, undo_remove_web_user, delete_invitation, reinvite_web_user, delete_request,
-    location_restriction_for_users, accept_invitation, post_user_role, delete_user_role, register_fcm_device_token,
-    test_httpdigest)
+    accept_invitation,
+    add_domain_membership,
+    change_password,
+    DefaultProjectUserSettingsView,
+    delete_invitation,
+    delete_phone_number,
+    delete_request,
+    delete_user_role,
+    domain_accounts,
+    DomainRequestView,
+    EditWebUserView,
+    InviteWebUserView,
+    ListWebUsersView,
+    location_restriction_for_users,
+    make_phone_number_default,
+    post_user_role,
+    register_fcm_device_token,
+    reinvite_web_user,
+    remove_web_user,
+    test_httpdigest,
+    undo_remove_web_user,
+    verify_phone_number,
+)
 from .views.mobile.custom_data_fields import UserFieldsView
-from .views.mobile.groups import (GroupsListView, EditGroupMembersView,
-    BulkSMSVerificationView)
+from .views.mobile.groups import (
+    BulkSMSVerificationView,
+    EditGroupMembersView,
+    GroupsListView,
+)
 from .views.mobile.users import (
-    UploadCommCareUsers, EditCommCareUserView,
-    ConfirmBillingAccountForExtraUsersView, UserUploadStatusView,
-    CommCareUserSelfRegistrationView, MobileWorkerListView,
-    CreateCommCareUserModal, DemoRestoreStatusView,
-    update_user_data, update_user_groups, archive_commcare_user, delete_commcare_user, restore_commcare_user,
-    toggle_demo_mode, reset_demo_user_restore, demo_restore_job_poll, user_upload_job_poll,
-    download_commcare_users, set_commcare_user_group, DeletedMobileWorkerListView)
+    archive_commcare_user,
+    CommCareUserSelfRegistrationView,
+    ConfirmBillingAccountForExtraUsersView,
+    CreateCommCareUserModal,
+    delete_commcare_user,
+    DeletedMobileWorkerListView,
+    demo_restore_job_poll,
+    DemoRestoreStatusView,
+    download_commcare_users,
+    EditCommCareUserView,
+    MobileWorkerListView,
+    reset_demo_user_restore,
+    restore_commcare_user,
+    set_commcare_user_group,
+    toggle_demo_mode,
+    update_user_data,
+    update_user_groups,
+    UploadCommCareUsers,
+    user_upload_job_poll,
+    UserUploadStatusView,
+)
 
 
 urlpatterns = [

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -18,7 +18,7 @@ from .views.mobile.users import (
     CreateCommCareUserModal, DemoRestoreStatusView,
     update_user_data, update_user_groups, archive_commcare_user, delete_commcare_user, restore_commcare_user,
     toggle_demo_mode, reset_demo_user_restore, demo_restore_job_poll, user_upload_job_poll,
-    download_commcare_users, set_commcare_user_group)
+    download_commcare_users, set_commcare_user_group, DeletedMobileWorkerListView)
 
 
 urlpatterns = [
@@ -57,6 +57,9 @@ urlpatterns = [
     url(r'^commcare/$',
         MobileWorkerListView.as_view(),
         name=MobileWorkerListView.urlname),
+    url(r'^commcare/deleted/$',
+        DeletedMobileWorkerListView.as_view(),
+        name=DeletedMobileWorkerListView.urlname),
     url(r'^commcare/fields/$', UserFieldsView.as_view(), name=UserFieldsView.urlname),
     url(r'^commcare/account/(?P<couch_user_id>[ \w-]+)/$', EditCommCareUserView.as_view(),
         name=EditCommCareUserView.urlname),


### PR DESCRIPTION
Context: [FB 240847](http://manage.dimagi.com/default.asp?240847)

![deleted_users](https://cloud.githubusercontent.com/assets/708421/20562612/25ca9d1e-b18d-11e6-8362-c5bed603fe96.png)

We can undelete mobile workers from the UI if we know their ID. This PR includes a management command to find the IDs of deleted users, and a page to list them.

@nickpell @sravfeyn 

(Feel free to push back against "OCD" commit 4ad95a6 if it's going to cause merge conflicts for Django upgrades.)