### PR TITLE
Fix bottom level aggregation

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -547,23 +547,23 @@ class NestedTermAggregationsHelper(object):
         terms=[
             AggregationTerm('entry_id', 'entry_id'),
         ],
-        bottom_level_aggregation=SumAggregation('balance', 'balance'),
+        inner_most_aggregation=SumAggregation('balance', 'balance'),
     ).get_data()
     """
 
-    def __init__(self, base_query, terms, bottom_level_aggregation=None):
+    def __init__(self, base_query, terms, inner_most_aggregation=None):
         self.base_query = base_query
         self.terms = terms
-        self.bottom_level_aggregation = bottom_level_aggregation
+        self.inner_most_aggregation = inner_most_aggregation
 
     @property
     def query(self):
         previous_term = None
 
-        if self.bottom_level_aggregation is not None:
-            if not isinstance(self.bottom_level_aggregation, SumAggregation):
+        if self.inner_most_aggregation is not None:
+            if not isinstance(self.inner_most_aggregation, SumAggregation):
                 raise ValueError('currently only SumAggregations and its children are supported')
-            term = self.bottom_level_aggregation
+            term = self.inner_most_aggregation
             previous_term = term
 
         for name, field in reversed(self.terms):
@@ -582,18 +582,18 @@ class NestedTermAggregationsHelper(object):
                     _add_terms(bucket, remaining_terms[0], remaining_terms[1:], current_counts, current_key=key)
                 else:
                     # base case
-                    if self.bottom_level_aggregation is None:
+                    if self.inner_most_aggregation is None:
                         current_counts[key] += bucket.doc_count
                     else:
-                        current_counts[key] += getattr(bucket, self.bottom_level_aggregation.name).value
+                        current_counts[key] += getattr(bucket, self.inner_most_aggregation.name).value
 
         counts = defaultdict(lambda: 0)
         _add_terms(self.query.size(0).run().aggregations, self.terms[0], self.terms[1:], current_counts=counts)
         return self._format_counts(counts)
 
     def _format_counts(self, counts):
-        final_aggregation_name = ('doc_count' if self.bottom_level_aggregation is None
-                                  else self.bottom_level_aggregation.name)
+        final_aggregation_name = ('doc_count' if self.inner_most_aggregation is None
+                                  else self.inner_most_aggregation.name)
         row_class = namedtuple('NestedQueryRow', [term.name for term in self.terms] + [final_aggregation_name])
         for combined_key, count in counts.items():
             yield row_class(*(combined_key + (count,)))

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -13,7 +13,11 @@ from corehq.apps.es.aggregations import (
     ExtendedStatsAggregation,
     TopHitsAggregation,
     MissingAggregation,
-    NestedAggregation)
+    NestedAggregation,
+    SumAggregation,
+    NestedTermAggregationsHelper,
+    AggregationTerm,
+)
 from corehq.apps.es.es_query import HQESQuery, ESQuerySet
 from corehq.apps.es.tests.utils import ElasticTestMixin
 from corehq.elastic import SIZE_LIMIT
@@ -398,4 +402,50 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                 'actions',
             )
         )
+        self.checkQuery(query, json_output)
+
+    def test_nested_terms_helper(self):
+        json_output = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {"match_all": {}}
+                        ]
+                    },
+                    "query": {"match_all": {}}
+                }
+            },
+            "aggs": {
+                "app_id": {
+                    "terms": {
+                        "field": "app_id",
+                        "size": SIZE_LIMIT,
+                    },
+                    "aggs": {
+                        "user_id": {
+                            "terms": {
+                                "field": "user_id",
+                                "size": SIZE_LIMIT,
+                            },
+                            "aggs": {
+                                "balance": {
+                                    "sum": {"field": "balance"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "size": SIZE_LIMIT
+        }
+        base_query = HQESQuery('cases')
+        query = NestedTermAggregationsHelper(
+            base_query=base_query,
+            terms=[
+                AggregationTerm('app_id', 'app_id'),
+                AggregationTerm('user_id', 'user_id')
+            ],
+            bottom_level_aggregation=SumAggregation('balance', 'balance')
+        ).query
         self.checkQuery(query, json_output)

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -446,6 +446,6 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                 AggregationTerm('app_id', 'app_id'),
                 AggregationTerm('user_id', 'user_id')
             ],
-            bottom_level_aggregation=SumAggregation('balance', 'balance')
+            inner_most_aggregation=SumAggregation('balance', 'balance')
         ).query
         self.checkQuery(query, json_output)

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -886,7 +886,7 @@ class AdminDomainMapReport(AdminDomainStatsReport):
         active_users_per_country = (NestedTermAggregationsHelper(
                                     base_query=DomainES().real_domains().is_active_project().filter(filters),
                                     terms=[AggregationTerm('countries', 'deployment.countries')],
-                                    bottom_level_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
+                                    inner_most_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
                                     ).get_data())
         return active_users_per_country
 

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -536,7 +536,7 @@ def get_aggregated_ledger_values(domain, case_ids, section_id, entry_ids=None):
     return NestedTermAggregationsHelper(
         base_query=query,
         terms=terms,
-        bottom_level_aggregation=SumAggregation('balance', 'balance'),
+        inner_most_aggregation=SumAggregation('balance', 'balance'),
     ).get_data()
 
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -12,6 +12,7 @@ from corehq.form_processor.models import CommCareCaseSQL, CaseTransaction
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
 from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
+from corehq.pillows.mappings.ledger_mapping import LEDGER_INDEX_INFO
 from corehq.pillows.mappings.user_mapping import USER_INDEX, USER_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from dimagi.utils.dates import DateSpan
@@ -50,6 +51,7 @@ from corehq.apps.reports.analytics.esaccessors import (
     get_username_in_last_form_user_id_submitted,
     get_form_ids_having_multimedia,
     scroll_case_names,
+    get_aggregated_ledger_values,
 )
 from corehq.apps.es.aggregations import MISSING_KEY
 from corehq.util.test_utils import make_es_ready_form, trap_extra_setup
@@ -1153,6 +1155,60 @@ class TestCaseESAccessors(BaseESAccessorsTest):
 
         results = get_case_counts_opened_by_user(self.domain, datespan, case_types=['not-here'])
         self.assertEqual(results, {})
+
+
+class TestLedgerESAccessors(BaseESAccessorsTest):
+    es_index_info = LEDGER_INDEX_INFO
+    domain = uuid.uuid4().hex
+
+    def _send_ledger_to_es(self, section_id, case_id, entry_id, balance):
+        ledger = {
+            "_id": uuid.uuid4().hex,
+            "domain": self.domain,
+            "section_id": section_id,
+            "case_id": case_id,
+            "entry_id": entry_id,
+            "balance": balance,
+        }
+        send_to_elasticsearch('ledgers', ledger)
+        self.es.indices.refresh(self.es_index_info.index)
+        return ledger
+
+    def _check_result(self, expected, entry_ids=None):
+        result = []
+        for row in get_aggregated_ledger_values(self.domain, 'case', 'section', entry_ids):
+            result.append(row._asdict())
+        self.assertEqual(result, expected)
+
+    def test_one_ledger(self):
+        self._send_ledger_to_es('section', 'case', 'entry_id', 1)
+        self._check_result([
+            {'entry_id': 'entry_id', 'balance': 1}
+        ])
+
+    def test_two_ledger(self):
+        self._send_ledger_to_es('section', 'case', 'entry_id', 1)
+        self._send_ledger_to_es('section', 'case', 'entry_id', 3)
+        self._check_result([
+            {'entry_id': 'entry_id', 'balance': 4}
+        ])
+
+    def test_multiple_entries(self):
+        self._send_ledger_to_es('section', 'case', 'entry_id', 1)
+        self._send_ledger_to_es('section', 'case', 'entry_id', 3)
+        self._send_ledger_to_es('section', 'case', 'entry_id2', 3)
+        self._check_result([
+            {'entry_id': 'entry_id2', 'balance': 3},
+            {'entry_id': 'entry_id', 'balance': 4},
+        ])
+
+    def test_filter_entries(self):
+        self._send_ledger_to_es('section', 'case', 'entry_id', 1)
+        self._send_ledger_to_es('section', 'case', 'entry_id', 3)
+        self._send_ledger_to_es('section', 'case', 'entry_id2', 3)
+        self._check_result([
+            {'entry_id': 'entry_id', 'balance': 4},
+        ], entry_ids=['entry_id'])
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)


### PR DESCRIPTION
@czue I think this was your original intention, but correct me if I'm wrong https://github.com/dimagi/commcare-hq/pull/12076 and https://github.com/dimagi/commcare-hq/pull/12102

Right now it's creating something like

```
agg1: {
   nested_agg2: {
      nested_agg3: {}
   },
   bottom_agg: {}
}
```

but I think you want `bottom_agg` inside of `nested_agg3` right? 

This hasn't come up before because it's only used in two places and each only has one aggregation term

buddy @benrudolph 