### PR TITLE
Setup two-way sync for keywords

### DIFF
--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -23,6 +23,7 @@ from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import ServerTime, UserTime
 from dimagi.utils.couch import LockableMixIn, CriticalSection
 from dimagi.utils.couch.cache.cache_core import get_redis_client
+from dimagi.utils.couch.migration import SyncCouchToSQLMixin
 from dimagi.utils.logging import notify_exception
 from random import randint
 from django.conf import settings
@@ -1866,7 +1867,7 @@ class SurveyKeywordAction(DocumentSchema):
     named_args_separator = StringProperty() # Can be None in which case there is no separator (i.e., a100 b200)
 
 
-class SurveyKeyword(Document):
+class SurveyKeyword(SyncCouchToSQLMixin, Document):
     domain = StringProperty()
     keyword = StringProperty()
     description = StringProperty()

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1953,7 +1953,6 @@ class SurveyKeyword(SyncCouchToSQLMixin, Document):
         return Keyword
 
     def _migration_sync_to_sql(self, sql_object):
-        from corehq.apps.sms.models import KeywordAction
         with transaction.atomic():
             sql_object.domain = self.domain
             sql_object.keyword = self.keyword
@@ -1965,8 +1964,7 @@ class SurveyKeyword(SyncCouchToSQLMixin, Document):
             sql_object.keywordaction_set.all().delete()
 
             for couch_action in self.actions:
