### PR TITLE
fix custom fields

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -19,6 +19,19 @@ hqDefine('case_importer/js/excel_fields.js', function () {
                 customCaseField: ko.observable(excelField),
                 isCustom: ko.observable(false),
             };
+            row.selectedCaseFieldOrBlank = ko.computed({
+                read: function () {
+                    return row.isCustom() ? '' : row.selectedCaseField();
+                },
+                write: row.selectedCaseField,
+            });
+            row.customCaseFieldOrBlank = ko.computed({
+                read: function () {
+                    return row.isCustom() ? row.customCaseField() : '';
+                },
+                write: row.customCaseField,
+            });
+
             row.caseField = ko.computed(function () {
                 if (row.isCustom()) {
                     return row.customCaseField();

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -26,7 +26,7 @@
            placeholder="Enter new property name"
            data-bind="
         visible: isCustom(),
-        value: customCaseField
+        value: customCaseFieldOrBlank
     "/>
 
     <select class="form-control case_field" name="case_field[]" data-bind="
@@ -35,7 +35,7 @@
         optionsCaption: django.gettext('Select property name...'),
         optionsText: 'field',
         optionsValue: 'field',
-        value: selectedCaseField
+        value: selectedCaseFieldOrBlank
     "></select>
 
     <div data-bind="


### PR DESCRIPTION
broken in https://github.com/dimagi/commcare-hq/pull/14254. Strictly speaking, I think the bug predates that, but the fact that I made autofill the default exacerbates it.

this page of the case importer expects two independent lists of case fields: the known ones and the custom ones. For any given index into the lists, only one should have a non-empty value. After django parses those into arrays, it'll look something like

```
case_fields=[u'name', u'age', u'date', u'weight', u'']
custom_fields=[u'', u'', u'', u'', u'num']
```

Now, case importer doesn't actually _validate_ that this invariant holds, it just assumes it. So when merging the two, it first looks in `case_fields` and if it's not there, looks in `custom_fields`. What that means from a user perspective is that if a value in the dropdown (for known case properties) was ever selected during that current screen interaction but then you check the box to make a new property instead, it'll silently use the (hidden) selected value over the (intended) write-in value.