### PR TITLE
Index location fixture

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -104,8 +104,9 @@ class FlatLocationSerializer(object):
             'code', flat=True
         )
         location_type_attrs = ['{}_id'.format(t) for t in all_types if t is not None]
+        attrs_to_index = location_type_attrs + ['id', 'type']
 
-        return [self._get_schema_node(fixture_id, location_type_attrs),
+        return [self._get_schema_node(fixture_id, attrs_to_index),
                 self._get_fixture_node(fixture_id, restore_user, all_locations, location_type_attrs)]
 
     def _get_fixture_node(self, fixture_id, restore_user, all_locations, location_type_attrs):
@@ -130,9 +131,9 @@ class FlatLocationSerializer(object):
 
         return root_node
 
-    def _get_schema_node(self, fixture_id, location_type_attrs):
+    def _get_schema_node(self, fixture_id, attrs_to_index):
         indices_node = Element('indices')
-        for index_attr in location_type_attrs + ['id', 'type']:
+        for index_attr in attrs_to_index:
             element = Element('index')
             element.text = '@{}'.format(index_attr)
             indices_node.append(element)

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -105,7 +105,8 @@ class FlatLocationSerializer(object):
         )
         location_type_attrs = ['{}_id'.format(t) for t in all_types if t is not None]
 
-        return [self._get_fixture_node(fixture_id, restore_user, all_locations, location_type_attrs)]
+        return [self._get_schema_node(fixture_id, location_type_attrs),
+                self._get_fixture_node(fixture_id, restore_user, all_locations, location_type_attrs)]
 
     def _get_fixture_node(self, fixture_id, restore_user, all_locations, location_type_attrs):
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id, 'indexed': 'true'})
@@ -128,6 +129,16 @@ class FlatLocationSerializer(object):
             outer_node.append(location_node)
 
         return root_node
+
+    def _get_schema_node(self, fixture_id, location_type_attrs):
+        indices_node = Element('indices')
+        for index_attr in location_type_attrs + ['id', 'type']:
+            element = Element('index')
+            element.text = '@{}'.format(index_attr)
+            indices_node.append(element)
+        node = Element('schema', {'id': fixture_id})
+        node.append(indices_node)
+        return node
 
 
 def should_sync_hierarchical_fixture(project):

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -133,7 +133,7 @@ class FlatLocationSerializer(object):
 
     def _get_schema_node(self, fixture_id, attrs_to_index):
         indices_node = Element('indices')
-        for index_attr in attrs_to_index:
+        for index_attr in sorted(attrs_to_index):  # sorted only for tests
             element = Element('index')
             element.text = '@{}'.format(index_attr)
             indices_node.append(element)

--- a/corehq/apps/locations/tests/data/expand_from_root_flat.xml
+++ b/corehq/apps/locations/tests/data/expand_from_root_flat.xml
@@ -1,4 +1,4 @@
-<fixture id="locations" user_id="{user_id}">
+<fixture id="locations" indexed="true" user_id="{user_id}">
     <locations>
         <location city_id="{boston_id}" county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
             <name>Boston</name>

--- a/corehq/apps/locations/tests/data/index_location_fixtures.xml
+++ b/corehq/apps/locations/tests/data/index_location_fixtures.xml
@@ -3,8 +3,8 @@
     <indices>
       <index>@city_id</index>
       <index>@county_id</index>
-      <index>@state_id</index>
       <index>@id</index>
+      <index>@state_id</index>
       <index>@type</index>
     </indices>
   </schema>

--- a/corehq/apps/locations/tests/data/index_location_fixtures.xml
+++ b/corehq/apps/locations/tests/data/index_location_fixtures.xml
@@ -1,0 +1,76 @@
+<partial>
+  <fixture id="locations" user_id="{user_id}">
+    <locations>
+      <location city_id="{boston_id}" county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
+        <name>Boston</name>
+        <site_code>boston</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>city</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+      <location city_id="{cambridge_id}" county_id="{middlesex_id}" id="{cambridge_id}" state_id="{massachusetts_id}" type="city">
+        <name>Cambridge</name>
+        <site_code>cambridge</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>city</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+      <location city_id="" id="{massachusetts_id}" type="state" county_id="" state_id="{massachusetts_id}">
+        <name>Massachusetts</name>
+        <site_code>massachusetts</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>state</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+      <location city_id="" county_id="{middlesex_id}" id="{middlesex_id}" state_id="{massachusetts_id}" type="county">
+        <name>Middlesex</name>
+        <site_code>middlesex</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>county</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+      <location city_id="{revere_id}" county_id="{suffolk_id}" id="{revere_id}" state_id="{massachusetts_id}" type="city">
+        <name>Revere</name>
+        <site_code>revere</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>city</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+      <location city_id="{somerville_id}" county_id="{middlesex_id}" id="{somerville_id}" state_id="{massachusetts_id}" type="city">
+        <name>Somerville</name>
+        <site_code>somerville</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>city</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+      <location city_id="" county_id="{suffolk_id}" id="{suffolk_id}" state_id="{massachusetts_id}" type="county">
+        <name>Suffolk</name>
+        <site_code>suffolk</site_code>
+        <external_id/>
+        <latitude/>
+        <longitude/>
+        <location_type>county</location_type>
+        <supply_point_id/>
+        <location_data/>
+      </location>
+    </locations>
+  </fixture>
+</partial>

--- a/corehq/apps/locations/tests/data/index_location_fixtures.xml
+++ b/corehq/apps/locations/tests/data/index_location_fixtures.xml
@@ -1,5 +1,14 @@
 <partial>
-  <fixture id="locations" user_id="{user_id}">
+  <schema id="locations">
+    <indices>
+      <index>@city_id</index>
+      <index>@county_id</index>
+      <index>@state_id</index>
+      <index>@id</index>
+      <index>@type</index>
+    </indices>
+  </schema>
+  <fixture id="locations" user_id="{user_id}" indexed="true">
     <locations>
       <location city_id="{boston_id}" county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
         <name>Boston</name>

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -239,11 +239,18 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
             'index_location_fixtures',
             ['Massachusetts', 'Suffolk', 'Boston', 'Revere', 'Middlesex', 'Cambridge', 'Somerville'],
         )
-        expected_fixture = extract_xml_partial(expected_result, './fixture')
         fixture_nodes = flat_location_fixture_generator(self.user, V2)
-        self.assertEqual(len(fixture_nodes), 1)
-        fixture = extract_xml_partial(ElementTree.tostring(fixture_nodes[0]), '.')
+        self.assertEqual(len(fixture_nodes), 2)  # fixture schema, then fixture
+
+        # check the fixture like usual
+        fixture = extract_xml_partial(ElementTree.tostring(fixture_nodes[1]), '.')
+        expected_fixture = extract_xml_partial(expected_result, './fixture')
         self.assertXmlEqual(expected_fixture, fixture)
+
+        # check the schema
+        schema = extract_xml_partial(ElementTree.tostring(fixture_nodes[0]), '.')
+        expected_schema = extract_xml_partial(expected_result, './schema')
+        self.assertXmlEqual(expected_schema, schema)
 
 
 @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting


### PR DESCRIPTION
This adds a schema block for the locations fixture, telling mobile to index the appropriate attributes.  This is based on https://github.com/dimagi/commcare-core/pull/502
@proteusvacuum @czue @ctsims 

@ctsims how confident are you that this won't break anything?  I'll throw this up on staging and see about loading an app or two.