### PR TITLE
Use deterministic order for UCR expanded columns

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -272,8 +272,8 @@ class ESQuery(object):
         query._aggregations.extend(aggregations)
         return query
 
-    def terms_aggregation(self, term, name, size=None):
-        return self.aggregation(aggregations.TermsAggregation(name, term, size=size))
+    def terms_aggregation(self, term, name, size=None, sort_field=None, order="desc"):
+        return self.aggregation(aggregations.TermsAggregation(name, term, size=size, sort_field=sort_field, order=order))
 
     def date_histogram(self, name, datefield, interval, timezone=None):
         return self.aggregation(aggregations.DateHistogram(name, datefield, interval, timezone=timezone))

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -104,7 +104,7 @@ class ESAlchemy(object):
     def distinct_values(self, column, size):
         # missing aggregation can be removed on upgrade to ES 2.0
         missing_agg_name = column + '_missing'
-        query = self.es.terms_aggregation(column, column, size=size).size(0)
+        query = self.es.terms_aggregation(column, column, size=size, sort_field="_term").size(0)
         query = query.aggregation(MissingAggregation(missing_agg_name, column))
         results = query.run()
         missing_result = getattr(results.aggregations, missing_agg_name).result

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -66,7 +66,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
             )
         column = table.c[column]
 
-        query = self.session_helper.Session.query(column).limit(limit + 1).distinct()
+        query = self.session_helper.Session.query(column).order_by(column).limit(limit + 1).distinct()
         result = query.all()
         distinct_values = [x[0] for x in result]
         if len(distinct_values) > limit:

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -221,7 +221,7 @@ class TestExpandedColumn(TestCase):
             'blueberry'
         ])
         vals = get_distinct_values(data_source.config, column)[0]
-        self.assertSetEqual(set(vals), set(['apple', 'banana', 'blueberry']))
+        self.assertListEqual(vals, ['apple', 'banana', 'blueberry'])
 
     @run_with_all_ucr_backends
     def test_no_distinct_values(self):


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?243225

UCR "expanded" columns create one report column for each distinct value in a data source column. The ordering of those was previously non-deterministic. This ensures that the columns will be in alphabetical order.

cc @czue @emord @esoergel 