### PR TITLE
Different environments for web apps and preview

### DIFF
--- a/corehq/apps/cloudcare/const.py
+++ b/corehq/apps/cloudcare/const.py
@@ -1,0 +1,2 @@
+WEB_APPS_ENVIRONMENT = 'web-apps'
+PREVIEW_APP_ENVIRONMENT = 'preview-app'

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -175,6 +175,7 @@ FormplayerFrontend.on("start", function (options) {
     user.domain = options.domain;
     user.formplayer_url = options.formplayer_url;
     user.debuggerEnabled = options.debuggerEnabled;
+    user.environment = options.environment;
     user.restoreAs = FormplayerFrontend.request('restoreAsUser', user.domain, user.username);
 
     savedDisplayOptions = _.pick(

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -92,7 +92,11 @@ Util.getSavedDisplayOptions = function() {
 
 Util.getDisplayOptionsKey = function() {
     var user = FormplayerFrontend.request('currentUser');
-    return user.domain + ':' + user.username + ':' + 'displayOptions';
+    return [
+        user.environment,
+        user.domain,
+        user.username,
+    ].join(':');
 };
 
 Util.CloudcareUrl = function (options) {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -101,6 +101,7 @@
             gridPolyfillPath: "{% static 'css-grid-polyfill-binaries/css-polyfills.js' %}",
             debuggerEnabled: instanceViewerEnabled,
             singleAppMode: {{ single_app_mode|JSON }},
+            environment: {{ environment|JSON }},
         };
         FormplayerFrontend.start(options);
         $(function () {

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -188,6 +188,7 @@
                 phoneMode: true,
                 oneQuestionPerScreen: true,
                 allowedHost: "{{ request.get_host }}",
+                environment: {{ environment|JSON }},
                 {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
                 debuggerEnabled: true,
                 {% endif %}

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -61,6 +61,7 @@ from corehq.apps.cloudcare.decorators import require_cloudcare_access
 from corehq.apps.cloudcare.exceptions import RemoteAppError
 from corehq.apps.cloudcare.models import ApplicationAccess
 from corehq.apps.cloudcare.touchforms_api import BaseSessionDataHelper, CaseSessionDataHelper
+from corehq.apps.cloudcare.const import WEB_APPS_ENVIRONMENT, PREVIEW_APP_ENVIRONMENT
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_digest_ex, domain_admin_required
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.formdetails import readable
@@ -289,6 +290,7 @@ class FormplayerMain(View):
             "formplayer_url": settings.FORMPLAYER_URL,
             "single_app_mode": False,
             "home_url": reverse(self.urlname, args=[domain]),
+            "environment": WEB_APPS_ENVIRONMENT,
         }
         return render(request, "cloudcare/formplayer_home.html", context)
 
@@ -340,6 +342,7 @@ class FormplayerPreviewSingleApp(View):
             "formplayer_url": settings.FORMPLAYER_URL,
             "single_app_mode": True,
             "home_url": reverse(self.urlname, args=[domain, app_id]),
+            "environment": WEB_APPS_ENVIRONMENT,
         }
         return render(request, "cloudcare/formplayer_home.html", context)
 
@@ -354,6 +357,7 @@ class PreviewAppView(TemplateView):
             'app': app,
             'formplayer_url': settings.FORMPLAYER_URL,
             "maps_api_key": settings.GMAPS_API_KEY,
+            "environment": PREVIEW_APP_ENVIRONMENT,
         })
 
 


### PR DESCRIPTION
@biyeun @wpride this ensures that display settings only get saved to the environment they're in. namely OQPS is only set for app preview not both web apps and app preview

cc: @emord 