### PR TITLE
don't verify nimbus SSL

### DIFF
--- a/corehq/apps/nimbus_api/form_validation.py
+++ b/corehq/apps/nimbus_api/form_validation.py
@@ -42,7 +42,8 @@ def validate_form(form_xml):
         response = requests.post(
             get_nimbus_url() + const.ENDPOINT_VALIDATE_FORM,
             data=form_xml,
-            headers={'Content-Type': 'application/xml'}
+            headers={'Content-Type': 'application/xml'},
+            verify=False
         )
     except RequestException as e:
         notify_exception(None, "Error calling Nimbus form validation endpoint")


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?246037

This is to get around the issue on NIC where we have two certs for
the nginx site and requests is using the wrong one (the first
in the list).

@benrudolph @calellowitz 