### PR TITLE
ICDS: Dashboard Fixes

### DIFF
--- a/custom/icds_reports/static/tableau_app.js
+++ b/custom/icds_reports/static/tableau_app.js
@@ -57,8 +57,8 @@ function setUpNav(viz) {
 
     // Filter out the sheets for a single AWC. These are accessed via drilldown
     sheets = _.filter(sheets, function(sheet) {
-        return (sheet.getName() != "Demographics" && sheet.getName() != 'AWC-Info');
-    })
+        return (sheet.getName() !== "Demographics" && sheet.getName() !== 'AWC-Info');
+    });
     _.each(sheets, function(sheet) {
         addNavigationLink(sheet.getName(), sheet.getIsActive());
     });

--- a/custom/icds_reports/static/tableau_app.js
+++ b/custom/icds_reports/static/tableau_app.js
@@ -31,7 +31,7 @@ function initializeViz(o) {
 
     $("#resetFilters").click(function () {
         currentSheet = history.state.sheetName;
-        switchVisualization(currentSheet, workbook, initialParams);
+        switchVisualization(currentSheet, workbook, initialLocationParams);
     });
 }
 
@@ -48,7 +48,10 @@ function setUpInitialTableauParams() {
         'block': tableauOptions.blockCode,
     };
     params[locationKey] = tableauOptions.userLocation;
