### PR TITLE
"Restore As" permissions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -118,7 +118,11 @@ FormplayerFrontend.module("Users.Views", function(Views, FormplayerFrontend, Bac
                     limit: this.limit,
                     page: this.model.get('page'),
                 }),
-            }).done(this.render.bind(this));
+            })
+            .done(this.render.bind(this))
+            .fail(function(xhr){
+                FormplayerFrontend.trigger('showError', xhr.responseText);
+            });
         },
         onClickNext: function(e) {
             e.preventDefault();

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -29,7 +29,7 @@
           </div>
         </div>
 
-        {% if request|toggle_enabled:'RESTORE_AS_CLOUDCARE' %}
+        {% if request|can_use_restore_as %}
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-restore-as-item appicon appicon-restore-as">
             <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
@@ -76,7 +76,7 @@
             </div>
           </div>
         </div>
-        {% if request|toggle_enabled:'RESTORE_AS_CLOUDCARE' %}
+        {% if request|can_use_restore_as %}
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
           <div class="js-restore-as-item appicon appicon-restore-as">
             <i class="fa fa-user appicon-icon" aria-hidden="true"></i>

--- a/corehq/apps/cloudcare/templates/formplayer/users.html
+++ b/corehq/apps/cloudcare/templates/formplayer/users.html
@@ -101,7 +101,7 @@
 
 </script>
 <script type="text/template" id="restore-as-banner-template">
-  {% if request|toggle_enabled:'RESTORE_AS_CLOUDCARE' %}
+  {% if request|can_use_restore_as %}
     <% if (restoreAs) { %>
     <div class="restore-as-banner module-banner">
         <span>

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -44,6 +44,7 @@ from corehq.apps.app_manager.models import Application, ApplicationBase, RemoteA
 from corehq.apps.app_manager.suite_xml.sections.details import get_instances_for_module
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from corehq.apps.app_manager.util import get_cloudcare_session_data
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.cloudcare.api import (
     api_closed_to_status,
     CaseAPIResult,
@@ -233,6 +234,7 @@ class CloudcareMain(View):
             return render(request, "cloudcare/cloudcare_home.html", context)
 
 
+@location_safe
 class FormplayerMain(View):
 
     preview = False

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -231,7 +231,7 @@ def can_use_restore_as(request):
         return False
 
     if (request.couch_user.is_commcare_user() and
-            not request.couch_user.can_edit_data()):
+            not request.couch_user.can_edit_commcare_users()):
         return False
 
     return True

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -15,8 +15,10 @@ from django.core.urlresolvers import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from dimagi.utils.decorators.memoized import memoized
+from django_prbac.utils import has_privilege
 
 from dimagi.utils.make_uuid import random_hex
+from corehq import privileges
 from corehq.apps.domain.models import Domain
 from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
@@ -221,6 +223,18 @@ def toggle_enabled(request, toggle_or_toggle_name):
 def is_new_cloudcare(request):
     from corehq import toggles
     return _toggle_enabled(toggles, request, toggles.USE_FORMPLAYER_FRONTEND)
+
+
+@register.filter
+def can_use_restore_as(request):
+    if not has_privilege(request, privileges.DATA_CLEANUP):
+        return False
+
+    if (request.couch_user.is_commcare_user() and
+            not request.couch_user.has_permission(request.domain, 'edit_data')):
+        return False
+
+    return True
 
 
 @register.simple_tag

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -227,6 +227,9 @@ def is_new_cloudcare(request):
 
 @register.filter
 def can_use_restore_as(request):
+    if not hasattr(request, 'couch_user'):
+        return False
+
     return (
         request.couch_user.can_edit_commcare_users() and
         has_privilege(request, privileges.DATA_CLEANUP)

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -231,7 +231,7 @@ def can_use_restore_as(request):
         return False
 
     if (request.couch_user.is_commcare_user() and
-            not request.couch_user.has_permission(request.domain, 'edit_data')):
+            not request.couch_user.can_edit_data()):
         return False
 
     return True

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -227,14 +227,10 @@ def is_new_cloudcare(request):
 
 @register.filter
 def can_use_restore_as(request):
-    if not has_privilege(request, privileges.DATA_CLEANUP):
-        return False
-
-    if (request.couch_user.is_commcare_user() and
-            not request.couch_user.can_edit_commcare_users()):
-        return False
-
-    return True
+    return (
+        request.couch_user.can_edit_commcare_users() and
+        has_privilege(request, privileges.DATA_CLEANUP)
+    )
 
 
 @register.simple_tag

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -327,7 +327,7 @@ def user_can_access_other_user(domain, user, other_user):
         .accessible_to_user(domain, user)
         .values_list('id', flat=True))
 
-    return other_user.sql_locations.filter(id__in=accessible_location_ids).count() > 0
+    return other_user.get_sql_locations(domain).filter(id__in=accessible_location_ids).exists()
 
 
 def can_edit_location(view_fn):

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -323,11 +323,10 @@ def user_can_access_other_user(domain, user, other_user):
     if user.has_permission(domain, 'access_all_locations'):
         return True
 
-    accessible_location_ids = (SQLLocation.objects
-        .accessible_to_user(domain, user)
-        .values_list('id', flat=True))
-
-    return other_user.get_sql_locations(domain).filter(id__in=accessible_location_ids).exists()
+    return (other_user
+            .get_sql_locations(domain)
+            .accessible_to_user(domain, user)
+            .exists())
 
 
 def can_edit_location(view_fn):

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -319,6 +319,19 @@ def user_can_access_any_location_id(domain, user, location_ids):
             .exists())
 
 
