### PR TITLE
Escape fewer things from filenames

### DIFF
--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -1,4 +1,3 @@
-import re
 import logging
 from celery.task import task
 
@@ -7,19 +6,12 @@ from corehq.apps.export.export import get_export_file, rebuild_export
 from corehq.apps.export.dbaccessors import get_inferred_schema
 from corehq.apps.export.system_properties import MAIN_CASE_TABLE_PROPERTIES
 from corehq.util.decorators import serial_task
+from corehq.util.files import safe_filename_header
 from corehq.util.quickcache import quickcache
 from couchexport.models import Format
-from couchexport.tasks import escape_quotes
 from soil.util import expose_cached_download
 
 logger = logging.getLogger('export_migration')
-
-
-def _format_filename(filename, extension):
-    filename = escape_quotes('%s.%s' % (filename, extension))
-    filename = filename.encode('utf8')
-    filename = re.sub(r"(\n|\r)", "", filename)
-    return filename
 
 
 @task
@@ -33,14 +25,14 @@ def populate_export_download_task(export_instances, filters, download_id, filena
     )
 
     file_format = Format.from_format(export_file.format)
-    filename = _format_filename(filename or export_instances[0].name, file_format.extension)
+    filename = filename or export_instances[0].name
     payload = export_file.file.payload
     expose_cached_download(
         payload,
         expiry,
         ".{}".format(file_format.extension),
         mimetype=file_format.mimetype,
-        content_disposition='attachment; filename="%s"' % filename,
+        content_disposition=safe_filename_header(filename, file_format.extension),
         download_id=download_id,
     )
     export_file.file.delete()

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -1,8 +1,7 @@
 # encoding: utf-8
 import json
 
-from django.http.response import HttpResponse
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase
 from django.core.urlresolvers import reverse
 
 from corehq.apps.users.models import WebUser
@@ -12,7 +11,6 @@ from corehq.apps.export.dbaccessors import (
     get_form_export_instances,
     get_case_export_instances,
 )
-from corehq.apps.export.tasks import _format_filename
 from corehq.apps.export.views import (
     CreateNewCustomFormExportView,
     CreateNewCustomCaseExportView,
@@ -169,33 +167,3 @@ class ExportViewTest(TestCase):
             follow=True
         )
         self.assertEqual(resp.status_code, 500)  # This is an ajax call which handles the 500
-
-
-class TestFormatFilename(SimpleTestCase):
-
-    def assertWorksAsHeader(self, filename):
-        # Django does some filename validation when trying to set this as a header
-        response = HttpResponse()
-        response['filename'] = filename
-
-    def test_basic_usage(self):
-        filename = _format_filename('test', 'zip')
-        self.assertEqual(filename, 'test.zip')
-        self.assertWorksAsHeader(filename)
-
-    def test_default_export_name(self):
-        # This (with .zip) is a valid filename
-        base_filename = "Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-23 2016-12-23"
-        filename = _format_filename(base_filename, 'zip')
-        self.assertEqual(filename, base_filename + '.zip')
-        self.assertWorksAsHeader(filename)
-
-    def test_no_newlines(self):
-        filename = _format_filename('line 1\nline 2', 'zip')
-        self.assertEqual(filename, 'line 1line 2.zip')
-        self.assertWorksAsHeader(filename)
-
-    def test_newlines_and_wacky_unicode(self):
-        base_filename = u"ICDS CAS - AWW > ड्य\n ूलिस्ट > टीकों का रà\n ��कार्ड: 2016-05-31 2016-05-31.zip"
-        filename = _format_filename(base_filename, 'zip')
-        self.assertWorksAsHeader(filename)

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -1,10 +1,10 @@
 # coding: utf-8
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase
 from elasticsearch.exceptions import ConnectionError
 from mock import Mock
 
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.reports.util import create_export_filter, safe_for_fs
+from corehq.apps.reports.util import create_export_filter
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
@@ -55,12 +55,3 @@ class ReportUtilTests(TestCase):
             filter_.dumps(),
             '[{"function": "corehq.apps.reports.util.case_users_filter", "kwargs": {"users": ["' +
             self.user.user_id + '"], "groups": []}}]')
