### PR TITLE
Mk 241159 notify user for error

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -282,7 +282,7 @@ class LocationQueriesMixin(object):
 
     def accessible_to_user(self, domain, user):
         if user.has_permission(domain, 'access_all_locations'):
-            return self.all()
+            return self.filter(domain=domain)
 
         assigned_location_ids = user.get_location_ids(domain)
         if not assigned_location_ids:

--- a/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
@@ -34,6 +34,14 @@ $(function() {
             $('#{{ css_id }}').val(null);
         }
     }).trigger('change');
+
+    $('#{{ submit_form_id }}').on('submit', function() {
+         // Notify user in case the source list has options but none selected
+         if(!!$('#{{ source_css_id }}').val() && !$('#{{ css_id }}').val()) {
+             alert("{{ empty_primary_location_message|safe }}");
+             return false;
+         }
+    })
 });
 
 </script>

--- a/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
@@ -15,6 +15,10 @@ $(function() {
             data: {'results': $(e).select2('data')},
         }
         $('#{{ css_id }}').select2(options);
+        option_ids = _.map(options.data.results, function(option) { return option.id })
+        if(!option_ids.includes($('#{{ css_id }}').val())) {
+            $('#{{ css_id }}').val(null);
+        }
     };
 
     // This custom event is fired in autocomplete_select_widget.html

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -772,7 +772,7 @@ class PrimaryLocationWidget(forms.Widget):
     Options for this field are dynamically set in JS depending on what options are selected
     for 'assigned_locations'. This works in conjunction with SupplyPointSelectWidget.
     """
-    def __init__(self, css_id, source_css_id, attrs=None):
+    def __init__(self, css_id, source_css_id, submit_form_id, empty_primary_location_message, attrs=None):
         """
         args:
             css_id: css_id of primary_location field
@@ -781,11 +781,15 @@ class PrimaryLocationWidget(forms.Widget):
         super(PrimaryLocationWidget, self).__init__(attrs)
         self.css_id = css_id
         self.source_css_id = source_css_id
+        self.submit_form_id = submit_form_id
+        self.empty_primary_location_message = empty_primary_location_message
 
     def render(self, name, value, attrs=None):
         return get_template('locations/manage/partials/drilldown_location_widget.html').render(Context({
             'css_id': self.css_id,
             'source_css_id': self.source_css_id,
+            'submit_form_id': self.submit_form_id,
+            'empty_primary_location_message': self.empty_primary_location_message,
             'name': name,
             'value': value or ''
         }))
@@ -813,12 +817,25 @@ class CommtrackUserForm(forms.Form):
             self.domain = kwargs['domain']
             del kwargs['domain']
         super(CommtrackUserForm, self).__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+
+        self.helper.form_method = 'POST'
+        self.helper.form_class = 'form-horizontal'
+        self.helper.form_tag = False
+        self.helper.form_id = 'commtrack_form'
+
+        self.helper.label_class = 'col-sm-3 col-md-2'
+        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+
         self.fields['assigned_locations'].widget = SupplyPointSelectWidget(
             self.domain, multiselect=True, id='id_assigned_locations'
         )
         self.fields['primary_location'].widget = PrimaryLocationWidget(
             css_id='id_primary_location',
-            source_css_id='id_assigned_locations'
+            source_css_id='id_assigned_locations',
+            submit_form_id=self.helper.form_id,
+            empty_primary_location_message = _("Primary location can't be empty if user has any locations set")
         )
         if self.commtrack_enabled:
             programs = Program.by_domain(self.domain, wrap=False)
@@ -828,14 +845,6 @@ class CommtrackUserForm(forms.Form):
         else:
             self.fields['program_id'].widget = forms.HiddenInput()
 
-        self.helper = FormHelper()
-
-        self.helper.form_method = 'POST'
-        self.helper.form_class = 'form-horizontal'
-        self.helper.form_tag = False
-
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
 
     @property
     @memoized

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -835,7 +835,7 @@ class CommtrackUserForm(forms.Form):
             css_id='id_primary_location',
             source_css_id='id_assigned_locations',
             submit_form_id=self.helper.form_id,
-            empty_primary_location_message = _("Primary location can't be empty if user has any locations set")
+            empty_primary_location_message=_("Primary location can't be empty if user has any locations set")
         )
         if self.commtrack_enabled:
             programs = Program.by_domain(self.domain, wrap=False)

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -71,7 +71,7 @@
 
     {% if update_form %}
         <hr />
-        <form id="commtrack_form" class="form form-horizontal" name="" method="post">
+        <form id='{{ update_form.helper.form_id }}' class="form form-horizontal" name="" method="post">
             {% csrf_token %}
             <input type="hidden" name="form_type" value="commtrack" />
             <fieldset>


### PR DESCRIPTION
This PR started with pre-populating locations on user edit page instead of loading it asyncly since that had a huge delay. Sravan took care of that aspect [here](https://github.com/dimagi/commcare-hq/pull/14143). So i just retained some precaution to enforce user to assign a primary location if a location is assigned.

This does couple of things
1. for a user that has access to all locations, still filter for just the current domain.
2. give a warning to user if not selecting primary location after assigning a location and avoid a request that finally returns an error
