### PR TITLE
Case import history

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -52,6 +52,7 @@ from corehq.apps.app_manager.suite_xml.utils import get_select_chain
 from corehq.apps.app_manager.suite_xml.generator import SuiteGenerator, MediaSuiteGenerator
 from corehq.apps.app_manager.xpath_validator import validate_xpath
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
+from corehq.apps.users.dbaccessors.couch_users import get_display_name_for_user_id
 from corehq.util.timezones.utils import get_timezone_for_domain
 from dimagi.ext.couchdbkit import *
 from django.conf import settings
@@ -4993,12 +4994,8 @@ class SavedAppBuild(ApplicationBase):
         })
         comment_from = data['comment_from']
         if comment_from:
-            try:
-                comment_user = CouchUser.get(comment_from)
-            except ResourceNotFound:
-                data['comment_user_name'] = comment_from
-            else:
-                data['comment_user_name'] = comment_user.full_name
+            data['comment_user_name'] = get_display_name_for_user_id(
+                self.domain, comment_from, default=comment_from)
 
         return data
 

--- a/corehq/apps/case_importer/migrations/0001_initial.py
+++ b/corehq/apps/case_importer/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CaseUploadRecord',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('domain', models.CharField(max_length=256)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('upload_id', models.UUIDField()),
+                ('task_id', models.UUIDField()),
+            ],
+        ),
+    ]

--- a/corehq/apps/case_importer/migrations/0002_auto_20161206_1937.py
+++ b/corehq/apps/case_importer/migrations/0002_auto_20161206_1937.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_importer', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='caseuploadrecord',
+            name='task_id',
+            field=models.UUIDField(unique=True),
+        ),
+        migrations.AlterField(
+            model_name='caseuploadrecord',
+            name='upload_id',
+            field=models.UUIDField(unique=True),
+        ),
+    ]

--- a/corehq/apps/case_importer/migrations/0003_caseuploadrecord_couch_user_id.py
+++ b/corehq/apps/case_importer/migrations/0003_caseuploadrecord_couch_user_id.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_importer', '0002_auto_20161206_1937'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='caseuploadrecord',
+            name='couch_user_id',
+            field=models.CharField(default='unknown', max_length=256),
+            preserve_default=False,
+        ),
+    ]

--- a/corehq/apps/case_importer/migrations/0004_caseuploadrecord_case_type.py
+++ b/corehq/apps/case_importer/migrations/0004_caseuploadrecord_case_type.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_importer', '0003_caseuploadrecord_couch_user_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='caseuploadrecord',
+            name='case_type',
+            field=models.CharField(default='case', max_length=256),
+            preserve_default=False,
+        ),
+    ]

--- a/corehq/apps/case_importer/models.py
+++ b/corehq/apps/case_importer/models.py
@@ -1,7 +1,1 @@
-# This file is only here so that django will recognize that 
-# this is a valid app and run the associated unit tests.
-
-from dimagi.ext.couchdbkit import Document
-
-
-class _(Document): pass
+from .tracking.models import CaseUploadRecord

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -102,13 +102,14 @@
         <!--ko if: state() == states.SUCCESS && case_uploads()-->
         <table class="table table-striped">
             <tr>
-                <th class="col-md-4">{% trans "Status" %}</th>
-                <th class="col-md-4">{% trans "Uploaded by" %}</th>
-                <th class="col-md-4">{% trans "Time" %}</th>
+                <th class="col-md-3">{% trans "Status" %}</th>
+                <th class="col-md-3">{% trans "Case Type" %}</th>
+                <th class="col-md-3">{% trans "Uploaded by" %}</th>
+                <th class="col-md-3">{% trans "Time" %}</th>
             </tr>
             <!--ko foreach: case_uploads-->
             <tr>
-                <td class="col-md-4">
+                <td class="col-md-3">
                     <!--ko if: task_status.state == $root.states.SUCCESS-->
                     <span class="label label-success">{% trans "Success" %}</span>
                     <!--/ko-->
@@ -129,10 +130,13 @@
                     </div>
                     <!--/ko-->
                 </td>
-                <td class="col-md-4">
+                <td class="col-md-3">
+                    <!--ko text: case_type--><!--/ko-->
+                </td>
+                <td class="col-md-3">
                     <!--ko text: user--><!--/ko-->
                 </td>