-                KeywordAction.objects.create(
-                    keyword=sql_object,
+                sql_object.keywordaction_set.create(
                     action=couch_action.action,
                     recipient=couch_action.recipient,
                     recipient_id=couch_action.recipient_id,

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1886,13 +1886,6 @@ class SurveyKeyword(SyncCouchToSQLMixin, Document):
 
     def is_structured_sms(self):
         return METHOD_STRUCTURED_SMS in [a.action for a in self.actions]
-
-    def deleted(self):
-        return self.doc_type != 'SurveyKeyword'
-
-    def retire(self):
-        self.doc_type += "-Deleted"
-        self.save()
     
     @property
     def get_id(self):
@@ -1934,6 +1927,10 @@ class SurveyKeyword(SyncCouchToSQLMixin, Document):
     def save(self, *args, **kwargs):
         self.clear_caches()
         return super(SurveyKeyword, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        self.clear_caches()
+        return super(SurveyKeyword, self).delete(*args, **kwargs)
 
     def clear_caches(self):
         self.domain_has_keywords.clear(SurveyKeyword, self.domain)

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -28,7 +28,7 @@ from dimagi.utils.logging import notify_exception
 from random import randint
 from django.conf import settings
 from dimagi.utils.couch.database import iter_docs
-from django.db import models
+from django.db import models, transaction
 from string import Formatter
 
 
@@ -1949,6 +1949,36 @@ class SurveyKeyword(SyncCouchToSQLMixin, Document):
         ).all()
         count = reduced[0]['value'] if reduced else 0
         return count > 0
+
+    @classmethod
+    def _migration_get_sql_model_class(cls):
+        from corehq.apps.sms.models import Keyword
+        return Keyword
+
+    def _migration_sync_to_sql(self, sql_object):
+        from corehq.apps.sms.models import KeywordAction
+        with transaction.atomic():
+            sql_object.domain = self.domain
+            sql_object.keyword = self.keyword
+            sql_object.description = self.description
+            sql_object.delimiter = self.delimiter
+            sql_object.override_open_sessions = self.override_open_sessions
+            sql_object.initiator_doc_type_filter = self.initiator_doc_type_filter
+            sql_object.save(sync_to_couch=False)
+            sql_object.keywordaction_set.all().delete()
+
+            for couch_action in self.actions:
+                KeywordAction.objects.create(
+                    keyword=sql_object,
+                    action=couch_action.action,
+                    recipient=couch_action.recipient,
+                    recipient_id=couch_action.recipient_id,
+                    message_content=couch_action.message_content,
+                    form_unique_id=couch_action.form_unique_id,
+                    use_named_args=couch_action.use_named_args,
+                    named_args=couch_action.named_args,
+                    named_args_separator=couch_action.named_args_separator
+                )
 
 
 class EmailUsage(models.Model):

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -63,7 +63,7 @@
     </script>
     <script type="text/html" id="keyword-deleted-template">
         <td class="col-md-5">
-            <a data-bind="attr: { href: editUrl }, text: keyword"></a>
+            <a data-bind="text: keyword"></a>
         </td>
         <td class="col-md-5" data-bind="text: description"></td>
         <td class="col-md-2"><span class="label label-inverse">{% trans 'DELETED' %}</span></td>

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -1119,6 +1119,12 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
             'deleteModalId': 'delete-%s' % keyword._id,
         }
 
+    def _fmt_deleted_keyword_data(self, keyword):
+        return {
+            'keyword': keyword.keyword,
+            'description': keyword.description,
+        }
+
     def get_deleted_item_data(self, item_id):
         try:
             s = SurveyKeyword.get(item_id)
@@ -1126,9 +1132,9 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
             raise Http404()
         if s.domain != self.domain or s.doc_type != "SurveyKeyword":
             raise Http404()
-        s.retire()
+        s.delete()
         return {
-            'itemData': self._fmt_keyword_data(s),
+            'itemData': self._fmt_deleted_keyword_data(s),
             'template': 'keyword-deleted-template',
         }
 

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -569,17 +569,18 @@ class BaseMessagingEventReport(BaseCommConnectLogReport):
             return content_cache[keyword_id]
         try:
             keyword = SurveyKeyword.get(keyword_id)
-            if keyword.deleted():
-                display = '%s %s' % (keyword.description, _('(Deleted Keyword)'))
-            else:
-                urlname = (EditStructuredKeywordView.urlname if keyword.is_structured_sms()
-                    else EditNormalKeywordView.urlname)
-                display = '<a target="_blank" href="%s">%s</a>' % (
-                    reverse(urlname, args=[keyword.domain, keyword_id]),
-                    keyword.description,
-                )
+            if keyword.doc_type.endswith('-Deleted'):
+                # We'll get rid of this once we move to postgres
+                raise ResourceNotFound()
         except ResourceNotFound:
-            display = '-'
+            display = _('(Deleted Keyword)')
+        else:
+            urlname = (EditStructuredKeywordView.urlname if keyword.is_structured_sms()
+                else EditNormalKeywordView.urlname)
+            display = '<a target="_blank" href="%s">%s</a>' % (
+                reverse(urlname, args=[keyword.domain, keyword_id]),
+                keyword.description,
+            )
 
         content_cache[keyword_id] = display
         return display

--- a/corehq/apps/sms/management/commands/migrate_keywords.py
+++ b/corehq/apps/sms/management/commands/migrate_keywords.py
@@ -1,0 +1,68 @@
+from corehq.apps.reminders.models import SurveyKeyword
+from corehq.apps.sms.models import Keyword, MigrationStatus
+from dimagi.utils.couch.database import iter_docs_with_retry
+from django.core.management.base import BaseCommand
+from optparse import make_option
+
+
+class Command(BaseCommand):
+    args = ""
+    help = ("Syncs all keywords stored in Couch to Postgres")
+    option_list = BaseCommand.option_list + (
+        make_option("--balance-only",
+                    action="store_true",
+                    dest="balance_only",
+                    default=False,
+                    help="Include this option to only run the balancing step."),
+    )
+
+    def get_couch_ids(self):
+        result = SurveyKeyword.view(
+            'reminders/survey_keywords',
+            include_docs=False,
+            reduce=False,
+        ).all()
+        return [row['id'] for row in result]
+
+    def get_couch_count(self):
+        result = SurveyKeyword.view(
+            'reminders/survey_keywords',
+            include_docs=False,
+            reduce=True,
+        ).all()
+        if result:
+            return result[0]['value']
+        return 0
+
+    def get_sql_count(self):
+        return Keyword.objects.count()
+
+    def migrate(self, log_file):
+        count = 0
+        ids = self.get_couch_ids()
+        total_count = len(ids)
+        for doc in iter_docs_with_retry(SurveyKeyword.get_db(), ids):
+            try:
+                couch_obj = SurveyKeyword.wrap(doc)
+                couch_obj._migration_do_sync()
+            except Exception as e:
+                log_file.write('Could not sync SurveyKeyword %s: %s\n' % (doc['_id'], e))
+
+            count += 1
+            if (count % 1000) == 0:
+                print 'Processed %s / %s documents' % (count, total_count)
+
+    def balance(self, log_file):
+        sql_count = self.get_sql_count()
+        couch_count = self.get_couch_count()
+
+        log_file.write("%s / %s keywords migrated\n" % (sql_count, couch_count))
+        if couch_count != sql_count:
+            log_file.write("***ERROR: Counts do not match. Please investigate before continuing.\n")
+
+    def handle(self, *args, **options):
+        with open('keyword_migration.log', 'w') as f:
+            if not options['balance_only']:
+                self.migrate(f)
+                MigrationStatus.set_migration_completed(MigrationStatus.MIGRATION_KEYWORDS)
+            self.balance(f)

--- a/corehq/apps/sms/migrations/0021_add_keyword.py
+++ b/corehq/apps/sms/migrations/0021_add_keyword.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+import dimagi.utils.couch.migration
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sms', '0020_remove_selfregistrationinvitation_odk_url'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Keyword',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('couch_id', models.CharField(max_length=126, null=True, db_index=True)),
+                ('domain', models.CharField(max_length=126, db_index=True)),
+                ('keyword', models.CharField(max_length=126)),
+                ('description', models.TextField(null=True)),
+                ('delimiter', models.CharField(max_length=126, null=True)),
+                ('override_open_sessions', models.NullBooleanField()),
+                ('initiator_doc_type_filter', jsonfield.fields.JSONField(default=list)),
+            ],
+            bases=(dimagi.utils.couch.migration.SyncSQLToCouchMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='KeywordAction',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('action', models.CharField(max_length=126)),
+                ('recipient', models.CharField(max_length=126)),
+                ('recipient_id', models.CharField(max_length=126, null=True)),
+                ('message_content', models.TextField(null=True)),
+                ('form_unique_id', models.CharField(max_length=126, null=True)),
+                ('use_named_args', models.NullBooleanField()),
+                ('named_args', jsonfield.fields.JSONField(default=dict)),
+                ('named_args_separator', models.CharField(max_length=126, null=True)),
+                ('keyword', models.ForeignKey(to='sms.Keyword')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='SQLICDSBackend',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('sms.sqlsmsbackend',),
+        ),
+        migrations.AlterIndexTogether(
+            name='keyword',
+            index_together=set([('domain', 'keyword')]),
+        ),
+    ]

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -2270,6 +2270,7 @@ class MigrationStatus(models.Model):
     MIGRATION_DOMAIN_DEFAULT_BACKEND = 'domain_default_backend'
     MIGRATION_LOGS = 'logs'
     MIGRATION_PHONE_NUMBERS = 'phone_numbers'
