### PR TITLE
Small debugger button

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -502,9 +502,18 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     // Called afterRender, ensures that the debugger takes the whole screen
     self.adjustWidth = function() {
         var $debug = $('#instance-xml-home'),
+            leftMargin = 0,
             $body = $('body');
 
-        $debug.width($body.width() - $debug.offset().left);
+        // HACK: we do not need to take into accunt the left margin for anything but
+        // Old cloudcare. When we do it messes up app preview's debugger width.
+        // If it's less than 5, we're in app preview so ignore it.
+        // Remove this once we're on new cloudcare.
+        if ($debug.offset().left > 5) {
+            leftMargin = $debug.offset();
+        }
+
+        $debug.width($body.width() - leftMargin);
     };
 };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -502,18 +502,9 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     // Called afterRender, ensures that the debugger takes the whole screen
     self.adjustWidth = function() {
         var $debug = $('#instance-xml-home'),
-            leftMargin = 0,
             $body = $('body');
 
-        // HACK: we do not need to take into accunt the left margin for anything but
-        // Old cloudcare. When we do it messes up app preview's debugger width.
-        // If it's less than 5, we're in app preview so ignore it.
-        // Remove this once we're on new cloudcare.
-        if ($debug.offset().left > 5) {
-            leftMargin = $debug.offset();
-        }
-
-        $debug.width($body.width() - leftMargin);
+        $debug.width($body.width());
     };
 };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -28,13 +28,18 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
         var maxHeight,
             maxHeightForm,
             user = FormplayerFrontend.request('currentUser'),
+            restoreAsBannerHeight = 0,
             debuggerHeight = 0;
 
         if (user.debuggerEnabled) {
             debuggerHeight = 34;
         }
+        if (user.restoreAs) {
+            restoreAsBannerHeight = FormplayerFrontend.regions.restoreAsBanner.$el.height();
+        }
         maxHeight = ($(window).height() -
-            FormplayerFrontend.regions.breadcrumb.$el.height());
+            FormplayerFrontend.regions.breadcrumb.$el.height() -
+            restoreAsBannerHeight);
 
         // Max height of the form is the space between the debugger and the breadcrumbs
         maxHeightForm = maxHeight - debuggerHeight;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -26,14 +26,9 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
     };
     var setScrollableMaxHeight = function() {
         var maxHeight,
-            maxHeightForm,
             user = FormplayerFrontend.request('currentUser'),
-            restoreAsBannerHeight = 0,
-            debuggerHeight = 0;
+            restoreAsBannerHeight = 0;
 
-        if (user.debuggerEnabled) {
-            debuggerHeight = 34;
-        }
         if (user.restoreAs) {
             restoreAsBannerHeight = FormplayerFrontend.regions.restoreAsBanner.$el.height();
         }
@@ -41,13 +36,10 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
             FormplayerFrontend.regions.breadcrumb.$el.height() -
             restoreAsBannerHeight);
 
-        // Max height of the form is the space between the debugger and the breadcrumbs
-        maxHeightForm = maxHeight - debuggerHeight;
-
         $('.scrollable-container').css('max-height', maxHeight + 'px');
         $('.form-scrollable-container').css({
-            'min-height': maxHeightForm + 'px',
-            'max-height': maxHeightForm + 'px',
+            'min-height': maxHeight + 'px',
+            'max-height': maxHeight + 'px',
         });
     };
 

--- a/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
+++ b/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
@@ -2,12 +2,13 @@
   width: 800px;
   position: fixed;
   bottom: 0;
+  left: 0;
   z-index: @zindex-dropdown + 5;
   background-color: white;
   overflow: hidden;
 
-  -webkit-transition: height 0.5s;
-  transition: height 0.5s;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
 }
 
 .debugger .debugger-content {

--- a/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
+++ b/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
@@ -7,8 +7,8 @@
   background-color: white;
   overflow: hidden;
 
-  -webkit-transition: all 0.5s;
-  transition: all 0.5s;
+  -webkit-transition: height 0.5s;
+  transition: height 0.5s;
 }
 
 .debugger .debugger-content {

--- a/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
@@ -1,3 +1,8 @@
+.debugger {
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+
 .debugger.debugger-maximized {
   height: @preview-phone-height;
   max-height: 100vh;

--- a/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
@@ -3,6 +3,27 @@
   max-height: 100vh;
 }
 
+.debugger.debugger-minimized {
+  height: 30px;
+  // Javascript auto sets the width for normal web apps so we need to override that with !important
+  // This way form entry javascript doesn't need to know whether its in web apps or preview
+  width: 30px !important;
+  border-radius: 15px;
+
+  // Space the debugger button so it's not flush against the phone
+  bottom: 3px;
+  left: 3px;
+
+  .box-shadow(0 0 5px 0 rgba(0, 0, 0, 0.45));
+
+  .debugger-tab-title {
+    text-align: center;
+    .debugger-title {
+      display: none;
+    }
+  }
+}
+
 .debugger .debugger-content {
   font-size: 1rem;
 }

--- a/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
@@ -17,7 +17,8 @@
 
   // Space the debugger button so it's not flush against the phone
   bottom: 3px;
-  left: 3px;
+  right: 3px;
+  left: initial;
 
   .box-shadow(0 0 5px 0 rgba(0, 0, 0, 0.45));
 


### PR DESCRIPTION
@biyeun @orangejenny this makes the debugger button smaller and less intrusive for app preview. what do you think? i also think this is way less intrusive when you use one question per screen. there's always loads of whitespace at the bottom.

![veolmahtic](https://cloud.githubusercontent.com/assets/918514/21843455/b2b4d582-d7f3-11e6-90b7-cb9239a41c39.gif)

cc: @emord 