-                <td class="col-md-4" data-bind="text: created"></td>
+                <td class="col-md-3" data-bind="text: created"></td>
             </tr>
             <!--/ko-->
         </table>

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -105,7 +105,7 @@
                 <th class="col-md-2">{% trans "Status" %}</th>
                 <th class="col-md-1">{% trans "Case Type" %}</th>
                 <th class="col-md-1">{% trans "Uploaded by" %}</th>
-                <th class="col-md-6">{% trans "Success Message" %}</th>
+                <th class="col-md-6">{% trans "Details" %}</th>
                 <th class="col-md-2">{% trans "Time" %}</th>
             </tr>
             <!--ko foreach: case_uploads-->

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -102,16 +102,22 @@
         <!--ko if: state() == states.SUCCESS && case_uploads()-->
         <table class="table table-striped">
             <tr>
-                <th class="col-md-3">{% trans "Status" %}</th>
-                <th class="col-md-3">{% trans "Case Type" %}</th>
-                <th class="col-md-3">{% trans "Uploaded by" %}</th>
-                <th class="col-md-3">{% trans "Time" %}</th>
+                <th class="col-md-2">{% trans "Status" %}</th>
+                <th class="col-md-1">{% trans "Case Type" %}</th>
+                <th class="col-md-1">{% trans "Uploaded by" %}</th>
+                <th class="col-md-6">{% trans "Success Message" %}</th>
+                <th class="col-md-2">{% trans "Time" %}</th>
             </tr>
             <!--ko foreach: case_uploads-->
             <tr>
-                <td class="col-md-3">
+                <td class="col-md-2">
                     <!--ko if: task_status.state == $root.states.SUCCESS-->
-                    <span class="label label-success">{% trans "Success" %}</span>
+                        <!--ko if: _.isEmpty(task_status.result.errors)-->
+                        <span class="label label-success">{% trans "Success" %}</span>
+                        <!--/ko-->
+                        <!--ko if: !_.isEmpty(task_status.result.errors)-->
+                        <span class="label label-warning">{% trans "Success with warnings" %}</span>
+                        <!--/ko-->
                     <!--/ko-->
                     <!--ko if: task_status.state == $root.states.FAILED-->
                     <span class="label label-danger">{% trans "Failed" %}</span>
@@ -130,13 +136,16 @@
                     </div>
                     <!--/ko-->
                 </td>
-                <td class="col-md-3">
+                <td class="col-md-1">
                     <!--ko text: case_type--><!--/ko-->
                 </td>
-                <td class="col-md-3">
+                <td class="col-md-1">
                     <!--ko text: user--><!--/ko-->
                 </td>
-                <td class="col-md-3" data-bind="text: created"></td>
+                <td class="col-md-6" data-bind="with: task_status">
+                    {% include 'case_importer/partials/ko_import_status.html' %}
+                </td>
+                <td class="col-md-2" data-bind="text: created"></td>
             </tr>
             <!--/ko-->
         </table>

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -99,7 +99,7 @@
 
     <h2>Recent Uploads</h2>
     <div id="recent-uploads" class="ko-template">
-        <!--ko if: state() == states.SUCCESS && case_uploads()-->
+        <!--ko if: state() == states.SUCCESS && !_.isEmpty(case_uploads())-->
         <table class="table table-striped">
             <tr>
                 <th class="col-md-2">{% trans "Status" %}</th>
@@ -150,7 +150,7 @@
             <!--/ko-->
         </table>
         <!--/ko-->
-        <!--ko if: state() === states.SUCCESS && !case_uploads()-->
+        <!--ko if: state() === states.SUCCESS && _.isEmpty(case_uploads())-->
         <div class="alert alert-info">
             You have no recent uploads.
         </div>

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -100,15 +100,15 @@
     <h2>Recent Uploads</h2>
     <div id="recent-uploads" class="ko-template">
         <!--ko if: state() == states.SUCCESS && case_uploads()-->
-        <table class="table">
+        <table class="table table-striped">
             <tr>
-                <th>{% trans "Time" %}</th>
-                <th>{% trans "Status" %}</th>
+                <th class="col-md-4">{% trans "Status" %}</th>
+                <th class="col-md-4">{% trans "Uploaded by" %}</th>
+                <th class="col-md-4">{% trans "Time" %}</th>
             </tr>
             <!--ko foreach: case_uploads-->
             <tr>
