### PR TITLE
better data dictionary generation

### DIFF
--- a/corehq/apps/data_dictionary/migrations/0005_casetype_fully_generated.py
+++ b/corehq/apps/data_dictionary/migrations/0005_casetype_fully_generated.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_dictionary', '0004_auto_20161130_2125'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='casetype',
+            name='fully_generated',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -14,6 +14,7 @@ class CaseType(models.Model):
     domain = models.CharField(max_length=255, default=None)
     name = models.CharField(max_length=255, default=None)
     description = models.TextField(default='', blank=True)
+    fully_generated = models.BooleanField(default=False)
 
     class Meta:
         unique_together = ('domain', 'name')

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -76,3 +76,11 @@ class GenerateDictionaryTest(TestCase):
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
         self.assertEqual(CaseProperty.objects.filter(case_type__domain=self.domain).count(), 1)
+
+    def test_parent_property(self, mock):
+        mock.return_value = {'type': ['property', 'parent/property']}
+        with self.assertNumQueries(4):
+            generate_data_dictionary(self.domain)
+
+        self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
+        self.assertEqual(CaseProperty.objects.filter(case_type__domain=self.domain).count(), 1)

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -24,7 +24,7 @@ class GenerateDictionaryTest(TestCase):
 
     def test_empty_type(self, mock):
         mock.return_value = {'': ['prop']}
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             generate_data_dictionary(self.domain)
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 0)
@@ -32,7 +32,7 @@ class GenerateDictionaryTest(TestCase):
 
     def test_no_properties(self, mock):
         mock.return_value = {'type': []}
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             generate_data_dictionary(self.domain)
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
@@ -40,7 +40,7 @@ class GenerateDictionaryTest(TestCase):
 
     def test_one_type(self, mock):
         mock.return_value = {'type': ['property']}
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             generate_data_dictionary(self.domain)
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
@@ -48,7 +48,7 @@ class GenerateDictionaryTest(TestCase):
 
     def test_two_types(self, mock):
         mock.return_value = {'type': ['property'], 'type2': ['property']}
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             generate_data_dictionary(self.domain)
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 2)
@@ -56,7 +56,7 @@ class GenerateDictionaryTest(TestCase):
 
     def test_two_properties(self, mock):
         mock.return_value = {'type': ['property', 'property2']}
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             generate_data_dictionary(self.domain)
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
@@ -71,7 +71,7 @@ class GenerateDictionaryTest(TestCase):
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
         self.assertEqual(CaseProperty.objects.filter(case_type__domain=self.domain).count(), 1)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             generate_data_dictionary(self.domain)
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -9,7 +9,7 @@ from corehq.apps.data_dictionary.util import generate_data_dictionary
 
 @patch('corehq.apps.data_dictionary.util._get_all_case_properties')
 class GenerateDictionaryTest(TestCase):
-    domain = uuid.uuid4()
+    domain = uuid.uuid4().hex
 
     def tearDown(self):
         CaseType.objects.filter(domain=self.domain).delete()

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -16,7 +16,7 @@ class UpdateCasePropertyViewTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.domain = create_domain(cls.domain_name)
-        cls.couch_user = WebUser.create(None, "test5", "foobar")
+        cls.couch_user = WebUser.create(None, "test", "foobar")
         cls.couch_user.add_domain_membership(cls.domain_name, is_admin=True)
         cls.couch_user.save()
         cls.case_type_obj = CaseType(name='caseType', domain=cls.domain_name)
@@ -32,7 +32,7 @@ class UpdateCasePropertyViewTest(TestCase):
     def setUp(self):
         self.url = reverse('update_case_property', args=[self.domain_name])
         self.client = Client()
