### PR TITLE
add UI for overwriting a module's case list/details using another module

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_detail.html
@@ -17,6 +17,7 @@
 </legend>
 <div data-bind="with: longScreen">
     {% include 'app_manager/v1/partials/case_list_properties.html' %}
+    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
 </div>
 
 {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -67,6 +67,7 @@
         </div>
     </div>
     {% include 'app_manager/v1/partials/case_list_properties.html' %}
+    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
 </div>
 
 {% if detail.type == 'case' %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
@@ -1,23 +1,29 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load xforms_extras %}
+{% load app_manager_extras %}
 {% if module.module_type != 'basic' or request|toggle_enabled:'COPY_CASE_CONFIGS' %}
 <form class="form-inline" method='POST' action='{% url "overwrite_module_case_list" domain app.id module.id %}'>
     {% csrf_token %}
     <fieldset>
         <legend>{% trans "Use Configuration from Existing Module" %}</legend>
-        <p class="help-block">{% trans "This will <strong>overwrite</strong> the current case list/details screen with the configuration from the selected module." %}</p>
-        <label for="other_module_id">{% trans "Module" %}: </label>
-        <select name='source_module_id' class='form-control'>{% for other_mod in app.get_modules %}
-            {% if other_mod.id !=  module.id and other_mod.module_type != 'report' and other_mod.case_type == module.case_type %}
-                <option value={{ other_mod.id }}>{{ other_mod.name|html_trans:langs }}</option>
-            {% endif %}
-        {% endfor %}</select>
-        <input name="detail_type" type="hidden" data-bind="value: columnKey" />
-        <button class='btn btn-danger' type="submit">
-            <i class="fa fa-copy"></i>
-            {% trans "Overwrite Case List" %}
-        </button>
+            <p class="help-block">{% trans "This will <strong>overwrite</strong> the current case list/details screen with the configuration from the selected module." %}</p>
+    {% with app|get_available_modules_for_case_list_configuration:module as available_modules %}
+        {% if available_modules %}
+            <label for="other_module_id">{% trans "Module" %}: </label>
+            <select name='source_module_id' class='form-control'>{% for other_mod in app.get_modules %}
+                {% if other_mod.id !=  module.id and other_mod.module_type != 'report' and other_mod.case_type == module.case_type %}
+                    <option value={{ other_mod.id }}>{{ other_mod.name|html_trans:langs }}</option>
+                {% endif %}
+            {% endfor %}</select>
+            <input name="detail_type" type="hidden" data-bind="value: columnKey" />
+            <button class='btn btn-danger' type="submit">
+                <i class="fa fa-copy"></i>
+                {% trans "Overwrite Case List" %}
+        {% else %}
+            <p><em>{% trans "Didn't find any other modules with the same case type."%}</em></p>
+        {% endif %}
+    {% endwith %}
     </fieldset>
 </form>
 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load xforms_extras %}
+<form class="form-inline" method='POST' action='{% url "overwrite_module_case_list" domain app.id module.id %}'>
+    {% csrf_token %}
+    <fieldset>
+        <legend>{% trans "Use Configuration from Existing Module" %}</legend>
+        <p class="help-block">{% trans "This will <strong>overwrite</strong> the current case list/details screen with the configuration from the selected module." %}</p>
+        <label for="other_module_id">{% trans "Module" %}: </label>
+        <select name='source_module_id' class='form-control'>{% for other_mod in app.get_modules %}
+            {% if other_mod.id !=  module.id and other_mod.module_type != 'report' %}
+                <option value={{ other_mod.id }}>{{ other_mod.name|html_trans:langs }}</option>
+            {% endif %}
+        {% endfor %}</select>
+        <input name="detail_type" type="hidden" data-bind="value: columnKey" />
+        <button class='btn btn-danger' type="submit">
+            <i class="fa fa-copy"></i>
+            {% trans "Overwrite Case List" %}
+        </button>
+    </fieldset>
+</form>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
@@ -9,7 +9,7 @@
         <p class="help-block">{% trans "This will <strong>overwrite</strong> the current case list/details screen with the configuration from the selected module." %}</p>
         <label for="other_module_id">{% trans "Module" %}: </label>
         <select name='source_module_id' class='form-control'>{% for other_mod in app.get_modules %}
