### PR TITLE
Evaluate selection and recent queries for CC debugger

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -495,6 +495,9 @@ Formplayer.ViewModels.EvaluateXPath = function() {
     self.onClickSelectedXPath = function() {
         self.evaluate(self.selectedXPath());
     };
+    self.onClickSavedQuery = function(query) {
+        self.xpath(query.xpath);
+    };
     self.evaluate = function(xpath) {
         var callback = function(result, status) {
             self.result(result);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -517,14 +517,14 @@ Formplayer.ViewModels.EvaluateXPath = function() {
     /**
      * Set autocomplete for xpath input.
      *
-     * @param {Array} questionData - List of questions to be autocompleted for the xpath input
+     * @param {Array} autocompleteData - List of questions to be autocompleted for the xpath input
      */
-    self.autocomplete = function(questionData) {
+    self.autocomplete = function(autocompleteData) {
         self.$xpath = $('#xpath');
         self.$xpath.atwho('setIframe', window.frameElement, true);
         self.$xpath.atwho({
             at: '',
-            data: questionData,
+            data: autocompleteData,
             searchKey: 'value',
             maxLen: Infinity,
             displayTpl: function(d) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -483,15 +483,27 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
 Formplayer.ViewModels.EvaluateXPath = function() {
     var self = this;
     self.xpath = ko.observable('');
+    self.selectedXPath = ko.observable('');
     self.$xpath = null;
     self.result = ko.observable('');
     self.success = ko.observable(true);
-    self.evaluate = function(form) {
+    self.onSubmitXPath = function() {
+        self.evaluate(self.xpath());
+    };
+    self.onClickSelectedXPath = function() {
+        self.evaluate(self.selectedXPath());
+    };
+    self.evaluate = function(xpath) {
         var callback = function(result, status) {
             self.result(result);
             self.success(status === "accepted");
         };
-        $.publish('formplayer.' + Formplayer.Const.EVALUATE_XPATH, [self.xpath(), callback]);
+        $.publish('formplayer.' + Formplayer.Const.EVALUATE_XPATH, [xpath, callback]);
+    };
+
+    self.onMouseUp = function() {
+        var text = window.getSelection().toString();
+        self.selectedXPath(text);
     };
 
     self.matcher = function(flag, subtext) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -493,7 +493,9 @@ Formplayer.ViewModels.EvaluateXPath = function() {
         self.evaluate(self.xpath());
     };
     self.onClickSelectedXPath = function() {
-        self.evaluate(self.selectedXPath());
+        if (self.selectedXPath()) {
+            self.evaluate(self.selectedXPath());
+        }
     };
     self.onClickSavedQuery = function(query) {
         self.xpath(query.xpath);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -437,6 +437,7 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
             self.formattedQuestionsHtml(resp.formattedQuestions);
             self.instanceXml(resp.instanceXml);
             self.evalXPath.autocomplete(resp.questionList);
+            self.evalXPath.recentXPathQueries(resp.recentXPathQueries || []);
         });
     });
 
@@ -484,6 +485,7 @@ Formplayer.ViewModels.EvaluateXPath = function() {
     var self = this;
     self.xpath = ko.observable('');
     self.selectedXPath = ko.observable('');
+    self.recentXPathQueries = ko.observableArray();
     self.$xpath = null;
     self.result = ko.observable('');
     self.success = ko.observable(true);
@@ -500,6 +502,10 @@ Formplayer.ViewModels.EvaluateXPath = function() {
         };
         $.publish('formplayer.' + Formplayer.Const.EVALUATE_XPATH, [xpath, callback]);
     };
+
+    self.isSuccess = function(query) {
+        return query.status === 'accepted';
+    }
 
     self.onMouseUp = function() {
         var text = window.getSelection().toString();

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -508,7 +508,7 @@ Formplayer.ViewModels.EvaluateXPath = function() {
 
     self.isSuccess = function(query) {
         return query.status === 'accepted';
-    }
+    };
 
     self.onMouseUp = function() {
         var text = window.getSelection().toString();
@@ -530,6 +530,7 @@ Formplayer.ViewModels.EvaluateXPath = function() {
      */
     self.autocomplete = function(autocompleteData) {
         self.$xpath = $('#xpath');
+        self.$xpath.atwho('destroy');
         self.$xpath.atwho('setIframe', window.frameElement, true);
         self.$xpath.atwho({
             at: '',

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -187,7 +187,7 @@
 
 <script type="text/html" id="debugger-eval-ko-template">
     <div class="col-sm-12">
-      <form class="form-horizontal" data-bind="submit: evaluate">
+      <form class="form-horizontal" data-bind="submit: onSubmitXPath">
           <div class="form-group">
               <textarea
                   id="xpath"
@@ -195,10 +195,15 @@
                   name="xpath"
                   placeholder="XPath Expression"
                   autocomplete="off"
-                  data-bind="value: xpath" ></textarea>
+                  data-bind="value: xpath, event: { mouseup: onMouseUp }" ></textarea>
           </div>
           <div class="form-group">
-                <input class="btn btn-default" id="evaluate-button" value="Evaluate" type="submit"/>
+                <input class="btn btn-success" id="evaluate-button" value="Evaluate" type="submit"/>
+                <input
+                    class="btn btn-default"
+                    value="Evaluate Selection"
+                    type="button"
+                    data-bind="css: { disabled: !selectedXPath() }, click: onClickSelectedXPath"/>
           </div>
           <div class="col-sm-12">
               <p

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -215,6 +215,24 @@
                       css: { 'text-danger': !success() }
               "></p>
           </div>
+          <div class="col-sm-12" data-bind="foreach: recentXPathQueries">
+            <div class="row">
+              <div class="col-sm-1">
+                <span><i class="fa" data-bind="
+                    css: {
+                      'fa-check': $parent.isSuccess($data),
+                      'fa-times': !$parent.isSuccess($data)
+                    }
+                    "></i></span>
+              </div>
+              <div class="col-sm-8">
+                <span data-bind="text: xpath"></span>
+              </div>
+              <div class="col-sm-3">
+                <span data-bind="text: output"></span>
+              </div>
+            </div>
+          </div>
       </form>
     </div>
 </script>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -186,8 +186,8 @@
 </script>
 
 <script type="text/html" id="debugger-eval-ko-template">
-    <div class="col-sm-12">
       <form class="form-horizontal" data-bind="submit: onSubmitXPath">
+          <div class="col-sm-12">
           <div class="form-group">
               <textarea
                   id="xpath"
@@ -197,6 +197,8 @@
                   autocomplete="off"
                   data-bind="value: xpath, event: { mouseup: onMouseUp }" ></textarea>
           </div>
+          </div>
+          <div class="col-sm-12">
           <div class="form-group">
                 <input class="btn btn-success" id="evaluate-button" value="Evaluate" type="submit"/>
                 <input
@@ -205,36 +207,44 @@
                     type="button"
                     data-bind="css: { disabled: !selectedXPath() }, click: onClickSelectedXPath"/>
           </div>
+          </div>
           <div class="col-sm-12">
-              <p
+              <div
                   id="evaluate-result"
                   type="text"
-                  style="display: block;"
                   data-bind="
                       text: result,
                       css: { 'text-danger': !success() }
-              "></p>
-          </div>
-          <div class="col-sm-12" data-bind="foreach: recentXPathQueries">
-            <div class="row">
-              <div class="col-sm-1">
-                <span><i class="fa" data-bind="
-                    css: {
-                      'fa-check': $parent.isSuccess($data),
-                      'fa-times': !$parent.isSuccess($data)
-                    }
-                    "></i></span>
-              </div>
-              <div class="col-sm-8">
-                <span data-bind="text: xpath"></span>
-              </div>
-              <div class="col-sm-3">
-                <span data-bind="text: output"></span>
-              </div>
-            </div>
+              "></div>
           </div>
       </form>
-    </div>
+      <div class="row">
+        <div class="col-sm-12">
+          <h3>{% trans "Recent Queries" %}</h3>
+        </div>
+      </div>
+      <table class="table table-striped table-hover">
+        <tbody data-bind="foreach: recentXPathQueries">
+          <tr class="query-container" data-bind="click: $parent.onClickSavedQuery">
+            <td class="col-sm-1 query-status">
+              <span><i class="fa" data-bind="
+                  css: {
+                    'fa-check': $parent.isSuccess($data),
+                    'fa-times': !$parent.isSuccess($data),
+                    'text-success': $parent.isSuccess($data),
+                    'text-danger': !$parent.isSuccess($data)
+                  }
+                  "></i></span>
+            </td>
+            <td class="col-sm-8 debugger-code">
+              <span data-bind="text: xpath"></span>
+            </td>
+            <td class="col-sm-3">
+              <span data-bind="text: output"></span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 </script>
 
 <script type="text/html" id="question-fullform-ko-template">

--- a/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
+++ b/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
@@ -64,3 +64,11 @@
   -webkit-transition: background-color 0.5s;
   transition: background-color 0.5s;
 }
+
+.debugger .query-container:hover {
+  cursor: pointer;
+}
+
+#evaluate-result {
+  min-height: 20px;
+}


### PR DESCRIPTION
@wpride a little :turkey: PID. this adds saved queries and allows you to just evaluate a selection of your xpath query.

![selections](https://cloud.githubusercontent.com/assets/918514/20657778/a04c504c-b506-11e6-816c-862405ba7ccd.gif)

label cause i just want to make sure this doesn't completely trash the old CC debugger. needs this: https://github.com/dimagi/formplayer/pull/195

cc: @mkangia 