### PR TITLE
Refactor formplayer breadcrumbs

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -134,7 +134,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.formplayerEnabled = true;
     data.displayOptions = $.extend(true, {}, user.displayOptions);
     data.onerror = function (resp) {
-        showError(resp.human_readable_message || resp.message, $("#cloudcare-notifications"));
+        showError(resp.exception, $("#cloudcare-notifications"));
     };
     data.onsubmit = function (resp) {
         if (resp.status === "success") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -82,7 +82,7 @@ FormplayerFrontend.reqres.setHandler('currentUser', function () {
 
 FormplayerFrontend.on('clearForm', function () {
     $('#webforms').html("");
-    $('#menu-container').removeClass('hide');
+    $('.menu-scrollable-container').removeClass('hide');
     $('#webforms-nav').html("");
     $('#cloudcare-debugger').html("");
     $('.atwho-container').remove();
@@ -164,7 +164,7 @@ FormplayerFrontend.on('startForm', function (data) {
     };
     var sess = new WebFormSession(data);
     sess.renderFormXml(data, $('#webforms'));
-    $('#menu-container').addClass('hide');
+    $('.menu-scrollable-container').addClass('hide');
 });
 
 FormplayerFrontend.on("start", function (options) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -122,6 +122,8 @@ FormplayerFrontend.reqres.setHandler('handleNotification', function(notification
 
 FormplayerFrontend.on('startForm', function (data) {
     FormplayerFrontend.request("clearMenu");
+    FormplayerFrontend.Menus.Util.showBreadcrumbs(data.breadcrumbs);
+
     data.onLoading = tfLoading;
     data.onLoadingComplete = tfLoadingComplete;
     var user = FormplayerFrontend.request('currentUser');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -142,15 +142,17 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
 
     Menus.Util = {
         showBreadcrumbs: function (breadcrumbs) {
-            var breadcrumbsModel = [];
-            for (var i = 0; i < breadcrumbs.length; i++) {
-                var obj = {};
-                obj.data = breadcrumbs[i];
-                obj.id = i;
-                breadcrumbsModel.push(obj);
-            }
-            var detailCollection = new Backbone.Collection();
-            detailCollection.reset(breadcrumbsModel);
+            var detailCollection,
+                breadcrumbModels;
+
+            breadcrumbModels = _.map(breadcrumbs, function(breadcrumb, idx) {
+                return {
+                    data: breadcrumb,
+                    id: idx,
+                };
+            });
+
+            detailCollection = new Backbone.Collection(breadcrumbModels);
             var breadcrumbView = new Menus.Views.BreadcrumbListView({
                 collection: detailCollection,
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -57,7 +57,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
             }
 
             if (menuResponse.breadcrumbs) {
-                Menus.Controller.showBreadcrumbs(menuResponse.breadcrumbs);
+                Menus.Util.showBreadcrumbs(menuResponse.breadcrumbs);
             } else {
                 FormplayerFrontend.regions.breadcrumb.empty();
             }
@@ -69,22 +69,6 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
         showPersistentCaseTile: function (persistentCaseTile) {
             var detailView = Menus.Controller.getCaseTile(persistentCaseTile);
             FormplayerFrontend.regions.persistentCaseTile.show(detailView.render());
-        },
-
-        showBreadcrumbs: function (breadcrumbs) {
-            var breadcrumbsModel = [];
-            for (var i = 0; i < breadcrumbs.length; i++) {
-                var obj = {};
-                obj.data = breadcrumbs[i];
-                obj.id = i;
-                breadcrumbsModel.push(obj);
-            }
-            var detailCollection = new Backbone.Collection();
-            detailCollection.reset(breadcrumbsModel);
-            var breadcrumbView = new Menus.Views.BreadcrumbListView({
-                collection: detailCollection,
-            });
-            FormplayerFrontend.regions.breadcrumb.show(breadcrumbView.render());
         },
 
         showDetail: function (model, detailTabIndex) {
@@ -157,6 +141,22 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
     };
 
     Menus.Util = {
+        showBreadcrumbs: function (breadcrumbs) {
+            var breadcrumbsModel = [];
+            for (var i = 0; i < breadcrumbs.length; i++) {
+                var obj = {};
+                obj.data = breadcrumbs[i];
+                obj.id = i;
+                breadcrumbsModel.push(obj);
+            }
+            var detailCollection = new Backbone.Collection();
+            detailCollection.reset(breadcrumbsModel);
+            var breadcrumbView = new Menus.Views.BreadcrumbListView({
+                collection: detailCollection,
+            });
+            FormplayerFrontend.regions.breadcrumb.show(breadcrumbView.render());
+        },
+
         getMenuView: function (menuResponse) {
             var menuData = {
                 collection: menuResponse,

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -145,11 +145,11 @@
             <section id="formplayer-progress-container"></section>
             <div id="restore-as-region"></div>
             <div id="breadcrumb-region"></div>
-            <div id="persistent-case-tile" class="container"></div>
             <section id="cloudcare-notifications" class="container notifications-container"></section>
+            <div id="persistent-case-tile" class="container"></div>
             <div id="menu-region" class="container"></div>
+            <section id="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
         </div>
-        <section id="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
         <small id="version-info"></small>
         {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
             <section id="cloudcare-debugger" data-bind="

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -56,8 +56,8 @@
 </script>
 
 <script type="text/html" id="form-fullform-ko-template">
-    <div class="breadcrumb-form-container"
-         data-bind="css: { 'breadcrumb-form-single-question': showInFormNavigation }">
+    <div class="webforms-nav-container"
+         data-bind="css: { 'webforms-nav-single-question': showInFormNavigation }">
       <div class="webforms-nav"
            data-bind="template: { name: 'form-navigation-ko-template' }"></div>
     </div>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -93,7 +93,6 @@
 </script>
 
 <script type="text/html" id="instance-viewer-ko-template">
-        <hr/>
         <div id="instance-xml-home" class="debugger" data-bind="
             css: {
                 'debugger-minimized': isMinimized,

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -58,10 +58,6 @@
 <script type="text/html" id="form-fullform-ko-template">
     <div class="breadcrumb-form-container"
          data-bind="css: { 'breadcrumb-form-single-question': showInFormNavigation }">
-      <ol class="breadcrumb breadcrumb-form">
-        <li class="js-home breadcrumb-text"><i class="fa fa-home"></i></li>
-        <li class="breadcrumb-text" data-bind="text: title"></li>
-      </ol>
       <div class="webforms-nav"
            data-bind="template: { name: 'form-navigation-ko-template' }"></div>
     </div>

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -162,18 +162,18 @@
               <div id="menu-region" class="content menu-content"></div>
               <small id="version-info"></small>
             </div>
+            <div class="scrollable-container dragscroll form-scrollable-container">
+              <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
+              {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
+                  <section id="cloudcare-debugger" data-bind="
+                  template: {
+                      name: 'instance-viewer-ko-template',
+                      afterRender: adjustWidth
+                  }
+              "></section>
+              {% endif %}
+            </div>
         </div>
-        <div class="scrollable-container dragscroll form-scrollable-container">
-          <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
-          {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
-              <section id="cloudcare-debugger" data-bind="
-              template: {
-                  name: 'instance-viewer-ko-template',
-                  afterRender: adjustWidth
-              }
-          "></section>
-        </div>
-        {% endif %}
 
         <script>
         $(function () {

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -158,7 +158,7 @@
             <section id="cloudcare-notifications" class="notifications-container"></section>
             <div id="restore-as-region"></div>
             <div id="breadcrumb-region"></div>
-            <div class="scrollable-container dragscroll">
+            <div class="scrollable-container dragscroll menu-scrollable-container">
               <div id="menu-region" class="content menu-content"></div>
               <small id="version-info"></small>
             </div>

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/formnav.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/formnav.less
@@ -24,14 +24,14 @@
   width: 100%;
   background-color: @cc-bg;
   box-sizing: border-box;
-  height: 35px;
+  height: 33px;
   padding: 0;
 }
 
 .btn-formnav {
   background-color: transparent;
   line-height: 12px;
-  padding: 12px 17px 11px;
+  padding: 12px 17px 9px;
   border: none;
   color: @cc-brand-mid;
 

--- a/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
@@ -50,6 +50,6 @@
   .box-shadow(0 0 5px 2px rgba(0,0,0,.3));
 }
 
-.breadcrumb-form-single-question {
-  height: 66px;
+.webforms-nav-single-question {
+  height: 33px;
 }

--- a/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/breadcrumb.less
@@ -46,10 +46,10 @@
   position: fixed;
   z-index: 10;
   width: 100%;
-  height: 30px;
+  height: @webforms-breadcrumb-height;
   .box-shadow(0 0 5px 2px rgba(0,0,0,.3));
 }
 
 .webforms-nav-single-question {
-  height: 33px;
+  height: @webforms-nav-height;
 }

--- a/corehq/apps/style/static/preview_app/less/preview_app/form.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/form.less
@@ -1,7 +1,8 @@
 .form-container {
-  padding-top: 35px;
   background-color: white;
-  min-height: 403px;
+  min-height: -webkit-calc(~"100vh - " (@webforms-nav-height + @webforms-breadcrumb-height));
+  min-height: -moz-calc(~"100vh - " (@webforms-nav-height + @webforms-breadcrumb-height));
+  min-height: calc(~"100vh - " (@webforms-nav-height + @webforms-breadcrumb-height));
   box-sizing: border-box;
 
   .page-header {

--- a/corehq/apps/style/static/preview_app/less/preview_app/form.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/form.less
@@ -40,12 +40,7 @@
 }
 
 .form-single-question {
-  padding-top: 66px;
-  min-height: 443px;
-}
-
-.preview-tablet-mode .form-single-question {
-  min-height: 642px;
+  padding-top: 0px;
 }
 
 .form-container .form-actions {

--- a/corehq/apps/style/static/preview_app/less/preview_app/variables.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/variables.less
@@ -2,3 +2,6 @@
 @preview-tablet-width: 450px;
 @preview-tablet-height: 644px;
 @preview-phone-height: 444px;
+
+@webforms-nav-height: 33px;
+@webforms-breadcrumb-height: 30px;


### PR DESCRIPTION
@biyeun @wpride this refactors some of the HTML in formplayer to have the formplayer templates inside the menu navigation. this allows us to use the menu breadcrumbs while rendering form entry, which means we have breadcrumbs that actually work. i realized this was also necessary for form entry error handling. we were hiding the menu navigation, which contained the cloudcare notifcations div, so no errors were being shown during form entry. broken up by commit. hold on merge because i want to ensure with B that style for one question per screen are OK

<img width="1664" alt="screen shot 2017-01-02 at 4 35 18 pm" src="https://cloud.githubusercontent.com/assets/918514/21591066/817c1cd2-d109-11e6-94a3-2f4b573a6417.png">

needs this guy: https://github.com/dimagi/formplayer/pull/232

cc: @millerdev 