### PR TITLE
Remove keywords and reminders from clone domain

### DIFF
--- a/corehq/apps/hqadmin/management/commands/clone_domain.py
+++ b/corehq/apps/hqadmin/management/commands/clone_domain.py
@@ -21,8 +21,6 @@ types = [
     'apps',
     'user_fields',
     'user_roles',
-    'reminders',
-    'keywords',
     'auto_case_updates',
 ]
 
@@ -75,14 +73,6 @@ class Command(BaseCommand):
         if self._clone_type(options, 'user_roles'):
             from corehq.apps.users.models import UserRole
             self._copy_all_docs_of_type(UserRole)
-
-        if self._clone_type(options, 'reminders'):
-            from corehq.apps.reminders.models import CaseReminderHandler
-            self._copy_all_docs_of_type(CaseReminderHandler)
-
-        if self._clone_type(options, 'keywords'):
-            from corehq.apps.reminders.models import SurveyKeyword
-            self._copy_all_docs_of_type(SurveyKeyword)
 
         if self._clone_type(options, 'auto_case_updates'):
             self.copy_auto_case_update_rules()


### PR DESCRIPTION
Looks like this was added in https://github.com/dimagi/commcare-hq/pull/11381

Copying over reminders and keywords to a new domain is a bit more involved than just copying the data as you have to also resolve any new references to form unique ids and resolve any new references to contact ids like group or user ids. I think there might not have been an issue in the original use of this for the migration to the ICDS SQL domain because it didn't have any reminders or keywords that had those kinds of references.

@snopoke @czue I'm proposing removing copying of reminders and keywords from this command for now. Can we leave it out or do we still need this?

fyi @emord 