### PR TITLE
Do not include shared_properties

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 
 from corehq.apps.export.esaccessors import get_ledger_section_entry_combinations
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.decorators.profile import profile
 from couchdbkit import SchemaListProperty, SchemaProperty, BooleanProperty, DictProperty
 
 from corehq import feature_previews
@@ -1043,6 +1044,7 @@ class ExportDataSchema(Document):
         app_label = 'export'
 
     @classmethod
+    @profile('generate_schema_from_builds')
     def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False):
         """Builds a schema from Application builds for a given identifier
 
@@ -1380,11 +1382,12 @@ class CaseExportDataSchema(ExportDataSchema):
         case_property_mapping = get_case_properties(
             app,
             [case_type],
-            include_parent_properties=False
+            include_parent_properties=False,
+            include_shared_properties=False,
         )
         parent_types, _ = (
             ParentCasePropertyBuilder(app)
-            .get_parent_types_and_contributed_properties(case_type)
+            .get_parent_types_and_contributed_properties(case_type, include_shared_properties=False)
         )
         case_schemas = []
         case_schemas.append(CaseExportDataSchema._generate_schema_from_case_property_mapping(


### PR DESCRIPTION
@czue @NoahCarnahan this optimization shaves off a few seconds for me locally on a 10 build icds app (went down from 18 seconds to 15 seconds). What this does is essentially disallows getting shared case properties. when set to `True` it will call a function called `get_all_shared_apps_in_domain` which is `memoized` but still a hefty call to make for project with lots of apps. since we already go through all apps in the domain, this won't change the functionality much. *however* if you export an app that has shared properties in another app and that app doesn't have any submissions, then the shared case properties won't show up. we can mitigate this by including the current version of every app in the analysis (currently it only includes the current version of the app of the case you selected). put this one in a separate PR cause it's more wishy washy and i'm not sure it's worth it