### PR TITLE
add report_id to mobile ucr fixture

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -95,7 +95,7 @@ class ReportFixturesProvider(object):
         )
         filters_elem = ReportFixturesProvider._get_filters_elem(defer_filters, filter_options_by_field)
 
-        report_elem = E.report(id=report_config.uuid)
+        report_elem = E.report(id=report_config.uuid, report_id=report_config.report_id)
         report_elem.append(filters_elem)
         report_elem.append(rows_elem)
         return report_elem

--- a/corehq/apps/app_manager/tests/data/fixtures/expected_report.xml
+++ b/corehq/apps/app_manager/tests/data/fixtures/expected_report.xml
@@ -1,4 +1,4 @@
-<report id="c0ffee">
+<report id="c0ffee" report_id="deadbeef">
   <filters/>
   <rows>
     <row index="0" is_total_row="False">


### PR DESCRIPTION
this isn't actually used by the app, but it makes debugging stuff from the restore way easier

@orangejenny / anyone