+def user_can_access_other_user(domain, user, other_user):
+    if user.has_permission(domain, 'access_all_locations'):
+        return True
+
+    accessible_location_ids = (SQLLocation.objects .accessible_to_user(domain, user) .values_list('id', flat=True))
+
+    other_user_locations = other_user.sql_locations
+    return any(map(
+        lambda location_id: location_id in accessible_location_ids,
+        other_user_locations.values_list('id', flat=True) if other_user_locations else []
+    ))
+
+
 def can_edit_location(view_fn):
     """
     Decorator controlling a user's access to a specific location.

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -327,12 +327,7 @@ def user_can_access_other_user(domain, user, other_user):
         .accessible_to_user(domain, user)
         .values_list('id', flat=True))
 
-    other_user_locations = other_user.sql_locations
-
-    if other_user_locations:
-        return other_user_locations.filter(id__in=accessible_location_ids).count() > 0
-
-    return False
+    return other_user.sql_locations.filter(id__in=accessible_location_ids).count() > 0
 
 
 def can_edit_location(view_fn):

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -323,13 +323,16 @@ def user_can_access_other_user(domain, user, other_user):
     if user.has_permission(domain, 'access_all_locations'):
         return True
 
-    accessible_location_ids = (SQLLocation.objects .accessible_to_user(domain, user) .values_list('id', flat=True))
+    accessible_location_ids = (SQLLocation.objects
+        .accessible_to_user(domain, user)
+        .values_list('id', flat=True))
 
     other_user_locations = other_user.sql_locations
-    return any(map(
-        lambda location_id: location_id in accessible_location_ids,
-        other_user_locations.values_list('id', flat=True) if other_user_locations else []
-    ))
+
+    if other_user_locations:
+        return other_user_locations.filter(id__in=accessible_location_ids).count() > 0
+
+    return False
 
 
 def can_edit_location(view_fn):

--- a/corehq/apps/ota/exceptions.py
+++ b/corehq/apps/ota/exceptions.py
@@ -4,3 +4,7 @@ class PrimeRestoreException(Exception):
 
 class PrimeRestoreUserException(PrimeRestoreException):
     pass
+
+
+class RestorePermissionDenied(Exception):
+    """ Raised when the user is not permitted to restore """

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -24,6 +24,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
 
     @classmethod
     def setUpClass(cls):
+        delete_all_users()
         super(RestorePermissionsTest, cls).setUpClass()
         delete_all_users()
 
@@ -68,14 +69,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         cls.location_user.set_location(cls.locations['ma'])
         cls.wrong_location_user.set_location(cls.locations['montreal'])
 
-        cls.restrict_user_to_location(cls.commcare_user)
-
-        role = cls.commcare_user.get_role(cls.domain)
-        role.permissions.edit_commcare_users = True
-        role.save()
-
-        cls.commcare_user.set_role(cls.domain, role.get_qualified_id())
-        cls.commcare_user.save()
+        cls.restrict_user_to_assigned_locations(cls.commcare_user)
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -47,6 +47,11 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             domain=cls.domain,
             password='***',
         )
+        cls.no_edit_commcare_user = CommCareUser.create(
+            username=format_username('noedit', cls.domain),
+            domain=cls.domain,
+            password='***',
+        )
         cls.location_user = CommCareUser.create(
             username=format_username('location', cls.domain),
             domain=cls.domain,
@@ -59,6 +64,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         )
 
         cls.commcare_user.set_location(cls.locations['usa'])
+        cls.no_edit_commcare_user.set_location(cls.locations['usa'])
         cls.location_user.set_location(cls.locations['ma'])
         cls.wrong_location_user.set_location(cls.locations['montreal'])
 
@@ -170,6 +176,16 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
+
+    def test_commcare_user_as_user_disallow_no_edit_data(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.no_edit_commcare_user,
+            u'{}@{}'.format(self.location_user.raw_username, self.domain),
+            True,
+        )
+        self.assertFalse(is_permitted)
+        self.assertIsNotNone(message)
 
     def test_commcare_user_as_user_in_location(self):
         is_permitted, message = is_permitted_to_restore(

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -71,7 +71,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         cls.restrict_user_to_location(cls.commcare_user)
 
         role = cls.commcare_user.get_role(cls.domain)
-        role.permissions.edit_data = True
+        role.permissions.edit_commcare_users = True
         role.save()
 
         cls.commcare_user.set_role(cls.domain, role.get_qualified_id())

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -101,7 +101,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             False,
         )
         self.assertFalse(is_permitted)
-        self.assertIsNotNone(message)
+        self.assertRegexpMatches(message, 'was not in the domain')
 
     def test_web_user_permitted(self):
         is_permitted, message = is_permitted_to_restore(
@@ -123,7 +123,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
 
-    def test_web_user_as_user_bad_privelege(self):
+    def test_web_user_as_user_bad_privilege(self):
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.web_user,
@@ -131,7 +131,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             False,
         )
         self.assertFalse(is_permitted)
-        self.assertIsNotNone(message)
+        self.assertRegexpMatches(message, 'does not have permissions')
 
     def test_web_user_as_user_bad_username(self):
         is_permitted, message = is_permitted_to_restore(
@@ -141,7 +141,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             True,
         )
         self.assertFalse(is_permitted)
-        self.assertIsNotNone(message)
+        self.assertRegexpMatches(message, 'Invalid restore user')
 
     def test_web_user_as_user_bad_domain(self):
         is_permitted, message = is_permitted_to_restore(
@@ -151,7 +151,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             True,
         )
         self.assertFalse(is_permitted)
-        self.assertIsNotNone(message)
+        self.assertRegexpMatches(message, 'was not in the domain')
 
     def test_web_user_as_other_web_user(self):
         is_permitted, message = is_permitted_to_restore(
@@ -185,7 +185,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             True,
         )
         self.assertFalse(is_permitted)
-        self.assertIsNotNone(message)
+        self.assertRegexpMatches(message, 'does not have permission')
 
     def test_commcare_user_as_user_in_location(self):
         is_permitted, message = is_permitted_to_restore(
@@ -204,7 +204,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             True,
         )
         self.assertFalse(is_permitted)
-        self.assertIsNotNone(message)
+        self.assertRegexpMatches(message, 'not in allowed locations')
 
 
 class GetRestoreUserTest(TestCase):

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -64,6 +64,13 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
 
         cls.restrict_user_to_location(cls.commcare_user)
 
+        role = cls.commcare_user.get_role(cls.domain)
+        role.permissions.edit_data = True
+        role.save()
+
+        cls.commcare_user.set_role(cls.domain, role.get_qualified_id())
+        cls.commcare_user.save()
+
     @classmethod
     def tearDownClass(cls):
         super(RestorePermissionsTest, cls).tearDownClass()

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -24,9 +24,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
 
     @classmethod
     def setUpClass(cls):
-        delete_all_users()
         super(RestorePermissionsTest, cls).setUpClass()
-        delete_all_users()
 
         cls.other_project = Domain(name=cls.other_domain)
         cls.other_project.save()

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -1,21 +1,31 @@
 from django.test import TestCase
 
 from corehq.apps.users.models import WebUser, CommCareUser
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.util import format_username
 from corehq.apps.domain.models import Domain
+from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 
 from corehq.apps.ota.utils import is_permitted_to_restore, get_restore_user
 
 
-class RestorePermissionsTest(TestCase):
+class RestorePermissionsTest(LocationHierarchyTestCase):
     domain = 'goats'
     other_domain = 'sheep'
+    location_type_names = ['country', 'state']
+    location_structure = [
+        ('usa', [
+            ('ma', []),
+        ]),
+        ('canada', [
+            ('montreal', []),
+        ]),
+    ]
 
     @classmethod
     def setUpClass(cls):
         super(RestorePermissionsTest, cls).setUpClass()
-        cls.project = Domain(name=cls.domain)
-        cls.project.save()
+        delete_all_users()
 
         cls.other_project = Domain(name=cls.other_domain)
         cls.other_project.save()
@@ -37,14 +47,27 @@ class RestorePermissionsTest(TestCase):
             domain=cls.domain,
             password='***',
         )
+        cls.location_user = CommCareUser.create(
+            username=format_username('location', cls.domain),
+            domain=cls.domain,
+            password='***',
+        )
+        cls.wrong_location_user = CommCareUser.create(
+            username=format_username('wrong-location', cls.domain),
+            domain=cls.domain,
+            password='***',
+        )
+
+        cls.commcare_user.set_location(cls.locations['usa'])
+        cls.location_user.set_location(cls.locations['ma'])
+        cls.wrong_location_user.set_location(cls.locations['montreal'])
+
+        cls.restrict_user_to_location(cls.commcare_user)
 
     @classmethod
     def tearDownClass(cls):
         super(RestorePermissionsTest, cls).tearDownClass()
-        cls.web_user.delete()
-        cls.commcare_user.delete()
-        cls.super_user.delete()
-        cls.project.delete()
+        delete_all_users()
         cls.other_project.delete()
 
     def test_commcare_user_permitted(self):
@@ -141,6 +164,25 @@ class RestorePermissionsTest(TestCase):
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
 
+    def test_commcare_user_as_user_in_location(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.commcare_user,
+            u'{}@{}'.format(self.location_user.raw_username, self.domain),
+            True,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.commcare_user,
+            u'{}@{}'.format(self.wrong_location_user.raw_username, self.domain),
+            True,
+        )
+        self.assertFalse(is_permitted)
+        self.assertIsNotNone(message)
+
 
 class GetRestoreUserTest(TestCase):
 
@@ -163,6 +205,11 @@ class GetRestoreUserTest(TestCase):
         )
         cls.commcare_user = CommCareUser.create(
             username=format_username('jane', cls.domain),
+            domain=cls.domain,
+            password='***',
+        )
+        cls.other_commcare_user = CommCareUser.create(
+            username=format_username('john', cls.domain),
             domain=cls.domain,
             password='***',
         )
@@ -224,3 +271,11 @@ class GetRestoreUserTest(TestCase):
                 '{}@wrong-domain'.format(self.commcare_user.raw_username, self.domain)
             )
         )
+
+    def test_get_restore_user_as_user_for_commcare_user(self):
+        user = get_restore_user(
+            self.domain,
+            self.commcare_user,
+            '{}@{}'.format(self.other_commcare_user.raw_username, self.domain)
+        )
+        self.assertEquals(user.user_id, self.other_commcare_user._id)

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -154,8 +154,10 @@ def _ensure_accessible_location(domain, couch_user, as_user):
 
 
 def _ensure_edit_data_permission(domain, couch_user):
-    if couch_user.is_commcare_user() and not couch_user.has_permission(domain, 'edit_data'):
-        raise RestorePermissionDenied(_(u'{} does not have permission to edit data').format(couch_user.username))
+    if couch_user.is_commcare_user() and not couch_user.has_permission(domain, 'edit_commcare_users'):
+        raise RestorePermissionDenied(
+            _(u'{} does not have permission to edit commcare users').format(couch_user.username)
+        )
 
 
 def get_restore_user(domain, couch_user, as_user):

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -117,12 +117,12 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privil
 
 def _ensure_valid_domain(domain, couch_user):
     if not couch_user.is_member_of(domain):
-        raise RestorePermissionDenied(u"{} was not in the domain {}".format(couch_user.username, domain))
+        raise RestorePermissionDenied(_(u"{} was not in the domain {}").format(couch_user.username, domain))
 
 
 def _ensure_cleanup_permission(domain, couch_user, as_user, has_data_cleanup_privilege):
     if not has_data_cleanup_privilege and not couch_user.is_superuser:
-        raise RestorePermissionDenied(u"{} does not have permissions to restore as {}".format(
+        raise RestorePermissionDenied(_(u"{} does not have permissions to restore as {}").format(
             couch_user.username,
             as_user,
         ))
@@ -134,28 +134,28 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user):
         user_domain = as_user.split('@')[1]
     except IndexError:
         raise RestorePermissionDenied(
-            u"Invalid restore user {}. Format is <user>@<domain>".format(as_user)
+            _(u"Invalid restore user {}. Format is <user>@<domain>").format(as_user)
         )
     else:
         if user_domain != domain:
             # In this case we may be dealing with a WebUser
             user = WebUser.get_by_username(as_user)
             if not user or not user.is_member_of(domain):
-                raise RestorePermissionDenied(u"{} was not in the domain {}".format(username, domain))
+                raise RestorePermissionDenied(_(u"{} was not in the domain {}").format(username, domain))
 
 
 def _ensure_accessible_location(domain, couch_user, as_user):
     if couch_user.is_commcare_user():
         as_user_obj = CommCareUser.get_by_username('{}.commcarehq.org'.format(as_user))
         if not as_user_obj:
-            raise RestorePermissionDenied(u'Invalid restore user {}'.format(as_user))
+            raise RestorePermissionDenied(_(u'Invalid restore user {}').format(as_user))
         elif not user_can_access_other_user(domain, couch_user, as_user_obj):
-            raise RestorePermissionDenied(u'Restore user {} not in allowed locations'.format(as_user))
+            raise RestorePermissionDenied(_(u'Restore user {} not in allowed locations').format(as_user))
 
 
 def _ensure_edit_data_permission(domain, couch_user):
     if couch_user.is_commcare_user() and not couch_user.has_permission(domain, 'edit_data'):
-        raise RestorePermissionDenied(u'{} does not have permission to edit data'.format(couch_user.username))
+        raise RestorePermissionDenied(_(u'{} does not have permission to edit data').format(couch_user.username))
 
 
 def get_restore_user(domain, couch_user, as_user):

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -109,7 +109,7 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user):
         user_domain = as_user.split('@')[1]
     except IndexError:
         raise RestorePermissionDenied(
-            u"Invalid to restore user {}. Format is <user>@<domain>".format(as_user)
+            u"Invalid restore user {}. Format is <user>@<domain>".format(as_user)
         )
     else:
         if user_domain != domain:

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -145,12 +145,13 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user):
 
 
 def _ensure_accessible_location(domain, couch_user, as_user):
-    if couch_user.is_commcare_user():
-        as_user_obj = CommCareUser.get_by_username('{}.commcarehq.org'.format(as_user))
-        if not as_user_obj:
-            raise RestorePermissionDenied(_(u'Invalid restore user {}').format(as_user))
-        elif not user_can_access_other_user(domain, couch_user, as_user_obj):
-            raise RestorePermissionDenied(_(u'Restore user {} not in allowed locations').format(as_user))
+    as_user_obj = CommCareUser.get_by_username('{}.commcarehq.org'.format(as_user))
+    if not as_user_obj:
+        as_user_obj = WebUser.get_by_username(as_user)
+    if not as_user_obj:
+        raise RestorePermissionDenied(_(u'Invalid restore user {}').format(as_user))
+    elif not user_can_access_other_user(domain, couch_user, as_user_obj):
+        raise RestorePermissionDenied(_(u'Restore user {} not in allowed locations').format(as_user))
 
 
 def _ensure_edit_data_permission(domain, couch_user):

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -128,6 +128,11 @@ def _ensure_accessible_location(domain, couch_user, as_user):
             raise RestorePermissionDenied(u'Restore user {} not in allowed locations'.format(as_user))
 
 
+def _ensure_edit_data_permission(domain, couch_user):
+    if couch_user.is_commcare_user() and not couch_user.has_permission(domain, 'edit_data'):
+        raise RestorePermissionDenied(u'{} does not have permission to edit data'.format(couch_user.username))
+
+
 def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privilege):
     """
     This function determines if the couch_user is permitted to restore
