### PR TITLE
Serialize named tuple as dict

### DIFF
--- a/corehq/ex-submodules/soil/util.py
+++ b/corehq/ex-submodules/soil/util.py
@@ -52,7 +52,7 @@ def get_download_context(download_id, message=None, require_result=False):
         'error': task_status.error,
         'is_ready': is_ready,
         'is_alive': is_alive() if heartbeat_enabled() else True,
-        'progress': task_status.progress,
+        'progress': task_status.progress._asdict(),
         'download_id': download_id,
         'allow_dropbox_sync': isinstance(download_data, FileDownload) and download_data.use_transfer,
         'has_file': download_data is not None and download_data.has_file,


### PR DESCRIPTION
@dannyroberts the soil change broke progress bars on exports because it changed the datatype of `progress`. A namedtuple when serialized returns an array while on the frontend we expect it to be a dictionary. i'm assuming this'll probably break the case import progress bar. going to take a look at that quickly (should be easy to fix)
http://manage.dimagi.com/default.asp?243918

cc: @millerdev 