### PR TITLE
Proper height for login as

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -28,13 +28,18 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
         var maxHeight,
             maxHeightForm,
             user = FormplayerFrontend.request('currentUser'),
+            restoreAsBannerHeight = 0,
             debuggerHeight = 0;
 
         if (user.debuggerEnabled) {
             debuggerHeight = 34;
         }
+        if (user.restoreAs) {
+            restoreAsBannerHeight = FormplayerFrontend.regions.restoreAsBanner.$el.height();
+        }
         maxHeight = ($(window).height() -
-            FormplayerFrontend.regions.breadcrumb.$el.height());
+            FormplayerFrontend.regions.breadcrumb.$el.height() -
+            restoreAsBannerHeight);
 
         // Max height of the form is the space between the debugger and the breadcrumbs
         maxHeightForm = maxHeight - debuggerHeight;


### PR DESCRIPTION
@biyeun @wpride Fixes the fact that the submit button and the last module would be cut off if you were using login as. http://manage.dimagi.com/default.asp?245504

<img width="304" alt="screen shot 2017-01-11 at 11 19 58 am" src="https://cloud.githubusercontent.com/assets/918514/21842587/1d602b4c-d7f0-11e6-980b-ddd99362da26.png">
<img width="310" alt="screen shot 2017-01-11 at 11 19 50 am" src="https://cloud.githubusercontent.com/assets/918514/21842588/1d63d526-d7f0-11e6-92a2-6c90a3e0bc81.png">

cc: @emord 
