### PR TITLE
replacing db calls with dict lookups

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -138,7 +138,7 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
 
         if user_filter[HQUserType.REGISTERED].show:
             # now add all the registered users who never submitted anything
-            users.extend(user for id, user in registered_users_by_id.items()if id not in submitted_user_ids)
+            users.extend(user for id, user in registered_users_by_id.items() if id not in submitted_user_ids)
 
     if simplified:
         return [_report_user_dict(user) for user in users]

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -136,9 +136,8 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
 
         if user_filter[HQUserType.REGISTERED].show:
             # now add all the registered users who never submitted anything
-            for user_id in registered_user_ids:
+            for user_id, user in registered_user_ids.items():
                 if user_id not in submitted_user_ids:
-                    user = CommCareUser.get_by_user_id(user_id)
                     users.append(user)
 
     if simplified:

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -119,7 +119,9 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
         submitted_user_ids = set(get_all_user_ids_submitted(domain))
         registered_users_by_id = dict([(user.user_id, user) for user in CommCareUser.by_domain(domain)])
         if include_inactive:
-            registered_users_by_id.update(dict([(u.user_id, u) for u in CommCareUser.by_domain(domain, is_active=False)]))
+            registered_users_by_id.update(dict(
+                [(u.user_id, u) for u in CommCareUser.by_domain(domain, is_active=False)]
+            ))
         for user_id in submitted_user_ids:
             if user_id in registered_users_by_id and user_filter[HQUserType.REGISTERED].show:
                 user = registered_users_by_id[user_id]

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -117,14 +117,14 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
             user_filter = HQUserType.all()
         users = []
         submitted_user_ids = get_all_user_ids_submitted(domain)
-        registered_user_ids = dict([(user.user_id, user) for user in CommCareUser.by_domain(domain)])
+        registered_users_by_id = dict([(user.user_id, user) for user in CommCareUser.by_domain(domain)])
         if include_inactive:
-            registered_user_ids.update(dict([(u.user_id, u) for u in CommCareUser.by_domain(domain, is_active=False)]))
+            registered_users_by_id.update(dict([(u.user_id, u) for u in CommCareUser.by_domain(domain, is_active=False)]))
         for user_id in submitted_user_ids:
-            if user_id in registered_user_ids and user_filter[HQUserType.REGISTERED].show:
-                user = registered_user_ids[user_id]
+            if user_id in registered_users_by_id and user_filter[HQUserType.REGISTERED].show:
+                user = registered_users_by_id[user_id]
                 users.append(user)
-            elif (user_id not in registered_user_ids and
+            elif (user_id not in registered_users_by_id and
                  (user_filter[HQUserType.ADMIN].show or
                   user_filter[HQUserType.DEMO_USER].show or
                   user_filter[HQUserType.UNKNOWN].show)):
@@ -136,7 +136,7 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
 
         if user_filter[HQUserType.REGISTERED].show:
             # now add all the registered users who never submitted anything
-            for user_id, user in registered_user_ids.items():
+            for user_id, user in registered_users_by_id.items():
                 if user_id not in submitted_user_ids:
                     users.append(user)
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -116,7 +116,7 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
         if not user_filter:
             user_filter = HQUserType.all()
         users = []
-        submitted_user_ids = get_all_user_ids_submitted(domain)
+        submitted_user_ids = set(get_all_user_ids_submitted(domain))
         registered_users_by_id = dict([(user.user_id, user) for user in CommCareUser.by_domain(domain)])
         if include_inactive:
             registered_users_by_id.update(dict([(u.user_id, u) for u in CommCareUser.by_domain(domain, is_active=False)]))
@@ -136,9 +136,7 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
 
         if user_filter[HQUserType.REGISTERED].show:
             # now add all the registered users who never submitted anything
-            for user_id, user in registered_users_by_id.items():
-                if user_id not in submitted_user_ids:
-                    users.append(user)
+            users.extend(user for id, user in registered_users_by_id.items()if id not in submitted_user_ids)
 
     if simplified:
         return [_report_user_dict(user) for user in users]


### PR DESCRIPTION
@esoergel cc: @czue @snopoke @sravfeyn 
While investigating http://manage.dimagi.com/default.asp?245323 , we noticed this small optimization that replaces db calls (13k lookups in the case of the icds domain) with dict lookups when pulling the users list for most reports. I am not sure this will be enough of a speedup to make that report load for all users, but should definitely be a step in the right direction.
🎩 to ethan for the initial spot.