### PR TITLE
Test user as and begin conforming to a standard

### DIFF
--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -24,7 +24,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
 
     @classmethod
     def setUpClass(cls):
-        delete_all_users()
         super(RestorePermissionsTest, cls).setUpClass()
 
         cls.other_project = Domain(name=cls.other_domain)
@@ -323,7 +322,6 @@ class GetRestoreUserTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        delete_all_users()
         super(GetRestoreUserTest, cls).setUpClass()
         cls.project = Domain(name=cls.domain)
         cls.project.save()

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -24,6 +24,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
 
     @classmethod
     def setUpClass(cls):
+        delete_all_users()
         super(RestorePermissionsTest, cls).setUpClass()
 
         cls.other_project = Domain(name=cls.other_domain)
@@ -179,6 +180,25 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
 
+    def test_commcare_user_as_self(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.commcare_user,
+            self.commcare_user.username,
+            True,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.commcare_user,
+            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
+            True,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
     def test_super_user_as_user_other_domain(self):
         """
         Superusers should be able to restore as other mobile users even if it's the wrong domain
@@ -303,6 +323,7 @@ class GetRestoreUserTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        delete_all_users()
         super(GetRestoreUserTest, cls).setUpClass()
         cls.project = Domain(name=cls.domain)
         cls.project.save()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1557,7 +1557,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         # get faked location group objects
         groups = []
         for sql_location in self.sql_locations:
-            groups.extend(self.sql_location.get_case_sharing_groups(self._id))
+            groups.extend(sql_location.get_case_sharing_groups(self._id))
 
         groups += [group for group in Group.by_user(self) if group.case_sharing]
         return groups


### PR DESCRIPTION
@czue and fyi @wpride this tests all the different types of restore protocols we support `username@domain` and `username@domain.commcarehq.org`. i want to phase out `username@domain` cause it's complicating code that could be way simpler

PRs for touchforms and formplayer here:
https://github.com/dimagi/formplayer/pull/204
https://github.com/dimagi/touchforms/pull/279 - was able to submit and restore with this change, will let me know if you forsee an issue with this

cc: @emord 