### PR TITLE
Fix new report builder drag-and-drop issue

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -82,7 +82,6 @@ var reportBuilder = function () {
             self.refreshPreview(newValue);
             self.saveButton.fire('change');
         });
-        self.selectedColumns.extend({ rateLimit: 50 });
 
         self.reportTypeListLabel = (config['sourceType'] === "case") ? "Case List" : "Form List";
         self.reportTypeAggLabel = (config['sourceType'] === "case") ? "Case Summary" : "Form Summary";

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -275,26 +275,3 @@ var reportBuilder = function () {
     return self;
 
 }();
-
-
-// Copied verbatim from detail-screen-config.js
-// TODO: DRY. Put this in a common place used by both -- COMMCAREHQ?
-ko.bindingHandlers.sortableList = {
-    init: function(element, valueAccessor) {
-        var list = valueAccessor();
-        $(element).sortable({
-            handle: '.grip',
-            cursor: 'move',
-            update: function(event, ui) {
-                var item = ko.dataFor(ui.item.get(0));
-                var position = ko.utils.arrayIndexOf(ui.item.parent().children(), ui.item[0]);
-                if (position >= 0) {
-                    list.remove(item);
-                    list.splice(position, 0, item);  // TODO: Inserts in ViewModel but not in UI!?
-                }
-                ui.item.remove();
-                item.notifyButton();
-            },
-        });
-    },
-};

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -65,10 +65,17 @@
               <th>&nbsp;</th>
             </tr>
           </thead>
-          <tbody data-bind="foreach: selectedColumns, sortableList: selectedColumns">
-            <tr>
+          <tbody data-bind="sortable: {
+                    data: selectedColumns,
+                    afterAdd: function (elem) { $(elem).hide().fadeIn() },
+                    beforeRemove: function (elem) { $(elem).fadeOut() }
+                 }
+            ">
+            <tr data-bind="attr: {'data-order': _sortableOrder}">
               <td>
-                <i class="grip fa fa-arrows-v icon-blue" style="cursor: move"></i>
+                <i class="grip sortable-handle" style="cursor: move;"
+                   data-bind="css: COMMCAREHQ.icons.GRIP + ' hq-icon-full'">
+                </i>
               </td>
               <td data-bind="text: label"></td>
               <td>


### PR DESCRIPTION
(note this is a PR into `nh/new_rb`, not `master`)
@kaapstorm I found the source of the drag-and-drop issue, although I still can't quite explain it. The drag and drop works as expected if we remove the `rateLimit` property from the observable array. Don't know why that makes it work, but I think the rate limit is unnecessary. Did you add rateLimit for a particular reason?

The second commit just uses an existing drag and drop binding (that resides in `style/ko/knockout_bindings.ko.js`) instead of copying the one from `detail-screen-config.js`.

FYI buddies @esoergel @czue 