### PR TITLE
ICDS: Remove Case History Expressions

### DIFF
--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
@@ -1106,14 +1106,11 @@
                 "type": "nested",
                 "argument_expression": {
                   "type": "named",
-                  "name": "get_latest_cf_update"
+                  "name": "get_latest_cf_repeat"
                 },
                 "value_expression": {
-                  "type": "property_path",
-                  "property_path": [
-                    "updated_unknown_properties",
-                    "comp_feeding"
-                  ]
+                  "type": "property_name",
+                  "property_name": "comp_feeding"
                 }
               }
             },
@@ -1139,14 +1136,11 @@
                 "type": "nested",
                 "argument_expression": {
                   "type": "named",
-                  "name": "get_latest_cf_update"
+                  "name": "get_latest_cf_repeat"
                 },
                 "value_expression": {
-                  "type": "property_path",
-                  "property_path": [
-                    "updated_unknown_properties",
-                    "diet_diversity"
-                  ]
+                  "type": "property_name",
+                  "property_name": "diet_diversity"
                 }
               }
             },
@@ -1172,14 +1166,11 @@
                 "type": "nested",
                 "argument_expression": {
                   "type": "named",
-                  "name": "get_latest_cf_update"
+                  "name": "get_latest_cf_repeat"
                 },
                 "value_expression": {
-                  "type": "property_path",
-                  "property_path": [
-                    "updated_unknown_properties",
-                    "diet_quantity"
-                  ]
+                  "type": "property_name",
+                  "property_name": "diet_quantity"
                 }
               }
             },
@@ -1200,19 +1191,16 @@
             {
               "type": "boolean_expression",
               "operator": "eq",
-              "property_value": "yes",
+              "property_value": "1",
               "expression": {
                 "type": "nested",
                 "argument_expression": {
                   "type": "named",
-                  "name": "get_latest_cf_update"
+                  "name": "get_latest_cf_repeat"
                 },
                 "value_expression": {
-                  "type": "property_path",
-                  "property_path": [
-                    "updated_unknown_properties",
-                    "hand_wash"
-                  ]
+                  "type": "property_name",
+                  "property_name": "hand_wash"
                 }
               }
             },
@@ -2530,36 +2518,25 @@
           "child_health_case_id"
         ]
       },