@@ -146,6 +151,7 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privil
             _ensure_cleanup_permission(domain, couch_user, as_user, has_data_cleanup_privilege)
             _ensure_valid_restore_as_user(domain, couch_user, as_user)
             _ensure_accessible_location(domain, couch_user, as_user)
+            _ensure_edit_data_permission(domain, couch_user)
     except RestorePermissionDenied as e:
         return False, unicode(e)
     else:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -25,6 +25,7 @@ from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.ota.forms import PrimeRestoreCacheForm, AdvancedPrimeRestoreCacheForm
 from corehq.apps.ota.tasks import queue_prime_restore
 from corehq.apps.users.models import CouchUser, CommCareUser
+from corehq.apps.locations.permissions import location_safe
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
 from corehq.tabs.tabclasses import ProjectSettingsTab
@@ -37,6 +38,7 @@ from soil import MultipleTaskDownload
 from .utils import demo_user_restore_response, get_restore_user, is_permitted_to_restore, handle_401_response
 
 
+@location_safe
 @json_error
 @handle_401_response
 @login_or_digest_or_basic_or_apikey()

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -942,13 +942,6 @@ APP_MANAGER_V2 = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-RESTORE_AS_CLOUDCARE = StaticToggle(
-    'restore_as_cloudcare',
-    'Restore as a different user for cloudcare',
-    TAG_PRODUCT_PATH,
-    [NAMESPACE_USER, NAMESPACE_DOMAIN],
-)
-
 DATA_MIGRATION = StaticToggle(
     'data_migration',
     'Disable submissions and restores during a data migration',


### PR DESCRIPTION
@czue this implements permissions for the restore as feature (and removes the toggle it was previously behind). this does:

- Allow mobile users to be able to restore as other mobile users
- Allow mobile workers to conditionally be able to view the Login As button in web apps

Being able to pull the list of users in a location safe way was already implemented, but it requires the Edit Mobile Workers permission which is unfortunate.

In order to restore as another mobile worker when you're a mobile worker you'll need to have the `DATA_CLEANUP` permission and you need to have the `edit_data` permission and have that user in your location or its descendants. Wasn't sure if you imagined having a totally separate permission for using restore as

Still todo:

- [x] Better error handling when permission is denied in web apps
- [x] Reconcile that Edit Mobile Workers permission (don't think it should be required for getting a list of mobile workers)

 🐟 or 🏠 

cc some location folk to make sure i'm doing things correctly with locations: @esoergel @proteusvacuum 