-
-
-class TestSafeFilename(SimpleTestCase):
-
-    def test_safe_for_fs_bytestring(self):
-        self.assertEqual(safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), 'spam 𐍃𐍀𐌰𐌼-&.txt')
-
-    def test_safe_for_fs_unicode(self):
-        self.assertEqual(safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -2,8 +2,6 @@
 from collections import namedtuple
 from datetime import datetime, timedelta
 from importlib import import_module
-from unidecode import unidecode
-from urllib import quote
 import math
 import pytz
 import warnings
@@ -451,38 +449,6 @@ def get_INFilter_element_bindparam(base_name, index):
 
 def get_INFilter_bindparams(base_name, values):
     return tuple(get_INFilter_element_bindparam(base_name, i) for i, val in enumerate(values))
-
-
-def safe_for_fs(filename):
-    """
-    Returns a filename with FAT32-, NTFS- and HFS+-illegal characters removed.
-
-    Unicode or bytestring datatype of filename is preserved.
-
-    >>> safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt')
-    u'spam 𐍃𐍀𐌰𐌼-&.txt'
-    >>> safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt')
-    'spam 𐍃𐍀𐌰𐌼-&.txt'
-    """
-    is_unicode = isinstance(filename, unicode)
-    unsafe_chars = u':*?"<>|/\\\r\n' if is_unicode else ':*?"<>|/\\\r\n'
-    empty = u'' if is_unicode else ''
-    for c in unsafe_chars:
-        filename = filename.replace(c, empty)
-    return filename
-
-
-def safe_filename_header(filename):
-    # Removes illegal characters from filename and formats for 'Content-Disposition' HTTP header
-    #
-    # See IETF advice https://tools.ietf.org/html/rfc6266#appendix-D
-    # and http://greenbytes.de/tech/tc2231/#attfnboth as a solution to disastrous browser compatibility
-
-    filename = filename if isinstance(filename, unicode) else filename.decode('utf8')
-    safe_filename = safe_for_fs(filename)
-    ascii_filename = unidecode(safe_filename)
-    return 'attachment; filename="{}"; filename*=UTF-8\'\'{}'.format(
-        ascii_filename, quote(safe_filename.encode('utf8')))
 
 
 def resync_case_to_es(domain, case):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -123,6 +123,7 @@ from corehq.apps.users.models import (
     WebUser,
 )
 from corehq.util.couch import get_document_or_404
+from corehq.util.files import safe_filename_header
 from corehq.util.workbook_json.export import WorkBook
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse, reverse
@@ -159,7 +160,6 @@ from .util import (
     get_group,
     group_filter,
     users_matching_filter,
-    safe_filename_header,
     resync_case_to_es)
 from corehq.apps.style.decorators import (
     use_jquery_ui,

--- a/corehq/ex-submodules/couchexport/shortcuts.py
+++ b/corehq/ex-submodules/couchexport/shortcuts.py
@@ -68,7 +68,7 @@ def export_response(file, format, filename, checkpoint=None):
             filename=filename,
             format=format
         )
-        from corehq.apps.reports.util import safe_filename_header
+        from corehq.util.files import safe_filename_header
         response['Content-Disposition'] = safe_filename_header(filename)
 
     if checkpoint:

--- a/corehq/ex-submodules/couchexport/shortcuts.py
+++ b/corehq/ex-submodules/couchexport/shortcuts.py
@@ -63,13 +63,8 @@ def export_response(file, format, filename, checkpoint=None):
         response = StreamingHttpResponse(FileWrapper(file), content_type=format.mimetype)
 
     if format.download:
-        filename = filename if isinstance(filename, unicode) else filename.decode('utf8')
-        filename = u'{filename}.{format.extension}'.format(
-            filename=filename,
-            format=format
-        )
         from corehq.util.files import safe_filename_header
-        response['Content-Disposition'] = safe_filename_header(filename)
+        response['Content-Disposition'] = safe_filename_header(filename, format.extension)
 
     if checkpoint:
         response['X-CommCareHQ-Export-Token'] = checkpoint.get_id

--- a/corehq/util/files.py
+++ b/corehq/util/files.py
@@ -10,22 +10,21 @@ def file_extention_from_filename(filename):
     return ''
 
 
-def safe_for_fs(filename):
+def safe_filename(filename, extension=None):
     """
     Returns a filename with FAT32-, NTFS- and HFS+-illegal characters removed.
 
     Unicode or bytestring datatype of filename is preserved.
 
-    >>> safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt')
+    >>> safe_filename(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt')
     u'spam 𐍃𐍀𐌰𐌼-&.txt'
-    >>> safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt')
-    'spam 𐍃𐍀𐌰𐌼-&.txt'
     """
-    is_unicode = isinstance(filename, unicode)
-    unsafe_chars = u':*?"<>|/\\\r\n' if is_unicode else ':*?"<>|/\\\r\n'
-    empty = u'' if is_unicode else ''
+    filename = filename if isinstance(filename, unicode) else filename.decode('utf8')
+    if extension is not None:
+        filename = u"{}.{}".format(filename, extension)
+    unsafe_chars = u':*?"<>|/\\\r\n'
     for c in unsafe_chars:
-        filename = filename.replace(c, empty)
+        filename = filename.replace(c, u'')
     return filename
 
 
@@ -34,11 +33,7 @@ def safe_filename_header(filename, extension=None):
     #
     # See IETF advice https://tools.ietf.org/html/rfc6266#appendix-D
     # and http://greenbytes.de/tech/tc2231/#attfnboth as a solution to disastrous browser compatibility
-
-    filename = filename if isinstance(filename, unicode) else filename.decode('utf8')
-    if extension is not None:
-        filename = u"{}.{}".format(filename, extension)
-    safe_filename = safe_for_fs(filename)
-    ascii_filename = unidecode(safe_filename)
+    filename = safe_filename(filename, extension)
+    ascii_filename = unidecode(filename)
     return 'attachment; filename="{}"; filename*=UTF-8\'\'{}'.format(
-        ascii_filename, quote(safe_filename.encode('utf8')))
+        ascii_filename, quote(filename.encode('utf8')))

