### PR TITLE
Add accounts email to invoices

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1821,7 +1821,7 @@ class Invoice(InvoiceBase):
     @property
     def email_recipients(self):
         if self.subscription.service_type == SubscriptionType.IMPLEMENTATION:
-            return [settings.FINANCE_EMAIL]
+            return [settings.FINANCE_EMAIL, settings.ACCOUNTS_EMAIL]
         else:
             return self.contact_emails
 

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -249,7 +249,7 @@ class TestContractedInvoices(BaseInvoiceTestCase):
         For contracted invoices, emails should be sent to finance@dimagi.com
         """
 
-        expected_recipient = ["finance@dimagi.com"]
+        expected_recipient = ["finance@dimagi.com", "accounts@dimagi.com"]
 
         tasks.generate_invoices(self.invoice_date)
 


### PR DESCRIPTION
@nickpell this is from http://manage.dimagi.com/default.asp?243637. i did not actually run this code, but i'm assuming it's correct. it's the only place finance@ is used

cc: @emord 