### PR TITLE
initial_page_data template tag

### DIFF
--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -341,7 +341,7 @@ $(function () {
         self.loadData = function () {
             self.loading(self.loading() + 3);
             $.ajax({
-                url: DataTypeUrl,
+                url: hqImport('hqwebapp/js/urllib.js').reverse('fixture_data_types'),
                 type: 'get',
                 dataType: 'json',
                 success: function (data) {

--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -41,7 +41,7 @@ $(function () {
             self._id = ko.observable();
         }
         self.view_link = ko.computed(function(){
-            return TableViewUrl + "?table_id="+self._id();
+            return hqImport('hqwebapp/js/urllib.js').reverse('fixture_interface_dispatcher') + "?table_id=" + self._id();
         }, self);
         self.aboutToDelete = ko.observable(false);
         self.addField = function (data, event, o) {
@@ -100,7 +100,7 @@ $(function () {
         self.save = function () {
             $.ajax({
                 type: self._id() ? (self._destroy ? 'delete' : 'put') : 'post',
-                url: UpdateTableUrl + (self._id() || ''),
+                url: hqImport('hqwebapp/js/urllib.js').reverse('update_lookup_tables') + (self._id() || ''),
                 data: JSON.stringify(self.serialize()),
                 dataType: 'json',
                 error: function(data) {
@@ -265,7 +265,7 @@ $(function () {
             if (tables.length > 0){
                 // POST, because a long querystring can overflow the request
                 $.ajax({
-                    url: FixtureDownloadUrl,
+                    url: hqImport('hqwebapp/js/urllib.js').reverse('download_fixtures'),
                     type: 'POST',
                     data: {'table_ids': tables},
                     dataType: 'json',

--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -1,0 +1,17 @@
+(function () {
+    var initialPageData = $.parseJSON($("#initial-page-json").text());
+    if (initialPageData.renderReportTables) {
+        var reportTables = new HQReportDataTables(initialPageData.reportTablesOptions);
+        if (typeof standardHQReport !== 'undefined') {
+            standardHQReport.handleTabularReportCookies(reportTables);
+        }
+        reportTables.render();
+    }
+
+    $(function() {
+        $('.header-popover').popover({
+            trigger: 'hover',
+            placement: 'bottom'
+        });
+    });
+})();

--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -1,7 +1,24 @@
 (function () {
-    var initialPageData = $.parseJSON($("#initial-page-json").text());
+    var initialPageData = {};
+    _.each($(".initial-page-data"), function(div) {
+        var data = $(div).data();
+        initialPageData[data.name] = data.value;
+    });
     if (initialPageData.renderReportTables) {
-        var reportTables = new HQReportDataTables(initialPageData.reportTablesOptions);
+        var reportTables = new HQReportDataTables(_.pick(initialPageData, [
+            'slug',
+            'defaultRows',
+            'startAtRowNum',
+            'showAllRowsOption',
+            'autoWidth',
+            'aoColumns',
+            'customSort',
+            'ajaxSource',
+            'ajaxParams',
+            'fixColumns',
+            'fixColsNumLeft',
+            'fixColsWidth',
+        ]));
         if (typeof standardHQReport !== 'undefined') {
             standardHQReport.handleTabularReportCookies(reportTables);
         }

--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -2,27 +2,7 @@
 $(function () {
     var data = hqImport('hqwebapp/js/initial_page_data.js').get;
     if (data('renderReportTables')) {
-        var options = {};
-        _.each([
-            'slug',
-            'defaultRows',
-            'startAtRowNum',
-            'showAllRowsOption',
-            'autoWidth',
-            'aoColumns',
-            'customSort',
-            'ajaxSource',
-            'ajaxParams',
-            'fixColumns',
-            'fixColsNumLeft',
-            'fixColsWidth',
-        ], function(name) {
-            var value = data(name);
-            if (value !== undefined) {
-                options[name] = value;
-            }
-        });
-        var reportTables = new HQReportDataTables(options);
+        var reportTables = new HQReportDataTables(data('dataTablesOptions'));
         if (typeof standardHQReport !== 'undefined') {
             standardHQReport.handleTabularReportCookies(reportTables);
         }

--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -1,11 +1,8 @@
-(function () {
-    var initialPageData = {};
-    _.each($(".initial-page-data"), function(div) {
-        var data = $(div).data();
-        initialPageData[data.name] = data.value;
-    });
-    if (initialPageData.renderReportTables) {
-        var reportTables = new HQReportDataTables(_.pick(initialPageData, [
+$(function () {
+    var data = hqImport('hqwebapp/js/initial_page_data.js').get;
+    if (data('renderReportTables')) {
+        var options = {};
+        _.each([
             'slug',
             'defaultRows',
             'startAtRowNum',
@@ -18,7 +15,13 @@
             'fixColumns',
             'fixColsNumLeft',
             'fixColsWidth',
-        ]));
+        ], function(name) {
+            var value = data(name);
+            if (value !== undefined) {
+                options[name] = value;
+            }
+        });
+        var reportTables = new HQReportDataTables(options);
         if (typeof standardHQReport !== 'undefined') {
             standardHQReport.handleTabularReportCookies(reportTables);
         }
@@ -31,4 +34,4 @@
             placement: 'bottom'
         });
     });
-})();
+});

--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -1,3 +1,4 @@
+/* global hqImport, standardHQReport, HQReportDataTables */
 $(function () {
     var data = hqImport('hqwebapp/js/initial_page_data.js').get;
     if (data('renderReportTables')) {
@@ -31,7 +32,7 @@ $(function () {
     $(function() {
         $('.header-popover').popover({
             trigger: 'hover',
-            placement: 'bottom'
+            placement: 'bottom',
         });
     });
 });

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -8,7 +8,6 @@
 <script src="{% static 'fixtures/js/lookup-manage.js' %}"></script>
 {% endblock %}
 
-
 {% block js-inline %}
     {% registerurl 'download_fixtures' domain %}
     {% registerurl 'fixture_interface_dispatcher' domain 'view_lookup_tables' %}

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -10,13 +10,10 @@
 
 
 {% block js-inline %}
+    {% registerurl 'download_fixtures' domain %}
+    {% registerurl 'fixture_interface_dispatcher' domain 'view_lookup_tables' %}
     {% registerurl 'fixture_data_types' domain %}
-    <script>
-        var FixtureDownloadUrl = "{% url 'download_fixtures' domain%}" +"?";
-        var FixtureFileDownloadUrl = "{% url 'download_fixture_file' domain%}" +"?";
-        var TableViewUrl = "{% url 'fixture_interface_dispatcher' domain 'view_lookup_tables'%}";
-        var UpdateTableUrl = "{% url 'update_lookup_tables' domain %}";
-    </script>
+    {% registerurl 'update_lookup_tables' domain %}
 {% endblock %}
 
 {% block page_title %}

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -4,15 +4,17 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
+<script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
 <script src="{% static 'fixtures/js/lookup-manage.js' %}"></script>
 {% endblock %}
 
+
 {% block js-inline %}
+    {% registerurl 'fixture_data_types' domain %}
     <script>
         var FixtureDownloadUrl = "{% url 'download_fixtures' domain%}" +"?";
         var FixtureFileDownloadUrl = "{% url 'download_fixture_file' domain%}" +"?";
         var TableViewUrl = "{% url 'fixture_interface_dispatcher' domain 'view_lookup_tables'%}";
-        var DataTypeUrl = "{% url 'fixture_data_types' domain %}";
         var UpdateTableUrl = "{% url 'update_lookup_tables' domain %}";
     </script>
 {% endblock %}

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -23,26 +23,8 @@
 
 {% block page_content %}
     {% initial_page_data 'renderReportTables' 1 %}
-    {% initial_page_data 'slug' report.slug %}
-    {% initial_page_data 'defaultRows' report_table.default_rows|default:10 %}
-    {% initial_page_data 'startAtRowNum' report_table.start_at_row|default:0 %}
-    {% initial_page_data 'showAllRowsOption' report_table.show_all_rows %}
-    {% initial_page_data 'autoWidth' report_table.headers.auto_width %}
-    {% if report_table.headers.render_aoColumns %}
-        {% initial_page_data 'aoColumns' report_table.headers.render_aoColumns %}
-    {% endif %}
-    {% if report_table.headers.custom_sort %}
-        {% initial_page_data 'customSort' report_table.headers.custom_sort %}
-    {% endif %}
-    {% if report_table.pagination.is_on %}
-        {% initial_page_data 'ajaxSource' report_table.pagination.source %}
-        {% initial_page_data 'ajaxParams' report_table.pagination.params %}
-    {% endif %}
-    {% if report_table.left_col.is_fixed %}
-        {% initial_page_data 'fixColumns' True %}
-        {% initial_page_data 'fixColsNumLeft' report_table.left_col.fixed.num %}
-        {% initial_page_data 'fixColsWidth' report_table.left_col.fixed.width %}
-    {% endif %}
+    {% initial_page_data 'dataTablesOptions' data_tables_options %}
+
 {% block reportcontent %}
 {% block reporttable %}
 

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -102,42 +102,26 @@
 {% endblock %}
 {% endblock %}
 
-{% block js-inline %} {{ block.super }}
-    <script>
-
-        {% if report_table and report_table.datatables %}
-            var reportTables = new HQReportDataTables({
-                dataTableElem: '#report_table_{{ report.slug }}',
-                defaultRows: {{ report_table.default_rows|default:10 }},
-                startAtRowNum: {{ report_table.start_at_row|default:0 }},
-                showAllRowsOption: {{ report_table.show_all_rows|JSON }},
-
-                {% if report_table.headers.render_aoColumns %}aoColumns: {{ report_table.headers.render_aoColumns|JSON }},{% endif %}
-                autoWidth: {{ report_table.headers.auto_width|JSON }},
-                {% if report_table.headers.custom_sort %}customSort: {{ report_table.headers.custom_sort|JSON }},{% endif %}
-
-                {% if report_table.pagination.is_on %}
-                    ajaxSource: '{{ report_table.pagination.source }}',
-                    ajaxParams: {{ report_table.pagination.params|JSON }},
-                {% endif %}
-
-                {% if report_table.left_col.is_fixed %}
-                    fixColumns: true,
-                    fixColsNumLeft: {{ report_table.left_col.fixed.num }},
-                    fixColsWidth: {{ report_table.left_col.fixed.width }},
-                {% endif %}
-            });
-            if (typeof standardHQReport !== 'undefined') {
-                standardHQReport.handleTabularReportCookies(reportTables);
-            }
-            reportTables.render();
-        {% endif %}
-
-        $(function() {
-            $('.header-popover').popover({
-                trigger: 'hover',
-                placement: 'bottom'
-            });
-        });
-    </script>
+{% block initial_page_data %}
+    {% if report_table and report_table.datatables %}
+        "renderReportTables": 1,
+        "reportTablesOptions": {
+            "slug": "{{ report.slug }}",
+            "defaultRows": {{ report_table.default_rows|default:10 }},
+            "startAtRowNum": {{ report_table.start_at_row|default:0 }},
+            "showAllRowsOption": {{ report_table.show_all_rows|JSON }},
+            "autoWidth": {{ report_table.headers.auto_width|JSON }}
+            {% if report_table.headers.render_aoColumns %}, "aoColumns": {{ report_table.headers.render_aoColumns|JSON }}{% endif %}
+            {% if report_table.headers.custom_sort %}, "customSort": {{ report_table.headers.custom_sort|JSON }}{% endif %}
+            {% if report_table.pagination.is_on %}
+                , "ajaxSource": "{{ report_table.pagination.source }}"
+                , "ajaxParams": {{ report_table.pagination.params|JSON }}
+            {% endif %}
+            {% if report_table.left_col.is_fixed %}
+                , "fixColumns": true
+                , "fixColsNumLeft": {{ report_table.left_col.fixed.num }}
+                , "fixColsWidth": {{ report_table.left_col.fixed.width }}
+            {% endif %}
+        }
+    {% endif %}
 {% endblock %}

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -16,7 +16,32 @@
     {% endif%}
 {% endblock %}
 
+{% block js %}{{ block.super }}
+    <script src="{% static 'fixtures/js/view-table.js' %}"></script>
+{% endblock %}
+
 {% block page_content %}
+    {% initial_page_data 'renderReportTables' 1 %}
+    {% initial_page_data 'slug' report.slug %}
+    {% initial_page_data 'defaultRows' report_table.default_rows|default:10 %}
+    {% initial_page_data 'startAtRowNum' report_table.start_at_row|default:0 %}
+    {% initial_page_data 'showAllRowsOption' report_table.show_all_rows %}
+    {% initial_page_data 'autoWidth' report_table.headers.auto_width %}
+    {% if report_table.headers.render_aoColumns %}
+        {% initial_page_data 'aoColumns' report_table.headers.render_aoColumns %}
+    {% endif %}
+    {% if report_table.headers.custom_sort %}
+        {% initial_page_data 'customSort' report_table.headers.custom_sort %}
+    {% endif %}
+    {% if report_table.pagination.is_on %}
+        {% initial_page_data 'ajaxSource' report_table.pagination.source %}
+        {% initial_page_data 'ajaxParams' report_table.pagination.params %}
+    {% endif %}
+    {% if report_table.left_col.is_fixed %}
+        {% initial_page_data 'fixColumns' True %}
+        {% initial_page_data 'fixColsNumLeft' report_table.left_col.fixed.num %}
+        {% initial_page_data 'fixColsWidth' report_table.left_col.fixed.width %}
+    {% endif %}
 {% block reportcontent %}
 {% block reporttable %}
 
@@ -100,28 +125,4 @@
 {% endblock %}
 {% block posttable %}{% endblock %}
 {% endblock %}
-{% endblock %}
-
-{% block initial_page_data %}
-    {% if report_table and report_table.datatables %}
-        "renderReportTables": 1,
-        "reportTablesOptions": {
-            "slug": "{{ report.slug }}",
-            "defaultRows": {{ report_table.default_rows|default:10 }},
-            "startAtRowNum": {{ report_table.start_at_row|default:0 }},
-            "showAllRowsOption": {{ report_table.show_all_rows|JSON }},
-            "autoWidth": {{ report_table.headers.auto_width|JSON }}
-            {% if report_table.headers.render_aoColumns %}, "aoColumns": {{ report_table.headers.render_aoColumns|JSON }}{% endif %}
-            {% if report_table.headers.custom_sort %}, "customSort": {{ report_table.headers.custom_sort|JSON }}{% endif %}
-            {% if report_table.pagination.is_on %}
-                , "ajaxSource": "{{ report_table.pagination.source }}"
-                , "ajaxParams": {{ report_table.pagination.params|JSON }}
-            {% endif %}
-            {% if report_table.left_col.is_fixed %}
-                , "fixColumns": true
-                , "fixColsNumLeft": {{ report_table.left_col.fixed.num }}
-                , "fixColsWidth": {{ report_table.left_col.fixed.width }}
-            {% endif %}
-        }
-    {% endif %}
 {% endblock %}

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
+    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'fixtures/js/view-table.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -21,7 +21,7 @@ hqDefine('hqwebapp/js/initial_page_data.js', function () {
      *  Find any unregistered data. Error on any duplicates.
      */
     var gather = function() {
-        _.each($(".initial-page-data"), function(div) {
+        _.each($("#initial-page-data").children(), function(div) {
             var $div = $(div),
                 data = $div.data();
             if (COMMCAREHQ_INITIAL_PAGE_DATA[data.name] !== undefined) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -1,5 +1,15 @@
+/*
+ *  Manage data needed by JavaScript but supplied by server.
+ *
+ *  In django templates, use {% initial_page_data varName varValue %} to
+ *  define data, then in JavaScript use this module's get function to
+ *  access it.
+ */
 var COMMCAREHQ_INITIAL_PAGE_DATA = {};
 hqDefine('hqwebapp/js/initial_page_data.js', function () {
+    /*
+     * Fetch a named value.
+     */
     var get = function(name) {
         if (COMMCAREHQ_INITIAL_PAGE_DATA[name] === undefined) {
             gather();
@@ -7,6 +17,9 @@ hqDefine('hqwebapp/js/initial_page_data.js', function () {
         return COMMCAREHQ_INITIAL_PAGE_DATA[name];
     };
 
+    /*
+     *  Find any unregistered data. Error on any duplicates.
+     */
     var gather = function() {
         _.each($(".initial-page-data"), function(div) {
             var $div = $(div),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -1,0 +1,27 @@
+var COMMCAREHQ_INITIAL_PAGE_DATA = {};
+hqDefine('hqwebapp/js/initial_page_data.js', function () {
+    var get = function(name) {
+        if (COMMCAREHQ_INITIAL_PAGE_DATA[name] === undefined) {
+            gather();
+        }
+        return COMMCAREHQ_INITIAL_PAGE_DATA[name];
+    };
+
+    var gather = function() {
+        _.each($(".initial-page-data"), function(div) {
+            var $div = $(div),
+                data = $div.data();
+            if (COMMCAREHQ_INITIAL_PAGE_DATA[data.name] !== undefined) {
+                throw new Error("Duplicate key in initial page data: " + data.name);
+            }
+            COMMCAREHQ_INITIAL_PAGE_DATA[data.name] = data.value;
+            $div.remove();
+        });
+    };
+
+    $(gather);
+
+    return {
+        get: get,
+    };
+});

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -622,7 +622,7 @@ def initial_page_data(parser, token):
                 resolved = json.dumps(resolved)[1:-1]
             else:
                 resolved = json.dumps(resolved)
-            return ("<div class='initial-page-data hide' data-name=\"{}\" data-value=\"{}\"></div>"
+            return ("<div data-name=\"{}\" data-value=\"{}\"></div>"
                     .format(name, escape(resolved)))
 
     nodelist = NodeList([FakeNode()])

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 from django.http import QueryDict
 from django import template
 from django.core.urlresolvers import reverse
-from django.utils.html import format_html
+from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.utils import has_privilege
@@ -605,3 +605,26 @@ def registerurl(parser, token):
     nodelist = NodeList([FakeNode()])
 
     return AddToBlockNode(nodelist, 'js-inline')
+
+
+@register.tag
+def initial_page_data(parser, token):
+    split_contents = token.split_contents()
+    tag = split_contents[0]
+    name = parse_literal(split_contents[1], parser, tag)
+    value = parser.compile_filter(split_contents[2])
+
+    class FakeNode(template.Node):
+
+        def render(self, context):
+            resolved = value.resolve(context)
+            if isinstance(resolved, basestring):
+                resolved = json.dumps(resolved)[1:-1]
+            else:
+                resolved = json.dumps(resolved)
+            return ("<div class='initial-page-data hide' data-name=\"{}\" data-value=\"{}\"></div>"
+                    .format(name, escape(resolved)))
+
+    nodelist = NodeList([FakeNode()])
+
+    return AddToBlockNode(nodelist, 'initial_page_data')

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -358,11 +358,9 @@
         {# modals #}
         {% block modals %}{% endblock modals %}
 
-        <div id="initial-page-data" class="hide">
-            {
-                {% block initial_page_data %}{% endblock %}
-            }
-        </div>
+        {% block initial_page_data %}
+            {# do not override this block, use initial_page_data template tag to populate #}
+        {% endblock %}
 
         {# javascript below this line #}
 

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -358,6 +358,12 @@
         {# modals #}
         {% block modals %}{% endblock modals %}
 
+        <div id="initial-page-data" class="hide">
+            {
+                {% block initial_page_data %}{% endblock %}
+            }
+        </div>
+
         {# javascript below this line #}
 
         {# HQ Specific Libraries #}

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -358,7 +358,7 @@
         {# modals #}
         {% block modals %}{% endblock modals %}
 
-        <div id="initial-page-data">
+        <div id="initial-page-data" class="hide">
         {% block initial_page_data %}
             {# do not override this block, use initial_page_data template tag to populate #}
         {% endblock %}

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -358,11 +358,11 @@
         {# modals #}
         {% block modals %}{% endblock modals %}
 
-        <script type="text/html" id="initial-page-data">
+        <div id="initial-page-data">
         {% block initial_page_data %}
             {# do not override this block, use initial_page_data template tag to populate #}
         {% endblock %}
-        </script>
+        </div>
 
         {# javascript below this line #}
 

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -358,9 +358,11 @@
         {# modals #}
         {% block modals %}{% endblock modals %}
 
+        <script type="text/html" id="initial-page-data">
         {% block initial_page_data %}
             {# do not override this block, use initial_page_data template tag to populate #}
         {% endblock %}
+        </script>
 
         {# javascript below this line #}
 


### PR DESCRIPTION
I'd like to get much more of our JavaScript into actual JavaScript files, out of html templates. One of the blockers is making data accessible to js files. This PR adds a template tag that stores given data as json in hidden divs, and a library to access that data from js files. Not ideal that it's a global namespace, but I don't think it's worse than what we're currently doing, I'd guess that most of our current inline js isn't scoped in any way.

@dimagi/js-team 