### PR TITLE
allow specifying case type for autoload case actions

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -197,6 +197,10 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
                         self.applyAccordion('open', 0);
                     }
                 });
+
+                $('.hq-help-template').each(function () {
+                    COMMCAREHQ.transformHelpTemplate($(this), true);
+                });
             });
         };
     };
@@ -637,7 +641,15 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
                     // suggestedProperties need to be those of case type "commcare-user"
                     if (value === 'usercase') {
                         self.case_type('commcare-user');
+                    } else {
+                        self.case_type(null);
                     }
+
+                    _.defer(function () {
+                        $('.hq-help-template').each(function () {
+                            COMMCAREHQ.transformHelpTemplate($(this), true);
+                        });
+                    });
                 });
             }
 
@@ -695,6 +707,9 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
                         } else if (mode === 'fixture') {
                             return 'Lookup table tag required';
                         }
+                    }
+                    if (!self.case_type()) {
+                        return 'Expected case type required';
                     }
                     return null;
                 } else {

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_advanced.html
@@ -211,6 +211,16 @@
     </div>
 </script>
 
+<script type="text/html" id="auto-select:case-type">
+    {% trans "Expected Case Type" %}
+    <input type="text" class="form-control" data-bind="value: $parent.case_type" />
+    <span class="hq-help-template"
+              data-title="{% trans "Expected Case Type" %}"
+              data-content="{% blocktrans %}This is used for case property suggestions and when creating case indexes but
+              it does not get validated against the loaded case.{% endblocktrans %}"
+        ></span>
+</script>
+
 <script type="text/html" id="auto-select:undefined">
 </script>
 
@@ -218,12 +228,14 @@
     &nbsp;
     {% trans "XPath function" %}
     <input type="text" class="form-control" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:user">
     &nbsp;
     {% trans "User data key:" %}
     <input type="text" class="form-control" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:case">
@@ -234,6 +246,7 @@
     </select>
     {% trans "Index name:" %}
     <input type="text" class="input-medium" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:fixture">
@@ -242,6 +255,7 @@
     <input type="text" class="input-large" data-bind="value: value_source" />
     {% trans "Table Field:" %}
     <input type="text" class="input-large" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:usercase">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_advanced.html
@@ -211,6 +211,16 @@
     </div>
 </script>
 
+<script type="text/html" id="auto-select:case-type">
+    {% trans "Expected Case Type" %}
+    <input type="text" class="form-control" data-bind="value: $parent.case_type" />
+    <span class="hq-help-template"
+              data-title="{% trans "Expected Case Type" %}"
+              data-content="{% blocktrans %}This is used for case property suggestions and when creating case indexes but
+              it does not get validated against the loaded case.{% endblocktrans %}"
+        ></span>
+</script>
+
 <script type="text/html" id="auto-select:undefined">
 </script>
 
@@ -218,12 +228,14 @@
     &nbsp;
     {% trans "XPath function" %}
     <input type="text" class="form-control" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:user">
     &nbsp;
     {% trans "User data key:" %}
     <input type="text" class="form-control" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:case">
@@ -234,6 +246,7 @@
     </select>
     {% trans "Index name:" %}
     <input type="text" class="input-medium" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:fixture">
@@ -242,6 +255,7 @@
     <input type="text" class="input-large" data-bind="value: value_source" />
     {% trans "Table Field:" %}
     <input type="text" class="input-large" data-bind="value: value_key" />
+    <!-- ko template: {name: 'auto-select:case-type'} --><!-- /ko -->
 </script>
 
 <script type="text/html" id="auto-select:usercase">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_advanced.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_advanced.html.diff.txt
@@ -89,7 +89,7 @@
      </div>
      <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
          <div class="panel-body">
-@@ -400,13 +400,13 @@
+@@ -414,13 +414,13 @@
              </legend>
              <div id="case-load-accordion" class="panel-group" data-bind="foreach: load_update_cases">
                  <!-- ko if: auto_select -->
@@ -106,7 +106,7 @@
                  <!-- /ko -->
              </div>
          </div>
-@@ -416,7 +416,7 @@
+@@ -430,7 +430,7 @@
                  {% trans "Open New Cases" %}
              </legend>
              <div id="case-open-accordion" class="panel-group" data-bind="foreach: open_cases">


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?244499

Allowing the user to specify the case type has two benefits:
1. we can use it when creating case indexes
2. we can use it to autosuggest case properties from the appropriate case type which makes doing the case management much easier

@calellowitz @proteusvacuum 