### PR TITLE
99DOTS: Rename phone number case property

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -531,7 +531,7 @@ class RepeatRecord(Document):
         self.failure_reason = unicode(exception)
         self.save()
         if reraise:
-            raise exception
+            raise
 
     def fire(self, max_tries=3, force_send=False):
         headers = self.repeater.get_headers(self)

--- a/custom/enikshay/const.py
+++ b/custom/enikshay/const.py
@@ -1,2 +1,2 @@
-PRIMARY_PHONE_NUMBER = 'phone_number'
+PRIMARY_PHONE_NUMBER = 'contact_phone_number'
 BACKUP_PHONE_NUMBER = 'secondary_contact_phone_number'

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -129,18 +129,21 @@ def _update_episode_case(domain, case_id, updated_properties):
 def _get_phone_numbers(case_properties):
     primary_number = _parse_number(case_properties.get(PRIMARY_PHONE_NUMBER))
     backup_number = _parse_number(case_properties.get(BACKUP_PHONE_NUMBER))
-    if backup_number is not None:
+    if primary_number and backup_number:
         return ", ".join([_format_number(primary_number), _format_number(backup_number)])
-    return _format_number(primary_number)
+    elif primary_number:
+        return _format_number(primary_number)
+    elif backup_number:
+        return _format_number(backup_number)
 
 
 def _parse_number(number):
-    if number is not None:
+    if number:
         return phonenumbers.parse(number, "IN")
 
 
 def _format_number(phonenumber):
-    if phonenumber is not None:
+    if phonenumber:
         return phonenumbers.format_number(
             phonenumber,
             phonenumbers.PhoneNumberFormat.INTERNATIONAL

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -11,7 +11,7 @@ from casexml.apps.case.tests.util import delete_all_cases
 
 from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
 from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator
-from custom.enikshay.const import PRIMARY_PHONE_NUMBER, BACKUP_PHONE_NUMBER
+from custom.enikshay.const import PRIMARY_PHONE_NUMBER
 from custom.enikshay.integrations.ninetyninedots.repeaters import (
     NinetyNineDotsRegisterPatientRepeater,
     NinetyNineDotsUpdatePatientRepeater
@@ -123,7 +123,7 @@ class TestUpdatePatientRepeater(ENikshayRepeaterTestBase):
     @run_with_all_backends
     def test_trigger(self):
         self.create_case_structure()
-        self._update_person({'phone_number': '999999999', })
+        self._update_person({PRIMARY_PHONE_NUMBER: '999999999', })
         self.assertEqual(0, len(self.repeat_records().all()))
 
         self._create_99dots_registered_case()
@@ -132,7 +132,7 @@ class TestUpdatePatientRepeater(ENikshayRepeaterTestBase):
         self._update_person({'name': 'Elrond', })
         self.assertEqual(0, len(self.repeat_records().all()))
 
-        self._update_person({'phone_number': '999999999', })
+        self._update_person({PRIMARY_PHONE_NUMBER: '999999999', })
         self.assertEqual(1, len(self.repeat_records().all()))
 
     @run_with_all_backends
@@ -149,7 +149,7 @@ class TestUpdatePatientRepeater(ENikshayRepeaterTestBase):
             case_id=self.person_id,
             attrs={
                 'case_type': 'person',
-                'update': {'phone_number': '9999999999'}
+                'update': {PRIMARY_PHONE_NUMBER: '9999999999'}
             }
         )
 
@@ -203,8 +203,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
     def test_get_payload_secondary_number_only(self):
         self.primary_phone_number = None
         cases = self.create_case_structure()
-        person = cases[self.person_id].dynamic_case_properties()
-        self._assert_payload_equal(cases, u"+91{}".format(person.get(BACKUP_PHONE_NUMBER).replace("0", "")))
+        self._assert_payload_equal(cases, u"+91{}".format(self.secondary_phone_number.replace("0", "")))
 
     @run_with_all_backends
     def test_handle_success(self):

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -14,6 +14,8 @@ class ENikshayCaseStructureMixin(object):
         self.person_id = u"person"
         self.occurrence_id = u"occurrence"
         self.episode_id = u"episode"
+        self.primary_phone_number = "0123456789"
+        self.secondary_phone_number = "0999999999"
 
     @property
     def person(self):
@@ -25,8 +27,8 @@ class ENikshayCaseStructureMixin(object):
                 "update": {
                     'name': "Pippin",
                     'aadhaar_number': "499118665246",
-                    PRIMARY_PHONE_NUMBER: "0123456789",
-                    BACKUP_PHONE_NUMBER: "0999999999",
+                    PRIMARY_PHONE_NUMBER: self.primary_phone_number,
+                    BACKUP_PHONE_NUMBER: self.secondary_phone_number,
                     'merm_id': "123456789",
                     'dob': "1987-08-15",
                 }


### PR DESCRIPTION
We changed the phone number case property again, and it was failing with an unhelpful error message.
This should fix both of those things.

http://manage.dimagi.com/default.asp?242313
@emord @dannyroberts 