### PR TITLE
Kill app diff feature flag

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -319,16 +319,22 @@ def get_all_app_ids(domain):
     return [result['id'] for result in results]
 
 
-def get_all_built_app_ids_and_versions(domain):
+def get_all_built_app_ids_and_versions(domain, app_id=None):
     """
     Returns a list of all the app_ids ever built and their version.
     [[AppBuildVersion(app_id, build_id, version)], ...]
+    If app_id is provided, limit to bulds for that app.
     """
     from .models import Application
+    startkey = [domain]
+    endkey = [domain, {}]
+    if app_id:
+        startkey = [domain, app_id]
+        endkey = [domain, app_id, {}]
     results = Application.get_db().view(
         'app_manager/saved_app',
-        startkey=[domain],
-        endkey=[domain, {}],
+        startkey=startkey,
+        endkey=endkey,
         include_docs=False,
     ).all()
     return map(lambda result: AppBuildVersion(

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -7,7 +7,7 @@ from django.http import Http404
 
 from corehq.apps.es import AppES
 
-AppBuildVersion = namedtuple('AppBuildVersion', ['app_id', 'build_id', 'version'])
+AppBuildVersion = namedtuple('AppBuildVersion', ['app_id', 'build_id', 'version', 'comment'])
 
 
 @quickcache(['domain'], timeout=1 * 60 * 60)
@@ -322,7 +322,7 @@ def get_all_app_ids(domain):
 def get_all_built_app_ids_and_versions(domain, app_id=None):
     """
     Returns a list of all the app_ids ever built and their version.
-    [[AppBuildVersion(app_id, build_id, version)], ...]
+    [[AppBuildVersion(app_id, build_id, version, comment)], ...]
     If app_id is provided, limit to bulds for that app.
     """
     from .models import Application
@@ -335,12 +335,13 @@ def get_all_built_app_ids_and_versions(domain, app_id=None):
         'app_manager/saved_app',
         startkey=startkey,
         endkey=endkey,
-        include_docs=False,
+        include_docs=True,
     ).all()
     return map(lambda result: AppBuildVersion(
         app_id=result['key'][1],
         build_id=result['id'],
         version=result['key'][2],
+        comment=result['value']['build_comment'],
     ), results)
 
 

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -205,7 +205,6 @@ hqDefine('app_manager/js/releases.js', function () {
         self.deployAnyway = {};
         self.currentAppVersion = ko.observable(self.options.currentAppVersion);
         self.lastAppVersion = ko.observable();
-        self.selectingVersion = ko.observable("");
 
         self.download_modal = $(self.options.download_modal_id);
         self.async_downloader = new AsyncDownloader(self.download_modal);

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/releases.html
@@ -208,7 +208,7 @@
                         saveValueName: 'comment',
                         errorMessage:'{% trans "Error updating comment.  Please try again."|escapejs %}',
                     "></inline-edit>
-                    {% if request|toggle_enabled:"VIEW_BUILD_SOURCE" %}
+                    {% if request.user.is_superuser %}
                         <h6>
                             {% blocktrans %}
                                 View

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/releases.html
@@ -20,14 +20,12 @@
             fetch: '{% url "paginate_releases" domain app.id %}',
             delete: '{% url "delete_copy" domain app.id %}',
             cloudcare: '{% url "cloudcare_get_app" domain '___' %}',
-            compare: '{% url "diff" domain '___' '___' %}',
             jad: '{% url "download_jad" domain '___' %}',
             jar: '{% url "download_jar" domain '___' %}',
             ccz: '{% url "download_ccz" domain '___' %}',
             odk: '{% url "odk_install" domain '___' %}',
             odk_media: '{% url "odk_media_install" domain '___' %}',
             source: '{% url "download_index" domain '___' %}',
-            summary: '{% url "app_summary" domain '___' %}',
             release: '{% url "release_build" domain app.id '___' %}',
             newBuild: '{% url "save_copy" domain app.id %}',
             revertBuild: '{% url "revert_to_copy" domain app.id %}',
@@ -208,39 +206,6 @@
                         saveValueName: 'comment',
                         errorMessage:'{% trans "Error updating comment.  Please try again."|escapejs %}',
                     "></inline-edit>
-                    {% if request.user.is_superuser %}
-                        <h6>
-                            {% blocktrans %}
-                                View
-                                <a data-bind="attr: {href: $root.url('summary', id)}">app summary</a>
-                                or
-                                <a data-bind="attr: {href: $root.url('source', id)}" class="view-source-files-link">source files</a>
-                                <br />
-                                <a href="#" class="hide" data-bind="click: function() {
-                                        $root.selectingVersion(id());
-                                    }, visible: !$root.selectingVersion(),
-                                    css: {hide: false}
-                                ">
-                                    Compare with another version
-                                </a>
-                                <a href="#" class="hide" data-bind="
-                                    visible: $root.selectingVersion() === id(),
-                                    click: function() {$root.selectingVersion('')},
-                                    css: {hide: false}
-                                ">
-                                    Cancel
-                                </a>
-                                <a href="#" class="btn btn-xs btn-success hide"
-                                   data-bind="
-                                        attr: {href: $root.url('compare', $root.selectingVersion(), id())},
-                                        visible: $root.selectingVersion() && $root.selectingVersion() != id(),
-                                        css: {hide: false}
-                                    ">
-                                    Compare
-                                </a>
-                            {% endblocktrans %}
-                        </h6>
-                    {% endif %}
                 </td>
                 {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <td>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/releases_deploy_modal.html
@@ -299,6 +299,15 @@
                         </div>
                     </div>
                 {% endif %}
+                {% if request.user.is_superuser %}
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <a data-bind="attr: {href: $root.url('source', id)}">
+                                {% trans 'View Source Files' %}
+                            </a>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         {% endif %}
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
@@ -5,7 +5,7 @@
 
 {% block page_content %}
     {% registerurl 'diff' app.domain app.id '---' %}
-    {% initial_page_data 'version_map' version_map %}
+    {% initial_page_data 'built_versions' built_versions %}
     {% initial_page_data 'current_version' app.built_with.build_number %}
 
     <p class="form-inline" id="compare-form">
@@ -65,6 +65,12 @@
 
 {% block stylesheets %}{{ block.super }}
     <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}" />
+    <style type="text/css">
+        /* Limit atwho dropdown width */
+        .atwho-view {
+            max-width: 300px;
+        }
+    </style>
 {% endblock %}
 
 {% block js-inline %}
@@ -75,20 +81,33 @@
             $(this).parents('tr').next('tr').toggleClass("hide");
         });
 