+    MIGRATION_KEYWORDS = 'keywords'
 
     class Meta:
         db_table = 'messaging_migrationstatus'

--- a/corehq/apps/sms/tests/migration.py
+++ b/corehq/apps/sms/tests/migration.py
@@ -12,7 +12,6 @@ class BaseMigrationTestCase(TestCase):
 
     def setUp(self):
         self.domain = 'test-sms-sql-migration'
-        self.deleteAllObjects()
 
     def deleteAllObjects(self):
         for obj in SurveyKeyword.get_all(self.domain):

--- a/corehq/apps/sms/tests/migration.py
+++ b/corehq/apps/sms/tests/migration.py
@@ -1,5 +1,9 @@
 from datetime import datetime, timedelta
 from django.test import TestCase
+from corehq.apps.reminders.models import (SurveyKeyword, SurveyKeywordAction,
+    KEYWORD_ACTION_CHOICES, KEYWORD_RECIPIENT_CHOICES)
+from corehq.apps.sms.models import Keyword, KeywordAction
+from couchdbkit import ResourceNotFound
 import random
 import string
 
@@ -8,13 +12,16 @@ class BaseMigrationTestCase(TestCase):
 
     def setUp(self):
         self.domain = 'test-sms-sql-migration'
-        self.deleteAllLogs()
+        self.deleteAllObjects()
 
