### PR TITLE
Enterprise Plan gets report builder

### DIFF
--- a/corehq/apps/accounting/bootstrap/config/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/bootstrap/config/cchq_software_plan_bootstrap.py
@@ -47,7 +47,7 @@ BOOTSTRAP_CONFIG = {
             FeatureType.SMS: dict(monthly_limit=0),
         }
     },
-    (SoftwarePlanEdition.ENTERPRISE, False, False): {
+    (SoftwarePlanEdition.ENTERPRISE, False, True): {
         'role': 'enterprise_plan_v0',
         'product_rate': dict(monthly_fee=Decimal('0.00')),
         'feature_rates': {
@@ -98,7 +98,7 @@ BOOTSTRAP_CONFIG_TESTING = {
             FeatureType.SMS: dict(monthly_limit=0),
         }
     },
-    (SoftwarePlanEdition.ENTERPRISE, False, False): {
+    (SoftwarePlanEdition.ENTERPRISE, False, True): {
         'role': 'enterprise_plan_v0',
         'product_rate': dict(monthly_fee=Decimal('0.00')),
         'feature_rates': {


### PR DESCRIPTION
I haven't been able to reproduced locally (and I'm not sure why) so I don't know whether this PR resolves the problem with [Enterprise Plan customers](https://www.commcarehq.org/a/airstanzania/settings/project/subscription/) not being able to view [report builder-built reports](https://www.commcarehq.org/a/airstanzania/reports/builder/subscribe/pricing/). 

This PR doesn't address the issue with Pro Plan customers [with report builder](https://www.commcarehq.org/a/tz-lad/settings/project/subscription/), who also can't view [their reports](https://www.commcarehq.org/a/tz-lad/reports/builder/subscribe/activating_subscription/). Is that because they have more than 5, @nickpell?

I assume this is related to PR #14638 

@nickpell cc @NoahCarnahan @proteusvacuum 
