### PR TITLE
Remove USE_FORMPLAYER_FRONTEND toggle

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -46,7 +46,7 @@
         }
     </style>
 
-    {% if request|toggle_enabled:"USE_FORMPLAYER_FRONTEND"%}
+    {% if not request|toggle_enabled:"USE_OLD_CLOUDCARE"%}
         <script src="{% static 'cloudcare/js/formplayer/utils/util.js' %}"></script>
     {% endif %}
 
@@ -251,7 +251,7 @@
                 return urlRoot + '#' + Util.objectToEncodedUrl(urlObject.toJson());
             };
 
-            {% if request|toggle_enabled:"USE_FORMPLAYER_FRONTEND"%}
+            {% if not request|toggle_enabled:"USE_OLD_CLOUDCARE"%}
             var cloudCareUrl = getFormplayerUrl("{% url "formplayer_single_app" domain app.id %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}");
             {% else %}
                 var cloudCareUrl = getCloudCareUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_view_base.html
@@ -46,7 +46,7 @@
         }
     </style>
 
-    {% if request|toggle_enabled:"USE_FORMPLAYER_FRONTEND"%}
+    {% if not request|toggle_enabled:"USE_OLD_CLOUDCARE"%}
         <script src="{% static 'cloudcare/js/formplayer/utils/util.js' %}"></script>
     {% endif %}
 
@@ -239,7 +239,7 @@
                 return urlRoot + '#' + Util.objectToEncodedUrl(urlObject.toJson());
             };
 
-            {% if request|toggle_enabled:"USE_FORMPLAYER_FRONTEND"%}
+            {% if not request|toggle_enabled:"USE_OLD_CLOUDCARE"%}
             var cloudCareUrl = getFormplayerUrl("{% url "formplayer_single_app" domain app.id %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}");
             {% else %}
                 var cloudCareUrl = getCloudCareUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -431,7 +431,7 @@
             </label>
         </div>
     </div>
-    {% if not request|toggle_enabled:"USE_FORMPLAYER_FRONTEND" %}
+    {% if request|toggle_enabled:"USE_OLD_CLOUDCARE" %}
     <div class="help-block clear-container">
         <button class="btn btn-default btn-xs clear" data-bind="
             click: onClear

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -142,7 +142,7 @@ class CloudcareMain(View):
 
         else:
             # big TODO: write a new apps view for Formplayer, can likely cut most out now
-            if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
+            if not toggles.USE_OLD_CLOUDCARE.enabled(domain):
                 apps = get_cloudcare_apps(domain)
             else:
                 apps = get_brief_apps_in_domain(domain)
@@ -235,7 +235,7 @@ class CloudcareMain(View):
             'use_sqlite_backend': use_sqlite_backend(domain),
         }
         context.update(_url_context())
-        if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
+        if not toggles.USE_OLD_CLOUDCARE.enabled(domain):
             return render(request, "cloudcare/formplayer_home.html", context)
         else:
             return render(request, "cloudcare/cloudcare_home.html", context)
@@ -771,7 +771,7 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
 
     @property
     def page_title(self):
-        if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+        if not toggles.USE_OLD_CLOUDCARE.enabled(self.domain):
             return _("Web Apps Permissions")
         else:
             return _("CloudCare Permissions")

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -222,7 +222,7 @@ def toggle_enabled(request, toggle_or_toggle_name):
 @register.filter
 def is_new_cloudcare(request):
     from corehq import toggles
-    return _toggle_enabled(toggles, request, toggles.USE_FORMPLAYER_FRONTEND)
+    return not _toggle_enabled(toggles, request, toggles.USE_OLD_CLOUDCARE)
 
 
 @register.filter

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -71,7 +71,6 @@ class TestDefaultLandingPages(TestCase):
         response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
         self.assertEqual(response.status_code, 404)
 
-    @flag_enabled('USE_FORMPLAYER_FRONTEND')
     def test_formplayer_default_override(self):
         web_user = self._make_web_user('elodin@theuniversity.com', role=self.webapps_role)
         self.addCleanup(web_user.delete)

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -88,7 +88,7 @@ class TestDefaultLandingPages(TestCase):
 @generate_cases([
     (None, DomainDashboardView.urlname),
     ('reports_role', MySavedReportsView.urlname),
-    ('webapps_role', 'cloudcare_main', ['']),
+    ('webapps_role', FormplayerMain.urlname),
 ], TestDefaultLandingPages)
 def test_web_user_landing_page(self, role, expected_urlname, extra_url_args=None):
     if role is not None:
