### PR TITLE
Make search and claim endpoints location safe

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -54,6 +54,7 @@ def restore(request, domain, app_id=None):
     return response
 
 
+@location_safe
 @json_error
 @login_or_digest_or_basic_or_apikey()
 @check_domain_migration
@@ -101,6 +102,7 @@ def search(request, domain):
     return HttpResponse(fixtures, content_type="text/xml")
 
 
+@location_safe
 @csrf_exempt
 @require_POST
 @json_error


### PR DESCRIPTION
Adds location safe decorator to search and claim endpoints. 

There is already messaging when you turn this feature on that you will have access to all the cases in that domain, so I figured we're pretty safe for now. 