### PR TITLE
less aggresive case type rename

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -452,6 +452,7 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
             old_case_type = module["case_type"]
             module["case_type"] = case_type
 
+            # rename other reference to the old case type
             other_careplan_modules = []
             all_advanced_modules = []
             modules_with_old_case_type_exist = False

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -444,7 +444,11 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
     resp = {'update': {}, 'corrections': {}}
     if should_edit("case_type"):
         case_type = request.POST.get("case_type", None)
-        if not case_type or is_valid_case_type(case_type, module):
+        if case_type == USERCASE_TYPE and not isinstance(module, AdvancedModule):
+            return HttpResponseBadRequest('"{}" is a reserved case type'.format(USERCASE_TYPE))
+        elif case_type and not is_valid_case_type(case_type, module):
+            return HttpResponseBadRequest("case type is improperly formatted")
+        else:
             old_case_type = module["case_type"]
             module["case_type"] = case_type
 
@@ -476,10 +480,6 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
                             if action.case_type == old_case_type:
                                 action.case_type = case_type
 
-        elif case_type == USERCASE_TYPE and not isinstance(module, AdvancedModule):
-            return HttpResponseBadRequest('"{}" is a reserved case type'.format(USERCASE_TYPE))
-        else:
-            return HttpResponseBadRequest("case type is improperly formatted")
     if should_edit("put_in_root"):
         module["put_in_root"] = json.loads(request.POST.get("put_in_root"))
     if should_edit("display_style"):


### PR DESCRIPTION
Only change the case type of an advanced form action if:
* action is a load action and reference the edited module
* action is an open action in a form belonging to the edited module
  or there are no modules with the old case type in the app