### PR TITLE
Repeat child cases in exports

### DIFF
--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -174,7 +174,7 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
 
     def test_get_questions(self):
         form = self.app.get_form(self.form_unique_id)
-        questions = form.wrapped_xform().get_questions(['en', 'es'], include_translations=True, form=form)
+        questions = form.wrapped_xform().get_questions(['en', 'es'], include_translations=True)
 
         non_label_questions = [
             q for q in QUESTIONS if q['tag'] not in ('label', 'trigger')]
@@ -184,7 +184,7 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
     def test_get_questions_with_triggers(self):
         form = self.app.get_form(self.form_unique_id)
         questions = form.wrapped_xform().get_questions(
-            ['en', 'es'], include_triggers=True, include_translations=True, form=form)
+            ['en', 'es'], include_triggers=True, include_translations=True)
 
         self.assertEqual(questions, QUESTIONS)
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -477,7 +477,7 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
             )
 
         try:
-            xform_questions = xform.get_questions(langs, include_triggers=True, form=form)
+            xform_questions = xform.get_questions(langs, include_triggers=True)
             form.validate_form()
         except etree.XMLSyntaxError as e:
             form_errors.append(u"Syntax Error: %s" % e)

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -903,8 +903,6 @@ class XForm(WrappedNode):
         :param include_triggers: When set to True will return label questions as well as regular questions
         :param include_groups: When set will return repeats and group questions
         :param include_translations: When set to True will return all the translations for the question
