### PR TITLE
remove nonexisting kwarg

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -306,7 +306,6 @@ class DomainWireInvoiceFactory(object):
             date_end=date_end,
             date_due=date_due,
             balance=balance,
-            account=account
         )
 
         record = WireBillingRecord.generate_record(wire_invoice)


### PR DESCRIPTION
passing wrong kwarg to ```create``` fails hard in django 1.10