### PR TITLE
Reduce bulk payload size for ES

### DIFF
--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -14,6 +14,7 @@ from pillowtop.utils import prepare_bulk_payloads, build_bulk_payload, ErrorColl
 
 MAX_TRIES = 3
 RETRY_TIME_DELAY_FACTOR = 15
+MAX_PAYLOAD_SIZE = 10 ** 7  # ~10 MB
 
 
 class Reindexer(six.with_metaclass(ABCMeta)):
@@ -142,8 +143,7 @@ class BulkPillowReindexProcessor(BaseDocProcessor):
         for change, exception in error_collector.errors:
             pillow_logging.error("Error procesing doc %s: %s", change.id, exception)
 
-        max_payload_size = pow(10, 8)  # ~ 100Mb
-        payloads = prepare_bulk_payloads(bulk_changes, max_payload_size)
+        payloads = prepare_bulk_payloads(bulk_changes, MAX_PAYLOAD_SIZE)
         if len(payloads) > 1:
             pillow_logging.info("Payload split into %s parts" % len(payloads))
 


### PR DESCRIPTION
This is my theory for why a lot of apps are missing from ES. Apps tend to be the largest docs we have and attempting to save 100 MB of apps tends to timeout on our ES. We do retry the request, but it will often fail again, and the reindex will exit. I noticed this while doing a manual index of apps.

EDIT: There were > 7k apps missing from ES

I found this email from Oct 24 (when the last app reindex was):

```
Traceback (most recent call last):
  File "/home/cchq/www/production/releases/2016-10-24_19.20/corehq/apps/hqcase/management/commands/ptop_preindex.py", line 130, in handle
    job.get()
  File "/home/cchq/www/production/releases/2016-10-24_19.20/python_env/local/lib/python2.7/site-packages/gevent/greenlet.py", line 251, in get
    raise self._exception
BulkProcessingFailed: Processing batch failed
```

It doesn't really give info, but I think it's probably due to this.

Because 10 MB retries have (from my experience) 100% success rate, the estimated time remaining went from 2.5 hours to 1.25 hours

@czue guessing you have the most context on pillowtop. Does this seem like a likely explanation to you?

@orangejenny buddy @proteusvacuum 