### PR TITLE
add location sync settings

### DIFF
--- a/corehq/apps/calendar_fixture/fixture_provider.py
+++ b/corehq/apps/calendar_fixture/fixture_provider.py
@@ -1,7 +1,7 @@
-from xml.etree.ElementTree import Element
 import datetime
-from corehq.toggles import CUSTOM_CALENDAR_FIXTURE
+from xml.etree.ElementTree import Element
 from django.utils.translation import ugettext as _
+from corehq.toggles import CUSTOM_CALENDAR_FIXTURE
 
 
 class CalendarFixtureProvider(object):
@@ -40,5 +40,6 @@ class CalendarFixtureProvider(object):
             current_day += datetime.timedelta(days=1)
 
         return [root_node]
+
 
 calendar_fixture_generator = CalendarFixtureProvider()

--- a/corehq/apps/calendar_fixture/fixture_provider.py
+++ b/corehq/apps/calendar_fixture/fixture_provider.py
@@ -15,10 +15,10 @@ class CalendarFixtureProvider(object):
         root_node = Element('fixture', {'id': self.id, 'user_id': restore_user.user_id})
         calendar_node = Element('calendar')
         root_node.append(calendar_node)
-        current_year = datetime.datetime.today().year
-        current_day = datetime.date(current_year, 1, 1)
+        current_day = _get_calendar_start_date(restore_user.domain)
+        end_date = _get_calendar_end_date(restore_user.domain)
         last_day = current_day - datetime.timedelta(days=1)
-        while current_day.year == current_year:
+        while current_day < end_date:
             if current_day.year != last_day.year:
                 current_year_element = Element('year', {'number': str(current_day.year)})
                 calendar_node.append(current_year_element)
@@ -40,6 +40,14 @@ class CalendarFixtureProvider(object):
             current_day += datetime.timedelta(days=1)
 
         return [root_node]
+
+
+def _get_calendar_start_date(domain):
+    return datetime.date(datetime.datetime.now().year, 1, 1)
+
+
+def _get_calendar_end_date(domain):
+    return datetime.date(datetime.datetime.now().year + 1, 1, 1)
 
 
 calendar_fixture_generator = CalendarFixtureProvider()

--- a/corehq/apps/calendar_fixture/fixture_provider.py
+++ b/corehq/apps/calendar_fixture/fixture_provider.py
@@ -45,12 +45,7 @@ class CalendarFixtureProvider(object):
 
 
 def get_calendar_range(domain):
-    try:
-        calendar_settings = CalendarFixtureSettings.objects.get(domain=domain)
-    except CalendarFixtureSettings.DoesNotExist:
-        # this will use the default values in the models
-        calendar_settings = CalendarFixtureSettings()
-
+    calendar_settings = CalendarFixtureSettings.for_domain(domain=domain)
     today = datetime.datetime.today()
     return (
         today - datetime.timedelta(days=calendar_settings.days_before),

--- a/corehq/apps/calendar_fixture/forms.py
+++ b/corehq/apps/calendar_fixture/forms.py
@@ -1,0 +1,30 @@
+from django import forms
+from django.utils.translation import ugettext as _
+from corehq.apps.calendar_fixture.models import CalendarFixtureSettings
+from crispy_forms.helper import FormHelper
+from crispy_forms import layout
+from crispy_forms.bootstrap import StrictButton
+
+
+class CalendarFixtureForm(forms.ModelForm):
+    class Meta:
+        model = CalendarFixtureSettings
+        fields = ['days_before', 'days_after']
+
+    def __init__(self, *args, **kwargs):
+        super(CalendarFixtureForm, self).__init__(*args, **kwargs)
+        self.fields['days_before'].label = _('Start calendar this many days in the past.')
+        self.fields['days_after'].label = _('End calendar this many days in the future.')
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-horizontal'
+        self.helper.label_class = 'col-sm-3 col-md-3'
+        self.helper.field_class = 'col-sm-3 col-md-3'
+        self.helper.layout = layout.Layout(
+            'days_before',
+            'days_after',
+            StrictButton(
+                _("Update Settings"),
+                type="submit",
+                css_class='btn-primary',
+            )
+        )

--- a/corehq/apps/calendar_fixture/migrations/0001_initial.py
+++ b/corehq/apps/calendar_fixture/migrations/0001_initial.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CalendarFixtureSettings',
+            fields=[
+                ('domain', models.CharField(max_length=255, serialize=False, primary_key=True)),
+                ('days_before', models.PositiveIntegerField(default=300)),
+                ('days_after', models.PositiveIntegerField(default=65)),
+            ],
+        ),
+    ]

--- a/corehq/apps/calendar_fixture/models.py
+++ b/corehq/apps/calendar_fixture/models.py
@@ -18,4 +18,4 @@ class CalendarFixtureSettings(models.Model):
         try:
             return cls.objects.get(domain=domain)
         except cls.DoesNotExist:
-            return CalendarFixtureSettings(domain=domain)
+            return cls(domain=domain)

--- a/corehq/apps/calendar_fixture/models.py
+++ b/corehq/apps/calendar_fixture/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+
+
+DEFAULT_DAYS_BEFORE = 300
+DEFAULT_DAYS_AFTER = 90
+
+
+class CalendarFixtureSettings(models.Model):
+    domain = models.CharField(primary_key=True, max_length=255)
+    days_before = models.PositiveIntegerField(default=DEFAULT_DAYS_BEFORE)
+    days_after = models.PositiveIntegerField(default=DEFAULT_DAYS_AFTER)

--- a/corehq/apps/calendar_fixture/models.py
+++ b/corehq/apps/calendar_fixture/models.py
@@ -9,3 +9,13 @@ class CalendarFixtureSettings(models.Model):
     domain = models.CharField(primary_key=True, max_length=255)
     days_before = models.PositiveIntegerField(default=DEFAULT_DAYS_BEFORE)
     days_after = models.PositiveIntegerField(default=DEFAULT_DAYS_AFTER)
