### PR TITLE
delay application of select2

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -26,54 +26,53 @@
             select_params: {{ select.options|JSON }},
             current_selection: ko.observableArray({{ select.selected|JSON }}),
         });
-    });
-    {% if not endpoint %}
-        _.delay(function() {
+
+        {% if not endpoint %}
             $('#{{ css_id }}').select2();
-        });
-    {% else %}
-        {% comment %}
-        This is a select2 widget using a remote endpoint for paginated,
-        infinite scrolling options.
-        Check out EmwfOptionsView as an example
-        The endpoint should return json in this form:
-        {
-            "total": 9935,
-            "results": [
-                {
-                    "text": "kingofthebritains (Arthur Pendragon)",
-                    "id": "a242ly1b392b270qp"
+        {% else %}
+            {% comment %}
+            This is a select2 widget using a remote endpoint for paginated,
+            infinite scrolling options.
+            Check out EmwfOptionsView as an example
+            The endpoint should return json in this form:
+            {
+                "total": 9935,
+                "results": [
+                    {
+                        "text": "kingofthebritains (Arthur Pendragon)",
+                        "id": "a242ly1b392b270qp"
+                    },
+                    {
+                        "text": "thebrave (Sir Lancelot)",
+                        "id": "92b270qpa242ly1b3"
+                    }
+                ]
+            }
+            {% endcomment %}
+            $('#{{ css_id }}').select2({
+                ajax: {
+                    url: "{{ endpoint }}",
+                    dataType: 'json',
+                    data: function (term, page) {
+                        return {
+                            q: term,
+                            page_limit: 10,
+                            page: page,
+                         };
+                    },
+                    results: function (data, page) {
+                        var more = (page * 10) < data.total;
+                        return {results: data.results, more: more};
+                    }
                 },
-                {
-                    "text": "thebrave (Sir Lancelot)",
-                    "id": "92b270qpa242ly1b3"
-                }
-            ]
-        }
-        {% endcomment %}
-        $('#{{ css_id }}').select2({
-            ajax: {
-                url: "{{ endpoint }}",
-                dataType: 'json',
-                data: function (term, page) {
-                    return {
-                        q: term,
-                        page_limit: 10,
-                        page: page,
-                     };
+                initSelection: function (element, callback) {
+                    var data = {{ select.selected|JSON }};
+                    callback(data);
                 },
-                results: function (data, page) {
-                    var more = (page * 10) < data.total;
-                    return {results: data.results, more: more};
-                }
-            },
-            initSelection: function (element, callback) {
-                var data = {{ select.selected|JSON }};
-                callback(data);
-            },
-            multiple: true,
-            escapeMarkup: function (m) { return m; }
-        }).select2('val', {{ select.selected|JSON }});
-    {% endif %}
+                multiple: true,
+                escapeMarkup: function (m) { return m; }
+            }).select2('val', {{ select.selected|JSON }});
+        {% endif %}
+    });
 </script>
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -28,7 +28,9 @@
         });
     });
     {% if not endpoint %}
-        $('#{{ css_id }}').select2();
+        _.delay(function() {
+            $('#{{ css_id }}').select2();
+        });
     {% else %}
         {% comment %}
         This is a select2 widget using a remote endpoint for paginated,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?244947

Was able to reproduce locally and found that if I ran `$('#report_filter_group').select2();` in the console after the filters had re-loaded then the group options were correctly rendered.

Adding the delay fixed it for me locally, not sure if this is the best solution @dimagi/js-team?