### PR TITLE
Support Decimal types in eval expression

### DIFF
--- a/corehq/apps/userreports/expressions/utils.py
+++ b/corehq/apps/userreports/expressions/utils.py
@@ -1,6 +1,7 @@
 import copy
 import ast
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 from types import NoneType
 
 from simpleeval import SimpleEval, DEFAULT_OPERATORS, InvalidExpression, DEFAULT_FUNCTIONS
@@ -36,7 +37,7 @@ def eval_statements(statement, variable_context):
     """
     # variable values should be numbers
     var_types = set(type(value) for value in variable_context.values())
-    if not var_types.issubset({int, float, long, date, datetime, NoneType, bool}):
+    if not var_types.issubset({int, float, long, Decimal, date, datetime, NoneType, bool}):
         raise InvalidExpression
 
     evaluator = SimpleEval(operators=SAFE_OPERATORS, names=variable_context, functions=FUNCTIONS)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -867,7 +867,9 @@ def test_add_days_to_date_expression(self, source_doc, count_expression, expecte
             "b": 5
         },
         5 + 2
-    )
+    ),
+    ({}, "a + b", {"a": Decimal(2), "b": Decimal(3)}, Decimal(5)),
+    ({}, "a + b", {"a": Decimal(2.2), "b": Decimal(3.1)}, Decimal(5.3)),
 ])
 def test_valid_eval_expression(self, source_doc, statement, context, expected_value):
     expression = ExpressionFactory.from_spec({
@@ -875,7 +877,8 @@ def test_valid_eval_expression(self, source_doc, statement, context, expected_va
         "statement": statement,
         "context_variables": context
     })
-    self.assertEqual(expression(source_doc), expected_value)
+    # almostEqual handles decimal (im)precision - it means "equal to 7 places"
+    self.assertAlmostEqual(expression(source_doc), expected_value)
 
 
 @generate_cases([


### PR DESCRIPTION
@NoahCarnahan @czue
An expression I was working on returned None when it looked like it should have worked.  These test cases fail without the change.