### PR TITLE
Keep case detail name input from updating too aggressively

### DIFF
--- a/corehq/apps/style/static/style/js/ui-element.js
+++ b/corehq/apps/style/static/style/js/ui-element.js
@@ -64,7 +64,7 @@ var uiElement;
         this.$edit_view = $elem.on('change textchange', function () {
             that.fire('change');
         });
-        $elem.data('lastValue', initialValue);
+
         this.$noedit_view = $('<span class="ui-element-input"/>');
 
         this.on('change', function () {
@@ -73,6 +73,9 @@ var uiElement;
         });
         this.setEdit(this.edit);
         this.val(initialValue);
+
+        // Trigger the textchange plugin's logic, so that it gets the correct initialValue set
+        $elem.trigger('keyup');
     };
     Input.prototype = {
         val: function (value) {

--- a/corehq/apps/style/static/style/js/ui-element.js
+++ b/corehq/apps/style/static/style/js/ui-element.js
@@ -64,6 +64,7 @@ var uiElement;
         this.$edit_view = $elem.on('change textchange', function () {
             that.fire('change');
         });
+        $elem.data('lastValue', initialValue);
         this.$noedit_view = $('<span class="ui-element-input"/>');
 
         this.on('change', function () {

--- a/corehq/apps/style/static/style/js/ui-element.js
+++ b/corehq/apps/style/static/style/js/ui-element.js
@@ -64,7 +64,6 @@ var uiElement;
         this.$edit_view = $elem.on('change textchange', function () {
             that.fire('change');
         });
-
         this.$noedit_view = $('<span class="ui-element-input"/>');
 
         this.on('change', function () {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?236098

https://github.com/dimagi/commcare-hq/pull/12410 fixed this but caused a worse bug that was fixed by https://github.com/dimagi/commcare-hq/pull/12458 which re-broke the original issue. This PR fixes the original bug and doesn't break case detail saving.

[TextChange plugin](https://gist.github.com/mkelly12/424774)

@czue