### PR TITLE
Get system column without transform

### DIFF
--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -75,7 +75,7 @@ def _cached_add_inferred_export_properties(sender, domain, case_type, properties
     for case_property in properties:
         path = [PathNode(name=case_property)]
         system_property_column = filter(
-            lambda column: column.item.path == path,
+            lambda column: column.item.path == path and column.item.transform is None,
             MAIN_CASE_TABLE_PROPERTIES,
         )
 

--- a/corehq/apps/export/tests/test_add_inferred_export_properties.py
+++ b/corehq/apps/export/tests/test_add_inferred_export_properties.py
@@ -71,6 +71,18 @@ class InferredSchemaSignalTest(TestCase):
         self.assertEqual(group_schema.items[0].__class__, ExportItem)
         self._check_sql_props(props)
 
+    def test_add_inferred_export_properties_system_with_transform(self):
+        """
+        Ensures that when we add a system property, it uses the system's item type
+        """
+        props = set(['user_id'])  # user_id maps to two system properties
+        self._add_props(props)
+        schema = get_inferred_schema(self.domain, self.case_type)
+        group_schema = schema.group_schemas[0]
+        self.assertEqual(len(group_schema.items), 1)
+        self.assertEqual(group_schema.items[0].__class__, ExportItem)
+        self._check_sql_props(props)
+
     def test_cache_add_inferred_export_properties(self):
         props = set(['one', 'two'])
         self._add_props(props)

--- a/corehq/apps/export/tests/test_add_inferred_export_properties.py
+++ b/corehq/apps/export/tests/test_add_inferred_export_properties.py
@@ -73,15 +73,13 @@ class InferredSchemaSignalTest(TestCase):
 
     def test_add_inferred_export_properties_system_with_transform(self):
         """
-        Ensures that when we add a system property, it uses the system's item type
+        Ensures that when we add a system property with redundant paths, it uses the item's transform
         """
         props = set(['user_id'])  # user_id maps to two system properties
         self._add_props(props)
         schema = get_inferred_schema(self.domain, self.case_type)
         group_schema = schema.group_schemas[0]
         self.assertEqual(len(group_schema.items), 1)
-        self.assertEqual(group_schema.items[0].__class__, ExportItem)
-        self._check_sql_props(props)
 
     def test_cache_add_inferred_export_properties(self):
         props = set(['one', 'two'])


### PR DESCRIPTION
@emord there were assertions on this method when it would try to add `user_id` because that path maps to two system properties. this ensures we take the one that doesn't have a transform