### PR TITLE
Support multiple groups in export filters

### DIFF
--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -29,7 +29,7 @@ def get_case_export_base_query(domain, case_type):
 def get_groups_user_ids(group_ids):
     q = (GroupES()
          .doc_id(group_ids))
-    return q.values_list("users", flat=True)
+    return [user for user_list in q.values_list("users", flat=True) for user in user_list]
 
 
 def get_ledger_section_entry_combinations(domain):

--- a/corehq/apps/export/tests/test_esaccessors.py
+++ b/corehq/apps/export/tests/test_esaccessors.py
@@ -1,11 +1,13 @@
 import uuid
 
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 
-from corehq.apps.export.esaccessors import get_ledger_section_entry_combinations
+from corehq.apps.export.esaccessors import get_ledger_section_entry_combinations, get_groups_user_ids
 from corehq.elastic import send_to_elasticsearch, get_es_new
 from corehq.form_processor.models import LedgerValue
 from corehq.pillows.mappings.ledger_mapping import LEDGER_INDEX_INFO
+from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
+from corehq.apps.groups.models import Group
 from corehq.util.elastic import ensure_index_deleted
 from pillowtop.es_utils import initialize_index_and_mapping
 
@@ -48,3 +50,44 @@ class TestExportESAccessors(TestCase):
             self.expected_combos,
             {(combo.section_id, combo.entry_id) for combo in combos}
         )
+
+
+class TestGroupUserIds(SimpleTestCase):
+    domain = 'group-es-domain'
+
+    @classmethod
+    def setUpClass(cls):
+        ensure_index_deleted(GROUP_INDEX_INFO.index)
+        cls.es = get_es_new()
+        initialize_index_and_mapping(cls.es, GROUP_INDEX_INFO)
+        cls.es.indices.refresh(GROUP_INDEX_INFO.index)
+
+    @classmethod
+    def tearDownClass(cls):
+        ensure_index_deleted(GROUP_INDEX_INFO.index)
+
+    def _send_group_to_es(self, _id=None, users=None):
+        group = Group(
+            domain=self.domain,
+            name='narcos',
+            users=users or [],
+            case_sharing=False,
+            reporting=True,
+            _id=_id or uuid.uuid4().hex,
+        )
+        send_to_elasticsearch('groups', group.to_json())
+        self.es.indices.refresh(GROUP_INDEX_INFO.index)
+        return group
+
+    def test_one_group_to_users(self):
+        group1 = self._send_group_to_es(users=['billy', 'joel'])
+
+        user_ids = get_groups_user_ids([group1._id])
+        self.assertEqual(set(user_ids), set(['billy', 'joel']))
+
+    def test_multiple_groups_to_users(self):
+        group1 = self._send_group_to_es(users=['billy', 'joel'])
+        group2 = self._send_group_to_es(users=['eric', 'clapton'])
+
+        user_ids = get_groups_user_ids([group1._id, group2._id])
+        self.assertEqual(set(user_ids), set(['billy', 'joel', 'eric', 'clapton']))


### PR DESCRIPTION
I think when this was originally written, the caller thought `flat=True` would flatten the list returned by `users`, but `flat=True` flattens the dictionary. normally the response looks like this:
```
[{"users": ['myid', 'other']}]
```
with `flat=True`
```
[['myid', 'other']]
```
And then when you'd have multiple groups, it'd be a list of lists causing ES to choke. this fixes that.

http://manage.dimagi.com/default.asp?244916

cc: @millerdev @gcapalbo 