+
+    def __repr__(self):
+        return u'{}: {} before - {} after'.format(self.domain, self.days_before, self.days_after)
+
+    @classmethod
+    def for_domain(cls, domain):
+        try:
+            return cls.objects.get(domain=domain)
+        except cls.DoesNotExist:
+            return CalendarFixtureSettings(domain=domain)

--- a/corehq/apps/calendar_fixture/tests.py
+++ b/corehq/apps/calendar_fixture/tests.py
@@ -1,0 +1,40 @@
+import uuid
+from xml.etree import ElementTree
+from datetime import date
+from django.test import TestCase
+from casexml.apps.case.xml import V2
+from corehq.apps.calendar_fixture.fixture_provider import calendar_fixture_generator
+from corehq.apps.users.models import CommCareUser
+from corehq.toggles import CUSTOM_CALENDAR_FIXTURE
+from corehq.util.decorators import temporarily_enable_toggle
+
+
+class TestFixture(TestCase):
+
+    def test_nothing(self):
+        user = CommCareUser(_id=uuid.uuid4().hex, domain='not-enabled')
+        self.assertEqual([], calendar_fixture_generator(user, V2))
+
+    @temporarily_enable_toggle(CUSTOM_CALENDAR_FIXTURE, 'test-calendar')
+    def test_fixture_enabled(self):
+        user = CommCareUser(_id=uuid.uuid4().hex, domain='test-calendar')
+        fixture = calendar_fixture_generator(user, V2)[0]
+        self.assertEqual(user._id, fixture.attrib['user_id'])
+        self._check_first_date(fixture, date(2016, 1, 1))
+        self._check_last_date(fixture, date(2016, 12, 31))
+
+    def _check_first_date(self, fixture, expected_date):
+        year_element = fixture[0][0]
+        self.assertEqual(str(expected_date.year), year_element.attrib['number'])
+        month_element = fixture[0][0][0]
+        self.assertEqual(str(expected_date.month), month_element.attrib['number'])
+        day_element = fixture[0][0][0][0]
+        self.assertEqual(str(int(expected_date.strftime('%s')) / (60 * 60 * 24)), day_element.attrib['date'])
+
+    def _check_last_date(self, fixture, expected_date):
+        year_element = fixture[0][-1]
+        self.assertEqual(str(expected_date.year), year_element.attrib['number'])
+        month_element = fixture[0][-1][-1]
+        self.assertEqual(str(expected_date.month), month_element.attrib['number'])
+        day_element = fixture[0][-1][-1][-1]
+        self.assertEqual(str(int(expected_date.strftime('%s')) / (60 * 60 * 24)), day_element.attrib['date'])

--- a/corehq/apps/calendar_fixture/tests.py
+++ b/corehq/apps/calendar_fixture/tests.py
@@ -5,8 +5,7 @@ from casexml.apps.case.xml import V2
 from corehq.apps.calendar_fixture.fixture_provider import calendar_fixture_generator
 from corehq.apps.calendar_fixture.models import DEFAULT_DAYS_BEFORE, DEFAULT_DAYS_AFTER, CalendarFixtureSettings
 from corehq.apps.users.models import CommCareUser
-from corehq.toggles import CUSTOM_CALENDAR_FIXTURE
-from corehq.util.decorators import temporarily_enable_toggle
+from corehq.util.test_utils import flag_enabled
 
 
 class TestFixture(TestCase):
@@ -15,7 +14,7 @@ class TestFixture(TestCase):
         user = CommCareUser(_id=uuid.uuid4().hex, domain='not-enabled')
         self.assertEqual([], calendar_fixture_generator(user, V2))
 
-    @temporarily_enable_toggle(CUSTOM_CALENDAR_FIXTURE, 'test-calendar-defaults')
+    @flag_enabled('CUSTOM_CALENDAR_FIXTURE')
     def test_fixture_defaults(self):
         user = CommCareUser(_id=uuid.uuid4().hex, domain='test-calendar-defaults')
         fixture = calendar_fixture_generator(user, V2)[0]
@@ -24,7 +23,7 @@ class TestFixture(TestCase):
         self._check_first_date(fixture, today - timedelta(days=DEFAULT_DAYS_BEFORE))
         self._check_last_date(fixture, today + timedelta(days=DEFAULT_DAYS_AFTER))
 
-    @temporarily_enable_toggle(CUSTOM_CALENDAR_FIXTURE, 'test-calendar-settings')
+    @flag_enabled('CUSTOM_CALENDAR_FIXTURE')
     def test_fixture_customization(self):
         user = CommCareUser(_id=uuid.uuid4().hex, domain='test-calendar-settings')
         days_before = 50

--- a/corehq/apps/calendar_fixture/tests.py
+++ b/corehq/apps/calendar_fixture/tests.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from django.test import TestCase
 from casexml.apps.case.xml import V2
 from corehq.apps.calendar_fixture.fixture_provider import calendar_fixture_generator

--- a/corehq/apps/calendar_fixture/tests.py
+++ b/corehq/apps/calendar_fixture/tests.py
@@ -28,7 +28,7 @@ class TestFixture(TestCase):
         user = CommCareUser(_id=uuid.uuid4().hex, domain='test-calendar-settings')
         days_before = 50
         days_after = 10
