### PR TITLE
use advanced_plan_v0 for managed and hosted plans

### DIFF
--- a/corehq/apps/accounting/bootstrap/config/resellers_and_managed_hosting.py
+++ b/corehq/apps/accounting/bootstrap/config/resellers_and_managed_hosting.py
@@ -7,7 +7,7 @@ from corehq.apps.accounting.models import (
 
 BOOTSTRAP_CONFIG = {
     (SoftwarePlanEdition.MANAGED_HOSTING, False): {
-        'role': 'managed_hosting_plan_v0',
+        'role': 'advanced_plan_v0',
         'product_rate': dict(monthly_fee=Decimal('1000.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=0, per_excess_fee=Decimal('1.00')),
@@ -15,7 +15,7 @@ BOOTSTRAP_CONFIG = {
         }
     },
     (SoftwarePlanEdition.RESELLER, False): {
-        'role': 'reseller_plan_v0',
+        'role': 'advanced_plan_v0',
         'product_rate': dict(monthly_fee=Decimal('1000.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=10, per_excess_fee=Decimal('1.00')),


### PR DESCRIPTION
needed alongside https://github.com/dimagi/commcare-hq/pull/14396

kinda confused how the managed/hosted plans ever got set in the first place.  In any case, this ensures that the migration is consistent with what is currently on our production environments.