### PR TITLE
Add model validation to location excel uploads

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -738,7 +738,7 @@ class LocationTreeValidator(object):
                             u"Error with location in sheet '{}', at row {}. {}: {}").format(
                                 location.location_type, location.index, field, issue
                         ))
-                        
+
         return errors
 
 

--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -725,7 +725,7 @@ class LocationTreeValidator(object):
         errors = []
         for location in self.locations:
             location.lookup_old_collection_data(self.old_collection)  # This method sets location.db_object
-            exclude_fields = []
+            exclude_fields = ["location_type"]  # Skip foreign key validation
             if not location.db_object.location_id:
                 # Don't validate location_id if its blank because SQLLocation.save() will add it
                 exclude_fields.append("location_id")

--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -8,6 +8,7 @@ https://docs.google.com/document/d/1gZFPP8yXjPazaJDP9EmFORi88R-jSytH6TTgMxTGQSk/
 import copy
 from collections import Counter, defaultdict
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.translation import ugettext as _
 
@@ -518,6 +519,10 @@ class LocationTreeValidator(object):
 
         # Location names must be unique among siblings
         errors.extend(self._check_location_names())
+
+        # Model field validation must pass
+        errors.extend(self._check_model_validation())
+
         return errors
 
     @memoized
@@ -713,6 +718,27 @@ class LocationTreeValidator(object):
                         (_(u"There are {} locations with the name '{}' under the parent '{}'")
                          .format(count, name, parent))
                     )
+        return errors
+
+    @memoized
+    def _check_model_validation(self):
+        errors = []
+        for location in self.locations:
+            location.lookup_old_collection_data(self.old_collection)  # This method sets location.db_object
+            exclude_fields = []
+            if not location.db_object.location_id:
+                # Don't validate location_id if its blank because SQLLocation.save() will add it
+                exclude_fields.append("location_id")
+            try:
+                location.db_object.full_clean(exclude=exclude_fields)
+            except ValidationError as e:
+                for field, issues in e.message_dict.iteritems():
+                    for issue in issues:
+                        errors.append(_(
+                            u"Error with location in sheet '{}', at row {}. {}: {}").format(
+                                location.location_type, location.index, field, issue
+                        ))
+                        
         return errors
 
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -374,18 +374,18 @@ class OnlyUnarchivedLocationManager(LocationManager):
 
 class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
     domain = models.CharField(max_length=255, db_index=True)
-    name = models.CharField(max_length=100, null=True)
+    name = models.CharField(max_length=100, null=True, blank=True)
     location_id = models.CharField(max_length=100, db_index=True, unique=True)
     _migration_couch_id_name = "location_id"  # Used for SyncSQLToCouchMixin
     location_type = models.ForeignKey(LocationType, on_delete=models.CASCADE)
     site_code = models.CharField(max_length=255)
-    external_id = models.CharField(max_length=255, null=True)
-    metadata = jsonfield.JSONField(default=dict)
+    external_id = models.CharField(max_length=255, null=True, blank=True)
+    metadata = jsonfield.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)
     is_archived = models.BooleanField(default=False)
-    latitude = models.DecimalField(max_digits=20, decimal_places=10, null=True)
-    longitude = models.DecimalField(max_digits=20, decimal_places=10, null=True)
+    latitude = models.DecimalField(max_digits=20, decimal_places=10, null=True, blank=True)
+    longitude = models.DecimalField(max_digits=20, decimal_places=10, null=True, blank=True)
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children', on_delete=models.CASCADE)
 
     # Use getter and setter below to access this value
@@ -395,7 +395,7 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
     _products = models.ManyToManyField(SQLProduct)
     stocks_all_products = models.BooleanField(default=True)
 
-    supply_point_id = models.CharField(max_length=255, db_index=True, unique=True, null=True)
+    supply_point_id = models.CharField(max_length=255, db_index=True, unique=True, null=True, blank=True)
 
     objects = _tree_manager = LocationManager()
     # This should really be the default location manager

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -374,7 +374,7 @@ class OnlyUnarchivedLocationManager(LocationManager):
 
 class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
     domain = models.CharField(max_length=255, db_index=True)
-    name = models.CharField(max_length=100, null=True, blank=True)
+    name = models.CharField(max_length=100, null=True)
     location_id = models.CharField(max_length=100, db_index=True, unique=True)
     _migration_couch_id_name = "location_id"  # Used for SyncSQLToCouchMixin
     location_type = models.ForeignKey(LocationType, on_delete=models.CASCADE)

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 from django.test import SimpleTestCase, TestCase
+from mock import patch, MagicMock
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType, SQLLocation
@@ -192,11 +193,18 @@ class TestTreeUtils(SimpleTestCase):
         self.assertEqual(set(to_validator('b')), set(['b', 'c']))
         self.assertEqual(set(to_validator('c')), set(['c']))
 
+class MockLocationStub(LocationStub):
+    def lookup_old_collection_data(self, old_collection):
+        try:
+            return super(MockLocationStub, self).lookup_old_collection_data(old_collection)
+        except AttributeError:
+            # This will happen if the LocationStub is not new and an old_collection is not given
+            self.db_object = MagicMock()
 
 def get_validator(location_types, locations, old_collection=None):
     validator = LocationTreeValidator(
         [LocationTypeStub(*loc_type) for loc_type in location_types],
-        [LocationStub(*loc) for loc in locations],
+        [MockLocationStub(*loc) for loc in locations],
         old_collection=old_collection
     )
     return validator
@@ -220,7 +228,6 @@ def make_collection(types, locations):
         custom_data_validator=None,
         domain_name='location-bulk-management',
     )
-
 
 class TestTreeValidator(SimpleTestCase):
 

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from django.test import SimpleTestCase, TestCase
-from mock import patch, MagicMock
+from mock import MagicMock
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType, SQLLocation
@@ -192,6 +192,7 @@ class TestTreeUtils(SimpleTestCase):
         self.assertEqual(set(to_validator('a')), set(['a', 'b', 'c']))
         self.assertEqual(set(to_validator('b')), set(['b', 'c']))
         self.assertEqual(set(to_validator('c')), set(['c']))
+
 
 class MockLocationStub(LocationStub):
     def lookup_old_collection_data(self, old_collection):


### PR DESCRIPTION
Bulk location uploads were missing some validation, such as on the length of the name field. This requirement existed on the django model, but the model was never validated with `full_clean()`. This PR ensures that the model is validated before attempting to save it.
Prompted by [#244300](http://manage.dimagi.com/default.asp?244300).
@czue @esoergel 