-      "get_latest_cf_update": {
-        "type": "reduce_items",
-        "aggregation_fn": "last_item",
-        "items_expression": {
-          "type": "icds_get_case_history_by_date",
-          "start_date": {
-            "type": "icds_month_start"
-          },
+      "get_latest_cf_repeat": {
+        "type": "icds_get_last_form_repeat",
+        "forms_expression": {
+          "type": "icds_get_case_forms_by_date",
+          "xmlns": [
+            "http://openrosa.org/formdesigner/792DAF2B-E117-424A-A673-34E1513ABD88"
+          ],
           "end_date": {
             "type": "icds_month_end"
-          },
-          "filter": {
-            "type": "not",
-            "filter": {
-              "operator": "in",
-              "type": "boolean_expression",
-              "expression": {
-                "type": "property_path",
-                "property_path": [
-                  "updated_unknown_properties",
-                  "comp_feeding"
-                ]
-              },
-              "property_value": [
-                "",
-                null
-              ]
-            }
           }
-        }
+        },
+        "repeat_path": [
+          "form",
+          "child",
+          "item"
+        ],
+        "case_id_path": [
+          "child_health_case_id"
+        ]
       },
       "get_all_cf_repeats": {
         "type": "icds_get_all_forms_repeats",
@@ -2578,7 +2555,7 @@
           "item"
         ],
         "case_id_path": [
-          "@id"
+          "child_health_case_id"
         ]
       },
       "get_all_ebf_repeats": {

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
@@ -1951,18 +1951,22 @@
         }
       },
       "nutrition_status_last_recorded": {
-        "type": "switch",
-        "switch_on": {
-          "type": "nested",
-          "argument_expression": {
+        "type": "conditional",
+        "test": {
+          "type": "boolean_expression",
+          "operator": "gt",
+          "expression": {
             "type": "reduce_items",
-            "aggregation_fn": "last_item",
+            "aggregation_fn": "count",
             "items_expression": {
-              "type": "icds_get_case_history_by_date",
+              "type": "icds_get_case_forms_by_date",
               "end_date": {
                 "type": "icds_month_end"
               },
-              "filter": {
+              "xmlns": [
+                "http://openrosa.org/formdesigner/b183124a25f2a0ceab266e4564d3526199ac4d75"
+              ],
+              "form_filter": {
                 "type": "not",
                 "filter": {
                   "operator": "in",
@@ -1970,7 +1974,7 @@
                   "expression": {
                     "type": "property_path",
                     "property_path": [
-                      "updated_unknown_properties",
+                      "form",
                       "zscore_grading_wfa"
                     ]
                   },
@@ -1982,53 +1986,148 @@
               }
             }
           },
-          "value_expression": {
-            "type": "property_path",
-            "property_path": [
-              "updated_unknown_properties",
-              "zscore_grading_wfa"
-            ]
+          "property_value": 0
+        },
+        "expression_if_true": {
+          "type": "switch",
+          "switch_on": {
+            "type": "nested",
+            "value_expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "zscore_grading_wfa"
+              ]
+            },
+            "argument_expression": {
+              "type": "reduce_items",
+              "aggregation_fn": "last_item",
+              "items_expression": {
+                "type": "icds_get_case_forms_by_date",
+                "end_date": {
+                  "type": "icds_month_end"
+                },
+                "xmlns": [
+                  "http://openrosa.org/formdesigner/b183124a25f2a0ceab266e4564d3526199ac4d75"
+                ],
+                "form_filter": {
+                  "type": "not",
+                  "filter": {
+                    "operator": "in",
+                    "type": "boolean_expression",
+                    "expression": {
+                      "type": "property_path",
+                      "property_path": [
+                        "form",
+                        "zscore_grading_wfa"
+                      ]
+                    },
+                    "property_value": [
+                      "",
+                      null
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "cases": {
+            "red": {
+              "type": "constant",
+              "constant": "severely_underweight"
+            },
+            "yellow": {
+              "type": "constant",
+              "constant": "moderately_underweight"
+            },
+            "green": {
+              "type": "constant",
+              "constant": "normal"
+            },
+            "white": {
+              "type": "constant",
+              "constant": "normal"
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": "unknown"
           }
         },
-        "cases": {
-          "red": {
-            "type": "constant",
-            "constant": "severely_underweight"
+        "expression_if_false": {
+          "type": "switch",
+          "switch_on": {
+            "type": "nested",
+            "value_expression": {
+              "type": "property_name",
+              "property_name": "zscore_grading_wfa"
+            },
+            "argument_expression": {
+              "type": "icds_get_last_form_repeat",
+              "forms_expression": {
+                "type": "icds_get_case_forms_by_date",
+                "end_date": {
+                  "type": "icds_month_end"
+                },
+                "xmlns": [
+                  "http://openrosa.org/formdesigner/376FA2E1-6FD1-4C9E-ACB4-E046038CD5E2"
+                ]
+              },
+              "repeat_path": [
+                "form",
+                "child"
+              ],
+              "case_id_path": [
+                "case_open_child_health_3",
+                "case",
+                "@case_id"
+              ]
+            }
           },
-          "yellow": {
-            "type": "constant",
-            "constant": "moderately_underweight"
+          "cases": {
+            "red": {
+              "type": "constant",
+              "constant": "severely_underweight"
+            },
+            "yellow": {
+              "type": "constant",
+              "constant": "moderately_underweight"
+            },
+            "green": {
+              "type": "constant",
+              "constant": "normal"
+            },
+            "white": {
+              "type": "constant",
+              "constant": "normal"
+            }
           },
-          "green": {
+          "default": {
             "type": "constant",
-            "constant": "normal"
-          },
-          "white": {
-            "type": "constant",
-            "constant": "normal"
+            "constant": "unknown"
           }
-        },
-        "default": {
-          "type": "constant",
-          "constant": "unknown"
         }
       },
       "current_month_nutrition_status": {
-        "type": "switch",
-        "switch_on": {
-          "type": "nested",
-          "argument_expression": {
+        "type": "conditional",
+        "test": {
+          "type": "boolean_expression",
+          "operator": "gt",
+          "expression": {
             "type": "reduce_items",
-            "aggregation_fn": "last_item",
+            "aggregation_fn": "count",
             "items_expression": {
-              "type": "icds_get_case_history_by_date",
+              "type": "icds_get_case_forms_by_date",
               "start_date": {
                 "type": "icds_month_start"
               },
               "end_date": {
                 "type": "icds_month_end"
               },
-              "filter": {
+              "xmlns": [
+                "http://openrosa.org/formdesigner/b183124a25f2a0ceab266e4564d3526199ac4d75"
+              ],
+              "form_filter": {
                 "type": "not",
                 "filter": {
                   "operator": "in",
@@ -2036,7 +2135,7 @@
                   "expression": {
                     "type": "property_path",
                     "property_path": [
-                      "updated_unknown_properties",
+                      "form",
                       "zscore_grading_wfa"
                     ]
                   },
@@ -2048,35 +2147,132 @@
               }
             }
           },
-          "value_expression": {
-            "type": "property_path",
-            "property_path": [
-              "updated_unknown_properties",
-              "zscore_grading_wfa"
-            ]
+          "property_value": 0
+        },
+        "expression_if_true": {
+          "type": "switch",
+          "switch_on": {
+            "type": "nested",
+            "value_expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "zscore_grading_wfa"
+              ]
+            },
+            "argument_expression": {
+              "type": "reduce_items",
+              "aggregation_fn": "last_item",
+              "items_expression": {
+                "type": "icds_get_case_forms_by_date",
+                "start_date": {
+                  "type": "icds_month_start"
+                },
+                "end_date": {
+                  "type": "icds_month_end"
+                },
+                "xmlns": [
+                  "http://openrosa.org/formdesigner/b183124a25f2a0ceab266e4564d3526199ac4d75"
+                ],
+                "form_filter": {
+                  "type": "not",
+                  "filter": {
+                    "operator": "in",
+                    "type": "boolean_expression",
+                    "expression": {
+                      "type": "property_path",
+                      "property_path": [
+                        "form",
+                        "zscore_grading_wfa"
+                      ]
+                    },
+                    "property_value": [
+                      "",
+                      null
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "cases": {
+            "red": {
+              "type": "constant",
+              "constant": "severely_underweight"
+            },
+            "yellow": {
+              "type": "constant",
+              "constant": "moderately_underweight"
+            },
+            "green": {
+              "type": "constant",
+              "constant": "normal"
+            },
+            "white": {
+              "type": "constant",
+              "constant": "normal"
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": "unweighed"
           }
         },
-        "cases": {
-          "red": {
-            "type": "constant",
-            "constant": "severely_underweight"
+        "expression_if_false": {
+          "type": "switch",
+          "switch_on": {
+            "type": "nested",
+            "value_expression": {
+              "type": "property_name",
+              "property_name": "zscore_grading_wfa"
+            },
+            "argument_expression": {
+              "type": "icds_get_last_form_repeat",
+              "forms_expression": {
+                "type": "icds_get_case_forms_by_date",
+                "start_date": {
+                  "type": "icds_month_start"
+                },
+                "end_date": {
+                  "type": "icds_month_end"
+                },
+                "xmlns": [
+                  "http://openrosa.org/formdesigner/376FA2E1-6FD1-4C9E-ACB4-E046038CD5E2"
+                ]
+              },
+              "repeat_path": [
+                "form",
+                "child"
+              ],
+              "case_id_path": [
+                "case_open_child_health_3",
+                "case",
+                "@case_id"
+              ]
+            }
           },
-          "yellow": {
-            "type": "constant",
-            "constant": "moderately_underweight"
+          "cases": {
+            "red": {
+              "type": "constant",
+              "constant": "severely_underweight"
+            },
+            "yellow": {
+              "type": "constant",
+              "constant": "moderately_underweight"
+            },
+            "green": {
+              "type": "constant",
+              "constant": "normal"
+            },
+            "white": {
+              "type": "constant",
+              "constant": "normal"
+            }
           },
-          "green": {
+          "default": {
             "type": "constant",
-            "constant": "normal"
-          },
-          "white": {
-            "type": "constant",
-            "constant": "normal"
+            "constant": "unweighed"
           }
-        },
-        "default": {
-          "type": "constant",
-          "constant": "unweighed"
         }
       },
       "pse_days": {

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -11,7 +11,6 @@ CUSTOM_UCR_EXPRESSIONS = [
     ('icds_parent_parent_id', 'custom.icds_reports.ucr.expressions.parent_parent_id'),
     ('icds_open_in_month', 'custom.icds_reports.ucr.expressions.open_in_month'),
     ('icds_get_case_forms_by_date', 'custom.icds_reports.ucr.expressions.get_case_forms_by_date'),
-    ('icds_get_case_history_by_date', 'custom.icds_reports.ucr.expressions.get_case_history_by_date'),
     ('icds_get_all_forms_repeats', 'custom.icds_reports.ucr.expressions.get_all_forms_repeats'),
     ('icds_get_last_form_repeat', 'custom.icds_reports.ucr.expressions.get_last_form_repeat'),
     ('icds_alive_in_month', 'custom.icds_reports.ucr.expressions.alive_in_month'),
@@ -32,13 +31,6 @@ class GetCaseFormsByDateSpec(JsonObject):
     start_date = DefaultProperty(required=False)
     end_date = DefaultProperty(required=False)
     form_filter = DefaultProperty(required=False)
-
-
-class GetCaseHistoryByDateSpec(JsonObject):
-    type = TypeProperty('icds_get_case_history_by_date')
-    start_date = DefaultProperty(required=False)
-    end_date = DefaultProperty(required=False)
-    filter = DefaultProperty(required=False)
 
 
 class GetAllFormsRepeatsSpec(JsonObject):
@@ -390,76 +382,6 @@ def get_case_forms_by_date(spec, context):
                 "type": "get_case_forms",
                 "case_id_expression": case_id_expression
             }
-        }
-    return ExpressionFactory.from_spec(spec, context)
-
-
-def get_case_history_by_date(spec, context):
-    GetCaseHistoryByDateSpec.wrap(spec)
-
-    filters = []
-    if spec['start_date'] is not None:
-        start_date_filter = {
-            'operator': 'gte',
-            'expression': {
-                'datatype': 'integer',
-                'from_date_expression': spec['start_date'],
-                'type': 'diff_days',
-                'to_date_expression': {
-                    'datatype': 'date',
-                    'type': 'property_name',
-                    'property_name': "date"
-                }
-            },
-            'type': 'boolean_expression',
-            'property_value': 0
-        }
-        filters.append(start_date_filter)
-    if spec['end_date'] is not None:
-        end_date_filter = {
-            'operator': 'gte',
-            'expression': {
-                'datatype': 'integer',
-                'from_date_expression': {
-                    'datatype': 'date',
-                    'type': 'property_name',
-                    'property_name': "date"
-                },
-                'type': 'diff_days',
-                'to_date_expression': spec['end_date']
-            },
-            'type': 'boolean_expression',
-            'property_value': 0
-        }
-        filters.append(end_date_filter)
-    if spec['filter'] is not None:
-        filters.append(spec['filter'])
-
-    spec = {
-        'type': 'sort_items',
-        'sort_expression': {
-            'type': 'property_name',
-            'property_name': 'date',
-            'datatype': 'date'
-        },
-        'items_expression': {
-            'type': 'root_doc',
-            'expression': {
-                'datatype': 'array',
-                'type': 'property_name',
-                'property_name': 'actions'
-            }
-        }
-    }
-
-    if len(filters) > 0:
-        spec = {
-            'type': 'filter_items',
-            'filter_expression': {
-                'type': 'and',
-                'filters': filters
-            },
-            'items_expression': spec
         }
     return ExpressionFactory.from_spec(spec, context)
 

--- a/custom/icds_reports/ucr/tests/base_test.py
+++ b/custom/icds_reports/ucr/tests/base_test.py
@@ -71,6 +71,6 @@ class BaseICDSDatasourceTest(TestCase, TestFileMixin):
         for index, test_values in cases:
             row = query.all()[index]._asdict()
             self.assertEqual(row['month'], start_date + relativedelta(months=index))
-            for key, value in test_values:
-                self.assertEqual(row[key], value,
-                                 str(index) + ":" + key + ' ' + str(row[key]) + '!=' + str(value))
+            for key, exp_value in test_values:
+                self.assertEqual(row[key], exp_value,
+                                 str(index) + ":" + key + ' ' + str(row[key]) + '!=' + str(exp_value))

--- a/custom/icds_reports/ucr/tests/test_child_health_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_child_health_monthly.py
@@ -14,6 +14,8 @@ XMLNS_EBF_FORM = 'http://openrosa.org/formdesigner/89097FB1-6C08-48BA-95B2-67BCF
 XMLNS_CF_FORM = 'http://openrosa.org/formdesigner/792DAF2B-E117-424A-A673-34E1513ABD88'
 XMLNS_GMP_FORM = 'http://openrosa.org/formdesigner/b183124a25f2a0ceab266e4564d3526199ac4d75'
 XMLNS_DAILYFEEDING_FORM = 'http://openrosa.org/formdesigner/66d52f84d606567ea29d5fae88f569d2763b8b62'
+XMLNS_HH_REG_FORM = 'http://openrosa.org/formdesigner/1D568275-1D19-46DB-8C54-2C9765DF6335'
+XMLNS_ADD_MEMBER_FORM = 'http://openrosa.org/formdesigner/756ec44475658f3f463f8012632def2bc9fbe731'
 
 NUTRITION_STATUS_NORMAL = "green"
 NUTRITION_STATUS_MODERATE = "yellow"
@@ -312,10 +314,10 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
 
     def _submit_cf_form(
             self, form_date, case_id, comp_feeding=None, diet_diversity=None,
-            diet_quantity=None, handwashing=None, demo_comp_feeding=None, case_id_2=None):
+            diet_quantity=None, hand_wash=None, demo_comp_feeding=None, case_id_2=None):
 
         form = ElementTree.Element('data')
-        form.attrib['xmlns'] = XMLNS_EBF_FORM
+        form.attrib['xmlns'] = XMLNS_CF_FORM
         form.attrib['xmlns:jrm'] = 'http://openrosa.org/jr/xforms'
 
         meta = ElementTree.Element('meta')
@@ -326,23 +328,25 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         case.attrib['date_modified'] = form_date.isoformat()
         case.attrib['case_id'] = case_id
         case.attrib['xmlns'] = 'http://commcarehq.org/case/transaction/v2'
-        case_update = ElementTree.Element('update')
-        add_element(case_update, 'comp_feeding', comp_feeding)
-        add_element(case_update, 'diet_diversity', diet_diversity)
-        add_element(case_update, 'diet_diversity', diet_quantity)
-        add_element(case_update, 'handwashing', handwashing)
-        case.append(case_update)
         form.append(case)
 
         child = ElementTree.Element('child')
         child_repeat1 = ElementTree.Element('item')
         add_element(child_repeat1, 'child_health_case_id', case_id)
         add_element(child_repeat1, 'demo_comp_feeding', demo_comp_feeding)
+        add_element(child_repeat1, 'comp_feeding', comp_feeding)
+        add_element(child_repeat1, 'diet_diversity', diet_diversity)
+        add_element(child_repeat1, 'diet_quantity', diet_quantity)
+        add_element(child_repeat1, 'hand_wash', hand_wash)
         child.append(child_repeat1)
         if case_id_2 is not None:
             child_repeat2 = ElementTree.Element('item')
             add_element(child_repeat2, 'child_health_case_id', case_id_2)
-            add_element(child_repeat1, 'demo_comp_feeding', 'no')
+            add_element(child_repeat2, 'demo_comp_feeding', 'no')
+            add_element(child_repeat2, 'comp_feeding', 'no')
+            add_element(child_repeat2, 'diet_diversity', 'no')
+            add_element(child_repeat2, 'diet_quantity', 'no')
+            add_element(child_repeat2, 'hand_wash', '0')
             child.append(child_repeat2)
         form.append(child)
 
@@ -774,7 +778,6 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-
     def test_nutrition_status_gmp(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -994,7 +997,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
             date_modified=datetime(2016, 3, 12),
         )
 
-        #Dec: No data, Jan: EBF, Mar: Not EBF
+        # Dec: No data, Jan: EBF, Mar: Not EBF
         self._submit_ebf_form(
             form_date=datetime(2016, 1, 10),
             case_id=case_id,
@@ -1085,7 +1088,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
             date_modified=datetime(2016, 3, 12),
         )
 
-        #Dec: not EBF, Jan: EBF
+        # Dec: not EBF, Jan: EBF
         self._submit_pnc_form(
             form_date=datetime(2015, 12, 14),
             case_id=case_id,
@@ -1231,6 +1234,76 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
                  ('ebf_no_bf_pregnant_again', 0),
                  ('ebf_no_bf_child_too_old', 0),
                  ('ebf_no_bf_mother_sick', 0)]
+             ),
+        ]
+        self._run_iterative_monthly_test(case_id=case_id, cases=cases)
+
+    def test_cf(self):
+        case_id = uuid.uuid4().hex
+        case_id_2 = uuid.uuid4().hex
+        self._create_case(
+            case_id=case_id,
+            dob=date(2015, 5, 12),
+            date_opened=datetime(2015, 5, 14),
+            date_modified=datetime(2016, 3, 12),
+        )
+        self._create_case(
+            case_id=case_id_2,
+            dob=date(2015, 05, 12),
+            date_opened=datetime(2015, 5, 14),
+            date_modified=datetime(2016, 3, 12),
+        )
+
+        # Dec: No data, Jan: CF, Mar: Not CF
+        self._submit_cf_form(
+            form_date=datetime(2016, 1, 10),
+            case_id=case_id,
+            comp_feeding='yes',
+            diet_diversity='yes',
+            diet_quantity='yes',
+            hand_wash='1',
+            demo_comp_feeding='yes',
+            case_id_2=case_id_2,
+        )
+        self._submit_cf_form(
+            form_date=datetime(2016, 3, 10),
+            case_id=case_id,
+            comp_feeding='no',
+            diet_diversity='no',
+            diet_quantity='no',
+            hand_wash='0',
+            demo_comp_feeding='no',
+            case_id_2=case_id_2,
+        )
+
+        cases = [
+            (0, [('cf_eligible', 1),
+                 ('cf_in_month', 0),
+                 ('cf_diet_diversity', 0),
+                 ('cf_diet_quantity', 0),
+                 ('cf_handwashing', 0),
+                 ('cf_demo', 0)]
+             ),
+            (1, [('cf_eligible', 1),
+                 ('cf_in_month', 1),
+                 ('cf_diet_diversity', 1),
+                 ('cf_diet_quantity', 1),
+                 ('cf_handwashing', 1),
+                 ('cf_demo', 1)]
+             ),
+            (2, [('cf_eligible', 1),
+                 ('cf_in_month', 1),
+                 ('cf_diet_diversity', 1),
+                 ('cf_diet_quantity', 1),
+                 ('cf_handwashing', 1),
+                 ('cf_demo', 1)]
+             ),
+            (3, [('cf_eligible', 1),
+                 ('cf_in_month', 0),
+                 ('cf_diet_diversity', 0),
+                 ('cf_diet_quantity', 0),
+                 ('cf_handwashing', 0),
+                 ('cf_demo', 1)]
              ),
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)


### PR DESCRIPTION
This removes the references to the case history from the ICDS data sources (since case history does not work on SQL domains). 