### PR TITLE
Allow non-superusers to import apps.

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/import_app.html
@@ -39,9 +39,8 @@
         {% csrf_token %}
 {% if app %}
         <p>Import application <strong>{{ app.name }}</strong> from domain <strong>{{ app.domain }}</strong>?</p>
-{% else %}
-        <div class="form-horizontal{% if not is_superuser %} hide{% endif %}">
 {% endif %}
+        <div class="form-horizontal">
             <div class="form-group">
                 <label class="col-sm-2 control-label">Name</label>
                 <div class="col-sm-10">

--- a/corehq/apps/app_manager/templates/app_manager/v2/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/import_app.html
@@ -39,9 +39,8 @@
         {% csrf_token %}
 {% if app %}
         <p>Import application <strong>{{ app.name }}</strong> from domain <strong>{{ app.domain }}</strong>?</p>
-{% else %}
-        <div class="form-horizontal{% if not is_superuser %} hide{% endif %}">
 {% endif %}
+        <div class="form-horizontal">
             <div class="form-group">
                 <label class="col-sm-2 control-label">Name</label>
                 <div class="col-sm-10">

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -396,7 +396,6 @@ def import_app(request, domain, template="app_manager/v1/import_app.html"):
         return render(request, template, {
             'domain': domain,
             'app': app,
-            'is_superuser': request.couch_user.is_superuser
         })
 
 


### PR DESCRIPTION
@orangejenny @nickpell
http://manage.dimagi.com/default.asp?244593
I think this was done in error.  As-is, non superusers can access the page, but they see a blank form.  If they edit the html to remove the "hide" class, they can submit the form sucessfully.  Server-side validation checks for the "edit apps" permission.  This page is documented on the public wiki, so I assume it's intended to be usable by non superusers.
