### PR TITLE
Fix tabs on app settings in app manager v2

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
@@ -222,7 +222,7 @@
                 {% if linked_apps_enabled %}
                     <div id="whitelist-section" class="panel panel-appmanager panel-appmanager-form" data-bind="visible: linkedDomains().length > 0">
                     <legend>{% trans 'Linked Project Whitelist' %}</legend>
-                    <div class="tab-pane">
+                    <div class="tab-pane panel-body">
                         <div class="help-block">
                             {% blocktrans %}
                                 Project spaces on this list are able to update linked applications

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
@@ -166,23 +166,28 @@
 </script>
 
 <div class="tabbable">
-    {% if app.get_doc_type != 'LinkedApplication' %}
-        <ul class="nav nav-tabs">
-            <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
-            {% if app.get_doc_type == 'Application' %}
-                <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
-            {% endif %}
-            <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
-            <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
-        </ul>
+    <ul class="nav nav-tabs">
+    {% if app.get_doc_type == 'LinkedApplication' %}
+        <li class="active"><a href="#linked-app" data-toggle="tab">{% trans "Linked Application" %}</a></li>
+        <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
+    {% else %}
+        <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
+        {% if app.get_doc_type == 'Application' %}
+            <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
+        {% endif %}
+        <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
+        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
     {% endif %}
+    </ul>
     <div class="tab-content appmanager-tab-content">
         {% if app.get_doc_type == 'LinkedApplication' %}
+        <div class="tab-pane active" id="linked-app">
             <p> Your app is at version {{ app.version }}. The master app is at version {{ master_version }}. </p>
             <a class="btn btn-primary"
                href="{% url 'pull_master_app' domain app.id %}">
                 {% trans 'Update from Master App' %}
             </a>