@@ -105,9 +105,9 @@ def test_web_user_landing_page(self, role, expected_urlname, extra_url_args=None
 
 
 @generate_cases([
-    (None, 'cloudcare_main', ['']),
+    (None, FormplayerMain.urlname),
     ('reports_role', MySavedReportsView.urlname),
-    ('webapps_role', 'cloudcare_main', ['']),
+    ('webapps_role', FormplayerMain.urlname),
 ], TestDefaultLandingPages)
 def test_mobile_worker_landing_page(self, role, expected_urlname, extra_url_args=None):
     if role is not None:

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -123,7 +123,6 @@ def request_new_domain(request, form, is_new_user=True):
                                        request.user.get_full_name())
     send_new_request_update_email(request.user, get_ip(request), new_domain.name, is_new_user=is_new_user)
 
-    set_toggle(toggles.USE_FORMPLAYER_FRONTEND.slug, new_domain.name, True, namespace=toggles.NAMESPACE_DOMAIN)
     meta = get_meta(request)
     track_created_new_project_space_on_hubspot.delay(current_user, request.COOKIES, meta)
     return new_domain.name

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -14,7 +14,7 @@ class LandingPage(namedtuple('LandingPage', ['id', 'name', 'urlname'])):
 
 def get_cloudcare_urlname(domain):
     from corehq.apps.cloudcare.views import FormplayerMain
-    if toggles.USE_FORMPLAYER_FRONTEND.enabled(domain):
+    if not toggles.USE_OLD_CLOUDCARE.enabled(domain):
         return FormplayerMain.urlname
     else:
         return 'corehq.apps.cloudcare.views.default'

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -666,14 +666,14 @@ class CloudcareTab(UITab):
     @property
     def view(self):
         from corehq.apps.cloudcare.views import FormplayerMain
-        if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+        if not toggles.USE_OLD_CLOUDCARE.enabled(self.domain):
             return FormplayerMain.urlname
         else:
             return "corehq.apps.cloudcare.views.default"
 
     @property
     def title(self):
-        if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+        if not toggles.USE_OLD_CLOUDCARE.enabled(self.domain):
             return _("Web Apps")
         else:
             return _("CloudCare")
@@ -1021,7 +1021,7 @@ class ProjectUsersTab(UITab):
             ]
 
             if self.can_view_cloudcare:
-                if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+                if not toggles.USE_OLD_CLOUDCARE.enabled(self.domain):
                     title = _("Web Apps Permissions")
                 else:
                     title = _("CloudCare Permissions")

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -726,23 +726,11 @@ HSPH_HACK = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-USE_FORMPLAYER_FRONTEND = PredictablyRandomToggle(
-    'use_formplayer_frontend',
-    'Use New CloudCare',
-    TAG_PRODUCT_PATH,
+USE_OLD_CLOUDCARE = StaticToggle(
+    'use_old_cloudcare',
+    'Use Old CloudCare',
+    TAG_ONE_OFF,
     [NAMESPACE_DOMAIN],
-    randomness=1.0,
-    always_disabled=[
-        'hsph-betterbirth',
-        'figo-ppiud-srilanka',
-        'broadreach-sa',
-        'goal-global',
-        'ipm-senegal',
-        'madla-malaria',
-        'myrice',
-        'pact',
-        'icrc-almanach',
-    ]
 )
 
 FIXTURE_CASE_SELECTION = StaticToggle(


### PR DESCRIPTION
@czue this was followup from the PR where i bumped it to 100%. we need to add these domains when this gets merged. will coordinate with interrupt. all the domains with a check box need to be added to the toggle

- [x] 'hsph-betterbirth'		
- [x] 'figo-ppiud-srilanka'	
- [x] 'broadreach-sa'	
- [x] 'goal-global'	
- [ ] 'ipm-senegal'		
- [x] 'madla-malaria'	
- [x] 'myrice'
- [x] 'pact'		
- [x] 'icrc-almanach' <- for swiss



(this'll probably break a bunch of tests)
cc: @emord 