### PR TITLE
allow TaskStatusResultError to be non-int

### DIFF
--- a/corehq/apps/case_importer/tracking/task_status.py
+++ b/corehq/apps/case_importer/tracking/task_status.py
@@ -29,7 +29,10 @@ class TaskStatusResultError(jsonobject.StrictJsonObject):
     title = jsonobject.StringProperty()
     description = jsonobject.StringProperty()
     column = jsonobject.StringProperty()
-    rows = jsonobject.ListProperty(int)
+    # usually an int, but field has been hijacked to include other debug info
+    # search 'row_number=' in tasks.py
+    # longer-term solution would be to have another field for debug info
+    rows = jsonobject.ListProperty()
 
 
 def normalize_task_status_result(result):


### PR DESCRIPTION
because some errors are using it this way

http://manage.dimagi.com/default.asp?246211 @snopoke 