### PR TITLE
add xmlns and d3 data

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -13,7 +13,7 @@ from dimagi.utils.couch.loosechange import map_reduce
 from corehq.apps.reports.api import ReportDataSource
 from datetime import datetime, timedelta
 from dateutil import parser
-from casexml.apps.stock.const import SECTION_TYPE_STOCK
+from casexml.apps.stock.const import SECTION_TYPE_STOCK, COMMTRACK_REPORT_XMLNS
 from casexml.apps.stock.models import StockReport
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from couchforms.models import XFormInstance
@@ -461,6 +461,7 @@ class ReportingStatusDataSource(ReportDataSource, CommtrackDataSourceMixin, Mult
             )
 
             form_xmlnses = [form['xmlns'] for form in self.all_relevant_forms.values()]
+            form_xmlnses.append(COMMTRACK_REPORT_XMLNS)
             spoint_loc_map = {
                 doc['_id']: doc['location_id']
                 for doc in iter_docs(SupplyPointCase.get_db(), sp_ids)

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -493,4 +493,6 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
     @property
     def charts(self):
         if 'location_id' in self.request.GET: # hack: only get data if we're loading an actual report
-            return [PieChart(None, _('Current Reporting'), self.master_pie_chart_data())]
+            chart = PieChart(_('Current Reporting'), 'current_reporting', [])
+            chart.data = self.master_pie_chart_data()
+            return [chart]


### PR DESCRIPTION
@esoergel i believe something is completely busted with our `PieGraph` constructor. it's really hard for me to test all the places it's used because many of them are custom reports, so i decided to just to hack the `chart.data` as i saw other instances do. also the xmlns thing is a total hack, but again this report is on its way out and having a hard to justifying spending lots of time fixing it

http://manage.dimagi.com/default.asp?240149

cc: @emord 