### PR TITLE
adding url param to mark atypical users

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -208,6 +208,10 @@ def track_user_sign_in_on_hubspot(webuser, cookies, meta, path):
             tracking_dict.update({
                 'phone': webuser.phone_numbers[0],
             })
+        if webuser.atypical_user:
+            tracking_dict.update({
+                'atypical_user': True
+            })
         tracking_dict.update(get_ab_test_properties(webuser))
         _track_on_hubspot(webuser, tracking_dict)
         _send_form_to_hubspot(HUBSPOT_SIGNUP_FORM_ID, webuser, cookies, meta)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -51,6 +51,7 @@ class RegisterWebUserForm(forms.Form):
                href='#eulaModal'>
                CommCare HQ End User License Agreement</a>.""")))
     xform = forms.CharField(required=False, widget=forms.HiddenInput())
+    atypical_user = forms.BooleanField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, *args, **kwargs):
         self.show_phone_number = kwargs.pop('show_number', False)
@@ -114,6 +115,7 @@ class RegisterWebUserForm(forms.Form):
                     hqcrispy.ValidationMessage('passwordDelayed'),
                     crispy.Div(*phone_number_fields),
                     hqcrispy.InlineField('xform'),
+                    hqcrispy.InlineField('atypical_user'),
                     twbscrispy.StrictButton(
                         ugettext("Next"),
                         css_class="btn btn-success btn-lg",

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -186,6 +186,7 @@ hqDefine('registration/js/new_user.ko.js', function () {
                 eula_confirmed: self.eulaConfirmed(),
                 phone_number: _private.getPhoneNumberFn() || self.phoneNumber(),
                 xform: defaults.xform,
+                atypical_user: defaults.atypical_user
             };
         };
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -51,6 +51,7 @@ def activate_new_user(form, is_domain_admin=True, domain=None, ip=None):
     new_user.last_login = now
     new_user.date_joined = now
     new_user.last_password_set = now
+    new_user.atypical_user = form.cleaned_data.get('atypical_user', False)
     new_user.save()
 
     return new_user

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -167,6 +167,10 @@ class UserRegistrationView(BasePageView):
         return self.request.POST.get('xform', '')
 
     @property
+    def atypical_user(self):
+        return self.request.GET.get('internal', False)
+
+    @property
     @memoized
     def ab(self):
         return ab_tests.ABTest(ab_tests.NEW_USER_NUMBER, self.request)
@@ -176,11 +180,12 @@ class UserRegistrationView(BasePageView):
         prefills = {
             'email': self.prefilled_email,
             'xform': self.prefilled_xform,
+            'atypical_user': True if self.atypical_user else False
         }
         return {
             'reg_form': RegisterWebUserForm(
                 initial=prefills,
-                show_number=(self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM)
+                show_number=(self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM),
             ),
             'reg_form_defaults': prefills,
             'hide_password_feedback': settings.ENABLE_DRACONIAN_SECURITY_FEATURES,

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2012,6 +2012,9 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     login_attempts = IntegerProperty(default=0)
     attempt_date = DateProperty()
     fcm_device_token = StringProperty()
+    # this property is used to mark users who signed up from internal invitations
+    # such as those going through the recruiting pipeline
+    # to better mark them in our analytics
     atypical_user = BooleanProperty(default=False)
 
     def sync_from_old_couch_user(self, old_couch_user):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2012,6 +2012,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     login_attempts = IntegerProperty(default=0)
     attempt_date = DateProperty()
     fcm_device_token = StringProperty()
+    atypical_user = BooleanProperty(default=False)
 
     def sync_from_old_couch_user(self, old_couch_user):
         super(WebUser, self).sync_from_old_couch_user(old_couch_user)


### PR DESCRIPTION
@gcapalbo This is from the third request in https://docs.google.com/document/d/1IiK3kj-wlHaOdokTP2RQ9f1ehTXiJkf0VCpthc5wvRc/edit#heading=h.edog63lkny5l

The idea is that users that sign up for hq via the job application or similar processes will be given urls to the signup page that include the internal parameter. we can then mark them in hubspot as atypical users and exclude them from our workflows