### PR TITLE
case activity report

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -216,9 +216,17 @@ class TermsAggregation(Aggregation):
         if sort_field:
             self.order(sort_field, order)
 
-    def order(self, field, order="desc"):
+    def order(self, field, order="desc", reset=True):
         query = deepcopy(self)
-        query.body['order'] = {field: order}
+        order_field = {field: order}
+
+        if reset:
+            query.body['order'] = [order_field]
+        else:
+            if not query.body.get('order'):
+                query.body['order'] = []
+            query.body['order'].append(order_field)
+
         return query
 
     def size(self, size):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -372,8 +372,11 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         def _fill_out_buckets(buckets, rows):
             returned_user_ids = {b.key for b in buckets}
             not_returned_user_ids = set(self.paginated_user_ids) - returned_user_ids
+            extra_rows = []
             for user_id in not_returned_user_ids:
-                rows.append(self.Row(self, self.users_by_id[user_id], {}))
+                extra_rows.append(self.Row(self, self.users_by_id[user_id], {}))
+            extra_rows.sort(key=lambda row: row.user.raw_username)
+            rows.extend(extra_rows)
             return rows
 
         es_results = self.es_queryset(

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -375,7 +375,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         )
         buckets = es_results.aggregations.users.buckets_list
         if self.missing_users:
-            buckets[None] = es_results.aggregations.missing_users.bucket
+            buckets.append(es_results.aggregations.missing_users.bucket)
         rows = []
         for bucket in buckets:
             user = self.users_by_id[bucket.key]

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -397,7 +397,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
             rows.sort(key=lambda row: row.user.raw_username)
 
         self.total_row = self._total_row
-        if len(rows) == self.pagination.count:
+        if len(rows) <= self.pagination.count:
             return map(self._format_row, rows)
         else:
             start = self.pagination.start

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -383,7 +383,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
 
         if self.should_sort_by_username:
             # ES handles sorting for all other columns
-            rows.sort(key=lambda row: row.user)
+            rows.sort(key=lambda row: row.user.raw_username)
 
         self.total_row = self._total_row
         if len(rows) == self.pagination.count:

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -473,6 +473,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         if self.sort_column:
             order = "desc" if self.pagination.desc else "asc"
             top_level_aggregation = top_level_aggregation.order(self.sort_column, order)
+            top_level_aggregation = top_level_aggregation.order("_term", order, reset=False)
 
         query = (
             case_es.CaseES()

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -468,7 +468,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         top_level_aggregation = self.add_landmark_aggregations(top_level_aggregation, self.end_date)
 
         if size:
-            top_level_aggregation.size(size)
+            top_level_aggregation = top_level_aggregation.size(size)
 
         if self.sort_column:
             order = "desc" if self.pagination.desc else "asc"


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?241962

@benrudolph Not a great solution here. It uses ES in a way it's not really intended to be used in a couple of ways:

1) sorting by a field that isn't in the doc (username)
2) aggregations aren't really meant to return empty results, but in this report that is what is expected. It's possible to change that https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-aggregations-bucket-terms-aggregation.html#_minimum_document_count but that also means that filters don't apply to those empty buckets, so it would return users that aren't in the domain

:fish: 