### PR TITLE
Catch ValueError

### DIFF
--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -58,16 +58,21 @@ def safe_recursive_lookup(item, path):
         return None
     try:
         return recursive_lookup(item, path)
-    except (KeyError, TypeError):
+    except (KeyError, TypeError, ValueError):
         # key errors are missing keys
         # type errors are valid keys that return the wrong type
+        # value errors are empty keys
         return None
 
 
 def recursive_lookup(dict_object, keys):
     """
     Given a dict object and list of keys, nest into those keys.
-    Raises KeyError if the path isn't found.
+
+    :raises KeyError if the path isn't found.
+    :raises TypeError if dict_object is not a dict
+    :raises ValueError if keys is empty
+
     >>> recursive_lookup({'foo': 1}, ['foo'])
     1
     >>> recursive_lookup({'foo': {'bar': 1}}, ['foo'])


### PR DESCRIPTION
A simpler response to [FB 242106](http://manage.dimagi.com/default.asp?242106); just catch the ValueError if the path is empty in a custom form export.

Supersedes PR #14040. 

@benrudolph @sravfeyn @nickpell 
