### PR TITLE
Allow restore as self for web user

### DIFF
--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -198,6 +198,16 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
 
+    def test_web_user_as_self(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.web_user,
+            self.web_user.username,
+            True,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
     def test_super_user_as_user_other_domain(self):
         """
         Superusers should be able to restore as other mobile users even if it's the wrong domain

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -106,12 +106,11 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privil
     """
     try:
         _ensure_valid_domain(domain, couch_user)
-        if as_user is not None:
-            if not _restoring_as_yourself(couch_user, as_user):
-                _ensure_cleanup_permission(domain, couch_user, as_user, has_data_cleanup_privilege)
-                _ensure_valid_restore_as_user(domain, couch_user, as_user)
-                _ensure_accessible_location(domain, couch_user, as_user)
-                _ensure_edit_data_permission(domain, couch_user)
+        if as_user is not None and not _restoring_as_yourself(couch_user, as_user):
+            _ensure_cleanup_permission(domain, couch_user, as_user, has_data_cleanup_privilege)
+            _ensure_valid_restore_as_user(domain, couch_user, as_user)
+            _ensure_accessible_location(domain, couch_user, as_user)
+            _ensure_edit_data_permission(domain, couch_user)
     except RestorePermissionDenied as e:
         return False, unicode(e)
     else:

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -120,11 +120,14 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privil
 
 def _restoring_as_yourself(couch_user, as_user):
     username, domain = _parse_restore_as_user(as_user)
-    return (
-        isinstance(couch_user, CommCareUser)
-        and couch_user.raw_username == username
-        and couch_user.domain == domain
-    )
+    if isinstance(couch_user, CommCareUser):
+        return (
+            couch_user.raw_username == username
+            and couch_user.domain == domain
+        )
+    else:
+        # Must be dealing with web user
+        return couch_user.username == as_user
 
 
 def _ensure_valid_domain(domain, couch_user):


### PR DESCRIPTION
Need to be able to restore as yourself for web users when they preview a form and aren't on new cloudcare

cc: @emord 