-        var version_map = hqImport('hqwebapp/js/initial_page_data.js').get('version_map'),
-            current_version = hqImport('hqwebapp/js/initial_page_data.js').get('current_version'),
+        var current_version = hqImport('hqwebapp/js/initial_page_data.js').get('current_version'),
+            built_versions = hqImport('hqwebapp/js/initial_page_data.js').get('built_versions'),
             $form = $("#compare-form"),
-            $input = $form.find("input"),
-            versions = _.without(_.keys(version_map), String(current_version));
+            $input = $form.find("input");
+
+        built_versions = _.sortBy(_.filter(built_versions, function(v) {
+            return v.version != current_version;
+        }), function(v) { return parseInt(v.version); }).reverse();
+        version_map = _.indexBy(built_versions, 'version');
 
         $input.atwho({
             at: "",
-            data: _.sortBy(versions, function(v) { return parseInt(v); }).reverse(),
+            data: _.map(built_versions, function(v) {
+                return {
+                    id: v.version,
+                    name: v.version + (v.comment ? " (" + v.comment + ")" : ""),
+                };
+            }),
             limit: Infinity,
             maxLen: Infinity,
             suffix: "",
             tabSelectsMatch: false,
             callbacks: {
+                beforeInsert: function(value, $li) {
+                    value = value.split(/\s+/);
+                    return value[0];
+                },
                 filter: function(query, data, searchKey) {
                     return _.filter(data, function(item) {
                         return item.name.indexOf(query) !== -1;
@@ -109,7 +128,7 @@
                 alert(version + " is not a valid version");
                 return;
             }
-            window.location = hqImport('hqwebapp/js/urllib.js').reverse('diff', version_map[version]);
+            window.location = hqImport('hqwebapp/js/urllib.js').reverse('diff', version_map[version].build_id);
         });
     });
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
@@ -57,7 +57,13 @@
     {% compress js %}
         <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
         <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
+        <script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
+        <script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
     {% endcompress %}
+{% endblock %}
+
+{% block stylesheets %}{{ block.super }}
+    <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}" />
 {% endblock %}
 
 {% block js-inline %}
