### PR TITLE
Decrease async restore timeout

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/const.py
+++ b/corehq/ex-submodules/casexml/apps/phone/const.py
@@ -11,7 +11,7 @@ INITIAL_SYNC_CACHE_THRESHOLD = 60  # 1 minute
 INITIAL_ASYNC_TIMEOUT_THRESHOLD = 10
 # The Retry-After header parameter. Ask the phone to retry in this many seconds
 # to see if the task is done.
-ASYNC_RETRY_AFTER = 30
+ASYNC_RETRY_AFTER = 15
 
 ASYNC_RESTORE_CACHE_KEY_PREFIX = "async-restore-task"
 RESTORE_CACHE_KEY_PREFIX = "ota-restore"


### PR DESCRIPTION
Decrease async restore retry-after parameter to potentially reduce sync times for people who have this turned on.
FYI @amstone326 
@mkangia 