-        :param form: When included adds a hashtagValue to the dict returned
-
         """
 
         if not self.exists():
@@ -916,7 +914,6 @@ class XForm(WrappedNode):
 
         control_nodes = self.get_control_nodes()
         leaf_data_nodes = self.get_leaf_data_nodes()
-        use_hashtags = not not form
 
         for node, path, repeat, group, items, is_leaf, data_type, relevant, required in control_nodes:
             excluded_paths.add(path)
@@ -940,9 +937,6 @@ class XForm(WrappedNode):
                 "required": required == "true()",
                 "comment": self._get_comment(leaf_data_nodes, path),
             }
-            if use_hashtags:
-                question.update({"hashtagValue": self.hashtag_path(path)})
-
             if include_translations:
                 question["translations"] = self.get_label_translations(node, langs)
 
@@ -998,16 +992,12 @@ class XForm(WrappedNode):
                                 "stock_type_attributes": dict(parent.attrib),
                             })
 
-                if use_hashtags:
-                    hashtag_path = self.hashtag_path(path)
-                    question.update({
-                        "label": hashtag_path,
-                        "hashtagValue": hashtag_path,
-                    })
-                else:
-                    question.update({
-                        "label": path,
-                    })
+                hashtag_path = self.hashtag_path(path)
+                question.update({
+                    "label": hashtag_path,
+                    "hashtagValue": hashtag_path,
+                })
+
                 if include_translations:
                     question["translations"] = {}
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -936,6 +936,7 @@ class XForm(WrappedNode):
                 "relevant": relevant,
                 "required": required == "true()",
                 "comment": self._get_comment(leaf_data_nodes, path),
+                "hashtagValue": self.hashtag_path(path),
             }
             if include_translations:
                 question["translations"] = self.get_label_translations(node, langs)

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -14,7 +14,8 @@ from corehq.apps.export.transforms import (
 
 # When fixing a bug that requires existing schemas to be rebuilt,
 # bump the version number.
-DATA_SCHEMA_VERSION = 7
+FORM_DATA_SCHEMA_VERSION = 8
+CASE_DATA_SCHEMA_VERSION = 7
 
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -52,6 +52,18 @@ PROPERTY_TAG_STOCK = 'stock'
 # This list comes from casexml.apps.case.xml.parser.CaseActionBase.from_v2
 KNOWN_CASE_PROPERTIES = ["type", "name", "external_id", "user_id", "owner_id", "opened_on"]
 
+# Attributes found on a case block. <case case_id="..." date_modified="..." ...>
+CASE_ATTRIBUTES = ['@case_id', '@date_modified', '@user_id']
+
+# Elements that are found in a case create block
+# <case>
+#   <create>
+#       <case_name>
+#       ...
+#   </create>
+# </case>
+CASE_CREATE_ELEMENTS = ['case_name', 'owner_id', 'case_type']
+
 FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
 MAX_EXPORTABLE_ROWS = 100000

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1311,7 +1311,7 @@ class FormExportDataSchema(ExportDataSchema):
                 #
                 # /data/repeat/other_group/question
                 #
-                # We want to currate a path that looks like:
+                # We want to create a path that looks like:
                 #
                 # /data/repeat/case/update/other_group/question
                 path_suffix = case_path[len(subcase_action.repeat_context):]

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -53,7 +53,8 @@ from corehq.apps.export.const import (
     PROPERTY_TAG_CASE,
     USER_DEFINED_SPLIT_TYPES,
     PLAIN_USER_DEFINED_SPLIT_TYPE,
-    DATA_SCHEMA_VERSION,
+    CASE_DATA_SCHEMA_VERSION,
+    FORM_DATA_SCHEMA_VERSION,
     MISSING_VALUE,
     EMPTY_VALUE,
     KNOWN_CASE_PROPERTIES,
@@ -1060,7 +1061,7 @@ class ExportDataSchema(Document):
         current_schema = cls.get_latest_export_schema(domain, app_id, identifier)
         if (current_schema
                 and not force_rebuild
-                and current_schema.version == DATA_SCHEMA_VERSION):
+                and current_schema.version == cls.schema_version()):
             original_id, original_rev = current_schema._id, current_schema._rev
         else:
             current_schema = cls()
@@ -1095,7 +1096,7 @@ class ExportDataSchema(Document):
 
         current_schema.domain = domain
         current_schema.app_id = app_id
-        current_schema.version = DATA_SCHEMA_VERSION
+        current_schema.version = cls.schema_version()
         current_schema._set_identifier(identifier)
 
         current_schema = cls._save_export_schema(
@@ -1209,6 +1210,10 @@ class FormExportDataSchema(ExportDataSchema):
     @property
     def type(self):
         return FORM_EXPORT
+
+    @classmethod
+    def schema_version(cls):
+        return FORM_DATA_SCHEMA_VERSION
 
     @classmethod
     def _get_inferred_schema(cls, domain, xmlns):
@@ -1431,6 +1436,10 @@ class CaseExportDataSchema(ExportDataSchema):
 
     def _set_identifier(self, case_type):
         self.case_type = case_type
+
+    @classmethod
+    def schema_version(cls):
+        return CASE_DATA_SCHEMA_VERSION
 
     @classmethod
     def _get_inferred_schema(cls, domain, case_type):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1261,7 +1261,10 @@ class FormExportDataSchema(ExportDataSchema):
         if repeats_with_subcases:
             repeat_case_schema = FormExportDataSchema._generate_schema_from_repeat_subcases(
                 xform,
-                repeats_with_subcases
+                repeats_with_subcases,
+                app.langs,
+                app.copy_of or app._id,  # If it's not a copy, must be current
+                app.version,
             )
             schemas.append(repeat_case_schema)
 

--- a/corehq/apps/export/tests/data/nested_repeat_form.xml
+++ b/corehq/apps/export/tests/data/nested_repeat_form.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Mother</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E011B809-6A4D-4F91-8586-6ACC0522BFD8" uiVersion="1" version="1" name="Mother">
+					<child jr:template="">
+						<weight>
+							<name />
+						</weight>
+						<age />
+						<grand_child jr:template="">
+							<age />
+						</grand_child>
+					</child>
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/child" nodeset="/data/child" />
+			<bind vellum:nodeset="#form/child/weight" nodeset="/data/child/weight" />
+			<bind vellum:nodeset="#form/child/weight/name" nodeset="/data/child/weight/name" type="xsd:string" />
+			<bind vellum:nodeset="#form/child/age" nodeset="/data/child/age" type="xsd:int" />
+			<bind vellum:nodeset="#form/child/grand_child" nodeset="/data/child/grand_child" />
+			<bind vellum:nodeset="#form/child/grand_child/age" nodeset="/data/child/grand_child/age" type="xsd:string" />
+			<itext>
+				<translation lang="en" default="" />
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<group>
+			<repeat vellum:nodeset="#form/child" nodeset="/data/child">
+				<group vellum:ref="#form/child/weight" ref="/data/child/weight">
+					<input vellum:ref="#form/child/weight/name" ref="/data/child/weight/name" />
+				</group>
+				<input vellum:ref="#form/child/age" ref="/data/child/age" />
+				<group>
+					<repeat vellum:nodeset="#form/child/grand_child" nodeset="/data/child/grand_child">
+						<input vellum:ref="#form/child/grand_child/age" ref="/data/child/grand_child/age" />
+					</repeat>
+				</group>
+			</repeat>
+		</group>
+	</h:body>
+</h:html>

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -8,7 +8,7 @@ from corehq.apps.export.models.new import MAIN_TABLE, \
 
 from corehq.util.context_managers import drop_connected_signals
 from corehq.apps.app_manager.tests.util import TestXmlMixin
-from corehq.apps.app_manager.models import XForm, Application
+from corehq.apps.app_manager.models import XForm, Application, OpenSubCaseAction
 from corehq.apps.app_manager.signals import app_post_save
 from corehq.apps.export.dbaccessors import delete_all_export_data_schemas, delete_all_inferred_schemas
 from corehq.apps.export.tasks import add_inferred_export_properties
@@ -23,8 +23,13 @@ from corehq.apps.export.models import (
     LabelItem,
     PARENT_CASE_TABLE,
 )
-from corehq.apps.export.const import KNOWN_CASE_PROPERTIES
-from corehq.apps.export.const import PROPERTY_TAG_UPDATE, DATA_SCHEMA_VERSION
+from corehq.apps.export.const import (
+    KNOWN_CASE_PROPERTIES,
+    PROPERTY_TAG_UPDATE,
+    DATA_SCHEMA_VERSION,
+    CASE_ATTRIBUTES,
+    CASE_CREATE_ELEMENTS,
+)
 
 
 class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
@@ -124,6 +129,53 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
         self.assertEqual(form_items[1].path, [PathNode(name='form'), PathNode(name='question2')])
         self.assertEqual(form_items[1].options[0].value, 'choice1')
         self.assertEqual(form_items[1].options[1].value, 'choice2')
+
+    def test_repeat_subcases_schema_generation(self):
+        form_xml = self.get_xml('nested_repeat_form')
+        repeats_with_subcases = [
+            OpenSubCaseAction(
+                repeat_context='/data/repeat',
+                case_properties={
+                    'weight': '/data/repeat/group/weight',
+                }
+            ),
+            OpenSubCaseAction(
+                repeat_context='/data/repeat/nested_repeat',
+                case_properties={
+                    'age': '/data/repeat/nested_repeat/age',
+                }
+            ),
+        ]
+
+        schema = FormExportDataSchema._generate_schema_from_repeat_subcases(
+            XForm(form_xml),
+            repeats_with_subcases,
+            ['en'],
+            self.app_id,
+            1,
+        )
+
+        self.assertEqual(len(schema.group_schemas), 2)
+
+        group_schema = schema.group_schemas[0]
+        attribute_items = filter(lambda item: item.path[-1].name in CASE_ATTRIBUTES, group_schema.items)
+
+        self.assertEqual(len(attribute_items), len(CASE_ATTRIBUTES))
+        self.assertTrue(all(map(
+            lambda item: item.readable_path.startswith('form.repeat.case'),
+            attribute_items,
+        )))
+
+        create_items = filter(lambda item: item.path[-1].name in CASE_CREATE_ELEMENTS, group_schema.items)
+        self.assertEqual(len(create_items), len(CASE_CREATE_ELEMENTS))
+        self.assertTrue(all(map(
+            lambda item: item.readable_path.startswith('form.repeat.case.create'),
+            create_items,
+        )))
+
+        update_items = list(set(group_schema.items) - set(create_items) - set(attribute_items))
+        self.assertEqual(len(update_items), 1)
+        self.assertEqual(update_items[0].readable_path, 'form.repeat.case.update.group.weight')
 
     def test_xform_parsing_with_stock_questions(self):
         form_xml = self.get_xml('stock_form')

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -26,7 +26,7 @@ from corehq.apps.export.models import (
 from corehq.apps.export.const import (
     KNOWN_CASE_PROPERTIES,
     PROPERTY_TAG_UPDATE,
-    DATA_SCHEMA_VERSION,
+    FORM_DATA_SCHEMA_VERSION,
     CASE_ATTRIBUTES,
     CASE_CREATE_ELEMENTS,
 )
@@ -673,16 +673,16 @@ class TestExportDataSchemaVersionControl(TestCase, TestXmlMixin):
         self.assertEqual(schema._id, existing_schema._id)
 
         with patch(
-                'corehq.apps.export.models.new.DATA_SCHEMA_VERSION',
-                DATA_SCHEMA_VERSION + 1):
+                'corehq.apps.export.models.new.FORM_DATA_SCHEMA_VERSION',
+                FORM_DATA_SCHEMA_VERSION + 1):
             rebuilt_schema = FormExportDataSchema.generate_schema_from_builds(
                 app.domain,
                 app._id,
                 'my_sweet_xmlns'
             )
         self.assertNotEqual(schema._id, rebuilt_schema._id)
-        self.assertEqual(schema.version, DATA_SCHEMA_VERSION)
-        self.assertEqual(rebuilt_schema.version, DATA_SCHEMA_VERSION + 1)
+        self.assertEqual(schema.version, FORM_DATA_SCHEMA_VERSION)
+        self.assertEqual(rebuilt_schema.version, FORM_DATA_SCHEMA_VERSION + 1)
 
 
 class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):

--- a/corehq/apps/reports/tests/readable_forms/mismatched_group_hierarchy.result.yaml
+++ b/corehq/apps/reports/tests/readable_forms/mismatched_group_hierarchy.result.yaml
@@ -1,6 +1,7 @@
 - calculate: null
   comment: null
   group: null
+  hashtagValue: '#form/need_facility_trigger'
   label: You first need to log a facility before you can record information.
   options:
   - {label: Go back and exit form, value: exit_form}
@@ -16,6 +17,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/current_site_confirm'
     label: 'Registering birth at facility: ____ (____)'
     options:
     - {label: 'Yes', value: '1'}
@@ -27,15 +29,16 @@
     tag: select1
     type: Select
     value: /data/current_site_confirm
-  - {calculate: null, comment: null, group: /data/whole_form, label: Yearly Number,
-    relevant: null, repeat: null, required: true, response: '7', tag: input, type: Int,
-    value: /data/fada_yearly_number}
-  - {calculate: null, comment: null, group: /data/whole_form, label: Monthly Number,
-    relevant: null, repeat: null, required: true, response: '36', tag: input, type: Int,
-    value: /data/fada_monthly_number}
+  - {calculate: null, comment: null, group: /data/whole_form, hashtagValue: '#form/fada_yearly_number',
+    label: Yearly Number, relevant: null, repeat: null, required: true, response: '7',
+    tag: input, type: Int, value: /data/fada_yearly_number}
+  - {calculate: null, comment: null, group: /data/whole_form, hashtagValue: '#form/fada_monthly_number',
+    label: Monthly Number, relevant: null, repeat: null, required: true, response: '36',
+    tag: input, type: Int, value: /data/fada_monthly_number}
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/already_registered'
     label: "A patient with this ID (____) has already been registered.\_ Are you sure\
       \ the entered information is correct?"
     options:
@@ -49,12 +52,13 @@
     tag: select1
     type: Select
     value: /data/already_registered
-  - {calculate: null, comment: null, group: /data/whole_form, label: Date of Admission,
-    relevant: null, repeat: null, required: true, response: '2014-01-01', tag: input,
-    type: Date, value: /data/fada_date_admission}
+  - {calculate: null, comment: null, group: /data/whole_form, hashtagValue: '#form/fada_date_admission',
+    label: Date of Admission, relevant: null, repeat: null, required: true, response: '2014-01-01',
+    tag: input, type: Date, value: /data/fada_date_admission}
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_observation_points_observed'
     label: 'Observation Points Observed:'
     options:
     - {label: '1', value: '1'}
@@ -71,6 +75,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_mother_referred'
     label: Was the mother referred out at any point during your observation?
     options:
     - {label: Yes before delivery, value: '2'}
@@ -86,6 +91,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_maternal_death'
     label: Was there a maternal death at any point during your observation?
     options:
     - {label: 'Yes', value: '1'}
@@ -100,6 +106,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_stillbirth_neonatal_death'
     label: 'Was there a stillbirth or neonatal death any point during your observation? '
     options:
     - {label: 'Yes', value: '1'}
@@ -114,6 +121,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_csection'
     label: Was a cesarean section performed?
     options:
     - {label: 'Yes', value: '1'}
@@ -128,6 +136,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_healthworker_assent'
     label: Did health care worker assent to observation?
     options:
     - {label: 'Yes', value: '1'}
@@ -144,6 +153,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_assisted_by_obv1'
       label: ' Assisted with woman''s care (check all that apply)'
       options:
       - {label: Doctor, value: '1'}
@@ -160,6 +170,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_maternal_temp'
       label: Maternal temperature obtained?
       options:
       - {label: 'Yes', value: '1'}
@@ -174,6 +185,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_maternal_bp'
       label: Maternal blood pressure obtained?
       options:
       - {label: 'Yes', value: '1'}
@@ -188,6 +200,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_partograph'
       label: Was partograph started?
       options:
       - {label: 'Yes', value: '1'}
@@ -202,6 +215,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_checklist_picked_up_obv1'
       label: Was the paper checklist picked up during care ?
       options:
       - {label: 'Yes', value: '1'}
@@ -216,6 +230,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_checklist_used_after_care_obv1'
       label: Was the paper checklist picked up after the care was given?
       options:
       - {label: 'Yes', value: '1'}
@@ -230,6 +245,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_checklist_poster_used_obv1'
       label: Was the checklist poster observed during care?
       options:
       - {label: 'Yes', value: 'yes'}
@@ -244,6 +260,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv1
+      hashtagValue: '#form/fada_obv1/fada_birth_companion_present_obv1'
       label: Was a birth companion present?
       options:
       - {label: 'Yes', value: '1'}
@@ -257,6 +274,7 @@
       value: /data/fada_obv1/fada_birth_companion_present_obv1
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_obv1'
     label: 1. On Admission
     relevant: selected(/data/fada_observation_points_observed, '1')
     repeat: null
@@ -270,6 +288,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_assisted_by_obv2'
       label: ' Assisted with woman''s care (check all that apply)'
       options:
       - {label: Doctor, value: '1'}
@@ -286,6 +305,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_oxycotin_administered_obv2'
       label: Was Oxytocin administered?
       options:
       - {label: 'Yes', value: '1'}
@@ -300,6 +320,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_oxycotin_administration_location'
       label: Where was oxytocin administered?
       options:
       - {label: Intramuscular (IM), value: '1'}
@@ -314,6 +335,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_water_usage'
       label: "Was water used to clean hands\_ just before delivery?"
       options:
       - {label: 'Yes', value: '1'}
@@ -328,6 +350,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_soap_usage'
       label: Was soap used to clean hands just before delivery?
       options:
       - {label: 'Yes', value: '1'}
@@ -342,6 +365,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_alcohol_rub'
       label: Was alcohol rub used just before delivery?
       options:
       - {label: 'Yes', value: '1'}
@@ -356,6 +380,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_clean_gloves'
       label: Were clean gloves used at the time of delivery?
       options:
       - {label: 'Yes', value: '1'}
@@ -370,6 +395,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_clean_towel'
       label: Was clean towel available at the bedside?
       options:
       - {label: 'Yes', value: '1'}
@@ -384,6 +410,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_scissors_blade'
       label: Were sterile scissors/blade to cut cord available at the bedside?
       options:
       - {label: 'Yes', value: '1'}
@@ -398,6 +425,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_cord_tie'
       label: Was a cord ligature/tie available at the bedside?
       options:
       - {label: 'Yes', value: '1'}
@@ -412,6 +440,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_mucus_extractor'
       label: Was an aspiration bulb or mucus extractor available at the bedside?
       options:
       - {label: 'Yes', value: '1'}
@@ -426,6 +455,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_neonatal_bag'
       label: Was a neonatal bag and mask available at the bedside?
       options:
       - {label: 'Yes', value: '1'}
@@ -440,6 +470,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_pads'
       label: Were pads for the mother available at the bedside?
       options:
       - {label: 'Yes', value: '1'}
@@ -454,6 +485,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_checklist_picked_up_obv2'
       label: Was the paper checklist picked up during care ?
       options:
       - {label: 'Yes', value: '1'}
@@ -468,6 +500,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_checklist_used_after_care_obv2'
       label: Was the paper checklist picked up after the care was given?
       options:
       - {label: 'Yes', value: '1'}
@@ -482,6 +515,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv2
+      hashtagValue: '#form/fada_obv2/fada_checklist_poster_used_obv2'
       label: Was the checklist poster observed during care?
       options:
       - {label: 'Yes', value: 'yes'}
@@ -495,6 +529,7 @@
       value: /data/fada_obv2/fada_checklist_poster_used_obv2
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_obv2'
     label: 2. Just before delivery
     relevant: selected(/data/fada_observation_points_observed, '2')
     repeat: null
@@ -508,6 +543,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv3
+      hashtagValue: '#form/fada_obv3/fada_assisted_by_obv3'
       label: Assisted with woman's care (check all that apply)
       options:
       - {label: Doctor, value: '1'}
@@ -524,6 +560,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv3
+      hashtagValue: '#form/fada_obv3/fada_oxycotin_administered_obv3'
       label: Was Oxytocin administered?
       options:
       - {label: 'Yes', value: '1'}
@@ -538,6 +575,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv3
+      hashtagValue: '#form/fada_obv3/fada_neonatal_bag_usage'
       label: Was neonatal bag and mask used on baby?
       options:
       - {label: 'Yes', value: '1'}
@@ -552,6 +590,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv3
+      hashtagValue: '#form/fada_obv3/fada_birth_companion_present_obv3'
       label: Was a birth companion present?
       options:
       - {label: 'Yes', value: '1'}
@@ -565,6 +604,7 @@
       value: /data/fada_obv3/fada_birth_companion_present_obv3
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_obv3'
     label: 3. At one minute after delivery
     relevant: selected(/data/fada_observation_points_observed, '3')
     repeat: null
@@ -578,6 +618,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_assisted_by_obv4'
       label: Assisted with woman's care (check all that apply)
       options:
       - {label: Doctor, value: '1'}
@@ -594,6 +635,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_baby_wt'
       label: Was newborn weight taken?
       options:
       - {label: 'Yes', value: '1'}
@@ -608,6 +650,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_baby_temp'
       label: Was newborn temperature taken?
       options:
       - {label: 'Yes', value: '1'}
@@ -622,6 +665,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_baby_skin_to_skin'
       label: Was baby placed skin-to-skin on mother's abdomen?
       options:
       - {label: 'Yes', value: '1'}
@@ -636,6 +680,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_baby_skin_to_skin_for_1_hour'
       label: Was the baby still skin-to-skin after 1 hour?
       options:
       - {label: 'Yes', value: '1'}
@@ -650,6 +695,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_breastfeeding'
       label: Was breastfeeding initiated?
       options:
       - {label: 'Yes', value: '1'}
@@ -664,6 +710,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_checklist_picked_up_obv4'
       label: Was the paper checklist picked up during care ?
       options:
       - {label: 'Yes', value: '1'}
@@ -678,6 +725,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_checklist_used_after_care_obv4'
       label: Was the paper checklist picked up after the care was given?
       options:
       - {label: 'Yes', value: '1'}
@@ -692,6 +740,7 @@
     - calculate: null
       comment: null
       group: /data/fada_obv4
+      hashtagValue: '#form/fada_obv4/fada_checklist_poster_used_obv4'
       label: Was the checklist poster observed during care?
       options:
       - {label: 'Yes', value: 'yes'}
@@ -705,6 +754,7 @@
       value: /data/fada_obv4/fada_checklist_poster_used_obv4
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_obv4'
     label: 4. At one hour after delivery
     relevant: selected(/data/fada_observation_points_observed, '4')
     repeat: null
@@ -718,6 +768,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_maternal_temp_anytime'
       label: Was maternal temperature obtained at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -732,6 +783,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_maternal_bp_anytime'
       label: Was maternal blood pressure obtained at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -746,6 +798,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_magnesium'
       label: Was magnesium Sulphate given to mother at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -760,6 +813,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_ab_mother'
       label: Was antibiotics given to mother at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -774,6 +828,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_ab_baby'
       label: Was antibiotics given to baby at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -788,6 +843,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_arv_mother'
       label: Was antiretroviral to mother at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -802,6 +858,7 @@
     - calculate: null
       comment: null
       group: /data/fada_other_observations
+      hashtagValue: '#form/fada_other_observations/fada_arv_baby'
       label: Was antiretroviral to baby at any time?
       options:
       - {label: 'Yes', value: '1'}
@@ -815,6 +872,7 @@
       value: /data/fada_other_observations/fada_arv_baby
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_other_observations'
     label: 5.Were any of the following observed at any time?
     relevant: null
     repeat: null
@@ -826,6 +884,7 @@
   - calculate: null
     comment: null
     group: /data/whole_form
+    hashtagValue: '#form/fada_highlight_record'
     label: Would you like to highlight this record for your team leader?
     options:
     - {label: 1. Yes, value: 'yes'}
@@ -837,14 +896,15 @@
     tag: select1
     type: Select
     value: /data/fada_highlight_record
-  - {calculate: null, comment: null, group: /data/whole_form, label: Comment to supervisor,
-    relevant: /data/fada_highlight_record = 'yes', repeat: null, required: true, response: null,
-    tag: input, type: Text, value: /data/fada_highlight_comment}
-  - {calculate: null, comment: null, group: /data/whole_form, label: GPS Capture,
-    relevant: null, repeat: null, required: false, response: 8.8888888 -9.9999999
-      0.0 30.000, tag: input, type: Geopoint, value: /data/fada_gps_location}
+  - {calculate: null, comment: null, group: /data/whole_form, hashtagValue: '#form/fada_highlight_comment',
+    label: Comment to supervisor, relevant: /data/fada_highlight_record = 'yes', repeat: null,
+    required: true, response: null, tag: input, type: Text, value: /data/fada_highlight_comment}
+  - {calculate: null, comment: null, group: /data/whole_form, hashtagValue: '#form/fada_gps_location',
+    label: GPS Capture, relevant: null, repeat: null, required: false, response: 8.8888888
+      -9.9999999 0.0 30.000, tag: input, type: Geopoint, value: /data/fada_gps_location}
   comment: null
   group: null
+  hashtagValue: '#form/whole_form'
   label: ''
   relevant: /data/fada_facility_id != ''
   repeat: null
@@ -854,26 +914,29 @@
   type: Group
   value: /data/whole_form
 - {calculate: 'instance(''casedb'')/casedb/case[@case_type=''facility''][@status=''open''][facility_id
-    = /data/fada_facility_id]/number_usage', comment: null, group: null, label: facility_number_usage,
-  relevant: null, repeat: null, required: null, response: '1', tag: hidden, type: DataBindOnly,
-  value: /data/facility_number_usage}
+    = /data/fada_facility_id]/number_usage', comment: null, group: null, hashtagValue: '#form/facility_number_usage',
+  label: '#form/facility_number_usage', relevant: null, repeat: null, required: null,
+  response: '1', tag: hidden, type: DataBindOnly, value: /data/facility_number_usage}
 - {calculate: 'instance(''casedb'')/casedb/case[@case_type=''current_user_data'']/facility_id',
-  comment: null, group: null, label: fada_facility_id, relevant: null, repeat: null,
-  required: null, response: '600', tag: hidden, type: DataBindOnly, value: /data/fada_facility_id}
+  comment: null, group: null, hashtagValue: '#form/fada_facility_id', label: '#form/fada_facility_id',
+  relevant: null, repeat: null, required: null, response: '600', tag: hidden, type: DataBindOnly,
+  value: /data/fada_facility_id}
 - {calculate: 'concat(/data/fada_facility_id, format-date(/data/fada_date_admission,
-    ''%Y%m''), /data/patient_number_padded)', comment: null, group: null, label: fada_patient_id,
-  relevant: null, repeat: null, required: null, response: '2093402934', tag: hidden,
-  type: DataBindOnly, value: /data/fada_patient_id}
+    ''%Y%m''), /data/patient_number_padded)', comment: null, group: null, hashtagValue: '#form/fada_patient_id',
+  label: '#form/fada_patient_id', relevant: null, repeat: null, required: null, response: '2093402934',
+  tag: hidden, type: DataBindOnly, value: /data/fada_patient_id}
 - {calculate: 'instance(''casedb'')/casedb/case[@case_type=''facility''][@status=''open''][facility_id
-    = /data/fada_facility_id]/owner_id', comment: null, group: null, label: facility_owner_id,
-  relevant: null, repeat: null, required: null, response: '', tag: hidden, type: DataBindOnly,
-  value: /data/facility_owner_id}
+    = /data/fada_facility_id]/owner_id', comment: null, group: null, hashtagValue: '#form/facility_owner_id',
+  label: '#form/facility_owner_id', relevant: null, repeat: null, required: null,
+  response: '', tag: hidden, type: DataBindOnly, value: /data/facility_owner_id}
 - {calculate: 'if(/data/patient_number >= 10000, string(/data/patient_number), if(/data/patient_number
     >= 1000, concat(''0'', string(/data/patient_number)), if(/data/patient_number
     >= 100, concat(''00'', string(/data/patient_number)), if(/data/patient_number
     >= 10, concat(''000'', string(/data/patient_number)), concat(''0000'', string(/data/patient_number))))))',
-  comment: null, group: null, label: patient_number_padded, relevant: null, repeat: null,
-  required: null, response: '01225', tag: hidden, type: DataBindOnly, value: /data/patient_number_padded}
+  comment: null, group: null, hashtagValue: '#form/patient_number_padded', label: '#form/patient_number_padded',
+  relevant: null, repeat: null, required: null, response: '01225', tag: hidden, type: DataBindOnly,
+  value: /data/patient_number_padded}
 - {calculate: 'if(/data/facility_number_usage = 1, /data/fada_monthly_number, /data/fada_yearly_number)',
-  comment: null, group: null, label: patient_number, relevant: null, repeat: null,
-  required: null, response: '1234', tag: hidden, type: DataBindOnly, value: /data/patient_number}
+  comment: null, group: null, hashtagValue: '#form/patient_number', label: '#form/patient_number',
+  relevant: null, repeat: null, required: null, response: '1234', tag: hidden, type: DataBindOnly,
+  value: /data/patient_number}

--- a/corehq/apps/reports/tests/readable_forms/top_level_refless_group.result.yaml
+++ b/corehq/apps/reports/tests/readable_forms/top_level_refless_group.result.yaml
@@ -1,12 +1,14 @@
 - calculate: null
   children:
-  - {calculate: null, comment: null, group: '', label: '', relevant: null, repeat: null,
-    required: false, response: null, tag: group, type: FieldList, value: ''}
-  - {calculate: null, comment: null, group: '', label: Date of Encounter, relevant: null,
-    repeat: null, required: true, response: null, tag: input, type: Date, value: /progress_note/note/encounter_date}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: '', relevant: null,
+    repeat: null, required: false, response: null, tag: group, type: FieldList, value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/encounter_date,
+    label: Date of Encounter, relevant: null, repeat: null, required: true, response: null,
+    tag: input, type: Date, value: /progress_note/note/encounter_date}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/times/missed_visit
     label: Missed Visit
     options:
     - {label: 'Yes', value: 'yes'}
@@ -18,35 +20,45 @@
     tag: select1
     type: Select
     value: /progress_note/note/times/missed_visit
-  - {calculate: null, comment: null, group: '', label: Activity Time, relevant: null,
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: Activity
+      Time, relevant: null, repeat: null, required: false, response: null, tag: group,
+    type: FieldList, value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/office,
+    label: PACT Office Visit, relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Int, value: /progress_note/note/times/office}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/home,
+    label: Home Visit, relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Int, value: /progress_note/note/times/home}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/other,
+    label: Other Visit, relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Int, value: /progress_note/note/times/other}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/wait,
+    label: Time Waiting for Client, relevant: null, repeat: null, required: false,
+    response: null, tag: input, type: Int, value: /progress_note/note/times/wait}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/accompaniment,
+    label: Accompaniment Time, relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Int, value: /progress_note/note/times/accompaniment}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/phone,
+    label: Phone Call/Leave Message, relevant: null, repeat: null, required: false,
+    response: null, tag: input, type: Int, value: /progress_note/note/times/phone}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/discussion,
+    label: Provider/Discussion Message, relevant: null, repeat: null, required: false,
+    response: null, tag: input, type: Int, value: /progress_note/note/times/discussion}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/administrative,
+    label: Administrative, relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Int, value: /progress_note/note/times/administrative}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/travel,
+    label: Travel, relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Int, value: /progress_note/note/times/travel}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: '', relevant: null,
     repeat: null, required: false, response: null, tag: group, type: FieldList, value: ''}
-  - {calculate: null, comment: null, group: '', label: PACT Office Visit, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/office}
-  - {calculate: null, comment: null, group: '', label: Home Visit, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/home}
-  - {calculate: null, comment: null, group: '', label: Other Visit, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/other}
-  - {calculate: null, comment: null, group: '', label: Time Waiting for Client, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/wait}
-  - {calculate: null, comment: null, group: '', label: Accompaniment Time, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/accompaniment}
-  - {calculate: null, comment: null, group: '', label: Phone Call/Leave Message, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/phone}
-  - {calculate: null, comment: null, group: '', label: Provider/Discussion Message,
-    relevant: null, repeat: null, required: false, response: null, tag: input, type: Int,
-    value: /progress_note/note/times/discussion}
-  - {calculate: null, comment: null, group: '', label: Administrative, relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/administrative}
-  - {calculate: null, comment: null, group: '', label: Travel, relevant: null, repeat: null,
-    required: false, response: null, tag: input, type: Int, value: /progress_note/note/times/travel}
-  - {calculate: null, comment: null, group: '', label: '', relevant: null, repeat: null,
-    required: false, response: null, tag: group, type: FieldList, value: ''}
-  - {calculate: null, comment: null, group: '', label: Location of Other Visit, relevant: /progress_note/note/times/other
-      > 0, repeat: null, required: false, response: null, tag: input, type: Text,
-    value: /progress_note/note/times/other_location}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/other_location,
+    label: Location of Other Visit, relevant: /progress_note/note/times/other > 0,
+    repeat: null, required: false, response: null, tag: input, type: Text, value: /progress_note/note/times/other_location}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/times/accompaniment_type
     label: Accompaniment Type
     options:
     - {label: HIV MD, value: hivmd}
@@ -63,14 +75,16 @@
     tag: select1
     type: Select
     value: /progress_note/note/times/accompaniment_type
-  - {calculate: null, comment: null, group: '', label: Specify Accompaniment Type,
-    relevant: /progress_note/note/times/accompaniment_type = 'other', repeat: null,
-    required: false, response: null, tag: input, type: Text, value: /progress_note/note/times/accompaniment_other}
-  - {calculate: null, comment: null, group: '', label: '', relevant: null, repeat: null,
-    required: false, response: null, tag: group, type: FieldList, value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/times/accompaniment_other,
+    label: Specify Accompaniment Type, relevant: /progress_note/note/times/accompaniment_type
+      = 'other', repeat: null, required: false, response: null, tag: input, type: Text,
+    value: /progress_note/note/times/accompaniment_other}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: '', relevant: null,
+    repeat: null, required: false, response: null, tag: group, type: FieldList, value: ''}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/discussed_appointments
     label: Discussed scheduled appointments
     options:
     - {label: 'Yes', value: 'yes'}
@@ -85,6 +99,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/discussed_goals
     label: Discussed goals for current/upcoming appointment
     options:
     - {label: 'Yes', value: 'yes'}
@@ -99,6 +114,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/discussed_followup
     label: Discussed follow up after appointment
     options:
     - {label: 'Yes', value: 'yes'}
@@ -110,11 +126,12 @@
     tag: select1
     type: Select
     value: /progress_note/note/discussed_followup
-  - {calculate: null, comment: null, group: '', label: '', relevant: null, repeat: null,
-    required: false, response: null, tag: group, type: FieldList, value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: '', relevant: null,
+    repeat: null, required: false, response: null, tag: group, type: FieldList, value: ''}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/reviewed_cd
     label: "Reviewed patient\u2019s CD4 & VL"
     options:
     - {label: 'Yes', value: 'yes'}
@@ -129,6 +146,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/discussed_qsp
     label: Discussed QSP
     options:
     - {label: 'Yes', value: 'yes'}
@@ -140,20 +158,22 @@
     tag: select1
     type: Select
     value: /progress_note/note/discussed_qsp
-  - {calculate: null, comment: null, group: '', label: Adherence, relevant: null,
-    repeat: null, required: false, response: null, tag: group, type: FieldList, value: ''}
-  - {calculate: null, comment: null, group: '', label: Doses Missed in the Last 7
-      Days, relevant: null, repeat: null, required: false, response: null, tag: input,
-    type: Int, value: /progress_note/note/adherence/missed}
-  - {calculate: null, comment: null, group: '', label: Doses Possible in the Last
-      7 Days, relevant: null, repeat: null, required: false, response: null, tag: input,
-    type: Int, value: /progress_note/note/adherence/possible}
-  - {calculate: null, comment: null, group: '', label: 'Patient''s response to "How
-      was it taking your meds today?"', relevant: null, repeat: null, required: false,
-    response: null, tag: input, type: Text, value: /progress_note/note/adherence/freetext}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: Adherence,
+    relevant: null, repeat: null, required: false, response: null, tag: group, type: FieldList,
+    value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/adherence/missed,
+    label: Doses Missed in the Last 7 Days, relevant: null, repeat: null, required: false,
+    response: null, tag: input, type: Int, value: /progress_note/note/adherence/missed}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/adherence/possible,
+    label: Doses Possible in the Last 7 Days, relevant: null, repeat: null, required: false,
+    response: null, tag: input, type: Int, value: /progress_note/note/adherence/possible}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/adherence/freetext,
+    label: 'Patient''s response to "How was it taking your meds today?"', relevant: null,
+    repeat: null, required: false, response: null, tag: input, type: Text, value: /progress_note/note/adherence/freetext}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/adherence/self_report
     label: 'Patient Self Report: How much of your medicine did you take in the last
       week'
     options:
@@ -169,11 +189,12 @@
     tag: select1
     type: Select
     value: /progress_note/note/adherence/self_report
-  - {calculate: null, comment: null, group: '', label: '', relevant: null, repeat: null,
-    required: false, response: null, tag: group, type: FieldList, value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: '', relevant: null,
+    repeat: null, required: false, response: null, tag: group, type: FieldList, value: ''}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/newreferral
     label: New Referral(s)
     options:
     - {label: 'Yes', value: 'yes'}
@@ -188,6 +209,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/newbw
     label: New Bloodwork Record(s)
     options:
     - {label: 'Yes', value: 'yes'}
@@ -204,14 +226,17 @@
     - calculate: null
       children:
       - {calculate: null, comment: null, group: /progress_note/note/referrals/referral,
-        label: '', relevant: null, repeat: /progress_note/note/referrals/referral,
-        required: false, response: null, tag: group, type: FieldList, value: /progress_note/note/referrals/referral}
+        hashtagValue: /progress_note/note/referrals/referral, label: '', relevant: null,
+        repeat: /progress_note/note/referrals/referral, required: false, response: null,
+        tag: group, type: FieldList, value: /progress_note/note/referrals/referral}
       - {calculate: null, comment: null, group: /progress_note/note/referrals/referral,
-        label: Referral Date, relevant: null, repeat: /progress_note/note/referrals/referral,
-        required: false, response: null, tag: input, type: Date, value: /progress_note/note/referrals/referral/ref_date}
+        hashtagValue: /progress_note/note/referrals/referral/ref_date, label: Referral
+          Date, relevant: null, repeat: /progress_note/note/referrals/referral, required: false,
+        response: null, tag: input, type: Date, value: /progress_note/note/referrals/referral/ref_date}
       - calculate: null
         comment: null
         group: /progress_note/note/referrals/referral
+        hashtagValue: /progress_note/note/referrals/referral/ref_type
         label: Type of Referral
         options:
         - {label: Social, value: social}
@@ -236,6 +261,7 @@
       value: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/referrals/referral
     label: Referral
     relevant: null
     repeat: null
@@ -249,14 +275,17 @@
     - calculate: null
       children:
       - {calculate: null, comment: null, group: /progress_note/note/bwresults/bw,
-        label: '', relevant: null, repeat: /progress_note/note/bwresults/bw, required: false,
-        response: null, tag: group, type: FieldList, value: /progress_note/note/bwresults/bw}
+        hashtagValue: /progress_note/note/bwresults/bw, label: '', relevant: null,
+        repeat: /progress_note/note/bwresults/bw, required: false, response: null,
+        tag: group, type: FieldList, value: /progress_note/note/bwresults/bw}
       - {calculate: null, comment: null, group: /progress_note/note/bwresults/bw,
-        label: Date of Tests, relevant: null, repeat: /progress_note/note/bwresults/bw,
-        required: true, response: null, tag: input, type: Date, value: /progress_note/note/bwresults/bw/test_date}
+        hashtagValue: /progress_note/note/bwresults/bw/test_date, label: Date of Tests,
+        relevant: null, repeat: /progress_note/note/bwresults/bw, required: true,
+        response: null, tag: input, type: Date, value: /progress_note/note/bwresults/bw/test_date}
       - calculate: null
         comment: null
         group: /progress_note/note/bwresults/bw
+        hashtagValue: /progress_note/note/bwresults/bw/tests
         label: Types of test performed
         options:
         - {label: Viral Load, value: vl}
@@ -269,18 +298,22 @@
         type: MSelect
         value: /progress_note/note/bwresults/bw/tests
       - {calculate: null, comment: null, group: /progress_note/note/bwresults/bw,
-        label: Viral Load Result, relevant: 'selected(../tests,''vl'')', repeat: /progress_note/note/bwresults/bw,
+        hashtagValue: /progress_note/note/bwresults/bw/vl, label: Viral Load Result,
+        relevant: 'selected(../tests,''vl'')', repeat: /progress_note/note/bwresults/bw,
         required: true, response: null, tag: input, type: Int, value: /progress_note/note/bwresults/bw/vl}
       - calculate: null
         children:
         - {calculate: null, comment: null, group: /progress_note/note/bwresults/bw/cd,
-          label: CD4 Count Result, relevant: null, repeat: /progress_note/note/bwresults/bw,
-          required: true, response: null, tag: input, type: Int, value: /progress_note/note/bwresults/bw/cd/cdcnt}
+          hashtagValue: /progress_note/note/bwresults/bw/cd/cdcnt, label: CD4 Count
+            Result, relevant: null, repeat: /progress_note/note/bwresults/bw, required: true,
+          response: null, tag: input, type: Int, value: /progress_note/note/bwresults/bw/cd/cdcnt}
         - {calculate: null, comment: null, group: /progress_note/note/bwresults/bw/cd,
-          label: CD4 Percent Result (Optional), relevant: null, repeat: /progress_note/note/bwresults/bw,
+          hashtagValue: /progress_note/note/bwresults/bw/cd/cdper, label: CD4 Percent
+            Result (Optional), relevant: null, repeat: /progress_note/note/bwresults/bw,
           required: false, response: null, tag: input, type: Int, value: /progress_note/note/bwresults/bw/cd/cdper}
         comment: null
         group: /progress_note/note/bwresults/bw
+        hashtagValue: /progress_note/note/bwresults/bw/cd
         label: ''
         relevant: selected(../tests,'cd')
         repeat: /progress_note/note/bwresults/bw
@@ -301,6 +334,7 @@
       value: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/bwresults/bw
     label: Bloodwork
     relevant: null
     repeat: null
@@ -309,11 +343,13 @@
     tag: repeat
     type: Repeat
     value: /progress_note/note/bwresults/bw
-  - {calculate: null, comment: null, group: '', label: Conversations, relevant: null,
-    repeat: null, required: false, response: null, tag: group, type: Group, value: ''}
+  - {calculate: null, comment: null, group: '', hashtagValue: '', label: Conversations,
+    relevant: null, repeat: null, required: false, response: null, tag: group, type: Group,
+    value: ''}
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/which
     label: In what topics did you have a discussion?
     options:
     - {label: Introduction to the Health Promotion Curriculum, value: conversations_1}
@@ -342,6 +378,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_1
     label: Introduction to the Health Promotion Curriculum
     options:
     - {label: Initial Adherence Assessment, value: conversation_01_A_c}
@@ -360,6 +397,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_2
     label: Me and IHV
     options:
     - {label: Me and HIV, value: conversation_02_A_c}
@@ -375,6 +413,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_3
     label: Using a Pillbox
     options:
     - {label: How to read a pill bottle, value: conversation_03_A_c}
@@ -393,6 +432,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_4
     label: Handling your ART Medications
     options:
     - {label: Pharmacy Plan, value: conversation_04_A_c}
@@ -411,6 +451,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_5
     label: What is Adherence
     options:
     - {label: "Your patient\u2019s perceptions of treatment", value: conversation_05_A_c}
@@ -429,6 +470,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_6
     label: Side Effects
     options:
     - {label: Understanding Side Effects, value: conversation_06_A_d}
@@ -445,6 +487,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_7
     label: What is HIV and How does it Affect My Body
     options:
     - {label: 'What is HIV and how does it affect my body?', value: conversation_07_A_c}
@@ -464,6 +507,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_8
     label: Identifying and Building Social Support Networks
     options:
     - {label: Understanding Social Support, value: conversation_08_A_c}
@@ -480,6 +524,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_9
     label: Adherence Strengths and Difficulties
     options:
     - {label: Your ART Experience, value: conversation_09_A_c}
@@ -495,6 +540,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_10
     label: Medical Appointments and Providers
     options:
     - {label: Appointment logistics, value: conversation_10_A_c}
@@ -510,6 +556,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_11
     label: Health Maintenance
     options:
     - {label: Introduction to Health Maintenance, value: conversation_11_A_d}
@@ -527,6 +574,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_12
     label: Harm Reduction
     options:
     - {label: 'What is Harm Reduction?', value: conversation_12_A_d}
@@ -545,6 +593,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_13
     label: Harm Reduction - Substance Abuse
     options:
     - {label: Assessment, value: conversation_13_A_d}
@@ -564,6 +613,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_14
     label: Harm Reduction - Safety in Relationships
     options:
     - {label: 'What is Harm Reduction?', value: conversation_14_A_d}
@@ -582,6 +632,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_15
     label: Healthy Living - Diet and Exercise
     options:
     - {label: Healthy eating assessment, value: conversation_15_A_d}
@@ -600,6 +651,7 @@
   - calculate: null
     comment: null
     group: ''
+    hashtagValue: /progress_note/note/conversations/conversations_16
     label: Wrap Up
     options:
     - {label: Review the Patient Workbook tools, value: conversation_16_A_c}
@@ -611,12 +663,14 @@
     tag: select
     type: MSelect
     value: /progress_note/note/conversations/conversations_16
-  - {calculate: null, comment: null, group: '', label: "\nAny other notes from the\
-      \ meeting?\n\n     Please Include:\n     1) Environment/context\n     2) Themes/activities\n\
-      \     3) Take-home message\n                                        ", relevant: null,
-    repeat: null, required: false, response: null, tag: input, type: Text, value: /progress_note/note/memo}
+  - {calculate: null, comment: null, group: '', hashtagValue: /progress_note/note/memo,
+    label: "\nAny other notes from the meeting?\n\n     Please Include:\n     1) Environment/context\n\
+      \     2) Themes/activities\n     3) Take-home message\n                    \
+      \                    ", relevant: null, repeat: null, required: false, response: null,
+    tag: input, type: Text, value: /progress_note/note/memo}
   comment: null
   group: null
+  hashtagValue: ''
   label: 'Client #____'
   relevant: null
   repeat: null
@@ -625,26 +679,34 @@
   tag: group
   type: Group
   value: ''
-- {calculate: null, comment: null, group: null, label: meta/userID, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/userID}
-- {calculate: null, comment: null, group: null, label: meta/timeStart, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/timeStart}
-- {calculate: null, comment: null, group: null, label: meta/timeEnd, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/timeEnd}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/userID,
+  label: meta/userID, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/userID}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/timeStart,
+  label: meta/timeStart, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/timeStart}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/timeEnd,
+  label: meta/timeEnd, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/timeEnd}
 - {calculate: 'instance(''casedb'')/casedb/case[@case_id= /progress_note/case/@case_id]/pactid',
-  comment: null, group: null, label: note/pact_id, relevant: null, repeat: null, required: null,
-  response: '111', tag: hidden, type: DataBindOnly, value: /progress_note/note/pact_id}
-- {calculate: null, comment: null, group: null, label: meta/username, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/username}
-- {calculate: null, comment: null, group: null, label: meta/deviceID, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/deviceID}
-- {calculate: /progress_note/note/encounter_date, comment: null, group: null, label: case/update/last_note,
-  relevant: null, repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly,
-  value: /progress_note/case/update/last_note}
-- {calculate: null, comment: null, group: null, label: meta/instanceID, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/instanceID}
-- {calculate: null, comment: null, group: null, label: meta/appVersion, relevant: null,
-  repeat: null, required: null, response: null, tag: hidden, type: DataBindOnly, value: /progress_note/meta/appVersion}
+  comment: null, group: null, hashtagValue: /progress_note/note/pact_id, label: note/pact_id,
+  relevant: null, repeat: null, required: null, response: '111', tag: hidden, type: DataBindOnly,
+  value: /progress_note/note/pact_id}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/username,
+  label: meta/username, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/username}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/deviceID,
+  label: meta/deviceID, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/deviceID}
+- {calculate: /progress_note/note/encounter_date, comment: null, group: null, hashtagValue: /progress_note/case/update/last_note,
+  label: case/update/last_note, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/case/update/last_note}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/instanceID,
+  label: meta/instanceID, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/instanceID}
+- {calculate: null, comment: null, group: null, hashtagValue: /progress_note/meta/appVersion,
+  label: meta/appVersion, relevant: null, repeat: null, required: null, response: null,
+  tag: hidden, type: DataBindOnly, value: /progress_note/meta/appVersion}
 - {calculate: null, comment: null, group: null, label: note/adherence/freetext, relevant: null,
   repeat: null, required: null, response: '67', tag: null, type: null, value: /progress_note/note/adherence/freetext}
 - {calculate: null, comment: null, group: null, label: note/adherence/missed, relevant: null,


### PR DESCRIPTION
@czue @NoahCarnahan more functionality so we can convert more exports. This ensures that we include the ability to export case properties from repeat groups when you create cases from a repeat. Found this when trying to migrate the `nw-veges` domain

cc: @millerdev 

best read commit by commit 🐟 

this is what it looks like:

<img width="1111" alt="screen shot 2016-12-15 at 5 53 27 pm" src="https://cloud.githubusercontent.com/assets/918514/21245241/77dee56a-c2ef-11e6-8fac-0d2becd71974.png">
<img width="1387" alt="screen shot 2016-12-15 at 5 53 42 pm" src="https://cloud.githubusercontent.com/assets/918514/21245240/77db5f9e-c2ef-11e6-9e24-f61d934c0478.png">