-    def deleteAllLogs(self):
-        pass
+    def deleteAllObjects(self):
+        for obj in SurveyKeyword.get_all(self.domain):
+            obj.delete()
+
+        Keyword.objects.filter(domain=self.domain).delete()
 
     def tearDown(self):
-        self.deleteAllLogs()
+        self.deleteAllObjects()
 
     def randomBoolean(self):
         return [True, False][random.randint(0, 1)]
@@ -31,6 +38,18 @@ class BaseMigrationTestCase(TestCase):
         result = result.replace(microsecond=0)
         return result
 
+    def randomList(self, min_items=0, max_items=2):
+        return [self.randomString() for i in range(random.randint(min_items, max_items))]
+
+    def randomChoice(self, choices):
+        return choices[random.randint(0, len(choices) - 1)]
+
+    def randomDict(self, min_items=0, max_items=2):
+        return {
+            self.randomString(): self.randomString()
+            for i in range(random.randint(min_items, max_items))
+        }
+
     def checkFieldValues(self, object1, object2, fields):
         for field_name in fields:
             value1 = getattr(object1, field_name)
@@ -38,3 +57,158 @@ class BaseMigrationTestCase(TestCase):
             self.assertIsNotNone(value1)
             self.assertIsNotNone(value2)
             self.assertEqual(value1, value2)
