### PR TITLE
Add new properties for building UCRs in place

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -65,6 +65,9 @@ class DataSourceBuildInformation(DocumentSchema):
     finished = BooleanProperty(default=False)
     # Start time of the most recent build SQL table celery task.
     initiated = DateTimeProperty()
+    # same as previous attributes but used for rebuilding tables in place
+    finished_in_place = BooleanProperty(default=False)
+    initiated_in_place = DateTimeProperty()
 
 
 class DataSourceMeta(DocumentSchema):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -67,14 +67,12 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None):
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         adapter = get_indicator_adapter(config, can_handle_laboratory=True)
         if not id_is_static(indicator_config_id):
-            # Save the start time now in case anything goes wrong. This way we'll be
-            # able to see if the rebuild started a long time ago without finishing.
-            config.meta.build.initiated = datetime.datetime.utcnow()
-            config.meta.build.finished = False
+            config.meta.build.initiated_in_place = datetime.datetime.utcnow()
+            config.meta.build.finished_in_place = False
             config.save()
 
         adapter.build_table()
-        _iteratively_build_table(config)
+        _iteratively_build_table(config, in_place=True)
 
 
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True, acks_late=True)
@@ -94,7 +92,7 @@ def resume_building_indicators(indicator_config_id, initiated_by=None):
             _iteratively_build_table(config, last_id, resume_helper)
 
 
-def _iteratively_build_table(config, last_id=None, resume_helper=None):
+def _iteratively_build_table(config, last_id=None, resume_helper=None, in_place=False):
     resume_helper = resume_helper or DataSourceResumeHelper(config)
     indicator_config_id = config._id
 
@@ -113,15 +111,22 @@ def _iteratively_build_table(config, last_id=None, resume_helper=None):
 
     if not id_is_static(indicator_config_id):
         resume_helper.clear_ids()
-        config.meta.build.finished = True
+        if in_place:
+            config.meta.build.finished_in_place = True
+        else:
+            config.meta.build.finished = True
         try:
             config.save()
         except ResourceConflict:
             current_config = DataSourceConfiguration.get(config._id)
             # check that a new build has not yet started
-            if config.meta.build.initiated == current_config.meta.build.initiated:
-                current_config.meta.build.finished = True
-                current_config.save()
+            if in_place:
+                if config.meta.build.initiated_in_place == current_config.meta.build.initiated_in_place:
+                    current_config.meta.build.finished_in_place = True
+            else:
+                if config.meta.build.initiated == current_config.meta.build.initiated:
+                    current_config.meta.build.finished = True
+            current_config.save()
         adapter = get_indicator_adapter(config, raise_errors=True, can_handle_laboratory=True)
         adapter.after_table_build()
 


### PR DESCRIPTION
Adding these properties so that https://github.com/dimagi/commcare-hq/blob/je/ucr-rebuild-inplace/corehq/apps/userreports/templates/userreports/configurable_report.html#L144-L145 doesn't show as a warning on data sources that are currenlty being rebuilt

@benrudolph @snopoke 