-                <td data-bind="text: created"></td>
-                <td>
+                <td class="col-md-4">
                     <!--ko if: task_status.state == $root.states.SUCCESS-->
                     <span class="label label-success">{% trans "Success" %}</span>
                     <!--/ko-->
@@ -129,6 +129,10 @@
                     </div>
                     <!--/ko-->
                 </td>
+                <td class="col-md-4">
+                    <!--ko text: user--><!--/ko-->
+                </td>
+                <td class="col-md-4" data-bind="text: created"></td>
             </tr>
             <!--/ko-->
         </table>

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -2,6 +2,53 @@
 {% load report_tags %}
 {% load i18n %}
 
+{% block js-inline %}
+<script id="caseUploadsResource" type="text/plain">{% url 'case_importer_uploads' domain %}</script>
+<script>
+(function () {
+    var caseUploadResource = $('#caseUploadsResource').text();
+    function RecentUploads() {
+        var self = {};
+        // this is used both for the state of the ajax request
+        // and for the state of celery task
+        self.states = {
+            NOT_STARTED: 0,
+            STARTED: 1,
+            SUCCESS: 2,
+            FAILED: 3,
+        };
+        self.case_uploads = ko.observableArray(null);
+        self.state = ko.observable(self.states.NOT_STARTED);
+        self.fetchCaseUploads = function () {
+            if (self.state() === self.states.NOT_STARTED) {
+                // only show spinner on first fetch
+                self.state(self.states.STARTED);
+            }
+            $.get(caseUploadResource).success(function (data) {
+                self.state(self.states.SUCCESS);
+                self.case_uploads(data);
+                var anyInProgress = _.any(self.case_uploads(), function (case_upload) {
+                    return case_upload.task_status.state === self.states.STARTED ||
+                            case_upload.task_status.state === self.states.NOT_STARTED;
+                });
+                if (anyInProgress) {
+                    _.delay(self.fetchCaseUploads, 15000);
+                }
+            }).error(function () {
+                self.state(self.states.FAILED);
+            });
+        };
+        return self;
+    }
+    $(function () {
+        var recentUploads = RecentUploads();
+        $('#recent-uploads').koApplyBindings(recentUploads);
+        _.delay(recentUploads.fetchCaseUploads);
+    });
+}());
+</script>
+{% endblock %}
+
 {% block page_content %}
     {% include 'case_importer/partials/help_message.html' %}
 
@@ -48,4 +95,54 @@
             </div>
         </div>
     </form>
