### PR TITLE
Custom Queries in Case Search

### DIFF
--- a/corehq/apps/case_search/admin.py
+++ b/corehq/apps/case_search/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from corehq.apps.case_search.models import CaseSearchQueryAddition
 
+
 class CaseSearchQueryAdditionAdmin(admin.ModelAdmin):
     list_display = ('domain', 'name', 'id')
 

--- a/corehq/apps/case_search/admin.py
+++ b/corehq/apps/case_search/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from corehq.apps.case_search.models import CaseSearchQueryAddition
+
+class CaseSearchQueryAdditionAdmin(admin.ModelAdmin):
+    list_display = ('name', 'id')
+
+
+admin.site.register(CaseSearchQueryAddition, CaseSearchQueryAdditionAdmin)

--- a/corehq/apps/case_search/admin.py
+++ b/corehq/apps/case_search/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from corehq.apps.case_search.models import CaseSearchQueryAddition
 
 class CaseSearchQueryAdditionAdmin(admin.ModelAdmin):
-    list_display = ('name', 'id')
+    list_display = ('domain', 'name', 'id')
 
 
 admin.site.register(CaseSearchQueryAddition, CaseSearchQueryAdditionAdmin)

--- a/corehq/apps/case_search/migrations/0003_casesearchqueryaddition.py
+++ b/corehq/apps/case_search/migrations/0003_casesearchqueryaddition.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_search', '0002_auto_20161114_1901'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CaseSearchQueryAddition',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('domain', models.CharField(max_length=256, db_index=True)),
+                ('name', models.CharField(max_length=256)),
+                ('query_addition', jsonfield.fields.JSONField(default=dict)),
+            ],
+        ),
+    ]

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -143,7 +143,12 @@ def merge_queries(base_query, query_addition):
         return a
 
     new_query = copy.deepcopy(base_query)
-    merge(new_query, query_addition)
+    try:
+        merge(new_query, query_addition)
+    except QueryMergeException as e:
+        e.original_query = base_query
+        e.query_addition = query_addition
+        raise e
     return new_query
 
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -102,7 +102,13 @@ class CaseSearchQueryAddition(models.Model):
         db_index=True,
     )
     name = models.CharField(max_length=256, null=False, blank=False)
-    query_addition = JSONField(default=dict)
+    query_addition = JSONField(
+        default=dict,
+        help_text="More information about how this field is used can be found <a href='https://docs.google.com/doc"
+                  "ument/d/1MKllkHZ6JlxhfqZLZKWAnfmlA3oUqCLOc7iKzxFTzdY/edit#heading=h.k5pky76mwwon'>here</a>. Thi"
+                  "s ES <a href='https://www.elastic.co/guide/en/elasticsearch/guide/1.x/bool-query.html'>document"
+                  "ation</a> may also be useful."
+    )
 
 
 class QueryMergeException(Exception):

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -91,6 +91,17 @@ class CaseSearchConfig(models.Model):
         self._config = value.to_json()
 
 
+class CaseSearchQueryAddition(models.Model):
+    domain = models.CharField(
+        max_length=256,
+        null=False,
+        blank=False,
+        db_index=True,
+    )
+    name = models.CharField(max_length=256, null=False, blank=False)
+    query_addition = JSONField(default=dict)
+
+
 def case_search_enabled_for_domain(domain):
     try:
         CaseSearchConfig.objects.get(pk=domain, enabled=True)

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -107,7 +107,8 @@ class CaseSearchQueryAddition(models.Model):
         help_text="More information about how this field is used can be found <a href='https://docs.google.com/doc"
                   "ument/d/1MKllkHZ6JlxhfqZLZKWAnfmlA3oUqCLOc7iKzxFTzdY/edit#heading=h.k5pky76mwwon'>here</a>. Thi"
                   "s ES <a href='https://www.elastic.co/guide/en/elasticsearch/guide/1.x/bool-query.html'>document"
