### PR TITLE
Make sure locs in URL are accessible

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -93,7 +93,8 @@ class ReportFixturesProvider(object):
             {ui_filter.field for ui_filter in defer_filters.values()},
             filter_options_by_field
         )
-        filters_elem = ReportFixturesProvider._get_filters_elem(defer_filters, filter_options_by_field)
+        filters_elem = ReportFixturesProvider._get_filters_elem(
+            defer_filters, filter_options_by_field, restore_user._couch_user)
 
         report_elem = E.report(id=report_config.uuid, report_id=report_config.report_id)
         report_elem.append(filters_elem)
@@ -107,14 +108,14 @@ class ReportFixturesProvider(object):
         return report, data_source
 
     @staticmethod
-    def _get_filters_elem(defer_filters, filter_options_by_field):
+    def _get_filters_elem(defer_filters, filter_options_by_field, couch_user):
         filters_elem = E.filters()
         for filter_slug, ui_filter in defer_filters.items():
             # @field is maybe a bad name for this attribute,
             # since it's actually the filter slug
             filter_elem = E.filter(field=filter_slug)
             option_values = filter_options_by_field[ui_filter.field]
-            choices = ui_filter.choice_provider.get_sorted_choices_for_values(option_values)
+            choices = ui_filter.choice_provider.get_sorted_choices_for_values(option_values, couch_user)
             for choice in choices:
                 # add the correct text from ui_filter.choice_provider
                 option_elem = E.option(choice.display, value=choice.value)

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -93,7 +93,7 @@ class ReportFiltersSuiteTest(TestCase, TestXmlMixin):
             def query(self, query_context):
                 pass
 
-            def get_choices_for_known_values(self, values):
+            def get_choices_for_known_values(self, values, user):
                 _map = {'cory': 'Cory Zue', 'ctsims': 'Clayton Sims', 'daniel': 'Daniel Roberts'}
                 return [Choice(value, _map.get(value, value)) for value in values]
 

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -348,11 +348,12 @@ class DynamicChoiceListFilter(BaseFilter):
 
     def value(self, **kwargs):
         selection = unicode(kwargs.get(self.name, ""))
+        user = kwargs.get("request_user", None)
         if selection:
             choices = selection.split(CHOICE_DELIMITER)
             typed_choices = [transform_from_datatype(self.datatype)(c) for c in choices]
-            return self.choice_provider.get_sorted_choices_for_values(typed_choices)
-        return self.default_value(kwargs.get("request_user", None))
+            return self.choice_provider.get_sorted_choices_for_values(typed_choices, user)
+        return self.default_value(user)
 
     def default_value(self, request_user=None):
         if hasattr(self.choice_provider, 'default_value'):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -218,7 +218,8 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         return self._locations_query(query, user).count()
 
     def get_choices_for_known_values(self, values, user):
