### PR TITLE
[prefactor] Get rid of CommTrack, CommConnect default product plans

### DIFF
--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -87,24 +87,24 @@ def ensure_plans(config, dry_run, verbose, apps):
             default_product_plan.product_type = SoftwareProductType.COMMCARE
         if dry_run:
             log_accounting_info(
-                "[DRY RUN] Setting plan as default for edition '%s'."
-                % (default_product_plan.edition,)
+                "[DRY RUN] Setting plan as default for edition '%s' with is_trial='%s'."
+                % (default_product_plan.edition, is_trial)
             )
         else:
             try:
                 default_product_plan = DefaultProductPlan.objects.get(edition=edition, is_trial=is_trial)
                 if verbose:
                     log_accounting_info(
-                        "Default for edition '%s' already exists."
-                        % (default_product_plan.edition,)
+                        "Default for edition '%s' with is_trial='%s' already exists."
+                        % (default_product_plan.edition, is_trial)
                     )
             except DefaultProductPlan.DoesNotExist:
                 default_product_plan.plan = software_plan
                 default_product_plan.save()
                 if verbose:
                     log_accounting_info(
-                        "Setting plan as default for edition '%s'."
-                        % (default_product_plan.edition,)
+                        "Setting plan as default for edition '%s' with is_trial='%s'."
+                        % (default_product_plan.edition, is_trial)
                     )
 
 

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -59,11 +59,13 @@ def ensure_plans(config, dry_run, verbose, apps):
 
             software_plan_version = SoftwarePlanVersion(role=role, plan=software_plan)
 
+            # TODO - squash migrations and remove this
             # must save before assigning many-to-many relationship
             if hasattr(SoftwarePlanVersion, 'product_rates'):
                 software_plan_version.save()
 
             product_rate.save()
+            # TODO - squash migrations and remove this
             if hasattr(SoftwarePlanVersion, 'product_rates'):
                 software_plan_version.product_rates.add(product_rate)
             elif hasattr(SoftwarePlanVersion, 'product_rate'):
@@ -71,6 +73,7 @@ def ensure_plans(config, dry_run, verbose, apps):
             else:
                 raise AccountingError('SoftwarePlanVersion does not have product_rate or product_rates field')
 
+            # TODO - squash migrations and remove this
             # must save before assigning many-to-many relationship
             if hasattr(SoftwarePlanVersion, 'product_rate'):
                 software_plan_version.save()
@@ -83,6 +86,7 @@ def ensure_plans(config, dry_run, verbose, apps):
         default_product_plan = DefaultProductPlan(
             edition=edition, is_trial=is_trial
         )
+        # TODO - squash migrations and remove this
         if hasattr(default_product_plan, 'product_type'):
             default_product_plan.product_type = SoftwareProductType.COMMCARE
         if dry_run:

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -10,12 +10,6 @@ from corehq.apps.accounting.models import (
 )
 from corehq.apps.accounting.utils import log_accounting_error, log_accounting_info
 