--- a/corehq/util/files.py
+++ b/corehq/util/files.py
@@ -29,13 +29,15 @@ def safe_for_fs(filename):
     return filename
 
 
-def safe_filename_header(filename):
+def safe_filename_header(filename, extension=None):
     # Removes illegal characters from filename and formats for 'Content-Disposition' HTTP header
     #
     # See IETF advice https://tools.ietf.org/html/rfc6266#appendix-D
     # and http://greenbytes.de/tech/tc2231/#attfnboth as a solution to disastrous browser compatibility
 
     filename = filename if isinstance(filename, unicode) else filename.decode('utf8')
+    if extension is not None:
+        filename = u"{}.{}".format(filename, extension)
     safe_filename = safe_for_fs(filename)
     ascii_filename = unidecode(safe_filename)
     return 'attachment; filename="{}"; filename*=UTF-8\'\'{}'.format(

--- a/corehq/util/files.py
+++ b/corehq/util/files.py
@@ -1,5 +1,42 @@
+# encoding: utf-8
+from unidecode import unidecode
+from urllib import quote
+
+
 def file_extention_from_filename(filename):
     extension = filename.rsplit('.', 1)[-1]
     if extension:
         return '.{}'.format(extension)
     return ''
+
+
+def safe_for_fs(filename):
+    """
+    Returns a filename with FAT32-, NTFS- and HFS+-illegal characters removed.
+
+    Unicode or bytestring datatype of filename is preserved.
+
+    >>> safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt')
+    u'spam 𐍃𐍀𐌰𐌼-&.txt'
+    >>> safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt')
+    'spam 𐍃𐍀𐌰𐌼-&.txt'
+    """
+    is_unicode = isinstance(filename, unicode)
+    unsafe_chars = u':*?"<>|/\\\r\n' if is_unicode else ':*?"<>|/\\\r\n'
+    empty = u'' if is_unicode else ''
+    for c in unsafe_chars:
+        filename = filename.replace(c, empty)
+    return filename
+
+
+def safe_filename_header(filename):
+    # Removes illegal characters from filename and formats for 'Content-Disposition' HTTP header
+    #
+    # See IETF advice https://tools.ietf.org/html/rfc6266#appendix-D
+    # and http://greenbytes.de/tech/tc2231/#attfnboth as a solution to disastrous browser compatibility
+
+    filename = filename if isinstance(filename, unicode) else filename.decode('utf8')
+    safe_filename = safe_for_fs(filename)
+    ascii_filename = unidecode(safe_filename)
+    return 'attachment; filename="{}"; filename*=UTF-8\'\'{}'.format(
+        ascii_filename, quote(safe_filename.encode('utf8')))

--- a/corehq/util/tests/test_files.py
+++ b/corehq/util/tests/test_files.py
@@ -2,17 +2,38 @@
 from django.http.response import HttpResponse
 from django.test import SimpleTestCase
 
-from corehq.apps.export.tasks import _format_filename
-from corehq.util.files import safe_for_fs
+from corehq.util.files import safe_filename, safe_filename_header
 
 
 class TestSafeFilename(SimpleTestCase):
 
     def test_safe_for_fs_bytestring(self):
-        self.assertEqual(safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), 'spam 𐍃𐍀𐌰𐌼-&.txt')
+        self.assertEqual(safe_filename('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
 
     def test_safe_for_fs_unicode(self):
-        self.assertEqual(safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
+        self.assertEqual(safe_filename(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
+
+    def test_basic_usage(self):
+        filename = safe_filename('test', 'zip')
+        self.assertEqual(filename, 'test.zip')
+
+    def test_default_export_name(self):
+        base_filename = "Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-23 2016-12-23"
+        # colons are not allowed in filenames on Mac
+        # > and < are not allowed on Windows
+        expected_name = u"Surveys  Survey Category 1 (Ex. Household)  Survey 1 2016-12-23 2016-12-23.zip"
+        filename = safe_filename(base_filename, 'zip')
+        self.assertEqual(filename, expected_name)
+
+    def test_no_newlines(self):
+        filename = safe_filename('line 1\nline 2', 'zip')
+        self.assertEqual(filename, 'line 1line 2.zip')
+
+    def test_newlines_and_wacky_unicode(self):
+        base_filename = u"ICDS CAS - AWW > ड्य\n ूलिस्ट > टीकों का रà\n ��कार्ड: 2016-05-31 2016-05-31"
+        expected_name = u"ICDS CAS - AWW  ड्य ूलिस्ट  टीकों का रà ��कार्ड 2016-05-31 2016-05-31.zip"
+        filename = safe_filename(base_filename, 'zip')
+        self.assertEqual(filename, expected_name)
 
 
 class TestFormatFilename(SimpleTestCase):
@@ -22,24 +43,5 @@ class TestFormatFilename(SimpleTestCase):
         response = HttpResponse()
         response['filename'] = filename
 
-    def test_basic_usage(self):
-        filename = _format_filename('test', 'zip')
-        self.assertEqual(filename, 'test.zip')
-        self.assertWorksAsHeader(filename)
 
-    def test_default_export_name(self):
-        # This (with .zip) is a valid filename
-        base_filename = "Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-23 2016-12-23"
-        filename = _format_filename(base_filename, 'zip')
-        self.assertEqual(filename, base_filename + '.zip')
-        self.assertWorksAsHeader(filename)
-
-    def test_no_newlines(self):
-        filename = _format_filename('line 1\nline 2', 'zip')
-        self.assertEqual(filename, 'line 1line 2.zip')
-        self.assertWorksAsHeader(filename)
-
-    def test_newlines_and_wacky_unicode(self):
-        base_filename = u"ICDS CAS - AWW > ड्य\n ूलिस्ट > टीकों का रà\n ��कार्ड: 2016-05-31 2016-05-31.zip"
-        filename = _format_filename(base_filename, 'zip')
-        self.assertWorksAsHeader(filename)
+    # TODO generate cases with a series of these

--- a/corehq/util/tests/test_files.py
+++ b/corehq/util/tests/test_files.py
@@ -3,45 +3,46 @@ from django.http.response import HttpResponse
 from django.test import SimpleTestCase
 
 from corehq.util.files import safe_filename, safe_filename_header
-
-
-class TestSafeFilename(SimpleTestCase):
-
-    def test_safe_for_fs_bytestring(self):
-        self.assertEqual(safe_filename('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
-
-    def test_safe_for_fs_unicode(self):
-        self.assertEqual(safe_filename(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
-
-    def test_basic_usage(self):
-        filename = safe_filename('test', 'zip')
-        self.assertEqual(filename, 'test.zip')
-
-    def test_default_export_name(self):
-        base_filename = "Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-23 2016-12-23"
-        # colons are not allowed in filenames on Mac
-        # > and < are not allowed on Windows
-        expected_name = u"Surveys  Survey Category 1 (Ex. Household)  Survey 1 2016-12-23 2016-12-23.zip"
-        filename = safe_filename(base_filename, 'zip')
-        self.assertEqual(filename, expected_name)
-
-    def test_no_newlines(self):
-        filename = safe_filename('line 1\nline 2', 'zip')
-        self.assertEqual(filename, 'line 1line 2.zip')
-
-    def test_newlines_and_wacky_unicode(self):
-        base_filename = u"ICDS CAS - AWW > ड्य\n ूलिस्ट > टीकों का रà\n ��कार्ड: 2016-05-31 2016-05-31"
-        expected_name = u"ICDS CAS - AWW  ड्य ूलिस्ट  टीकों का रà ��कार्ड 2016-05-31 2016-05-31.zip"
-        filename = safe_filename(base_filename, 'zip')
-        self.assertEqual(filename, expected_name)
+from corehq.util.test_utils import generate_cases
 
 
 class TestFormatFilename(SimpleTestCase):
 
-    def assertWorksAsHeader(self, filename):
-        # Django does some filename validation when trying to set this as a header
+    def assertWorksAsHeader(self, filename_header):
+        # Django does some validation when trying to set this as a header
         response = HttpResponse()
-        response['filename'] = filename
+        response['Content-Disposition'] = filename_header
+
+    def test_add_extension(self):
+        filename = safe_filename('test', 'zip')
+        self.assertEqual(filename, 'test.zip')
+
+    def test_header_format(self):
+        header = safe_filename_header('test', 'zip')
+        self.assertWorksAsHeader(header)
+        expected = 'attachment; filename="test.zip"; filename*=UTF-8\'\'test.zip'
+        self.assertEqual(header, expected)
 
 
-    # TODO generate cases with a series of these
+@generate_cases([
+
+    ('spam*?: 𐍃𐍀𐌰𐌼-&.txt',
+     u'spam 𐍃𐍀𐌰𐌼-&.txt'),
+
+    (u'spam*?: 𐍃𐍀𐌰𐌼-&.txt',
+     u'spam 𐍃𐍀𐌰𐌼-&.txt'),
+
+    ('line 1\nline 2',
+     'line 1line 2'),
+
+    # colons are not allowed in filenames on Mac, > and < are not allowed on Windows
+    ("Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-23 2016-12-23.zip",
+     u"Surveys  Survey Category 1 (Ex. Household)  Survey 1 2016-12-23 2016-12-23.zip"),
+
+    (u"ICDS CAS - AWW > ड्य\n ूलिस्ट > टीकों का रà\n ��कार्ड: 2016-05-31 2016-05-31.zip",
+     u"ICDS CAS - AWW  ड्य ूलिस्ट  टीकों का रà ��कार्ड 2016-05-31 2016-05-31.zip"),
+
+], TestFormatFilename)
+def test_format_and_set_as_header(self, filename, expected_filename):
+    self.assertEqual(safe_filename(filename), expected_filename)
+    self.assertWorksAsHeader(safe_filename_header(filename))

--- a/corehq/util/tests/test_files.py
+++ b/corehq/util/tests/test_files.py
@@ -1,0 +1,45 @@
+# encoding: utf-8
+from django.http.response import HttpResponse
+from django.test import SimpleTestCase
+
+from corehq.apps.export.tasks import _format_filename
+from corehq.util.files import safe_for_fs
+
+
+class TestSafeFilename(SimpleTestCase):
+
+    def test_safe_for_fs_bytestring(self):
+        self.assertEqual(safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), 'spam 𐍃𐍀𐌰𐌼-&.txt')
+
+    def test_safe_for_fs_unicode(self):
+        self.assertEqual(safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
+
+
+class TestFormatFilename(SimpleTestCase):
+
+    def assertWorksAsHeader(self, filename):
+        # Django does some filename validation when trying to set this as a header
+        response = HttpResponse()
+        response['filename'] = filename
+
+    def test_basic_usage(self):
+        filename = _format_filename('test', 'zip')
+        self.assertEqual(filename, 'test.zip')
+        self.assertWorksAsHeader(filename)
+
+    def test_default_export_name(self):
+        # This (with .zip) is a valid filename
+        base_filename = "Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-23 2016-12-23"
+        filename = _format_filename(base_filename, 'zip')
+        self.assertEqual(filename, base_filename + '.zip')
+        self.assertWorksAsHeader(filename)
+
+    def test_no_newlines(self):
+        filename = _format_filename('line 1\nline 2', 'zip')
+        self.assertEqual(filename, 'line 1line 2.zip')
+        self.assertWorksAsHeader(filename)
+
+    def test_newlines_and_wacky_unicode(self):
+        base_filename = u"ICDS CAS - AWW > ड्य\n ूलिस्ट > टीकों का रà\n ��कार्ड: 2016-05-31 2016-05-31.zip"
+        filename = _format_filename(base_filename, 'zip')
+        self.assertWorksAsHeader(filename)


### PR DESCRIPTION
@dannyroberts @NoahCarnahan

Prompted by http://manage.dimagi.com/default.asp?244453
Looks like the url escaping was done in response to http://manage.dimagi.com/default.asp?228419, but that is more restrictive than is strictly necessary.

This PR tests a couple things we've had issues with in the past, and verifies that it gives reasonable output.