### PR TITLE
Release app preview to everyone else

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -27,6 +27,7 @@ from corehq.apps.app_manager.util import (
     app_callout_templates,
     is_usercase_in_use,
 )
+from corehq.apps.cloudcare.utils import should_show_preview_app
 from corehq.apps.fixtures.fixturegenerators import item_lists_by_domain
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import (
@@ -150,11 +151,10 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
     context.update({
         'live_preview_ab': live_preview_ab.context,
         'is_onboarding_domain': domain_obj.is_onboarding_domain,
-        'show_live_preview': (
-            toggles.PREVIEW_APP.enabled(domain)
-            or toggles.PREVIEW_APP.enabled(request.couch_user.username)
-            or (domain_obj.is_onboarding_domain
-                and live_preview_ab.version == ab_tests.LIVE_PREVIEW_ENABLED)
+        'show_live_preview': should_show_preview_app(
+            request,
+            domain_obj,
+            request.couch_user.username,
         )
     })
 

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -35,6 +35,7 @@ from corehq.apps.app_manager.util import (
 )
 from corehq import toggles
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
+from corehq.apps.cloudcare.utils import should_show_preview_app
 from corehq.util.soft_assert import soft_assert
 from dimagi.utils.couch.resource_conflict import retry_resource
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -286,10 +287,10 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
     context.update({
         'live_preview_ab': live_preview_ab.context,
         'is_onboarding_domain': domain_obj.is_onboarding_domain,
-        'show_live_preview': (
-            toggles.PREVIEW_APP.enabled(domain)
-            or toggles.PREVIEW_APP.enabled(request.couch_user.username)
-            or (domain_obj.is_onboarding_domain and live_preview_ab.version == ab_tests.LIVE_PREVIEW_ENABLED)
+        'show_live_preview': should_show_preview_app(
+            request,
+            domain_obj,
+            request.couch_user.username,
         )
     })
 

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -1,0 +1,12 @@
+from corehq.toggles import PREVIEW_APP
+from corehq.apps.analytics import ab_tests
+
+
+def should_show_preview_app(request, domain_obj, username):
+    live_preview_ab = ab_tests.ABTest(ab_tests.LIVE_PREVIEW, request)
+    if domain_obj.is_onboarding_domain and live_preview_ab.version == ab_tests.LIVE_PREVIEW_ENABLED:
+        return True
+    elif domain_obj.is_onboarding_domain:
+        return False
+
+    return PREVIEW_APP.enabled(domain_obj.name) or PREVIEW_APP.enabled(username)

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -6,7 +6,7 @@ def should_show_preview_app(request, domain_obj, username):
     live_preview_ab = ab_tests.ABTest(ab_tests.LIVE_PREVIEW, request)
     if domain_obj.is_onboarding_domain and live_preview_ab.version == ab_tests.LIVE_PREVIEW_ENABLED:
         return True
-    elif domain_obj.is_onboarding_domain:
+    elif domain_obj.is_onboarding_domain and not request.couch_user.is_dimagi:
         return False
 
     return PREVIEW_APP.enabled(domain_obj.name) or PREVIEW_APP.enabled(username)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -936,11 +936,12 @@ CUSTOM_CALENDAR_FIXTURE = StaticToggle(
 )
 
 
-PREVIEW_APP = StaticToggle(
+PREVIEW_APP = PredictablyRandomToggle(
     'preview_app',
     'Preview an application in the app builder',
     TAG_PRODUCT_PATH,
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
+    randomness=0.2,
 )
 
 DISABLE_COLUMN_LIMIT_IN_UCR = StaticToggle(


### PR DESCRIPTION
@orangejenny @wpride this rolls out app preview to 20% of domains. if it is an onboarding domain, it will _never_ show app preview. i think this is worth the sacrifice since i don't expect a ton of domains to fall into this category. if it becomes an issue, we can address it. would also be good to know how long we have to be in this state

cc: @emord 