-        self.client.login(username='test5', password='foobar')
+        self.client.login(username='test', password='foobar')
 
     def _get_property(self):
         return CaseProperty.objects.filter(

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -58,7 +58,7 @@ def add_properties_to_data_dictionary(domain, case_type, properties):
     if not properties:
         return
 
-    new_case_properties = _create_properties_for_case_types(domain, {case_type: properties})
+    _create_properties_for_case_types(domain, {case_type: properties})
 
 
 def _create_properties_for_case_types(domain, case_type_to_prop):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -7,6 +7,7 @@ from corehq.apps.export.models.new import CaseExportDataSchema
 def generate_data_dictionary(domain):
     properties = _get_all_case_properties(domain)
     _create_properties_for_case_types(domain, properties)
+    CaseType.objects.filter(domain=domain, name__in=properties.keys()).update(fully_generated=True)
 
 
 def _get_all_case_properties(domain):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -1,4 +1,5 @@
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
+from corehq.apps.app_manager.util import all_case_properties_by_domain
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.export.models.new import CaseExportDataSchema
 
@@ -29,6 +30,9 @@ def generate_data_dictionary(domain):
 
 def _get_all_case_properties(domain):
     case_type_to_properties = {}
+    case_properties_from_apps = all_case_properties_by_domain(
+        domain, include_parent_properties=False
+    )
 
     for case_type in get_case_types_from_apps(domain):
         properties = set()
@@ -41,7 +45,10 @@ def _get_all_case_properties(domain):
                     name = '/'.join([p.name for p in item.path])
                 properties.add(name)
 
-        case_type_to_properties[case_type] = list(properties)
+        case_type_props_from_app = case_properties_from_apps.get(case_type, {})
+        properties |= set(case_type_props_from_app)
+
+        case_type_to_properties[case_type] = properties
 
     return case_type_to_properties
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -1,3 +1,4 @@
+from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.app_manager.util import all_case_properties_by_domain
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
@@ -5,9 +6,12 @@ from corehq.apps.export.models.new import CaseExportDataSchema
 
 
 def generate_data_dictionary(domain):
+    if toggles.OLD_EXPORTS.enabled(domain):
+        return False
     properties = _get_all_case_properties(domain)
     _create_properties_for_case_types(domain, properties)
     CaseType.objects.filter(domain=domain, name__in=properties.keys()).update(fully_generated=True)
+    return True
 
 
 def _get_all_case_properties(domain):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -71,6 +71,8 @@ def _create_properties_for_case_types(domain, case_type_to_prop):
             case_type_obj = CaseType.objects.create(domain=domain, name=case_type)
 
         for prop in props:
+            if '/' in prop:
+                continue
             if (case_type not in current_properties or
                     prop not in current_properties[case_type]):
                 new_case_properties.append(CaseProperty(

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -9,7 +9,7 @@ def generate_data_dictionary(domain):
 
     properties = _get_all_case_properties(domain)
     new_case_properties = []
-    for case_type, properties in properties.items():
+    for case_type, props in properties.items():
         if not case_type:
             continue
 
@@ -18,7 +18,7 @@ def generate_data_dictionary(domain):
         else:
             case_type_obj = CaseType.objects.create(domain=domain, name=case_type)
 
-        for prop in properties:
+        for prop in props:
             if (case_type not in current_properties or
                     prop not in current_properties[case_type]):
                 new_case_properties.append(CaseProperty(

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -5,27 +5,8 @@ from corehq.apps.export.models.new import CaseExportDataSchema
 
 
 def generate_data_dictionary(domain):
-    current_case_types, current_properties = _get_current_case_types_and_properties(domain)
-
     properties = _get_all_case_properties(domain)
-    new_case_properties = []
-    for case_type, props in properties.items():
-        if not case_type:
-            continue
-
-        if case_type in current_case_types:
-            case_type_obj = current_case_types[case_type]
-        else:
-            case_type_obj = CaseType.objects.create(domain=domain, name=case_type)
-
-        for prop in props:
-            if (case_type not in current_properties or
-                    prop not in current_properties[case_type]):
-                new_case_properties.append(CaseProperty(
-                    case_type=case_type_obj, name=prop
-                ))
-
-    CaseProperty.objects.bulk_create(new_case_properties)
+    _create_properties_for_case_types(domain, properties)
 
 
 def _get_all_case_properties(domain):
@@ -69,16 +50,30 @@ def _get_current_case_types_and_properties(domain):
 
 
 def add_properties_to_data_dictionary(domain, case_type, properties):
-    case_type_obj, created = CaseType.objects.get_or_create(domain=domain, name=case_type)
-    if not created:
-        old_properties = set(CaseProperty.objects.filter(case_type=case_type_obj).values_list('name', flat=True))
-    else:
-        old_properties = set()
-    new_properties = []
+    if not properties:
+        return
 
-    for case_property in properties:
-        if case_property not in old_properties:
-            old_properties.add(case_property)
-            new_properties.append(CaseProperty(name=case_property, case_type=case_type_obj))
+    new_case_properties = _create_properties_for_case_types(domain, {case_type: properties})
 
-    CaseProperty.objects.bulk_create(new_properties)
+
+def _create_properties_for_case_types(domain, case_type_to_prop):
+    current_case_types, current_properties = _get_current_case_types_and_properties(domain)
+    new_case_properties = []
+
+    for case_type, props in case_type_to_prop.items():
+        if not case_type:
+            continue
+
+        if case_type in current_case_types:
+            case_type_obj = current_case_types[case_type]
+        else:
+            case_type_obj = CaseType.objects.create(domain=domain, name=case_type)
+
+        for prop in props:
+            if (case_type not in current_properties or
+                    prop not in current_properties[case_type]):
+                new_case_properties.append(CaseProperty(
+                    case_type=case_type_obj, name=prop
+                ))
+
+    CaseProperty.objects.bulk_create(new_case_properties)

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -18,7 +18,10 @@ from corehq.tabs.tabclasses import ApplicationsTab
 @login_and_domain_required
 @toggles.DATA_DICTIONARY.required_decorator()
 def generate_data_dictionary(request, domain):
-    util.generate_data_dictionary(domain)
+    if not util.generate_data_dictionary(domain):
+        return JsonResponse({
+            "failed": "Data Dictionary requires access to new exports"
+        }, status=400)
     return JsonResponse({"status": "success"})
 
 

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -18,10 +18,13 @@ from corehq.tabs.tabclasses import ApplicationsTab
 @login_and_domain_required
 @toggles.DATA_DICTIONARY.required_decorator()
 def generate_data_dictionary(request, domain):
-    if not util.generate_data_dictionary(domain):
+    try:
+        util.generate_data_dictionary(domain)
+    except util.OldExportsEnabledException:
         return JsonResponse({
             "failed": "Data Dictionary requires access to new exports"
         }, status=400)
+
     return JsonResponse({"status": "success"})
 
 

--- a/corehq/apps/export/tests/test_add_inferred_export_properties.py
+++ b/corehq/apps/export/tests/test_add_inferred_export_properties.py
@@ -17,8 +17,7 @@ class InferredSchemaSignalTest(TestCase):
         caches['locmem'].clear()
         caches['default'].clear()
 
-    def _add_props(self, props, num_queries=5):
-        # should be 3, but the transaction in tests adds two when creating a case type
+    def _add_props(self, props, num_queries=3):
         with self.assertNumQueries(num_queries):
             add_inferred_export_properties(
                 'TestSend',
@@ -47,7 +46,7 @@ class InferredSchemaSignalTest(TestCase):
         props_two = set(['one', 'three'])
         combined_props = props | props_two
         self._add_props(props)
-        self._add_props(props_two, 3)
+        self._add_props(props_two)
 
         schema = get_inferred_schema(self.domain, self.case_type)
         group_schema = schema.group_schemas[0]


### PR DESCRIPTION
Improvements on generating the data dictionary. Now includes the current app's case properties and marks a data dictionary as "fully generated" if it's been generated from the export. That will be eventually removed once all domains are converted, but some non-"fully generated" domains currently have case properties from the inferred property task

buddy @proteusvacuum :fish: 