+
+
+    <h2>Recent Uploads</h2>
+    <div id="recent-uploads" class="ko-template">
+        <!--ko if: state() == states.SUCCESS && case_uploads()-->
+        <table class="table">
+            <tr>
+                <th>{% trans "Time" %}</th>
+                <th>{% trans "Status" %}</th>
+            </tr>
+            <!--ko foreach: case_uploads-->
+            <tr>
+                <td data-bind="text: created"></td>
+                <td>
+                    <!--ko if: task_status.state == $root.states.SUCCESS-->
+                    <span class="label label-success">{% trans "Success" %}</span>
+                    <!--/ko-->
+                    <!--ko if: task_status.state == $root.states.FAILED-->
+                    <span class="label label-danger">{% trans "Failed" %}</span>
+                    <!--/ko-->
+                    <!--ko if: task_status.state == $root.states.NOT_STARTED-->
+                    {% trans "Waiting to start" %}
+                    <!--/ko-->
+                    <!--ko if: task_status.state == $root.states.STARTED-->
+                    <div class="progress">
+                        <div class="progress-bar progress-bar-info"
+                             role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                             data-bind="attr: {style: 'width: ' + task_status.progress.percent + '%;'}">
+                            <span><!--ko text: task_status.progress.percent --><!--/ko-->%
+                                {% trans "Complete" %}</span>
+                          </div>
+                    </div>
+                    <!--/ko-->
+                </td>
+            </tr>
+            <!--/ko-->
+        </table>
+        <!--/ko-->
+        <!--ko if: state() === states.SUCCESS && !case_uploads()-->
+        <div class="alert alert-info">
+            You have no recent uploads.
+        </div>
+        <!--/ko-->
+        <!--ko if: state() === states.STARTED -->
+        <i class="fa fa-spinner fa-spin"></i>
+        <!--/ko-->
+        <!--ko if: state() === states.FAILED -->
+        <i class="fa fa-warning"></i>
+        <!--/ko-->
+    </div>
 {% endblock %}

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -1,0 +1,64 @@
+{% load i18n %}
+<!--ko if: state === $root.states.SUCCESS-->
+    <div class="text-success">
+        <!--ko if: result.match_count-->
+            <p>
+                {% blocktrans with match_count='result.match_count' %}
+                    <strong data-bind="text: {{ match_count }}"></strong> rows were matched and
+                    updated.
+                {% endblocktrans %}
+            </p>
+        <!--/ko-->
+
+        <!--ko if: result.created_count > 0-->
+            <p>
+                {% blocktrans with created_count='result.created_count' %}
+                    <strong data-bind="text: {{ created_count }}"></strong> rows did
+                    not match any existing cases and had new cases created
+                    for them. If case_id's were used, these were ignored.
+                {% endblocktrans %}
+            </p>
+        <!--/ko-->
+
+        <!--ko if: result.match_count === 0 && result.created_count === 0-->
+            <p>
+                {% trans "No cases were created or updated during this import." %}
+            </p>
+        <!--/ko-->
+
+        <!--ko if: result.too_many_matches > 0-->
+            <p>
+                {% blocktrans with too_many_matches='result.too_many_matches' %}
+                    <strong data-bind="text: {{ too_many_matches }}"></strong> rows matched more
+                    than one case at the same time - this means that there are cases
+                    in your system with the same external ID.
+                {% endblocktrans %}
+            </p>
+        <!--/ko-->
+    </div>
+    <!--ko if: !_.isEmpty(result.errors)-->
+    <div class="alert alert-warning">
+        <ul class="list-unstyled">
+        <!--ko foreach: _.pairs(result.errors).map(_.partial(_.object, ['error','columns']))-->
+            <!--ko foreach: _.pairs(columns).map(_.partial(_.object, ['column', 'value']))-->
+                <!--ko if: value.rows-->
+                <li>
+                    <p>
+                        <strong data-bind="text: value.error"></strong>
+                        <!--ko if: column !== 'null'--> {% trans 'in column' %}
+                            <strong data-bind="text: column"></strong><!--/ko-->
+                    </p>
+                    <p data-bind="text: value.description">
+                    </p>
+                    <p>
+                        <span>{% trans "Affected rows:" %}</span>
+                        <span data-bind="text: value.rows.join(', ')"></span>
+                    </p>
+                </li>
+                <!--/ko-->
+            <!--/ko-->
+        <!--/ko-->
+        </ul>
+    </div>
+    <!--/ko-->
+<!--/ko-->

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -54,6 +54,7 @@ class CaseUpload(object):
             upload_id=self.upload_id,
             task_id=task.task_id,
             couch_user_id=config.couch_user_id,
+            case_type=config.case_type,
         ).save()
 
     def get_task_status(self):

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -53,7 +53,7 @@ class CaseUpload(object):
             domain=domain,
             upload_id=self.upload_id,
             task_id=task.task_id,
-
+            couch_user_id=config.couch_user_id,
         ).save()
 
     def get_task_status(self):

--- a/corehq/apps/case_importer/tracking/dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/dbaccessors.py
@@ -1,0 +1,8 @@
+from corehq.apps.case_importer.tracking.models import CaseUploadRecord, CaseUploadJSON
+
+
+def get_case_uploads(domain, limit):
+    return map(
+        CaseUploadJSON.from_model,
+        CaseUploadRecord.objects.filter(domain=domain).order_by('-created')[:limit]
+    )

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -11,6 +11,7 @@ class CaseUploadRecord(models.Model):
     upload_id = models.UUIDField(unique=True)
     task_id = models.UUIDField(unique=True)
     couch_user_id = models.CharField(max_length=256)
+    case_type = models.CharField(max_length=256)
 
     @property
     @memoized
@@ -26,6 +27,7 @@ class CaseUploadJSON(jsonobject.JsonObject):
     upload_id = jsonobject.StringProperty(required=True)
     task_id = jsonobject.StringProperty(required=True)
     couch_user_id = jsonobject.StringProperty(required=True)
