### PR TITLE
Don't 500 when a dev wants to change their subscription locally

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2854,7 +2854,14 @@ class StripePaymentMethod(PaymentMethod):
 
     @property
     def all_cards(self):
-        return filter(lambda card: card is not None, self.customer.cards.data)
+        try:
+            return filter(lambda card: card is not None, self.customer.cards.data)
+        except stripe.error.AuthenticationError:
+            if not settings.STRIPE_PRIVATE_KEY:
+                log_accounting_info("Private key is not defined in settings")
+                return []
+            else:
+                raise
 
     def all_cards_serialized(self, billing_account):
         return [{


### PR DESCRIPTION
Follows the same pattern as [`utils.get_customer_cards()`](https://github.com/dimagi/commcare-hq/blob/ef6a15aaa82b7ceee6042a60119931ebf552c669/corehq/apps/accounting/utils.py#L204-L204)

@nickpell cc buddies @proteusvacuum @czue 

