### PR TITLE
Ensure we send over preserveCache params on async restore

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -301,11 +301,18 @@ FormplayerFrontend.on("sync", function () {
         domain = user.domain,
         formplayer_url = user.formplayer_url,
         complete,
+        data = {
+            "username": username,
+            "domain": domain,
+            "restoreAs": user.restoreAs,
+        },
         options;
 
     complete = function(response) {
         if (response.responseJSON.status === 'retry') {
             FormplayerFrontend.trigger('retry', response.responseJSON, function() {
+                // Ensure that when we hit the sync db route we don't use the overwrite_cache param
+                options.data = JSON.stringify($.extend(true, { preserveCache: true }, data));
                 $.ajax(options);
             }, gettext('Waiting for server progress'));
         } else {
@@ -315,11 +322,7 @@ FormplayerFrontend.on("sync", function () {
     };
     options = {
         url: formplayer_url + "/sync-db",
-        data: JSON.stringify({
-            "username": username,
-            "domain": domain,
-            "restoreAs": user.restoreAs,
-        }),
+        data: JSON.stringify(data),
         complete: complete,
     };
     Util.setCrossDomainAjaxOptions(options);


### PR DESCRIPTION
@czue @wpride this sends the `preserveCache` param when using async restore and sync db

cc: @emord 

https://github.com/dimagi/formplayer/pull/249