@@ -69,9 +75,30 @@
         });
 
         var version_map = hqImport('hqwebapp/js/initial_page_data.js').get('version_map');
-        var $form = $("#compare-form");
+        var $form = $("#compare-form"),
+            $input = $form.find("input");
+
+        $input.atwho({
+            at: "",
+            data: _.sortBy(_.keys(version_map), function(v) { return parseInt(v); }).reverse(),
+            limit: Infinity,
+            maxLen: Infinity,
+            suffix: "",
+            tabSelectsMatch: false,
+            callbacks: {
+                filter: function(query, data, searchKey) {
+                    return _.filter(data, function(item) {
+                        return item.name.indexOf(query) !== -1;
+                    });
+                },
+                matcher: function(flag, subtext, should_startWithSpace) {
+                    return $input.val();
+                },
+            }
+        });
+
         $form.find("button").click(function() {
-            var version = $form.find("input").val();
+            var version = $input.val();
             if (!version) {
                 alert("Please enter a version to compare");
                 return;

--- a/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
@@ -1,11 +1,23 @@
 {% extends "style/full_screen.html" %}
 
+{% load hq_shared_tags %}
+{% load compress %}
+
 {% block page_content %}
-    <p>
+    {% registerurl 'diff' app.domain app.id '---' %}
+    {% initial_page_data 'version_map' version_map %}
+
+    <p class="form-inline" id="compare-form">
       See
       <a href="{% url "view_app" app.domain app.copy_of|default_if_none:app.get_id %}">
         current app
       </a> for the latest work in progress.
+
+    {% if not other_app %}
+        Or compare with another version:
+        <input type="text" class="form-control input-sm" placeholder="version" />
+        <button class="btn btn-default btn-sm">Compare</button>
+    {% endif %}
     </p>
 
     {% block downloads %}{% endblock %}
@@ -41,12 +53,33 @@
     {% block post_files %}{% endblock %}
 {% endblock page_content %}
 
+{% block js %}{{ block.super }}
+    {% compress js %}
+        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
+    {% endcompress %}
+{% endblock %}
+
 {% block js-inline %}
 <script>
     $(function(){
         $('.toggle-next').click(function(e){
             e.preventDefault();
             $(this).parents('tr').next('tr').toggleClass("hide");
+        });
+
+        var version_map = hqImport('hqwebapp/js/initial_page_data.js').get('version_map');
+        var $form = $("#compare-form");
+        $form.find("button").click(function() {
+            var version = $form.find("input").val();
+            if (!version) {
+                alert("Please enter a version to compare");
+                return;
+            } else if (!version_map[version]) {
+                alert(version + " is not a valid version");
+                return;
+            }
+            window.location = hqImport('hqwebapp/js/urllib.js').reverse('diff', version_map[version]);
         });
     });
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
@@ -6,6 +6,7 @@
 {% block page_content %}
     {% registerurl 'diff' app.domain app.id '---' %}
     {% initial_page_data 'version_map' version_map %}
+    {% initial_page_data 'current_version' app.built_with.build_number %}
 
     <p class="form-inline" id="compare-form">
       See
@@ -74,13 +75,15 @@
             $(this).parents('tr').next('tr').toggleClass("hide");
         });
 
-        var version_map = hqImport('hqwebapp/js/initial_page_data.js').get('version_map');
-        var $form = $("#compare-form"),
-            $input = $form.find("input");
+        var version_map = hqImport('hqwebapp/js/initial_page_data.js').get('version_map'),
+            current_version = hqImport('hqwebapp/js/initial_page_data.js').get('current_version'),
+            $form = $("#compare-form"),
+            $input = $form.find("input"),
+            versions = _.without(_.keys(version_map), String(current_version));
 
         $input.atwho({
             at: "",
-            data: _.sortBy(_.keys(version_map), function(v) { return parseInt(v); }).reverse(),
+            data: _.sortBy(versions, function(v) { return parseInt(v); }).reverse(),
             limit: Infinity,
             maxLen: Infinity,
             suffix: "",

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
@@ -216,7 +216,7 @@
                         saveValueName: 'comment',
                         errorMessage:'{% trans "Error updating comment.  Please try again."|escapejs %}',
                     "></inline-edit-v2>
-                    {% if request|toggle_enabled:"VIEW_BUILD_SOURCE" %}
+                    {% if request.user.is_superuser %}
                         <h6>
                             {% blocktrans %}
                                 View

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
@@ -20,14 +20,12 @@
             fetch: '{% url "paginate_releases" domain app.id %}',
             delete: '{% url "delete_copy" domain app.id %}',
             cloudcare: '{% url "cloudcare_get_app" domain '___' %}',
-            compare: '{% url "diff" domain '___' '___' %}',
             jad: '{% url "download_jad" domain '___' %}',
             jar: '{% url "download_jar" domain '___' %}',
             ccz: '{% url "download_ccz" domain '___' %}',
             odk: '{% url "odk_install" domain '___' %}',
             odk_media: '{% url "odk_media_install" domain '___' %}',
             source: '{% url "download_index" domain '___' %}',
-            summary: '{% url "app_summary" domain '___' %}',
             release: '{% url "release_build" domain app.id '___' %}',
             newBuild: '{% url "save_copy" domain app.id %}',
             revertBuild: '{% url "revert_to_copy" domain app.id %}',
@@ -216,39 +214,6 @@
                         saveValueName: 'comment',
                         errorMessage:'{% trans "Error updating comment.  Please try again."|escapejs %}',
                     "></inline-edit-v2>
-                    {% if request.user.is_superuser %}
-                        <h6>
-                            {% blocktrans %}
-                                View
-                                <a data-bind="attr: {href: $root.url('summary', id)}">app summary</a>
-                                or
-                                <a data-bind="attr: {href: $root.url('source', id)}" class="view-source-files-link">source files</a>
-                                <br />
-                                <a href="#" class="hide" data-bind="click: function() {
-                                        $root.selectingVersion(id());
-                                    }, visible: !$root.selectingVersion(),
-                                    css: {hide: false}
-                                ">
-                                    Compare with another version
-                                </a>
-                                <a href="#" class="hide" data-bind="
-                                    visible: $root.selectingVersion() === id(),
-                                    click: function() {$root.selectingVersion('')},
-                                    css: {hide: false}
-                                ">
-                                    Cancel
-                                </a>
-                                <a href="#" class="btn btn-xs btn-success hide"
-                                   data-bind="
-                                        attr: {href: $root.url('compare', $root.selectingVersion(), id())},
-                                        visible: $root.selectingVersion() && $root.selectingVersion() != id(),
-                                        css: {hide: false}
-                                    ">
-                                    Compare
-                                </a>
-                            {% endblocktrans %}
-                        </h6>
-                    {% endif %}
                 </td>
                 {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <td>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
@@ -312,6 +312,15 @@
                         </div>
                     </div>
                 {% endif %}
+                {% if request.user.is_superuser %}
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <a data-bind="attr: {href: $root.url('source', id)}">
+                                {% trans 'View Source Files' %}
+                            </a>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         {% endif %}
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/source_files.html
@@ -1,11 +1,24 @@
 {% extends "style/full_screen.html" %}
 
+{% load hq_shared_tags %}
+{% load compress %}
+
 {% block page_content %}
-    <p>
+    {% registerurl 'diff' app.domain app.id '---' %}
+    {% initial_page_data 'built_versions' built_versions %}
+    {% initial_page_data 'current_version' app.built_with.build_number %}
+
+    <p class="form-inline" id="compare-form">
       See
       <a href="{% url "view_app" app.domain app.copy_of|default_if_none:app.get_id %}">
         current app
       </a> for the latest work in progress.
+
+    {% if not other_app %}
+        Or compare with another version:
+        <input type="text" class="form-control input-sm" placeholder="version" />
+        <button class="btn btn-default btn-sm">Compare</button>
+    {% endif %}
     </p>
 
     {% block downloads %}{% endblock %}
@@ -41,12 +54,81 @@
     {% block post_files %}{% endblock %}
 {% endblock page_content %}
 
+{% block js %}{{ block.super }}
+    {% compress js %}
+        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
+        <script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
+        <script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
+    {% endcompress %}
+{% endblock %}
+
+{% block stylesheets %}{{ block.super }}
+    <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}" />
+    <style type="text/css">
+        /* Limit atwho dropdown width */
+        .atwho-view {
+            max-width: 300px;
+        }
+    </style>
+{% endblock %}
+
 {% block js-inline %}
 <script>
     $(function(){
         $('.toggle-next').click(function(e){
             e.preventDefault();
             $(this).parents('tr').next('tr').toggleClass("hide");
+        });
+
+        var current_version = hqImport('hqwebapp/js/initial_page_data.js').get('current_version'),
+            built_versions = hqImport('hqwebapp/js/initial_page_data.js').get('built_versions'),
+            $form = $("#compare-form"),
+            $input = $form.find("input");
+
+        built_versions = _.sortBy(_.filter(built_versions, function(v) {
+            return v.version != current_version;
+        }), function(v) { return parseInt(v.version); }).reverse();
+        version_map = _.indexBy(built_versions, 'version');
+
+        $input.atwho({
+            at: "",
+            data: _.map(built_versions, function(v) {
+                return {
+                    id: v.version,
+                    name: v.version + (v.comment ? " (" + v.comment + ")" : ""),
+                };
+            }),
+            limit: Infinity,
+            maxLen: Infinity,
+            suffix: "",
+            tabSelectsMatch: false,
+            callbacks: {
+                beforeInsert: function(value, $li) {
+                    value = value.split(/\s+/);
+                    return value[0];
+                },
+                filter: function(query, data, searchKey) {
+                    return _.filter(data, function(item) {
+                        return item.name.indexOf(query) !== -1;
+                    });
+                },
+                matcher: function(flag, subtext, should_startWithSpace) {
+                    return $input.val();
+                },
+            }
+        });
+
+        $form.find("button").click(function() {
+            var version = $input.val();
+            if (!version) {
+                alert("Please enter a version to compare");
+                return;
+            } else if (!version_map[version]) {
+                alert(version + " is not a valid version");
+                return;
+            }
+            window.location = hqImport('hqwebapp/js/urllib.js').reverse('diff', version_map[version].build_id);
         });
     });
 </script>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -46,9 +46,11 @@
+@@ -44,9 +44,11 @@
              fetchLimit: {{ fetchLimit }},
          };
          var el = $('#releases-table');
@@ -15,7 +15,7 @@
  
          var app_langs = {{ app.langs|JSON }};
          var app_profiles = {{ app.build_profiles|JSON }}
-@@ -59,7 +61,7 @@
+@@ -57,7 +59,7 @@
          {% endif %}
      });
  
