### PR TITLE
UCR: Add Get Case Sharing Groups Expression

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -558,6 +558,17 @@ The `date_expression` can be any valid expression, or simply constant
     },
 }
 ```
+#### 'Get Case Sharing Groups' expression
+'get_case_sharing_groups' will return an array of the case sharing groups that are assigned to a provided user ID.  The array will contain one document per case sharing group.
+```json
+{
+    "type": "get_case_sharing_groups",
+    "user_id_expression": {
+        "type": "property_path",
+        "property_path": ["form", "meta", "userID"]
+    }
+}
+```
 
 
 #### Filter, Sort, Map and Reduce Expressions
@@ -678,7 +689,6 @@ This returns number of family members
     "items_expression": {},
 }
 ```
-
 
 #### Named Expressions
 

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -8,7 +8,8 @@ from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, Pr
     ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec, \
     IdentityExpressionSpec, IteratorExpressionSpec, SwitchExpressionSpec, ArrayIndexExpressionSpec, \
     NestedExpressionSpec, DictExpressionSpec, NamedExpressionSpec, EvalExpressionSpec, FormsExpressionSpec, \
-    IterationNumberExpressionSpec, SubcasesExpressionSpec, SplitStringExpressionSpec
+    IterationNumberExpressionSpec, SubcasesExpressionSpec, SplitStringExpressionSpec, \
+    CaseSharingGroupsExpressionSpec
 from corehq.apps.userreports.expressions.date_specs import AddDaysExpressionSpec, AddMonthsExpressionSpec, \
     MonthStartDateExpressionSpec, MonthEndDateExpressionSpec, DiffDaysExpressionSpec
 from corehq.apps.userreports.expressions.list_specs import FilterItemsExpressionSpec, \
@@ -177,6 +178,14 @@ def _get_subcases_expression(spec, context):
     wrapped.configure(
         case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, context)
     )
+    return
+
+
+def _get_case_sharing_groups_expression(spec, context):
+    wrapped = CaseSharingGroupsExpressionSpec.wrap(spec)
+    wrapped.configure(
+        user_id_expression=ExpressionFactory.from_spec(wrapped.user_id_expression, context)
+    )
     return wrapped
 
 
@@ -256,6 +265,7 @@ class ExpressionFactory(object):
         'evaluator': _evaluator_expression,
         'get_case_forms': _get_forms_expression,
         'get_subcases': _get_subcases_expression,
+        'get_case_sharing_groups': _get_case_sharing_groups_expression,
         'filter_items': _filter_items_expression,
         'map_items': _map_items_expression,
         'reduce_items': _reduce_items_expression,

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -178,7 +178,7 @@ def _get_subcases_expression(spec, context):
     wrapped.configure(
         case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, context)
     )
-    return
+    return wrapped
 
 
 def _get_case_sharing_groups_expression(spec, context):

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -345,7 +345,7 @@ class CaseSharingGroupsExpressionSpec(JsonObject):
 
     def _get_case_sharing_groups(self, user_id, context):
         domain = context.root_doc['domain']
-        cache_key = (self.__class__.__name__, user_id)
+        cache_key = (self.__class__.__name__, domain, user_id)
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -354,6 +354,7 @@ class CaseSharingGroupsExpressionSpec(JsonObject):
             return []
 
         case_sharing_groups = user.get_case_sharing_groups()
+        case_sharing_groups = [g.to_json() for g in case_sharing_groups]
         context.set_cache_value(cache_key, case_sharing_groups)
         return case_sharing_groups
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -3,6 +3,7 @@ from simpleeval import InvalidExpression
 from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 from corehq.apps.userreports.document_stores import get_document_store
 from corehq.apps.userreports.exceptions import BadSpecError
+from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.couch import get_db_by_doc_type
 from dimagi.ext.jsonobject import JsonObject, StringProperty, ListProperty, DictProperty
@@ -325,6 +326,36 @@ class SubcasesExpressionSpec(JsonObject):
         subcases = [c.to_json() for c in CaseAccessors(domain).get_reverse_indexed_cases([case_id])]
         context.set_cache_value(cache_key, subcases)
         return subcases
+
+
+class CaseSharingGroupsExpressionSpec(JsonObject):
+    type = TypeProperty('get_case_sharing_groups')
+    user_id_expression = DictProperty(required=True)
+
+    def configure(self, user_id_expression):
+        self._user_id_expression = user_id_expression
+
+    def __call__(self, item, context=None):
+        user_id = self._user_id_expression(item, context)
+        if not user_id:
+            return []
+
+        assert context.root_doc['domain']
+        return self._get_case_sharing_groups(user_id, context)
+
+    def _get_case_sharing_groups(self, user_id, context):
+        domain = context.root_doc['domain']
+        cache_key = (self.__class__.__name__, user_id)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        user = CommCareUser.get_by_user_id(user_id, domain)
+        if not user:
+            return []
+
+        case_sharing_groups = user.get_case_sharing_groups()
+        context.set_cache_value(cache_key, case_sharing_groups)
+        return case_sharing_groups
 
 
 class SplitStringExpressionSpec(JsonObject):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1113,6 +1113,16 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(case_sharing_groups), 2)
 
