### PR TITLE
Live preview A/B test not setting property

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/apps_base.html
@@ -86,7 +86,7 @@
 
         // push LIVE PREVIEW ab test state to kissmetrics
       {% if is_onboarding_domain %}
-        window.analytics.workflow(["set", {"{{ live_preview_ab.name }}": "{{ live_preview_ab.version }}"}]);
+        analytics.workflow("Set live preview A/B test state", {"{{ live_preview_ab.name }}": "{{ live_preview_ab.version }}"});
       {% endif %}
     });
     $(function () {

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/apps_base.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/apps_base.html.diff.txt
@@ -99,7 +99,7 @@
  
 -        // push LIVE PREVIEW ab test state to kissmetrics
 -      {% if is_onboarding_domain %}
--        window.analytics.workflow(["set", {"{{ live_preview_ab.name }}": "{{ live_preview_ab.version }}"}]);
+-        analytics.workflow("Set live preview A/B test state", {"{{ live_preview_ab.name }}": "{{ live_preview_ab.version }}"});
 -      {% endif %}
 +        var previewApp = hqImport('app_manager/js/preview_app.js');
 +        previewApp.initPreviewWindow(hqLayout);


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/14137/commits/ccefab721b30864c9bc2443538d5cc147dbb4e6e ...`_kmq.push` and `analytics.workflow` take slightly different arguments. This is probably why we haven't been seeing data on the test come through Kiss.

The event name isn't relevant here, just made one up.

@benrudolph / @biyeun 
cc @mkangia 