@@ -24,7 +24,7 @@
  </script>
  <script>
      $(function () {
-@@ -67,7 +69,13 @@
+@@ -65,7 +67,13 @@
      });
  </script>
  
@@ -39,7 +39,7 @@
  <div class="tabbable">
      <ul class="nav nav-tabs">
          <li class="active"><a href="#versions-tab" data-toggle="tab">{% trans "Versions" %}</a></li>
-@@ -104,7 +112,7 @@
+@@ -102,7 +110,7 @@
                  ">{% trans 'Make New Version' %}</button>
  
      <div id="build-errors-wrapper"></div>
@@ -48,7 +48,7 @@
          <tr>
              <th colspan="2">{% trans "Version" %}</th>
              <th colspan="2">{% trans "Date &amp; Time" %}</th>
-@@ -199,7 +207,7 @@
+@@ -197,7 +205,7 @@
                  </td>
                  <td>
                      <b data-bind="text: comment_user_name"></b>
@@ -57,16 +57,16 @@
                          value: build_comment,
                          rows: 1,
                          placeholder: '{% trans "(Click here to add a comment)"|escapejs %}',
-@@ -207,7 +215,7 @@
+@@ -205,7 +213,7 @@
                          saveParams: {'build_id': id},
                          saveValueName: 'comment',
                          errorMessage:'{% trans "Error updating comment.  Please try again."|escapejs %}',
 -                    "></inline-edit>
 +                    "></inline-edit-v2>
