### PR TITLE
don't guess billing account

### DIFF
--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -150,14 +150,14 @@ def doc_value_wrapper(doc_cls, value_cls):
 
 def can_add_extra_mobile_workers(request):
     from corehq.apps.users.models import CommCareUser
-    from corehq.apps.accounting.models import BillingAccount
+    from corehq.apps.accounting.models import Subscription
     num_web_users = CommCareUser.total_by_domain(request.domain)
     user_limit = request.plan.user_limit
     if user_limit == -1 or num_web_users < user_limit:
         return True
     if not has_privilege(request, privileges.ALLOW_EXCESS_USERS):
-        account = BillingAccount.get_account_by_domain(request.domain)
-        if account is None or account.date_confirmed_extra_charges is None:
+        current_subscription = Subscription.get_subscribed_plan_by_domain(request.domain)[1]
+        if current_subscription is None or current_subscription.account.date_confirmed_extra_charges is None:
             return False
     return True
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe, mark_for_escaping
 from django.utils.translation import ugettext_noop, ugettext as _, ugettext_lazy
 from corehq import privileges, toggles
 from corehq.apps.accounting.dispatcher import AccountingAdminInterfaceDispatcher
-from corehq.apps.accounting.models import BillingAccount, Invoice
+from corehq.apps.accounting.models import Invoice, Subscription
 from corehq.apps.accounting.utils import domain_has_privilege, is_accounting_admin
 from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_brief_apps_in_domain
 from corehq.apps.domain.utils import user_has_custom_top_menu
@@ -1192,7 +1192,7 @@ class ProjectSettingsTab(UITab):
                     DomainBillingStatementsView, ConfirmSubscriptionRenewalView,
                     InternalSubscriptionManagementView,
                 )
-                billing_account = BillingAccount.get_account_by_domain(self.domain)
+                current_subscription = Subscription.get_subscribed_plan_by_domain(self.domain)[1]
                 subscription = [
                     {
                         'title': DomainSubscriptionView.page_title,
@@ -1209,15 +1209,15 @@ class ProjectSettingsTab(UITab):
                         ]
                     },
                 ]
-                if billing_account is not None:
+                if current_subscription is not None:
                     subscription.append(
                         {
-                            'title':  EditExistingBillingAccountView.page_title,
+                            'title': EditExistingBillingAccountView.page_title,
                             'url': reverse(EditExistingBillingAccountView.urlname,
                                            args=[self.domain]),
                         },
                     )
-                if (billing_account is not None
+                if (current_subscription is not None
                         and Invoice.exists_for_domain(self.domain)):
                     subscription.append(
                         {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?241339

```BillingAccount.get_account_by_domain``` is flawed because it tries to guess the billing account rather than just using the account with the current subscription.  This PR is a step towards getting rid of this function accept under special circumstances (like tests or first time subscription creation for a domain).