### PR TITLE
Locations in webuser restore

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -155,7 +155,7 @@ def get_all_locations_to_sync(user):
     else:
         all_locations = set()
 
-        user_locations = set(user.sql_locations)
+        user_locations = set(user.get_sql_locations(user.domain))
         # old flagged multi-locations, ToDo remove in next phase
         user_locations |= {location for location in _gather_multiple_locations(user)}
         for user_location in user_locations:

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -84,7 +84,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
         self.assertXmlEqual(empty_fixture, fixture)
 
     def test_simple_location_fixture(self, uses_locations):
-        self.user.set_location(self.locations['Suffolk'].couch_location)
+        self.user._couch_user.set_location(self.locations['Suffolk'].couch_location)
 
         self._assert_fixture_has_locations(
             'simple_fixture',
@@ -92,8 +92,8 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
         )
 
     def test_multiple_locations(self, uses_locations):
-        self.user.add_to_assigned_locations(self.locations['Suffolk'].couch_location)
-        self.user.add_to_assigned_locations(self.locations['New York City'].couch_location)
+        self.user._couch_user.add_to_assigned_locations(self.locations['Suffolk'].couch_location)
+        self.user._couch_user.add_to_assigned_locations(self.locations['New York City'].couch_location)
 
         self._assert_fixture_has_locations(
             'multiple_locations',
@@ -137,7 +137,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
             Mass
             - Suffolk
         """
-        self.user.set_location(self.locations['Suffolk'].couch_location)
+        self.user._couch_user.set_location(self.locations['Suffolk'].couch_location)
         location_type = self.locations['Suffolk'].location_type
         location_type.expand_to = location_type
         location_type.save()
@@ -148,7 +148,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
         )
 
     def test_expand_to_county_from_state(self, uses_locations):
-        self.user.set_location(self.locations['Massachusetts'].couch_location)
+        self.user._couch_user.set_location(self.locations['Massachusetts'].couch_location)
         location_type = self.locations['Massachusetts'].location_type
         location_type.expand_to = self.locations['Suffolk'].location_type
         location_type.save()
@@ -159,7 +159,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
         )
 
     def test_expand_from_county_at_city(self, uses_locations):
-        self.user.set_location(self.locations['Boston'].couch_location)
+        self.user._couch_user.set_location(self.locations['Boston'].couch_location)
         location_type = self.locations['Boston'].location_type
         location_type.expand_from = self.locations['Suffolk'].location_type
         location_type.save()
@@ -170,7 +170,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
         )
 
     def test_expand_from_root_at_city(self, uses_locations):
-        self.user.set_location(self.locations['Boston'].couch_location)
+        self.user._couch_user.set_location(self.locations['Boston'].couch_location)
         location_type = self.locations['Boston'].location_type
         location_type.expand_from_root = True
         location_type.save()
@@ -182,7 +182,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
         )
 
     def test_expand_from_root_to_county(self, uses_locations):
-        self.user.set_location(self.locations['Massachusetts'].couch_location)
+        self.user._couch_user.set_location(self.locations['Massachusetts'].couch_location)
         location_type = self.locations['Massachusetts'].location_type
         location_type.expand_from_root = True
         location_type.expand_to = self.locations['Suffolk'].location_type
@@ -203,7 +203,7 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
                 )
 
     def test_include_without_expanding(self, uses_locations):
-        self.user.set_location(self.locations['Boston'].couch_location)
+        self.user._couch_user.set_location(self.locations['Boston'].couch_location)
         location_type = self.locations['Boston'].location_type
         location_type.expand_from = self.locations['Suffolk'].location_type
         location_type.include_without_expanding = self.locations['Massachusetts'].location_type
@@ -261,7 +261,7 @@ class ForkedHierarchyLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLo
         self.locations = setup_locations_with_structure(self.domain, self.location_structure)
 
     def test_forked_locations(self, *args):
-        self.user.set_location(self.locations['Massachusetts'].couch_location)
+        self.user._couch_user.set_location(self.locations['Massachusetts'].couch_location)
         location_type = self.locations['Massachusetts'].location_type
         location_type.expand_to = self.locations['Middlesex'].location_type
         location_type.save()

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -259,7 +259,10 @@ class WebUserLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsM
 
     def test_multiple_locations(self, uses_locations):
         self.user._couch_user.add_to_assigned_locations(self.domain, self.locations['Suffolk'].couch_location)
-        self.user._couch_user.add_to_assigned_locations(self.domain, self.locations['New York City'].couch_location)
+        self.user._couch_user.add_to_assigned_locations(
+            self.domain,
+            self.locations['New York City'].couch_location
+        )
 
         self._assert_fixture_has_locations(
             'multiple_locations',

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1556,7 +1556,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         from corehq.apps.groups.models import Group
         # get faked location group objects
         groups = []
-        for sql_location in self.sql_locations:
+        for sql_location in self._sql_locations:
             groups.extend(sql_location.get_case_sharing_groups(self._id))
 
         groups += [group for group in Group.by_user(self) if group.case_sharing]
@@ -1636,7 +1636,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return None
 
     @property
-    def sql_locations(self):
+    def _sql_locations(self):
         from corehq.apps.locations.models import SQLLocation
         if self.assigned_location_ids:
             return SQLLocation.objects.filter(location_id__in=self.assigned_location_ids)
@@ -1647,7 +1647,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return self.assigned_location_ids
 
     def get_sql_locations(self, domain):
-        return self.sql_locations
+        return self._sql_locations
 
     def add_to_assigned_locations(self, location):
         if self.location_id:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1556,7 +1556,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         from corehq.apps.groups.models import Group
         # get faked location group objects
         groups = []
-        for sql_location in self._sql_locations:
+        for sql_location in self.get_sql_locations(self.domain):
             groups.extend(sql_location.get_case_sharing_groups(self._id))
 
         groups += [group for group in Group.by_user(self) if group.case_sharing]
@@ -1635,19 +1635,15 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 pass
         return None
 
-    @property
-    def _sql_locations(self):
+    def get_location_ids(self, domain):
+        return self.assigned_location_ids
+
+    def get_sql_locations(self, domain):
         from corehq.apps.locations.models import SQLLocation
         if self.assigned_location_ids:
             return SQLLocation.objects.filter(location_id__in=self.assigned_location_ids)
         else:
             return SQLLocation.objects.none()
-
-    def get_location_ids(self, domain):
-        return self.assigned_location_ids
-
-    def get_sql_locations(self, domain):
-        return self._sql_locations
 
     def add_to_assigned_locations(self, location):
         if self.location_id:

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -82,6 +82,9 @@ class OTARestoreUser(object):
         "User's primary SQLLocation"
         return self._couch_user.get_sql_location(self.domain)
 
+    def get_sql_locations(self, domain):
+        return self._couch_user.get_sql_locations(domain)
+
     def get_fixture_data_items(self):
         raise NotImplementedError()
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -82,11 +82,6 @@ class OTARestoreUser(object):
         "User's primary SQLLocation"
         raise NotImplementedError()
 
-    @property
-    def sql_locations(self):
-        "SQLLocation objects of all locations the user is assigned to"
-        raise NotImplementedError()
-
     def get_fixture_data_items(self):
         raise NotImplementedError()
 
@@ -129,10 +124,6 @@ class OTARestoreWebUser(OTARestoreUser):
     @property
     def sql_location(self):
         return None
-
-    @property
-    def sql_locations(self):
-        return []
 
     @property
     def locations(self):
@@ -178,10 +169,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
     @property
     def sql_location(self):
         return self._couch_user.sql_location
-
-    @property
-    def sql_locations(self):
-        return self._couch_user.sql_locations
 
     @property
     def locations(self):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -106,11 +106,10 @@ class OTARestoreUser(object):
     def get_ucr_filter_value(self, ucr_filter, ui_filter):
         return ucr_filter.get_filter_value(self._couch_user, ui_filter)
 
+    @memoized
     def get_locations_to_sync(self):
-        """
-        Returns a LocationSet object contianing all locations that should sync
-        """
-        raise NotImplementedError()
+        from corehq.apps.locations.fixtures import get_all_locations_to_sync
+        return get_all_locations_to_sync(self)
 
 
 class OTARestoreWebUser(OTARestoreUser):
@@ -147,11 +146,6 @@ class OTARestoreWebUser(OTARestoreUser):
         from corehq.apps.fixtures.models import UserFixtureStatus
 
         return UserFixtureStatus.DEFAULT_LAST_MODIFIED
-
-    def get_locations_to_sync(self):
-        # todo: not yet implemented for web users
-        from corehq.apps.locations.fixtures import LocationSet
-        return LocationSet()
 
 
 class OTARestoreCommCareUser(OTARestoreUser):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -160,12 +160,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
     def locations(self):
         return self._couch_user.locations
 
-    def add_to_assigned_locations(self, location):
-        return self._couch_user.add_to_assigned_locations(location)
-
-    def set_location(self, location):
-        return self._couch_user.set_location(location)
-
     def get_fixture_data_items(self):
         from corehq.apps.fixtures.models import FixtureDataItem
 
@@ -202,11 +196,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
         from corehq.apps.fixtures.models import UserFixtureType
 
         return self._couch_user.fixture_status(UserFixtureType.LOCATION)
-
-    @memoized
-    def get_locations_to_sync(self):
-        from corehq.apps.locations.fixtures import get_all_locations_to_sync
-        return get_all_locations_to_sync(self)
 
 
 class CaseState(LooselyEqualDocumentSchema, IndexHoldingMixIn):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -80,7 +80,7 @@ class OTARestoreUser(object):
     @property
     def sql_location(self):
         "User's primary SQLLocation"
-        raise NotImplementedError()
+        return self._couch_user.get_sql_location(self.domain)
 
     def get_fixture_data_items(self):
         raise NotImplementedError()
@@ -122,10 +122,6 @@ class OTARestoreWebUser(OTARestoreUser):
         super(OTARestoreWebUser, self).__init__(domain, couch_user, **kwargs)
 
     @property
-    def sql_location(self):
-        return None
-
-    @property
     def locations(self):
         return []
 
@@ -165,10 +161,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
 
         assert isinstance(couch_user, CommCareUser)
         super(OTARestoreCommCareUser, self).__init__(domain, couch_user, **kwargs)
-
-    @property
-    def sql_location(self):
-        return self._couch_user.sql_location
 
     @property
     def locations(self):


### PR DESCRIPTION
@proteusvacuum @esoergel this implements locations for web user restore. it also makes `sql_locations` private. i was going to do the same for `sql_location`, but that looked way way more painful to pinpoint all the usages. want to test on a phone before merging just in case, but works fine on app preview which should be the same thing. also i removed the public api calls to `set_location` and `add_to_assigned_locations`. they were only used in tests, i don't think we should make it feel supported. the restore user is essentially a read only thing that shouldn't be modifying any of the underlying data. here's what my web user's payload looks like:
```xml
<fixture id="commtrack:locations" user_id="8d7a5c6e0e1af478aca5a39bebe5317c">
   <countrys>
      <country id="f655a5755f32e3b3032c5b48960dc220">
         <name>USA</name>
         <site_code>usa</site_code>
         <external_id />
         <latitude />
         <longitude />
         <location_type>Country</location_type>
         <supply_point_id>dce2a8c54d934352bf0b5be0927f7875</supply_point_id>
         <location_data />
         <states>
            <state id="f655a5755f32e3b3032c5b48960dbf7d">
               <name>MA</name>
               <site_code>ma</site_code>
               <external_id />
               <latitude />
               <longitude />
               <location_type>State</location_type>
               <supply_point_id>6911d49a271648fda38034a54588e534</supply_point_id>
               <location_data />
            </state>
         </states>
      </country>
   </countrys>
</fixture>
```

cc: @mkangia 