### PR TITLE
Only process current apps

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1046,7 +1046,8 @@ class ExportDataSchema(Document):
         app_label = 'export'
 
     @classmethod
-    def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False):
+    def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False,
+            only_process_current_builds=False):
         """Builds a schema from Application builds for a given identifier
 
         :param domain: The domain that the export belongs to
@@ -1065,11 +1066,13 @@ class ExportDataSchema(Document):
         else:
             current_schema = cls()
 
-        app_build_ids = cls._get_app_build_ids_to_process(
-            domain,
-            app_id,
-            current_schema.last_app_versions,
-        )
+        app_build_ids = []
+        if not only_process_current_builds:
+            app_build_ids = cls._get_app_build_ids_to_process(
+                domain,
+                app_id,
+                current_schema.last_app_versions,
+            )
         app_build_ids.extend(cls._get_current_app_ids_for_domain(domain, app_id))
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids, chunksize=10):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1070,10 +1070,7 @@ class ExportDataSchema(Document):
             app_id,
             current_schema.last_app_versions,
         )
-        if app_id:
-            app_build_ids.append(app_id)
-        else:
-            app_build_ids.extend(cls._get_current_app_ids_for_domain(domain))
+        app_build_ids.extend(cls._get_current_app_ids_for_domain(domain, app_id))
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids, chunksize=10):
             if (not app_doc.get('has_submissions', False) and
@@ -1217,8 +1214,8 @@ class FormExportDataSchema(ExportDataSchema):
         self.xmlns = form_xmlns
 
     @classmethod
-    def _get_current_app_ids_for_domain(cls, domain):
-        raise BadExportConfiguration('Form exports should only use one app_id and this should not be called')
+    def _get_current_app_ids_for_domain(cls, domain, app_id):
+        return [app_id]
 
     @staticmethod
     def _get_app_build_ids_to_process(domain, app_id, last_app_versions):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1087,7 +1087,11 @@ class ExportDataSchema(Document):
                 identifier,
             )
 
-            current_schema.record_update(app.copy_of or app._id, app.version)
+            # Only record the version of builds on the schema. We don't care about
+            # whether or not the schema has seen the current build because that always
+            # gets processed.
+            if app.copy_of:
+                current_schema.record_update(app.copy_of, app.version)
 
         inferred_schema = cls._get_inferred_schema(domain, identifier)
         if inferred_schema:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1461,7 +1461,7 @@ class CaseExportDataSchema(ExportDataSchema):
         return get_inferred_schema(domain, case_type)
 
     @classmethod
-    def _get_current_app_ids_for_domain(cls, domain):
+    def _get_current_app_ids_for_domain(cls, domain, app_id):
         return get_app_ids_in_domain(domain)
 
     @staticmethod

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -24,6 +24,7 @@ hqDefine('export/js/models.js', function () {
 
         self.buildSchemaProgress = ko.observable(0);
         self.showBuildSchemaProgressBar = ko.observable(false);
+        self.errorOnBuildSchema = ko.observable(false);
 
         // Detetrmines the state of the save. Used for controlling the presentaiton
         // of the Save button.
@@ -90,6 +91,7 @@ hqDefine('export/js/models.js', function () {
             },
             error: function() {
                 $btn.prop('disable', false);
+                self.errorOnBuildSchema(true);
             },
         });
     };
@@ -112,7 +114,7 @@ hqDefine('export/js/models.js', function () {
                 }
             },
             error: function() {
-                console.log('error');
+                self.errorOnBuildSchema(true);
             },
         });
     };

--- a/corehq/apps/export/static/export/spec/ExportInstance.spec.js
+++ b/corehq/apps/export/static/export/spec/ExportInstance.spec.js
@@ -7,7 +7,7 @@ describe('ExportInstance model', function() {
     var basicFormExport, savedFormExport;
     hqImport('hqwebapp/js/urllib.js').registerUrl(
         "build_schema", "/a/---/data/export/build_full_schema/"
-    )
+    );
     beforeEach(function() {
         basicFormExport = _.clone(SampleExportInstances.basic, { saveUrl: 'http://saveurl/' });
         savedFormExport = _.clone(SampleExportInstances.saved, { saveUrl: 'http://saveurl/' });

--- a/corehq/apps/export/static/export/spec/data/export_instances.js
+++ b/corehq/apps/export/static/export/spec/data/export_instances.js
@@ -2,6 +2,8 @@ SampleExportInstances = {
     basic: {
         "name": null,
         "type": "form",
+        "domain": "domain",
+        "app_id": "1234",
         "tables": [{
             "path": null,
             "name": null,

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -87,3 +87,13 @@ def _cached_add_inferred_export_properties(sender, domain, case_type, properties
             group_schema.put_item(path, inferred_from=sender, item_cls=ScalarItem)
 
     inferred_schema.save()
+
+
+@task(queue='background_queue')
+def generate_schema_for_all_builds(schema_cls, domain, app_id, identifier):
+    schema_cls.generate_schema_from_builds(
+        domain,
+        app_id,
+        identifier,
+        only_process_current_builds=False,
+    )

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -89,11 +89,12 @@ def _cached_add_inferred_export_properties(sender, domain, case_type, properties
     inferred_schema.save()
 
 
-@task(queue='background_queue')
-def generate_schema_for_all_builds(schema_cls, domain, app_id, identifier):
+@task(queue='background_queue', bind=True)
+def generate_schema_for_all_builds(self, schema_cls, domain, app_id, identifier):
     schema_cls.generate_schema_from_builds(
         domain,
         app_id,
         identifier,
         only_process_current_builds=False,
+        task=self,
     )

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -4,6 +4,7 @@
 
 {% block js %}
     {{ block.super }}
+    <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
     <script src="{% static 'export/js/const.js' %}"></script>
     <script src="{% static 'export/js/utils.js' %}"></script>
     <script src="{% static 'export/js/models.js' %}"></script>
@@ -21,7 +22,9 @@
                     hasDailySavedAccess: {{ has_daily_saved_export_access|JSON }},
                 }
             );
-
+            hqImport('hqwebapp/js/urllib.js').registerUrl(
+                "build_schema", "/a/---/data/export/build_full_schema/"
+            )
             $('#customize-export').koApplyBindings(customExportView);
             $('.export-tooltip').tooltip();
         });
@@ -158,31 +161,51 @@
         </fieldset>
         {% endif %}
 
-        {% if allow_deid %}
         <fieldset>
-            <legend>{% trans "Privacy Settings" %}</legend>
+            <legend>{% trans "Settings" %}</legend>
+            {% if allow_deid %}
             <div class="form-group">
-                <label for="is_safe" class="col-sm-4 col-md-3 col-lg-2 control-label"></label>
-                <div class="col-sm-4 col-md-3 col-lg-2 deid-column" data-bind="visible: isDeidColumnVisible()">
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox" id="is_deidentified" data-bind="checked: is_deidentified" />
-                            {% trans "Publish as De-Identified" %}
-                        </label>
+                <label for="is_safe" class="col-sm-3 col-md-2 control-label"></label>
+                <div class="col-sm-9 col-md-8 col-lg-6 deid-column" >
+                    <div data-bind="visible: isDeidColumnVisible()">
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" id="is_deidentified" data-bind="checked: is_deidentified" />
+                                {% trans "Publish as De-Identified" %}
+                            </label>
+                        </div>
+                        <span class="help-inline">
+                            {% trans "Check only if this export has been fully and safely de-identified." %}
+                        </span>
                     </div>
-                    <span class="help-inline">
-                        {% trans "Check only if this export has been fully and safely de-identified." %}
-                    </span>
+                    <button class="btn btn-default" data-bind="
+                        visible: !isDeidColumnVisible(),
+                        click: showDeidColumn
+                    ">
+                        {% trans "Allow me to mark sensitive data" %}
+                    </button>
                 </div>
-                <button class="btn btn-default" data-bind="
-                    visible: !isDeidColumnVisible(),
-                    click: showDeidColumn
-                ">
-                    {% trans "Allow me to mark sensitive data" %}
-                </button>
             </div>
+            <div class="form-group">
+                <label class="col-sm-3 col-md-2 control-label">
+                    {% trans "Process all applications for deleted questions" %}
+                </label>
+                <div class="col-sm-9 col-md-8 col-lg-6">
+                    <button class="btn btn-default" data-bind="click: onBeginSchemaBuild">
+                        {% trans "Process" %}
+                    </button>
+                    <div class="spacer"></div>
+                    <div class="progress " data-bind="visible: showBuildSchemaProgressBar">
+                      <div class="progress-bar" role="progressbar" data-bind="
+                          style: {
+                              width: buildSchemaProgress() + '%'
+                          }
+                      "></div>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
         </fieldset>
-        {% endif %}
         <div class="form-actions">
             <div class="col-sm-offset-4 col-md-offset-3 col-lg-offset-2 col-sm-8 col-md-9 col-lg-10 controls">
                 <button type="submit" class="btn btn-lg btn-primary" data-bind="

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -186,7 +186,7 @@
                     </button>
                 </div>
             </div>
-            <div class="form-group">
+            <div class="form-group" data-bind="css: { 'has-error': errorOnBuildSchema }">
                 <label class="col-sm-3 col-md-2 control-label">
                     {% trans "Process all applications for deleted questions" %}
                 </label>
@@ -194,6 +194,9 @@
                     <button class="btn btn-default" data-bind="click: onBeginSchemaBuild">
                         {% trans "Process" %}
                     </button>
+                    <div class="help-block" data-bind="visible: errorOnBuildSchema">
+                        {% trans "Unable to process applications. Please report an issue if this persists" %}
+                    </div>
                     <div class="spacer"></div>
                     <div class="progress " data-bind="visible: showBuildSchemaProgressBar">
                       <div class="progress-bar" role="progressbar" data-bind="

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -191,9 +191,10 @@
                     {% trans "Process all applications for deleted questions" %}
                 </label>
                 <div class="col-sm-9 col-md-8 col-lg-6">
-                    <button class="btn btn-default" data-bind="click: onBeginSchemaBuild">
-                        {% trans "Process" %}
-                    </button>
+                    <button class="btn btn-default" data-bind="
+                        click: onBeginSchemaBuild,
+                        text: schemaProgressText
+                    "></button>
                     <div class="help-block" data-bind="visible: errorOnBuildSchema">
                         {% trans "Unable to process applications. Please report an issue if this persists" %}
                     </div>

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -186,6 +186,8 @@
                     </button>
                 </div>
             </div>
+            {% endif %}
+            {% if request|toggle_enabled:"DO_NOT_PROCESS_OLD_BUILDS" %}
             <div class="form-group" data-bind="css: { 'has-error': errorOnBuildSchema }">
                 <label class="col-sm-3 col-md-2 control-label">
                     {% trans "Process all applications for deleted questions" %}

--- a/corehq/apps/export/templates/export/spec/ko/mocha.html
+++ b/corehq/apps/export/templates/export/spec/ko/mocha.html
@@ -2,6 +2,8 @@
 {% load hq_shared_tags %}
 
 {% block dependencies %}
+<script src="{% static 'style/js/hq.helpers.js' %}"></script>
+<script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
 <script src="{% static 'export/js/const.js' %}"></script>
 <script src="{% static 'export/js/utils.js' %}"></script>
 <script src="{% static 'export/js/models.js' %}"></script>

--- a/corehq/apps/export/tests/data/basic_form.xml
+++ b/corehq/apps/export/tests/data/basic_form.xml
@@ -4,7 +4,7 @@
 		<h:title>Buy Candy Corn</h:title>
 		<model>
 			<instance>
-				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="undefined" uiVersion="1" version="1" name="Buy Candy Corn">
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="xmlns" uiVersion="1" version="1" name="Buy Candy Corn">
 					<question1 />
 					<question2 />
 				</data>

--- a/corehq/apps/export/tests/data/basic_form_version2.xml
+++ b/corehq/apps/export/tests/data/basic_form_version2.xml
@@ -4,7 +4,7 @@
 		<h:title>Buy Candy Corn</h:title>
 		<model>
 			<instance>
-				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="undefined" uiVersion="1" version="1" name="Buy Candy Corn">
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="xmlns" uiVersion="1" version="1" name="Buy Candy Corn">
 					<question1 />
 					<question2 />
 				</data>

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -545,6 +545,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         cls.first_build._id = '123'
         cls.first_build.copy_of = cls.current_app.get_id
         cls.first_build.version = 3
+        cls.first_build.has_submissions = True
 
         cls.advanced_app = Application.new_app('domain', "Untitled Application")
         module = cls.advanced_app.add_module(AdvancedModule.new_module('Untitled Module', None))
@@ -622,13 +623,14 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         )
 
         self.assertEqual(len(schema.group_schemas), 1)
-        self.assertEqual(schema.last_app_versions[app._id], app.version)
+        self.assertEqual(schema.last_app_versions[app._id], self.first_build.version)
 
         # After the first schema has been saved let's add a second app to process
         second_build = Application.wrap(self.get_json('basic_application'))
         second_build._id = '456'
         second_build.copy_of = app.get_id
         second_build.version = 6
+        second_build.has_submissions = True
         second_build.save()
         self.addCleanup(second_build.delete)
 
@@ -639,7 +641,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         )
 
         self.assertEqual(new_schema._id, schema._id)
-        self.assertEqual(new_schema.last_app_versions[app._id], app.version)
+        self.assertEqual(new_schema.last_app_versions[app._id], second_build.version)
         self.assertEqual(len(new_schema.group_schemas), 1)
 
     def test_build_with_inferred_schema(self):
@@ -801,6 +803,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         cls.first_build._id = '123'
         cls.first_build.copy_of = cls.current_app.get_id
         cls.first_build.version = 3
+        cls.first_build.has_submissions = True
 
         cls.apps = [
             cls.current_app,
@@ -842,7 +845,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
             self.case_type,
         )
 
-        self.assertEqual(schema.last_app_versions[app._id], app.version)
+        self.assertEqual(schema.last_app_versions[app._id], self.first_build.version)
         # One for case, one for case history
         self.assertEqual(len(schema.group_schemas), 2)
 
@@ -851,6 +854,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         second_build._id = '456'
         second_build.copy_of = app.get_id
         second_build.version = 6
+        second_build.has_submissions = True
         with drop_connected_signals(app_post_save):
             second_build.save()
         self.addCleanup(second_build.delete)
@@ -862,7 +866,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         )
 
         self.assertEqual(new_schema._id, schema._id)
-        self.assertEqual(new_schema.last_app_versions[app._id], app.version)
+        self.assertEqual(new_schema.last_app_versions[app._id], second_build.version)
         # One for case, one for case history
         self.assertEqual(len(new_schema.group_schemas), 2)
 

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -19,6 +19,7 @@ from corehq.apps.export.views import (
     DownloadNewFormExportView,
     BulkDownloadNewFormExportView,
     DownloadNewCaseExportView,
+    GenerateSchemaFromAllBuildsView,
     download_daily_saved_export,
 )
 
@@ -83,4 +84,7 @@ urlpatterns = [
     url(r"^custom/dailysaved/download/(?P<export_instance_id>[\w\-]+)/$",
         download_daily_saved_export,
         name="download_daily_saved_export"),
+    url(r"^build_full_schema/$",
+        GenerateSchemaFromAllBuildsView.as_view(),
+        name=GenerateSchemaFromAllBuildsView.urlname),
 ]

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -30,6 +30,7 @@ from django.utils.decorators import method_decorator
 import json
 import re
 from django.utils.safestring import mark_safe
+from django.views.generic import View
 
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
 import pytz
@@ -45,6 +46,7 @@ from corehq.apps.export.utils import (
     revert_new_exports,
 )
 from corehq.apps.export.custom_export_helpers import make_custom_export_helper
+from corehq.apps.export.tasks import generate_schema_for_all_builds
 from corehq.apps.export.exceptions import (
     ExportNotFound,
     ExportAppException,
@@ -116,6 +118,7 @@ from dimagi.utils.couch.undo import DELETED_SUFFIX
 from soil import DownloadBase
 from soil.exceptions import TaskFailedError
 from soil.util import get_download_context
+from soil.progress import get_task_status
 
 
 def user_can_view_deid_exports(domain, couch_user):
@@ -1819,6 +1822,40 @@ class DownloadNewCaseExportView(GenericDownloadNewExportMixin, DownloadCaseExpor
         accessible_user_ids = user_ids_at_locations(accessible_location_ids)
         accessible_ids = accessible_user_ids + list(accessible_location_ids)
         return OR(OwnerFilter(accessible_ids), LastModifiedByFilter(accessible_user_ids))
+
+
+class GenerateSchemaFromAllBuildsView(View):
+    urlname = 'build_full_schema'
+
+    def export_cls(self, type_):
+        return CaseExportDataSchema if type_ == CASE_EXPORT else FormExportDataSchema
+
+    def get(self, request, *args, **kwargs):
+        download_id = request.GET.get('download_id')
+        download = DownloadBase.get(download_id)
+        if download is None:
+            return json_response({
+                'download_id': download_id,
+                'progress': None,
+            })
+
+        status = get_task_status(download.task)
+        return json_response({
+            'download_id': download_id,
+            'progress': status.progress._asdict(),
+        })
+
+    def post(self, request, *args, **kwargs):
+        download = DownloadBase()
+        download.set_task(generate_schema_for_all_builds.delay(
+            self.export_cls(kwargs.get('type')),
+            request.domain,
+            request.POST.get('app_id'),
+            request.POST.get('identifier'),
+        ))
+        return json_response({
+            'download_id': download.download_id
+        })
 
 
 @csrf_exempt

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1842,6 +1842,10 @@ class GenerateSchemaFromAllBuildsView(View):
         status = get_task_status(download.task)
         return json_response({
             'download_id': download_id,
+            'success': status.success(),
+            'failed': status.failed(),
+            'missing': status.missing(),
+            'not_started': status.not_started(),
             'progress': status.progress._asdict(),
         })
 
@@ -1853,6 +1857,7 @@ class GenerateSchemaFromAllBuildsView(View):
             request.POST.get('app_id'),
             request.POST.get('identifier'),
         ))
+        download.save()
         return json_response({
             'download_id': download.download_id
         })

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1630,6 +1630,7 @@ class EditNewCustomFormExportView(BaseEditNewCustomExportView):
             self.domain,
             export_instance.app_id,
             export_instance.xmlns,
+            only_process_current_builds=DO_NOT_PROCESS_OLD_BUILDS.enabled(self.domain),
         )
 
 
@@ -1643,6 +1644,7 @@ class EditNewCustomCaseExportView(BaseEditNewCustomExportView):
             self.domain,
             self.request.GET.get('app_id'),
             export_instance.case_type,
+            only_process_current_builds=DO_NOT_PROCESS_OLD_BUILDS.enabled(self.domain),
         )
 
 

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -10,6 +10,7 @@ from django.template.defaultfilters import filesizeformat
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
+from corehq.toggles import DO_NOT_PROCESS_OLD_BUILDS
 from corehq.apps.export.export import get_export_download, get_export_size
 from corehq.apps.export.filters import (
     FormSubmittedByFilter,
@@ -1507,6 +1508,7 @@ class CreateNewCustomFormExportView(BaseModifyNewCustomView):
             self.domain,
             app_id,
             xmlns,
+            only_process_current_builds=DO_NOT_PROCESS_OLD_BUILDS.enabled(self.domain),
         )
         self.export_instance = self.export_instance_cls.generate_instance_from_schema(schema)
 
@@ -1527,6 +1529,7 @@ class CreateNewCustomCaseExportView(BaseModifyNewCustomView):
             self.domain,
             app_id,
             case_type,
+            only_process_current_builds=DO_NOT_PROCESS_OLD_BUILDS.enabled(self.domain),
         )
         self.export_instance = self.export_instance_cls.generate_instance_from_schema(schema)
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -992,3 +992,10 @@ COPY_CASE_CONFIGS = StaticToggle(
     TAG_PRODUCT_CORE,
     [NAMESPACE_DOMAIN]
 )
+
+DO_NOT_PROCESS_OLD_BUILDS = StaticToggle(
+    'do_not_process_old_builds',
+    'Do not process old build for export generation',
+    TAG_PRODUCT_CORE,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
@NoahCarnahan @czue This implements a strategy Cory and I discussed the other day. Essentially it it only processes the most current applications and ignores the old ones. The old builds only give information about deleted questions, and we decided it probably wasn't worth the performance hit. It gives the ability to process the older builds if requested. I'm not set on the UX / wording yet, so I put behind a feature flag. Some scenarios I manually tested:

- You already have an export instance, the schema is deleted and then rebuilt with only latest builds. The deleted questions you have selected, stay selected
- You have an export with the most recent builds, you then process the old builds, deleted questions do indeed show up.

Here's what the current UX looks like:
At the beginning:
<img width="1387" alt="screen shot 2017-01-06 at 11 50 52 am" src="https://cloud.githubusercontent.com/assets/918514/21714351/313957de-d407-11e6-8ec7-556a2802c64a.png">
While loading:
![screen shot 2017-01-06 at 11 51 46 am](https://cloud.githubusercontent.com/assets/918514/21714232/99989656-d406-11e6-8f39-15e18e8949a9.png)
After loading:
<img width="1374" alt="screen shot 2017-01-06 at 11 51 08 am" src="https://cloud.githubusercontent.com/assets/918514/21714236/9e6bb6ea-d406-11e6-8c2a-a9b94afc5f6f.png">

Probably can be reviewed all at once or commit by commit
cc: @millerdev @gcapalbo 