-                     {% if request|toggle_enabled:"VIEW_BUILD_SOURCE" %}
-                         <h6>
-                             {% blocktrans %}
-@@ -325,17 +333,18 @@
+                 </td>
+                 {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
+                 <td>
+@@ -290,17 +298,18 @@
          </div>
      </script>
      <script type="text/html" id="deploy-build-modal-template">

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -157,11 +157,18 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         })
 
     def test_get_all_built_app_ids_and_versions(self):
-        app_build_verions = get_all_built_app_ids_and_versions(self.domain)
+        app_build_versions = get_all_built_app_ids_and_versions(self.domain)
 
-        self.assertEqual(len(app_build_verions), 3)
-        self.assertEqual(len(filter(lambda abv: abv.app_id == '1234', app_build_verions)), 1)
-        self.assertEqual(len(filter(lambda abv: abv.app_id == self.apps[0]._id, app_build_verions)), 2)
+        self.assertEqual(len(app_build_versions), 3)
+        self.assertEqual(len(filter(lambda abv: abv.app_id == '1234', app_build_versions)), 1)
+        self.assertEqual(len(filter(lambda abv: abv.app_id == self.apps[0]._id, app_build_versions)), 2)
+
+    def test_get_all_built_app_ids_and_versions_by_app(self):
+        app_build_versions = get_all_built_app_ids_and_versions(self.domain, app_id='1234')
+
+        self.assertEqual(len(app_build_versions), 1)
+        self.assertEqual(len(filter(lambda abv: abv.app_id == '1234', app_build_versions)), 1)
+        self.assertEqual(len(filter(lambda abv: abv.app_id != '1234', app_build_versions)), 0)
 
 
 class TestAppGetters(TestCase):

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -12,7 +12,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
 from corehq import toggles
