### PR TITLE
Show full path by default in UCR location filter

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -1181,7 +1181,10 @@ user                 | Select a user
 owner                | Select a possible case owner owner (user, group, or location)
 
 
-Location choice providers also support an "include_descendants" property to include descendant locations in the results, which defaults to `false`.
+Location choice providers also support two additional configuration options:
+
+* "include_descendants" - Include descendant locations in the results. Defaults to `false`.
+* "show_full_path" - display the full path to the location in the filter.  Defaults to `true`.
 
 Example assuming "village" is a location ID, which is converted to names using the location `choice_provider`:
 ```json
@@ -1193,7 +1196,8 @@ Example assuming "village" is a location ID, which is converted to names using t
   "datatype": "string",
   "choice_provider": {
       "type": "location",
-      "include_descendants": false
+      "include_descendants": false,
+      "show_full_path": true
   }
 }
 ```
@@ -1326,13 +1330,13 @@ Expanded columns have a type of `"expanded"`. Expanded columns will be "expanded
 
 If you have a data source like this:
 ```
-+---------+----------+-------------+
++---------|----------|-------------+
 | Patient | district | test_result |
-+---------+----------+-------------+
++---------|----------|-------------+
 | Joe     | North    | positive    |
 | Bob     | North    | positive    |
 | Fred    | South    | negative    |
-+---------+----------+-------------+
++---------|----------|-------------+
 ```
 and a report configuration like this:
 ```
@@ -1358,12 +1362,12 @@ columns:
 ```
 Then you will get a report like this:
 ```
-+----------+----------------------+----------------------+
++----------|----------------------|----------------------+
 | district | test_result-positive | test_result-negative |
-+----------+----------------------+----------------------+
++----------|----------------------|----------------------+
 | North    | 2                    | 0                    |
 | South    | 0                    | 1                    |
-+----------+----------------------+----------------------+
++----------|----------------------|----------------------+
 ```
 
 Expanded columns have an optional parameter `"max_expansion"` (defaults to 10) which limits the number of columns that can be created.  WARNING: Only override the default if you are confident that there will be no adverse performance implications for the server.

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -1184,7 +1184,7 @@ owner                | Select a possible case owner owner (user, group, or locat
 Location choice providers also support two additional configuration options:
 
 * "include_descendants" - Include descendant locations in the results. Defaults to `false`.
-* "show_full_path" - display the full path to the location in the filter.  Defaults to `true`.
+* "show_full_path" - display the full path to the location in the filter.  Defaults to `false`.
 
 Example assuming "village" is a location ID, which is converted to names using the location `choice_provider`:
 ```json
@@ -1196,7 +1196,7 @@ Example assuming "village" is a location ID, which is converted to names using t
   "datatype": "string",
   "choice_provider": {
       "type": "location",
-      "include_descendants": false,
+      "include_descendants": true,
       "show_full_path": true
   }
 }

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -155,9 +155,11 @@ class LocationChoiceProvider(ChainableChoiceProvider):
     def __init__(self, report, filter_slug):
         super(LocationChoiceProvider, self).__init__(report, filter_slug)
         self.include_descendants = False
+        self.show_full_path = True
 
     def configure(self, spec):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)
+        self.show_full_path = spec.get('show_full_path', self.show_full_path)
 
     def _locations_query(self, query_text, user):
         active_locations = SQLLocation.active_objects
@@ -200,7 +202,9 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         return [Choice(SHOW_ALL_CHOICE, "[{}]".format(ugettext('Show All')))]
 
     def _locations_to_choices(self, locations):
-        return [Choice(loc.location_id, loc.display_name) for loc in locations]
+        def display(loc):
+            return loc.get_path_display() if self.show_full_path else loc.display_name
+        return [Choice(loc.location_id, display(loc)) for loc in locations]
 
 
 class UserChoiceProvider(ChainableChoiceProvider):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -155,7 +155,7 @@ class LocationChoiceProvider(ChainableChoiceProvider):
     def __init__(self, report, filter_slug):
         super(LocationChoiceProvider, self).__init__(report, filter_slug)
         self.include_descendants = False
-        self.show_full_path = True
+        self.show_full_path = False
 
     def configure(self, spec):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -345,7 +345,7 @@ class OwnerChoiceProviderTest(LocationHierarchyTestCase, ChoiceProviderTestMixin
                              [cls.mobile_worker.username]),
             SearchableChoice(cls.web_user.get_id, cls.web_user.username,
                              [cls.web_user.username]),
-            SearchableChoice(cls.location.location_id, cls.location.get_path_display(),
+            SearchableChoice(cls.location.location_id, cls.location.display_name,
                              [cls.location.name, cls.location.site_code]),
         ]
         cls.choice_provider = OwnerChoiceProvider(report, None)

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -160,7 +160,7 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         choices = [
             SearchableChoice(
                 location.location_id,
-                location.display_name,
+                location.get_path_display(),
                 searchable_text=[location.site_code, location.name]
             )
             for location in cls.locations.itervalues()
@@ -191,12 +191,12 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         scoped_choices = [
             SearchableChoice(
                 location.location_id,
-                location.display_name,
+                location.get_path_display(),
                 searchable_text=[location.site_code, location.name]
             )
             for location in [
-                self.locations['Cambridge'],
                 self.locations['Middlesex'],
+                self.locations['Cambridge'],
                 self.locations['Somerville'],
             ]
         ]
@@ -340,7 +340,7 @@ class OwnerChoiceProviderTest(LocationHierarchyTestCase, ChoiceProviderTestMixin
                              [cls.mobile_worker.username]),
             SearchableChoice(cls.web_user.get_id, cls.web_user.username,
                              [cls.web_user.username]),
-            SearchableChoice(cls.location.location_id, cls.location.display_name,
+            SearchableChoice(cls.location.location_id, cls.location.get_path_display(),
                              [cls.location.name, cls.location.site_code]),
         ]
         cls.choice_provider = OwnerChoiceProvider(report, None)

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -169,6 +169,10 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         choices = [choice for name, choice in choice_tuples]
         cls.web_user = WebUser.create(cls.domain, 'blah', 'password')
         cls.choice_provider = LocationChoiceProvider(report, None)
+        cls.choice_provider.configure({
+            "include_descendants": False,
+            "show_full_path": True,
+        })
         cls.static_choice_provider = StaticChoiceProvider(choices)
         cls.choice_query_context = partial(ChoiceQueryContext, user=cls.web_user)
 

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -157,15 +157,16 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         delete_all_users()
         super(LocationChoiceProviderTest, cls).setUpClass()
         report = ReportConfiguration(domain=cls.domain)
-        choices = [
-            SearchableChoice(
+        choice_tuples = [
+            (location.name, SearchableChoice(
                 location.location_id,
                 location.get_path_display(),
                 searchable_text=[location.site_code, location.name]
-            )
+            ))
             for location in cls.locations.itervalues()
         ]
-        choices.sort(key=lambda choice: choice.display)
+        choice_tuples.sort()
+        choices = [choice for name, choice in choice_tuples]
         cls.web_user = WebUser.create(cls.domain, 'blah', 'password')
         cls.choice_provider = LocationChoiceProvider(report, None)
         cls.static_choice_provider = StaticChoiceProvider(choices)
@@ -195,8 +196,8 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
                 searchable_text=[location.site_code, location.name]
             )
             for location in [
-                self.locations['Middlesex'],
                 self.locations['Cambridge'],
+                self.locations['Middlesex'],
                 self.locations['Somerville'],
             ]
         ]


### PR DESCRIPTION
You can still disable it if desired.
@czue @noahcarnahan
Cory, I think we discussed this before and there was an argument that the full path display may be too long for some applications.  Is this an acceptable compromise.