### PR TITLE
Add endpoint to retrieve a list of apps for installation on phone

### DIFF
--- a/corehq/apps/app_manager/tests/data/list_apps/list_apps.xml
+++ b/corehq/apps/app_manager/tests/data/list_apps/list_apps.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apps>
+  <app profile="http://onering.com/a/rohan/apps/download/None/profile.xml?latest=true" domain="rohan" name="Untitled Application" environment="production" media-profile="http://onering.com/a/rohan/apps/download/None/media_profile.xml?latest=true"/>
+  <app profile="http://onering.com/a/angmar/apps/download/None/profile.xml?latest=true" domain="angmar" name="Untitled Application" environment="production" media-profile="http://onering.com/a/angmar/apps/download/None/media_profile.xml?latest=true"/>
+  <app profile="http://onering.com/a/mordor/apps/download/None/profile.xml?latest=true" domain="mordor" name="Untitled Application" environment="production" media-profile="http://onering.com/a/mordor/apps/download/None/media_profile.xml?latest=true"/>
+</apps>

--- a/corehq/apps/app_manager/tests/data/list_apps/list_apps.xml
+++ b/corehq/apps/app_manager/tests/data/list_apps/list_apps.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <apps>
-  <app profile="http://onering.com/a/rohan/apps/download/None/profile.xml?latest=true" domain="rohan" name="Untitled Application" environment="production" media-profile="http://onering.com/a/rohan/apps/download/None/media_profile.xml?latest=true"/>
-  <app profile="http://onering.com/a/angmar/apps/download/None/profile.xml?latest=true" domain="angmar" name="Untitled Application" environment="production" media-profile="http://onering.com/a/angmar/apps/download/None/media_profile.xml?latest=true"/>
-  <app profile="http://onering.com/a/mordor/apps/download/None/profile.xml?latest=true" domain="mordor" name="Untitled Application" environment="production" media-profile="http://onering.com/a/mordor/apps/download/None/media_profile.xml?latest=true"/>
+  <app profile="http://onering.com/a/rohan/apps/download/app_id/profile.xml?latest=true" domain="rohan" name="Untitled Application" environment="production" media-profile="http://onering.com/a/rohan/apps/download/app_id/media_profile.xml?latest=true"/>
+  <app profile="http://onering.com/a/angmar/apps/download/app_id/profile.xml?latest=true" domain="angmar" name="Untitled Application" environment="production" media-profile="http://onering.com/a/angmar/apps/download/app_id/media_profile.xml?latest=true"/>
+  <app profile="http://onering.com/a/mordor/apps/download/app_id/profile.xml?latest=true" domain="mordor" name="Untitled Application" environment="production" media-profile="http://onering.com/a/mordor/apps/download/app_id/media_profile.xml?latest=true"/>
 </apps>

--- a/corehq/apps/app_manager/tests/test_list_apps_view.py
+++ b/corehq/apps/app_manager/tests/test_list_apps_view.py
@@ -17,6 +17,7 @@ class ListAppsTest(SimpleTestCase, TestXmlMixin):
         self.factories = {domain: AppFactory(domain, build_version='2.9.0') for domain in self.domains}
         for factory in self.factories.itervalues():
             factory.new_basic_module('register', 'orc')
+            factory.app._id = 'app_id'  # force an ID so we don't have to save the apps
 
     @override_settings(BASE_ADDRESS='onering.com')
     @override_settings(SERVER_ENVIRONMENT='production')

--- a/corehq/apps/app_manager/tests/test_list_apps_view.py
+++ b/corehq/apps/app_manager/tests/test_list_apps_view.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+
+from corehq.apps.app_manager.views.phone import get_app_list_xml
+
+
+class ListAppsTest(SimpleTestCase, TestXmlMixin):
+    file_path = ('data', 'list_apps')
+
+    def setUp(self):
+        super(ListAppsTest, self).setUp()
+
+        self.domains = ['angmar', 'rohan', 'mordor']
+        self.factories = {domain: AppFactory(domain, build_version='2.9.0') for domain in self.domains}
+        for factory in self.factories.itervalues():
+            factory.new_basic_module('register', 'orc')
+
+    @override_settings(BASE_ADDRESS='onering.com')
+    @override_settings(SERVER_ENVIRONMENT='production')
+    def test_get_app_list_xml(self):
+        self.assertXmlEqual(
+            self.get_xml('list_apps'),
+            get_app_list_xml([factory.app for factory in self.factories.itervalues()]).serializeDocument()
+        )

