### PR TITLE
form filters don't have sharing_Groups

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -631,7 +631,6 @@ class DashboardFeedFilterForm(forms.Form):
             selected_items = (
                 export_instance_filters.users +
                 export_instance_filters.reporting_groups +
-                export_instance_filters.sharing_groups +
                 export_instance_filters.locations +
                 export_instance_filters.user_types
             )


### PR DESCRIPTION
@NoahCarnahan if it's a case export it adds the sharing groups in the if statment right after this

buddy @benrudolph 