### PR TITLE
Allow certain properties to be skipped

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -76,3 +76,30 @@ MISSING_VALUE = '---'
 EMPTY_VALUE = ''
 
 UNKNOWN_INFERRED_FROM = 'unknown'
+
+SKIPPABLE_PROPERTIES = frozenset([
+    'initial_processing_complete',
+    '_rev',
+    'computed_modified_on_',
+    'server_modified_on',
+    'domain',
+    'form.#type',
+    'form.@uiVersion',
+    'openrosa_headers.HTTP_X_OPENROSA_VERSION',
+    'openrosa_headers.HTTP_ACCEPT_LANGUAGE',
+    'openrosa_headers.HTTP_DATE',
+    'problem',
+    'doc_type',
+    'path',
+    'version',
+    'date_header',
+    'migrating_blobs_from_couch',
+    'orig_id',
+    'edited_on',
+    'deprecated_date',
+    'deprecated_form_id',
+    'auth_context.authenticated',
+    'auth_context.doc_type',
+    'auth_context.domain',
+    'auth_context.user_id',
+])

--- a/corehq/apps/export/tests/data/saved_export_schemas/skippable_properties.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/skippable_properties.json
@@ -1,0 +1,46 @@
+{
+   "_id": "a28d333f56bd9df737e75a6844d3d749",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Skippable Properties",
+   "index": "[\"aspace\", \"my_sweet_xmlns\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "app_id": "58b0156dc3a8420669efb286bc81e048",
+   "schema_id": "a28d333f56bd9df737e75a6844b54b36",
+   "split_multiselects": false,
+   "tables": [
+       {
+           "index": "#",
+           "doc_type": "ExportTable",
+           "order": [
+           ],
+           "columns": [
+               {
+                   "index": "initial_processing_complete",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "InitialProcessingComplete"
+               },
+               {
+                   "index": "doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "DocType"
+               }
+           ],
+           "display": "My Forms"
+       }
+   ],
+   "include_errors": false,
+   "default_format": "csv",
+   "type": "form",
+   "is_safe": false
+}
+

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -600,6 +600,18 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestConvertBase):
         )
         self.assertEqual(column.deid_transform, DEID_DATE_TRANSFORM)
 
+    def test_skippable_export_columns(self, _, __):
+        instance, _ = self._convert_form_export('skippable_properties')
+
+        table = instance.get_table(MAIN_TABLE)
+
+        index, column = table.get_column(
+            [PathNode(name='initial_processing_complete')], None, None
+        )
+        self.assertIsInstance(column, UserDefinedExportColumn)
+        self.assertFalse(column.is_editable)
+        self.assertEqual(column.custom_path, [PathNode(name='initial_processing_complete')])
+
     def test_system_property_conversion(self, _, __):
         instance, _ = self._convert_form_export('system_properties')
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -32,6 +32,7 @@ from .const import (
     FORM_EXPORT,
     DEID_TRANSFORM_FUNCTIONS,
     TRANSFORM_FUNCTIONS,
+    SKIPPABLE_PROPERTIES,
 )
 
 
@@ -227,7 +228,7 @@ def convert_saved_export_to_export_instance(
                     info.append('Column has deid_transform: {}'.format(transform))
                 ordering.append(new_column)
             except SkipConversion, e:
-                if is_remote_app_migration or force_convert_columns:
+                if is_remote_app_migration or force_convert_columns or column.index in SKIPPABLE_PROPERTIES:
                     # In the event that we skip a column and it's a remote application,
                     # just add a user defined column
                     if export_type == CASE_EXPORT:


### PR DESCRIPTION
@NoahCarnahan this allows the conversion process to auto skip a bunch of properties and add them as user defined columns. this ensures that the export being migrated stays the same, but newly created exports won't have these deprecated properties. i've seen quite a few exports fail because they had these old properties checked and we'd cancel the conversion because of it.

cc: @millerdev 