### PR TITLE
Gracefully handle deleted locations

### DIFF
--- a/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html
@@ -36,6 +36,12 @@ $("#{{ id }}").select2({
             $.get("{{ query_url }}", payload).done(function(data) {
                 callback(data);
                 $(element).trigger('select-ready');
+            }).fail(function (jqXHR) {
+                if (jqXHR.status === 404) {
+                    // Location has been deleted.
+                    callback({});  // There is nothing to see here.
+                    $(element).trigger('select-ready');
+                }
             });
         }
     },

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -886,7 +886,7 @@ class CommtrackUserForm(forms.Form):
         cleaned_data = super(CommtrackUserForm, self).clean()
 
         primary_location_id = cleaned_data['primary_location']
-        assigned_location_ids = cleaned_data['assigned_locations']
+        assigned_location_ids = cleaned_data.get('assigned_locations', [])
         if primary_location_id:
             if primary_location_id not in assigned_location_ids:
                 self.add_error('primary_location',


### PR DESCRIPTION
Context: [FB 242342](http://manage.dimagi.com/default.asp?242342)

When locations are deleted from the UI, HQ cleans up mobile workers that are assigned to them, but not when deleting locations using a bulk upload.

This PR is to allow mobile workers that refer to deleted locations to be edited and saved without throwing a 500.

@sravfeyn cc @nickpell 
