### PR TITLE
reveal No mobile workers message only when no mobile workers…

### DIFF
--- a/corehq/apps/es/fake/users_fake.py
+++ b/corehq/apps/es/fake/users_fake.py
@@ -20,3 +20,6 @@ class UserESFake(HQESQueryFake):
     def transform_doc(doc):
         doc['username.exact'] = doc.get('username', '')
         return transform_user_for_elasticsearch(doc)
+
+    def count(self):
+        return len(self._result_docs)

--- a/corehq/apps/style/static/style/js/pagination.ng.js
+++ b/corehq/apps/style/static/style/js/pagination.ng.js
@@ -70,6 +70,7 @@
                 $scope.total = data.response.total;
                 $scope.currentPage = data.response.page;
                 $scope.query = data.response.query;
+                $scope.total_records = data.response.total_records;
                 $cookies.put(paginationLimitCookieName, $scope.limit);
                 if ($scope.notLoaded) {
                     $scope.notLoaded = false;

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -352,13 +352,13 @@ $(function () {
                     </div>
                 </div>
                 <div class="alert alert-info"
-                     ng-show="!!query && paginatedItems.length == 0 && !notLoaded && !hasError">
+                     ng-show="total_records != 0 && paginatedItems.length == 0 && !notLoaded && !hasError">
                     {% blocktrans %}
                     No Mobile Workers were found that matched your query.
                     {% endblocktrans %}
                 </div>
                 <div class="alert alert-info"
-                     ng-show="!query && paginatedItems.length == 0 && !notLoaded && !hasError">
+                     ng-show="total_records == 0 && paginatedItems.length == 0 && !notLoaded && !hasError">
                     {% blocktrans %}
                         <strong>There are currently no Mobile Workers in this project.</strong>
                         Please Create a new Mobile Worker above to get started.

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -673,7 +673,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         users_query = self._user_query(query, page - 1, limit)
 
         # run with a blank query to fetch total records with same scope as in search
-        total_records = self._user_query('', 0, 0).run().total
+        total_records = self._user_query('', 0, 0).count()
         if in_data.get('showDeactivatedUsers', False):
             users_query = users_query.show_only_inactive()
         users_data = users_query.run()

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -671,6 +671,9 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
         # backend pages start at 0
         users_query = self._user_query(query, page - 1, limit)
+
+        # run with a blank query to fetch total records with same scope as in search
+        total_records = self._user_query('', 0, 0).run().total
         if in_data.get('showDeactivatedUsers', False):
             users_query = users_query.show_only_inactive()
         users_data = users_query.run()
@@ -680,6 +683,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
                 'total': users_data.total,
                 'page': page,
                 'query': query,
+                'total_records': total_records
             },
             'success': True,
         }


### PR DESCRIPTION
… in system

http://manage.dimagi.com/default.asp?245147

Update to show "There are currently no Mobile Workers in this project." only when there are actually no users and retain the message "No Mobile Workers were found that matched your query." when search returns no result.

buddy @dannyroberts 