### PR TITLE
A few advanced appearance attrs

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -314,9 +314,6 @@ function DropdownEntry(question, options) {
 DropdownEntry.prototype = Object.create(EntrySingleAnswer.prototype);
 DropdownEntry.prototype.constructor = EntrySingleAnswer;
 DropdownEntry.prototype.onPreProcess = function(newValue) {
-    if (newValue === undefined) {
-        return;
-    }
     if (newValue === Formplayer.Const.NO_ANSWER) {
         this.answer(newValue);
     } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -303,6 +303,27 @@ SingleSelectEntry.prototype.onPreProcess = function(newValue) {
     }
 };
 
+function DropdownEntry(question, options) {
+    var self = this;
+    EntrySingleAnswer.call(this, question, options);
+    self.templateType = 'dropdown';
+    self.options = _.map(question.choices(), function(choice, idx) {
+        return { text: choice, idx: idx + 1 };
+    });
+}
+DropdownEntry.prototype = Object.create(EntrySingleAnswer.prototype);
+DropdownEntry.prototype.constructor = EntrySingleAnswer;
+DropdownEntry.prototype.onPreProcess = function(newValue) {
+    if (newValue === undefined) {
+        return;
+    }
+    if (newValue === Formplayer.Const.NO_ANSWER) {
+        this.answer(newValue);
+    } else {
+        this.answer(+newValue);
+    }
+};
+
 $.datetimepicker.setDateFormatter({
     parseDate: function (date, format) {
         var d = moment(date, format);
@@ -525,7 +546,8 @@ GeoPointEntry.prototype.constructor = EntryArrayAnswer;
 function getEntry(question) {
     var entry = null;
     var options = {};
-    var rawStyle;
+    var isNumeric = false;
+    var isMinimal = false;
 
     var displayOptions = _getDisplayOptions(question);
     var isPhoneMode = ko.utils.unwrapObservable(displayOptions.phoneMode);
@@ -534,8 +556,10 @@ function getEntry(question) {
     case Formplayer.Const.STRING:
     // Barcode uses text box for CloudCare so it's possible to still enter a barcode field
     case Formplayer.Const.BARCODE:
-        rawStyle = question.style ? ko.utils.unwrapObservable(question.style.raw) === 'numeric' : false;
-        if (rawStyle) {
+        if (question.style) {
+            isNumeric = ko.utils.unwrapObservable(question.style.raw) === Formplayer.Const.NUMERIC;
+        }
+        if (isNumeric) {
             entry = new PhoneEntry(question, { enableAutoUpdate: isPhoneMode });
         } else {
             entry = new FreeTextEntry(question, { enableAutoUpdate: isPhoneMode });
@@ -551,7 +575,14 @@ function getEntry(question) {
         entry = new FloatEntry(question, { enableAutoUpdate: isPhoneMode });
         break;
     case Formplayer.Const.SELECT:
-        entry = new SingleSelectEntry(question, {});
+        if (question.style) {
+            isMinimal = ko.utils.unwrapObservable(question.style.raw) === Formplayer.Const.MINIMAL;
+        }
+        if (isMinimal) {
+            entry = new DropdownEntry(question, {});
+        } else {
+            entry = new SingleSelectEntry(question, {});
+        }
         break;
     case Formplayer.Const.MULTI_SELECT:
         entry = new MultiSelectEntry(question, {});

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -675,6 +675,10 @@ Formplayer.Const = {
     INFO: 'info',
     BARCODE: 'barcode',
 
+    // Appearance attributes
+    NUMERIC: 'numeric',
+    MINIMAL: 'minimal',
+
     // Note it's important to differentiate these two
     NO_PENDING_ANSWER: undefined,
     NO_ANSWER: null,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -268,6 +268,11 @@ function Form(json) {
         });
     };
 
+    self.afterRender = function() {
+        // Once form has finished rendering, render all popovers
+        $('.js-form-container [data-toggle="popover"]').popover();
+    };
+
     $.unsubscribe('session');
     $.subscribe('session.reconcile', function(e, response, element) {
         // TODO where does response status parsing belong?

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
@@ -1,3 +1,6 @@
+/* eslint-env mocha */
+/* globals Question, DropdownEntry, Formplayer */
+
 describe('Entries', function() {
     var questionJSON,
         spy;
@@ -45,6 +48,34 @@ describe('Entries', function() {
 
         valid = entry.isValid('abc');
         assert.isFalse(valid);
+    });
+
+    it('Should return DropdownEntry', function() {
+        var entry;
+
+        questionJSON.datatype = Formplayer.Const.SELECT;
+        questionJSON.style = { raw: Formplayer.Const.MINIMAL };
+        questionJSON.choices = ['a', 'b'];
+
+        entry = (new Question(questionJSON)).entry;
+        assert.isTrue(entry instanceof DropdownEntry);
+        assert.equal(entry.templateType, 'dropdown');
+        assert.deepEqual(entry.options, [{
+            text: 'a',
+            idx: 1,
+        }, {
+            text: 'b',
+            idx: 2,
+        }]);
+
+        entry.rawAnswer(1);
+        this.clock.tick(1000);
+        assert.isTrue(spy.calledOnce);
+        assert.equal(entry.answer(), 1);
+
+        entry.rawAnswer(2);
+        this.clock.tick(1000);
+        assert.isTrue(spy.calledTwice);
     });
 
     it('Should return FloatEntry', function() {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -146,7 +146,12 @@
             <section id="cloudcare-notifications" class="container notifications-container"></section>
             <div id="persistent-case-tile" class="container"></div>
             <div id="menu-region" class="container"></div>
-            <section id="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
+            <section id="webforms" data-bind="
+                template: {
+                    name: 'form-fullform-ko-template',
+                    afterRender: afterRender
+                }">
+            </section>
         </div>
         <small id="version-info"></small>
         {% if request.couch_user.can_edit_data %}

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -61,7 +61,9 @@
       <div class="webforms-nav"
            data-bind="template: { name: 'form-navigation-ko-template' }"></div>
     </div>
-    <div class="container form-container" data-bind="css: { 'form-single-question': showInFormNavigation }">
+    <div class="container form-container js-form-container" data-bind="
+          css: { 'form-single-question': showInFormNavigation },
+      ">
 
       <div class="page-header">
         <h1 class="title" data-bind="text: title, visible: !showInFormNavigation()"></h1>
@@ -264,7 +266,21 @@
             }
         ">
         <label class="caption control-label" data-bind="css: Formplayer.Const.LABEL_WIDTH">
-            <div data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></div>
+            <div>
+                <!-- ko if: help() -->
+                <a
+                    class="help-popover"
+                    tabindex="0"
+                    role="button"
+                    data-trigger="focus"
+                    data-placement="top"
+                    data-toggle="popover"
+                    data-bind="attr: { 'data-content': help }">
+                    <i class="fa fa-info-circle"></i>
+                </a>
+                <!-- /ko -->
+                <span data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
+            </div>
             <i class="hint-text" data-bind="text: ko.utils.unwrapObservable($data.hint)"></i>
         </label>
         <div class="widget-container controls" data-bind="css: Formplayer.Const.CONTROL_WIDTH">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -263,10 +263,10 @@
                 on: $root.forceRequiredVisible,
             }
         ">
-        <label class="caption control-label" data-bind="
-            html: ko.utils.unwrapObservable($data.caption_markdown) || caption(),
-            css: Formplayer.Const.LABEL_WIDTH
-            "></label>
+        <label class="caption control-label" data-bind="css: Formplayer.Const.LABEL_WIDTH">
+            <div data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></div>
+            <i class="hint-text" data-bind="text: ko.utils.unwrapObservable($data.hint)"></i>
+        </label>
         <div class="widget-container controls" data-bind="css: Formplayer.Const.CONTROL_WIDTH">
             <div class="loading">
                 <i class="fa fa-check text-success" data-bind="visible: clean "></i>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -455,6 +455,17 @@
     </div>
     {% endif %}
 </script>
+<script type="text/html" id="dropdown-entry-ko-template">
+    <select class="form-control" data-bind="
+        options: options,
+        optionsValue: 'idx',
+        optionsText: 'text',
+        value: rawAnswer,
+        valueAllowUnset: true,
+        optionsCaption: gettext('Choose...')
+        ">
+    </select>
+</script>
 <script type="text/html" id="date-entry-ko-template">
     <div class="input-group">
         <input type="text" class="form-control" data-bind="attr: { id: entryId } "/>

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -163,7 +163,12 @@
               <small id="version-info"></small>
             </div>
             <div class="scrollable-container dragscroll form-scrollable-container">
-              <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
+              <section id="webforms" data-bind="
+                  template: {
+                      name: 'form-fullform-ko-template',
+                      afterRender: afterRender
+                  }">
+              </section>
               {% if request.couch_user.can_edit_data %}
               <section id="cloudcare-debugger" data-bind="
                   template: {

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -1,3 +1,8 @@
 .hint-text {
   font-size: 80%;
 }
+
+.help-popover, .help-popover:hover, .help-popover:focus {
+  text-decoration: none;
+  outline: 0;
+}

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -1,0 +1,3 @@
+.hint-text {
+  font-size: 80%;
+}


### PR DESCRIPTION
@wpride added some advanced appearance attributes to web apps
<img width="1792" alt="screen shot 2017-01-25 at 1 17 02 pm" src="https://cloud.githubusercontent.com/assets/918514/22289148/bfed15b0-e302-11e6-987a-8930df6d17c6.png">
<img width="1792" alt="screen shot 2017-01-25 at 1 32 55 pm" src="https://cloud.githubusercontent.com/assets/918514/22289156/cbb6d2dc-e302-11e6-9426-592f89d4c4ac.png">

Adds the following:

- Hint text
- Help text
- Dropdown instead of single select (this doesn't currently work because the backend doesn't send the proper appearance property. once that is fixed though this will work and it doesn't hurt to merge)

cc: @emord 
design: @biyeun / @orangejenny 

