### PR TITLE
fix format

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -634,6 +634,6 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
             reports = _get_report_builder_reports(project)
             if reports:
                 return _fmt_alert(_(
-                    "You have %(number_of_reports) report builder reports."
+                    "You have %(number_of_reports)d report builder reports."
                     "By selecting this plan you will lose access to those reports."
                 ) % {'number_of_reports': len(reports)})


### PR DESCRIPTION
@esoergel how do you mark a translation as wrong. I think that this one was translated incorrectly.

Search https://raw.githubusercontent.com/dimagi/commcare-hq/je/fix-format/locale/es/LC_MESSAGES/django.po for "corehq/apps/accounting/subscription_changes.py:637" The translator left out `number_of_reports`

buddy @proteusvacuum 