### PR TITLE
Rebuild UCR tables in place

### DIFF
--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -1,5 +1,5 @@
 import datetime
-from elasticsearch import NotFoundError
+from elasticsearch import NotFoundError, RequestError
 from corehq.apps.userreports.util import get_table_name
 from corehq.apps.userreports.adapter import IndicatorAdapter
 from corehq.apps.es.es_query import HQESQuery
@@ -123,7 +123,14 @@ class IndicatorESAdapter(IndicatorAdapter):
 
     def rebuild_table(self):
         self.drop_table()
-        self.es.indices.create(index=self.table_name, body=UCR_INDEX_SETTINGS)
+        self.build_table()
+
+    def build_table(self):
+        try:
+            self.es.indices.create(index=self.table_name, body=UCR_INDEX_SETTINGS)
+        except RequestError:
+            # table already exists
+            pass
 
     def drop_table(self):
         try:

--- a/corehq/apps/userreports/laboratory/adapter.py
+++ b/corehq/apps/userreports/laboratory/adapter.py
@@ -14,6 +14,10 @@ class IndicatorLaboratoryAdapter(IndicatorAdapter):
         self.es_adapter.rebuild_table()
         self.sql_adapter.rebuild_table()
 
+    def build_table(self):
+        self.es_adapter.build_table()
+        self.sql_adapter.build_table()
+
     def drop_table(self):
         self.es_adapter.drop_table()
         self.sql_adapter.drop_table()

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -37,6 +37,15 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         finally:
             self.session_helper.Session.commit()
 
+    def build_table(self):
+        self.session_helper.Session.remove()
+        try:
+            build_table(self.engine, self.get_table())
+        except ProgrammingError, e:
+            raise TableRebuildError('problem building UCR table {}: {}'.format(self.config, e))
+        finally:
+            self.session_helper.Session.commit()
+
     def drop_table(self):
         # this will hang if there are any open sessions, so go ahead and close them
         self.session_helper.Session.remove()
@@ -136,3 +145,8 @@ def rebuild_table(engine, table):
     with engine.begin() as connection:
         table.drop(connection, checkfirst=True)
         table.create(connection)
+
+
+def build_table(engine, table):
+    with engine.begin() as connection:
+        table.create(connection, checkfirst=True)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -58,6 +58,25 @@ def rebuild_indicators(indicator_config_id, initiated_by=None):
         _iteratively_build_table(config)
 
 
+@task(queue=UCR_CELERY_QUEUE, ignore_result=True)
+def rebuild_indicators_in_place(indicator_config_id, initiated_by=None):
+    config = _get_config_by_id(indicator_config_id)
+    success = _('Your UCR table {} has finished rebuilding').format(config.table_id)
+    failure = _('There was an error rebuilding Your UCR table {}.').format(config.table_id)
+    send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
+    with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
+        adapter = get_indicator_adapter(config, can_handle_laboratory=True)
+        if not id_is_static(indicator_config_id):
+            # Save the start time now in case anything goes wrong. This way we'll be
+            # able to see if the rebuild started a long time ago without finishing.
+            config.meta.build.initiated = datetime.datetime.utcnow()
+            config.meta.build.finished = False
+            config.save()
+
+        adapter.build_table()
+        _iteratively_build_table(config)
+
+
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True, acks_late=True)
 def resume_building_indicators(indicator_config_id, initiated_by=None):
     config = _get_config_by_id(indicator_config_id)

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -33,6 +33,12 @@
       {% trans 'Resume Build (Advanced)' %}
     </button>
   </form>
+  <form method='post' action="{% url 'build_in_place' domain data_source.get_id %}">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-default disable-on-submit">
+      {% trans 'Rebuild Tables In Place (Advanced)' %}
+    </button>
+  </form>
   {% endif %}
 {% endif %}
 {% endblock %}

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -15,10 +15,13 @@ from corehq.apps.userreports.views import (
     delete_data_source,
     rebuild_data_source,
     resume_building_data_source,
+    build_data_source_in_place,
     export_data_source,
     data_source_status,
     choice_list_api,
-    ExpressionDebuggerView, evaluate_expression)
+    ExpressionDebuggerView,
+    evaluate_expression
+)
 
 urlpatterns = [
     url(r'^$', UserConfigReportsHomeView.as_view(),
@@ -44,6 +47,8 @@ urlpatterns = [
         name='rebuild_configurable_data_source'),
     url(r'^data_sources/resume/(?P<config_id>[\w-]+)/$', resume_building_data_source,
         name='resume_build'),
+    url(r'^data_sources/build_in_place/(?P<config_id>[\w-]+)/$', build_data_source_in_place,
+        name='build_in_place'),
     url(r'^data_sources/preview/(?P<config_id>[\w-]+)/$',
         PreviewDataSourceView.as_view(),
         name=PreviewDataSourceView.urlname),

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -90,7 +90,9 @@ from corehq.apps.userreports.reports.filters.choice_providers import (
 )
 from corehq.apps.userreports.reports.view import ConfigurableReport
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
-from corehq.apps.userreports.tasks import rebuild_indicators, resume_building_indicators
+from corehq.apps.userreports.tasks import (
+    rebuild_indicators, resume_building_indicators, rebuild_indicators_in_place
+)
 from corehq.apps.userreports.ui.forms import (
     ConfigurableReportEditForm,
     ConfigurableDataSourceEditForm,
@@ -1112,6 +1114,27 @@ def resume_building_data_source(request, domain, config_id):
             _(u'Resuming rebuilding table "{}".').format(config.display_name)
         )
         resume_building_indicators.delay(config_id, request.user.username)
+    return HttpResponseRedirect(reverse(
+        EditDataSourceView.urlname, args=[domain, config._id]
+    ))
+
+
+@toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
+@require_POST
+def build_data_source_in_place(request, domain, config_id):
+    config, is_static = get_datasource_config_or_404(config_id, domain)
+    if config.is_deactivated:
+        config.is_deactivated = False
+        config.save()
+
+    messages.success(
+        request,
+        _('Table "{}" is now being rebuilt. Data should start showing up soon').format(
+            config.display_name
+        )
+    )
+
+    rebuild_indicators_in_place.delay(config_id, request.user.username)
     return HttpResponseRedirect(reverse(
         EditDataSourceView.urlname, args=[domain, config._id]
     ))


### PR DESCRIPTION
This adds a button to rebuild a UCR table/index without destroying the table. I plan on using this to convert UCRs from postgres to laboratory on prod without screwing up a domain's reports during a rebuild.

@benrudolph 