### PR TITLE
populate dob

### DIFF
--- a/custom/enikshay/nikshay_datamigration/factory.py
+++ b/custom/enikshay/nikshay_datamigration/factory.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from dimagi.utils.decorators.memoized import memoized
 
@@ -104,6 +104,7 @@ class EnikshayCaseFactory(object):
                     'current_address': self.patient_detail.paddress,
                     'current_address_district_choice': self.district.location_id,
                     'current_address_state_choice': self.state.location_id,
+                    'dob': date(date.today().year - self.patient_detail.page, 7, 1),
                     'dob_known': 'no',
                     'first_name': self.patient_detail.first_name,
                     'last_name': self.patient_detail.last_name,

--- a/custom/enikshay/nikshay_datamigration/migrations/0004_remove_all_tables.py
+++ b/custom/enikshay/nikshay_datamigration/migrations/0004_remove_all_tables.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nikshay_datamigration', '0003_add_outcome_again'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='followup',
+            name='PatientID',
+        ),
+        migrations.RemoveField(
+            model_name='outcome',
+            name='PatientId',
+        ),
+        migrations.DeleteModel(
+            name='Followup',
+        ),
+        migrations.DeleteModel(
+            name='Outcome',
+        ),
+        migrations.DeleteModel(
+            name='PatientDetail',
+        ),
+    ]

