### PR TITLE
Make location queryset order by tree and name

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -592,6 +592,9 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
         app_label = 'locations'
         unique_together = ('domain', 'site_code',)
 
+    class MPTTMeta:
+        order_insertion_by = ['name']
+
     def __unicode__(self):
         return u"{} ({})".format(self.name, self.domain)
 

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -142,7 +142,7 @@ class TestLocationQuerysetOrder(LocationHierarchyTestCase):
     def test_backwards_insertion(self):
         mass = self.make_loc("Mass", "state")
         suffolk = self.make_loc("Suffolk", "county", mass)
-        dorcester = self.make_loc("Dorcester", "city", suffolk)
+        dorchester = self.make_loc("Dorchester", "city", suffolk)
         boston = self.make_loc("Boston", "city", suffolk)
         middlesex = self.make_loc("Middlesex", "county", mass)
         somerville = self.make_loc("Somerville", "city", middlesex)
@@ -160,7 +160,7 @@ class TestLocationQuerysetOrder(LocationHierarchyTestCase):
                         "Somerville",
                     "Suffolk",
                         "Boston",
-                        "Dorcester",
+                        "Dorchester",
             ]
         )
 
@@ -172,7 +172,7 @@ class TestLocationQuerysetOrder(LocationHierarchyTestCase):
         middlesex = self.make_loc("Middlesex", "county", mass)
         arlington = self.make_loc("Arlington", "city", middlesex)
         boston = self.make_loc("Boston", "city", suffolk)
-        dorcester = self.make_loc("Dorcester", "city", suffolk)
+        dorchester = self.make_loc("Dorchester", "city", suffolk)
         somerville = self.make_loc("Somerville", "city", middlesex)
 
         cambridge = cambridge.sql_location
@@ -190,6 +190,6 @@ class TestLocationQuerysetOrder(LocationHierarchyTestCase):
                         "Somerville",
                     "Suffolk",
                         "Boston",
-                        "Dorcester",
+                        "Dorchester",
             ]
         )


### PR DESCRIPTION
@sravfeyn @mkangia @proteusvacuum
I just figured out that this was possible - it tells MPTT to factor in the "name" field when setting the "lft" property, which means that with the [default ordering](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/locations/models.py#L316-L316), we'll get something sensible and performant.

What this means is that the default ordering is probably what we should use in most cases, like for displaying in filters and such.  I'm pinging you three just to spread awareness of this, since it's not very obvious that this works at all, let alone how it works.

https://django-mptt.github.io/django-mptt/mptt.models.html#mptt.models.MPTTOptions

@dannyroberts buddy