### PR TITLE
Pass a string, not an Exception instance

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -2247,7 +2247,7 @@ class DownloadNewFormExportView(GenericDownloadNewExportMixin, DownloadFormExpor
         return form_filters
 
     def get_multimedia_task_kwargs(self, in_data, filter_form, export_object, download_id):
-        filter_slug = in_data['form_data']['emw']
+        filter_slug = in_data['form_data'][LocationRestrictedMobileWorkerFilter.slug]
         mobile_user_and_group_slugs = self._get_mobile_user_and_group_slugs(filter_slug)
         return filter_form.get_multimedia_task_kwargs(export_object, download_id, mobile_user_and_group_slugs)
 

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -878,7 +878,7 @@ class DownloadFormExportView(BaseDownloadExportView):
             from corehq.apps.reports.tasks import build_form_multimedia_zip
             download.set_task(build_form_multimedia_zip.delay(**task_kwargs))
         except Exception as e:
-            return format_angular_error(e)
+            return format_angular_error(str(e))
         return format_angular_success({
             'download_id': download.download_id,
         })


### PR DESCRIPTION
Context: [FB 246864](http://manage.dimagi.com/default.asp?246864)

This change doesn't resolve the underlying exception, but does avoid HQ from trying to encode an Exception instance as JSON. 

I'm opening this PR to discuss why the KeyError is being raised in the first place. I can't see why ["emw" is hardcoded here](https://github.com/dimagi/commcare-hq/blob/d8a8c3101c74d63d61351ad6472a325b6bdf4ea3/corehq/apps/export/views.py#L2250-L2250) (where the KeyError is being raised). It seems to refer to [`ExpandedMobileWorkerFilter.slug`](https://github.com/dimagi/commcare-hq/blob/0f511188e207f92ffebb64cd6229791257c6ea06/corehq/apps/reports/filters/users.py#L195-L195), but it's not obvious to me why that particular slug is used here. How do we know it's not going to be the slug of a subclass?

@mkangia @NoahCarnahan @benrudolph 