### PR TITLE
use last sync version in app status report if later than last submission 

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -158,19 +158,8 @@ class ApplicationStatusReport(DeploymentsReport):
                     xform_dict.get('version'),
                     xform_dict['form']['meta'],
                 )
-                build_html = _build_html(app_version_info)
-                commcare_version = (
-                    'CommCare {}'.format(app_version_info.commcare_version)
-                    if app_version_info.commcare_version
-                    else _("Unknown CommCare Version")
-                )
-                commcare_version_html = mark_safe('<span class="label label-info">{}</span>'.format(
-                    commcare_version)
-                )
-                app_name = app_name or _("Unknown App")
-                app_name = format_html(
-                    u'{} {} {}', app_name, mark_safe(build_html), commcare_version_html
-                )
+                app_name = _construct_app_name_html_from_name_and_version_info(app_name, app_version_info)
+
 
             if app_name is None and self.selected_app_id:
                 continue
@@ -199,6 +188,22 @@ class ApplicationStatusReport(DeploymentsReport):
             # Last sync
             row[2] = _fmt_timestamp(row[2])
         return result
+
+
+def _construct_app_name_html_from_name_and_version_info(app_name, app_version_info):
+    build_html = _build_html(app_version_info)
+    commcare_version = (
+        'CommCare {}'.format(app_version_info.commcare_version)
+        if app_version_info.commcare_version
+        else _("Unknown CommCare Version")
+    )
+    commcare_version_html = mark_safe('<span class="label label-info">{}</span>'.format(
+        commcare_version)
+    )
+    app_name = app_name or _("Unknown App")
+    return format_html(
+        u'{} {} {}', app_name, mark_safe(build_html), commcare_version_html
+    )
 
 
 class SyncHistoryReport(DeploymentsReport):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -277,8 +277,10 @@ LOG_FORMAT_SIMPLIFIED = 'simplified'
 
 class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
     date = DateTimeProperty()
-    # domain = StringProperty()
+    domain = StringProperty()  # this is only added as of 11/2016 - not guaranteed to be set
     user_id = StringProperty()
+    build_id = StringProperty()  # this is only added as of 11/2016 and only works with app-aware sync
+
     previous_log_id = StringProperty()  # previous sync log, forming a chain
     duration = IntegerProperty()  # in seconds
     log_format = StringProperty()

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -354,6 +354,10 @@ class RestoreParams(object):
         self.include_item_count = include_item_count
         self.app = app
 
+    @property
+    def app_id(self):
+        return self.app._id if self.app else None
+
 
 class RestoreCacheSettings(object):
     """
@@ -505,6 +509,8 @@ class RestoreState(object):
         previous_log_rev = None if self.is_initial else self.last_sync_log._rev
         last_seq = str(get_db().info()["update_seq"])
         new_synclog = SyncLog(
+            domain=self.restore_user.domain,
+            build_id=self.params.app_id,
             user_id=self.restore_user.user_id,
             last_seq=last_seq,
             owner_ids_on_phone=list(self.owner_ids),

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -98,9 +98,8 @@ class BaseOtaRestoreTest(TestCase, TestFileMixin):
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
 class OtaRestoreTest(BaseOtaRestoreTest):
-    """Tests OTA Restore"""
 
-    def testUserRestore(self):
+    def test_user_restore(self):
         self.assertEqual(0, SyncLog.view(
             "phone/sync_logs_by_user",
             include_docs=True,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -1,3 +1,4 @@
+import uuid
 from django.test import TestCase, SimpleTestCase
 from casexml.apps.case.xml import V1, V2
 from casexml.apps.phone.models import SyncLog, CaseState
@@ -117,7 +118,7 @@ class SyncLogModelTest(TestCase):
     def setUpClass(cls):
         cls.project = Domain(name=cls.domain)
         cls.project.save()
-        cls.restore_user = create_restore_user(cls.domain)
+        cls.restore_user = create_restore_user(cls.domain, username=uuid.uuid4().hex)
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -2,6 +2,10 @@ from django.test import TestCase, SimpleTestCase
 from casexml.apps.case.xml import V1, V2
 from casexml.apps.phone.models import SyncLog, CaseState
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
+from casexml.apps.phone.restore import RestoreParams, RestoreConfig
+from casexml.apps.phone.tests.utils import create_restore_user, generate_restore_payload
+from corehq.apps.app_manager.models import Application
+from corehq.apps.domain.models import Domain
 from corehq.form_processor.tests.utils import run_with_all_backends
 
 
@@ -104,3 +108,41 @@ class CachingReponseTest(TestCase):
         self.assertFalse(log.has_cached_payload(V2))
         self.assertEqual(None, log.get_cached_payload(V1))
         self.assertEqual(None, log.get_cached_payload(V2))
+
+
+class SyncLogModelTest(TestCase):
+    domain = 'sync-log-model-test'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = Domain(name=cls.domain)
+        cls.project.save()
+        cls.restore_user = create_restore_user(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+
+    def test_basic_properties(self):
+        # kick off a restore to generate the sync log
+        generate_restore_payload(self.project, self.restore_user, items=True)
+        sync_log = SyncLog.last_for_user(self.restore_user.user_id)
+        self.assertEqual(self.restore_user.user_id, sync_log.user_id)
+        self.assertEqual(self.restore_user.domain, sync_log.domain)
+
+    def test_build_id(self):
+        app = Application(domain=self.domain)
+        app.save()
+        config = RestoreConfig(
+            project=self.project,
+            restore_user=self.restore_user,
+            params=RestoreParams(
+                app=app,
+            ),
+        )
+        config.get_payload()  # this generates the sync log
+        sync_log = SyncLog.last_for_user(self.restore_user.user_id)
+        self.assertEqual(self.restore_user.user_id, sync_log.user_id)
+        self.assertEqual(self.restore_user.domain, sync_log.domain)
+        self.assertEqual(app._id, sync_log.build_id)
+        self.addCleanup(app.delete)


### PR DESCRIPTION
we encountered annoying behavior on the TB project where it looked like people hadn't updated their apps even though they did because they hadn't submitted any forms.

this uses the version from the app-aware sync if it is available and later than the last available version from submissions.

also adds `domain` and `build_id` properties to sync logs, the former because it has been bugging me for ages that it's not there, and the latter because it was needed for this feature.

@orangejenny fyi @proteusvacuum 

(easiest read commit-wise)
