### PR TITLE
Fix loading race condition

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -128,6 +128,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
         var $appPreview = $(module.SELECTORS.PREVIEW_WINDOW),
             $appBody = $(module.SELECTORS.APP_MANAGER_BODY),
             $togglePreviewBtn = $(module.SELECTORS.BTN_TOGGLE_PREVIEW),
+            $iframe = $(module.SELECTORS.PREVIEW_WINDOW_IFRAME),
             $messages = $(layoutController.selector.messages);
 
         _private.isFormdesigner = $(module.SELECTORS.FORMDESIGNER).length > 0;
@@ -193,14 +194,17 @@ hqDefine('app_manager/js/preview_app.js', function() {
                 $(module.SELECTORS.BTN_REFRESH).addClass('app-out-of-date');
             }
         });
-        $(module.SELECTORS.PREVIEW_WINDOW_IFRAME).on('load', function() {
+        var onload = function() {
             if (localStorage.getItem(module.DATA.TABLET)) {
                 _private.tabletView();
             } else {
                 _private.phoneView();
             }
-        });
-
+        };
+        $iframe.on('load', onload);
+        if ($iframe[0].contentWindow.document.readyState === 'complete') {
+            onload();
+        }
     };
 
     module.prependToggleTo = function (selector, layout, attempts) {

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -175,8 +175,22 @@
             </div>
         </div>
 
+        {% include 'form_entry/templates.html' %}
+        {% include 'formplayer/grid_view.html' %}
+        {% include 'formplayer/settings_view.html' %}
+        {% include 'formplayer/case_detail.html' %}
+        {% include 'formplayer/case_list.html' %}
+        {% include 'formplayer/menu_list.html' %}
+        {% include 'formplayer/session_list.html' %}
+        {% include 'formplayer/confirmation_modal.html' %}
+        {% include 'formplayer/users.html' %}
+        {% include 'formplayer/progress.html' %}
+        {% include 'formplayer/dependencies.html' %}
+        {% include "style/includes/ko.html" %}
+        {% include 'style/includes/analytics_all.html' %}
+        <script src="{% static 'cloudcare/js/preview_app/preview_app.js' %}"></script>
+        {% block js-inline %}{% endblock %}
         <script>
-        $(function () {
             window.GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is loaded on-demand
             hqImport('cloudcare/js/preview_app/preview_app.js').start({
                 apps: [{{ app|JSON }}],
@@ -201,22 +215,6 @@
               var scrollWidth = $(sc).prop('offsetWidth') - $(sc).prop('clientWidth');
               $(sc).addClass('has-scrollbar-'+scrollWidth);
             });
-        });
         </script>
-        {% include 'form_entry/templates.html' %}
-        {% include 'formplayer/grid_view.html' %}
-        {% include 'formplayer/settings_view.html' %}
-        {% include 'formplayer/case_detail.html' %}
-        {% include 'formplayer/case_list.html' %}
-        {% include 'formplayer/menu_list.html' %}
-        {% include 'formplayer/session_list.html' %}
-        {% include 'formplayer/confirmation_modal.html' %}
-        {% include 'formplayer/users.html' %}
-        {% include 'formplayer/progress.html' %}
-        {% include 'formplayer/dependencies.html' %}
-        {% include "style/includes/ko.html" %}
-        {% include 'style/includes/analytics_all.html' %}
-        <script src="{% static 'cloudcare/js/preview_app/preview_app.js' %}"></script>
-        {% block js-inline %}{% endblock %}
     </body>
 </html>


### PR DESCRIPTION
@orangejenny finally got to the bottom of this damn bug. essentially the new behavior in jquery (or web browsers) is that the readyState for an iframe can change to `complete` even if the javascript in the `ready` event in the iframe hasn't finished loading.

this combats that by moving the JS out of the ready event and to the bottom of the page. then the `complete` event is accurate and we're free to send messages to the preview app window.

cc: @emord