### PR TITLE
Check ReportBuilderView permission to show button

### DIFF
--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -4,6 +4,7 @@ import hashlib
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
+from corehq.apps.users.models import Permissions
 from corehq.util.soft_assert import soft_assert
 from corehq import privileges, toggles
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -67,6 +68,11 @@ def has_report_builder_trial(request):
 
 
 def can_edit_report(request, report):
+    edit_data_perm = Permissions.edit_data.name
+    user_can_edit = request.couch_user.has_permission(request.domain, edit_data_perm)
+    if not user_can_edit:
+        return False
+
     ucr_toggle = toggle_enabled(request, toggles.USER_CONFIGURABLE_REPORTS)
     report_builder_toggle = toggle_enabled(request, toggles.REPORT_BUILDER)
     report_builder_beta_toggle = toggle_enabled(request, toggles.REPORT_BUILDER_BETA_GROUP)


### PR DESCRIPTION
[FB 245748](http://manage.dimagi.com/default.asp?245748)

Checks the same permission as the [`ReportBuilderView.dispatch()` decorator](https://github.com/dimagi/commcare-hq/blob/2e62f859a5c3678a2a4340e1539257525b315c27/corehq/apps/userreports/views.py#L245-L245) to determine whether to show the "Edit Report" button.

@emord cc @czue @proteusvacuum 
