### PR TITLE
Export directory names

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -11,6 +11,7 @@ from soil import DownloadBase
 from couchexport.export import FormattedRow, get_writer
 from couchexport.files import Temp
 from couchexport.models import Format
+from corehq.util.files import safe_filename
 from corehq.apps.export.esaccessors import (
     get_form_export_base_query,
     get_case_export_base_query,
@@ -61,6 +62,7 @@ class _Writer(object):
             name = export_instances[0].name
         else:
             name = ''
+        name = safe_filename(name)
 
         fd, self._path = tempfile.mkstemp()
         with os.fdopen(fd, 'wb') as file:

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -59,7 +59,7 @@ class _Writer(object):
         assert self._path is None
 
         if len(export_instances) == 1:
-            name = export_instances[0].name
+            name = export_instances[0].name or ''
         else:
             name = ''
         name = safe_filename(name)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -800,8 +800,8 @@ class FormExportInstanceDefaults(ExportInstanceDefaults):
 
     @staticmethod
     def get_default_instance_name(schema):
-        return u'{}: {}'.format(
-            xmlns_to_name(schema.domain, schema.xmlns, schema.app_id),
+        return u'{} ({})'.format(
+            xmlns_to_name(schema.domain, schema.xmlns, schema.app_id, separator=" - "),
             datetime.now().strftime('%Y-%m-%d')
         )
 

--- a/corehq/apps/reports/display.py
+++ b/corehq/apps/reports/display.py
@@ -80,7 +80,9 @@ class _FormType(object):
             except KeyError:
                 self.app_id = None
 
-    def get_label(self, lang=None):
+    def get_label(self, lang=None, separator=None):
+        if separator is None:
+            separator = " > "
         form = get_form_analytics_metadata(self.domain, self.app_id, self.xmlns)
         if form and form.get('app'):
             langs = form['app']['langs']
@@ -88,7 +90,7 @@ class _FormType(object):
 
             if form.get('is_user_registration'):
                 form_name = "User Registration"
-                title = "%s > %s" % (app_name, form_name)
+                title = separator.join([app_name, form_name])
             else:
                 def _menu_name(menu, lang):
                     if lang and menu.get(lang):
@@ -102,7 +104,7 @@ class _FormType(object):
 
                 module_name = _menu_name(form["module"]["name"], lang)
                 form_name = _menu_name(form["form"]["name"], lang)
-                title = "%s > %s > %s" % (app_name, module_name, form_name)
+                title = separator.join([app_name, module_name, form_name])
 
             if form.get('app_deleted'):
                 title += ' [Deleted]'
@@ -114,5 +116,5 @@ class _FormType(object):
         return name
 
 
-def xmlns_to_name(domain, xmlns, app_id, lang=None):
-    return _FormType(domain, xmlns, app_id).get_label(lang)
+def xmlns_to_name(domain, xmlns, app_id, lang=None, separator=None):
+    return _FormType(domain, xmlns, app_id).get_label(lang, separator)


### PR DESCRIPTION
@czue @sravfeyn @benrudolph 
http://manage.dimagi.com/default.asp?243332
This is a two-fold fix:

Commit # 1 changes the default name of new form exports from something like:
`Surveys > Survey Category 1 (Ex. Household) > Survey 1: 2016-12-24`
to something like:
`Surveys - Survey Category 2 (Ex. Village) - Survey 2 (2016-12-27)`
This way what you see on the "edit export" page is a valid name, and will remain unchanged in the download.

Commit # 2 strips any illegal characters from these names before creating the download.

This is a similar issue to https://github.com/dimagi/commcare-hq/pull/14339