### PR TITLE
Fail gracefully if a user is missing a location.

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -750,17 +750,14 @@ class SupplyPointSelectWidget(forms.Widget):
 
     def render(self, name, value, attrs=None):
         location_ids = value.split(',') if value else []
-        from corehq.apps.locations.util import get_locations_from_ids
-        try:
-            locations = get_locations_from_ids(location_ids, self.domain)
-        except SQLLocation.DoesNotExist:
-            locations = []
+        locations = list(SQLLocation.active_objects
+                         .filter(domain=self.domain, location_id__in=location_ids))
         initial_data = [{'id': loc.location_id, 'name': loc.display_name} for loc in locations]
 
         return get_template('locations/manage/partials/autocomplete_select_widget.html').render(Context({
             'id': self.id,
             'name': name,
-            'value': value or '',
+            'value': ','.join(loc.location_id for loc in locations),
             'query_url': self.query_url,
             'multiselect': self.multiselect,
             'initial_data': initial_data,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?240767
@sravfeyn
Sometimes users are assigned to locations that no longer exist. This shouldn't happen, but it does, and at least this way they'll be able to edit their locations and it'll fix itself.