### PR TITLE
Fix TermsAggregation sorting

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -205,7 +205,7 @@ class TermsAggregation(Aggregation):
     type = "terms"
     result_class = BucketResult
 
-    def __init__(self, name, field, size=None, sort_field=None, order="asc"):
+    def __init__(self, name, field, size=None):
         assert re.match(r'\w+$', name), \
             "Names must be valid python variable names, was {}".format(name)
         self.name = name
@@ -213,10 +213,8 @@ class TermsAggregation(Aggregation):
             "field": field,
             "size": size if size is not None else SIZE_LIMIT,
         }
-        if sort_field:
-            self.body['order'] = [{sort_field: order}]
 
-    def order(self, field, order="desc", reset=True):
+    def order(self, field, order="asc", reset=True):
         query = deepcopy(self)
         order_field = {field: order}
 

--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -205,7 +205,7 @@ class TermsAggregation(Aggregation):
     type = "terms"
     result_class = BucketResult
 
-    def __init__(self, name, field, size=None, sort_field=None, order="desc"):
+    def __init__(self, name, field, size=None, sort_field=None, order="asc"):
         assert re.match(r'\w+$', name), \
             "Names must be valid python variable names, was {}".format(name)
         self.name = name
@@ -214,7 +214,7 @@ class TermsAggregation(Aggregation):
             "size": size if size is not None else SIZE_LIMIT,
         }
         if sort_field:
-            self.order(sort_field, order)
+            self.body['order'] = [{sort_field: order}]
 
     def order(self, field, order="desc", reset=True):
         query = deepcopy(self)

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -273,7 +273,10 @@ class ESQuery(object):
         return query
 
     def terms_aggregation(self, term, name, size=None, sort_field=None, order="asc"):
-        return self.aggregation(aggregations.TermsAggregation(name, term, size=size, sort_field=sort_field, order=order))
+        agg = aggregations.TermsAggregation(name, term, size=size)
+        if sort_field:
+            agg = agg.order(sort_field, order)
+        return self.aggregation(agg)
 
     def date_histogram(self, name, datefield, interval, timezone=None):
         return self.aggregation(aggregations.DateHistogram(name, datefield, interval, timezone=timezone))

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -272,7 +272,7 @@ class ESQuery(object):
         query._aggregations.extend(aggregations)
         return query
 
-    def terms_aggregation(self, term, name, size=None, sort_field=None, order="desc"):
+    def terms_aggregation(self, term, name, size=None, sort_field=None, order="asc"):
         return self.aggregation(aggregations.TermsAggregation(name, term, size=size, sort_field=sort_field, order=order))
 
     def date_histogram(self, name, datefield, interval, timezone=None):

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -449,3 +449,33 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
             inner_most_aggregation=SumAggregation('balance', 'balance')
         ).query
         self.checkQuery(query, json_output)
+
+    def test_terms_aggregation_with_order(self):
+        json_output = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {"match_all": {}}
+                        ]
+                    },
+                    "query": {"match_all": {}}
+                }
+            },
+            "aggs": {
+                "name": {
+                    "terms": {
+                        "field": "name",
+                        "size": 1000000,
+                        "order": [{
+                            "sort_field": "asc"
+                        }]
+                    },
+                },
+            },
+            "size": SIZE_LIMIT
+        }
+        query = HQESQuery('cases').aggregation(
+            TermsAggregation('name', 'name', sort_field="sort_field")
+        )
+        self.checkQuery(query, json_output)

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -476,6 +476,6 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
             "size": SIZE_LIMIT
         }
         query = HQESQuery('cases').aggregation(
-            TermsAggregation('name', 'name', sort_field="sort_field")
+            TermsAggregation('name', 'name').order('sort_field')
         )
         self.checkQuery(query, json_output)


### PR DESCRIPTION
Found this while looking at UCR errors. `self = self.order(sort_field, order)` doesn't work here, so just totally moved it to the helper.

I also changed default from `desc` to `asc` because that's default in SQL and it's only used in one place for UCRs

buddy @proteusvacuum 