### PR TITLE
fix usages of select_related

### DIFF
--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -205,7 +205,7 @@ def plan_rebuild_stock_state(case_id, section_id, product_id):
         .get_ordered_transactions_for_stock(
             case_id=case_id, section_id=section_id, product_id=product_id)
         .reverse()  # we want earliest transactions first
-        .select_related('report__type')
+        .select_related('report')
     )
     balance = None
     for stock_transaction in stock_transactions:

--- a/custom/ilsgateway/slab/utils.py
+++ b/custom/ilsgateway/slab/utils.py
@@ -13,12 +13,12 @@ def get_current_state(sql_location):
         stock_state.sql_product.code: stock_state.get_monthly_consumption()
         for stock_state in StockState.objects.filter(
             case_id=sql_location.supply_point_id
-        ).select_related('sql_product__code').order_by('sql_product__code')
+        ).select_related('sql_product').order_by('sql_product')
     }
 
     stock_transactions = StockTransaction.objects.filter(
         case_id=sql_location.supply_point_id, report__date__gte=ten_days_ago, type__in=['stockonhand', 'stockout']
-    ).select_related('sql_product__code').distinct('sql_product__code')\
+    ).select_related('sql_product').distinct('sql_product__code')\
         .order_by('sql_product__code', '-report__date')
 
     current_state = OrderedDict()

--- a/custom/ilsgateway/slab/utils.py
+++ b/custom/ilsgateway/slab/utils.py
@@ -13,7 +13,7 @@ def get_current_state(sql_location):
         stock_state.sql_product.code: stock_state.get_monthly_consumption()
         for stock_state in StockState.objects.filter(
             case_id=sql_location.supply_point_id
-        ).select_related('sql_product').order_by('sql_product')
+        ).select_related('sql_product').order_by('sql_product__code')
     }
 
     stock_transactions = StockTransaction.objects.filter(


### PR DESCRIPTION
```select_related``` must have a model field as its argument.  Otherwise fails hard in django 1.10

taken from https://github.com/dimagi/commcare-hq/pull/14077