-            {% if other_mod.id !=  module.id and other_mod.module_type != 'report' %}
+            {% if other_mod.id !=  module.id and other_mod.module_type != 'report' and other_mod.case_type == module.case_type %}
                 <option value={{ other_mod.id }}>{{ other_mod.name|html_trans:langs }}</option>
             {% endif %}
         {% endfor %}</select>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_module_overwrite.html
@@ -1,5 +1,7 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 {% load xforms_extras %}
+{% if module.module_type != 'basic' or request|toggle_enabled:'COPY_CASE_CONFIGS' %}
 <form class="form-inline" method='POST' action='{% url "overwrite_module_case_list" domain app.id module.id %}'>
     {% csrf_token %}
     <fieldset>
@@ -18,3 +20,4 @@
         </button>
     </fieldset>
 </form>
+{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_detail.html
@@ -17,6 +17,7 @@
 </legend>
 <div data-bind="with: longScreen">
     {% include 'app_manager/v2/partials/case_list_properties.html' %}
+    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
 </div>
 
 {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_detail.html
@@ -17,7 +17,7 @@
 </legend>
 <div data-bind="with: longScreen">
     {% include 'app_manager/v2/partials/case_list_properties.html' %}
-    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
+    {% include 'app_manager/v2/partials/case_list_module_overwrite.html' %}
 </div>
 
 {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -77,6 +77,7 @@
         </div>
     </div>
     {% include 'app_manager/v2/partials/case_list_properties.html' %}
+    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
 </div>
 
 {% if detail.type == 'case' %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -77,7 +77,7 @@
         </div>
     </div>
     {% include 'app_manager/v2/partials/case_list_properties.html' %}
-    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
+    {% include 'app_manager/v2/partials/case_list_module_overwrite.html' %}
 </div>
 
 {% if detail.type == 'case' %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_module_overwrite.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+{% load xforms_extras %}
+{% load app_manager_extras %}
+{% if module.module_type != 'basic' or request|toggle_enabled:'COPY_CASE_CONFIGS' %}
+<form class="form-inline" method='POST' action='{% url "overwrite_module_case_list" domain app.id module.id %}'>
+    {% csrf_token %}
+    <fieldset>
+        <legend>{% trans "Use Configuration from Existing Module" %}</legend>
+            <p class="help-block">{% trans "This will <strong>overwrite</strong> the current case list/details screen with the configuration from the selected module." %}</p>
+    {% with app|get_available_modules_for_case_list_configuration:module as available_modules %}
+        {% if available_modules %}
+            <label for="other_module_id">{% trans "Module" %}: </label>
+            <select name='source_module_id' class='form-control'>{% for other_mod in app.get_modules %}
+                {% if other_mod.id !=  module.id and other_mod.module_type != 'report' and other_mod.case_type == module.case_type %}
+                    <option value={{ other_mod.id }}>{{ other_mod.name|html_trans:langs }}</option>
+                {% endif %}
+            {% endfor %}</select>
+            <input name="detail_type" type="hidden" data-bind="value: columnKey" />
+            <button class='btn btn-danger' type="submit">
+                <i class="fa fa-copy"></i>
+                {% trans "Overwrite Case List" %}
+        {% else %}
+            <p><em>{% trans "Didn't find any other modules with the same case type."%}</em></p>
+        {% endif %}
+    {% endwith %}
+    </fieldset>
+</form>
+{% endif %}

--- a/corehq/apps/app_manager/templatetags/app_manager_extras.py
+++ b/corehq/apps/app_manager/templatetags/app_manager_extras.py
@@ -1,0 +1,14 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def get_available_modules_for_case_list_configuration(app, module):
+    return [
+        m for m in app.get_modules()
+        if m.id != module.id
+           and m.module_type not in ('reports', 'careplan')
+           and m.case_type == module.case_type
+    ]

--- a/corehq/apps/app_manager/templatetags/app_manager_extras.py
+++ b/corehq/apps/app_manager/templatetags/app_manager_extras.py
@@ -8,7 +8,7 @@ register = template.Library()
 def get_available_modules_for_case_list_configuration(app, module):
     return [
         m for m in app.get_modules()
-        if m.id != module.id
-           and m.module_type not in ('reports', 'careplan')
-           and m.case_type == module.case_type
+        if (m.id != module.id
+            and m.module_type not in ('reports', 'careplan')
+            and m.case_type == module.case_type)
     ]

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_detail.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_detail.html.diff.txt
@@ -9,12 +9,14 @@
  
  <div data-bind="saveButton: longScreen.saveButton"></div>
  
-@@ -16,7 +16,7 @@
+@@ -16,8 +16,8 @@
      ></span>
  </legend>
  <div data-bind="with: longScreen">
 -    {% include 'app_manager/v1/partials/case_list_properties.html' %}
+-    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
 +    {% include 'app_manager/v2/partials/case_list_properties.html' %}
-     {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
++    {% include 'app_manager/v2/partials/case_list_module_overwrite.html' %}
  </div>
  
+ {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_detail.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_detail.html.diff.txt
@@ -15,6 +15,6 @@
  <div data-bind="with: longScreen">
 -    {% include 'app_manager/v1/partials/case_list_properties.html' %}
 +    {% include 'app_manager/v2/partials/case_list_properties.html' %}
+     {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
  </div>
  
- {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -27,10 +27,10 @@
      </div>
 -    {% include 'app_manager/v1/partials/case_list_properties.html' %}
 +    {% include 'app_manager/v2/partials/case_list_properties.html' %}
+     {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
  </div>
  
- {% if detail.type == 'case' %}
-@@ -74,7 +84,7 @@
+@@ -75,7 +85,7 @@
      {% trans "Filtering and Sorting" %}
  </legend>
  
@@ -39,7 +39,7 @@
  
  <div data-bind="with: sortRows">
  {% if app.enable_multi_sort %}
-@@ -201,42 +211,15 @@
+@@ -202,42 +212,15 @@
  </div>
  {% endif %}
  

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -21,15 +21,17 @@
  
  <div data-bind="with: customXMLViewModel">
      <div data-bind="visible: enabled">
-@@ -66,7 +76,7 @@
+@@ -66,8 +76,8 @@
              </label>
          </div>
      </div>
 -    {% include 'app_manager/v1/partials/case_list_properties.html' %}
+-    {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
 +    {% include 'app_manager/v2/partials/case_list_properties.html' %}
-     {% include 'app_manager/v1/partials/case_list_module_overwrite.html' %}
++    {% include 'app_manager/v2/partials/case_list_module_overwrite.html' %}
  </div>
  
+ {% if detail.type == 'case' %}
 @@ -75,7 +85,7 @@
      {% trans "Filtering and Sorting" %}
  </legend>

--- a/corehq/apps/app_manager/tests/test_app_manager_v2_diffs.py
+++ b/corehq/apps/app_manager/tests/test_app_manager_v2_diffs.py
@@ -104,16 +104,22 @@ class TestAppManagerV2Diffs(SimpleTestCase):
             )
             filename_v1 = os.path.join(v1_dir, test_file)
             filename_v2 = os.path.join(v2_dir, test_file)
-
-            with open(diff_filename, 'r') as diff_file:
-                existing_diff_lines = diff_file.readlines()
-                current_diff = get_diff(filename_v1, filename_v2)
-                self.assertEqual(
-                    "".join(existing_diff_lines),
-                    "".join(current_diff),
-                    DIFF_FAILURE_MSG.format(
-                        test_file, filename_v1, filename_v2
+            try:
+                with open(diff_filename, 'r') as diff_file:
+                    existing_diff_lines = diff_file.readlines()
+                    current_diff = get_diff(filename_v1, filename_v2)
+                    self.assertEqual(
+                        "".join(existing_diff_lines),
+                        "".join(current_diff),
+                        DIFF_FAILURE_MSG.format(
+                            test_file, filename_v1, filename_v2
+                        )
                     )
+            except IOError:
+                raise Exception(
+                    "Issue opening diff file. "
+                    "You may need to manually create it using ./manage.py build_app_manager_v2_diffs.\n"
+                    "File path is {}".format(diff_filename)
                 )
 
     def test_yaml_01_diffs_exist(self):

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -23,6 +23,7 @@ from corehq.apps.app_manager.views import (
     odk_media_qr_code, odk_install, short_url, short_odk_url, save_copy, revert_to_copy, delete_copy, list_apps,
     direct_ccz, download_index, download_file, formdefs, release_manager, get_form_questions,
 )
+from corehq.apps.app_manager.views.forms import overwrite_module_case_list
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls
 from corehq.apps.hqmedia.urls import download_urls as media_download_urls
 
@@ -66,6 +67,7 @@ app_urls = [
     url(r'^copy/gzip$', export_gzip, name='gzip_app')
 ]
 
+
 urlpatterns = [
     url(r'^$', view_app, name='default_app'),
     url(r'^xform/(?P<form_unique_id>[\w-]+)/$', xform_display, name='xform_display'),
@@ -91,6 +93,8 @@ urlpatterns = [
     url(r'^delete_form/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/(?P<form_unique_id>[\w-]+)/$',
         delete_form, name="delete_form"),
 
+    url(r'^overwrite_module_case_list/(?P<app_id>[\w-]+)/(?P<module_id>[\w-]+)/$',
+        overwrite_module_case_list, name='overwrite_module_case_list'),
     url(r'^copy_form/(?P<app_id>[\w-]+)/(?P<module_id>[\w-]+)/(?P<form_id>[\w-]+)/$',
         copy_form, name='copy_form'),
 

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -22,8 +22,8 @@ from corehq.apps.app_manager.views import (
     edit_app_langs, edit_app_attr, edit_app_ui_translations, get_app_ui_translations, rearrange, odk_qr_code,
     odk_media_qr_code, odk_install, short_url, short_odk_url, save_copy, revert_to_copy, delete_copy, list_apps,
     direct_ccz, download_index, download_file, formdefs, release_manager, get_form_questions,
+    overwrite_module_case_list
 )
-from corehq.apps.app_manager.views.forms import overwrite_module_case_list
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls
 from corehq.apps.hqmedia.urls import download_urls as media_download_urls
 

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -95,6 +95,7 @@ from corehq.apps.app_manager.views.modules import (
     edit_module_detail_screens,
     edit_report_module,
     new_module,
+    overwrite_module_case_list,
     undo_delete_module,
     validate_module_for_build,
     view_module,

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -108,6 +108,26 @@ def delete_form(request, domain, app_id, module_unique_id, form_unique_id):
 
 @no_conflict_require_POST
 @require_can_edit_apps
+def overwrite_module_case_list(request, domain, app_id, module_id):
+    app = get_app(domain, app_id)
+    source_module_id = int(request.POST['source_module_id'])
+    detail_type = request.POST['detail_type']
+    assert detail_type in ['short', 'long']
+    source_module = app.get_module(source_module_id)
+    dest_module = app.get_module(module_id)
+    if not hasattr(source_module, 'case_details'):
+        messages.error(
+            _("Sorry, couldn't find case list configuration for module {}. "
+              "Please report an issue if you believe this is a mistake.").format(source_module.default_name()))
+    else:
+        setattr(dest_module.case_details, detail_type, getattr(source_module.case_details, detail_type))
+        app.save()
+        messages.success(request, _('Case list updated form module {}.').format(source_module.default_name()))
+    return back_to_main(request, domain, app_id=app_id, module_id=module_id)
+
+
+@no_conflict_require_POST
+@require_can_edit_apps
 def copy_form(request, domain, app_id, module_id, form_id):
     app = get_app(domain, app_id)
     to_module_id = int(request.POST['to_module_id'])

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -108,33 +108,6 @@ def delete_form(request, domain, app_id, module_unique_id, form_unique_id):
 
 @no_conflict_require_POST
 @require_can_edit_apps
-def overwrite_module_case_list(request, domain, app_id, module_id):
-    app = get_app(domain, app_id)
-    source_module_id = int(request.POST['source_module_id'])
-    detail_type = request.POST['detail_type']
-    assert detail_type in ['short', 'long']
-    source_module = app.get_module(source_module_id)
-    dest_module = app.get_module(module_id)
-    if not hasattr(source_module, 'case_details'):
-        messages.error(
-            request,
-            _("Sorry, couldn't find case list configuration for module {}. "
-              "Please report an issue if you believe this is a mistake.").format(source_module.default_name()))
-    elif source_module.case_type != dest_module.case_type:
-        messages.error(
-            request,
-            _("Please choose a module with the same case type as the current one ({}).").format(
-                dest_module.case_type)
-        )
-    else:
-        setattr(dest_module.case_details, detail_type, getattr(source_module.case_details, detail_type))
-        app.save()
-        messages.success(request, _('Case list updated form module {}.').format(source_module.default_name()))
-    return back_to_main(request, domain, app_id=app_id, module_id=module_id)
-
-
-@no_conflict_require_POST
-@require_can_edit_apps
 def copy_form(request, domain, app_id, module_id, form_id):
     app = get_app(domain, app_id)
     to_module_id = int(request.POST['to_module_id'])

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -117,6 +117,7 @@ def overwrite_module_case_list(request, domain, app_id, module_id):
     dest_module = app.get_module(module_id)
     if not hasattr(source_module, 'case_details'):
         messages.error(
+            request,
             _("Sorry, couldn't find case list configuration for module {}. "
               "Please report an issue if you believe this is a mistake.").format(source_module.default_name()))
     else:

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -120,6 +120,12 @@ def overwrite_module_case_list(request, domain, app_id, module_id):
             request,
             _("Sorry, couldn't find case list configuration for module {}. "
               "Please report an issue if you believe this is a mistake.").format(source_module.default_name()))
+    elif source_module.case_type != dest_module.case_type:
+        messages.error(
+            request,
+            _("Please choose a module with the same case type as the current one ({}).").format(
+                dest_module.case_type)
+        )
     else:
         setattr(dest_module.case_details, detail_type, getattr(source_module.case_details, detail_type))
         app.save()

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -597,6 +597,33 @@ def undo_delete_module(request, domain, record_id):
     return back_to_main(request, domain, app_id=record.app_id, module_id=record.module_id)
 
 
+@no_conflict_require_POST
+@require_can_edit_apps
+def overwrite_module_case_list(request, domain, app_id, module_id):
+    app = get_app(domain, app_id)
+    source_module_id = int(request.POST['source_module_id'])
+    detail_type = request.POST['detail_type']
+    assert detail_type in ['short', 'long']
+    source_module = app.get_module(source_module_id)
+    dest_module = app.get_module(module_id)
+    if not hasattr(source_module, 'case_details'):
+        messages.error(
+            request,
+            _("Sorry, couldn't find case list configuration for module {}. "
+              "Please report an issue if you believe this is a mistake.").format(source_module.default_name()))
+    elif source_module.case_type != dest_module.case_type:
+        messages.error(
+            request,
+            _("Please choose a module with the same case type as the current one ({}).").format(
+                dest_module.case_type)
+        )
+    else:
+        setattr(dest_module.case_details, detail_type, getattr(source_module.case_details, detail_type))
+        app.save()
+        messages.success(request, _('Case list updated form module {}.').format(source_module.default_name()))
+    return back_to_main(request, domain, app_id=app_id, module_id=module_id)
+
+
 def _update_search_properties(module, search_properties, lang='en'):
     """
     Updates the translation of a module's current search properties, and drops missing search properties.

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -966,3 +966,10 @@ NIMBUS_FORM_VALIDATION = PredictablyRandomToggle(
     [NAMESPACE_DOMAIN],
     randomness=0.1
 )
+
+COPY_CASE_CONFIGS = StaticToggle(
+    'copy_case_configs',
+    'Allow copying case list / details screens in basic modules.',
+    TAG_PRODUCT_CORE,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
faced with the prospect of redoing a giant case list / details screen i decided it'd be a better time spend to just build this feature.

This adds the section at the bottom to the case list and detail screens of all advanced modules, and basic modules using a feature flag.
![image](https://cloud.githubusercontent.com/assets/66555/21480526/6f8d5282-cb66-11e6-9227-fa3e8b370ea2.png)

@dimagi/product @orangejenny I think it'd be really good to productize the basic module version under the GS efficiency umbrella so am keen to hear what you think that takes versus this UI

@proteusvacuum thought you might enjoy this too. 