### PR TITLE
prevent modifying non-custom software plans

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1039,12 +1039,13 @@ class PlanInformationForm(forms.Form):
         plan.save()
         return plan
 
-    def update_plan(self, plan):
+    def update_plan(self, request, plan):
         plan.name = self.cleaned_data['name']
         plan.description = self.cleaned_data['description']
         plan.edition = self.cleaned_data['edition']
         plan.visibility = self.cleaned_data['visibility']
         plan.save()
+        messages.success(request, "The %s Software Plan was successfully updated." % self.plan.name)
 
 
 class SoftwarePlanVersionForm(forms.Form):

--- a/corehq/apps/accounting/migrations/0047_ensure_default_product_plans.py
+++ b/corehq/apps/accounting/migrations/0047_ensure_default_product_plans.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.apps.accounting.bootstrap.config.cchq_software_plan_bootstrap import (
+    BOOTSTRAP_CONFIG as ORIGINAL_BOOTSTRAP_CONFIG,
+)
+from corehq.apps.accounting.bootstrap.config.community_v1 import (
+    BOOTSTRAP_CONFIG as COMMUNITY_V1_BOOTSTRAP_CONFIG,
+)
+from corehq.apps.accounting.bootstrap.config.resellers_and_managed_hosting import (
+    BOOTSTRAP_CONFIG as RESELLERS_BOOTSTRAP_CONFIG,
+)
+from corehq.apps.accounting.bootstrap.utils import ensure_plans
+from corehq.sql_db.operations import HqRunPython
+
+
+# from 0003_bootstrap
+def cchq_software_plan_bootstrap(apps, schema_editor):
+    ensure_plans(ORIGINAL_BOOTSTRAP_CONFIG, dry_run=False, verbose=True, apps=apps)
+
+
+# from 0028_bootstrap_new_editions
+def cchq_new_editions_bootstrap(apps, schema_editor):
+    ensure_plans(RESELLERS_BOOTSTRAP_CONFIG, dry_run=False, verbose=True, apps=apps) #
+
+
+# from 0040_community_v1
+def _bootstrap_new_community_role(apps, schema_editor):
+    ensure_plans(COMMUNITY_V1_BOOTSTRAP_CONFIG, dry_run=False, verbose=True, apps=apps)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0046_created_by_blank'),
+    ]
+
+    operations = [
+        HqRunPython(cchq_software_plan_bootstrap),
+        HqRunPython(cchq_new_editions_bootstrap),
+        HqRunPython(_bootstrap_new_community_role),
+    ]

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -577,14 +577,12 @@ class EditSoftwarePlanView(AccountingSectionView, AsyncHandlerMixin):
         if 'update_version' in request.POST:
             if self.software_plan_version_form.is_valid():
                 self.software_plan_version_form.save(request)
-                return HttpResponseRedirect(self.page_url)
             else:
                 for errors in self.software_plan_version_form.errors:
                     for error in errors:
                         messages.error(request, error)
         elif self.plan_info_form.is_valid():
-            self.plan_info_form.update_plan(self.plan)
-            messages.success(request, "The %s Software Plan was successfully updated." % self.plan.name)
+            self.plan_info_form.update_plan(request, self.plan)
         return self.get(request, *args, **kwargs)
 
 


### PR DESCRIPTION
Solves the underlying issue in http://manage.dimagi.com/default.asp?244858 @czue 

After the migration gets run, I'll check for any existing subscriptions on the default plans if they're on the custom software plan versions and flag with Ops any that look wrong.