### PR TITLE
excluding mikolo from nimbus form validation

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1024,7 +1024,8 @@ NIMBUS_FORM_VALIDATION = PredictablyRandomToggle(
     [NAMESPACE_DOMAIN],
     randomness=1.0,
     always_disabled=[
-        'icrc-almanach'
+        'icrc-almanach',
+        'mikolo'
     ]
 )
 


### PR DESCRIPTION
@orangejenny 
Formplayer was crashing and burning (out of memory issues) so this unblocks ismaila's app building.