+    @run_with_all_backends
+    def test_wrong_domain(self):
+        new_domain = uuid.uuid4().hex
+        user = CommCareUser.create(domain=new_domain, username='test_single', password='123')
+        group = Group(domain=new_domain, name='group_single', users=[user._id], case_sharing=True)
+        group.save()
+
+        case_sharing_groups = self.expression({'user_id': user._id}, self.context)
+        self.assertEqual(len(case_sharing_groups), 0)
+
 
 class TestIterationNumberExpression(SimpleTestCase):
 

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1070,6 +1070,7 @@ class TestGetCaseSharingGroupsExpression(TestCase):
     def setUp(self):
         super(TestGetCaseSharingGroupsExpression, self).setUp()
         self.domain = uuid.uuid4().hex
+        self.second_domain = uuid.uuid4().hex
         self.expression = ExpressionFactory.from_spec({
             "type": "get_case_sharing_groups",
             "user_id_expression": {
@@ -1081,6 +1082,8 @@ class TestGetCaseSharingGroupsExpression(TestCase):
 
     def tearDown(self):
         for group in Group.by_domain(self.domain):
+            group.delete()
+        for group in Group.by_domain(self.second_domain):
             group.delete()
         for user in CommCareUser.all():
             user.delete()
@@ -1115,9 +1118,8 @@ class TestGetCaseSharingGroupsExpression(TestCase):
 
     @run_with_all_backends
     def test_wrong_domain(self):
-        new_domain = uuid.uuid4().hex
-        user = CommCareUser.create(domain=new_domain, username='test_single', password='123')
-        group = Group(domain=new_domain, name='group_single', users=[user._id], case_sharing=True)
+        user = CommCareUser.create(domain=self.second_domain, username='test_wrong_domain', password='123')
+        group = Group(domain=self.second_domain, name='group_wrong_domain', users=[user._id], case_sharing=True)
         group.save()
 
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1087,13 +1087,13 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         super(TestGetCaseSharingGroupsExpression, self).tearDown()
 
     @run_with_all_backends
-    def test_no_subcases(self):
+    def test_no_groups(self):
         user = CommCareUser.create(domain=self.domain, username='test_no_group', password='123')
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(case_sharing_groups), 0)
 
     @run_with_all_backends
-    def test_single_child(self):
+    def test_single_group(self):
         user = CommCareUser.create(domain=self.domain, username='test_single', password='123')
         group = Group(domain=self.domain, name='group_single', users=[user._id], case_sharing=True)
         group.save()

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -18,6 +18,7 @@ from corehq.apps.userreports.expressions.specs import (
 from corehq.apps.userreports.expressions.specs import eval_statements
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.users.models import CommCareUser
+from corehq.apps.groups.models import Group
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.util.test_utils import generate_cases, create_and_save_a_form, create_and_save_a_case
@@ -1062,6 +1063,55 @@ class TestGetSubcasesExpression(TestCase):
         subcases = self.expression(host.to_json(), self.context)
         self.assertEqual(len(subcases), 1)
         self.assertEqual(extension.case_id, subcases[0]['_id'])
+
+
+class TestGetCaseSharingGroupsExpression(TestCase):
+
+    def setUp(self):
+        super(TestGetCaseSharingGroupsExpression, self).setUp()
+        self.domain = uuid.uuid4().hex
+        self.expression = ExpressionFactory.from_spec({
+            "type": "get_case_sharing_groups",
+            "user_id_expression": {
+                "type": "property_name",
+                "property_name": "user_id"
+            },
+        })
+        self.context = EvaluationContext({"domain": self.domain})
+
+    def tearDown(self):
+        for group in Group.by_domain(self.domain):
+            group.delete()
+        for user in CommCareUser.all():
+            user.delete()
+        super(TestGetCaseSharingGroupsExpression, self).tearDown()
+
+    @run_with_all_backends
+    def test_no_subcases(self):
+        user = CommCareUser.create(domain=self.domain, username='test_no_group', password='123')
+        case_sharing_groups = self.expression({'user_id': user._id}, self.context)
+        self.assertEqual(len(case_sharing_groups), 0)
+
+    @run_with_all_backends
+    def test_single_child(self):
+        user = CommCareUser.create(domain=self.domain, username='test_single', password='123')
+        group = Group(domain=self.domain, name='group_single', users=[user._id], case_sharing=True)
+        group.save()
+
+        case_sharing_groups = self.expression({'user_id': user._id}, self.context)
+        self.assertEqual(len(case_sharing_groups), 1)
+        self.assertEqual(group._id, case_sharing_groups[0]['_id'])
+
+    @run_with_all_backends
+    def test_multiple_groups(self):
+        user = CommCareUser.create(domain=self.domain, username='test_multiple', password='123')
+        group1 = Group(domain=self.domain, name='group1', users=[user._id], case_sharing=True)
+        group1.save()
+        group2 = Group(domain=self.domain, name='group2', users=[user._id], case_sharing=True)
+        group2.save()
+
+        case_sharing_groups = self.expression({'user_id': user._id}, self.context)
+        self.assertEqual(len(case_sharing_groups), 2)
 
 
 class TestIterationNumberExpression(SimpleTestCase):


### PR DESCRIPTION
@snopoke @calellowitz 

This adds a UCR expression for accessing case sharing groups based on a user ID.  I need it for the Pradan project's UCRs.