### PR TITLE
Return error, not 500, on AdminRestoreView error

### DIFF
--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -25,7 +25,7 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'foo': 'bar',
                 'view': 'AdminRestoreView',
                 'payload': '<error>Unexpected restore response 500: bad response. If you believe this is a bug '
-                           'please report an issue.</error>',
+                           'please report an issue.</error>\n',
                 'restore_id': None,
                 'status_code': 500,
                 'timing_data': [],

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -24,7 +24,8 @@ class AdminRestoreViewTests(SimpleTestCase):
             self.assertEqual(context, {
                 'foo': 'bar',
                 'view': 'AdminRestoreView',
-                'payload': '<error>bad response</error>',
+                'payload': '<error>Unexpected restore response 500: bad response. If you believe this is a bug '
+                           'please report an issue.</error>',
                 'restore_id': None,
                 'status_code': 500,
                 'timing_data': [],

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -1,0 +1,32 @@
+from django.http import HttpResponse
+from django.test import SimpleTestCase
+from mock import patch, Mock
+from corehq.apps.hqadmin.views import AdminRestoreView
+
+
+class AdminRestoreViewTests(SimpleTestCase):
+
+    def test_get_context_data(self):
+        user = Mock()
+        user.domain = None
+        app_id = None
+        request = Mock()
+        request.GET = {}
+        request.openrosa_headers = {}
+        timing_context = Mock()
+        timing_context.to_list.return_value = []
+        with patch('corehq.apps.ota.views.has_privilege', return_value=False), \
+                patch('corehq.apps.hqadmin.views.get_restore_response',
+                      return_value=(HttpResponse('bad response', status=500), timing_context)):
+
+            view = AdminRestoreView(user=user, app_id=app_id, request=request)
+            context = view.get_context_data(foo='bar', view='AdminRestoreView')
+            self.assertEqual(context, {
+                'foo': 'bar',
+                'view': 'AdminRestoreView',
+                'payload': '<error>bad response</error>',
+                'restore_id': None,
+                'status_code': 500,
+                'timing_data': [],
+                'num_cases': 0,
+            })

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -499,8 +499,14 @@ class AdminRestoreView(TemplateView):
             num_cases = len(xml_payload.findall('{http://commcarehq.org/case/transaction/v2}case'))
             formatted_payload = etree.tostring(xml_payload, pretty_print=True)
         else:
-            # response is HttpResponse 500
-            error = E.error(response.content)
+            # get_restore_response return HttpResponse 401 (permissions), 404 (user not found) or 412
+            if response.status_code in (401, 404):
+                message = response.content
+            else:
+                message = _('Unexpected restore response {}: {}. '
+                            'If you believe this is a bug please report an issue.').format(response.status_code,
+                                                                                           response.content)
+            error = E.error(message)
             formatted_payload = etree.tostring(error)
             restore_id_element = None
             num_cases = 0


### PR DESCRIPTION
Context: [FB 242755](http://manage.dimagi.com/default.asp?242755)

AdminRestoreView.get_context_data wasn't handling 500 responses.

@snopoke cc @sravfeyn @wspride buddy @biyeun
