### PR TITLE
Only make repeat records for allowed case types

### DIFF
--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -29,8 +29,9 @@ class NikshayRegisterPatientRepeater(CaseRepeater):
     def allowed_to_forward(self, episode_case):
         # When case property episode.episode_pending_registration transitions from 'yes' to 'no',
         # and (episode.nikshay_registered != 'true'  or episode.nikshay_id != '')
+        allowed_case_types_and_users = self._allowed_case_type(episode_case) and self._allowed_user(episode_case)
         episode_case_properties = episode_case.dynamic_case_properties()
-        return (
+        return allowed_case_types_and_users and (
             not episode_case_properties.get('nikshay_registered', 'false') == 'true' and
             not episode_case_properties.get('nikshay_id', False) and
             episode_pending_registration_changed(episode_case)

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -47,9 +47,12 @@ class NikshayRepeaterTestBase(ENikshayCaseStructureMixin, TestCase):
     def repeat_records(self):
         return RepeatRecord.all(domain=self.domain, due_before=datetime.utcnow())
 
-    def _create_nikshay_enabled_case(self):
+    def _create_nikshay_enabled_case(self, case_id=None):
+        if case_id is None:
+            case_id = self.episode_id
+
         nikshay_enabled_case_on_update = CaseStructure(
-            case_id=self.episode_id,
+            case_id=case_id,
             attrs={
                 "create": False,
                 "update": dict(
@@ -106,6 +109,13 @@ class TestNikshayRegisterPatientRepeater(NikshayRepeaterTestBase):
         # set as registered, should not register a new repeat record
         self._create_nikshay_registered_case()
         self.assertEqual(1, len(self.repeat_records().all()))
+
+    @run_with_all_backends
+    def test_trigger_different_case_type(self):
+        # different case type
+        self.create_case(self.person)
+        self._create_nikshay_enabled_case(case_id=self.person_id)
+        self.assertEqual(0, len(self.repeat_records().all()))
 
 
 class TestNikshayRegisterPatientPayloadGenerator(ENikshayLocationStructureMixin, NikshayRepeaterTestBase):


### PR DESCRIPTION
Should prevent the `ERROR: ENikshayCaseNotFound emails`
Should stop the repeater from repeating for all cases in eNikshay. 
@mkangia 
cc @gcapalbo 