### PR TITLE
Remove paranoid selector

### DIFF
--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-advanced-autoload.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-advanced-autoload.xml
@@ -89,7 +89,7 @@
       <stack>
         <push>
           <command value="'m0-f0'"/>
-          <datum id="case_id_usercase" value="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+          <datum id="case_id_usercase" value="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
           <datum id="case_id_new_dugong_0" value="uuid()"/>
           <datum id="return_to" value="'m1'"/>
         </push>
@@ -124,11 +124,11 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
-      <datum id="case_id_usercase" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="case_id_usercase" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
       <datum id="case_id_new_dugong_0" function="uuid()"/>
     </session>
     <assertions>
-      <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]) = 1">
+      <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]) = 1">
         <text>
           <locale id="case_autoload.usercase.case_missing"/>
         </text>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-usercase.xml
@@ -52,7 +52,7 @@
         <push>
           <command value="'m1-f0'"/>
           <datum id="case_id_new_suite_test_0" value="uuid()"/>
-          <datum id="usercase_id" value="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+          <datum id="usercase_id" value="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
           <datum id="return_to" value="'m0'"/>
         </push>
       </stack>
@@ -137,7 +137,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_new_suite_test_0" function="uuid()"/>
-      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
     </session>
     <stack>
       <create if="count(instance('commcaresession')/session/data/return_to) = 1 and instance('commcaresession')/session/data/return_to = 'm0' and count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_new_suite_test_0]) &gt; 0">

--- a/corehq/apps/app_manager/tests/data/case_list_form/target_module_different_datums.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/target_module_different_datums.xml
@@ -9,7 +9,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_new_patient_0" function="uuid()"/>
-      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
     </session>
     <stack>
       <create if="count(instance('commcaresession')/session/data/return_to) = 1 and instance('commcaresession')/session/data/return_to = 'm1' and count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_new_patient_0]) &gt; 0">
@@ -32,7 +32,7 @@
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
       <datum id="case_id_new_visit_0" function="uuid()"/>
-      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
     </session>
   </entry>
   <entry>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-usercase.xml
@@ -9,7 +9,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_new_guppy_0" function="uuid()" />
-      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
     </session>
   </entry>
   <entry>
@@ -22,7 +22,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_new_guppy_0" function="uuid()" />
-      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
     </session>

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-usercase.xml
@@ -9,10 +9,10 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
-      <datum function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id" id="case_id_case_clinic"/>
+      <datum function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id" id="case_id_case_clinic"/>
     </session>
     <assertions>
-      <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]) = 1">
+      <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]) = 1">
         <text>
           <locale id="case_autoload.usercase.case_missing"/>
         </text>

--- a/corehq/apps/app_manager/tests/data/suite/usercase_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite/usercase_entry.xml
@@ -10,7 +10,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
-      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id"/>
+      <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/test_suite_form_filter_errors.py
+++ b/corehq/apps/app_manager/tests/test_suite_form_filter_errors.py
@@ -42,7 +42,7 @@ class FormFilterErrorTests(SimpleTestCase, TestXmlMixin):
             <text>
               <locale id="modules.m0"/>
             </text>
-            <command id="m0-f0" relevant="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/due_date &lt;= today()"/>
+            <command id="m0-f0" relevant="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/due_date &lt;= today()"/>
           </menu>
         </partial>
         """

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -187,7 +187,7 @@ class UserCaseXPath(XPath):
 
     def case(self):
         user_id = session_var(var='userid', path='context')
-        return CaseTypeXpath(USERCASE_TYPE).case().select('hq_user_id', user_id).select_raw(1)
+        return CaseTypeXpath(USERCASE_TYPE).case().select('hq_user_id', user_id)
 
 
 class CaseXPath(XPath):

--- a/scripts/docker
+++ b/scripts/docker
@@ -173,6 +173,8 @@ fi
 export JS_SETUP="${JS_SETUP:-no}"
 export NOSE_DIVIDED_WE_RUN="$NOSE_DIVIDED_WE_RUN"
 export REUSE_DB="$REUSE_DB"
+export TRAVIS_HQ_USERNAME="$TRAVIS_HQ_USERNAME"
+export TRAVIS_HQ_PASSWORD="$TRAVIS_HQ_PASSWORD"
 
 if [ "$TRAVIS" == "true" -o "$DOCKER_HQ_OVERLAY" == "none" ]; then
     # don't mount /mnt/commcare-hq-ro volume read-only on travis


### PR DESCRIPTION
Makes `UserCaseXPath` consistent with user case xpath expressions generated by vellum. I don't think this will have any adverse side effects, but I'd appreciate some review on that assertion. For example, [`xpath_references_case`](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/util.py#L98) uses the user case xpath in a `str.replace()` operation, which I think should still work. I think that's the only place where an expression generated by `UserCaseXPath` is used to match other expressions.

@czue @kaapstorm @snopoke @nickpell 