### PR TITLE
Ensure dashboard feed tables are always in the same order

### DIFF
--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -7,6 +7,8 @@ import zipfile
 import csv
 import json
 import bz2
+from collections import OrderedDict
+
 from django.template import Context
 from django.template.loader import render_to_string, get_template
 import xlwt
@@ -243,7 +245,7 @@ class OnDiskExportWriter(ExportWriter):
     writer_class = CsvFileWriter
 
     def _init(self):
-        self.tables = {}
+        self.tables = OrderedDict()
         self.table_names = {}
 
     def _init_table(self, table_index, table_title):


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?244229
Since the bug is non-deterministic, its a little hard to tell if this definitely solves the problem, but by looking at the code it looks like `items()` is [eventually called](https://github.com/dimagi/commcare-hq/blob/6986d37c9908c15420c5096969ff6fe1e6fbdea8/corehq/ex-submodules/couchexport/writers.py#L492) on this dictionary, and the non-deterministic order of that functions return value is causing the tables to be returned in varying order.
@czue 