### PR TITLE
Chunk es query

### DIFF
--- a/corehq/apps/es/tests/test_utils.py
+++ b/corehq/apps/es/tests/test_utils.py
@@ -6,58 +6,49 @@ from corehq.apps.es.forms import FormES
 
 
 QUERY = {
-  'sort': [
-    {
-      'received_on': {
-        'order': 'asc'
-      }
-    }
-  ],
-  'query': {
-    'filtered': {
-      'filter': {
-        'and': [
-          {
-            'term': {
-              'domain.exact': u'aspace'
-            }
-          },
-          {
-            'term': {
-              'app_id': u'09fe257a198ad1ae109ed627ed847ee9'
-            }
-          },
-          {
-            'term': {
-              'xmlns.exact': u'http://openrosa.org/formdesigner/11FAC65A-F2CD-427F-A870-CF126336AAB5'
-            }
-          },
-          {
-            'or': {
-              'terms': {
-                'form.meta.userID': [
-                  u'51cd680c0bd1c21bb5e63dab99748248',
-                  u'38b858717522c898e37f6239eda0ba5a'
-                ]
-              }
-            },
-          },
-          {
-            'range': {
-              'received_on': {
-                'lt': '2017-01-28T00:00:00+07:00',
-                'gte': '2015-01-27T00:00:00+07:00'
-              }
-            }
-          }
-        ]
-      },
-      'query': {
-            'match_all': {
+    'sort': [{
+        'received_on': {
+            'order': 'asc'
         }
-      }
+    }],
+    'query': {
+        'filtered': {
+            'filter': {
+                'and': [{
+                    'term': {
+                        'domain.exact': 'aspace'
+                    }
+                }, {
+                    'term': {
+                        'app_id': '09fe257a198ad1ae109ed627ed847ee9'
+                    }
+                }, {
+                    'term': {
+                        'xmlns.exact': 'http://openrosa.org/formdesigner/11FAC65A-F2CD-427F-A870-CF126336AAB5'
+                    }
+                }, {
+                    'or': {
+                        'terms': {
+                            'form.meta.userID': [
+                                '51cd680c0bd1c21bb5e63dab99748248',
+                                '38b858717522c898e37f6239eda0ba5a'
+                            ]
+                        }
+                    },
+                }, {
+                    'range': {
+                        'received_on': {
+                            'lt': '2017-01-28T00:00:00+07:00',
+                            'gte': '2015-01-27T00:00:00+07:00'
+                        }
+                    }
+                }]
+            },
+            'query': {
+                'match_all': {}
+            }
+        }
     }
-  }
 }
 
 

--- a/corehq/apps/es/tests/test_utils.py
+++ b/corehq/apps/es/tests/test_utils.py
@@ -1,0 +1,94 @@
+from django.test import SimpleTestCase
+
+from corehq.util.test_utils import generate_cases
+from corehq.apps.es.utils import chunk_query
+from corehq.apps.es.forms import FormES
+
+
+QUERY = {
+  'sort': [
+    {
+      'received_on': {
+        'order': 'asc'
+      }
+    }
+  ],
+  'query': {
+    'filtered': {
+      'filter': {
+        'and': [
+          {
+            'term': {
+              'domain.exact': u'aspace'
+            }
+          },
+          {
+            'term': {
+              'app_id': u'09fe257a198ad1ae109ed627ed847ee9'
+            }
+          },
+          {
+            'term': {
+              'xmlns.exact': u'http://openrosa.org/formdesigner/11FAC65A-F2CD-427F-A870-CF126336AAB5'
+            }
+          },
+          {
+            'or': {
+              'terms': {
+                'form.meta.userID': [
+                  u'51cd680c0bd1c21bb5e63dab99748248',
+                  u'38b858717522c898e37f6239eda0ba5a'
+                ]
+              }
+            },
+          },
+          {
+            'range': {
+              'received_on': {
+                'lt': '2017-01-28T00:00:00+07:00',
+                'gte': '2015-01-27T00:00:00+07:00'
+              }
+            }
+          }
+        ]
+      },
+      'query': {
+            'match_all': {
+        }
+      }
+    }
+  }
+}
+
+
+class TestChunkQuery(SimpleTestCase):
+    '''
+    Tests the ability to chunk ES queries based on a term
+    '''
+
+    def test_chunking_size(self):
+        form_es_query = FormES()
+        form_es_query.es_query = QUERY
+
+        queries = chunk_query(form_es_query, 'form.meta.userID', chunk_size=1)
+        ids = queries[0].es_query['query']['filtered']['filter']['and'][3]['or']['terms']['form.meta.userID']
+        self.assertEqual(len(ids), 1)
+
+        ids = queries[1].es_query['query']['filtered']['filter']['and'][3]['or']['terms']['form.meta.userID']
+        self.assertEqual(len(ids), 1)
+
+        queries = chunk_query(form_es_query, 'form.meta.userID', chunk_size=10)
+        ids = queries[0].es_query['query']['filtered']['filter']['and'][3]['or']['terms']['form.meta.userID']
+        self.assertEqual(len(ids), 2)
+
+
+@generate_cases([
+    ([QUERY, 'form.meta.userID'], 2),
+    ([QUERY, 'xmlns.exact'], 1),
+    ([QUERY, 'does-not-exist'], 1),
+], TestChunkQuery)
+def test_chunk_query(self, chunk_query_args, expected_number_of_queries):
+    form_es_query = FormES()
+    form_es_query.es_query = chunk_query_args[0]
+    chunk_query_args[0] = form_es_query
+    self.assertEqual(len(chunk_query(*chunk_query_args, chunk_size=1)), expected_number_of_queries)

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -38,6 +38,20 @@ def flatten_field_dict(results, fields_property='fields'):
 
 
 def chunk_query(query, term, chunk_size=1000):
+    '''
+    This takes a ESQuery and a term and then chunks the query into identical queries
+    except having chunked the term. For example, if you have a query that has 100,000
+    queries and the chunk_size is 1000, it will return 100 queries.
+
+    :param query: An ESQuery
+    :param term: A term that you wish to be chunked, such as 'form.meta.userID'
+    :param chunk_size: The chunk size
+
+    :return: If it cannot find anything to chunk or the chunked term is not an array,
+        it will just return the same query wrapped in an array. Otherwise, it will return
+        an array of ESQuerys with the chunked term.
+
+    '''
     query = deepcopy(query)
 
     path_to_term = _chunk_query([], None, query.es_query, term)

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -69,6 +69,7 @@ FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
 MAX_EXPORTABLE_ROWS = 100000
 CASE_SCROLL_SIZE = 10000
+USER_ID_CHUNK_SIZE = 1000
 
 # When a question is missing completely from a form/case this should be the value
 MISSING_VALUE = '---'

--- a/corehq/apps/export/tests/test_export_filters.py
+++ b/corehq/apps/export/tests/test_export_filters.py
@@ -5,7 +5,7 @@ from elasticsearch.exceptions import ConnectionError
 
 from corehq.apps.export.esaccessors import get_case_export_base_query
 from corehq.apps.export.export import (
-    _get_export_documents,
+    _iter_export_documents,
 )
 from corehq.apps.export.filters import (
     GroupOwnerFilter,
@@ -104,7 +104,7 @@ class ExportFilterResultTest(SimpleTestCase):
     def test_filter_combination(self):
         owner_filter = OwnerFilter(DEFAULT_USER)
         closed_filter = IsClosedFilter(False)
-        doc_generator = _get_export_documents(
+        doc_generator = _iter_export_documents(
             CaseExportInstance(domain=DOMAIN, case_type=DEFAULT_CASE_TYPE),
             [owner_filter, closed_filter]
         )
@@ -112,11 +112,11 @@ class ExportFilterResultTest(SimpleTestCase):
 
     def test_group_filters(self):
         group_filter = GroupOwnerFilter(self.group_id)
-        doc_generator = _get_export_documents(
+        doc_generator = _iter_export_documents(
             CaseExportInstance(domain=DOMAIN, case_type=DEFAULT_CASE_TYPE),
             [group_filter]
         )
-        self.assertEqual(2, len([x for x in doc_generator]))
+        self.assertEqual(2, len([x for chunk in doc_generator for x in chunk]))
 
     def test_get_case_export_base_query(self):
         q = get_case_export_base_query(DOMAIN, DEFAULT_CASE_TYPE)
@@ -128,7 +128,7 @@ class ExportFilterResultTest(SimpleTestCase):
         Confirm that the FormSubmittedByFilter works when None is one of the
         arguments.
         """
-        doc_generator = _get_export_documents(
+        doc_generator = _iter_export_documents(
             FormExportInstance(domain=DOMAIN, app_id=DEFAULT_APP_ID, xmlns=DEFAULT_XMLNS),
             [FormSubmittedByFilter([uuid.uuid4().hex, None, uuid.uuid4().hex])]
         )


### PR DESCRIPTION
@esoergel @NoahCarnahan curious what you guys think of this strategy. It's fairly hacky, but this will chunk your ES query by a term. This way if you're icds and have 100,000 user_ids, we don't insert all of them in the actual query. This doesn't address the problem of loading 100,000 user_ids into memory, but should help with ReadTimeouts when querying ES.

cc: @snopoke @emord 