### PR TITLE
Enable and test label conversion in migrations

### DIFF
--- a/corehq/apps/export/tests/data/saved_export_schemas/basic_label.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/basic_label.json
@@ -1,0 +1,46 @@
+{
+   "_id": "a28d333f56bd9df737e75a6844d3d748",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Tester",
+   "index": "[\"aspace\", \"my_sweet_xmlns\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "app_id": "58b0156dc3a8420669efb286bc81e048",
+   "schema_id": "a28d333f56bd9df737e75a6844b54b36",
+   "split_multiselects": false,
+   "tables": [
+       {
+           "index": "#",
+           "doc_type": "ExportTable",
+           "order": [
+           ],
+           "columns": [
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               },
+               {
+                   "index": "form.label",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "My Label"
+               }
+           ],
+           "display": "My Forms"
+       }
+   ],
+   "include_errors": false,
+   "default_format": "csv",
+   "type": "form",
+   "is_safe": false
+}
+

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -18,6 +18,7 @@ from corehq.apps.export.models import (
     UserDefinedExportColumn,
     ExportItem,
     StockItem,
+    LabelItem,
     FormExportInstance,
     CaseExportInstance,
     MAIN_TABLE,
@@ -426,6 +427,11 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestConvertBase):
                             label='Question 1',
                             last_occurrences={cls.app_id: 3},
                         ),
+                        LabelItem(
+                            path=[PathNode(name='form'), PathNode(name='label')],
+                            label='label',
+                            last_occurrences={cls.app_id: 3},
+                        ),
                     ],
                     last_occurrences={cls.app_id: 3},
                 ),
@@ -486,6 +492,18 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestConvertBase):
             None,
         )
         self.assertEqual(column.label, 'Question One')
+        self.assertEqual(column.selected, True)
+
+    def test_label_conversion(self, _, __):
+        instance, _ = self._convert_form_export('basic_label')
+
+        table = instance.get_table(MAIN_TABLE)
+        index, column = table.get_column(
+            [PathNode(name='form'), PathNode(name='label')],
+            'LabelItem',
+            None,
+        )
+        self.assertEqual(column.label, 'My Label')
         self.assertEqual(column.selected, True)
 
     def test_conversion_with_text_nodes(self, _, __):

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -511,6 +511,7 @@ def _get_normal_column(new_table, column_path, transform):
         'MultipleChoiceItem',
         'GeopointItem',
         'MultiMediaItem',
+        'LabelItem',
         'ExportItem',
     ]
     # Since old exports had no concept of item type, we just guess all


### PR DESCRIPTION
@czue @NoahCarnahan enables labels to be migrated during export conversion

cc: @millerdev 