### PR TITLE
Release debugger

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -446,6 +446,8 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     self.isMinimized = ko.observable(true);
     self.instanceXml = ko.observable('');
     self.formattedQuestionsHtml = ko.observable('');
+    // Whether or not to auto update after every question answer
+    self.autoUpdate = ko.observable(true);
     self.toggleState = function() {
         self.isMinimized(!self.isMinimized());
         // Wait to set the content heigh until after the CSS animation has completed.
@@ -460,12 +462,14 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
 
     $.unsubscribe('debugger.update');
     $.subscribe('debugger.update', function(e) {
-        $.publish('formplayer.' + Formplayer.Const.FORMATTED_QUESTIONS, function(resp) {
-            self.formattedQuestionsHtml(resp.formattedQuestions);
-            self.instanceXml(resp.instanceXml);
-            self.evalXPath.autocomplete(resp.questionList);
-            self.evalXPath.recentXPathQueries(resp.recentXPathQueries || []);
-        });
+        if (self.autoUpdate()) {
+            $.publish('formplayer.' + Formplayer.Const.FORMATTED_QUESTIONS, function(resp) {
+                self.formattedQuestionsHtml(resp.formattedQuestions);
+                self.instanceXml(resp.instanceXml);
+                self.evalXPath.autocomplete(resp.questionList);
+                self.evalXPath.recentXPathQueries(resp.recentXPathQueries || []);
+            });
+        }
     });
 
     self.setContentHeight = function() {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -450,8 +450,6 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     // Whether or not the debugger is in the middle of updating from an ajax request
     self.updating = ko.observable(false);
 
-    // Whether or not to auto update after every question answer
-    self.autoUpdate = ko.observable(true);
     self.toggleState = function() {
         self.isMinimized(!self.isMinimized());
         // Wait to set the content heigh until after the CSS animation has completed.
@@ -479,7 +477,7 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
 
     $.unsubscribe('debugger.update');
     $.subscribe('debugger.update', function(e) {
-        if (self.autoUpdate() && !self.isMinimized()) {
+        if (!self.isMinimized()) {
             self.updating(true);
             $.publish('formplayer.' + Formplayer.Const.FORMATTED_QUESTIONS, self.updateDebugger);
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/debugger_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/debugger_spec.js
@@ -18,5 +18,49 @@ describe('Debugger', function() {
             assert.equal(result, '');
         });
     });
+
+    describe('Update logic', function() {
+        var ccDebugger,
+            updateSpy;
+
+        beforeEach(function() {
+            ccDebugger = new Formplayer.ViewModels.CloudCareDebugger(),
+            updateSpy = sinon.spy();
+            $.subscribe('formplayer.' + Formplayer.Const.FORMATTED_QUESTIONS, updateSpy);
+            window.analytics = {
+                workflow: sinon.spy(),
+            };
+        });
+
+        afterEach(function() {
+            $.unsubscribe('formplayer.' + Formplayer.Const.FORMATTED_QUESTIONS);
+        });
+
+        it('Should update when opened', function() {
+            assert.isTrue(ccDebugger.isMinimized());
+
+            ccDebugger.toggleState();
+            assert.isFalse(ccDebugger.isMinimized());
+            assert.isTrue(updateSpy.calledOnce);
+
+            ccDebugger.toggleState();
+            assert.isTrue(ccDebugger.isMinimized());
+            assert.isTrue(updateSpy.calledOnce);
+        });
+
+        it('Should only update when opened', function() {
+            assert.isTrue(ccDebugger.isMinimized());
+
+            $.publish('debugger.update');
+            assert.isFalse(updateSpy.called);
+
+            ccDebugger.toggleState();
+            assert.isTrue(updateSpy.calledOnce);
+
+            $.publish('debugger.update');
+            // Called once on open and once on publish
+            assert.isTrue(updateSpy.calledTwice);
+        });
+    });
 });
 

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -88,10 +88,6 @@
         var username = "{{ username  }}";
         var domain = "{{ domain }}";
         var formplayer_url = "{{ formplayer_url }}";
-        var instanceViewerEnabled = false;
-        {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
-            instanceViewerEnabled = true;
-        {% endif %}
         var options = {
             apps: apps,
             language: language,
@@ -99,7 +95,9 @@
             domain: domain,
             formplayer_url: formplayer_url,
             gridPolyfillPath: "{% static 'css-grid-polyfill-binaries/css-polyfills.js' %}",
-            debuggerEnabled: instanceViewerEnabled,
+            {% if request.couch_user.can_edit_data %}
+            debuggerEnabled: true,
+            {% endif %}
             singleAppMode: {{ single_app_mode|JSON }},
             environment: {{ environment|JSON }},
         };
@@ -151,12 +149,12 @@
             <section id="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
         </div>
         <small id="version-info"></small>
-        {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
-            <section id="cloudcare-debugger" data-bind="
-            template: {
-                name: 'instance-viewer-ko-template',
-                afterRender: adjustWidth
-            }
+        {% if request.couch_user.can_edit_data %}
+        <section id="cloudcare-debugger" data-bind="
+          template: {
+              name: 'instance-viewer-ko-template',
+              afterRender: adjustWidth
+          }
         "></section>
         {% endif %}
     </div>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -192,7 +192,11 @@
                             <div class="form-group">
                                 <div class="controls" data-bind="css: Formplayer.Const.CONTROL_WIDTH">
                                     <label class="checkbox">
-                                        <input id="auto-sync-control" type="checkbox" checked="checked">{% trans "Auto Sync" %}
+                                        <input
+                                            id="auto-sync-control"
+                                            type="checkbox"
+                                            data-bind="checked: autoUpdate"
+                                            checked="checked">{% trans "Auto Sync" %}
                                         <span class="help-block">
                                         {% blocktrans %}
                                             When this is checked, the Data Preview tool will auto sync your XML after every question answered. On slow connetions, uncheck this.

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -159,16 +159,6 @@
                                 {% trans "Evaluate XPath" %}
                             </a>
                         </li>
-                        <li role="presentation">
-                            <a
-                                href="#debugger-settings"
-                                aria-controls="debugger-settings"
-                                role="tab"
-                                data-bind="click: collapseNavbar"
-                                data-toggle="tab">
-                                {% trans "Settings" %}
-                            </a>
-                        </li>
                       </ul>
                     </div><!-- /.navbar-collapse -->
                   </div><!-- /.container-fluid -->
@@ -187,26 +177,6 @@
                             name: 'debugger-eval-ko-template',
                             data: evalXPath }">
                         </div>
-                    </div>
-                    <div role="tabpanel" class="tab-pane" id="debugger-settings">
-                        <form class="form-horizontal debug-controls">
-                            <div class="form-group">
-                                <div class="controls" data-bind="css: Formplayer.Const.CONTROL_WIDTH">
-                                    <label class="checkbox">
-                                        <input
-                                            id="auto-sync-control"
-                                            type="checkbox"
-                                            data-bind="checked: autoUpdate"
-                                            checked="checked">{% trans "Auto Sync" %}
-                                        <span class="help-block">
-                                        {% blocktrans %}
-                                            When this is checked, the Data Preview tool will auto sync your XML after every question answered. On slow connetions, uncheck this.
-                                        {% endblocktrans %}
-                                        </span>
-                                    </label>
-                                </div>
-                            </div>
-                        </form>
                     </div>
                 </div>
             </div>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -96,7 +96,8 @@
         <div id="instance-xml-home" class="debugger" data-bind="
             css: {
                 'debugger-minimized': isMinimized,
-                'debugger-maximized': !isMinimized()
+                'debugger-maximized': !isMinimized(),
+                'debugger-updating': updating
             }
             ">
             <!-- Tab title -->

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -164,14 +164,14 @@
             </div>
             <div class="scrollable-container dragscroll form-scrollable-container">
               <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
-              {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
-                  <section id="cloudcare-debugger" data-bind="
+            {% if request.couch_user.can_edit_data %}
+              <section id="cloudcare-debugger" data-bind="
                   template: {
                       name: 'instance-viewer-ko-template',
                       afterRender: adjustWidth
                   }
               "></section>
-              {% endif %}
+            {% endif %}
             </div>
         </div>
 
@@ -189,7 +189,7 @@
                 oneQuestionPerScreen: !{{ request.couch_user.is_dimagi|JSON }},
                 allowedHost: "{{ request.get_host }}",
                 environment: {{ environment|JSON }},
-                {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
+                {% if request.couch_user.can_edit_data %}
                 debuggerEnabled: true,
                 {% endif %}
             });

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -164,14 +164,14 @@
             </div>
             <div class="scrollable-container dragscroll form-scrollable-container">
               <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
-            {% if request.couch_user.can_edit_data %}
+              {% if request.couch_user.can_edit_data %}
               <section id="cloudcare-debugger" data-bind="
                   template: {
                       name: 'instance-viewer-ko-template',
                       afterRender: adjustWidth
                   }
               "></section>
-            {% endif %}
+              {% endif %}
             </div>
         </div>
 

--- a/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
+++ b/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
@@ -18,6 +18,12 @@
   padding-bottom: 0;
 }
 
+.debugger-updating {
+  #debugger-form-data, #debugger-xml-instance {
+    opacity: 0.5;
+  }
+}
+
 
 .debugger.debugger-minimized {
   height: 30px;


### PR DESCRIPTION
@biyeun @wpride (also @snopoke since you're in charge of the product portion of this) This finishes off implementing the debugger release: https://docs.google.com/document/d/1PWznhCNj65zKUPo7PGCDwyVyYSXUJQwbjiKi8vJKZvM/edit#. I left the UI mostly the same because the proposed UI doesn't make as much sense for app preview, and i didn't think it was a show stopper. all analytics have already been added. can be read 🐟 or 🏠 

this PR does the following:

- release debugger from behind the flag (flag still in use for old cloudcare, maybe we should get rid of entirely?)
- puts the debugger under edit_data permissions as the spec says
- fixes form height scrolling issues. here's what it looks like now for OQPS and regular
<img width="314" alt="screen shot 2017-01-09 at 11 56 25 am" src="https://cloud.githubusercontent.com/assets/918514/21764669/f9fc8dd2-d66c-11e6-80e6-90e393fccb7b.png">
<img width="504" alt="screen shot 2017-01-09 at 11 55 51 am" src="https://cloud.githubusercontent.com/assets/918514/21764670/fa00903a-d66c-11e6-8174-e25de6121f39.png">
- fixes the setting that allows you to turn off the auto sync option. this may be something we want to be able to set globally, but for now i decided to just leave the functionality the same as it was before

- [x] Only  request on open of debugger and only do auto update when debugger is open
- [x] Do pass on docs (https://confluence.dimagi.com/display/commcarepublic/Using+Web+Apps and https://confluence.dimagi.com/display/commcarepublic/Beginner+Tutorial+Part+4+-+Testing+in+Preview)

cc: @millerdev @gcapalbo 
