### PR TITLE
support defining a default landing page per role

### DIFF
--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_noop, ugettext as _
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
 
-from corehq import privileges, toggles
+from corehq import privileges
 from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_brief_apps_in_domain
 from corehq.apps.dashboard.models import (
     TileConfiguration,
@@ -20,7 +20,6 @@ from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.users.views import DefaultProjectUserSettingsView
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.style.decorators import use_angular_js
-from corehq.apps.cloudcare.views import FormplayerMain
 from django_prbac.utils import has_privilege
 
 
@@ -35,15 +34,6 @@ def default_dashboard_url(request, domain):
 
     if domain in settings.CUSTOM_DASHBOARD_PAGE_URL_NAMES:
         return reverse(settings.CUSTOM_DASHBOARD_PAGE_URL_NAMES[domain], args=[domain])
-
-    if (couch_user
-            and not couch_user.has_permission(domain, 'access_all_locations')
-            and couch_user.is_commcare_user()):
-        if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
-            formplayer_view = FormplayerMain.urlname
-        else:
-            formplayer_view = "corehq.apps.cloudcare.views.default"
-        return reverse(formplayer_view, args=[domain])
 
     if couch_user and user_has_custom_top_menu(domain, couch_user):
         return reverse('saved_reports', args=[domain])

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -1,0 +1,109 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase, Client
+from corehq.apps.app_manager.models import Application
+from corehq.apps.dashboard.views import DomainDashboardView
+from corehq.apps.domain.models import Domain
+from corehq.apps.reports.views import MySavedReportsView
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
+from corehq.apps.users.models import UserRole, WebUser, Permissions, CommCareUser
+from corehq.util.test_utils import generate_cases
+
+
+DOMAIN = 'temerant'
+
+
+class TestDefaultLandingPages(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        delete_all_users()
+        cls.client = Client()
+
+        cls.domain = DOMAIN
+        cls.domain_object = Domain(name=cls.domain, is_active=True)
+        cls.domain_object.save()
+
+        cls.reports_role = UserRole(
+            domain=cls.domain, name='reports-role', default_landing_page='reports',
+            permissions=Permissions(view_reports=True),
+        )
+        cls.reports_role.save()
+        cls.webapps_role = UserRole(
+            domain=cls.domain, name='webapps-role', default_landing_page='webapps',
+            permissions=Permissions(edit_data=True),
+        )
+        cls.webapps_role.save()
+        cls.global_password = 'secret'
+
+        # make an app because not having one changes the default dashboard redirect to the apps page
+        app = Application.new_app(domain=cls.domain, name='sympathy')
+        app.save()
+
+    def _make_web_user(self, username, role=None, override_domain=None):
+        domain = override_domain or self.domain
+        web_user = WebUser.create(domain, username, self.global_password)
+        web_user.eula.signed = True
+        if role:
+            web_user.set_role(domain, role.get_qualified_id())
+        web_user.save()
+        return web_user
+
+    def _make_commcare_user(self, username, role=None, override_domain=None):
+        domain = override_domain or self.domain
+        web_user = CommCareUser.create(domain, username, self.global_password)
+        web_user.eula.signed = True
+        if role:
+            web_user.set_role(domain, role.get_qualified_id())
+        web_user.save()
+        return web_user
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_object.delete()
+
+    def test_no_role_cant_access(self):
+        user = self._make_web_user('elodin@theuniversity.com')
+        self.addCleanup(user.delete)
+        user.delete_domain_membership(self.domain)
+        user.save()
+        self.client.login(username=user.username, password=self.global_password)
+        response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
+        self.assertEqual(response.status_code, 404)
+
+
+@generate_cases([
+    (None, DomainDashboardView.urlname),
+    ('reports_role', MySavedReportsView.urlname),
+    ('webapps_role', 'cloudcare_main', ['']),
+], TestDefaultLandingPages)
+def test_web_user_landing_page(self, role, expected_urlname, extra_url_args=None):
+    if role is not None:
+        role = getattr(self, role)
+    extra_url_args = extra_url_args or []
+    user = self._make_web_user('elodin@theuniversity.com', role=role)
+    self.addCleanup(user.delete)
+    self.client.login(username=user.username, password=self.global_password)
+
+    response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(reverse(expected_urlname, args=[self.domain] + extra_url_args),
+                     response.request['PATH_INFO'])
+
+
+@generate_cases([
+    (None, 'cloudcare_main', ['']),
+    ('reports_role', MySavedReportsView.urlname),
+    ('webapps_role', 'cloudcare_main', ['']),
+], TestDefaultLandingPages)
+def test_mobile_worker_landing_page(self, role, expected_urlname, extra_url_args=None):
+    if role is not None:
+        role = getattr(self, role)
+    extra_url_args = extra_url_args or []
+    user = self._make_commcare_user('kvothe', role=role)
+    self.addCleanup(user.delete)
+    self.client.login(username=user.username, password=self.global_password)
+
+    response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(reverse(expected_urlname, args=[self.domain] + extra_url_args),
+                     response.request['PATH_INFO'])

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -37,7 +37,7 @@ from couchdbkit import ResourceNotFound
 from two_factor.views import LoginView
 from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
-from corehq.apps.users.landing_pages import get_redirect_url
+from corehq.apps.users.landing_pages import get_redirect_url, get_cloudcare_urlname
 
 from corehq.form_processor.utils.general import should_use_sql_backend
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
@@ -64,7 +64,6 @@ from corehq.apps.hqwebapp.doc_info import get_doc_info, get_object_info
 from corehq.apps.hqwebapp.encoders import LazyEncoder
 from corehq.apps.hqwebapp.forms import EmailAuthenticationForm, CloudCareAuthenticationForm
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import format_username
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL, CaseAccessorSQL
 from corehq.form_processor.exceptions import XFormNotFound, CaseNotFound
@@ -165,7 +164,7 @@ def redirect_to_default(req, domain=None):
                     if role and role.default_landing_page:
                         url = get_redirect_url(role.default_landing_page, domain)
                     elif couch_user.is_commcare_user():
-                        url = reverse("cloudcare_default", args=[domain])
+                        url = reverse(get_cloudcare_urlname(domain), args=[domain])
                     else:
                         return dashboard_default(req, domain)
             else:

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -1,14 +1,28 @@
 from collections import namedtuple
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_noop, ugettext as _
+from corehq import toggles
 
 
-LandingPage = namedtuple('LandingPage', ['id', 'name', 'urlname'])
+class LandingPage(namedtuple('LandingPage', ['id', 'name', 'urlname'])):
+
+    def get_urlname(self, domain):
+        if callable(self.urlname):
+            return self.urlname(domain)
+        return self.urlname
+
+
+def get_cloudcare_urlname(domain):
+    from corehq.apps.cloudcare.views import FormplayerMain
+    if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
+        return FormplayerMain.urlname
+    else:
+        return 'corehq.apps.cloudcare.views.default'
 
 
 ALLOWED_LANDING_PAGES = (
     LandingPage('dashboard', ugettext_noop('Dashboard'), 'dashboard_default'),
-    LandingPage('webapps', ugettext_noop('Web Apps'), 'cloudcare_default'),
+    LandingPage('webapps', ugettext_noop('Web Apps'), get_cloudcare_urlname),
     LandingPage('reports', ugettext_noop('Reports'), 'reports_home'),
 )
 
@@ -22,4 +36,4 @@ def get_landing_page(id):
 
 def get_redirect_url(id, domain):
     page = get_landing_page(id)
-    return reverse(page.urlname, args=[domain])
+    return reverse(page.get_urlname(domain), args=[domain])

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -1,0 +1,12 @@
+from collections import namedtuple
+from django.utils.translation import ugettext_noop, ugettext as _
+
+
+LandingPage = namedtuple('LandingPage', ['id', 'name', 'urlname'])
+
+
+ALLOWED_LANDING_PAGES = (
+    LandingPage('dashboard', ugettext_noop('Dashboard'), 'dashboard_default'),
+    LandingPage('webapps', ugettext_noop('Web Apps'), 'cloudcare_default'),
+    LandingPage('reports', ugettext_noop('Reports'), 'reports_home'),
+)

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_noop, ugettext as _
 
 
@@ -10,3 +11,15 @@ ALLOWED_LANDING_PAGES = (
     LandingPage('webapps', ugettext_noop('Web Apps'), 'cloudcare_default'),
     LandingPage('reports', ugettext_noop('Reports'), 'reports_home'),
 )
+
+
+def get_landing_page(id):
+    for landing_page in ALLOWED_LANDING_PAGES:
+        if landing_page.id == id:
+            return landing_page
+    raise ValueError(_("No landing page found with id {}".format(id)))
+
+
+def get_redirect_url(id, domain):
+    page = get_landing_page(id)
+    return reverse(page.urlname, args=[domain])

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -12,6 +12,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.domain.dbaccessors import get_docs_in_domain_by_class
+from corehq.apps.users.landing_pages import ALLOWED_LANDING_PAGES
 from corehq.apps.users.permissions import EXPORT_PERMISSIONS
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
@@ -202,6 +203,9 @@ class UserRolePresets(object):
 class UserRole(QuickCachedDocumentMixin, Document):
     domain = StringProperty()
     name = StringProperty()
+    default_landing_page = StringProperty(
+        choices=[page.id for page in ALLOWED_LANDING_PAGES],
+    )
     permissions = SchemaProperty(Permissions)
     is_archived = BooleanProperty(default=False)
 

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -52,6 +52,7 @@ hqDefine('users/js/roles.js', function () {
         self.allowEdit = o.allowEdit;
         self.reportOptions = o.reportOptions;
         self.canRestrictAccessByLocation = o.canRestrictAccessByLocation;
+        self.landingPageChoices = o.landingPageChoices;
         self.getReportObject = function (path) {
             var i;
             for (i = 0; i < self.reportOptions.length; i++) {

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -633,20 +633,6 @@
                                         </div>
                                     </div>
                                     <div class="form-group">
-                                        <label class="col-sm-4 control-label"
-                                               for="landing-page">
-                                            {% trans "Default Landing Page" %}
-                                        </label>
-                                        <div class="col-sm-8 controls">
-                                            <select class="form-control" id="landing-page" data-bind="
-                                                options: $root.landingPageChoices,
-                                                optionsText: 'name',
-                                                optionsValue: 'id',
-                                                value: default_landing_page
-                                            "></select>
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
                                         <label class="col-sm-4 control-label">
                                             {% trans "View All Reports" %}
                                         </label>
@@ -680,6 +666,20 @@
                                                     </div>
                                                 </div>
                                             </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="col-sm-4 control-label"
+                                               for="landing-page">
+                                            {% trans "Default Landing Page" %}
+                                        </label>
+                                        <div class="col-sm-8 controls">
+                                            <select class="form-control" id="landing-page" data-bind="
+                                                options: $root.landingPageChoices,
+                                                optionsText: 'name',
+                                                optionsValue: 'id',
+                                                value: default_landing_page
+                                            "></select>
                                         </div>
                                     </div>
                                 </div>

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -631,7 +631,18 @@
                                             </div>
                                         </div>
                                     </div>
-
+                                    <div class="form-group">
+                                        <label class="col-sm-4 control-label"
+                                               for="landing-page">
+                                            {% trans "Default Landing Page" %}
+                                        </label>
+                                        <div class="col-sm-8 controls">
+                                            <input data-bind="value: default_landing_page"
+                                                   type="text"
+                                                   id="landing-page"
+                                                   class="form-control" />
+                                        </div>
+                                    </div>
                                     <div class="form-group">
                                         <label class="col-sm-4 control-label">
                                             {% trans "View All Reports" %}

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -97,6 +97,7 @@
             reportOptions: {{ report_list|JSON }},
             allowEdit: {{ can_edit_roles|BOOL }},
             canRestrictAccessByLocation: {{ can_restrict_access_by_location|BOOL }},
+            landingPageChoices: {{ landing_page_choices|JSON }},
         });
         $userRolesTable.show();
 
@@ -637,10 +638,12 @@
                                             {% trans "Default Landing Page" %}
                                         </label>
                                         <div class="col-sm-8 controls">
-                                            <input data-bind="value: default_landing_page"
-                                                   type="text"
-                                                   id="landing-page"
-                                                   class="form-control" />
+                                            <select class="form-control" id="landing-page" data-bind="
+                                                options: $root.landingPageChoices,
+                                                optionsText: 'name',
+                                                optionsValue: 'id',
+                                                value: default_landing_page
+                                            "></select>
                                         </div>
                                     </div>
                                     <div class="form-group">

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -22,6 +22,7 @@ from django_otp.plugins.otp_static.models import StaticToken
 from djangular.views.mixins import allow_remote_invocation, JSONResponseMixin
 
 from couchdbkit.exceptions import ResourceNotFound
+from corehq.apps.users.landing_pages import ALLOWED_LANDING_PAGES
 from corehq.util.view_utils import json_error
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.decorators.memoized import memoized
@@ -473,6 +474,15 @@ class ListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
         return invitations
 
     @property
+    def landing_page_choices(self):
+        return [
+            {'id': None, 'name': _('Use Default')}
+        ] + [
+            {'id': page.id, 'name': _(page.name)}
+            for page in ALLOWED_LANDING_PAGES
+        ]
+
+    @property
     def page_context(self):
         if (not self.can_restrict_access_by_location
             and any(not role.permissions.access_all_locations
@@ -495,6 +505,7 @@ class ListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
             'domain_object': self.domain_object,
             'uses_locations': self.domain_object.uses_locations,
             'can_restrict_access_by_location': self.can_restrict_access_by_location,
+            'landing_page_choices': self.landing_page_choices,
         }
 
 


### PR DESCRIPTION
@esoergel @sheelio this implements the first half of https://github.com/dimagi/commcare-hq/pull/14504#issuecomment-272603395

"add a "default landing page" option to roles. This might currently have options of dashboard, web apps, and reports, and will default to dashboard for web users and web apps for mobile workers."


can be read by commit. ui looks like this: 

![image](https://cloud.githubusercontent.com/assets/66555/21962458/a65f9162-db4c-11e6-8b0d-8941708b7873.png)

currently options are "use default", "dashboard", "webapps" and "reports".

cc @orangejenny 