### PR TITLE
Drop unneeded stylesheet

### DIFF
--- a/corehq/apps/style/templates/style/soil_status_full.html
+++ b/corehq/apps/style/templates/style/soil_status_full.html
@@ -2,10 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block stylesheets %}{{ block.super }}
-    <link rel="stylesheet" href="{% static 'locations/css/manage.css' %}">
-{% endblock %}
-
 {% block js-inline %}{{ block.super }}
     <script>
         var autoRefresh = '';


### PR DESCRIPTION
@esoergel 

Added [during B3 migration](https://github.com/dimagi/commcare-hq/commit/8660842ec2f5a810fa2a0f1d7782644261a14f58), guessing in error. This template doesn't use any of the classes in manage.css except maaaaybe if the ajax call returns HTML containing them...but the only locations-related code that uses this template is [location_importer_job_poll](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/locations/views.py#L868), which uses a standard soil template, not a locations-specific template.