### PR TITLE
have case importer check for blank row before blank external id

### DIFF
--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -112,14 +112,15 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
                 prime_offset += 1
 
         search_id = importer_util.parse_search_id(config, columns, row)
-        if config.search_field == 'external_id' and not search_id:
-            # do not allow blank external id since we save this
-            errors.add(ImportErrors.BlankExternalId, i + 1)
-            continue
 
         fields_to_update = importer_util.populate_updated_fields(config, columns, row)
         if not any(fields_to_update.values()):
             # if the row was blank, just skip it, no errors
+            continue
+
+        if config.search_field == 'external_id' and not search_id:
+            # do not allow blank external id since we save this
+            errors.add(ImportErrors.BlankExternalId, i + 1)
             continue
 
         external_id = fields_to_update.pop('external_id', None)


### PR DESCRIPTION
otherwise it will show a warning on blank rows when keying by external id

minor thing I stumbled upon that inappropriately shows this error on a blank row (if you delete the last row in a spreadsheet, that row shows up with blank cells instead of not showing up at all, so this could actually be quite annoying):
<img width="588" alt="screen shot 2016-12-06 at 8 03 14 pm" src="https://cloud.githubusercontent.com/assets/137212/20950674/16910c04-bbef-11e6-9028-bfefd1746c97.png">
