### PR TITLE
Handle get_email_body for offline deploy

### DIFF
--- a/corehq/apps/hqadmin/management/utils.py
+++ b/corehq/apps/hqadmin/management/utils.py
@@ -7,12 +7,17 @@ from gevent.pool import Pool
 
 
 def get_deploy_email_message_body(environment, user, compare_url):
-    ref_comparison = compare_url.split('/')[-1]
-    last_deploy, current_deploy = ref_comparison.split('...')
-
-    pr_numbers = _get_pr_numbers(last_deploy, current_deploy)
-    pool = Pool(5)
-    pr_infos = filter(None, pool.map(_get_pr_info, pr_numbers))
+    try:
+        ref_comparison = compare_url.split('/')[-1]
+    except ValueError:
+        # Not a real compare_url
+        last_deploy = current_deploy = 'Unavailable'
+        pr_infos = []
+    else:
+        last_deploy, current_deploy = ref_comparison.split('...')
+        pr_numbers = _get_pr_numbers(last_deploy, current_deploy)
+        pool = Pool(5)
+        pr_infos = filter(None, pool.map(_get_pr_info, pr_numbers))
 
     return render_to_string('hqadmin/partials/project_snapshot.html', {
         'pr_merges': pr_infos,


### PR DESCRIPTION
anyone / @emord. during offline deploy we can't create release tags, so there is no compare url and i didn't think it was worth it to make some work around so i just skipped it