### PR TITLE
clean up / fix up role management

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -312,18 +312,18 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def role_choices(cls, domain):
-        return [cls._role_to_choice(role) for role in
+        return [cls.role_to_choice(role) for role in
                 [AdminUserRole(domain=domain)] + list(cls.by_domain(domain))]
 
     @classmethod
     def commcareuser_role_choices(cls, domain):
         return [('none', _('(none)'))] + [
-            cls._role_to_choice(role)
+            cls.role_to_choice(role)
             for role in list(cls.by_domain(domain))
         ]
 
     @staticmethod
-    def _role_to_choice(role):
+    def role_to_choice(role):
         return (role.get_qualified_id(), role.name or _('(No Name)'))
 
     @property

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -315,13 +315,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return [cls.role_to_choice(role) for role in
                 [AdminUserRole(domain=domain)] + list(cls.by_domain(domain))]
 
-    @classmethod
-    def commcareuser_role_choices(cls, domain):
-        return [('none', _('(none)'))] + [
-            cls.role_to_choice(role)
-            for role in list(cls.by_domain(domain))
-        ]
-
     @staticmethod
     def role_to_choice(role):
         return (role.get_qualified_id(), role.name or _('(No Name)'))

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -310,10 +310,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
     def get_default(cls, domain=None):
         return cls(permissions=Permissions(), domain=domain, name=None)
 
-    @staticmethod
-    def role_to_choice(role):
-        return (role.get_qualified_id(), role.name or _('(No Name)'))
-
     @property
     def ids_of_assigned_users(self):
         from corehq.apps.api.es import UserES

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -316,14 +316,14 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def commcareuser_role_choices(cls, domain):
-        return [('none','(none)')] + [
+        return [('none', _('(none)'))] + [
             cls._role_to_choice(role)
             for role in list(cls.by_domain(domain))
         ]
 
     @staticmethod
     def _role_to_choice(role):
-        return (role.get_qualified_id(), role.name or '(No Name)')
+        return (role.get_qualified_id(), role.name or _('(No Name)'))
 
     @property
     def ids_of_assigned_users(self):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -207,6 +207,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
         choices=[page.id for page in ALLOWED_LANDING_PAGES],
     )
     permissions = SchemaProperty(Permissions)
+    is_non_admin_editable = BooleanProperty(default=False)
     is_archived = BooleanProperty(default=False)
 
     def get_qualified_id(self):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -310,11 +310,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
     def get_default(cls, domain=None):
         return cls(permissions=Permissions(), domain=domain, name=None)
 
-    @classmethod
-    def role_choices(cls, domain):
-        return [cls.role_to_choice(role) for role in
-                [AdminUserRole(domain=domain)] + list(cls.by_domain(domain))]
-
     @staticmethod
     def role_to_choice(role):
         return (role.get_qualified_id(), role.name or _('(No Name)'))

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -311,15 +311,19 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def role_choices(cls, domain):
-        return [(role.get_qualified_id(), role.name or '(No Name)') for role in
+        return [cls._role_to_choice(role) for role in
                 [AdminUserRole(domain=domain)] + list(cls.by_domain(domain))]
 
     @classmethod
     def commcareuser_role_choices(cls, domain):
         return [('none','(none)')] + [
-            (role.get_qualified_id(), role.name or '(No Name)')
+            cls._role_to_choice(role)
             for role in list(cls.by_domain(domain))
         ]
+
+    @staticmethod
+    def _role_to_choice(role):
+        return (role.get_qualified_id(), role.name or '(No Name)')
 
     @property
     def ids_of_assigned_users(self):

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -35,6 +35,7 @@
             </dl>
         </fieldset>
     </div>
+    {% if can_edit_role %}
     <form class="form form-horizontal" name="user_role" method="post">
         {% csrf_token %}
         <input type="hidden" name="form_type" value="update-user" />
@@ -49,7 +50,7 @@
             </div>
         </fieldset>
     </form>
-
+    {% endif %}
     {% if update_permissions %}
         <hr />
         <form class="form form-horizontal" name="user_permissions" method="post">

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -682,6 +682,20 @@
                                             "></select>
                                         </div>
                                     </div>
+                                    <div class="form-group">
+                                        <label class="col-sm-4 control-label">
+                                            {% trans "Non-admin Editable" %}
+                                        </label>
+                                        <div class="col-sm-8 controls">
+                                            <div class="checkbox">
+                                                <label>
+                                                    <input type="checkbox"
+                                                           data-bind="checked: is_non_admin_editable" />
+                                                    {% trans "Allow non-admins to assign this role to other users." %}
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                             <div class="modal-footer">

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -285,7 +285,12 @@ class EditWebUserView(BaseEditUserView):
 
     @property
     def user_role_choices(self):
-        return UserRole.role_choices(self.domain)
+        editable_choices = self.editable_role_choices
+        if not self.request.couch_user.is_domain_admin(self.domain):
+            return editable_choices
+        else:
+            # domain admins can also grant admin to others
+            return [UserRole.role_to_choice(AdminUserRole(domain=self.domain))] + editable_choices
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -99,7 +99,6 @@ class BaseUserSettingsView(BaseDomainView):
     @property
     @memoized
     def section_url(self):
-        from corehq.apps.users.views import DefaultProjectUserSettingsView
         return reverse(DefaultProjectUserSettingsView.urlname, args=[self.domain])
 
     @property

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -815,7 +815,7 @@ class InviteWebUserView(BaseManageWebUserView):
     @property
     @memoized
     def invite_web_user_form(self):
-        role_choices = UserRole.role_choices(self.domain)
+        role_choices = _get_editable_role_choices(self.domain, self.request.couch_user, allow_admin_role=True)
         loc = None
         domain_request = DomainRequest.objects.get(id=self.request_id) if self.request_id else None
         initial = {

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -193,6 +193,10 @@ class BaseEditUserView(BaseUserSettingsView):
         return [UserRole.role_to_choice(role) for role in roles]
 
     @property
+    def can_change_user_roles(self):
+        return bool(self.editable_role_choices) and self.request.couch_user.user_id != self.editable_user_id
+
+    @property
     @memoized
     def form_user_update(self):
         if self.user_update_form_class is None:

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1075,9 +1075,12 @@ def register_fcm_device_token(request, domain, couch_user_id, device_token):
 
 
 def _get_editable_role_choices(domain, couch_user, allow_admin_role):
+    def role_to_choice(role):
+        return (role.get_qualified_id(), role.name or _('(No Name)'))
+
     roles = UserRole.by_domain(domain)
     if not couch_user.is_domain_admin(domain):
         roles = filter(lambda role: role.is_non_admin_editable, roles)
     elif allow_admin_role:
         roles = [AdminUserRole(domain=domain)] + roles
-    return [UserRole.role_to_choice(role) for role in roles]
+    return [role_to_choice(role) for role in roles]

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -214,6 +214,10 @@ class BaseEditUserView(BaseUserSettingsView):
 
         form = self.user_update_form_class()
         form.initialize_form(domain=self.request.domain, existing_user=self.editable_user)
+        if self.can_change_user_roles:
+            form.load_roles(current_role=self.existing_role, role_choices=self.user_role_choices)
+        else:
+            del form.fields['role']
         return form
 
     @property
@@ -299,13 +303,6 @@ class EditWebUserView(BaseEditUserView):
         else:
             # domain admins can also grant admin to others
             return [UserRole.role_to_choice(AdminUserRole(domain=self.domain))] + editable_choices
-
-    @property
-    @memoized
-    def form_user_update(self):
-        form = super(EditWebUserView, self).form_user_update
-        form.load_roles(current_role=self.existing_role, role_choices=self.user_role_choices)
-        return form
 
     @property
     def form_user_update_permissions(self):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -186,6 +186,14 @@ class BaseEditUserView(BaseUserSettingsView):
 
     @property
     @memoized
+    def editable_role_choices(self):
+        roles = UserRole.by_domain(self.domain)
+        if not self.request.couch_user.is_domain_admin(self.domain):
+            roles = filter(lambda role: role.is_non_admin_editable, roles)
+        return [UserRole.role_to_choice(role) for role in roles]
+
+    @property
+    @memoized
     def form_user_update(self):
         if self.user_update_form_class is None:
             raise NotImplementedError("You must specify a form to update the user!")

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -193,7 +193,15 @@ class BaseEditUserView(BaseUserSettingsView):
 
     @property
     def can_change_user_roles(self):
-        return bool(self.editable_role_choices) and self.request.couch_user.user_id != self.editable_user_id
+        return (
+            bool(self.editable_role_choices) and
+            self.request.couch_user.user_id != self.editable_user_id and
+            (
+                self.request.couch_user.is_domain_admin(self.domain) or
+                not self.existing_role or
+                self.existing_role in [choice[0] for choice in self.editable_role_choices]
+            )
+        )
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -326,6 +326,7 @@ class EditWebUserView(BaseEditUserView):
     def page_context(self):
         ctx = {
             'form_uneditable': BaseUserInfoForm(),
+            'can_edit_role': self.can_change_user_roles,
         }
         if (self.request.project.commtrack_enabled or
                 self.request.project.uses_locations):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -248,10 +248,6 @@ class EditCommCareUserView(BaseEditUserView):
         return [('none', _('(none)'))] + self.editable_role_choices
 
     @property
-    def can_change_user_roles(self):
-        return bool(self.editable_role_choices) and self.request.couch_user.user_id != self.editable_user_id
-
-    @property
     def existing_role(self):
         role = self.editable_user.get_role(self.domain)
         if role is None:

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -245,7 +245,10 @@ class EditCommCareUserView(BaseEditUserView):
 
     @property
     def user_role_choices(self):
-        return UserRole.commcareuser_role_choices(self.domain)
+        return [('none', _('(none)'))] + [
+            UserRole.role_to_choice(role)
+            for role in list(UserRole.by_domain(self.domain))
+        ]
 
     @property
     def can_change_user_roles(self):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -261,10 +261,6 @@ class EditCommCareUserView(BaseEditUserView):
     def form_user_update(self):
         form = super(EditCommCareUserView, self).form_user_update
         form.load_language(language_choices=get_domain_languages(self.domain))
-        if self.can_change_user_roles:
-            form.load_roles(current_role=self.existing_role, role_choices=self.user_role_choices)
-        else:
-            del form.fields['role']
         return form
 
     @property

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -248,14 +248,6 @@ class EditCommCareUserView(BaseEditUserView):
         return [('none', _('(none)'))] + self.editable_role_choices
 
     @property
-    @memoized
-    def editable_role_choices(self):
-        roles = UserRole.by_domain(self.domain)
-        if not self.request.couch_user.is_domain_admin(self.domain):
-            roles = filter(lambda role: role.is_non_admin_editable, roles)
-        return [UserRole.role_to_choice(role) for role in roles]
-
-    @property
     def can_change_user_roles(self):
         return bool(self.editable_role_choices) and self.request.couch_user.user_id != self.editable_user_id
 


### PR DESCRIPTION
The main feature here is a new option on roles "Allow non-admins to assign this role to other users" which will let someone with permission to edit web users or mobile workers be able to assign a subset of roles (the ones which have this property set).

Along the way I uncovered and attempted to address a number of quirks with our role security model. In particular the main change is that only admin users can create other admin users, and everyone else who has "edit web user" permissions defaults to not being able to set roles unless those roles have been explicitly granted the new permission.

is broken out by commit though might actually be easier to read all at once, not sure.