### PR TITLE
Add model id to resource not found

### DIFF
--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -130,8 +130,12 @@ class BlobMixin(Document):
                 raise NotFound
             blob = db.get(meta.id, self._blobdb_bucket())
         except NotFound:
-            raise ResourceNotFound(u"{model} attachment: {name!r}".format(
-                                   model=type(self).__name__, name=name))
+            raise ResourceNotFound(
+                u"{model} {model_id} attachment: {name!r}".format(
+                    model=type(self).__name__,
+                    name=name,
+                    model_id=self._id,
+                ))
         if stream:
             return blob
 

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -5,10 +5,10 @@ from base64 import b64encode
 from copy import deepcopy
 from hashlib import md5
 from os.path import join
-from unittest import TestCase
 from StringIO import StringIO
 
 from django.conf import settings
+from django.test import SimpleTestCase
 
 import corehq.blobs.mixin as mod
 from corehq.blobs import DEFAULT_BUCKET
@@ -19,7 +19,7 @@ from corehq.util.test_utils import generate_cases, trap_extra_setup
 from dimagi.ext.couchdbkit import Document
 
 
-class BaseTestCase(TestCase):
+class BaseTestCase(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -580,7 +580,7 @@ class TestBlobHelper(BaseTestCase):
             "external_blobs": {"not-found.txt": {"id": "hahaha"}},
         }, couch)
         self.assertFalse(obj.migrating_blobs_from_couch)
-        with self.assertRaises(mod.ResourceNotFound):
+        with self.assertRaisesMessage(mod.ResourceNotFound, '{} attachment'.format(obj._id)):
             obj.fetch_attachment("not-found.txt")
 
     def test_fetch_attachment_not_found_while_migrating(self):
@@ -590,7 +590,7 @@ class TestBlobHelper(BaseTestCase):
             "external_blobs": {"not-found.txt": {"id": "nope"}},
         }, self.couch)
         self.assertTrue(obj.migrating_blobs_from_couch)
-        with self.assertRaises(mod.ResourceNotFound):
+        with self.assertRaisesMessage(mod.ResourceNotFound, '{} attachment'.format(obj._id)):
             obj.fetch_attachment("not-found.txt")
 
     def test_put_and_fetch_attachment_from_blob_db(self):

--- a/corehq/blobs/tests/test_pillow.py
+++ b/corehq/blobs/tests/test_pillow.py
@@ -16,7 +16,7 @@ class TestBlobDeletionProcessor(BaseTestCase):
         self.obj.put_attachment("content", "name")
         change = Config(id=self.obj._id, deleted=True)
         self.processor.process_change(None, change)
-        msg = "FakeCouchDocument attachment: 'name'"
+        msg = "FakeCouchDocument {} attachment: 'name'".format(self.obj._id)
         with assert_raises(ResourceNotFound, msg=msg):
             self.obj.fetch_attachment("name")
 


### PR DESCRIPTION
@millerdev am i right in assuming that `self._id` will always be available? it seems like that would be the case, but perhaps there's an edge case where you try and fetch an attachment before the model has been saved? adding this because it's hard to track down the id of a model that throws a resourcenotfound: http://manage.dimagi.com/default.asp?244019