### PR TITLE
Remove lenient protocol

### DIFF
--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -291,7 +291,7 @@ class GetRestoreUserTest(TestCase):
         self.assertIsInstance(get_restore_user(self.domain, self.web_user, None), OTARestoreWebUser)
 
     def test_get_restore_user_commcare_user(self):
-        self.assertIsInstance(get_restore_user(self.domain, self.web_user, None), OTARestoreCommCareUser)
+        self.assertIsInstance(get_restore_user(self.domain, self.commcare_user, None), OTARestoreCommCareUser)
 
     def test_get_restore_user_as_user(self):
         self.assertIsInstance(
@@ -324,13 +324,12 @@ class GetRestoreUserTest(TestCase):
         )
 
     def test_get_restore_user_not_found(self):
-        self.assertIsNone(
+        with self.assertRaises(Exception):
             get_restore_user(
                 self.domain,
                 self.web_user,
                 '{}@wrong-domain'.format(self.commcare_user.raw_username, self.domain)
             )
-        )
 
     def test_get_restore_user_as_user_for_commcare_user(self):
         user = get_restore_user(

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -117,30 +117,12 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.web_user,
-            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
-            True,
-        )
-        self.assertTrue(is_permitted)
-        self.assertIsNone(message)
-
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.web_user,
             self.commcare_user.username,
             True,
         )
         self.assertTrue(is_permitted)
 
     def test_web_user_as_user_bad_privilege(self):
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.web_user,
-            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
-            False,
-        )
-        self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'does not have permissions')
-
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.web_user,
@@ -158,7 +140,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             True,
         )
         self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'Invalid restore user')
+        self.assertRegexpMatches(message, 'Invalid restore as user')
 
     def test_web_user_as_user_bad_domain(self):
         is_permitted, message = is_permitted_to_restore(
@@ -168,7 +150,7 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             True,
         )
         self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'was not in the domain')
+        self.assertRegexpMatches(message, 'Invalid restore as user')
 
     def test_web_user_as_other_web_user(self):
         is_permitted, message = is_permitted_to_restore(
@@ -190,15 +172,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
 
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.commcare_user,
-            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
-            True,
-        )
-        self.assertTrue(is_permitted)
-        self.assertIsNone(message)
-
     def test_web_user_as_self(self):
         is_permitted, message = is_permitted_to_restore(
             self.domain,
@@ -213,16 +186,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         """
         Superusers should be able to restore as other mobile users even if it's the wrong domain
         """
-
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.super_user,
-            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
-            False,
-        )
-        self.assertTrue(is_permitted)
-        self.assertIsNone(message)
-
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.super_user,
@@ -236,15 +199,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.no_edit_commcare_user,
-            u'{}@{}'.format(self.location_user.raw_username, self.domain),
-            True,
-        )
-        self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'does not have permission')
-
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.no_edit_commcare_user,
             self.location_user.username,
             True,
         )
@@ -252,24 +206,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertRegexpMatches(message, 'does not have permission')
 
     def test_commcare_user_as_user_in_location(self):
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.commcare_user,
-            u'{}@{}'.format(self.location_user.raw_username, self.domain),
-            True,
-        )
-        self.assertTrue(is_permitted)
-        self.assertIsNone(message)
-
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.commcare_user,
-            u'{}@{}'.format(self.wrong_location_user.raw_username, self.domain),
-            True,
-        )
-        self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'not in allowed locations')
-
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.commcare_user,
@@ -289,24 +225,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertRegexpMatches(message, 'not in allowed locations')
 
     def test_web_user_as_user_in_location(self):
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.web_location_user,
-            u'{}@{}'.format(self.location_user.raw_username, self.domain),
-            True,
-        )
-        self.assertTrue(is_permitted)
-        self.assertIsNone(message)
-
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.web_location_user,
-            u'{}@{}'.format(self.wrong_location_user.raw_username, self.domain),
-            True,
-        )
-        self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'not in allowed locations')
-
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.web_location_user,

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -6,7 +6,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.users.util import format_username
 from dimagi.utils.logging import notify_exception
 
-from corehq.apps.users.models import CommCareUser, WebUser, CouchUser
+from corehq.apps.users.models import CouchUser
 
 from dimagi.utils.web import json_response
 from corehq.apps.domain.auth import get_username_and_password_from_request, determine_authtype_from_request

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -98,7 +98,7 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privil
     for the domain and/or as_user
     :param domain: Domain of restore
     :param couch_user: The couch user attempting authentication
-    :param as_user: a string <user>@<domain> that the couch_user is attempting to get
+    :param as_user: a string username that the couch_user is attempting to get
         a restore for. If None will get restore of the couch_user.
     :param has_data_cleanup_privelege: Whether the user has permissions to do DATA_CLEANUP
     :returns: a tuple - first a boolean if the user is permitted,
@@ -144,20 +144,6 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user_obj):
         raise RestorePermissionDenied(_(u"{} was not in the domain {}").format(as_user_obj.username, domain))
 
 
-def _parse_restore_as_user(as_user):
-    try:
-        username = as_user.split('@')[0]
-        user_domain = as_user.split('@')[1]
-        hq_suffix = '.{}'.format(settings.HQ_ACCOUNT_ROOT)
-        if user_domain.endswith(settings.HQ_ACCOUNT_ROOT):
-            user_domain = user_domain[:-len(hq_suffix)]
-    except IndexError:
-        raise RestorePermissionDenied(
-            _(u"Invalid restore user {}. Format is <user>@<domain>").format(as_user)
-        )
-    return username, user_domain
-
-
 def _ensure_accessible_location(domain, couch_user, as_user_obj):
     if not user_can_access_other_user(domain, couch_user, as_user_obj):
         raise RestorePermissionDenied(
@@ -178,34 +164,19 @@ def get_restore_user(domain, couch_user, as_user):
     if specified
     :param domain: Domain of restore
     :param couch_user: The couch user attempting authentication
-    :param as_user: a string <user>@<domain> that the couch_user is attempting to get
+    :param as_user: a string username that the couch_user is attempting to get
         a restore user for. If None will get restore of the couch_user.
     :returns: An instance of OTARestoreUser
     """
+    couch_restore_user = couch_user
     restore_user = None
     if as_user is not None:
-        if '@' in as_user:
-            username, user_domain = _parse_restore_as_user(as_user)
-        else:
-            user_domain = None
-        # Likely a mobile worker because username contains domain
-        if domain == user_domain:
-            user = CommCareUser.get_by_username(format_username(username, domain))
-            if not user:
-                return None
-            restore_user = user.to_ota_restore_user()
-        # Likely a web user
-        else:
-            user = WebUser.get_by_username(as_user)
-            if not user:
-                return None
-            elif not user.is_member_of(domain):
-                return None
-            restore_user = user.to_ota_restore_user(domain)
-    elif couch_user.is_commcare_user():
-        restore_user = couch_user.to_ota_restore_user()
-    elif couch_user.is_web_user():
-        restore_user = couch_user.to_ota_restore_user(domain)
+        couch_restore_user = CouchUser.get_by_username(as_user)
+
+    if couch_restore_user.is_commcare_user():
+        restore_user = couch_restore_user.to_ota_restore_user()
+    elif couch_restore_user.is_web_user():
+        restore_user = couch_restore_user.to_ota_restore_user(domain)
 
     return restore_user
 


### PR DESCRIPTION
@czue @wpride removes the ability to use `as=<user>@<domain>`. Requires full username. tested old cloudcare, new cloudcare, and edit forms. i think this simplifies many things

cc: @emord 