### PR TITLE
Formplayer behind random toggle

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -722,11 +722,22 @@ HSPH_HACK = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-USE_FORMPLAYER_FRONTEND = StaticToggle(
+USE_FORMPLAYER_FRONTEND = PredictablyRandomToggle(
     'use_formplayer_frontend',
     'Use New CloudCare',
     TAG_PRODUCT_PATH,
     [NAMESPACE_DOMAIN],
+    randomness=0.3,
+    always_disabled=[
+        'hsph-betterbirth',
+        'figo-ppiud-srilanka',
+        'broadreach-sa',
+        'goal-global',
+        'ipm-senegal',
+        'madla-malaria',
+        'myrice',
+        'pact',
+    ]
 )
 
 FIXTURE_CASE_SELECTION = StaticToggle(


### PR DESCRIPTION
@wpride @czue this releases web apps to 30% of domains. it also sets domains that are actively using cloudcare to always disabled. this is based on @krsdimagi list of domains. we should make sure to merge this PR so that the debugger is also released: https://github.com/dimagi/commcare-hq/pull/14460 (will offline with simon about that)

cc: @emord 