-    initialParams = params;
+    initialLocationParams = params;
+    today = new Date();
+    lastMonth = new Date(today.getFullYear(), today.getMonth() - 1 , 1);
+    params['Month'] = lastMonth.getFullYear() + "-" + (lastMonth.getMonth() + 1) + "-01";
     applyParams(workbook, params);
 
     var historyObject = {

--- a/custom/icds_reports/static/tableau_app.js
+++ b/custom/icds_reports/static/tableau_app.js
@@ -54,6 +54,11 @@ function setUpInitialTableauParams() {
 
 function setUpNav(viz) {
     var sheets = workbook.getPublishedSheetsInfo();
+
+    // Filter out the sheets for a single AWC. These are accessed via drilldown
+    sheets = _.filter(sheets, function(sheet) {
+        return (sheet.getName() != "Demographics" && sheet.getName() != 'AWC-Info');
+    })
     _.each(sheets, function(sheet) {
         addNavigationLink(sheet.getName(), sheet.getIsActive());
     });

--- a/custom/icds_reports/static/tableau_app.js
+++ b/custom/icds_reports/static/tableau_app.js
@@ -11,6 +11,8 @@ var viz = {},
 
 var tableauOptions = {};
 
+var initialLocationParams = [];
+
 function initializeViz(o) {
     tableauOptions = o;
 
@@ -30,7 +32,7 @@ function initializeViz(o) {
     viz = new tableau.Viz(placeholderDiv, url, options);
 
     $("#resetFilters").click(function () {
-        currentSheet = history.state.sheetName;
+        var currentSheet = history.state.sheetName;
         switchVisualization(currentSheet, workbook, initialLocationParams);
     });
 }
@@ -49,8 +51,8 @@ function setUpInitialTableauParams() {
     };
     params[locationKey] = tableauOptions.userLocation;
     initialLocationParams = params;
-    today = new Date();
-    lastMonth = new Date(today.getFullYear(), today.getMonth() - 1 , 1);
+    var today = new Date();
+    var lastMonth = new Date(today.getFullYear(), today.getMonth() - 1 , 1);
     params['Month'] = lastMonth.getFullYear() + "-" + (lastMonth.getMonth() + 1) + "-01";
     applyParams(workbook, params);
 

--- a/custom/icds_reports/static/tableau_app.js
+++ b/custom/icds_reports/static/tableau_app.js
@@ -28,6 +28,11 @@ function initializeViz(o) {
         },
     };
     viz = new tableau.Viz(placeholderDiv, url, options);
+
+    $("#resetFilters").click(function () {
+        currentSheet = history.state.sheetName;
+        switchVisualization(currentSheet, workbook, initialParams);
+    });
 }
 
 function setUpWorkbook(viz) {
@@ -43,6 +48,7 @@ function setUpInitialTableauParams() {
         'block': tableauOptions.blockCode,
     };
     params[locationKey] = tableauOptions.userLocation;
+    initialParams = params;
     applyParams(workbook, params);
 
     var historyObject = {
@@ -197,7 +203,6 @@ function switchVisualization(sheetName, workbook, params) {
                 alert(err);
             });
 
-    enableResetFiltersButton();
 }
 
 function applyParams(workbook, params, lastWorksheet) {
@@ -213,19 +218,6 @@ function clearDebugInfo() {
     // TODO: Disabling the button doesn't work
     $("#inspectButton").prop('disabled', true);
 }
-
-function enableResetFiltersButton() {
-    $("#resetFilters").prop('disabled', false).click(function () {
-        // TODO: Only bind to this button once
-        viz.revertAllAsync();
-        disableResetFiltersButton();
-    });
-}
-
-function disableResetFiltersButton() {
-    $("#resetFilters").prop('disabled', true).unbind('click');
-}
-
 
 window.onpopstate = function (event) {
     if(!event.state.sheetName) {

--- a/custom/icds_reports/templates/icds_reports/tableau.html
+++ b/custom/icds_reports/templates/icds_reports/tableau.html
@@ -39,7 +39,7 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-md-2">
-            <button id="resetFilters" class="btn btn-block btn-primary" disabled="disabled">Reset Filtering</button>
+            <button id="resetFilters" class="btn btn-block btn-primary">Reset Drilldown</button>
             {% if debug %}
                 <button id="inspectButton" class="btn btn-block btn-primary" disabled="disabled">Inspect</button>
                 <div id="debugbar" class="well">

--- a/custom/icds_reports/templates/icds_reports/tableau.html
+++ b/custom/icds_reports/templates/icds_reports/tableau.html
@@ -54,7 +54,7 @@
             {% endif %}
         </div>
         <div class="col-md-10">
-            <div id="tableauPlaceholder" style="width:1100px; height:900px; overflow:visible;"></div>
+            <div id="tableauPlaceholder" style="width:1100px; height:2400px; overflow:visible;"></div>
         </div>
     </div>
 

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -23,14 +23,14 @@ def tableau(request, domain, workbook, worksheet):
 
     # set report view-by level based on user's location level
     couch_user = getattr(request, 'couch_user', None)
-    location_type_code, user_site_code, state_code, district_code, block_code = \
+    location_type_code, user_location_id, state_id, district_id, block_id = \
         _get_user_location(couch_user, domain)
     context.update({
         'view_by': location_type_code,
-        'view_by_value': user_site_code,
-        'state_code': state_code,
-        'district_code': district_code,
-        'block_code': block_code,
+        'view_by_value': user_location_id,
+        'state_id': state_id,
+        'district_id': district_id,
+        'block_id': block_id,
     })
 
     # the header is added by nginx
@@ -47,7 +47,7 @@ def tableau(request, domain, workbook, worksheet):
 
 def _get_user_location(user, domain):
     '''
-    Takes a couch_user and returns that users parentage and the location code
+    Takes a couch_user and returns that users parentage and the location id
     '''
     try:
         user_location_id = user.get_domain_membership(domain).location_id
@@ -55,27 +55,26 @@ def _get_user_location(user, domain):
         location_type_code = loc.location_type.code
 
         # Assuming no web users below block level
-        state_code = 'All'
-        district_code = 'All'
-        block_code = 'All'
+        state_id = 'All'
+        district_id = 'All'
+        block_id = 'All'
         if location_type_code == 'state':
-            state_code = loc.site_code
+            state_id = loc.location_id
         elif location_type_code == 'district':
-            state_code = loc.parent.site_code
-            district_code = loc.site_code
+            state_id = loc.parent.location_id
+            district_id = loc.location_id
         elif location_type_code == 'block':
-            state_code = loc.parent.parent.site_code
-            district_code = loc.parent.site_code
-            block_code = loc.site_code
+            state_id = loc.parent.parent.location_id
+            district_id = loc.parent.location_id
+            block_id = loc.location_id
 
-        user_site_code = loc.site_code
     except Exception:
         location_type_code = 'national'
-        user_site_code = ''
-        state_code = 'All'
-        district_code = 'All'
-        block_code = 'All'
-    return location_type_code, user_site_code, state_code, district_code, block_code
+        user_location_id = ''
+        state_id = 'All'
+        district_id = 'All'
+        block_id = 'All'
+    return location_type_code, user_location_id, state_id, district_id, block_id
 
 
 def get_tableau_trusted_url(client_ip):


### PR DESCRIPTION
@sravfeyn 

This PR does two things:
- It hides the AWC-only sheets from the dashboard dropdown. This is a bit hard-coded so open to ideas on how to do this better
- It passes location IDs to the dashboard instead of site codes.  This should improve performance since our location tables are indexed on IDs but not on site codes

This will require a corresponding update to the dashboards so we will need to coordinate deploying this.  