### PR TITLE
Fixed fixture view

### DIFF
--- a/corehq/apps/fixtures/_design/views/data_items_by_field_value/map.js
+++ b/corehq/apps/fixtures/_design/views/data_items_by_field_value/map.js
@@ -4,7 +4,8 @@ function (doc) {
             if (doc.fields.hasOwnProperty(key)) {
                 if (doc.fields[key] && doc.fields[key].doc_type === 'FieldList'){
                     for (var field_for_attribute in doc.fields[key].field_list){
-                        emit([doc.domain, doc.data_type_id, key, field_for_attribute.field_value]);
+                        var field = doc.fields[key].field_list[field_for_attribute];
+                        emit([doc.domain, doc.data_type_id, key, field.field_value]);
                     }
                 }
                 else {

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -164,3 +164,9 @@ class FixtureDataTest(TestCase):
                 self.domain, self.tag, 'state_name')
             delhi_id = fixtures['Delhi_state']['district_id']
             self.assertEqual(delhi_id, 'Delhi_id')
+
+    def test_get_item_by_field_value(self):
+        self.assertEqual(
+            FixtureDataItem.by_field_value(self.domain, self.data_type, 'state_name', 'Delhi_state').one().get_id,
+            self.data_item.get_id
+        )


### PR DESCRIPTION
@czue 

I believe that this bug causes problems here: http://manage.dimagi.com/default.asp?237347

If you look at the original code there is iteration over an array using ```in``` operator which causes field_attribute to be an index of the array and in the result of that ``` field_for_attribute.field_value``` always returns null. It seems to me like an obvious bug.

I guess that reindexing the whole view is an expensive operation. I made this PR to raise the problem. (Probably using ```in``` to iterate over array is bad idea at all)

cc @sravfeyn Git history says you are the author of this code.