### PR TITLE
Ability to include_without_expanding to the same level as 'expand_from'

### DIFF
--- a/corehq/apps/locations/static/locations/js/location_types.js
+++ b/corehq/apps/locations/static/locations/js/location_types.js
@@ -300,8 +300,11 @@ hqDefine('locations/js/location_types.js', function(){
             if (self.expand_from() !== ROOT_LOCATION_ID){
                 if (typeof(self.expand_from()) === 'undefined' || self.expand_from() === null){
                     options = self.parents().reverse();
+                    options.push(self);
                 } else {
-                    options = self.view.loc_types_by_id()[self.expand_from()].parents();
+                    var expand_from_type = self.view.loc_types_by_id()[self.expand_from()];
+                    options = expand_from_type.parents();
+                    options.push(expand_from_type);
                     options = options.reverse();
                 }
                 return options;

--- a/corehq/apps/locations/static/locations/spec/types_spec.js
+++ b/corehq/apps/locations/static/locations/spec/types_spec.js
@@ -82,17 +82,17 @@ describe('Location Types', function() {
                     this.block_model.include_without_expanding_options(),
                     extract_name
                 ),
-                    desired_loc_types_returned = _.map([this.state_model, this.district_model], extract_name);
+                    desired_loc_types_returned = _.map([this.state_model, this.district_model, this.block_model], extract_name);
                 assert.sameMembers(desired_loc_types_returned, returned_loc_types);
             });
 
-            it('Provides everything above the expand from level', function(){
+            it('Provides everything above and including the expand from level', function(){
                 this.block_model.expand_from(this.district_model.pk);
                 var returned_loc_types = _.map(
                     this.block_model.include_without_expanding_options(),
                     extract_name
                 ),
-                    desired_loc_types_returned = _.map([this.state_model], extract_name);
+                    desired_loc_types_returned = _.map([this.state_model, this.district_model], extract_name);
                 assert.sameMembers(desired_loc_types_returned, returned_loc_types);
             });
 

--- a/corehq/apps/locations/tests/data/include_without_expanding_same_level.xml
+++ b/corehq/apps/locations/tests/data/include_without_expanding_same_level.xml
@@ -1,0 +1,70 @@
+<fixture id="commtrack:locations" user_id="{user_id}">
+  <states>
+    <state id="{massachusetts_id}">
+      <name>Massachusetts</name>
+      <site_code>massachusetts</site_code>
+      <external_id />
+      <latitude />
+      <longitude />
+      <location_type>state</location_type>
+      <supply_point_id />
+      <location_data />
+      <countys>
+        <county id="{suffolk_id}">
+          <name>Suffolk</name>
+          <site_code>suffolk</site_code>
+          <external_id />
+          <latitude />
+          <longitude />
+          <location_type>county</location_type>
+          <supply_point_id />
+          <location_data />
+          <citys>
+            <city id="{boston_id}">
+              <name>Boston</name>
+              <site_code>boston</site_code>
+              <external_id />
+              <latitude />
+              <longitude />
+              <location_type>city</location_type>
+              <supply_point_id />
+              <location_data />
+            </city>
+            <city id="{revere_id}">
+              <name>Revere</name>
+              <site_code>revere</site_code>
+              <external_id />
+              <latitude />
+              <longitude />
+              <location_type>city</location_type>
+              <supply_point_id />
+              <location_data />
+            </city>
+          </citys>
+        </county>
+      </countys>
+    </state>
+    <state id="{new_york_id}">
+      <name>New York</name>
+      <site_code>new_york</site_code>
+      <external_id />
+      <latitude />
+      <longitude />
+      <location_type>state</location_type>
+      <supply_point_id />
+      <location_data />
+      <countys>
+        <county id="{new_york_city_id}">
+          <name>New York City</name>
+          <site_code>new york city</site_code>
+          <external_id />
+          <latitude />
+          <longitude />
+          <location_type>county</location_type>
+          <supply_point_id />
+          <location_data />
+        </county>
+      </countys>
+    </state>
+  </states>
+</fixture>

--- a/corehq/apps/locations/tests/data/include_without_expanding_same_level.xml
+++ b/corehq/apps/locations/tests/data/include_without_expanding_same_level.xml
@@ -10,6 +10,16 @@
       <supply_point_id />
       <location_data />
       <countys>
+        <county id="{middlesex_id}">
+          <name>Middlesex</name>
+          <site_code>middlesex</site_code>
+          <external_id />
+          <latitude />
+          <longitude />
+          <location_type>county</location_type>
+          <supply_point_id />
+          <location_data />
+        </county>
         <county id="{suffolk_id}">
           <name>Suffolk</name>
           <site_code>suffolk</site_code>
@@ -56,7 +66,7 @@
       <countys>
         <county id="{new_york_city_id}">
           <name>New York City</name>
-          <site_code>new york city</site_code>
+          <site_code>new_york_city</site_code>
           <external_id />
           <latitude />
           <longitude />


### PR DESCRIPTION
With the "include without expanding" feature, we should be able to select the same location type or the location type that is at the same level as the "include_without_expanding" location type.
This allows us to include all "districts" in eNikshay and doing an "expand_from = district", which will expand only the locations beneath the user's assigned district. 

Hard to explain in words, but I think the test case I wrote should make sense. 

@esoergel 
CC @nickpell 

