### PR TITLE
Switch copy form and xforms sections on form view actions tab

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_tab_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_tab_advanced.html
@@ -2,7 +2,30 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 <div class="tab-pane" id="advanced">
+    {% if allow_form_copy%}
+        <div class="panel panel-appmanager">
+            <form class="form-inline" method='POST' action='{% url "copy_form" domain app.id module.id form.id %}'>
+                <div class="panel-heading">
+                    <h4 class="panel-title panel-title-nolink">
+                        {% trans "Copy Form" %}
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <select name='to_module_id' class='form-control' style="min-width: 150px;">{% for mod in app.get_modules %}
+                        <option value={{ mod.id }}>{{ mod.name|html_trans:langs }}</option>
+                        {% endfor %}</select>
+                    <button class='btn btn-default' type="submit">
+                        <i class="fa fa-copy"></i>
+                        {% trans "Copy" %}
+                    </button>
+                </div>
+            </form>
+        </div>
+        {% csrf_token %}
+        <fieldset>
 
+        </fieldset>
+    {% endif %}
     <div class="panel panel-appmanager">
         <div class="panel-heading">
             <h4 class="panel-title panel-title-nolink">
@@ -35,28 +58,4 @@
             </ul>
         </div>
     </div>
-    {% if allow_form_copy%}
-        <div class="panel panel-appmanager">
-            <form class="form-inline" method='POST' action='{% url "copy_form" domain app.id module.id form.id %}'>
-                <div class="panel-heading">
-                    <h4 class="panel-title panel-title-nolink">
-                        {% trans "Copy Form" %}
-                    </h4>
-                </div>
-                <div class="panel-body">
-                    <select name='to_module_id' class='form-control' style="min-width: 150px;">{% for mod in app.get_modules %}
-                        <option value={{ mod.id }}>{{ mod.name|html_trans:langs }}</option>
-                        {% endfor %}</select>
-                    <button class='btn btn-default' type="submit">
-                        <i class="fa fa-copy"></i>
-                        {% trans "Copy" %}
-                    </button>
-                </div>
-            </form>
-        </div>
-        {% csrf_token %}
-        <fieldset>
-
-        </fieldset>
-    {% endif %}
 </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_tab_advanced.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_tab_advanced.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,109 +2,61 @@
+@@ -2,109 +2,60 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  <div class="tab-pane" id="advanced">
@@ -38,39 +38,6 @@
 -                            </div>
 -                        </div>
 -                    </div>
-+
-+    <div class="panel panel-appmanager">
-+        <div class="panel-heading">
-+            <h4 class="panel-title panel-title-nolink">
-+                {% trans "XForm" %}
-+            </h4>
-+        </div>
-+        <div class="panel-body">
-+            <ul class="nav nav-pills nav-stacked">
-+                <li>
-+                    <a href="#upload-xform" data-toggle="modal">
-+                        <i class="fa fa-arrow-up"></i>
-+                        {% trans "Upload" %}
-+                    </a>
-+                </li>
-+                <li>
-+                    <a {% if not form.source %}class="disabled"{% endif %}
-+                       href="{% url "get_xform_source" domain app.id module.id form.id %}?download=true">
-+                        <i class="fa fa-arrow-down"></i>
-+                        {% trans "Download" %}
-+                    </a>
-+                </li>
-+                <li>
-+                    <a id="xform-source-opener"
-+                       class="{% if not form.source %}disabled{% endif %}"
-+                       data-href="{% url "get_xform_source" domain app.id module.id form.id %}">
-+                        <i class="fa fa-search"></i>
-+                        {% trans "View" %}
-+                    </a>
-+                </li>
-+            </ul>
-+        </div>
-+    </div>
 +    {% if allow_form_copy%}
 +        <div class="panel panel-appmanager">
 +            <form class="form-inline" method='POST' action='{% url "copy_form" domain app.id module.id form.id %}'>
@@ -160,4 +127,36 @@
          </fieldset>
 -    </form>
      {% endif %}
++    <div class="panel panel-appmanager">
++        <div class="panel-heading">
++            <h4 class="panel-title panel-title-nolink">
++                {% trans "XForm" %}
++            </h4>
++        </div>
++        <div class="panel-body">
++            <ul class="nav nav-pills nav-stacked">
++                <li>
++                    <a href="#upload-xform" data-toggle="modal">
++                        <i class="fa fa-arrow-up"></i>
++                        {% trans "Upload" %}
++                    </a>
++                </li>
++                <li>
++                    <a {% if not form.source %}class="disabled"{% endif %}
++                       href="{% url "get_xform_source" domain app.id module.id form.id %}?download=true">
++                        <i class="fa fa-arrow-down"></i>
++                        {% trans "Download" %}
++                    </a>
++                </li>
++                <li>
++                    <a id="xform-source-opener"
++                       class="{% if not form.source %}disabled{% endif %}"
++                       data-href="{% url "get_xform_source" domain app.id module.id form.id %}">
++                        <i class="fa fa-search"></i>
++                        {% trans "View" %}
++                    </a>
++                </li>
++            </ul>
++        </div>
++    </div>
  </div>


### PR DESCRIPTION
Came up during hallway testing. Copying is more common than dealing with the xform, so it should go on top.

@czue / @biyeun 