### PR TITLE
Create "/lookup_tables/" versions of all "/fixtures/" urls.

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -65,7 +65,11 @@ domain_specific = [
     url(r'^case/', include('corehq.apps.hqcase.urls')),
     url(r'^case/', include('corehq.apps.case_search.urls')),
     url(r'^cloudcare/', include('corehq.apps.cloudcare.urls')),
-    url(r'^fixtures/', include('corehq.apps.fixtures.urls')),
+    # "fixtures" is not a word that we want to be user facing, therefore we have created versions of all of the
+    # fixture urls that contain 'lookup_tables' in the path instead of 'fixtures'. However, we don't want to break
+    # peoples bookmarks and such, so we've preserved the old urls containing 'fixtures' just in case.
+    url(r'^fixtures/', include('corehq.apps.fixtures.urls', namespace='deprecated_lookup_tables_url_space')),
+    url(r'^lookup_tables/', include('corehq.apps.fixtures.urls')),
     url(r'^importer/', include('corehq.apps.case_importer.urls')),
     url(r'^fri/', include('custom.fri.urls')),
     url(r'^ilsgateway/', include('custom.ilsgateway.urls')),


### PR DESCRIPTION
A few days ago Sarah asked for this on field/dev. Seemed like a pretty easy thing to fix so I thought I'd give it a try.

This PR preserves the existing "/fixtures/" urls, but also adds a "/lookup_tables/" url for each existing "fixtures" url. Also, the previous url names all refer to the new "/lookup_tables/" urls, while the old ones are put within a namespace to avoid collisions.

I decided to take this approach instead of using redirects because it seemed slightly performant, but   perhaps it would be considered better practice to use redirects instead.

@nickpell code buddy
@snopoke might have some opinions about weather this is the right approach or not