### PR TITLE
Make the TranslationTransform translate also in web UI

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -220,9 +220,11 @@ def _get_data_detail(config, domain):
 
             def _get_word_eval(word_translations, default_value):
                 word_eval = default_value
-                for lang_translation_pair in word_translations:
-                    lang = lang_translation_pair[0]
-                    translation = lang_translation_pair[1]
+                if isinstance(word_translations, dict):
+                    translation_pairs = word_translations.items()
+                else:
+                    translation_pairs = word_translations
+                for lang, translation in translation_pairs:
                     word_eval = _get_conditional(
                         "$lang = '{lang}'".format(
                             lang=lang,
@@ -239,12 +241,17 @@ def _get_data_detail(config, domain):
                 default_val = "column[@id='{column_id}']"
                 xpath_function = default_val
                 for word, translations in transform['translations'].items():
+                    if isinstance(translations, basestring):
+                        # This is a flat mapping, not per-language translations
+                        word_eval = "'{}'".format(translations)
+                    else:
+                        word_eval = _get_word_eval(translations, default_val)
                     xpath_function = _get_conditional(
                         u"{value} = '{word}'".format(
                             value=default_val,
                             word=word,
                         ),
-                        _get_word_eval(translations, default_val),
+                        word_eval,
                         xpath_function
                     )
                 return Xpath(

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -220,11 +220,7 @@ def _get_data_detail(config, domain):
 
             def _get_word_eval(word_translations, default_value):
                 word_eval = default_value
-                if isinstance(word_translations, dict):
-                    translation_pairs = word_translations.items()
-                else:
-                    translation_pairs = word_translations
-                for lang, translation in translation_pairs:
+                for lang, translation in word_translations.items():
                     word_eval = _get_conditional(
                         "$lang = '{lang}'".format(
                             lang=lang,

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated-mixed.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated-mixed.xml
@@ -1,0 +1,49 @@
+<partial>
+  <detail id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data" nodeset="rows/row">
+    <title>
+      <text>
+        <locale id="cchq.report_data_table"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.owner"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="if(column[@id='owner'] = '2', 'two', if(column[@id='owner'] = '&#2319;&#2325;', if($lang = 'es', 'uno', if($lang = 'en', 'one', column[@id='owner'])), column[@id='owner']))">
+            <variable name="lang">
+              <locale id="lang.current"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.count"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="column[@id='count']"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.is_starred"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="column[@id='is_starred']"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+</partial>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated-simple.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated-simple.xml
@@ -1,0 +1,49 @@
+<partial>
+  <detail id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data" nodeset="rows/row">
+    <title>
+      <text>
+        <locale id="cchq.report_data_table"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.owner"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="if(column[@id='owner'] = '2', 'two', if(column[@id='owner'] = '&#2319;&#2325;', 'one', column[@id='owner']))">
+            <variable name="lang">
+              <locale id="lang.current"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.count"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="column[@id='count']"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.is_starred"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="column[@id='is_starred']"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -730,17 +730,6 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         # Tuple mapping translation formats to the expected output of each
         translation_formats = [
             ({
-                u'एक': [
-                    ['en', 'one'],
-                    ['es', 'uno'],
-                ],
-                '2': [
-                    ['en', 'two'],
-                    ['es', 'dos\''],
-                    ['hin', u'दो'],
-                ],
-            }, 'reports_module_data_detail-translated'),
-            ({
                 u'एक': {
                     'en': 'one',
                     'es': 'uno',

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -727,9 +727,9 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary']",
         )
 
-        report_app_config._report.columns[0]['transform'] = {
-            'type': 'translation',
-            'translations': {
+        # Tuple mapping translation formats to the expected output of each
+        translation_formats = [
+            ({
                 u'एक': [
                     ['en', 'one'],
                     ['es', 'uno'],
@@ -739,14 +739,41 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                     ['es', 'dos\''],
                     ['hin', u'दो'],
                 ],
+            }, 'reports_module_data_detail-translated'),
+            ({
+                u'एक': {
+                    'en': 'one',
+                    'es': 'uno',
+                },
+                '2': {
+                    'en': 'two',
+                    'es': 'dos\'',
+                    'hin': u'दो',
+                },
+            }, 'reports_module_data_detail-translated'),
+            ({
+                u'एक': 'one',
+                '2': 'two',
+            }, 'reports_module_data_detail-translated-simple'),
+            ({
+                u'एक': {
+                    'en': 'one',
+                    'es': 'uno',
+                },
+                '2': 'two',
+            }, 'reports_module_data_detail-translated-mixed'),
+        ]
+        for translation_format, expected_output in translation_formats:
+            report_app_config._report.columns[0]['transform'] = {
+                'type': 'translation',
+                'translations': translation_format,
             }
-        }
-        report_app_config._report = ReportConfiguration.wrap(report_app_config._report._doc)
-        self.assertXmlPartialEqual(
-            self.get_xml('reports_module_data_detail-translated'),
-            app.create_suite(),
-            "./detail/detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data']",
-        )
+            report_app_config._report = ReportConfiguration.wrap(report_app_config._report._doc)
+            self.assertXmlPartialEqual(
+                self.get_xml(expected_output),
+                app.create_suite(),
+                "./detail/detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data']",
+            )
 
     def test_circular_parent_case_ref(self):
         factory = AppFactory()

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -77,6 +77,7 @@ An overview of the design, API and data structures used here.
         - [Aggregate by 'username' column](#aggregate-by-username-column)
         - [Aggregate by two columns](#aggregate-by-two-columns)
     - [Transforms](#transforms)
+        - [Translations and arbitrary mappings](#translations-and-arbitrary-mappings)
         - [Displaying username instead of user ID](#displaying-username-instead-of-user-id)
         - [Displaying username minus @domain.commcarehq.org instead of user ID](#displaying-username-minus-domaincommcarehqorg-instead-of-user-id)
         - [Displaying owner name instead of owner ID](#displaying-owner-name-instead-of-owner-id)
@@ -1214,7 +1215,10 @@ Choice lists allow manual configuration of a fixed, specified number of choices 
 
 ### Internationalization
 
-Report builders may specify translations for the filter display value. See the section on internationalization in the Report Column section for more information.
+Report builders may specify translations for the filter display value.
+Also see the sections on internationalization in the Report Column and
+the [translations transform](#translations-and-arbitrary-mappings).
+
 ```json
 {
     "type": "choice_list",
@@ -1421,9 +1425,11 @@ Column IDs in percentage fields *must be unique for the whole report*. If you us
 To sum a column and include the result in a totals row at the bottom of the report, set the `calculate_total` value in the column configuration to `true`.
 
 ### Internationalization
-Report columns can be translated into multiple languages. To specify translations
-for a column header, use an object as the `display` value in the configuration
-instead of a string. For example:
+Report columns can be translated into multiple languages.
+To translate values in a given column check out
+the [translations transform](#translations-and-arbitrary-mappings) below.
+To specify translations for a column header, use an object as the `display`
+value in the configuration instead of a string. For example:
 ```
 {
     "type": "field",
@@ -1480,11 +1486,73 @@ Note that if you use `is_primary_key` in any of your columns, you must include a
 ## Transforms
 
 Transforms can be used in two places - either to manipulate the value of a column just before it gets saved to a data source, or to transform the value returned by a column just before it reaches the user in a report.
+Here's an example of a transform used in a report config 'field' column:
+
+```json
+{
+    "type": "field",
+    "field": "owner_id",
+    "column_id": "owner_id",
+    "display": "Owner Name",
+    "format": "default",
+    "transform": {
+        "type": "custom",
+        "custom_type": "owner_display"
+    },
+    "aggregation": "simple"
+}
+```
+
 The currently supported transform types are shown below:
+
+### Translations and arbitrary mappings
+
+The translations transform can be used to give human readable strings:
+
+```json
+{
+    "type": "translation",
+    "translations": {
+        "lmp": "Last Menstrual Period",
+        "edd": "Estimated Date of Delivery"
+    }
+}
+```
+
+And for translations:
+
+```json
+{
+    "type": "translation",
+    "translations": {
+        "lmp": {
+            "en": "Last Menstrual Period",
+            "es": "Fecha Última Menstruación",
+        },
+        "edd": {
+            "en": "Estimated Date of Delivery",
+            "es": "Fecha Estimada de Parto",
+        }
+    }
+}
+```
+
+To use this in a mobile ucr, set the `'mobile_or_web'` property to `'mobile'`
+
+```json
+{
+    "type": "translation",
+    "mobile_or_web": "mobile",
+    "translations": {
+        "lmp": "Last Menstrual Period",
+        "edd": "Estimated Date of Delivery"
+    }
+}
+```
 
 ### Displaying username instead of user ID
 
-```
+```json
 {
     "type": "custom",
     "custom_type": "user_display"
@@ -1493,7 +1561,7 @@ The currently supported transform types are shown below:
 
 ### Displaying username minus @domain.commcarehq.org instead of user ID
 
-```
+```json
 {
     "type": "custom",
     "custom_type": "user_without_domain_display"
@@ -1502,7 +1570,7 @@ The currently supported transform types are shown below:
 
 ### Displaying owner name instead of owner ID
 
-```
+```json
 {
     "type": "custom",
     "custom_type": "owner_display"
@@ -1511,7 +1579,7 @@ The currently supported transform types are shown below:
 
 ### Displaying month name instead of month index
 
-```
+```json
 {
     "type": "custom",
     "custom_type": "month_display"
@@ -1522,7 +1590,7 @@ The currently supported transform types are shown below:
 
 Rounds decimal and floating point numbers to two decimal places.
 
-```
+```json
 {
     "type": "custom",
     "custom_type": "short_decimal_display"
@@ -1540,7 +1608,7 @@ If the format string is not valid or the input is not a number then the original
 
 #### Round to the nearest whole number
 
-```
+```json
 {
     "type": "number_format",
     "custom_type": "{0:.0f}"
@@ -1549,7 +1617,7 @@ If the format string is not valid or the input is not a number then the original
 
 #### Always round to 3 decimal places
 
-```
+```json
 {
     "type": "number_format",
     "custom_type": "{0:.3f}"
@@ -1559,7 +1627,7 @@ If the format string is not valid or the input is not a number then the original
 ### Date formatting
 Formats dates with the given format string. See [here](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior) for an explanation of format string behavior.
 If there is an error formatting the date, the transform is not applied to that value.
-```
+```json
 {
    "type": "date_format", 
    "format": "%Y-%m-%d %H:%M"

--- a/corehq/apps/userreports/management/commands/migrate_translation_transforms.py
+++ b/corehq/apps/userreports/management/commands/migrate_translation_transforms.py
@@ -1,0 +1,58 @@
+from optparse import make_option
+from django.core.management.base import BaseCommand
+from corehq.apps.userreports.models import ReportConfiguration
+from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
+from corehq.util.couch import iter_update, DocUpdate
+from corehq.util.log import with_progress_bar
+
+
+def reformat_translations(old_translations):
+    if not isinstance(old_translations, dict):
+        return old_translations
+    new_translations = {}
+    for k, translations in old_translations.items():
+        if isinstance(translations, basestring):
+            new_translations[k] = translations
+        else:
+            new_translations[k] = dict(translations)
+    return new_translations
+
+
+class Command(BaseCommand):
+    help = ("Migrate existing translation transforms to flag as mobile-only "
+            "and update mapping format")
+    option_list = (
+        make_option(
+            '--dry-run',
+            action='store_true',
+            dest='dry_run',
+            default=False,
+            help=("Don't actually perform the update, just list the reports "
+                  "that would be affected"),
+        ),
+    )
+
+    def handle(self, dry_run=False, *args, **options):
+        self.dry_run = dry_run
+        self.reports_using_transform = set()
+        report_ids = get_doc_ids_by_class(ReportConfiguration)
+        res = iter_update(
+            db=ReportConfiguration.get_db(),
+            fn=self.migrate_report,
+            ids=with_progress_bar(report_ids),
+            verbose=True,
+        )
+        print "Found {} reports using the transform:".format(len(self.reports_using_transform))
+        print "\n".join(self.reports_using_transform)
+        print "Updated the following reports:"
+        print "\n".join(res.updated_ids)
+
+    def migrate_report(self, report_config):
+        rc = ReportConfiguration.wrap(report_config)
+        for column in rc.report_columns:
+            if column.transform and column.transform['type'] == 'translation':
+                column.transform['mobile_or_web'] = 'mobile'
+                column.transform['translations'] = reformat_translations(column.transform['translations'])
+                self.reports_using_transform.add(rc._id)
+        if not self.dry_run:
+            return DocUpdate(rc.to_json())

--- a/corehq/apps/userreports/migrations/0002_migrate_translation_transforms.py
+++ b/corehq/apps/userreports/migrations/0002_migrate_translation_transforms.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.core.management import call_command
+from corehq.sql_db.operations import HqRunPython
+
+
+def migrate_translation_transforms(apps, schema_editor):
+    call_command('migrate_translation_transforms')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        HqRunPython(migrate_translation_transforms),
+    ]

--- a/corehq/apps/userreports/migrations/0002_migrate_translation_transforms.py
+++ b/corehq/apps/userreports/migrations/0002_migrate_translation_transforms.py
@@ -13,6 +13,7 @@ def migrate_translation_transforms(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('userreports', '0001_initial'),
     ]
 
     operations = [

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -143,3 +143,28 @@ class TranslationTransform(SimpleTestCase):
         self.assertEqual(transform('#0000FF'), 'Azul')
         self.assertEqual(transform('#800080'), 'Morado')
         self.assertEqual(transform('#123456'), '#123456')
+
+    def test_dont_translate_for_mobile(self):
+        transform = TransformFactory.get_transform({
+            "type": "translation",
+            "mobile_or_web": "mobile",
+            "translations": {
+                "#0000FF": "Blue",
+                "#800080": [["en", "Purple"], ["es", "Morado"]],  # legacy, mobile-only format
+            },
+        }).get_transform_function()
+        self.assertEqual(transform('#0000FF'), '#0000FF')
+        self.assertEqual(transform('#800080'), '#800080')
+        self.assertEqual(transform('#123456'), '#123456')
+
+    def test_bad_option(self):
+        with self.assertRaises(BadSpecError):
+            TransformFactory.get_transform({
+                "type": "translation",
+                "mobile_or_web": "neither!",
+                "translations": {
+                    "0": "zero",
+                    "1": {"en": "one", "es": "uno"},
+                    "2": {"en": "two", "es": "dos"}
+                },
+            })

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -87,7 +87,6 @@ class DaysElapsedTransformTest(SimpleTestCase):
         self.assertEqual(transform.transform(date), 5)
 
 
-
 class TranslationTransform(SimpleTestCase):
 
     def test_missing_translation(self):

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -82,6 +82,7 @@ class NumberFormatTransform(Transform):
 class TranslationTransform(Transform):
     type = TypeProperty('translation')
     translations = DictProperty()
+    # For mobile, the transform is a no-op and translation happens in the app
     mobile_or_web = StringProperty(default="web", choices=["mobile", "web"])
 
     def get_transform_function(self):

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -80,33 +80,6 @@ class NumberFormatTransform(Transform):
 
 
 class TranslationTransform(Transform):
-    """
-    Lets you map slugs to display strings, and/or translate them
-
-    Simple mapping
-        {
-            "type": "translation",
-            "translations": {
-                "#0000FF": "Blue",
-                "#800080": "Purple"
-            }
-        }
-
-    Translated mapping
-        {
-            "type": "translation",
-            "translations": {
-                "#0000FF": {
-                    "en": "Blue",
-                    "es": "Azul",
-                },
-                "#800080": {
-                    "en": "Purple",
-                    "es": "Morado",
-                }
-            }
-        }
-    """
     type = TypeProperty('translation')
     translations = DictProperty()
     mobile_or_web = StringProperty(default="web", choices=["mobile", "web"])

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -109,8 +109,11 @@ class TranslationTransform(Transform):
     """
     type = TypeProperty('translation')
     translations = DictProperty()
+    mobile_or_web = StringProperty(default="web", choices=["mobile", "web"])
 
     def get_transform_function(self):
+        if self.mobile_or_web == "mobile":  # Mobile translation happens later
+            return lambda value: value
 
         def transform_function(value):
             if value not in self.translations:

--- a/corehq/dbaccessors/couchapps/all_docs.py
+++ b/corehq/dbaccessors/couchapps/all_docs.py
@@ -64,6 +64,18 @@ def get_all_docs_with_doc_types(db, doc_types):
             yield result['doc']
 
 
+def get_doc_ids_by_class(doc_class):
+    """Useful for migrations, but has the potential to be very large"""
+    doc_type = doc_class.__name__
+    return [row['id'] for row in doc_class.get_db().view(
+        'all_docs/by_doc_type',
+        startkey=[doc_type],
+        endkey=[doc_type, {}],
+        include_docs=False,
+        reduce=False,
+    )]
+
+
 def delete_all_docs_by_doc_type(db, doc_types):
     for chunk in chunked(get_all_docs_with_doc_types(db, doc_types), 100):
         db.bulk_delete(chunk)

--- a/custom/icds_reports/ucr/reports/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr_2bi_preg_delivery_death_list.json
@@ -109,61 +109,26 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "delivery": [
-              [
-                "mar",
-                "प्रसूति"
-              ],
-              [
-                "tel",
-                "కాన్పు వివరాలు "
-              ],
-              [
-                "hin",
-                "प्रसव"
-              ],
-              [
-                "en",
-                "Delivery"
-              ]
-            ],
-            "pnc": [
-              [
-                "mar",
-                "प्रसुतीनंतरची देखभाल"
-              ],
-              [
-                "tel",
-                "కాన్పు తరువాత సంరక్షణ "
-              ],
-              [
-                "hin",
-                "प्रसव के बाद देख-रेख"
-              ],
-              [
-                "en",
-                "PNC"
-              ]
-            ],
-            "pregnant": [
-              [
-                "mar",
-                "गरोदर"
-              ],
-              [
-                "tel",
-                "గర్భవతా"
-              ],
-              [
-                "hin",
-                "गर्भवती"
-              ],
-              [
-                "en",
-                "Pregnant"
-              ]
-            ]
+            "delivery": {
+              "mar": "प्रसूति",
+              "tel": "కాన్పు వివరాలు ",
+              "hin": "प्रसव",
+              "en": "Delivery"
+            },
+            "pnc": {
+              "mar": "प्रसुतीनंतरची देखभाल",
+              "tel": "కాన్పు తరువాత సంరక్షణ ",
+              "hin": "प्रसव के बाद देख-रेख",
+              "en": "PNC"
+            },
+            "pregnant": {
+              "mar": "गरोदर",
+              "tel": "గర్భవతా",
+              "hin": "गर्भवती",
+              "en": "Pregnant"
+            }
           }
         },
         "column_id": "female_death_type",
@@ -181,43 +146,20 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "yes": [
-              [
-                "mar",
-                "होय"
-              ],
-              [
-                "tel",
-                "అవును"
-              ],
-              [
-                "hin",
-                "हाँ"
-              ],
-              [
-                "en",
-                "Yes"
-              ]
-            ],
-            "no": [
-              [
-                "mar",
-                "नाही"
-              ],
-              [
-                "tel",
-                "కాదు"
-              ],
-              [
-                "hin",
-                "नहीं"
-              ],
-              [
-                "en",
-                "No"
-              ]
-            ]
+            "yes": {
+              "mar": "होय",
+              "tel": "అవును",
+              "hin": "हाँ",
+              "en": "Yes"
+            },
+            "no": {
+              "mar": "नाही",
+              "tel": "కాదు",
+              "hin": "नहीं",
+              "en": "No"
+            }
           }
         },
         "column_id": "resident",

--- a/custom/icds_reports/ucr/reports/mpr_2bii_child_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr_2bii_child_death_list.json
@@ -109,61 +109,26 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "M": [
-              [
-                "mar",
-                "पुरुष"
-              ],
-              [
-                "tel",
-                "పురుషుడు"
-              ],
-              [
-                "hin",
-                "पुरुष"
-              ],
-              [
-                "en",
-                "M"
-              ]
-            ],
-            "O": [
-              [
-                "mar",
-                "अन्य"
-              ],
-              [
-                "tel",
-                "ఇతరులు"
-              ],
-              [
-                "hin",
-                "अन्य"
-              ],
-              [
-                "en",
-                "O"
-              ]
-            ],
-            "F": [
-              [
-                "mar",
-                "स्त्री"
-              ],
-              [
-                "tel",
-                "మహిళ"
-              ],
-              [
-                "hin",
-                "महिला"
-              ],
-              [
-                "en",
-                "F"
-              ]
-            ]
+            "M": {
+                "mar": "पुरुष",
+                "tel": "పురుషుడు",
+                "hin": "पुरुष",
+                "en": "M"
+            },
+            "O": {
+                "mar": "अन्य",
+                "tel": "ఇతరులు",
+                "hin": "अन्य",
+                "en": "O"
+            },
+            "F": {
+                "mar": "स्त्री",
+                "tel": "మహిళ",
+                "hin": "महिला",
+                "en": "F"
+            }
           }
         },
         "column_id": "sex",
@@ -181,79 +146,32 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "white": [
-              [
-                "mar",
-                "पांढरा"
-              ],
-              [
-                "tel",
-                "తెలుపు"
-              ],
-              [
-                "hin",
-                "सफेद"
-              ],
-              [
-                "en",
-                "White"
-              ]
-            ],
-            "green": [
-              [
-                "mar",
-                "हिरवा"
-              ],
-              [
-                "tel",
-                "ఆకుపచ్చ"
-              ],
-              [
-                "hin",
-                "हरा"
-              ],
-              [
-                "en",
-                "Green"
-              ]
-            ],
-            "red": [
-              [
-                "mar",
-                "लाल"
-              ],
-              [
-                "tel",
-                "ఎరుపు"
-              ],
-              [
-                "hin",
-                "लाल"
-              ],
-              [
-                "en",
-                "Red"
-              ]
-            ],
-            "yellow": [
-              [
-                "mar",
-                "पिवळा"
-              ],
-              [
-                "tel",
-                "పసుపు"
-              ],
-              [
-                "hin",
-                "पीला"
-              ],
-              [
-                "en",
-                "Yellow"
-              ]
-            ]
+            "white": {
+              "mar": "पांढरा",
+              "tel": "తెలుపు",
+              "hin": "सफेद",
+              "en": "White"
+            },
+            "green": {
+              "mar": "हिरवा",
+              "tel": "ఆకుపచ్చ",
+              "hin": "हरा",
+              "en": "Green"
+            },
+            "red": {
+              "mar": "लाल",
+              "tel": "ఎరుపు",
+              "hin": "लाल",
+              "en": "Red"
+            },
+            "yellow": {
+              "mar": "पिवळा",
+              "tel": "పసుపు",
+              "hin": "पीला",
+              "en": "Yellow"
+            }
           }
         },
         "column_id": "zscore_grading_wfa",
@@ -271,43 +189,20 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "yes": [
-              [
-                "mar",
-                "होय"
-              ],
-              [
-                "tel",
-                "అవును"
-              ],
-              [
-                "hin",
-                "हाँ"
-              ],
-              [
-                "en",
-                "Yes"
-              ]
-            ],
-            "no": [
-              [
-                "mar",
-                "नाही"
-              ],
-              [
-                "tel",
-                "కాదు"
-              ],
-              [
-                "hin",
-                "नहीं"
-              ],
-              [
-                "en",
-                "No"
-              ]
-            ]
+            "yes": {
+              "mar": "होय",
+              "tel": "అవును",
+              "hin": "हाँ",
+              "en": "Yes"
+            },
+            "no": {
+              "mar": "नाही",
+              "tel": "కాదు",
+              "hin": "नहीं",
+              "en": "No"
+            }
           }
         },
         "column_id": "resident",

--- a/custom/icds_reports/ucr/reports/mpr_2ci_child_birth_list.json
+++ b/custom/icds_reports/ucr/reports/mpr_2ci_child_birth_list.json
@@ -109,61 +109,26 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "M": [
-              [
-                "mar",
-                "पुरुष"
-              ],
-              [
-                "tel",
-                "పురుషుడు"
-              ],
-              [
-                "hin",
-                "पुरुष"
-              ],
-              [
-                "en",
-                "M"
-              ]
-            ],
-            "O": [
-              [
-                "mar",
-                "अन्य"
-              ],
-              [
-                "tel",
-                "ఇతరులు"
-              ],
-              [
-                "hin",
-                "अन्य"
-              ],
-              [
-                "en",
-                "O"
-              ]
-            ],
-            "F": [
-              [
-                "mar",
-                "स्त्री"
-              ],
-              [
-                "tel",
-                "మహిళ"
-              ],
-              [
-                "hin",
-                "महिला"
-              ],
-              [
-                "en",
-                "F"
-              ]
-            ]
+            "M": {
+              "mar": "पुरुष",
+              "tel": "పురుషుడు",
+              "hin": "पुरुष",
+              "en": "M"
+            },
+            "O": {
+              "mar": "अन्य",
+              "tel": "ఇతరులు",
+              "hin": "अन्य",
+              "en": "O"
+            },
+            "F": {
+              "mar": "स्त्री",
+              "tel": "మహిళ",
+              "hin": "महिला",
+              "en": "F"
+            }
           }
         },
         "column_id": "sex",
@@ -194,43 +159,20 @@
         "format": "default",
         "transform": {
           "type": "translation",
+          "mobile_or_web": "mobile",
           "translations": {
-            "yes": [
-              [
-                "mar",
-                "होय"
-              ],
-              [
-                "tel",
-                "అవును"
-              ],
-              [
-                "hin",
-                "हाँ"
-              ],
-              [
-                "en",
-                "Yes"
-              ]
-            ],
-            "no": [
-              [
-                "mar",
-                "नाही"
-              ],
-              [
-                "tel",
-                "కాదు"
-              ],
-              [
-                "hin",
-                "नहीं"
-              ],
-              [
-                "en",
-                "No"
-              ]
-            ]
+            "yes": {
+              "mar": "होय",
+              "tel": "అవును",
+              "hin": "हाँ",
+              "en": "Yes"
+            },
+            "no": {
+              "mar": "नाही",
+              "tel": "కాదు",
+              "hin": "नहीं",
+              "en": "No"
+            }
           }
         },
         "column_id": "resident",


### PR DESCRIPTION
@nickpell @czue

**UPDATE**
This PR implements the TranslationTransform for web, and adds support for the translation format we use elsewhere, that is, a lang->string dict or a simple string:
```python
In [1]: localize('1', 'en')
Out[1]: '1'

In [2]: localize({'en': 'one', 'es': 'dos'}, 'en')
Out[2]: 'one'
```
This maintains support for the old format in mobile reports, but documentation only reflects the new format (converting old stuff is left as an exercise for the reader).  Mobile reports will also now accept the new format, including flat mappings.

There's a `mobile_or_web` flag (defaulted to `'web'`) which is necessary for this to work on mobile, for ease of implementation.

Old description:

> I was looking to see if this existed and Nick pointed me at this transform.  The existing implementation is for mobile UCR, and the transform there happens on the device, not server-side.  Still, it looked pretty easy to implement for web, so I did this as a proof-of-concept.  It works well, and was pretty easy to write.

> In order to ready this to go live, we'd need to:

> * Reconcile the spec (I think that means migrating existing reports).  Nick's implementation uses a list of lists to store translation, and I used the translation semantics used for column headers (Nick mentioned offline that he'd been thinking about switching to that syntax).
> * Add documentation (easy)
> * Figure out how to make this work with both mobile UCR and web-based UCR.  The problem here is that `get_transform_function` should return a noop for mobile UCR, and return a proper translator for web UCR.  Is this something we've run into before?  I'm not sure how to cleanly fork the code like that.

> This was just a POC, so I don't want to go too far on this if it's not something we'd like to do anyways.  I'm leaning towards having two entirely separate transforms, one for mobile, one for the web.  This is pretty inelegant, but makes sense from an implementation perspective.

> How would you two recommend proceeding?

> [here's](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/ucr/reports/mpr_2ci_child_birth_list.json#L108) an existing mobile report using this transform, and [here's](https://github.com/dimagi/commcare-hq/pull/11569/files) the PR which introduced it (shows how it's implemented in the `suite.xml`)