+    case_type = jsonobject.StringProperty(required=True)
 
     @classmethod
     def from_model(cls, other):
@@ -35,4 +37,5 @@ class CaseUploadJSON(jsonobject.JsonObject):
             upload_id=unicode(other.upload_id),
             task_id=unicode(other.task_id),
             couch_user_id=other.couch_user_id,
+            case_type=other.case_type,
         )

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -1,13 +1,20 @@
 from django.db import models
 from dimagi.ext import jsonobject
+from dimagi.utils.decorators.memoized import memoized
+from soil.util import get_task
 
 
 class CaseUploadRecord(models.Model):
     domain = models.CharField(max_length=256)
     created = models.DateTimeField(auto_now_add=True)
 
-    upload_id = models.UUIDField()
-    task_id = models.UUIDField()
+    upload_id = models.UUIDField(unique=True)
+    task_id = models.UUIDField(unique=True)
+
+    @property
+    @memoized
+    def task(self):
+        return get_task(self.task_id)
 
 
 class CaseUploadJSON(jsonobject.JsonObject):

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -1,0 +1,28 @@
+from django.db import models
+from dimagi.ext import jsonobject
+
+
+class CaseUploadRecord(models.Model):
+    domain = models.CharField(max_length=256)
+    created = models.DateTimeField(auto_now_add=True)
+
+    upload_id = models.UUIDField()
+    task_id = models.UUIDField()
+
+
+class CaseUploadJSON(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+
+    domain = jsonobject.StringProperty(required=True)
+    created = jsonobject.DateTimeProperty(required=True)
+    upload_id = jsonobject.StringProperty(required=True)
+    task_id = jsonobject.StringProperty(required=True)
+
+    @classmethod
+    def from_model(cls, other):
+        return cls(
+            domain=other.domain,
+            created=other.created,
+            upload_id=unicode(other.upload_id),
+            task_id=unicode(other.task_id)
+        )

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -10,6 +10,7 @@ class CaseUploadRecord(models.Model):
 
     upload_id = models.UUIDField(unique=True)
     task_id = models.UUIDField(unique=True)
+    couch_user_id = models.CharField(max_length=256)
 
     @property
     @memoized
@@ -24,6 +25,7 @@ class CaseUploadJSON(jsonobject.JsonObject):
     created = jsonobject.DateTimeProperty(required=True)
     upload_id = jsonobject.StringProperty(required=True)
     task_id = jsonobject.StringProperty(required=True)
+    couch_user_id = jsonobject.StringProperty(required=True)
 
     @classmethod
     def from_model(cls, other):
@@ -31,5 +33,6 @@ class CaseUploadJSON(jsonobject.JsonObject):
             domain=other.domain,
             created=other.created,
             upload_id=unicode(other.upload_id),
-            task_id=unicode(other.task_id)
+            task_id=unicode(other.task_id),
+            couch_user_id=other.couch_user_id,
         )

--- a/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from corehq.apps.case_importer.tracking.dbaccessors import get_case_uploads
+from corehq.apps.case_importer.tracking.models import CaseUploadRecord, CaseUploadJSON
+from corehq.util.test_utils import DocTestMixin
+
+
+class DbaccessorsTest(TestCase, DocTestMixin):
+    domain = 'test-case-importer-dbaccessors'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.case_upload_1 = CaseUploadRecord(
+            upload_id='7ca20e75-8ba3-4d0d-9c9c-66371e8895dc',
+            task_id='a2ebc913-11e6-4b6b-b909-355a863e0682',
+            domain=cls.domain,
+        )
+        cls.case_upload_2 = CaseUploadRecord(
+            upload_id='63d07615-7f89-458e-863d-5f9b5f4f4b7b',
+            task_id='fe47f168-0632-40d9-b01a-79612e98298b',
+            domain=cls.domain,
+        )
+        cls.case_upload_1.save()
+        cls.case_upload_2.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.case_upload_1.delete()
+        cls.case_upload_2.delete()
+
+    def test_get_case_uploads(self):
+        self.assert_doc_lists_equal(
+            get_case_uploads(self.domain, limit=1),
+            # gets latest
+            [CaseUploadJSON.from_model(self.case_upload_2)])
+        self.assert_doc_lists_equal(
+            get_case_uploads(self.domain, limit=2),
+            # gets latest first
+            [CaseUploadJSON.from_model(self.case_upload_2),
+             CaseUploadJSON.from_model(self.case_upload_1)])

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -1,6 +1,10 @@
 from corehq.apps.case_importer.tracking.dbaccessors import get_case_uploads
 from corehq.apps.case_importer.views import require_can_edit_data