-PRODUCT_TYPES = [
-    SoftwareProductType.COMMCARE,
-    SoftwareProductType.COMMCONNECT,
-    SoftwareProductType.COMMTRACK,
-]
-
 FEATURE_TYPES = [
     FeatureType.USER,
     FeatureType.SMS,
@@ -28,90 +22,90 @@ def ensure_plans(config, dry_run, verbose, apps):
     SoftwarePlanVersion = apps.get_model('accounting', 'SoftwarePlanVersion')
     Role = apps.get_model('django_prbac', 'Role')
 
-    for product_type in PRODUCT_TYPES:
-        for plan_key, plan_deets in config.iteritems():
-            edition, is_trial = plan_key
-            features = _ensure_features(edition, dry_run, verbose, apps)
+    for plan_key, plan_deets in config.iteritems():
+        edition, is_trial = plan_key
+        features = _ensure_features(edition, dry_run, verbose, apps)
+        try:
+            role = _ensure_role(plan_deets['role'], apps)
+        except Role.DoesNotExist:
+            return
+
+        product, product_rate = _ensure_product_and_rate(
+            plan_deets['product_rate'], edition,
+            dry_run=dry_run, verbose=verbose, apps=apps,
+        )
+        feature_rates = _ensure_feature_rates(
+            plan_deets['feature_rates'], features, edition,
+            dry_run=dry_run, verbose=verbose, apps=apps,
+        )
+
+        software_plan = SoftwarePlan(
+            name='%s Edition' % product.name, edition=edition, visibility=SoftwarePlanVisibility.PUBLIC
+        )
+
+        if dry_run:
+            log_accounting_info("[DRY RUN] Creating Software Plan: %s" % software_plan.name)
+        else:
             try:
-                role = _ensure_role(plan_deets['role'], apps)
-            except Role.DoesNotExist:
-                return
+                software_plan = SoftwarePlan.objects.get(name=software_plan.name)
+                if verbose:
+                    log_accounting_info(
+                        "Plan '%s' already exists. Using existing plan to add version." % software_plan.name
+                    )
+            except SoftwarePlan.DoesNotExist:
+                software_plan.save()
+                if verbose:
+                    log_accounting_info("Creating Software Plan: %s" % software_plan.name)
 
-            product, product_rate = _ensure_product_and_rate(
-                plan_deets['product_rate'], product_type, edition,
-                dry_run=dry_run, verbose=verbose, apps=apps,
-            )
-            feature_rates = _ensure_feature_rates(
-                plan_deets['feature_rates'], features, edition,
-                dry_run=dry_run, verbose=verbose, apps=apps,
-            )
+            software_plan_version = SoftwarePlanVersion(role=role, plan=software_plan)
 
-            software_plan = SoftwarePlan(
-                name='%s Edition' % product.name, edition=edition, visibility=SoftwarePlanVisibility.PUBLIC
-            )
-
-            if dry_run:
-                log_accounting_info("[DRY RUN] Creating Software Plan: %s" % software_plan.name)
-            else:
-                try:
-                    software_plan = SoftwarePlan.objects.get(name=software_plan.name)
-                    if verbose:
-                        log_accounting_info(
-                            "Plan '%s' already exists. Using existing plan to add version." % software_plan.name
-                        )
-                except SoftwarePlan.DoesNotExist:
-                    software_plan.save()
-                    if verbose:
-                        log_accounting_info("Creating Software Plan: %s" % software_plan.name)
-
-                software_plan_version = SoftwarePlanVersion(role=role, plan=software_plan)
-
-                # must save before assigning many-to-many relationship
-                if hasattr(SoftwarePlanVersion, 'product_rates'):
-                    software_plan_version.save()
-
-                product_rate.save()
-                if hasattr(SoftwarePlanVersion, 'product_rates'):
-                    software_plan_version.product_rates.add(product_rate)
-                elif hasattr(SoftwarePlanVersion, 'product_rate'):
-                    software_plan_version.product_rate = product_rate
-                else:
-                    raise AccountingError('SoftwarePlanVersion does not have product_rate or product_rates field')
-
-                # must save before assigning many-to-many relationship
-                if hasattr(SoftwarePlanVersion, 'product_rate'):
-                    software_plan_version.save()
-
-                for feature_rate in feature_rates:
-                    feature_rate.save()
-                    software_plan_version.feature_rates.add(feature_rate)
+            # must save before assigning many-to-many relationship
+            if hasattr(SoftwarePlanVersion, 'product_rates'):
                 software_plan_version.save()
 
-            default_product_plan = DefaultProductPlan(
-                product_type=product.product_type, edition=edition, is_trial=is_trial
-            )
-            if dry_run:
-                log_accounting_info(
-                    "[DRY RUN] Setting plan as default for product '%s' and edition '%s'."
-                    % (product.product_type, default_product_plan.edition)
-                )
+            product_rate.save()
+            if hasattr(SoftwarePlanVersion, 'product_rates'):
+                software_plan_version.product_rates.add(product_rate)
+            elif hasattr(SoftwarePlanVersion, 'product_rate'):
+                software_plan_version.product_rate = product_rate
             else:
-                try:
-                    default_product_plan = DefaultProductPlan.objects.get(product_type=product.product_type,
-                                                                          edition=edition, is_trial=is_trial)
-                    if verbose:
-                        log_accounting_info(
-                            "Default for product '%s' and edition '%s' already exists."
-                            % (product.product_type, default_product_plan.edition)
-                        )
-                except DefaultProductPlan.DoesNotExist:
-                    default_product_plan.plan = software_plan
-                    default_product_plan.save()
-                    if verbose:
-                        log_accounting_info(
-                            "Setting plan as default for product '%s' and edition '%s'."
-                            % (product.product_type, default_product_plan.edition)
-                        )
+                raise AccountingError('SoftwarePlanVersion does not have product_rate or product_rates field')
+
+            # must save before assigning many-to-many relationship
+            if hasattr(SoftwarePlanVersion, 'product_rate'):
+                software_plan_version.save()
+
+            for feature_rate in feature_rates:
+                feature_rate.save()
+                software_plan_version.feature_rates.add(feature_rate)
+            software_plan_version.save()
+
+        default_product_plan = DefaultProductPlan(
+            edition=edition, is_trial=is_trial
+        )
+        if hasattr(default_product_plan, 'product_type'):
+            default_product_plan.product_type = SoftwareProductType.COMMCARE
+        if dry_run:
+            log_accounting_info(
+                "[DRY RUN] Setting plan as default for edition '%s'."
+                % (default_product_plan.edition,)
+            )
+        else:
+            try:
+                default_product_plan = DefaultProductPlan.objects.get(edition=edition, is_trial=is_trial)
+                if verbose:
+                    log_accounting_info(
+                        "Default for edition '%s' already exists."
+                        % (default_product_plan.edition,)
+                    )
+            except DefaultProductPlan.DoesNotExist:
+                default_product_plan.plan = software_plan
+                default_product_plan.save()
+                if verbose:
+                    log_accounting_info(
+                        "Setting plan as default for edition '%s'."
+                        % (default_product_plan.edition,)
+                    )
 
 
 def _ensure_role(role_slug, apps):
@@ -128,7 +122,7 @@ def _ensure_role(role_slug, apps):
     return role
 
 
-def _ensure_product_and_rate(product_rate, product_type, edition, dry_run, verbose, apps):
+def _ensure_product_and_rate(product_rate, edition, dry_run, verbose, apps):
     """
     Ensures that all the necessary SoftwareProducts and SoftwareProductRates are created for the plan.
     """
@@ -138,6 +132,7 @@ def _ensure_product_and_rate(product_rate, product_type, edition, dry_run, verbo
     if verbose:
         log_accounting_info('Ensuring Products and Product Rates')
 
+    product_type = SoftwareProductType.COMMCARE
     product = SoftwareProduct(name='%s %s' % (product_type, edition), product_type=product_type)
     if edition == SoftwarePlanEdition.ENTERPRISE:
         product.name = "Dimagi Only %s" % product.name

--- a/corehq/apps/accounting/migrations/0048_remove_defaultproductplan_product_type.py
+++ b/corehq/apps/accounting/migrations/0048_remove_defaultproductplan_product_type.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.sql_db.operations import HqRunPython
+
+
+def delete_deprecated_default_plans(apps, schema_editor):
+    DefaultProductPlan = apps.get_model('accounting', 'DefaultProductPlan')
+    DefaultProductPlan.objects.filter(product_type__in=[
+        'CommTrack',
+        'CommConnect'
+    ]).delete()
+
+
+def assert_only_commcare_default_plans(apps, schema_editor):
+    DefaultProductPlan = apps.get_model('accounting', 'DefaultProductPlan')
+    assert not DefaultProductPlan.objects.exclude(product_type='CommCare').exists()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0047_ensure_default_product_plans'),
+    ]
+
+    operations = [
+        HqRunPython(delete_deprecated_default_plans),
+        HqRunPython(assert_only_commcare_default_plans),
+        migrations.RemoveField(
+            model_name='defaultproductplan',
+            name='product_type',
+        ),
+        migrations.AlterUniqueTogether(
+            name='defaultproductplan',
+            unique_together=set([('edition', 'is_trial')]),
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -739,7 +739,6 @@ class DefaultProductPlan(models.Model):
     The latest SoftwarePlanVersion that's linked to this plan will be the one used to create a new subscription if
     nothing is found for that domain.
     """
-    product_type = models.CharField(max_length=25, choices=SoftwareProductType.CHOICES)
     edition = models.CharField(
         default=SoftwarePlanEdition.COMMUNITY,
         choices=SoftwarePlanEdition.CHOICES,
@@ -757,7 +756,7 @@ class DefaultProductPlan(models.Model):
         edition = edition or SoftwarePlanEdition.COMMUNITY
         try:
             default_product_plan = DefaultProductPlan.objects.select_related('plan').get(
-                product_type=SoftwareProductType.COMMCARE, edition=edition, is_trial=is_trial
+                edition=edition, is_trial=is_trial
             )
             return default_product_plan.plan.get_version()
         except DefaultProductPlan.DoesNotExist:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -750,6 +750,7 @@ class DefaultProductPlan(models.Model):
 
     class Meta:
         app_label = 'accounting'
+        unique_together = ('edition', 'is_trial')
 
     @classmethod
     def get_default_plan_version(cls, edition=None, is_trial=False):


### PR DESCRIPTION
This way we won't create a bunch of deprecated (CommTrack, CommConnect) software plans when we define report builder software plans in the migrations.

Recommend 🐡 

Builds on work started in https://github.com/dimagi/commcare-hq/pull/14396 to address http://manage.dimagi.com/default.asp?244858.  

@proteusvacuum 