### PR TITLE
add owner to related cases table

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -133,13 +133,15 @@ def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
     processors.update(default_processors)
 
     expr = prop_def.pop('expr')
-    name = prop_def.pop('name', _format_slug_string_for_display(expr))
+    name = prop_def.pop('name') or _format_slug_string_for_display(expr)
     format = prop_def.pop('format', None)
     process = prop_def.pop('process', None)
     timeago = prop_def.get('timeago', False)
 
-    # todo: nested attributes, jsonpath, indexing into related documents
-    val = data.get(expr, None)
+    if callable(expr):
+        val = expr(data)
+    else:
+        val = data.get(expr, None)
 
     if prop_def.pop('parse_date', None):
         val = _parse_date_or_datetime(val)

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -15,6 +15,7 @@ from django.utils.html import escape
 
 from corehq.apps.products.models import SQLProduct
 from couchdbkit import ResourceNotFound
+from corehq.apps.users.util import cached_owner_id_to_display
 
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 
@@ -116,6 +117,10 @@ class CaseDisplayWrapper(object):
             {
                 'name': _('Case Type'),
                 'expr': "type",
+            },
+            {
+                'name': _('Owner'),
+                'expr': lambda c: cached_owner_id_to_display(c.get('owner_id')),
             },
             {
                 'name': _('Date Opened'),


### PR DESCRIPTION
this is really helpful to understand what's going on for referral type of workflows where you have cases in the hierarchy with different owners. i realize it's kind of a useless column if the app doesn't use case sharing or referrals at all, but i think the benefits are worth it. cc @dimagi/product in case anyone wants to push back.

![image](https://cloud.githubusercontent.com/assets/66555/21718494/809949f6-d420-11e6-9d8c-05d9f25763d6.png)
