### PR TITLE
Use proper nimbus URL

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -15,8 +15,8 @@ from restkit import Resource
 from celery import Celery
 import requests
 from soil import heartbeat
-from dimagi.utils.web import get_url_base
 
+from corehq.apps.nimbus_api.utils import get_nimbus_url
 from corehq.apps.app_manager.models import Application
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
 from corehq.apps.es import GroupES
@@ -170,12 +170,8 @@ def check_couch():
 
 
 def check_formplayer():
-    formplayer_url = settings.FORMPLAYER_URL
-    if not formplayer_url.startswith('http'):
-        formplayer_url = '{}{}'.format(get_url_base(), formplayer_url)
-
     try:
-        res = requests.get('{}/serverup'.format(formplayer_url), timeout=5)
+        res = requests.get('{}/serverup'.format(get_nimbus_url()), timeout=5)
     except requests.exceptions.ConnectTimeout:
         return ServiceStatus(False, "Could not establish a connection in time")
     except requests.ConnectionError:

--- a/corehq/apps/nimbus_api/form_validation.py
+++ b/corehq/apps/nimbus_api/form_validation.py
@@ -1,11 +1,11 @@
 import jsonobject
 import requests
-from django.conf import settings
 from requests import HTTPError
 from requests import RequestException
 
 from corehq.apps.nimbus_api import const
 from corehq.apps.nimbus_api.exceptions import NimbusRequestException, NimbusAPIException
+from corehq.apps.nimbus_api.utils import get_nimbus_url
 from dimagi.utils.logging import notify_exception
 
 
@@ -40,7 +40,7 @@ class FormValidationResult(object):
 def validate_form(form_xml):
     try:
         response = requests.post(
-            settings.FORMPLAYER_URL + const.ENDPOINT_VALIDATE_FORM,
+            get_nimbus_url() + const.ENDPOINT_VALIDATE_FORM,
             data=form_xml,
             headers={'Content-Type': 'application/xml'}
         )

--- a/corehq/apps/nimbus_api/utils.py
+++ b/corehq/apps/nimbus_api/utils.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from dimagi.utils.web import get_url_base
+
+
+def get_nimbus_url():
+    formplayer_url = settings.FORMPLAYER_URL
+    if not formplayer_url.startswith('http'):
+        formplayer_url = '{}{}'.format(get_url_base(), formplayer_url)
+    return formplayer_url


### PR DESCRIPTION
@snopoke sorry should have caught this, but we use the fully qualified URL and CORS locally while on prod we just hit `/formplayer` and route to the correct server by using nginx. it was a neat trick to get the formplayer_url to work both locally and in prod from the client side, however it doesn't play as nicely on the server :/

cc: @emord 