### PR TITLE
Attempt to fix intermittent app manager blank screen

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
@@ -1,7 +1,5 @@
 // copied and modified from https://gist.github.com/dsully/1938283
-console.log("Loading bootstrap-tab-history-custom.js");
 $(function () {
-    console.log("Document ready handler in bootstrap-tab-history-custom.js");
 
     function loadPage(url) {
         window.location.href = url;
@@ -57,9 +55,11 @@ $(function () {
         link.tab('show');
     };
     $(window).on('load', function() {
-        console.log("Window ready handler in bootstrap-tab-history-custom.js");
         statechange();
     });
+    if (document.readyState === "complete") {
+        statechange();
+    }
     History.Adapter.bind(window, 'statechange', statechange);
     History.Adapter.bind(window, 'statechange', function () {
         var State = History.getState();


### PR DESCRIPTION
Blank screen is happening when window is loaded before the load event is attached to it. [jQuery docs](https://api.jquery.com/ready/) imply that `ready` maps to `DomContentLoaded`, which is the equivalent of `document.readyState === "interactive"`, whereas it looks like the window load event maps to `document.readyState === "complete"`...so, if the window has loaded already, the handler is never going to run, so call `statechange`.

https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState#readystatechange_as_an_alternative_to_DOMContentLoaded_event

@proteusvacuum / @benrudolph 