### PR TITLE
Only add instances a single time

### DIFF
--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -272,6 +272,12 @@ class Instance(IdNode, OrderedXmlObject):
 
     src = StringField('@src')
 
+    def __eq__(self, other):
+        return self.src == other.src and self.id == other.id
+
+    def __hash__(self):
+        return hash((self.src, self.id))
+
 
 class SessionDatum(IdNode, OrderedXmlObject):
     ROOT_NAME = 'datum'

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -822,6 +822,22 @@ class InstanceTests(SimpleTestCase, TestXmlMixin, SuiteMixin):
         with self.assertRaises(DuplicateInstanceIdError):
             self.factory.app.create_suite()
 
+    def test_duplicate_regular_instances(self):
+        """Make sure instances aren't getting added multiple times if they are referenced multiple times
+        """
+        self.factory.form_requires_case(self.form)
+        self.form.form_filter = "instance('casedb') instance('casedb') instance('locations') instance('locations')"
+        self.assertXmlPartialEqual(
+            u"""
+            <partial>
+                <instance id='casedb' src='jr://instance/casedb' />
+                <instance id='locations' src='jr://fixture/commtrack:locations' />
+            </partial>
+            """,
+            self.factory.app.create_suite(),
+            "entry/instance"
+        )
+
     def test_location_instances(self):
         self.form.form_filter = "instance('locations')/locations/"
         with flag_enabled('FLAT_LOCATION_FIXTURE'):


### PR DESCRIPTION
@mkangia 
This didn't happen before since we explictly checked that the id's hadn't been added yet. The "regular" instances weren't getting added multiple times because the same object was being returned in the `INSTANCE_BY_ID` dict. When I moved the more complicated instances to the factories, it creates a new `Instance` object every time. 


FYI @ctsims 