### PR TITLE
Fix missing rows in report builder preview

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -557,7 +557,6 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             view._lang = "en"
             view._report_config_id = report_config._id
             try:
-                # FIXME: Returning one case of test data, should return two
                 table = view.export_table
             except UserReportsError:
                 # User posted an invalid report configuration

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -854,7 +854,7 @@ class ReportPreview(BaseDomainView):
         if report_data['aggregate']:
             aggregation_columns = [c['column_id'] for c in report_data['columns'] if c['is_group_by_column']]
         else:
-            aggregation_columns = []
+            aggregation_columns = ['doc_id']
         table = ConfigurableReport.report_config_table(
             domain=domain,
             config_id=data_source,


### PR DESCRIPTION
(this is *not* a PR into master)

@kaapstorm looks like the case/form list report previews were always showing just one row. This is due to the not-obvious behavior of UCR that requires an aggregation by `["doc_id"]`, not `[]` to see one row per form/case.
If you were seeing missing rows in other circumstances as well, let me know and I'll see if I can track down the cause.