-        selected_locations = SQLLocation.active_objects.filter(location_id__in=values)
+        selected_locations = (SQLLocation.active_objects.filter(location_id__in=values)
+                              .accessible_to_user(self.domain, user))
         if self.include_descendants:
             selected_locations = SQLLocation.objects.get_queryset_descendants(
                 selected_locations, include_self=True

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -70,12 +70,12 @@ class ChoiceProvider(object):
     def query(self, query_context):
         pass
 
-    def get_sorted_choices_for_values(self, values):
-        return sorted(self.get_choices_for_values(values),
+    def get_sorted_choices_for_values(self, values, user):
+        return sorted(self.get_choices_for_values(values, user),
                       key=lambda choice: alphanumeric_sort_key(choice.display))
 
-    def get_choices_for_values(self, values):
-        choices = set(self.get_choices_for_known_values(values))
+    def get_choices_for_values(self, values, user):
+        choices = set(self.get_choices_for_known_values(values, user))
         used_values = {value for value, _ in choices}
         for value in values:
             if value not in used_values:
@@ -84,7 +84,7 @@ class ChoiceProvider(object):
         return choices
 
     @abstractmethod
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         pass
 
 
@@ -118,7 +118,7 @@ class StaticChoiceProvider(ChoiceProvider):
                         if any(query_context.query in text for text in choice.searchable_text)]
         return filtered_set[query_context.offset:query_context.offset + query_context.limit]
 
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         return {choice for choice in self.choices
                 if choice.value in values}
 
@@ -131,7 +131,7 @@ class ChainableChoiceProvider(ChoiceProvider):
         pass
 
     @abstractmethod
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         pass
 
     @abstractmethod
@@ -179,7 +179,7 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
         except ProgrammingError:
             return []
 
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         return []
 
 
@@ -217,7 +217,7 @@ class LocationChoiceProvider(ChainableChoiceProvider):
     def query_count(self, query, user):
         return self._locations_query(query, user).count()
 
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         selected_locations = SQLLocation.active_objects.filter(location_id__in=values)
         if self.include_descendants:
             selected_locations = SQLLocation.objects.get_queryset_descendants(
@@ -254,7 +254,7 @@ class UserChoiceProvider(ChainableChoiceProvider):
         user_es = get_search_users_in_domain_es_query(self.domain, query, limit=0, offset=0)
         return user_es.run().total
 
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         user_es = UserES().domain(self.domain).doc_id(values)
         return self.get_choices_from_es_query(user_es)
 
@@ -284,7 +284,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
         )
         return group_es.size(0).run().total
 
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         group_es = GroupES().domain(self.domain).is_case_sharing().doc_id(values)
         return self.get_choices_from_es_query(group_es)
 
@@ -330,13 +330,13 @@ class AbstractMultiProvider(ChoiceProvider):
                 offset -= choice_provider.query_count(query, user=user)
         return choices
 
-    def get_choices_for_known_values(self, values):
+    def get_choices_for_known_values(self, values, user):
         remaining_values = set(values)
         choices = []
         for choice_provider in self.choice_providers:
             if len(remaining_values) <= 0:
                 break
-            new_choices = choice_provider.get_choices_for_known_values(list(remaining_values))
+            new_choices = choice_provider.get_choices_for_known_values(list(remaining_values), user)
             remaining_values -= {value for value, _ in new_choices}
             choices.extend(new_choices)
         return choices

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -33,7 +33,7 @@ class StaticChoiceProviderTest(SimpleTestCase):
 
     def test_get_choices_for_values(self):
         self.assertEqual(
-            set(self.choice_provider.get_choices_for_values(['2', '4', '6'])),
+            set(self.choice_provider.get_choices_for_values(['2', '4', '6'], None)),
             {Choice('2', 'Two'), Choice('4', '4'), Choice('6', '6')}
         )
 
@@ -67,8 +67,8 @@ class ChoiceProviderTestMixin(object):
 
     def _test_get_choices_for_values(self, values):
         self.assertEqual(
-            self.choice_provider.get_choices_for_values(values),
-            self.static_choice_provider.get_choices_for_values(values),
+            self.choice_provider.get_choices_for_values(values, user),
+            self.static_choice_provider.get_choices_for_values(values, user),
         )
 
     def test_query_no_search_all(self):

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -225,7 +225,7 @@ class UserChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
         domain = domain or cls.domain
         domains = [domain]
         user = WebUser(username=email, domains=domains)
-        user.domain_memberships = [DomainMembership(domain=cls.domain)]
+        user.domain_memberships = [DomainMembership(domain=domain)]
         doc = user._doc
         doc['username.exact'] = doc['username']
         doc['base_username'] = email

--- a/custom/enikshay/reports/filters.py
+++ b/custom/enikshay/reports/filters.py
@@ -34,7 +34,7 @@ class EnikshayLocationFilter(BaseMultipleOptionFilter):
         choice_provider = LocationChoiceProvider(StubReport(domain=self.domain), None)
         # We don't include descendants here because they will show up in select box
         choice_provider.configure({'include_descendants': False})
-        choices = choice_provider.get_choices_for_known_values(location_ids)
+        choices = choice_provider.get_choices_for_known_values(location_ids, self.request.couch_user)
         if not choices:
             return self.default_options
         else:
@@ -50,7 +50,7 @@ class EnikshayLocationFilter(BaseMultipleOptionFilter):
         choice_provider.configure({'include_descendants': True})
         return [
             choice.value
-            for choice in choice_provider.get_choices_for_known_values(selected)
+            for choice in choice_provider.get_choices_for_known_values(selected, request.couch_user)
         ]
 
     @property


### PR DESCRIPTION
Reports using the location choice provider have the options restricted to only those locations which are accessible to the user.  However, a user could modify a URL to include, say, a parent location, and get data they shouldn't have access to.  More realistically, if someone on the project shared a URL, there would be no verification that the restricted user loading it has access to those locations.  This PR adds in that check.
@proteusvacuum We offlined about this one.
@NoahCarnahan code buddy