-from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.dbaccessors import get_all_built_app_ids_and_versions, get_app
 from corehq.apps.app_manager.decorators import safe_download
 from corehq.apps.app_manager.exceptions import ModuleNotFoundException, \
     AppManagerException, FormNotFoundException
@@ -351,10 +351,12 @@ def download_index(request, domain, app_id):
             ),
             extra_tags='html'
         )
+    built_versions = get_all_built_app_ids_and_versions(domain, request.app.copy_of)
     return render(request, template, {
         'app': request.app,
         'files': [{'name': f[0], 'source': f[1]} for f in files],
         'supports_j2me': request.app.build_spec.supports_j2me(),
+        'version_map': {v.version: v.build_id for v in built_versions},
     })
 
 

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -356,7 +356,12 @@ def download_index(request, domain, app_id):
         'app': request.app,
         'files': [{'name': f[0], 'source': f[1]} for f in files],
         'supports_j2me': request.app.build_spec.supports_j2me(),
-        'version_map': {v.version: v.build_id for v in built_versions},
+        'built_versions': [{
+            'app_id': app_id,
+            'build_id': build_id,
+            'version': version,
+            'comment': comment,
+        } for app_id, build_id, version, comment in built_versions]
     })
 
 

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -175,7 +175,7 @@ requires imports/proptable.html to be included in the main template
         <br/>
         <ul class="list-inline">
             {% if instance.app_id %}<li><a href="{% url "view_app" domain instance.app_id %}">{% trans "View app" %}</a></li>{% endif %}
-            {% if instance.build_id and request|toggle_enabled:"VIEW_BUILD_SOURCE" %}
+            {% if instance.build_id and request.user.is_superuser %}
                 <a href="{% url "download_index" domain instance.build_id %}">{% trans "View build" %}</a>
             {% endif %}
         </ul>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -812,13 +812,6 @@ LEGACY_SYNC_SUPPORT = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-VIEW_BUILD_SOURCE = StaticToggle(
-    'diff_builds',
-    'Allow users to view and diff build source files',
-    TAG_EXPERIMENTAL,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER]
-)
-
 EWS_WEB_USER_EXTENSION = StaticToggle(
     'ews_web_user_extension',
     'Enable EWSGhana web user extension',


### PR DESCRIPTION
Moved comparison options out of main deploy page, into source files page. Moved source files link out of main deploy page, into deploy modal - it's superuser-permissioned, as it was before https://github.com/dimagi/commcare-hq/pull/8299.

Before:
<img width="1116" alt="screen shot 2017-02-03 at 6 20 58 pm" src="https://cloud.githubusercontent.com/assets/1486591/22612261/8d64bfd4-ea3d-11e6-85cc-97b4d3cb439a.png">

and

<img width="1117" alt="screen shot 2017-02-03 at 6 21 36 pm" src="https://cloud.githubusercontent.com/assets/1486591/22612274/a23c035e-ea3d-11e6-9473-053846c492b2.png">

After:
<img width="616" alt="screen shot 2017-02-03 at 6 19 38 pm" src="https://cloud.githubusercontent.com/assets/1486591/22612285/aff8243c-ea3d-11e6-9bd4-7bb5d0a7635e.png">

and

<img width="862" alt="screen shot 2017-02-03 at 6 19 22 pm" src="https://cloud.githubusercontent.com/assets/1486591/22612263/934166f0-ea3d-11e6-8ad8-4768390da728.png">

@mkangia / @NoahCarnahan 