### PR TITLE
Actually bulk delete locations.

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -526,7 +526,7 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
         Delete a location and its dependants.
         This also unassigns users assigned to the location.
         """
-        to_delete = self.get_descendants(include_self=True).couch_locations()
+        to_delete = list(self.get_descendants(include_self=True).couch_locations())
         # if there are errors deleting couch locations, roll back sql delete
         with transaction.atomic():
             self.sql_full_delete()


### PR DESCRIPTION
@noahcarnahan @czue
Looks like this hasn't been deleting this locations properly.  I looked at the couchdbkit code for bulk deletion, and it passes through the list passed to it multiple times. Because `couch_locations` uses the output of `iter_docs`, it is a generator, and after the first pass, the generator is exhausted, so the deletion is never committed.