### PR TITLE
Remove Android / Cloudcare from Address format in Case Details

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -1371,7 +1371,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
             LATE_FLAG_EXTRA_LABEL: ' Days late ',
             FILTER_XPATH_EXTRA_LABEL: '',
             INVISIBLE_FORMAT: 'Search Only',
-            ADDRESS_FORMAT: 'Address (Android/CloudCare)',
+            ADDRESS_FORMAT: 'Address',
             PICTURE_FORMAT: 'Picture',
             AUDIO_FORMAT: 'Audio',
             CALC_XPATH_FORMAT: 'Calculate',


### PR DESCRIPTION
I think this distinction doesn't matter any more.

http://manage.dimagi.com/default.asp?243558

@mkangia 