### PR TITLE
Label questions for data schema

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -900,6 +900,11 @@ class XForm(WrappedNode):
 
         if the xform is bad, it will raise an XFormException
 
+        :param include_triggers: When set to True will return label questions as well as regular questions
+        :param include_groups: When set will return repeats and group questions
+        :param include_translations: When set to True will return all the translations for the question
+        :param form: When included adds a hashtagValue to the dict returned
+
         """
 
         if not self.exists():

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -14,7 +14,7 @@ from corehq.apps.export.transforms import (
 
 # When fixing a bug that requires existing schemas to be rebuilt,
 # bump the version number.
-DATA_SCHEMA_VERSION = 6
+DATA_SCHEMA_VERSION = 7
 
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -25,6 +25,7 @@ from .new import (
     InferredExportGroupSchema,
     ExportGroupSchema,
     TableConfiguration,
+    LabelItem,
     ScalarItem,
     GeopointItem,
     CaseIndexItem,

--- a/corehq/apps/export/tests/data/form_with_labels.xml
+++ b/corehq/apps/export/tests/data/form_with_labels.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Block on label</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/27D0F1C6-20C4-499C-84D8-B73B868AE5CE" uiVersion="1" version="1" name="Block on label">
+					<label />
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/label" nodeset="/data/label" />
+			<itext>
+				<translation lang="en" default="" />
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<trigger vellum:ref="#form/label" ref="/data/label" appearance="minimal" />
+	</h:body>
+</h:html>

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -20,6 +20,7 @@ from corehq.apps.export.models import (
     InferredSchema,
     ExportGroupSchema,
     ExportItem,
+    LabelItem,
     PARENT_CASE_TABLE,
 )
 from corehq.apps.export.const import KNOWN_CASE_PROPERTIES
@@ -51,6 +52,25 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
         form_items = filter(lambda item: item.tag is None, group_schema.items)
         self.assertEqual(form_items[0].path, [PathNode(name='form'), PathNode(name='question1')])
         self.assertEqual(form_items[1].path, [PathNode(name='form'), PathNode(name='question2')])
+
+    def test_labels_in_xform(self):
+        form_xml = self.get_xml('form_with_labels')
+
+        schema = FormExportDataSchema._generate_schema_from_xform(
+            XForm(form_xml),
+            [],
+            ['en'],
+            self.app_id,
+            1
+        )
+
+        self.assertEqual(len(schema.group_schemas), 1)
+
+        group_schema = schema.group_schemas[0]
+
+        self.assertEqual(len(group_schema.items), 1)
+        self.assertEqual(group_schema.items[0].path, [PathNode(name='form'), PathNode(name='label')])
+        self.assertIsInstance(group_schema.items[0], LabelItem)
 
     def test_xform_parsing_with_repeat_group(self):
         form_xml = self.get_xml('repeat_group_form')


### PR DESCRIPTION
@czue @NoahCarnahan this adds label questions to the export schema. One thing to note about this is that i've implemented this with labels being a different `ExportItem` (`LabelItem`). This means that if you reuse your label id, you will have two columns in your export. i figured you didn't want to mix label data, which is all `"OK"`, with real question data. if you think that's confusing though let me know. it would look like this:

<img width="1142" alt="screen shot 2016-12-14 at 12 39 05 pm" src="https://cloud.githubusercontent.com/assets/918514/21195067/26bd51a2-c200-11e6-99d1-74b29ec202a0.png">

it's similar to how if you change a multiple choice question to a text question but keep the same id. it will show up as two columns on the export page.

cc: @millerdev 