+        </div>
         {% endif %}
         <div class="tab-pane" id="commcare-settings">
             {% include 'app_manager/v2/partials/commcare_settings.html' %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
@@ -166,14 +166,16 @@
 </script>
 
 <div class="tabbable">
-    <ul class="nav nav-tabs">
-        <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
-        {% if app.get_doc_type == 'Application' %}
-            <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
-        {% endif %}
-        <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
-        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
-    </ul>
+    {% if app.get_doc_type != 'LinkedApplication' %}
+        <ul class="nav nav-tabs">
+            <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
+            {% if app.get_doc_type == 'Application' %}
+                <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
+            {% endif %}
+            <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
+            <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
+        </ul>
+    {% endif %}
     <div class="tab-content appmanager-tab-content">
         {% if app.get_doc_type == 'LinkedApplication' %}
             <p> Your app is at version {{ app.version }}. The master app is at version {{ master_version }}. </p>
@@ -182,7 +184,7 @@
                 {% trans 'Update from Master App' %}
             </a>
         {% endif %}
-        <div class="tab-pane active" id="commcare-settings">
+        <div class="tab-pane" id="commcare-settings">
             {% include 'app_manager/v2/partials/commcare_settings.html' %}
         </div>
         {% if app.get_doc_type == 'Application' %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
@@ -124,7 +124,7 @@
          <input type="number" class="col-sm-3 form-control" data-bind="
              value: visibleValue,
              valueUpdate: 'textchange',
-@@ -110,165 +111,168 @@
+@@ -110,165 +111,170 @@
  </script>
  
  <script type="text/html" id="CommcareSettings.widgets.textarea">
@@ -205,14 +205,16 @@
 +</script>
 +
 +<div class="tabbable">
-+    <ul class="nav nav-tabs">
-+        <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
-+        {% if app.get_doc_type == 'Application' %}
-+            <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
-+        {% endif %}
-+        <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
-+        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
-+    </ul>
++    {% if app.get_doc_type != 'LinkedApplication' %}
++        <ul class="nav nav-tabs">
++            <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
++            {% if app.get_doc_type == 'Application' %}
++                <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
++            {% endif %}
++            <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
++            <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
++        </ul>
++    {% endif %}
 +    <div class="tab-content appmanager-tab-content">
 +        {% if app.get_doc_type == 'LinkedApplication' %}
 +            <p> Your app is at version {{ app.version }}. The master app is at version {{ master_version }}. </p>
@@ -221,7 +223,7 @@
 +                {% trans 'Update from Master App' %}
 +            </a>
 +        {% endif %}
-+        <div class="tab-pane active" id="commcare-settings">
++        <div class="tab-pane" id="commcare-settings">
 +            {% include 'app_manager/v2/partials/commcare_settings.html' %}
 +        </div>
 +        {% if app.get_doc_type == 'Application' %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
@@ -124,7 +124,7 @@
          <input type="number" class="col-sm-3 form-control" data-bind="
              value: visibleValue,
              valueUpdate: 'textchange',
-@@ -110,165 +111,170 @@
+@@ -110,165 +111,175 @@
  </script>
  
  <script type="text/html" id="CommcareSettings.widgets.textarea">
@@ -205,23 +205,28 @@
 +</script>
 +
 +<div class="tabbable">
-+    {% if app.get_doc_type != 'LinkedApplication' %}
-+        <ul class="nav nav-tabs">
-+            <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
-+            {% if app.get_doc_type == 'Application' %}
-+                <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
-+            {% endif %}
-+            <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
-+            <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
-+        </ul>
++    <ul class="nav nav-tabs">
++    {% if app.get_doc_type == 'LinkedApplication' %}
++        <li class="active"><a href="#linked-app" data-toggle="tab">{% trans "Linked Application" %}</a></li>
++        <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
++    {% else %}
++        <li class="active"><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
++        {% if app.get_doc_type == 'Application' %}
++            <li><a href="#multimedia-tab" data-toggle="tab">{% trans "Multimedia" %}</a></li>
++        {% endif %}
++        <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
++        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
 +    {% endif %}
++    </ul>
 +    <div class="tab-content appmanager-tab-content">
 +        {% if app.get_doc_type == 'LinkedApplication' %}
++        <div class="tab-pane active" id="linked-app">
 +            <p> Your app is at version {{ app.version }}. The master app is at version {{ master_version }}. </p>
 +            <a class="btn btn-primary"
 +               href="{% url 'pull_master_app' domain app.id %}">
 +                {% trans 'Update from Master App' %}
 +            </a>
++        </div>
 +        {% endif %}
 +        <div class="tab-pane" id="commcare-settings">
 +            {% include 'app_manager/v2/partials/commcare_settings.html' %}
@@ -237,12 +242,66 @@
 +                    <button class="btn btn-default"
 +                            data-bind="click: load_if_necessary">{% trans "Try again" %}</button>
 +                </div>
-+            </div>
+             </div>
+-        </div>
+-    </aside>
+-</script>
+-
+-<inline-edit params="
+-    value: '{{ app.name|escapejs }}',
+-    readOnlyClass: 'h3',
+-    url: '{% url "edit_app_attr" domain app.id 'name' %}',
+-    placeholder: '{% trans "Untitled App"|escapejs %}',
+-    postSave: function(data) { return hqImport('app_manager/js/app_manager.js').updateDOM(data.update); },
+-    rows: 1,
+-    saveValueName: 'name',
+-"></inline-edit>
+-<br />
+-<inline-edit params="
+-    value: '{{ app.short_comment|escapejs }}',
+-    url: '{% url "edit_app_attr" domain app.id 'comment' %}',
+-    placeholder: '{% trans "Enter app description here"|escapejs %}',
+-    saveValueName: 'comment',
+-    readOnlyClass: 'app-comment',
+-    cols: 50,
+-"></inline-edit>
+-
+-<div class="tab-pane" id="commcare-settings">
+-    {% if app.get_doc_type == 'LinkedApplication' %}
+-        <p> Your app is at version {{ app.version }}. The master app is at version {{ master_version }}. </p>
+-        <a class="btn btn-primary"
+-            href="{% url 'pull_master_app' domain app.id %}">
+-            {% trans 'Update from Master App' %}
+-        </a>
+-
+-    {% else %}
+-    <br />
+-    <form class="form-horizontal">
+-        <div class="clearfix">
+-            <div class="pull-right">
+-                <div id="settings-save-btn"></div>
 +        {% endif %}
 +        {% if app.get_doc_type != 'LinkedApplication' %}
 +            <div class="tab-pane active" id="languages">
 +                {% include 'app_manager/v2/languages.html' %}
-+            </div>
+             </div>
+-        </div>
+-        <div data-bind="foreach: sections">
+-            <fieldset data-bind="visible: notEmpty">
+-                <legend>
+-                    <a data-toggle="collapse" data-bind="attr: {href: '#' + id}, css: {collapsed: reallyCollapse}">
+-                        <i class="fa fa-angle-double-down"></i>
+-                        <span data-bind="text: title"></span>
+-                    </a>
+-                </legend>
+-                <div class="collapse" data-bind="foreach: settings, attr: {id: id}, css: {'in': !reallyCollapse()}">
+-                    <div class="form-group" data-bind="
+-                        visible: visible,
+-                        css: {error: hasError()}
+-                    ">
+-                        <div class="col-sm-2 control-label">
+-                            <label data-bind="html: name, attr: {for: inputId}" class="inner-control-label"></label>
+-                            <span data-bind="makeHqHelp: { name: name, description: $data.description, format: $data.description_format}, visible: $data.description"></span>
 +        {% endif %}
 +        <div class="tab-pane" id="actions">
 +            {% if app.get_doc_type != 'LinkedApplication' %}
@@ -256,7 +315,7 @@
 +                {% if linked_apps_enabled %}
 +                    <div id="whitelist-section" class="panel panel-appmanager panel-appmanager-form" data-bind="visible: linkedDomains().length > 0">
 +                    <legend>{% trans 'Linked Project Whitelist' %}</legend>
-+                    <div class="tab-pane">
++                    <div class="tab-pane panel-body">
 +                        <div class="help-block">
 +                            {% blocktrans %}
 +                                Project spaces on this list are able to update linked applications
@@ -265,7 +324,21 @@
 +                                space. If you would like to prevent a project from making future updates,
 +                                you can remove them from the list here.
 +                            {% endblocktrans %}
-+                        </div>
+                         </div>
+-                        <div class="col-sm-4">
+-                            <span data-bind="template: $data.widget_template || 'CommcareSettings.widgets.' + widget"></span>
+-                            <p class="help-block" data-bind="visible: disabledButHasValue">
+-                                <span data-bind="text: $data.disabled_txt"></span>
+-                                <span data-bind="visible: !$data.disabled_txt">
+-                                {% blocktrans %}
+-                                    Oops!
+-                                    This setting shouldn't be here.
+-                                    Could you change it to the default
+-                                    to make it go away?
+-                                    Sorry about that.
+-                                {% endblocktrans %}
+-                                </span>
+-                            </p>
 +                        <div data-bind="saveButton: saveButton"></div>
 +                        <table class="table">
 +                            <thead>
@@ -307,83 +380,7 @@
 +                                <i class="fa fa-trash"></i>
 +                                {% trans "Delete this application" %}
 +                            </button>
-+                        </div>
-+                    </form>
-+                </form>
-             </div>
-         </div>
--    </aside>
--</script>
--
--<inline-edit params="
--    value: '{{ app.name|escapejs }}',
--    readOnlyClass: 'h3',
--    url: '{% url "edit_app_attr" domain app.id 'name' %}',
--    placeholder: '{% trans "Untitled App"|escapejs %}',
--    postSave: function(data) { return hqImport('app_manager/js/app_manager.js').updateDOM(data.update); },
--    rows: 1,
--    saveValueName: 'name',
--"></inline-edit>
--<br />
--<inline-edit params="
--    value: '{{ app.short_comment|escapejs }}',
--    url: '{% url "edit_app_attr" domain app.id 'comment' %}',
--    placeholder: '{% trans "Enter app description here"|escapejs %}',
--    saveValueName: 'comment',
--    readOnlyClass: 'app-comment',
--    cols: 50,
--"></inline-edit>
--
--<div class="tab-pane" id="commcare-settings">
--    {% if app.get_doc_type == 'LinkedApplication' %}
--        <p> Your app is at version {{ app.version }}. The master app is at version {{ master_version }}. </p>
--        <a class="btn btn-primary"
--            href="{% url 'pull_master_app' domain app.id %}">
--            {% trans 'Update from Master App' %}
--        </a>
--
--    {% else %}
--    <br />
--    <form class="form-horizontal">
--        <div class="clearfix">
--            <div class="pull-right">
--                <div id="settings-save-btn"></div>
--            </div>
-+        <div class="tab-pane" id="commcare-settings">
-+            {% include 'app_manager/v2/partials/commcare_settings.html' %}
-         </div>
--        <div data-bind="foreach: sections">
--            <fieldset data-bind="visible: notEmpty">
--                <legend>
--                    <a data-toggle="collapse" data-bind="attr: {href: '#' + id}, css: {collapsed: reallyCollapse}">
--                        <i class="fa fa-angle-double-down"></i>
--                        <span data-bind="text: title"></span>
--                    </a>
--                </legend>
--                <div class="collapse" data-bind="foreach: settings, attr: {id: id}, css: {'in': !reallyCollapse()}">
--                    <div class="form-group" data-bind="
--                        visible: visible,
--                        css: {error: hasError()}
--                    ">
--                        <div class="col-sm-2 control-label">
--                            <label data-bind="html: name, attr: {for: inputId}" class="inner-control-label"></label>
--                            <span data-bind="makeHqHelp: { name: name, description: $data.description, format: $data.description_format}, visible: $data.description"></span>
--                        </div>
--                        <div class="col-sm-4">
--                            <span data-bind="template: $data.widget_template || 'CommcareSettings.widgets.' + widget"></span>
--                            <p class="help-block" data-bind="visible: disabledButHasValue">
--                                <span data-bind="text: $data.disabled_txt"></span>
--                                <span data-bind="visible: !$data.disabled_txt">
--                                {% blocktrans %}
--                                    Oops!
--                                    This setting shouldn't be here.
--                                    Could you change it to the default
--                                    to make it go away?
--                                    Sorry about that.
--                                {% endblocktrans %}
--                                </span>
--                            </p>
--                        </div>
+                         </div>
 -                        <div class="col-sm-2 control-label">
 -                            <div class="pull-left">
 -                                <span class="label label-danger" data-bind="
@@ -431,10 +428,16 @@
 -                    <i class="fa fa-plus"></i>
 -                    {% trans "Add Custom Property" %}
 -                </button>
--            </div>
++                    </form>
++                </form>
+             </div>
 -        </fieldset>
 -        {% endif %}
 -    </form>
 -    {% endif %}
++        </div>
++        <div class="tab-pane" id="commcare-settings">
++            {% include 'app_manager/v2/partials/commcare_settings.html' %}
++        </div>
 +    </div>
  </div>


### PR DESCRIPTION
Something mixed up the tabs on app settings (`Data and Sharing` doesn't go under `Languages`), I think a bad merge in linked apps:

![screen shot 2017-01-20 at 4 43 52 pm](https://cloud.githubusercontent.com/assets/1486591/22166585/c8ba14da-df2f-11e6-8207-af98b96468a3.png)

After (normal app):
![screen shot 2017-01-20 at 4 43 24 pm](https://cloud.githubusercontent.com/assets/1486591/22166623/0042a93a-df30-11e6-876e-ce00805c2c75.png)

After (linked app):
![screen shot 2017-01-20 at 4 43 17 pm](https://cloud.githubusercontent.com/assets/1486591/22166631/08d36a6c-df30-11e6-99b4-fec42b3c53e6.png)

@calellowitz 