### PR TITLE
Redirect report builder reports to the paywall on community plans

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -21,7 +21,7 @@ from dimagi.utils.modules import to_function
 from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, Http404, HttpResponseBadRequest
+from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.translation import ugettext as _, ugettext_noop
 from braces.views import JSONResponseMixin
 from corehq.apps.locations.permissions import conditionally_location_safe
@@ -51,6 +51,7 @@ from corehq.apps.userreports.tasks import compare_ucr_dbs
 from corehq.apps.userreports.util import (
     default_language,
     has_report_builder_trial,
+    has_report_builder_access,
     can_edit_report,
     get_ucr_class_name)
 from corehq.util.couch import get_document_or_404, get_document_or_not_found, \
@@ -124,8 +125,12 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     @use_nvd3
     @conditionally_location_safe(has_location_filter)
     def dispatch(self, request, *args, **kwargs):
-        original = super(ConfigurableReport, self).dispatch(request, *args, **kwargs)
-        return original
+        if self.spec.report_meta.created_by_builder and has_report_builder_access(request):
+            original = super(ConfigurableReport, self).dispatch(request, *args, **kwargs)
+            return original
+        else:
+            from corehq.apps.userreports.views import paywall_home
+            return HttpResponseRedirect(paywall_home(self.domain))
 
     @property
     def section_url(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?246184

Before if a user had a bookmark to the report, they could still access the report page. This redirects them to paywall home, but should still allow them to get to any custom built UCRs

@kaapstorm 

buddies @benrudolph @snopoke 