### PR TITLE
don't use breadcrumbs for incomplete forms

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -2,4 +2,8 @@
 
 FormplayerFrontend.Constants = {
     ALLOWED_SAVED_OPTIONS: ['oneQuestionPerScreen'],
+
+    // These should match corehq/apps/cloudcare/const.py
+    WEB_APPS_ENVIRONMENT: 'web-apps',
+    PREVIEW_APP_ENVIRONMENT: 'preview-app',
 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -40,7 +40,13 @@ FormplayerFrontend.module("SessionNavigate.SessionList", function (SessionList, 
 
     SessionList.SessionListView = Marionette.CompositeView.extend({
         tagName: "div",
-        template: "#session-view-list-template",
+        getTemplate: function() {
+            var user = FormplayerFrontend.request('currentUser');
+            if (user.environment === FormplayerFrontend.Constants.PREVIEW_APP_ENVIRONMENT) {
+                return "#session-view-list-preview-template";
+            }
+            return "#session-view-list-web-apps-template";
+        },
         childView: SessionList.SessionView,
         childViewContainer: "tbody",
     });

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -2,13 +2,10 @@
 {% load i18n %}
 
 <script type="text/template" id="session-view-list-template">
-    <div class="breadcrumb-form-container">
-      <ol class="breadcrumb breadcrumb-form">
-        <li class="js-home breadcrumb-text"><i class="fa fa-home"></i></li>
-        <li class="breadcrumb-text">{% trans "Incomplete Forms" %}</li>
-      </ol>
-    </div>
     <div class="module-menu-container module-menu-bar-offset">
+        <div class="page-header menu-header">
+            <h1 class="page-title">{% trans "Incomplete Forms" %}</h1>
+        </div>
         <table class="table module-table">
             <tbody>
             </tbody>

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -1,7 +1,21 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<script type="text/template" id="session-view-list-template">
+<script type="text/template" id="session-view-list-preview-template">
+    <div class="breadcrumb-form-container">
+       <ol class="breadcrumb breadcrumb-form">
+         <li class="breadcrumb-text">{% trans "Incomplete Forms" %}</li>
+       </ol>
+    </div>
+    <div class="module-menu-container module-menu-bar-offset">
+        <table class="table module-table">
+            <tbody>
+            </tbody>
+        </table>
+    </div>
+</script>
+
+<script type="text/template" id="session-view-list-web-apps-template">
     <div class="module-menu-container module-menu-bar-offset">
         <div class="page-header menu-header">
             <h1 class="page-title">{% trans "Incomplete Forms" %}</h1>


### PR DESCRIPTION
@biyeun looks like you made this header breadcrumbs. was that intentional? https://github.com/dimagi/commcare-hq/commit/dd0ed819

changed it back because i thought it looked weird
before:
![screen shot 2017-01-05 at 12 54 19 pm](https://cloud.githubusercontent.com/assets/918514/21678212/7bea28a6-d346-11e6-89e3-4ccdb7d5a183.png)
after:
![screen shot 2017-01-05 at 12 55 24 pm](https://cloud.githubusercontent.com/assets/918514/21678231/9a99359e-d346-11e6-8de9-35a7db7e3c01.png)

cc: @millerdev @gcapalbo 