--- a/corehq/apps/app_manager/views/phone.py
+++ b/corehq/apps/app_manager/views/phone.py
@@ -1,0 +1,70 @@
+from django.http import HttpResponse
+from eulxml.xmlmap import XmlObject
+
+from django.conf import settings
+
+from corehq.apps.domain.auth import basicauth
+from corehq.apps.domain.decorators import check_lockout
+from corehq.apps.users.models import CouchUser
+from corehq.apps.app_manager.dbaccessors import get_built_app_ids, get_app
+from corehq.apps.app_manager.suite_xml.xml_models import (
+    StringField,
+    IntegerField,
+    NodeListField,
+)
+
+
+class App(XmlObject):
+    ROOT_NAME = 'app'
+
+    domain = StringField('@domain')
+    name = StringField('@name')
+    environment = StringField('@environment')
+    version = IntegerField('@version')
+    media_profile = StringField('@media-profile')
+    profile = StringField('@profile')
+
+
+class AppList(XmlObject):
+    ROOT_NAME = 'apps'
+    apps = NodeListField('app', App)
+
+
+@check_lockout
+@basicauth()
+def list_apps(request):
+    """Return a list of all apps available to the user
+
+    Used by the phone for app installation
+    """
+    couch_user = CouchUser.from_django_user(request.user)
+    return HttpResponse(
+        get_app_list_xml(
+            get_all_latest_builds_for_user(couch_user)
+        ).serializeDocument(),
+        content_type='application/xml',
+    )
+
+
+def get_all_latest_builds_for_user(user):
+    app_ids = [
+        (domain, app_id)
+        for domain in user.domains
+        for app_id in get_built_app_ids(domain)
+    ]
+    return [get_app(app_id[0], app_id[1], latest=True, target="release") for app_id in app_ids]
+
+
+def get_app_list_xml(apps):
+    app_xml = [
+        App(
+            domain=app.domain,
+            name=app.name,
+            version=app.version,
+            media_profile=app.media_profile_url,
+            profile=app.profile_url,
+            environment=settings.SERVER_ENVIRONMENT,
+        )
+        for app in apps
+    ]
+    return AppList(apps=app_xml)

--- a/urls.py
+++ b/urls.py
@@ -10,6 +10,7 @@ from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.utils import legacy_domain_re
 
 from django.contrib import admin
+from corehq.apps.app_manager.views.phone import list_apps
 from corehq.apps.domain.views import ProBonoStaticView, logo
 from corehq.apps.hqwebapp.views import eula, apache_license, bsd_license, product_agreement, cda, unsubscribe
 from corehq.apps.reports.views import ReportNotificationUnsubscribeView
@@ -151,6 +152,7 @@ urlpatterns = [
     url(r'^unsubscribe_report/(?P<scheduled_report_id>[\w-]+)/'
         r'(?P<user_email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/(?P<scheduled_report_secret>[\w-]+)/',
         ReportNotificationUnsubscribeView.as_view(), name=ReportNotificationUnsubscribeView.urlname),
+    url(r'^phone/list_apps', list_apps, name="list_accessible_apps")
 ] + LOCAL_APP_URLS
 
 if settings.ENABLE_PRELOGIN_SITE:


### PR DESCRIPTION
Send a list of apps accessible to a particular user to the phone for use in installation.

We'll be using this so that people can download any app that is accessible to them immediately after downloading CommCare from the play store.

@amstone326 
#hackathon

cc: @kaapstorm @czue 