### PR TITLE
Make dashboard location-safe

### DIFF
--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -131,6 +131,7 @@ class NewUserDashboardView(BaseDashboardView):
         return templates
 
 
+@location_safe
 class DomainDashboardView(JSONResponseMixin, BaseDashboardView):
     urlname = 'dashboard_domain'
     page_title = ugettext_noop("HQ Dashboard")

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_noop, ugettext as _
@@ -14,17 +15,13 @@ from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views import DomainViewMixin, LoginAndDomainMixin, \
     DefaultProjectSettingsView
 from corehq.apps.domain.utils import user_has_custom_top_menu
-from corehq.apps.export.views import CaseExportListView, FormExportListView
 from corehq.apps.hqwebapp.view_permissions import user_can_view_reports
-from corehq.apps.locations.views import LocationsListView
 from corehq.apps.hqwebapp.views import BasePageView
-from corehq.apps.users.permissions import can_view_case_exports, can_view_form_exports
 from corehq.apps.users.views import DefaultProjectUserSettingsView
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.style.decorators import use_angular_js
 from corehq.apps.cloudcare.views import FormplayerMain
 from django_prbac.utils import has_privilege
-from django.conf import settings
 
 
 @login_and_domain_required
@@ -39,21 +36,14 @@ def default_dashboard_url(request, domain):
     if domain in settings.CUSTOM_DASHBOARD_PAGE_URL_NAMES:
         return reverse(settings.CUSTOM_DASHBOARD_PAGE_URL_NAMES[domain], args=[domain])
 
-    if couch_user and not couch_user.has_permission(domain, 'access_all_locations'):
-        if couch_user.is_commcare_user():
-            if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
-                formplayer_view = FormplayerMain.urlname
-            else:
-                formplayer_view = "corehq.apps.cloudcare.views.default"
-            return reverse(formplayer_view, args=[domain])
-        if couch_user.has_permission(domain, 'view_reports'):
-            return reverse(CaseExportListView.urlname, args=[domain])
+    if (couch_user
+            and not couch_user.has_permission(domain, 'access_all_locations')
+            and couch_user.is_commcare_user()):
+        if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
+            formplayer_view = FormplayerMain.urlname
         else:
-            if can_view_case_exports(couch_user, domain):
-                return reverse(CaseExportListView.urlname, args=[domain])
-            elif can_view_form_exports(couch_user, domain):
-                return reverse(FormExportListView.urlname, args=[domain])
-        return reverse(LocationsListView.urlname, args=[domain])
+            formplayer_view = "corehq.apps.cloudcare.views.default"
+        return reverse(formplayer_view, args=[domain])
 
     if couch_user and user_has_custom_top_menu(domain, couch_user):
         return reverse('saved_reports', args=[domain])

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -35,6 +35,7 @@ from corehq.apps.data_interfaces.dispatcher import (
     EditDataInterfaceDispatcher,
     require_can_edit_data,
 )
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.style.decorators import use_typeahead, use_angular_js
 from corehq.const import SERVER_DATETIME_FORMAT
 from .dispatcher import require_form_management_privilege
@@ -51,6 +52,7 @@ from soil.util import expose_cached_download, get_download_context
 
 
 @login_and_domain_required
+@location_safe
 def default(request, domain):
     if not request.project or request.project.is_snapshot:
         raise Http404()

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -200,6 +200,7 @@ def can_view_attachments(request):
 
 
 @login_and_domain_required
+@location_safe
 def default(request, domain):
     if domain in WORLD_VISION_DOMAINS and get_domain_module_map().get(domain):
         from custom.world_vision.reports.mixed_report import MixedTTCReport
@@ -228,6 +229,7 @@ class BaseProjectReportSectionView(BaseDomainView):
         return reverse('reports_home', args=(self.domain, ))
 
 
+@location_safe
 class MySavedReportsView(BaseProjectReportSectionView):
     urlname = 'saved_reports'
     page_title = _("My Saved Reports")

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -44,6 +44,7 @@ from corehq.apps.es import AppES
 from corehq.apps.es.queries import search_string_query
 from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BasePageView, logout
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.registration.forms import AdminInvitesUserForm, WebUserInvitationForm
 from corehq.apps.registration.utils import activate_new_user
 from corehq.apps.reports.util import get_possible_reports
@@ -117,6 +118,7 @@ class BaseUserSettingsView(BaseDomainView):
         return context
 
 
+@location_safe
 class DefaultProjectUserSettingsView(BaseUserSettingsView):
     urlname = "users_default"
 


### PR DESCRIPTION
@czue @calellowitz IIRC you two were just doing some work regarding this behavior.
This PR makes the dashboard location-safe, along with the "default" views for the reports, data, and users tiles.

It does preserve the behavior Cal implemented, which is redirecting mobile workers to Cloudcare instead of the dashboard, but only if they're location restricted.  I don't see a reason why we shouldn't just do this for ALL mobile workers, actually, but that felt like too impactful a change to make without more explicit thought.

@NoahCarnahan @sravfeyn