+
+
+class KeywordMigrationTestCase(BaseMigrationTestCase):
+
+    def getCouchCount(self):
+        result = SurveyKeyword.view(
+            'reminders/survey_keywords',
+            startkey=[self.domain],
+            endkey=[self.domain, {}],
+            include_docs=False,
+            reduce=True,
+        ).all()
+        if result:
+            return result[0]['value']
+        return 0
+
+    def getSQLCount(self):
+        return Keyword.objects.filter(domain=self.domain).count()
+
+    def setRandomCouchObjectValues(self, obj):
+        obj.domain = self.domain
+        obj.keyword = self.randomString()
+        obj.description = self.randomString()
+        obj.delimiter = self.randomString()
+        obj.override_open_sessions = self.randomBoolean()
+        obj.initiator_doc_type_filter = self.randomList()
+
+        obj.actions = []
+        for i in range(random.randint(1, 3)):
+            obj.actions.append(SurveyKeywordAction(
+                recipient=self.randomChoice(KEYWORD_RECIPIENT_CHOICES),
+                recipient_id="{}{}".format(i, self.randomString()),
+                action=self.randomChoice(KEYWORD_ACTION_CHOICES),
+                message_content=self.randomString(),
+                form_unique_id=self.randomString(),
+                use_named_args=self.randomBoolean(),
+                named_args=self.randomDict(),
+                named_args_separator=self.randomString(),
+            ))
+        obj.save()
+
+    def setRandomSQLObjectValues(self, obj):
+        obj.domain = self.domain
+        obj.keyword = self.randomString()
+        obj.description = self.randomString()
+        obj.delimiter = self.randomString()
+        obj.override_open_sessions = self.randomBoolean()
+        obj.initiator_doc_type_filter = self.randomList()
+        obj.save(sync_to_couch=False)
+
+        obj.keywordaction_set.all().delete()
+        for i in range(random.randint(1, 3)):
+            obj.keywordaction_set.create(
+                action=self.randomChoice(KEYWORD_ACTION_CHOICES),
+                recipient=self.randomChoice(KEYWORD_RECIPIENT_CHOICES),
+                recipient_id="{}{}".format(i, self.randomString()),
+                message_content=self.randomString(),
+                form_unique_id=self.randomString(),
+                use_named_args=self.randomBoolean(),
+                named_args=self.randomDict(),
+                named_args_separator=self.randomString(),
+            )
+
+        # Sync to couch
+        obj.save()
+
+    def compareObjects(self, couch_obj, sql_obj):
+        keyword_fields = [
+            'domain',
+            'keyword',
+            'description',
+            'delimiter',
+            'override_open_sessions',
+            'initiator_doc_type_filter',
+        ]
+
+        keyword_action_fields = [
+            'recipient',
+            'recipient_id',
+            'action',
+            'message_content',
+            'form_unique_id',
+            'use_named_args',
+            'named_args',
+            'named_args_separator',
+        ]
+
+        self.checkFieldValues(couch_obj, sql_obj, keyword_fields)
+
+        self.assertEqual(len(couch_obj.actions), sql_obj.keywordaction_set.all().count())
+        couch_actions = sorted(couch_obj.actions, key=lambda obj: obj.recipient_id)
+        sql_actions = sql_obj.keywordaction_set.all().order_by('recipient_id')
+
+        for i in range(len(couch_actions)):
+            self.checkFieldValues(couch_actions[i], sql_actions[i], keyword_action_fields)
+
+    def testCouchSyncToSQL(self):
+        self.assertEqual(self.getCouchCount(), 0)
+        self.assertEqual(self.getSQLCount(), 0)
+
+        # Test Create
+        couch_obj = SurveyKeyword()
+        self.setRandomCouchObjectValues(couch_obj)
+        self.assertEqual(self.getCouchCount(), 1)
+        self.assertEqual(self.getSQLCount(), 1)
+
+        sql_obj = Keyword.objects.get(couch_id=couch_obj._id)
+        self.compareObjects(couch_obj, sql_obj)
+        self.assertTrue(SurveyKeyword.get_db().get_rev(couch_obj._id).startswith('1-'))
+
+        # Test Update
+        self.setRandomCouchObjectValues(couch_obj)
+        self.assertEqual(self.getCouchCount(), 1)
+        self.assertEqual(self.getSQLCount(), 1)
+        sql_obj = Keyword.objects.get(couch_id=couch_obj._id)
+        self.compareObjects(couch_obj, sql_obj)
+        self.assertTrue(SurveyKeyword.get_db().get_rev(couch_obj._id).startswith('2-'))
+
+        # Test Delete
+        couch_id = couch_obj._id
+        couch_obj.delete()
+        with self.assertRaises(ResourceNotFound):
+            SurveyKeyword.get(couch_id)
+        self.assertEqual(self.getCouchCount(), 0)
+        self.assertEqual(self.getSQLCount(), 0)
+
+    def testSQLSyncToCouch(self):
+        self.assertEqual(self.getCouchCount(), 0)
+        self.assertEqual(self.getSQLCount(), 0)
+
+        # Test Create
+        sql_obj = Keyword()
+        self.setRandomSQLObjectValues(sql_obj)
+        self.assertEqual(self.getCouchCount(), 1)
+        self.assertEqual(self.getSQLCount(), 1)
+
+        couch_obj = SurveyKeyword.get(sql_obj.couch_id)
+        self.compareObjects(couch_obj, sql_obj)
+        self.assertTrue(SurveyKeyword.get_db().get_rev(couch_obj._id).startswith('2-'))
+
+        # Test Update
+        self.setRandomSQLObjectValues(sql_obj)
+        self.assertEqual(self.getCouchCount(), 1)
+        self.assertEqual(self.getSQLCount(), 1)
+        couch_obj = SurveyKeyword.get(sql_obj.couch_id)
+        self.compareObjects(couch_obj, sql_obj)
+        self.assertTrue(SurveyKeyword.get_db().get_rev(couch_obj._id).startswith('3-'))
+
+        # Test Delete
+        couch_id = couch_obj._id
+        sql_obj.delete()
+        with self.assertRaises(ResourceNotFound):
+            SurveyKeyword.get(couch_id)
+        self.assertEqual(self.getCouchCount(), 0)
+        self.assertEqual(self.getSQLCount(), 0)

--- a/corehq/apps/sms/tests/migration.py
+++ b/corehq/apps/sms/tests/migration.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 from corehq.apps.reminders.models import (SurveyKeyword, SurveyKeywordAction,
     KEYWORD_ACTION_CHOICES, KEYWORD_RECIPIENT_CHOICES)
-from corehq.apps.sms.models import Keyword, KeywordAction
+from corehq.apps.sms.models import Keyword
 from couchdbkit import ResourceNotFound
 import random
 import string


### PR DESCRIPTION
First step in moving keywords from couch to postgres - setting up a two-way sync between the couch and sql models.

@kaapstorm 
@emord 