-        CalendarFixtureSettings.objects.create(
+        calendar_settings = CalendarFixtureSettings.objects.create(
             domain='test-calendar-settings',
             days_before=days_before,
             days_after=days_after,
@@ -38,6 +38,7 @@ class TestFixture(TestCase):
         today = datetime.today()
         self._check_first_date(fixture, today - timedelta(days=days_before))
         self._check_last_date(fixture, today + timedelta(days=days_after))
+        self.addCleanup(calendar_settings.delete)
 
     def _check_first_date(self, fixture, expected_date):
         year_element = fixture[0][0]

--- a/corehq/apps/calendar_fixture/tests.py
+++ b/corehq/apps/calendar_fixture/tests.py
@@ -1,9 +1,9 @@
 import uuid
-from xml.etree import ElementTree
-from datetime import date
+from datetime import date, datetime, timedelta
 from django.test import TestCase
 from casexml.apps.case.xml import V2
 from corehq.apps.calendar_fixture.fixture_provider import calendar_fixture_generator
+from corehq.apps.calendar_fixture.models import DEFAULT_DAYS_BEFORE, DEFAULT_DAYS_AFTER
 from corehq.apps.users.models import CommCareUser
 from corehq.toggles import CUSTOM_CALENDAR_FIXTURE
 from corehq.util.decorators import temporarily_enable_toggle
@@ -16,12 +16,13 @@ class TestFixture(TestCase):
         self.assertEqual([], calendar_fixture_generator(user, V2))
 
     @temporarily_enable_toggle(CUSTOM_CALENDAR_FIXTURE, 'test-calendar')
-    def test_fixture_enabled(self):
+    def test_fixture_defaults(self):
         user = CommCareUser(_id=uuid.uuid4().hex, domain='test-calendar')
         fixture = calendar_fixture_generator(user, V2)[0]
         self.assertEqual(user._id, fixture.attrib['user_id'])
-        self._check_first_date(fixture, date(2016, 1, 1))
-        self._check_last_date(fixture, date(2016, 12, 31))
+        today = datetime.today()
+        self._check_first_date(fixture, today - timedelta(days=DEFAULT_DAYS_BEFORE))
+        self._check_last_date(fixture, today + timedelta(days=DEFAULT_DAYS_AFTER))
 
     def _check_first_date(self, fixture, expected_date):
         year_element = fixture[0][0]

--- a/corehq/apps/domain/templates/domain/admin/calendar_fixture.html
+++ b/corehq/apps/domain/templates/domain/admin/calendar_fixture.html
@@ -1,11 +1,6 @@
 {% extends "style/base_section.html" %}
-{% load hq_shared_tags %}
-{% load hqstyle_tags %}
 {% load crispy_forms_tags %}
 {% load i18n %}
-{% block js-inline %}{{ block.super }}
-{% endblock %}
-
 {% block page_content %}
     <h1>{% trans "Calendar Fixture Settings" %}</h1>
     {% crispy form %}

--- a/corehq/apps/domain/templates/domain/admin/calendar_fixture.html
+++ b/corehq/apps/domain/templates/domain/admin/calendar_fixture.html
@@ -1,0 +1,12 @@
+{% extends "style/base_section.html" %}
+{% load hq_shared_tags %}
+{% load hqstyle_tags %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% block js-inline %}{{ block.super }}
+{% endblock %}
+
+{% block page_content %}
+    <h1>{% trans "Calendar Fixture Settings" %}</h1>
+    {% crispy form %}
+{% endblock %}

--- a/corehq/apps/domain/templates/domain/admin/location_fixture.html
+++ b/corehq/apps/domain/templates/domain/admin/location_fixture.html
@@ -1,0 +1,7 @@
+{% extends "style/base_section.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% block page_content %}
+    <h1>{% trans "Location Fixture Settings" %}</h1>
+    {% crispy form %}
+{% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -36,7 +36,7 @@ from corehq.apps.domain.views import (
     calculated_properties,
     toggle_diff,
     select,
-    CalendarFixtureConfigView)
+    CalendarFixtureConfigView, LocationFixtureConfigView)
 from corehq.apps.repeaters.views import AddCaseRepeaterView, RepeatRecordView
 from corehq.apps.reports.dispatcher import DomainReportDispatcher
 
@@ -181,6 +181,7 @@ domain_settings = [
     url(r'^multimedia/$', ManageProjectMediaView.as_view(), name=ManageProjectMediaView.urlname),
     url(r'^case_search/$', CaseSearchConfigView.as_view(), name=CaseSearchConfigView.urlname),
     url(r'^calendar_settings/$', CalendarFixtureConfigView.as_view(), name=CalendarFixtureConfigView.urlname),
+    url(r'^location_settings/$', LocationFixtureConfigView.as_view(), name=LocationFixtureConfigView.urlname),
     url(r'^commtrack/settings/$', RedirectView.as_view(url='commtrack_settings', permanent=True)),
     url(r'^internal/info/$', EditInternalDomainInfoView.as_view(), name=EditInternalDomainInfoView.urlname),
     url(r'^internal/calculations/$', EditInternalCalculationsView.as_view(), name=EditInternalCalculationsView.urlname),

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -36,7 +36,7 @@ from corehq.apps.domain.views import (
     calculated_properties,
     toggle_diff,
     select,
-)
+    CalendarFixtureConfigView)
 from corehq.apps.repeaters.views import AddCaseRepeaterView, RepeatRecordView
 from corehq.apps.reports.dispatcher import DomainReportDispatcher
 
@@ -180,6 +180,7 @@ domain_settings = [
     url(r'^snapshots/new/$', CreateNewExchangeSnapshotView.as_view(), name=CreateNewExchangeSnapshotView.urlname),
     url(r'^multimedia/$', ManageProjectMediaView.as_view(), name=ManageProjectMediaView.urlname),
     url(r'^case_search/$', CaseSearchConfigView.as_view(), name=CaseSearchConfigView.urlname),
+    url(r'^calendar_settings/$', CalendarFixtureConfigView.as_view(), name=CalendarFixtureConfigView.urlname),
     url(r'^commtrack/settings/$', RedirectView.as_view(url='commtrack_settings', permanent=True)),
     url(r'^internal/info/$', EditInternalDomainInfoView.as_view(), name=EditInternalDomainInfoView.urlname),
     url(r'^internal/calculations/$', EditInternalCalculationsView.as_view(), name=EditInternalCalculationsView.urlname),

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2092,9 +2092,8 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
     template_name = 'domain/admin/case_search.html'
 
     @method_decorator(domain_admin_required)
+    @toggles.CUSTOM_CALENDAR_FIXTURE.required_decorator()
     def dispatch(self, request, *args, **kwargs):
-        if not toggles.SYNC_SEARCH_CASE_CLAIM.enabled(request.domain):
-            raise Http404
         return super(CaseSearchConfigView, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -32,6 +32,7 @@ from PIL import Image
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.contrib.auth.models import User
 
+from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
@@ -2092,6 +2093,8 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
 
     @method_decorator(domain_admin_required)
     def dispatch(self, request, *args, **kwargs):
+        if not toggles.SYNC_SEARCH_CASE_CLAIM.enabled(request.domain):
+            raise Http404
         return super(CaseSearchConfigView, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2092,7 +2092,7 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
     template_name = 'domain/admin/case_search.html'
 
     @method_decorator(domain_admin_required)
-    @toggles.CUSTOM_CALENDAR_FIXTURE.required_decorator()
+    @toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
     def dispatch(self, request, *args, **kwargs):
         return super(CaseSearchConfigView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -43,6 +43,8 @@ from corehq.apps.case_search.models import (
     disable_case_search,
 )
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster
+from corehq.apps.locations.forms import LocationFixtureForm
+from corehq.apps.locations.models import LocationFixtureConfiguration
 from corehq.apps.repeaters.repeater_generators import RegisterGenerator
 
 from corehq.const import USER_DATE_FORMAT
@@ -2168,6 +2170,32 @@ class CalendarFixtureConfigView(BaseAdminProjectSettingsView):
     def page_context(self):
         calendar_settings = CalendarFixtureSettings.for_domain(self.domain)
         form = CalendarFixtureForm(instance=calendar_settings)
+        return {'form': form}
+
+
+class LocationFixtureConfigView(BaseAdminProjectSettingsView):
+    urlname = 'location_fixture_config'
+    page_title = ugettext_lazy('Location Fixture')
+    template_name = 'domain/admin/location_fixture.html'
+
+    @method_decorator(domain_admin_required)
+    @toggles.FLAT_LOCATION_FIXTURE.required_decorator()
+    def dispatch(self, request, *args, **kwargs):
+        return super(LocationFixtureConfigView, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        location_settings = LocationFixtureConfiguration.for_domain(self.domain)
+        form = LocationFixtureForm(request.POST, instance=location_settings)
+        if form.is_valid():
+            form.save()
+            messages.success(request, _("Location configuration updated successfully"))
+
+        return self.get(request, *args, **kwargs)
+
+    @property
+    def page_context(self):
+        location_settings = LocationFixtureConfiguration.for_domain(self.domain)
+        form = LocationFixtureForm(instance=location_settings)
         return {'form': form}
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -34,6 +34,8 @@ from django.contrib.auth.models import User
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
+from corehq.apps.calendar_fixture.forms import CalendarFixtureForm
+from corehq.apps.calendar_fixture.models import CalendarFixtureSettings
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
     CaseSearchConfigJSON,
@@ -2141,6 +2143,32 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
                 'config': current_values.config if current_values else {}
             }
         }
+
+
+class CalendarFixtureConfigView(BaseAdminProjectSettingsView):
+    urlname = 'calendar_fixture_config'
+    page_title = ugettext_lazy('Calendar Fixture')
+    template_name = 'domain/admin/calendar_fixture.html'
+
+    @method_decorator(domain_admin_required)
+    @toggles.CUSTOM_CALENDAR_FIXTURE.required_decorator()
+    def dispatch(self, request, *args, **kwargs):
+        return super(CalendarFixtureConfigView, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        calendar_settings = CalendarFixtureSettings.for_domain(self.domain)
+        form = CalendarFixtureForm(request.POST, instance=calendar_settings)
+        if form.is_valid():
+            form.save()
+            messages.success(request, _("Case search configuration updated successfully"))
+
+        return self.get(request, *args, **kwargs)
+
+    @property
+    def page_context(self):
+        calendar_settings = CalendarFixtureSettings.for_domain(self.domain)
+        form = CalendarFixtureForm(instance=calendar_settings)
+        return {'form': form}
 
 
 class DomainForwardingRepeatRecords(GenericTabularReport):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2160,7 +2160,7 @@ class CalendarFixtureConfigView(BaseAdminProjectSettingsView):
         form = CalendarFixtureForm(request.POST, instance=calendar_settings)
         if form.is_valid():
             form.save()
-            messages.success(request, _("Case search configuration updated successfully"))
+            messages.success(request, _("Calendar configuration updated successfully"))
 
         return self.get(request, *args, **kwargs)
 

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -12,7 +12,6 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.fixtures.exceptions import FixtureVersionError
 from dimagi.ext.couchdbkit import Document, DocumentSchema, DictProperty, StringProperty, StringListProperty, SchemaListProperty, IntegerProperty, BooleanProperty
 from corehq.apps.groups.models import Group
-from corehq.util.soft_assert import soft_assert
 from corehq.util.xml_utils import serialize
 from dimagi.utils.couch.bulk import CouchTransaction
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -84,7 +84,7 @@ class LocationFixtureProvider(object):
 class HierarchicalLocationSerializer(object):
 
     def get_xml_nodes(self, fixture_id, restore_user, all_locations):
-        if not restore_user.project.uses_locations:
+        if not should_sync_hierarchichal_fixture(restore_user.project):
             return []
 
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id})
@@ -125,6 +125,10 @@ class FlatLocationSerializer(object):
             outer_node.append(location_node)
 
         return [root_node]
+
+
+def should_sync_hierarchichal_fixture(project):
+    return project.uses_locations
 
 
 def should_sync_flat_fixture(domain):

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -98,7 +98,7 @@ class HierarchicalLocationSerializer(object):
 class FlatLocationSerializer(object):
 
     def get_xml_nodes(self, fixture_id, restore_user, all_locations):
-        if not toggles.FLAT_LOCATION_FIXTURE.enabled(restore_user.domain):
+        if not should_sync_flat_fixture(restore_user.domain):
             return []
 
         all_types = LocationType.objects.filter(domain=restore_user.domain).values_list(
@@ -125,6 +125,10 @@ class FlatLocationSerializer(object):
             outer_node.append(location_node)
 
         return [root_node]
+
+
+def should_sync_flat_fixture(domain):
+    return toggles.FLAT_LOCATION_FIXTURE.enabled(domain)
 
 
 location_fixture_generator = LocationFixtureProvider(

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -2,7 +2,7 @@ from itertools import groupby
 from collections import defaultdict
 from xml.etree.ElementTree import Element
 from casexml.apps.phone.models import OTARestoreUser
-from corehq.apps.locations.models import SQLLocation, LocationType
+from corehq.apps.locations.models import SQLLocation, LocationType, LocationFixtureConfiguration
 from corehq import toggles
 
 
@@ -128,11 +128,17 @@ class FlatLocationSerializer(object):
 
 
 def should_sync_hierarchichal_fixture(project):
-    return project.uses_locations
+    return (
+        project.uses_locations and
+        LocationFixtureConfiguration.for_domain(project.name).sync_hierarchical_fixture
+    )
 
 
 def should_sync_flat_fixture(domain):
-    return toggles.FLAT_LOCATION_FIXTURE.enabled(domain)
+    return (
+        toggles.FLAT_LOCATION_FIXTURE.enabled(domain) and
+        LocationFixtureConfiguration.for_domain(domain).sync_flat_fixture
+    )
 
 
 location_fixture_generator = LocationFixtureProvider(

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -84,7 +84,7 @@ class LocationFixtureProvider(object):
 class HierarchicalLocationSerializer(object):
 
     def get_xml_nodes(self, fixture_id, restore_user, all_locations):
-        if not should_sync_hierarchichal_fixture(restore_user.project):
+        if not should_sync_hierarchical_fixture(restore_user.project):
             return []
 
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id})
@@ -127,7 +127,7 @@ class FlatLocationSerializer(object):
         return [root_node]
 
 
-def should_sync_hierarchichal_fixture(project):
+def should_sync_hierarchical_fixture(project):
     return (
         project.uses_locations and
         LocationFixtureConfiguration.for_domain(project.name).sync_hierarchical_fixture

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy
 
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
+from crispy_forms.bootstrap import StrictButton
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.decorators.memoized import memoized
 
@@ -21,7 +22,7 @@ from corehq.apps.locations.permissions import LOCATION_ACCESS_DENIED
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import raw_username, user_display_string
 
-from .models import SQLLocation, LocationType
+from .models import SQLLocation, LocationType, LocationFixtureConfiguration
 from .permissions import user_can_access_location_id
 from .signals import location_edited
 
@@ -383,3 +384,29 @@ class UsersAtLocationForm(MultipleSelectionForm):
 
         self.unassign_users(to_remove)
         self.assign_users(to_add)
+
+
+class LocationFixtureForm(forms.ModelForm):
+    class Meta:
+        model = LocationFixtureConfiguration
+        fields = ['sync_flat_fixture', 'sync_hierarchical_fixture']
+
+    def __init__(self, *args, **kwargs):
+        super(LocationFixtureForm, self).__init__(*args, **kwargs)
+        self.fields['sync_flat_fixture'].label = _('Sync the flat location fixture (recommended).')
+        self.fields['sync_hierarchical_fixture'].label = _(
+            'Sync the hierarchicial location fixture (legacy format).'
+        )
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-horizontal'
+        self.helper.label_class = 'col-sm-3 col-md-3'
+        self.helper.field_class = 'col-sm-3 col-md-3'
+        self.helper.layout = crispy.Layout(
+            'sync_flat_fixture',
+            'sync_hierarchical_fixture',
+            StrictButton(
+                _("Update Settings"),
+                type="submit",
+                css_class='btn-primary',
+            )
+        )

--- a/corehq/apps/locations/migrations/0006_locationfixtureconfiguration.py
+++ b/corehq/apps/locations/migrations/0006_locationfixtureconfiguration.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0005_locationtype_include_without_expanding'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LocationFixtureConfiguration',
+            fields=[
+                ('domain', models.CharField(max_length=255, serialize=False, primary_key=True)),
+                ('sync_flat_fixture', models.BooleanField(default=True)),
+                ('sync_hierarchical_fixture', models.BooleanField(default=True)),
+            ],
+        ),
+    ]

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -950,6 +950,24 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
         return self.location_type_object.name
 
 
+class LocationFixtureConfiguration(models.Model):
+    domain = models.CharField(primary_key=True, max_length=255)
+    sync_flat_fixture = models.BooleanField(default=True)
+    sync_hierarchical_fixture = models.BooleanField(default=True)
+
+    def __repr__(self):
+        return u'{}: flat: {}, hierarchical: {}'.format(
+            self.domain, self.sync_flat_fixture, self.sync_heirarchical_fixture
+        )
+
+    @classmethod
+    def for_domain(cls, domain):
+        try:
+            return cls.objects.get(domain=domain)
+        except cls.DoesNotExist:
+            return cls(domain=domain)
+
+
 def _unassign_users_from_location(domain, location_id):
     """
     Unset location for all users assigned to that location.

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -119,7 +119,7 @@ class LocationType(models.Model):
         null=True,
         related_name='+',
         on_delete=models.SET_NULL,
-    )  # include all leves of this type and their ancestors
+    )  # include all levels of this type and their ancestors
     last_modified = models.DateTimeField(auto_now=True)
 
     emergency_level = StockLevelField(default=0.5)

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -957,7 +957,7 @@ class LocationFixtureConfiguration(models.Model):
 
     def __repr__(self):
         return u'{}: flat: {}, hierarchical: {}'.format(
-            self.domain, self.sync_flat_fixture, self.sync_heirarchical_fixture
+            self.domain, self.sync_flat_fixture, self.sync_hierarchical_fixture
         )
 
     @classmethod

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -377,7 +377,7 @@ class ShouldSyncLocationFixturesTest(TestCase):
         )
 
 
-class LocaitonFixtureSyncSettingsTest(TestCase):
+class LocationFixtureSyncSettingsTest(TestCase):
 
     def test_should_sync_flat_format_default(self):
         self.assertEqual(False, should_sync_flat_fixture('some-domain'))

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -25,7 +25,7 @@ from .util import (
     LocationTypeStructure,
 )
 from ..fixtures import _location_to_fixture, LocationSet, should_sync_locations, location_fixture_generator, \
-    flat_location_fixture_generator, should_sync_flat_fixture
+    flat_location_fixture_generator, should_sync_flat_fixture, should_sync_hierarchichal_fixture
 from ..models import SQLLocation, LocationType, Location
 
 
@@ -378,6 +378,18 @@ class ShouldSyncLocationFixturesTest(TestCase):
 
 
 class LocationFixtureSyncSettingsTest(TestCase):
+
+    def test_should_sync_hierarchical_format_default(self):
+        self.assertEqual(False, should_sync_hierarchichal_fixture(Domain()))
+
+    def test_should_sync_hierarchical_format_if_location_types_exist(self):
+        domain = 'sync-hierarchical-locations-test'
+        project = Domain(name='sync-hierarchical-locations-test')
+        project.save()
+        location_type = LocationType.objects.create(domain=domain, name='test-type')
+        self.assertEqual(False, should_sync_hierarchichal_fixture(Domain(name=domain)))
+        self.addCleanup(project.delete)
+        self.addCleanup(location_type.delete)
 
     def test_should_sync_flat_format_default(self):
         self.assertEqual(False, should_sync_flat_fixture('some-domain'))

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -25,7 +25,7 @@ from .util import (
     LocationTypeStructure,
 )
 from ..fixtures import _location_to_fixture, LocationSet, should_sync_locations, location_fixture_generator, \
-    flat_location_fixture_generator
+    flat_location_fixture_generator, should_sync_flat_fixture
 from ..models import SQLLocation, LocationType, Location
 
 
@@ -375,3 +375,13 @@ class ShouldSyncLocationFixturesTest(TestCase):
         self.assertFalse(
             should_sync_locations(SyncLog(date=after_archive), location_db, self.user.to_ota_restore_user())
         )
+
+
+class LocaitonFixtureSyncSettingsTest(TestCase):
+
+    def test_should_sync_flat_format_default(self):
+        self.assertEqual(False, should_sync_flat_fixture('some-domain'))
+
+    def test_should_sync_flat_format_enabled(self):
+        with flag_enabled('FLAT_LOCATION_FIXTURE'):
+            self.assertEqual(True, should_sync_flat_fixture('some-domain'))

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -26,7 +26,7 @@ from .util import (
     LocationTypeStructure,
 )
 from ..fixtures import _location_to_fixture, LocationSet, should_sync_locations, location_fixture_generator, \
-    flat_location_fixture_generator, should_sync_flat_fixture, should_sync_hierarchichal_fixture
+    flat_location_fixture_generator, should_sync_flat_fixture, should_sync_hierarchical_fixture
 from ..models import SQLLocation, LocationType, Location, LocationFixtureConfiguration
 
 
@@ -381,7 +381,7 @@ class ShouldSyncLocationFixturesTest(TestCase):
 class LocationFixtureSyncSettingsTest(TestCase):
 
     def test_should_sync_hierarchical_format_default(self):
-        self.assertEqual(False, should_sync_hierarchichal_fixture(Domain()))
+        self.assertEqual(False, should_sync_hierarchical_fixture(Domain()))
 
     @mock.patch('corehq.apps.accounting.utils.domain_has_privilege', lambda x, y: True)
     def test_should_sync_hierarchical_format_if_location_types_exist(self):
@@ -389,7 +389,7 @@ class LocationFixtureSyncSettingsTest(TestCase):
         project = Domain(name=domain)
         project.save()
         location_type = LocationType.objects.create(domain=domain, name='test-type')
-        self.assertEqual(True, should_sync_hierarchichal_fixture(project))
+        self.assertEqual(True, should_sync_hierarchical_fixture(project))
         self.addCleanup(project.delete)
         self.addCleanup(location_type.delete)
 
@@ -417,9 +417,9 @@ class LocationFixtureSyncSettingsTest(TestCase):
         location_settings = LocationFixtureConfiguration.objects.create(
             domain=domain, sync_hierarchical_fixture=False
         )
-        self.assertEqual(False, should_sync_hierarchichal_fixture(project))
+        self.assertEqual(False, should_sync_hierarchical_fixture(project))
         with flag_enabled('FLAT_LOCATION_FIXTURE'):
-            self.assertEqual(False, should_sync_hierarchichal_fixture(project))
+            self.assertEqual(False, should_sync_hierarchical_fixture(project))
         self.addCleanup(project.delete)
         self.addCleanup(location_type.delete)
         self.addCleanup(location_settings.delete)

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -1,3 +1,4 @@
+import uuid
 import mock
 import os
 from xml.etree import ElementTree
@@ -382,12 +383,13 @@ class LocationFixtureSyncSettingsTest(TestCase):
     def test_should_sync_hierarchical_format_default(self):
         self.assertEqual(False, should_sync_hierarchichal_fixture(Domain()))
 
+    @mock.patch('corehq.apps.accounting.utils.domain_has_privilege', lambda x, y: True)
     def test_should_sync_hierarchical_format_if_location_types_exist(self):
-        domain = 'sync-hierarchical-locations-test'
-        project = Domain(name='sync-hierarchical-locations-test')
+        domain = uuid.uuid4().hex
+        project = Domain(name=domain)
         project.save()
         location_type = LocationType.objects.create(domain=domain, name='test-type')
-        self.assertEqual(False, should_sync_hierarchichal_fixture(Domain(name=domain)))
+        self.assertEqual(True, should_sync_hierarchichal_fixture(project))
         self.addCleanup(project.delete)
         self.addCleanup(location_type.delete)
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1140,9 +1140,7 @@ class ProjectSettingsTab(UITab):
 
     @property
     def sidebar_items(self):
-        from corehq.apps.domain.views import (FeatureFlagsView,
-                                              FeaturePreviewsView,
-                                              TransferDomainView)
+        from corehq.apps.domain.views import FeatureFlagsView
 
         items = []
         user_is_admin = self.couch_user.is_domain_admin(self.domain)
@@ -1274,7 +1272,7 @@ class ProjectSettingsTab(UITab):
 
 
 def _get_administration_section(domain):
-    from corehq.apps.domain.views import (FeaturePreviewsView, TransferDomainView)
+    from corehq.apps.domain.views import FeaturePreviewsView, TransferDomainView
 
     administration = []
     if not settings.ENTERPRISE_MODE:

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1328,11 +1328,17 @@ def _get_administration_section(domain):
 
 
 def _get_feature_flag_items(domain):
+    from corehq.apps.domain.views import CalendarFixtureConfigView
     feature_flag_items = []
     if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
         feature_flag_items.append({
             'title': _('Case Search'),
             'url': reverse('case_search_config', args=[domain])
+        })
+    if toggles.CUSTOM_CALENDAR_FIXTURE.enabled(domain):
+        feature_flag_items.append({
+            'title': _('Calendar Fixture'),
+            'url': reverse(CalendarFixtureConfigView.urlname, args=[domain])
         })
     return feature_flag_items
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1180,63 +1180,7 @@ class ProjectSettingsTab(UITab):
         items.append((_('Project Information'), project_info))
 
         if user_is_admin:
-            administration = []
-            if not settings.ENTERPRISE_MODE:
-                administration.extend([
-                    {
-                        'title': _('CommCare Exchange'),
-                        'url': reverse('domain_snapshot_settings', args=[self.domain])
-                    },
-                    {
-                        'title': _('Multimedia Sharing'),
-                        'url': reverse('domain_manage_multimedia', args=[self.domain])
-                    }
-                ])
-
-            if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(self.domain):
-                administration.append({
-                    'title': _('Case Search'),
-                    'url': reverse('case_search_config', args=[self.domain])
-                })
-
-            def forward_name(repeater_type=None, **context):
-                if repeater_type == 'FormRepeater':
-                    return _("Forward Forms")
-                elif repeater_type == 'ShortFormRepeater':
-                    return _("Forward Form Stubs")
-                elif repeater_type == 'CaseRepeater':
-                    return _("Forward Cases")
-
-            administration.extend([
-                {'title': _('Data Forwarding'),
-                 'url': reverse('domain_forwarding', args=[self.domain]),
-                 'subpages': [
-                     {
-                         'title': forward_name,
-                         'urlname': 'add_repeater',
-                     },
-                     {
-                         'title': forward_name,
-                         'urlname': 'add_form_repeater',
-                     },
-                ]},
-                {
-                    'title': _('Data Forwarding Records'),
-                    'url': reverse('domain_report_dispatcher', args=[self.domain, 'repeat_record_report'])
-                }
-            ])
-
-            administration.append({
-                'title': _(FeaturePreviewsView.page_title),
-                'url': reverse(FeaturePreviewsView.urlname, args=[self.domain])
-            })
-
-            if toggles.TRANSFER_DOMAIN.enabled(self.domain):
-                administration.append({
-                    'title': _(TransferDomainView.page_title),
-                    'url': reverse(TransferDomainView.urlname, args=[self.domain])
-                })
-            items.append((_('Project Administration'), administration))
+            items.append((_('Project Administration'), _get_administration_section(self.domain)))
 
         from corehq.apps.users.models import WebUser
         if isinstance(self.couch_user, WebUser):
@@ -1323,6 +1267,68 @@ class ProjectSettingsTab(UITab):
             items.append((_('Internal Data (Dimagi Only)'), internal_admin))
 
         return items
+
+
+def _get_administration_section(domain):
+    from corehq.apps.domain.views import (FeatureFlagsView, FeaturePreviewsView, TransferDomainView)
+
+    administration = []
+    if not settings.ENTERPRISE_MODE:
+        administration.extend([
+            {
+                'title': _('CommCare Exchange'),
+                'url': reverse('domain_snapshot_settings', args=[domain])
+            },
+            {
+                'title': _('Multimedia Sharing'),
+                'url': reverse('domain_manage_multimedia', args=[domain])
+            }
+        ])
+
+    if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
+        administration.append({
+            'title': _('Case Search'),
+            'url': reverse('case_search_config', args=[domain])
+        })
+
+    def forward_name(repeater_type=None, **context):
+        if repeater_type == 'FormRepeater':
+            return _("Forward Forms")
+        elif repeater_type == 'ShortFormRepeater':
+            return _("Forward Form Stubs")
+        elif repeater_type == 'CaseRepeater':
+            return _("Forward Cases")
+
+    administration.extend([
+        {'title': _('Data Forwarding'),
+         'url': reverse('domain_forwarding', args=[domain]),
+         'subpages': [
+             {
+                 'title': forward_name,
+                 'urlname': 'add_repeater',
+             },
+             {
+                 'title': forward_name,
+                 'urlname': 'add_form_repeater',
+             },
+        ]},
+        {
+            'title': _('Data Forwarding Records'),
+            'url': reverse('domain_report_dispatcher', args=[domain, 'repeat_record_report'])
+        }
+    ])
+
+    administration.append({
+        'title': _(FeaturePreviewsView.page_title),
+        'url': reverse(FeaturePreviewsView.urlname, args=[domain])
+    })
+
+    if toggles.TRANSFER_DOMAIN.enabled(domain):
+        administration.append({
+            'title': _(TransferDomainView.page_title),
+            'url': reverse(TransferDomainView.urlname, args=[domain])
+        })
+    return administration
 
 
 class MySettingsTab(UITab):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1328,7 +1328,7 @@ def _get_administration_section(domain):
 
 
 def _get_feature_flag_items(domain):
-    from corehq.apps.domain.views import CalendarFixtureConfigView
+    from corehq.apps.domain.views import CalendarFixtureConfigView, LocationFixtureConfigView
     feature_flag_items = []
     if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
         feature_flag_items.append({
@@ -1339,6 +1339,11 @@ def _get_feature_flag_items(domain):
         feature_flag_items.append({
             'title': _('Calendar Fixture'),
             'url': reverse(CalendarFixtureConfigView.urlname, args=[domain])
+        })
+    if toggles.FLAT_LOCATION_FIXTURE.enabled(domain):
+        feature_flag_items.append({
+            'title': _('Location Fixture'),
+            'url': reverse(LocationFixtureConfigView.urlname, args=[domain])
         })
     return feature_flag_items
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1182,6 +1182,10 @@ class ProjectSettingsTab(UITab):
         if user_is_admin:
             items.append((_('Project Administration'), _get_administration_section(self.domain)))
 
+        feature_flag_items = _get_feature_flag_items(self.domain)
+        if feature_flag_items:
+            items.append((_('Pre-release Features'), feature_flag_items))
+
         from corehq.apps.users.models import WebUser
         if isinstance(self.couch_user, WebUser):
             if (user_is_billing_admin or self.couch_user.is_superuser) and not settings.ENTERPRISE_MODE:
@@ -1270,7 +1274,7 @@ class ProjectSettingsTab(UITab):
 
 
 def _get_administration_section(domain):
-    from corehq.apps.domain.views import (FeatureFlagsView, FeaturePreviewsView, TransferDomainView)
+    from corehq.apps.domain.views import (FeaturePreviewsView, TransferDomainView)
 
     administration = []
     if not settings.ENTERPRISE_MODE:
@@ -1284,12 +1288,6 @@ def _get_administration_section(domain):
                 'url': reverse('domain_manage_multimedia', args=[domain])
             }
         ])
-
-    if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
-        administration.append({
-            'title': _('Case Search'),
-            'url': reverse('case_search_config', args=[domain])
-        })
 
     def forward_name(repeater_type=None, **context):
         if repeater_type == 'FormRepeater':
@@ -1329,6 +1327,16 @@ def _get_administration_section(domain):
             'url': reverse(TransferDomainView.urlname, args=[domain])
         })
     return administration
+
+
+def _get_feature_flag_items(domain):
+    feature_flag_items = []
+    if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
+        feature_flag_items.append({
+            'title': _('Case Search'),
+            'url': reverse('case_search_config', args=[domain])
+        })
+    return feature_flag_items
 
 
 class MySettingsTab(UITab):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -908,8 +908,8 @@ ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
 
 CUSTOM_CALENDAR_FIXTURE = StaticToggle(
     'custom_calendar_fixture',
-    'Send a calendar fixture down to all users (UATBC/eNikshay one off)',
-    TAG_ONE_OFF,
+    'Send a calendar fixture down to all users (R&D)',
+    TAG_EXPERIMENTAL,
     [NAMESPACE_DOMAIN],
 )
 

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -166,17 +166,3 @@ def analytics_task(default_retry_delay=10, max_retries=3, queue='background_queu
                     self.retry(exc=e)
         return _inner
     return decorator
-
-
-class temporarily_enable_toggle(ContextDecorator):
-
-    def __init__(self, toggle, item, namespace=NAMESPACE_DOMAIN):
-        self.toggle_slug = toggle.slug
-        self.item = item
-        self.namespace = namespace
-
-    def __enter__(self):
-        update_toggle_cache(self.toggle_slug, self.item, True, namespace=self.namespace)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        clear_toggle_cache(self.toggle_slug, self.item, self.namespace)

--- a/settings.py
+++ b/settings.py
@@ -542,11 +542,12 @@ FIXTURE_GENERATORS = {
         "corehq.apps.products.fixtures.product_fixture_generator",
         "corehq.apps.programs.fixtures.program_fixture_generator",
         "corehq.apps.app_manager.fixtures.report_fixture_generator",
+        "corehq.apps.calendar_fixture.fixture_provider.calendar_fixture_generator",
         # custom
         "custom.bihar.reports.indicators.fixtures.generator",
         "custom.m4change.fixtures.report_fixtures.generator",
         "custom.m4change.fixtures.location_fixtures.generator",
-        "custom.enikshay.fixtures.calendar_fixture_generator",
+
     ],
     # fixtures that must be sent along with the phones cases
     'case': [

--- a/settings.py
+++ b/settings.py
@@ -290,6 +290,7 @@ HQ_APPS = (
     'corehq.apps.app_manager',
     'corehq.apps.es',
     'corehq.apps.fixtures',
+    'corehq.apps.calendar_fixture',
     'corehq.apps.case_importer_v1',
     'corehq.apps.reminders',
     'corehq.apps.translations',


### PR DESCRIPTION
https://trello.com/c/jnLH7if6/74-don-t-sync-the-old-location-fixture

allows configuration of syncing the flat versus hierarchical location fixtures in the ui.

this contains everything in https://github.com/dimagi/commcare-hq/pull/14023 (since i wanted to use the settings UI changes). easiest read commit-wise starting from https://github.com/dimagi/commcare-hq/commit/ff2b0803b6e3012d182c8b9e4a9874efbb76612d

@proteusvacuum / @orangejenny 