--- a/custom/enikshay/nikshay_datamigration/migrations/0005_page_integer.py
+++ b/custom/enikshay/nikshay_datamigration/migrations/0005_page_integer.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nikshay_datamigration', '0004_remove_all_tables'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PatientDetail',
+            fields=[
+                ('PregId', models.CharField(max_length=255, serialize=False, primary_key=True)),
+                ('scode', models.CharField(max_length=255, null=True)),
+                ('Dtocode', models.CharField(max_length=255, null=True)),
+                ('Tbunitcode', models.IntegerField()),
+                ('pname', models.CharField(max_length=255)),
+                ('pgender', models.CharField(max_length=255, choices=[(b'F', b'F'), (b'M', b'M'), (b'T', b'T')])),
+                ('page', models.IntegerField()),
+                ('poccupation', models.CharField(max_length=255)),
+                ('paadharno', models.BigIntegerField(null=True)),
+                ('paddress', models.CharField(max_length=255)),
+                ('pmob', models.CharField(max_length=255, null=True)),
+                ('plandline', models.CharField(max_length=255, null=True)),
+                ('ptbyr', models.CharField(max_length=255, null=True)),
+                ('cname', models.CharField(max_length=255, null=True)),
+                ('caddress', models.CharField(max_length=255, null=True)),
+                ('cmob', models.CharField(max_length=255, null=True)),
+                ('clandline', models.CharField(max_length=255, null=True)),
+                ('cvisitedby', models.CharField(max_length=255, null=True)),
+                ('dcpulmunory', models.CharField(max_length=255, choices=[(b'y', b'y'), (b'Y', b'Y'), (b'N', b'N'), (b'P', b'P')])),
+                ('dcexpulmunory', models.CharField(max_length=255)),
+                ('dcpulmunorydet', models.CharField(max_length=255, null=True)),
+                ('dotname', models.CharField(max_length=255, null=True)),
+                ('dotdesignation', models.CharField(max_length=255, null=True)),
+                ('dotmob', models.CharField(max_length=255, null=True)),
+                ('dotlandline', models.CharField(max_length=255, null=True)),
+                ('dotpType', models.CharField(max_length=255)),
+                ('dotcenter', models.CharField(max_length=255, null=True)),
+                ('PHI', models.IntegerField()),
+                ('dotmoname', models.CharField(max_length=255, null=True)),
+                ('dotmosdone', models.CharField(max_length=255)),
+                ('atbtreatment', models.CharField(max_length=255, null=True, choices=[(b'Y', b'Y'), (b'N', b'N')])),
+                ('atbduration', models.CharField(max_length=255, null=True)),
+                ('atbsource', models.CharField(max_length=255, null=True, choices=[(b'G', b'G'), (b'N', b'N'), (b'O', b'O'), (b'P', b'P')])),
+                ('atbregimen', models.CharField(max_length=255, null=True)),
+                ('atbyr', models.CharField(max_length=255, null=True)),
+                ('Ptype', models.CharField(max_length=255)),
+                ('pcategory', models.CharField(max_length=255)),
+                ('regBy', models.CharField(max_length=255)),
+                ('regDate', models.CharField(max_length=255)),
+                ('isRntcp', models.CharField(max_length=255)),
+                ('dotprovider_id', models.CharField(max_length=255)),
+                ('pregdate1', models.DateField()),
+                ('cvisitedDate1', models.CharField(max_length=255)),
+                ('InitiationDate1', models.CharField(max_length=255)),
+                ('dotmosignDate1', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Followup',
+            fields=[
+                ('id', models.AutoField(serialize=False, primary_key=True)),
+                ('PatientID', models.ForeignKey(to='nikshay_datamigration.PatientDetail')),
+                ('IntervalId', models.CharField(max_length=255)),
+                ('TestDate', models.CharField(max_length=255, null=True)),
+                ('DMC', models.CharField(max_length=255)),
+                ('LabNo', models.CharField(max_length=255, null=True)),
+                ('SmearResult', models.CharField(max_length=255)),
+                ('PatientWeight', models.CharField(max_length=255)),
+                ('DmcStoCode', models.CharField(max_length=255)),
+                ('DmcDtoCode', models.CharField(max_length=255)),
+                ('DmcTbuCode', models.CharField(max_length=255)),
+                ('RegBy', models.CharField(max_length=255)),
+                ('regdate', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Outcome',
+            fields=[
+                ('PatientId', models.OneToOneField(primary_key=True, serialize=False, to='nikshay_datamigration.PatientDetail')),
+                ('Outcome', models.CharField(max_length=255, choices=[(b'NULL', b'NULL'), (b'0', b'0'), (b'1', b'1'), (b'2', b'2'), (b'3', b'3'), (b'4', b'4'), (b'5', b'5'), (b'6', b'6'), (b'7', b'7')])),
+                ('OutcomeDate', models.CharField(max_length=255, null=True)),
+                ('MO', models.CharField(max_length=255, null=True)),
+                ('XrayEPTests', models.CharField(max_length=255, choices=[(b'NULL', b'NULL')])),
+                ('MORemark', models.CharField(max_length=255, null=True)),
+                ('HIVStatus', models.CharField(max_length=255, null=True, choices=[(b'NULL', b'NULL'), (b'Pos', b'Pos'), (b'Neg', b'Neg'), (b'Unknown', b'Unknown')])),
+                ('HIVTestDate', models.CharField(max_length=255, null=True)),
+                ('CPTDeliverDate', models.CharField(max_length=255, null=True)),
+                ('ARTCentreDate', models.CharField(max_length=255, null=True)),
+                ('InitiatedOnART', models.IntegerField(null=True, choices=[(0, 0), (1, 1)])),
+                ('InitiatedDate', models.CharField(max_length=255, null=True)),
+                ('userName', models.CharField(max_length=255)),
+                ('loginDate', models.DateTimeField()),
+                ('OutcomeDate1', models.CharField(max_length=255)),
+            ],
+        ),
+    ]

--- a/custom/enikshay/nikshay_datamigration/models.py
+++ b/custom/enikshay/nikshay_datamigration/models.py
@@ -24,7 +24,7 @@ class PatientDetail(models.Model):
             ('T', 'T'),
         ),
     )
-    page = models.CharField(max_length=255)
+    page = models.IntegerField()
     poccupation = models.CharField(max_length=255)
     paadharno = models.BigIntegerField(null=True)
     paddress = models.CharField(max_length=255)

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -121,6 +121,7 @@ class TestCreateEnikshayCases(TestCase):
                 ('current_address', 'Cambridge MA'),
                 ('current_address_district_choice', self.dto.location_id),
                 ('current_address_state_choice', self.sto.location_id),
+                ('dob', '1998-07-01'),
                 ('dob_known', 'no'),
                 ('first_name', 'A B'),
                 ('last_name', 'C'),


### PR DESCRIPTION
Drops the tables so I can reimport the data, casting ```page``` as an integer; populates ```dob``` according to the method used in the app.

@proteusvacuum @czue 

After this gets merged to master I'll run the migration in a private release and then repopulate the tables.  A full deploy isn't necessary since I assume the migration from then on would be run from branches containing this PR.