### PR TITLE
updates to jan 2017 pricing plans

### DIFF
--- a/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
+++ b/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
@@ -16,7 +16,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.STANDARD, False): {
         'role': 'standard_plan_v0',
-        'product_rate': dict(),
+        'product_rate': dict(monthly_fee=Decimal('100.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=50, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=100),
@@ -24,7 +24,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.PRO, False): {
         'role': 'pro_plan_v0',
-        'product_rate': dict(),
+        'product_rate': dict(monthly_fee=Decimal('500.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=250, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=500),
@@ -32,7 +32,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.ADVANCED, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(),
+        'product_rate': dict(monthly_fee=Decimal('1000.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=1000),

--- a/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
+++ b/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
@@ -19,7 +19,7 @@ BOOTSTRAP_CONFIG = {
         'product_rate': dict(monthly_fee=Decimal('100.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=50, per_excess_fee=Decimal('2.00')),
-            FeatureType.SMS: dict(monthly_limit=100),
+            FeatureType.SMS: dict(monthly_limit=50),
         }
     },
     (SoftwarePlanEdition.PRO, False): {
@@ -27,7 +27,7 @@ BOOTSTRAP_CONFIG = {
         'product_rate': dict(monthly_fee=Decimal('500.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=250, per_excess_fee=Decimal('2.00')),
-            FeatureType.SMS: dict(monthly_limit=500),
+            FeatureType.SMS: dict(monthly_limit=50),
         }
     },
     (SoftwarePlanEdition.ADVANCED, False): {
@@ -35,7 +35,7 @@ BOOTSTRAP_CONFIG = {
         'product_rate': dict(monthly_fee=Decimal('1000.00')),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('2.00')),
-            FeatureType.SMS: dict(monthly_limit=1000),
+            FeatureType.SMS: dict(monthly_limit=50),
         }
     },
     (SoftwarePlanEdition.ADVANCED, True): {

--- a/corehq/apps/accounting/migrations/0050_fix_product_rates.py
+++ b/corehq/apps/accounting/migrations/0050_fix_product_rates.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from corehq.apps.accounting.bootstrap.config.user_buckets_jan_2017 import (
+    BOOTSTRAP_CONFIG
+)
+from corehq.apps.accounting.bootstrap.utils import ensure_plans
+from corehq.sql_db.operations import HqRunPython
+
+
+def _bootstrap_with_updated_user_buckets(apps, schema_editor):
+    ensure_plans(BOOTSTRAP_CONFIG, dry_run=False, verbose=True, apps=apps)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0049_update_user_buckets'),
+    ]
+
+    operations = [
+        HqRunPython(_bootstrap_with_updated_user_buckets),
+    ]


### PR DESCRIPTION
Does two things:

1) Uses the right product prices
2) Uses the number of included SMS that previously was set on production but not updated in the code.

A followup step is to check any subscriptions that were created since Jan 3 (when included SMS was reset to 500) and decide with Ops whether to update these subscriptions or grandfather them in.