+from corehq.util.timezones.conversions import ServerTime
+from corehq.util.timezones.utils import get_timezone_for_request
 from dimagi.utils.web import json_response
+from soil.progress import get_task_status
+from soil.util import get_task
 
 
 @require_can_edit_data
@@ -10,5 +14,22 @@ def case_uploads(request, domain):
     except (TypeError, ValueError):
         limit = 10
 
-    case_uploads = get_case_uploads(domain, limit)
+    def to_user_json(case_upload):
+        case_upload_json = case_upload.to_json()
+        tz = get_timezone_for_request()
+        task_status = get_task_status(get_task(case_upload_json['task_id']))
+        return {
+            'created': ServerTime(case_upload.created).user_time(tz).ui_string(),
+            'domain': case_upload_json['domain'],
+            'upload_id': case_upload_json['upload_id'],
+            'task_status': {
+                'state': task_status.state,
+                'progress': {
+                    'percent': task_status.progress.percent,
+                }
+            }
+        }
+
+    case_uploads = [to_user_json(case_upload)
+                    for case_upload in get_case_uploads(domain, limit)]
     return json_response(case_uploads)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -1,0 +1,14 @@
+from corehq.apps.case_importer.tracking.dbaccessors import get_case_uploads
+from corehq.apps.case_importer.views import require_can_edit_data
+from dimagi.utils.web import json_response
+
+
+@require_can_edit_data
+def case_uploads(request, domain):
+    try:
+        limit = int(request.GET.get('limit'))
+    except (TypeError, ValueError):
+        limit = 10
+
+    case_uploads = get_case_uploads(domain, limit)
+    return json_response(case_uploads)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -16,13 +16,12 @@ def case_uploads(request, domain):
         limit = 10
 
     def to_user_json(case_upload):
-        case_upload_json = case_upload.to_json()
         tz = get_timezone_for_request()
-        task_status = get_task_status(get_task(case_upload_json['task_id']))
+        task_status = get_task_status(get_task(case_upload.task_id))
         return {
             'created': ServerTime(case_upload.created).user_time(tz).ui_string(),
-            'domain': case_upload_json['domain'],
-            'upload_id': case_upload_json['upload_id'],
+            'domain': case_upload.domain,
+            'upload_id': case_upload.upload_id,
             'task_status': {
                 'state': task_status.state,
                 'progress': {
@@ -30,7 +29,8 @@ def case_uploads(request, domain):
                 }
             },
             'user': get_display_name_for_user_id(
-                domain, case_upload.couch_user_id, default='')
+                domain, case_upload.couch_user_id, default=''),
+            'case_type': case_upload.case_type,
         }
 
     case_uploads = [to_user_json(case_upload)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -1,5 +1,6 @@
 from corehq.apps.case_importer.tracking.dbaccessors import get_case_uploads
 from corehq.apps.case_importer.views import require_can_edit_data
+from corehq.apps.users.dbaccessors.couch_users import get_display_name_for_user_id
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_request
 from dimagi.utils.web import json_response
@@ -27,7 +28,9 @@ def case_uploads(request, domain):
                 'progress': {
                     'percent': task_status.progress.percent,
                 }
-            }
+            },
+            'user': get_display_name_for_user_id(
+                domain, case_upload.couch_user_id, default='')
         }
 
     case_uploads = [to_user_json(case_upload)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -26,7 +26,8 @@ def case_uploads(request, domain):
                 'state': task_status.state,
                 'progress': {
                     'percent': task_status.progress.percent,
-                }
+                },
+                'result': task_status.result
             },
             'user': get_display_name_for_user_id(
                 domain, case_upload.couch_user_id, default=''),

