### PR TITLE
Drop couch lineage, only store relation in SQL

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -403,7 +403,7 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
 
     @classmethod
     def _migration_get_fields(cls):
-        return ["domain", "name", "lineage", "site_code", "external_id",
+        return ["domain", "name", "site_code", "external_id",
                 "metadata", "is_archived"]
 
     @classmethod
@@ -761,14 +761,11 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
     latitude = FloatProperty()
     longitude = FloatProperty()
 
-    # a list of doc ids, referring to the parent location, then the
-    # grand-parent, and so on up to the root location in the hierarchy
-    lineage = StringListProperty()
-
     @classmethod
     def wrap(cls, data):
         last_modified = data.get('last_modified')
         data.pop('location_type', None)  # Only store location type in SQL
+        data.pop('lineage', None)  # Don't try to store lineage
         # if it's missing a Z because of the Aug. 2014 migration
         # that added this in iso_format() without Z, then add a Z
         # (See also Group class)
@@ -778,18 +775,19 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
         return super(Location, cls).wrap(data)
 
     def __init__(self, *args, **kwargs):
-        from corehq.apps.locations.util import get_lineage_from_location, get_lineage_from_location_id
         if 'parent' in kwargs:
+            # if parent is in the kwargs, this was set from a constructor
+            # if parent isn't in kwargs, this was probably pulled from the db
+            # and we should look to SQL as source of truth
             parent = kwargs['parent']
             if parent:
                 if isinstance(parent, Document):
-                    lineage = get_lineage_from_location(parent)
+                    self._sql_parent = parent.sql_location
                 else:
                     # 'parent' is a doc id
-                    lineage = get_lineage_from_location_id(parent)
+                    self._sql_parent = SQLLocation.objects.get(location_id=parent)
             else:
-                lineage = []
-            kwargs['lineage'] = lineage
+                self._sql_parent = None
             del kwargs['parent']
 
         location_type = kwargs.pop('location_type', None)
@@ -865,8 +863,8 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
         location_type = self._sql_location_type or sql_location.location_type
         sql_location.location_type = location_type
         # sync parent connection
-        sql_location.parent = (SQLLocation.objects.get(location_id=self.parent_location_id)
-                               if self.parent_location_id else None)
+        if hasattr(self, '_sql_parent'):
+            sql_location.parent = self._sql_parent
 
         self._migration_sync_to_sql(sql_location)
 
@@ -941,9 +939,7 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
 
     @property
     def parent_location_id(self):
-        if self.lineage:
-            return self.lineage[0]
-        return None
+        return self.parent.location_id if self.parent else None
 
     @property
     def parent_id(self):
@@ -957,14 +953,18 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
 
     @property
     def parent(self):
-        parent_id = self.parent_location_id
-        return Location.get(parent_id) if parent_id else None
+        if hasattr(self, '_sql_parent'):
+            return self._sql_parent.couch_location if self._sql_parent else None
+        else:
+            return self.sql_location.parent.couch_location if self.sql_location.parent else None
+
+    @property
+    def lineage(self):
+        return self.sql_location.lineage
 
     @property
     def path(self):
-        _path = list(reversed(self.lineage))
-        _path.append(self._id)
-        return _path
+        return self.sql_location.path
 
     @property
     def descendants(self):

--- a/corehq/apps/locations/tests/test_reupholster.py
+++ b/corehq/apps/locations/tests/test_reupholster.py
@@ -1,15 +1,17 @@
 from django.test import TestCase
+from corehq.apps.commtrack.tests.util import bootstrap_location_types
 from corehq.apps.domain.shortcuts import create_domain
 
 from ..models import Location, LocationType
-from .test_locations import LocationTestBase
 from .util import make_loc, delete_all_locations
 
 
-class TestPathLineageAndHierarchy(LocationTestBase):
+class TestPathLineageAndHierarchy(TestCase):
 
     def setUp(self):
         super(TestPathLineageAndHierarchy, self).setUp()
+        self.domain = create_domain('locations-test')
+        bootstrap_location_types(self.domain.name)
         locs = [
             ('Mass', 'state'),
             ('Suffolk', 'district'),
@@ -20,7 +22,11 @@ class TestPathLineageAndHierarchy(LocationTestBase):
         for name, type_ in locs:
             parent = make_loc(name, type=type_, parent=parent)
             self.all_locs.append(parent)
-        self.all_loc_ids = [l._id for l in self.all_locs]
+        self.all_loc_ids = [l.location_id for l in self.all_locs]
+        self.loc_id_by_name = {l.name: l.location_id for l in self.all_locs}
+
+    def tearDown(self):
+        self.domain.delete()
 
     def test_path(self):
         for i in range(len(self.all_locs)):
@@ -34,22 +40,28 @@ class TestPathLineageAndHierarchy(LocationTestBase):
 
     def test_move(self):
         original_parent = self.all_locs[1].sql_location
-        new_parent = make_loc('New York', type='state').sql_location
         district = make_loc('NYC', type='block', parent=original_parent.couch_location).sql_location
         self.assertEqual(original_parent.site_code, district.couch_location.parent.site_code)
+        self.assertEqual([self.loc_id_by_name['Suffolk'], self.loc_id_by_name['Mass']],
+                         district.couch_location.lineage)
 
+        new_parent = make_loc('New York', type='state').sql_location
         district.parent = new_parent
         district.save()
         self.assertEqual(new_parent.site_code, district.couch_location.parent.site_code)
+        self.assertEqual([new_parent.location_id], district.couch_location.lineage)
 
     def test_move_to_root(self):
         original_parent = self.all_locs[1].sql_location
         district = make_loc('NYC', type='block', parent=original_parent.couch_location).sql_location
         self.assertEqual(original_parent.site_code, district.couch_location.parent.site_code)
+        self.assertEqual([self.loc_id_by_name['Suffolk'], self.loc_id_by_name['Mass']],
+                         district.couch_location.lineage)
 
         district.parent = None
         district.save()
         self.assertEqual(None, district.couch_location.parent)
+        self.assertEqual([], district.couch_location.lineage)
 
 
 class TestNoCouchLocationTypes(TestCase):

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -321,11 +321,3 @@ def get_locations_from_ids(location_ids, domain, base_queryset=None):
     if len(locations) != expected_count:
         raise SQLLocation.DoesNotExist('One or more of the locations was not found.')
     return locations
-
-
-def get_lineage_from_location_id(location_id):
-    return get_lineage_from_location(Location.get(location_id))
-
-
-def get_lineage_from_location(location):
-    return list(reversed(location.path))


### PR DESCRIPTION
@czue @sravfeyn
UCR is on SQL now, so I don't think we need this anymore.
http://manage.dimagi.com/default.asp?245138