-                  "ation</a> may also be useful."
+                  "ation</a> may also be useful. This JSON will be merged at the `query.filtered.query` path of th"
+                  "e query JSON."
     )
 
 

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -6,6 +6,7 @@ hqDefine('case_search/js/case_search.js', function(){
         var self = this;
         self.codeMirror = null;
         self.type = ko.observable();
+        self.customQueryAddition = ko.observable();
         self.results = ko.observableArray();
         self.case_data_url = case_data_url;
         self.parameters = ko.observableArray([{
@@ -31,7 +32,11 @@ hqDefine('case_search/js/case_search.js', function(){
             self.results([]);
             $.post({
                 url: window.location.href,
-                data: {q: JSON.stringify({type: self.type(), parameters: self.parameters()})},
+                data: {q: JSON.stringify({
+                    type: self.type(),
+                    parameters: self.parameters(),
+                    customQueryAddition: self.customQueryAddition()}
+                )},
                 success: function(data){
                     self.results(data.values);
                     var values = JSON.stringify(data.values, null, '    ');

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -87,6 +87,21 @@
                                 <span class="btn btn-primary" id="add-input" data-bind="click: addParameter"><i class="fa fa-plus"></i> Add input</span>
                             </div>
                         </div>
+                        {% if query_additions %}
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <strong>{% trans "Custom Query Addition" %}</strong>
+                            </div>
+                            <div class="panel-body">
+                                <select data-bind="value: customQueryAddition">
+                                    <option></option>
+                                    {% for query_addition in query_additions %}
+                                        <option value="{{ query_addition.id }}">{{ query_addition.name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        {% endif %}
                         <button type="submit" class="btn btn-success"><i class="fa fa-search"></i> {% trans "Search" %}</button>
                     </form>
                 </div>

--- a/corehq/apps/case_search/tests/test_query_additions.py
+++ b/corehq/apps/case_search/tests/test_query_additions.py
@@ -1,0 +1,40 @@
+from corehq.apps.case_search.models import merge_queries, QueryMergeException
+from django.test import SimpleTestCase
+
+from corehq.util.test_utils import generate_cases
+
+
+class TestQueryMerge(SimpleTestCase):
+    def test_invalid_merge(self):
+        with self.assertRaises(QueryMergeException):
+            merge_queries(
+                {"a": {"b": [1, 2, 3]}},
+                {"a": {"b": "banana"}},
+            )
+        with self.assertRaises(QueryMergeException):
+            merge_queries(
+                {"a": {"b": 1}},
+                {"a": "banana"},
+            )
+
+
+@generate_cases([
+    # base case
+    ({}, {}, {}),
+    # simple merge
+    ({"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
+    # second level merge
+    ({'a': {'b': {'c': 1}}}, {'a': {'b2': 2}}, {'a': {'b': {'c': 1}, 'b2': 2}}),
+    # list merge
+    ({'a': [1, 2]}, {'a': [3]}, {'a': [1, 2, 3]}),
+    # complex multi-branch merge
+    (
+        {"a": {("tuple", "key"): [1, 2]}, "b": [1,2], "c": {"d": 1, "e": 2}},
+        {"a": {("tuple", "key"): [3]}, "c": {"f": {"g": 4}}},
+        {"a": {("tuple", "key"): [1, 2, 3]}, "b": [1, 2], "c": {"d": 1, "e": 2, "f": {"g": 4}}},
+    ),
+], TestQueryMerge)
+def test_merge(self, base_query, addition, expected):
+    new = merge_queries(base_query, addition)
+    self.assertDictEqual(new, expected)
+

--- a/corehq/apps/case_search/tests/test_query_additions.py
+++ b/corehq/apps/case_search/tests/test_query_additions.py
@@ -29,7 +29,7 @@ class TestQueryMerge(SimpleTestCase):
     ({'a': [1, 2]}, {'a': [3]}, {'a': [1, 2, 3]}),
     # complex multi-branch merge
     (
-        {"a": {("tuple", "key"): [1, 2]}, "b": [1,2], "c": {"d": 1, "e": 2}},
+        {"a": {("tuple", "key"): [1, 2]}, "b": [1, 2], "c": {"d": 1, "e": 2}},
         {"a": {("tuple", "key"): [3]}, "c": {"f": {"g": 4}}},
         {"a": {("tuple", "key"): [1, 2, 3]}, "b": [1, 2], "c": {"d": 1, "e": 2, "f": {"g": 4}}},
     ),
@@ -37,4 +37,3 @@ class TestQueryMerge(SimpleTestCase):
 def test_merge(self, base_query, addition, expected):
     new = merge_queries(base_query, addition)
     self.assertDictEqual(new, expected)
-

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -47,7 +47,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         for param in search_params:
             search = search.case_property_query(**param)
         if query_addition:
-            addition = CaseSearchQueryAddition.objects.get(id=query_addition)
+            addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
             new_query = merge_queries(search.raw_query, addition.query_addition)
             search.es_query = new_query
         search_results = search.values()

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -48,7 +48,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             search = search.case_property_query(**param)
         if query_addition:
             addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
-            new_query = merge_queries(search.raw_query, addition.query_addition)
-            search.es_query = new_query
+            new_query = merge_queries(search.get_query(), addition.query_addition)
+            search = search.set_query(new_query)
         search_results = search.values()
         return json_response({'values': search_results})

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -20,6 +20,15 @@ class CaseSearchView(DomainViewMixin, TemplateView):
 
         return self.render_to_response(self.get_context_data())
 
+    def get_context_data(self, **kwargs):
+        context = super(CaseSearchView, self).get_context_data(**kwargs)
+        query_additions = CaseSearchQueryAddition.objects.filter(domain=self.domain)
+        context.update({
+            "query_additions": query_additions,
+        })
+        return context
+
+
     @json_error
     @cls_require_superuser_or_developer
     def post(self, request, *args, **kwargs):
@@ -30,11 +39,16 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         query = json.loads(request.POST.get('q'))
         case_type = query.get('type')
         search_params = query.get('parameters', [])
+        query_addition = query.get("customQueryAddition", None)
         search = CaseSearchES()
         search = search.domain(self.domain).is_closed(False)
         if case_type:
             search = search.case_type(case_type)
         for param in search_params:
             search = search.case_property_query(**param)
+        if query_addition:
+            addition = CaseSearchQueryAddition.objects.get(id=query_addition)
+            new_query = merge_queries(search.raw_query, addition.query_addition)
+            search.es_query = new_query
         search_results = search.values()
         return json_response({'values': search_results})

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -5,7 +5,7 @@ from corehq.apps.domain.views import DomainViewMixin
 from django.http import Http404
 from dimagi.utils.web import json_response
 from django.views.generic import TemplateView
-from corehq.apps.case_search.models import case_search_enabled_for_domain
+from corehq.apps.case_search.models import case_search_enabled_for_domain, CaseSearchQueryAddition, merge_queries
 from corehq.util.view_utils import json_error, BadRequest
 
 

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -294,6 +294,9 @@ class ESQuery(object):
         es.es_query['query']['filtered']['query'] = query
         return es
 
+    def get_query(self):
+        return self.es_query['query']['filtered']['query']
+
     def search_string_query(self, search_string, default_fields=None):
         """Accepts a user-defined search string"""
         return self.set_query(

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -192,16 +192,10 @@ class CaseClaimEndpointTests(TestCase):
         }
 
         query_partial = {
-            "query": {
-                "filtered": {
-                    "query": {
-                        "bool": {
-                            "must": [
-                                new_must_clause
-                            ]
-                        }
-                    }
-                }
+            "bool": {
+                "must": [
+                    new_must_clause
+                ]
             }
         }
 
@@ -227,7 +221,6 @@ class CaseClaimEndpointTests(TestCase):
                             {'term': {'domain.exact': DOMAIN}},
                             {'term': {'type.exact': CASE_TYPE}},
                             {'term': {'closed': False}},
-                            {'match_all': {}},
                             {'match_all': {}}
                         ]
                     },

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase, Client
-from mock import patch, MagicMock
+from mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import post_case_blocks
@@ -212,7 +212,10 @@ class CaseClaimEndpointTests(TestCase):
         client.login(username=USERNAME, password=PASSWORD)
         url = reverse('remote_search', kwargs={'domain': DOMAIN})
         some_case_name = "wut"
-        response = client.get(url, {'name': some_case_name, 'case_type': CASE_TYPE, SEARCH_QUERY_ADDITION_KEY: query_addition.id})
+        response = client.get(
+            url,
+            {'name': some_case_name, 'case_type': CASE_TYPE, SEARCH_QUERY_ADDITION_KEY: query_addition.id}
+        )
 
         self.assertEqual(response.status_code, 200)
 
@@ -239,7 +242,9 @@ class CaseClaimEndpointTests(TestCase):
                                                 'filter': {'term': {'case_properties.key': u'name'}},
                                                 'query': {
                                                     'match': {
-                                                        'case_properties.value': {'query': some_case_name, 'fuzziness': '0'}
+                                                        'case_properties.value': {
+                                                            'query': some_case_name, 'fuzziness': '0'
+                                                        }
                                                     }
                                                 }
                                             }

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -103,7 +103,7 @@ def search(request, domain):
 
     query_addition_debug_details = {}
     try:
-        _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details)
+        search_es = _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details)
     except QueryMergeException as e:
         return _handle_query_merge_exception(request, e)
     try:
@@ -120,11 +120,12 @@ def search(request, domain):
 def _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details):
     if query_addition_id:
         query_addition = CaseSearchQueryAddition.objects.get(id=query_addition_id, domain=domain)
-        query_addition_debug_details['original_query'] = search_es.raw_query
+        query_addition_debug_details['original_query'] = search_es.get_query()
         query_addition_debug_details['query_addition'] = query_addition.query_addition
-        new_query = merge_queries(search_es.raw_query, query_addition.query_addition)
+        new_query = merge_queries(search_es.get_query(), query_addition.query_addition)
         query_addition_debug_details['new_query'] = new_query
-        search_es.es_query = new_query
+        search_es = search_es.set_query(new_query)
+    return search_es
 
 
 def _handle_query_merge_exception(request, exception):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -103,7 +103,9 @@ def search(request, domain):
 
     query_addition_debug_details = {}
     try:
-        search_es = _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details)
+        search_es = _add_case_search_addition(
+            request, domain, search_es, query_addition_id, query_addition_debug_details
+        )
     except QueryMergeException as e:
         return _handle_query_merge_exception(request, e)
     try:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -102,7 +102,7 @@ def search(request, domain):
         search_es = search_es.case_property_query(key, value, fuzzy=(key in fuzzies))
 
     query_addition_debug_details = {}
-    _add_case_search_addition(request, search_es, query_addition_id, query_addition_debug_details)
+    _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details)
 
     try:
         results = search_es.values()
@@ -117,9 +117,9 @@ def search(request, domain):
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml")
 
-def _add_case_search_addition(request, search_es, query_addition_id, query_addition_debug_details):
+def _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details):
     if query_addition_id:
-        query_addition = CaseSearchQueryAddition.objects.get(id=query_addition_id)
+        query_addition = CaseSearchQueryAddition.objects.get(id=query_addition_id, domain=domain)
         query_addition_debug_details['original_query'] = search_es.raw_query
         query_addition_debug_details['query_adition'] = query_addition.query_addition
         try:


### PR DESCRIPTION
spec: https://docs.google.com/document/d/1MKllkHZ6JlxhfqZLZKWAnfmlA3oUqCLOc7iKzxFTzdY/edit#heading=h.k5pky76mwwon

This PR allows super users to create advanced [case search](https://confluence.dimagi.com/display/ccinternal/Remote+Case+Search+and+Claim) queries by merging arbitrary static json into the elasticsearch query. This allows for more advanced queries than are configurable in the UI. These query additions are created in the django admin interface, and added to a given module through its "default search property" UI, by specifying a property of "commcare_custom_search_query" and the `CaseSearchQueryAddition` instance's id as the value.

@proteusvacuum 
cc @nickpell 