--- a/corehq/apps/case_importer/urls.py
+++ b/corehq/apps/case_importer/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from corehq.apps.case_importer.tracking.views import case_uploads
 
 from corehq.apps.case_importer.views import (
     excel_commit,
@@ -13,4 +14,5 @@ urlpatterns = [
     url(r'^excel/commit/$', excel_commit, name='excel_commit'),
     url(r'^importer_ajax/(?P<download_id>[0-9a-fA-Z]{25,32})/$',
         importer_job_poll, name='importer_job_poll'),
+    url(r'^history/uploads/$', case_uploads, name='case_importer_uploads'),
 ]

--- a/corehq/apps/casegroups/tests.py
+++ b/corehq/apps/casegroups/tests.py
@@ -39,7 +39,7 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         super(DBAccessorsTest, cls).tearDownClass()
 
     def test_get_case_groups_in_domain(self):
-        self.assert_doc_lists_equal(
+        self.assert_doc_sets_equal(
             get_case_groups_in_domain(self.domain),
             self.case_groups,
         )

--- a/corehq/apps/users/dbaccessors/couch_users.py
+++ b/corehq/apps/users/dbaccessors/couch_users.py
@@ -14,3 +14,11 @@ def get_user_id_by_username(username):
     if row:
         return row["id"]
     return None
+
+
+def get_display_name_for_user_id(domain, user_id, default=None):
+    if user_id:
+        user = CouchUser.get_by_user_id(user_id, domain)
+        if user:
+            return user.full_name
+    return default

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_dbaccessors.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_dbaccessors.py
@@ -36,7 +36,7 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         get_db(None).delete_docs(cls.legacy_sync_logs)
 
     def test_get_sync_logs_for_user(self):
-        self.assert_doc_lists_equal(
+        self.assert_doc_sets_equal(
             get_sync_logs_for_user(self.user_id, 4),
             self.sync_logs + self.legacy_sync_logs)
 

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -204,7 +204,7 @@ class CachedDownload(DownloadBase):
             # can revisit when loading a whole file into memory becomes a
             # serious concern
             payload = ''.join(payload)
-        download_id = uuid.uuid4().hex
+        download_id = str(uuid.uuid4())
         ret = cls(download_id, **kwargs)
         cache.caches[ret.cache_backend].set(download_id, payload, expiry)
         return ret

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -126,8 +126,8 @@ class DownloadBase(object):
 
     @property
     def task(self):
-        from celery.task.base import Task
-        return Task.AsyncResult(self.task_id)
+        from soil.util import get_task
+        return get_task(self.task_id)
 
     def get_progress(self):
         task_progress = get_task_progress(self.task)

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -137,10 +137,16 @@ class DocTestMixin(object):
         self.assertEqual(type(doc1), type(doc2))
         self.assertEqual(doc1.to_json(), doc2.to_json())
 
+    def assert_doc_sets_equal(self, docs1, docs2):
+        self.assertEqual(
+            sorted([(doc._id, type(doc), doc.to_json()) for doc in docs1]),
+            sorted([(doc._id, type(doc), doc.to_json()) for doc in docs2]),
+        )
+
     def assert_doc_lists_equal(self, docs1, docs2):
         self.assertEqual(
-            sorted([(doc._id, doc.to_json()) for doc in docs1]),
-            sorted([(doc._id, doc.to_json()) for doc in docs2]),
+            [(type(doc), doc.to_json()) for doc in docs1],
+            [(type(doc), doc.to_json()) for doc in docs2],
         )
 
 


### PR DESCRIPTION
Currently on staging:

<img width="1172" alt="screen shot 2016-12-07 at 2 32 27 pm" src="https://cloud.githubusercontent.com/assets/137212/20983333/0e7b4a84-bc8a-11e6-81e3-ea31bf07914d.png">

This displays below **Select a file to upload** section on case importer landing page currently, but could be convinced to place somewhere else. Currently supported features:

- Shows 10 most recent uploads (including uploads in progress)
- Shows progress of any active upload in the project space (including the one you just uploaded, or multiple uploads running at the same time)
- As long as any of the uploads shown are in progress, it will show you the progress live. (It currently stops polling once all displayed uploads are complete, so you'd have to refresh the page to see new ones.)
- Shows full success message and warnings that you'd see on the polling page
- Shows case type, name of the user who uploaded it, and time (in your chosen timezone)

Working with @sheelio on where to go with this next, but wanted to open this up for review and comments.