### PR TITLE
Get app_manager ready for Python 3

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -1,6 +1,6 @@
-from builtins import object
 import functools
 
+from builtins import object
 from django.utils.translation import ugettext
 
 from corehq.apps.app_manager import id_strings
@@ -15,7 +15,7 @@ from langcodes import langs_by_code
 
 
 def non_empty_only(dct):
-    return dict([(key, value) for key, value in list(dct.items()) if value])
+    return {key: value for key, value in dct.items() if value}
 
 
 def convert_to_two_letter_code(lc):
@@ -209,7 +209,7 @@ class AppStringsBase(object):
                 self.create_app_strings(app, lc, for_default=True)
             )
 
-            for key, val in list(new_messages.items()):
+            for key, val in new_messages.items():
                 # do not overwrite a real trans with a blank trans
                 if not (val == '' and key in messages):
                     messages[key] = val
@@ -237,7 +237,7 @@ class AppStringsBase(object):
             AUTO_SELECT_RAW: u'custom xpath expression',
         }
 
-        for mode, text in list(mode_text.items()):
+        for mode, text in mode_text.items():
             key = 'case_autoload.{0}.property_missing'.format(mode)
             if key not in messages:
                 messages[key] = (u'The {} specified for case auto-selecting '
@@ -276,7 +276,7 @@ class SelectKnownAppStrings(AppStringsBase):
 
     def get_app_translation_keys(self, app):
         return set.union(set(), *(
-            set(t.keys()) for t in list(app.translations.values())
+            set(t.keys()) for t in app.translations.values()
         ))
 
     def app_strings_parts(self, app, lang, for_default=False):

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -1,3 +1,4 @@
+from builtins import object
 import functools
 
 from django.utils.translation import ugettext
@@ -14,7 +15,7 @@ from langcodes import langs_by_code
 
 
 def non_empty_only(dct):
-    return dict([(key, value) for key, value in dct.items() if value])
+    return dict([(key, value) for key, value in list(dct.items()) if value])
 
 
 def convert_to_two_letter_code(lc):
@@ -82,10 +83,10 @@ def _create_custom_app_strings(app, lang, for_default=False):
                 elif column.format == "graph":
                     for index, item in enumerate(column.graph_configuration.annotations):
                         yield id_strings.graph_annotation(module, detail_type, column, index), trans(item.values)
-                    for property, values in column.graph_configuration.locale_specific_config.iteritems():
+                    for property, values in column.graph_configuration.locale_specific_config.items():
                         yield id_strings.graph_configuration(module, detail_type, column, property), trans(values)
                     for index, item in enumerate(column.graph_configuration.series):
-                        for property, values in item.locale_specific_config.iteritems():
+                        for property, values in item.locale_specific_config.items():
                             yield id_strings.graph_series_configuration(
                                 module, detail_type, column, index, property
                             ), trans(values)
@@ -208,7 +209,7 @@ class AppStringsBase(object):
                 self.create_app_strings(app, lc, for_default=True)
             )
 
-            for key, val in new_messages.items():
+            for key, val in list(new_messages.items()):
                 # do not overwrite a real trans with a blank trans
                 if not (val == '' and key in messages):
                     messages[key] = val
@@ -236,7 +237,7 @@ class AppStringsBase(object):
             AUTO_SELECT_RAW: u'custom xpath expression',
         }
 
-        for mode, text in mode_text.items():
+        for mode, text in list(mode_text.items()):
             key = 'case_autoload.{0}.property_missing'.format(mode)
             if key not in messages:
                 messages[key] = (u'The {} specified for case auto-selecting '
@@ -275,7 +276,7 @@ class SelectKnownAppStrings(AppStringsBase):
 
     def get_app_translation_keys(self, app):
         return set.union(set(), *(
-            set(t.keys()) for t in app.translations.values()
+            set(t.keys()) for t in list(app.translations.values())
         ))
 
     def app_strings_parts(self, app, lang, for_default=False):

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -73,9 +73,7 @@ def _load_commcare_settings_layout(doc_type, domain):
         raise Exception(
             "CommCare settings layout should mention "
             "all the available settings. "
-            "The following settings went unmentioned: %s" % (
-                ', '.join(list(settings.keys()))
-            )
+            "The following settings went unmentioned: " + ', '.join(settings)
         )
     return layout
 

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -65,7 +65,7 @@ def _load_commcare_settings_layout(doc_type, domain):
                 section['settings'][i] = setting
             else:
                 section['settings'][i] = None
-        section['settings'] = filter(None, section['settings'])
+        section['settings'] = [_f for _f in section['settings'] if _f]
         for setting in section['settings']:
             setting['value'] = None
 
@@ -74,7 +74,7 @@ def _load_commcare_settings_layout(doc_type, domain):
             "CommCare settings layout should mention "
             "all the available settings. "
             "The following settings went unmentioned: %s" % (
-                ', '.join(settings.keys())
+                ', '.join(list(settings.keys()))
             )
         )
     return layout

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -274,7 +274,7 @@ def get_latest_app_ids_and_versions(domain, app_id=None):
 
     latest_ids_and_versions = {}
     if app_id:
-        results = filter(lambda r: r['value']['_id'] == app_id, results)
+        results = [r for r in results if r['value']['_id'] == app_id]
     for result in results:
         app_id = result['value']['_id']
         version = result['value']['version']
@@ -337,12 +337,12 @@ def get_all_built_app_ids_and_versions(domain, app_id=None):
         endkey=endkey,
         include_docs=True,
     ).all()
-    return map(lambda result: AppBuildVersion(
+    return [AppBuildVersion(
         app_id=result['key'][1],
         build_id=result['id'],
         version=result['key'][2],
         comment=result['value']['build_comment'],
-    ), results)
+    ) for result in results]
 
 
 def get_case_types_from_apps(domain):

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -30,7 +30,7 @@ def safe_download(f):
         try:
             request.app = get_app(domain, app_id, latest=latest, target=target)
             return f(request, *args, **kwargs)
-        except (AppEditingError, CaseError, ValueError), e:
+        except (AppEditingError, CaseError, ValueError) as e:
             logging.exception(e)
             messages.error(request, "Problem downloading file: %s" % e)
             return HttpResponseRedirect(reverse("view_app", args=[domain,app_id]))

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -1,5 +1,5 @@
-from builtins import str
 from builtins import object
+from builtins import str
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml import xml_models as sx
 from corehq.apps.app_manager.suite_xml import const
@@ -361,7 +361,7 @@ class EnumImage(Enum):
         width = 0
         if self.app.enable_case_list_icon_dynamic_width:
             for i, item in enumerate(self.column.enum):
-                for path in list(item.value.values()):
+                for path in item.value.values():
                     map_item = self.app.multimedia_map[path]
                     if map_item is not None:
                         image = CommCareMultimedia.get(map_item.multimedia_id)

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml import xml_models as sx
 from corehq.apps.app_manager.suite_xml import const
@@ -359,7 +361,7 @@ class EnumImage(Enum):
         width = 0
         if self.app.enable_case_list_icon_dynamic_width:
             for i, item in enumerate(self.column.enum):
-                for path in item.value.values():
+                for path in list(item.value.values()):
                     map_item = self.app.multimedia_map[path]
                     if map_item is not None:
                         image = CommCareMultimedia.get(map_item.multimedia_id)
@@ -482,7 +484,7 @@ class Graph(FormattedDetailColumn):
                                     #       figure out why their unquoted colors
                                     #       aren't working.
                                     sx.ConfigurationItem(id=k, xpath_function=v)
-                                    for k, v in s.config.iteritems()
+                                    for k, v in s.config.items()
                                 ] + [
                                     sx.ConfigurationItem(
                                         id=k,
@@ -494,7 +496,7 @@ class Graph(FormattedDetailColumn):
                                             k
                                         )
                                     )
-                                    for k, v in s.locale_specific_config.iteritems()
+                                    for k, v in s.locale_specific_config.items()
                                 ]
                             )
                         )
@@ -505,7 +507,7 @@ class Graph(FormattedDetailColumn):
                         [
                             sx.ConfigurationItem(id=k, xpath_function=v)
                             for k, v
-                            in self.column.graph_configuration.config.iteritems()
+                            in self.column.graph_configuration.config.items()
                         ] + [
                             sx.ConfigurationItem(
                                 id=k,
@@ -517,7 +519,7 @@ class Graph(FormattedDetailColumn):
                                 )
                             )
                             for k, v
-                            in self.column.graph_configuration.locale_specific_config.iteritems()
+                            in self.column.graph_configuration.locale_specific_config.items()
                         ]
                     )
                 ),

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -1,3 +1,4 @@
+from builtins import str
 import couchdbkit
 from corehq.apps.app_manager.const import APP_V2
 
@@ -70,7 +71,7 @@ class XFormValidationError(XFormException):
     def __str__(self):
         fatal_error_text = self.format_v1(self.fatal_error)
         ret = u"Validation Error%s" % (': %s' % fatal_error_text if fatal_error_text else '')
-        problems = filter(lambda problem: problem['message'] != self.fatal_error, self.validation_problems)
+        problems = [problem for problem in self.validation_problems if problem['message'] != self.fatal_error]
         if problems:
             ret += u"\n\nMore information:"
             for problem in problems:
@@ -86,8 +87,8 @@ class XFormValidationError(XFormException):
         # and just return the undecorated string
         #
         # ... unless the first line says
-        message_lines = unicode(msg).split('\n')[2:]
-        if len(message_lines) > 0 and ':' in message_lines[0] and 'XPath Dependency Cycle' not in unicode(msg):
+        message_lines = str(msg).split('\n')[2:]
+        if len(message_lines) > 0 and ':' in message_lines[0] and 'XPath Dependency Cycle' not in str(msg):
             message = ' '.join(message_lines[0].split(':')[1:])
         else:
             message = '\n'.join(message_lines)

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -1,5 +1,5 @@
-from builtins import str
 import couchdbkit
+from builtins import str
 from corehq.apps.app_manager.const import APP_V2
 
 

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 from distutils.version import LooseVersion, Version
 from django.conf import settings
 

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -1,7 +1,7 @@
-from past.builtins import basestring
 from builtins import object
 from distutils.version import LooseVersion, Version
 from django.conf import settings
+from past.builtins import basestring
 
 
 class CommCareFeatureSupportMixin(object):

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -1,11 +1,11 @@
-from builtins import map
-from builtins import object
-import logging
-from django.core.urlresolvers import reverse
-from django.http import Http404
 import collections
 import itertools
+import logging
+from builtins import map
+from builtins import object
 from django import forms
+from django.core.urlresolvers import reverse
+from django.http import Http404
 from django.utils.translation import ugettext as _
 
 from corehq import toggles
@@ -85,7 +85,7 @@ class ApplicationDataSourceUIHelper(object):
     def bootstrap(self, domain):
         self.all_sources = get_app_sources(domain)
         self.application_field.choices = sorted(
-            [(app_id, source['name']) for app_id, source in list(self.all_sources.items())],
+            [(app_id, source['name']) for app_id, source in self.all_sources.items()],
             key=lambda id_name_tuple: (id_name_tuple[1] or '').lower()
         )
         self.source_field.choices = []
@@ -98,12 +98,12 @@ class ApplicationDataSourceUIHelper(object):
         if self.enable_cases:
             _add_choices(
                 self.source_field,
-                [(ct['value'], ct['text']) for app in list(self.all_sources.values()) for ct in app['case']]
+                [(ct['value'], ct['text']) for app in self.all_sources.values() for ct in app['case']]
             )
         if self.enable_forms:
             _add_choices(
                 self.source_field,
-                [(ct['value'], ct['text']) for app in list(self.all_sources.values()) for ct in app['form']]
+                [(ct['value'], ct['text']) for app in self.all_sources.values() for ct in app['form']]
             )
 
         # NOTE: This corresponds to a view-model that must be initialized in your template.
@@ -356,7 +356,7 @@ class ApplicationDataRMIHelper(object):
     @staticmethod
     def _get_unique_choices(choices):
         final_choices = collections.defaultdict(list)
-        for k, val_list in list(choices.items()):
+        for k, val_list in choices.items():
             new_val_ids = []
             final_choices[k] = []
             for v in val_list:
@@ -473,7 +473,7 @@ class ApplicationDataRMIHelper(object):
     def _get_cases_for_apps(self, apps_by_type, as_dict=True):
         used_case_types = set()
         case_types_by_app = collections.defaultdict(list)
-        for app_type, apps in list(apps_by_type.items()):
+        for app_type, apps in apps_by_type.items():
             for app_choice in apps:
                 if not app_choice.id == self.UNKNOWN_SOURCE:
                     app = get_app(self.domain, app_choice.id)
@@ -486,7 +486,7 @@ class ApplicationDataRMIHelper(object):
                         ])
 
                         # Add user case if any module uses it
-                        if any([module.uses_usercase() for module in app.modules]):
+                        if any(module.uses_usercase() for module in app.modules):
                             case_types.add(USERCASE_TYPE)
 
                         used_case_types = used_case_types.union(case_types)

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -325,12 +325,14 @@ class ApplicationDataRMIHelper(object):
     @property
     @memoized
     def _deleted_app_forms(self):
-        return [f for f in self._all_forms if f.get('has_app', False) and f.get('app_deleted') and not f.get('show_xmlns', False)]
+        return [f for f in self._all_forms
+            if f.get('has_app', False) and f.get('app_deleted') and not f.get('show_xmlns', False)]
 
     @property
     @memoized
     def _available_app_forms(self):
-        return [f for f in self._all_forms if f.get('has_app', False) and not f.get('app_deleted') and not f.get('show_xmlns', False)]
+        return [f for f in self._all_forms
+            if f.get('has_app', False) and not f.get('app_deleted') and not f.get('show_xmlns', False)]
 
     @property
     @memoized

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -1,12 +1,12 @@
-from builtins import str
-from builtins import zip
+import logging
 from builtins import map
 from builtins import object
+from builtins import str
+from builtins import zip
 from collections import defaultdict
 from datetime import datetime
-import logging
-from lxml.builder import E
 from django.conf import settings
+from lxml.builder import E
 
 from casexml.apps.phone.models import OTARestoreUser
 
@@ -72,7 +72,7 @@ class ReportFixturesProvider(object):
         # apply filters specified in report module
         all_filter_values = {
             filter_slug: restore_user.get_ucr_filter_value(filter, report.get_ui_filter(filter_slug))
-            for filter_slug, filter in list(report_config.filters.items())
+            for filter_slug, filter in report_config.filters.items()
         }
         # apply all prefilters
         prefilters = [ReportFilterFactory.from_spec(p, report) for p in report.prefilters]
@@ -80,12 +80,12 @@ class ReportFixturesProvider(object):
         all_filter_values.update(prefilter_values)
         # filter out nulls
         filter_values = {
-            filter_slug: filter_value for filter_slug, filter_value in list(all_filter_values.items())
+            filter_slug: filter_value for filter_slug, filter_value in all_filter_values.items()
             if filter_value is not None
         }
         defer_filters = {
             filter_slug: report.get_ui_filter(filter_slug)
-            for filter_slug, filter_value in list(all_filter_values.items())
+            for filter_slug, filter_value in all_filter_values.items()
             if filter_value is None and is_valid_mobile_select_filter_type(report.get_ui_filter(filter_slug))
         }
         data_source.set_filter_values(filter_values)
@@ -94,7 +94,7 @@ class ReportFixturesProvider(object):
 
         rows_elem = ReportFixturesProvider._get_report_elem(
             data_source,
-            {ui_filter.field for ui_filter in list(defer_filters.values())},
+            {ui_filter.field for ui_filter in defer_filters.values()},
             filter_options_by_field
         )
         filters_elem = ReportFixturesProvider._get_filters_elem(
@@ -114,7 +114,7 @@ class ReportFixturesProvider(object):
     @staticmethod
     def _get_filters_elem(defer_filters, filter_options_by_field, couch_user):
         filters_elem = E.filters()
-        for filter_slug, ui_filter in list(defer_filters.items()):
+        for filter_slug, ui_filter in defer_filters.items():
             # @field is maybe a bad name for this attribute,
             # since it's actually the filter slug
             filter_elem = E.filter(field=filter_slug)
@@ -145,10 +145,10 @@ class ReportFixturesProvider(object):
             total_row = data_source.get_total_row()
             rows_elem.append(_row_to_row_elem(
                 dict(
-                    list(zip(
-                        [column_config.column_id for column_config in data_source.top_level_columns],
-                        list(map(str, total_row))
-                    ))
+                    zip(
+                        [col.column_id for col in data_source.top_level_columns],
+                        map(str, total_row)
+                    )
                 ),
                 data_source.get_total_records(),
                 is_total_row=True,

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -1,3 +1,7 @@
+from builtins import str
+from builtins import zip
+from builtins import map
+from builtins import object
 from collections import defaultdict
 from datetime import datetime
 import logging
@@ -68,7 +72,7 @@ class ReportFixturesProvider(object):
         # apply filters specified in report module
         all_filter_values = {
             filter_slug: restore_user.get_ucr_filter_value(filter, report.get_ui_filter(filter_slug))
-            for filter_slug, filter in report_config.filters.items()
+            for filter_slug, filter in list(report_config.filters.items())
         }
         # apply all prefilters
         prefilters = [ReportFilterFactory.from_spec(p, report) for p in report.prefilters]
@@ -76,12 +80,12 @@ class ReportFixturesProvider(object):
         all_filter_values.update(prefilter_values)
         # filter out nulls
         filter_values = {
-            filter_slug: filter_value for filter_slug, filter_value in all_filter_values.items()
+            filter_slug: filter_value for filter_slug, filter_value in list(all_filter_values.items())
             if filter_value is not None
         }
         defer_filters = {
             filter_slug: report.get_ui_filter(filter_slug)
-            for filter_slug, filter_value in all_filter_values.items()
+            for filter_slug, filter_value in list(all_filter_values.items())
             if filter_value is None and is_valid_mobile_select_filter_type(report.get_ui_filter(filter_slug))
         }
         data_source.set_filter_values(filter_values)
@@ -90,7 +94,7 @@ class ReportFixturesProvider(object):
 
         rows_elem = ReportFixturesProvider._get_report_elem(
             data_source,
-            {ui_filter.field for ui_filter in defer_filters.values()},
+            {ui_filter.field for ui_filter in list(defer_filters.values())},
             filter_options_by_field
         )
         filters_elem = ReportFixturesProvider._get_filters_elem(
@@ -110,7 +114,7 @@ class ReportFixturesProvider(object):
     @staticmethod
     def _get_filters_elem(defer_filters, filter_options_by_field, couch_user):
         filters_elem = E.filters()
-        for filter_slug, ui_filter in defer_filters.items():
+        for filter_slug, ui_filter in list(defer_filters.items()):
             # @field is maybe a bad name for this attribute,
             # since it's actually the filter slug
             filter_elem = E.filter(field=filter_slug)
@@ -141,10 +145,10 @@ class ReportFixturesProvider(object):
             total_row = data_source.get_total_row()
             rows_elem.append(_row_to_row_elem(
                 dict(
-                    zip(
-                        map(lambda column_config: column_config.column_id, data_source.top_level_columns),
-                        map(str, total_row)
-                    )
+                    list(zip(
+                        [column_config.column_id for column_config in data_source.top_level_columns],
+                        list(map(str, total_row))
+                    ))
                 ),
                 data_source.get_total_records(),
                 is_total_row=True,

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -1,3 +1,4 @@
+from builtins import zip
 import re
 
 ROOT = u'root'

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -1,5 +1,5 @@
-from builtins import zip
 import re
+from builtins import zip
 
 ROOT = u'root'
 

--- a/corehq/apps/app_manager/management/commands/audit_app_profile_properties.py
+++ b/corehq/apps/app_manager/management/commands/audit_app_profile_properties.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         domains = [row['key'] for row in Domain.get_all(include_docs=False)]
         settings = {s['id']: s['default'] for s in get_custom_commcare_settings() if 'default' in s}
-        deviant_counts = {id: 0 for id in list(settings.keys())}
+        deviant_counts = {id: 0 for id in settings}
         app_count = 0
         for domain in domains:
             for app in get_apps_in_domain(domain, include_remote=False):

--- a/corehq/apps/app_manager/management/commands/audit_app_profile_properties.py
+++ b/corehq/apps/app_manager/management/commands/audit_app_profile_properties.py
@@ -18,14 +18,14 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         domains = [row['key'] for row in Domain.get_all(include_docs=False)]
         settings = {s['id']: s['default'] for s in get_custom_commcare_settings() if 'default' in s}
-        deviant_counts = {id: 0 for id in settings.keys()}
+        deviant_counts = {id: 0 for id in list(settings.keys())}
         app_count = 0
         for domain in domains:
             for app in get_apps_in_domain(domain, include_remote=False):
                 #logger.info("looking at app {}".format(app.id))
                 if ('properties' in app.profile):
                     app_count = app_count + 1
-                    for id, default in settings.iteritems():
+                    for id, default in settings.items():
                         if (id not in app.profile['properties']):
                             #logger.info("{}: not found".format(id))
                             pass
@@ -35,6 +35,6 @@ class Command(BaseCommand):
                         else:
                             #logger.info("{}: {} == {}".format(id, app.profile['properties'][id], default))
                             pass
-        for id, count in deviant_counts.iteritems():
+        for id, count in deviant_counts.items():
             logger.info("{}\t{}".format(count, id))
         logger.info('done with audit_app_profile_properties, examined {} apps in {} domains'.format(app_count, len(domains)))

--- a/corehq/apps/app_manager/management/commands/build_app_manager_v2_diffs.py
+++ b/corehq/apps/app_manager/management/commands/build_app_manager_v2_diffs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import logging
 import os
 import filecmp

--- a/corehq/apps/app_manager/management/commands/build_apps.py
+++ b/corehq/apps/app_manager/management/commands/build_apps.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import contextlib
 import json
 import time
@@ -61,7 +62,7 @@ class Command(BaseCommand):
                 app_slugs.append(name[:-len(_JSON)])
 
         for slug in app_slugs:
-            print 'Fetching %s...' % slug
+            print('Fetching %s...' % slug)
             source_path = os.path.join(path, 'src', '%s.json' % slug)
             with open(source_path) as f:
                 j = json.load(f)
@@ -74,7 +75,7 @@ class Command(BaseCommand):
             if not app.domain:
                 app.domain = "test"
             build_path = os.path.join(path, build_slug, slug)
-            print ' Creating files...'
+            print(' Creating files...')
             if track_perf:
                 with record_performance_stats(perfpath, slug):
                     files = app.create_all_files()
@@ -84,7 +85,7 @@ class Command(BaseCommand):
             self.write_files(files, build_path)
 
     def write_files(self, files, path):
-        for filename, payload in files.items():
+        for filename, payload in list(files.items()):
             filepath = os.path.join(path, filename)
             dirpath, filename = os.path.split(filepath)
             try:

--- a/corehq/apps/app_manager/management/commands/build_apps.py
+++ b/corehq/apps/app_manager/management/commands/build_apps.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
             self.write_files(files, build_path)
 
     def write_files(self, files, path):
-        for filename, payload in list(files.items()):
+        for filename, payload in files.items():
             filepath = os.path.join(path, filename)
             dirpath, filename = os.path.split(filepath)
             try:

--- a/corehq/apps/app_manager/management/commands/download_app_forms.py
+++ b/corehq/apps/app_manager/management/commands/download_app_forms.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from django.core.management.base import BaseCommand, CommandError
 
 import os
@@ -33,4 +34,4 @@ class Command(BaseCommand):
                 form_path = os.path.join(module_dir, form_name)
                 with open(form_path, 'w') as f:
                     f.write(form.source.encode('utf-8'))
-                    print 'wrote {}'.format(form_path)
+                    print('wrote {}'.format(form_path))

--- a/corehq/apps/app_manager/management/commands/find_broken_builds.py
+++ b/corehq/apps/app_manager/management/commands/find_broken_builds.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from optparse import make_option
 from couchdbkit.exceptions import ResourceNotFound
 from django.core.management import BaseCommand
@@ -93,7 +94,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         args = list(args)
-        valid_functions = ', '.join(CHECK_FUNCTIONS.keys())
+        valid_functions = ', '.join(list(CHECK_FUNCTIONS.keys()))
         if not args:
             raise CommandError('Usage is find_broken_builds %s. Options are: %s' % (
                 self.args,
@@ -109,13 +110,13 @@ class Command(BaseCommand):
         end = options['enddate']
         ids = options['build_ids']
 
-        print 'Starting...\n'
+        print('Starting...\n')
         if not ids:
             ids = get_build_ids(start, end)
         else:
             ids = ids.split(',')
 
-        print 'Checking {} builds\n'.format(len(ids))
+        print('Checking {} builds\n'.format(len(ids)))
         for message in find_broken_builds(check_fn, ids):
             self.stderr.write(message)
 

--- a/corehq/apps/app_manager/management/commands/find_broken_builds.py
+++ b/corehq/apps/app_manager/management/commands/find_broken_builds.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         args = list(args)
-        valid_functions = ', '.join(list(CHECK_FUNCTIONS.keys()))
+        valid_functions = ', '.join(CHECK_FUNCTIONS)
         if not args:
             raise CommandError('Usage is find_broken_builds %s. Options are: %s' % (
                 self.args,

--- a/corehq/apps/app_manager/management/commands/find_case_metadata_with_errors.py
+++ b/corehq/apps/app_manager/management/commands/find_case_metadata_with_errors.py
@@ -29,7 +29,7 @@ class Command(AppMigrationCommandBase):
                     return None
                 actions = form.actions
                 if actions.case_preload:
-                    for action in list(actions.case_preload.preload.values()):
+                    for action in actions.case_preload.preload.values():
                         log_excessive_parents(app, action)
                 if actions.update_case:
                     for action in actions.update_case.update:

--- a/corehq/apps/app_manager/management/commands/find_case_metadata_with_errors.py
+++ b/corehq/apps/app_manager/management/commands/find_case_metadata_with_errors.py
@@ -29,7 +29,7 @@ class Command(AppMigrationCommandBase):
                     return None
                 actions = form.actions
                 if actions.case_preload:
-                    for action in actions.case_preload.preload.values():
+                    for action in list(actions.case_preload.preload.values()):
                         log_excessive_parents(app, action)
                 if actions.update_case:
                     for action in actions.update_case.update:

--- a/corehq/apps/app_manager/management/commands/helpers.py
+++ b/corehq/apps/app_manager/management/commands/helpers.py
@@ -54,7 +54,7 @@ class AppMigrationCommandBase(BaseCommand):
                 migrated_app = self.migrate_app(app_doc)
                 if migrated_app:
                     return DocUpdate(migrated_app)
-        except Exception, e:
+        except Exception as e:
             logger.exception("App {id} not properly migrated".format(id=app_doc['_id']))
             if self.options['failfast']:
                 raise e

--- a/corehq/apps/app_manager/management/commands/link_apps.py
+++ b/corehq/apps/app_manager/management/commands/link_apps.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from django.core.management import BaseCommand, CommandError
 
 from corehq.apps.app_manager.models import Application
@@ -12,7 +13,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if len(args) != 2:
             raise CommandError("Usage is ./manage.py link_apps %s" % self.args)
-        print "Linking apps"
+        print("Linking apps")
         master_id = args[0]
         linked_id = args[1]
         master_app = Application.get(master_id)

--- a/corehq/apps/app_manager/management/commands/migrate_advanced_form_preload.py
+++ b/corehq/apps/app_manager/management/commands/migrate_advanced_form_preload.py
@@ -18,7 +18,7 @@ class Command(AppMigrationCommandBase):
                 for action in load_actions:
                     preload = action['preload']
                     if preload and list(preload.values())[0].startswith('/'):
-                        action['preload'] = {v: k for k, v in list(preload.items())}
+                        action['preload'] = {v: k for k, v in preload.items()}
                         should_save = True
 
         return Application.wrap(app_doc) if should_save else None

--- a/corehq/apps/app_manager/management/commands/migrate_advanced_form_preload.py
+++ b/corehq/apps/app_manager/management/commands/migrate_advanced_form_preload.py
@@ -17,8 +17,8 @@ class Command(AppMigrationCommandBase):
                 load_actions = form.get('actions', {}).get('load_update_cases', [])
                 for action in load_actions:
                     preload = action['preload']
-                    if preload and preload.values()[0].startswith('/'):
-                        action['preload'] = {v: k for k, v in preload.items()}
+                    if preload and list(preload.values())[0].startswith('/'):
+                        action['preload'] = {v: k for k, v in list(preload.items())}
                         should_save = True
 
         return Application.wrap(app_doc) if should_save else None

--- a/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                 logger.info('migration failed')
                 failures[hit['_id']] = hit['domain']
 
-        for id, domain in failures.iteritems():
+        for id, domain in failures.items():
             logger.info('Failed: {} in {}'.format(id, domain))
         logger.info('Total: {} successes, {} failures'.format(len(hits) - len(failures), len(failures)))
         logger.info('Done with migrate_all_apps_to_cmitfb')

--- a/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
@@ -104,7 +104,7 @@ def migrate_preloads(app, form, preloads):
         hashtag = kwargs.pop("hashtag")
         xform.add_case_preloads(**kwargs)
         refs = {path: [hashtag + case_property]
-                for path, case_property in kwargs["preloads"].iteritems()}
+                for path, case_property in kwargs["preloads"].items()}
         if form.case_references:
             form.case_references.load.update(refs)
         else:

--- a/corehq/apps/app_manager/management/commands/migrate_localized_media.py
+++ b/corehq/apps/app_manager/management/commands/migrate_localized_media.py
@@ -1,7 +1,7 @@
-from past.builtins import basestring
 from corehq.apps.app_manager.management.commands.helpers import AppMigrationCommandBase
 from corehq.apps.app_manager.models import Application
 from optparse import make_option
+from past.builtins import basestring
 
 
 class Command(AppMigrationCommandBase):

--- a/corehq/apps/app_manager/management/commands/migrate_localized_media.py
+++ b/corehq/apps/app_manager/management/commands/migrate_localized_media.py
@@ -1,3 +1,4 @@
+from past.builtins import basestring
 from corehq.apps.app_manager.management.commands.helpers import AppMigrationCommandBase
 from corehq.apps.app_manager.models import Application
 from optparse import make_option

--- a/corehq/apps/app_manager/management/commands/upload_app_forms.py
+++ b/corehq/apps/app_manager/management/commands/upload_app_forms.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from optparse import make_option
 from django.core.management.base import BaseCommand, CommandError
 
@@ -56,7 +57,7 @@ class Command(BaseCommand):
                     save_xform(app, form, f.read())
 
         app.save()
-        print 'successfully updated {}'.format(app.name)
+        print('successfully updated {}'.format(app.name))
         if options['deploy']:
             # make build and star it
             comment = options.get('comment', 'form changes from {0}'.format(datetime.utcnow().strftime(SERVER_DATETIME_FORMAT_NO_SEC)))
@@ -67,4 +68,4 @@ class Command(BaseCommand):
             )
             copy.is_released = True
             copy.save(increment_version=False)
-            print 'successfully released new version'
+            print('successfully released new version')

--- a/corehq/apps/app_manager/remote_app.py
+++ b/corehq/apps/app_manager/remote_app.py
@@ -1,7 +1,8 @@
 from future import standard_library
 standard_library.install_aliases()
 from lxml import etree
-import urllib.request, urllib.error, urllib.parse
+import urllib.request
+import urllib.error
 import urllib.parse
 from django.core import urlresolvers
 from corehq.apps.app_manager.exceptions import AppEditingError

--- a/corehq/apps/app_manager/remote_app.py
+++ b/corehq/apps/app_manager/remote_app.py
@@ -1,6 +1,8 @@
+from future import standard_library
+standard_library.install_aliases()
 from lxml import etree
-import urllib2
-import urlparse
+import urllib.request, urllib.error, urllib.parse
+import urllib.parse
 from django.core import urlresolvers
 from corehq.apps.app_manager.exceptions import AppEditingError
 from corehq.apps.app_manager.xform import WrappedNode
@@ -39,7 +41,7 @@ def reset_suite_remote_url(suite_node, url_base, profile_url, download_index_url
     suite_local_text = suite_node.findtext('resource/location[@authority="local"]')
     suite_remote = suite_node.find('resource/location[@authority="remote"]')
     suite_name = strip_location(profile_url, suite_local_text)
-    suite_remote.xml.text = url_base + urlparse.urljoin(download_index_url,
+    suite_remote.xml.text = url_base + urllib.parse.urljoin(download_index_url,
                                                         suite_name)
 
 
@@ -56,7 +58,7 @@ def strip_location(profile_url, location):
 
 def make_remote_profile(app, langs=None):
     try:
-        profile = urllib2.urlopen(app.profile_url).read()
+        profile = urllib.request.urlopen(app.profile_url).read()
     except Exception:
         raise AppEditingError('Unable to access profile url: "%s"' % app.profile_url)
 

--- a/corehq/apps/app_manager/suite_xml/contributors.py
+++ b/corehq/apps/app_manager/suite_xml/contributors.py
@@ -1,9 +1,9 @@
+from builtins import object
 from abc import ABCMeta, abstractmethod, abstractproperty
+from future.utils import with_metaclass
 
 
-class BaseSuiteContributor(object):
-    __metaclass__ = ABCMeta
-
+class BaseSuiteContributor(with_metaclass(ABCMeta, object)):
     def __init__(self, suite, app, modules):
         from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
         self.suite = suite
@@ -12,9 +12,7 @@ class BaseSuiteContributor(object):
         self.entries_helper = EntriesHelper(app, modules)
 
 
-class SectionContributor(BaseSuiteContributor):
-    __metaclass__ = ABCMeta
-
+class SectionContributor(with_metaclass(ABCMeta, BaseSuiteContributor)):
     @abstractproperty
     def section_name(self):
         pass
@@ -24,8 +22,7 @@ class SectionContributor(BaseSuiteContributor):
         return []
 
 
-class SuiteContributorByModule(BaseSuiteContributor):
-    __metaclass__ = ABCMeta
+class SuiteContributorByModule(with_metaclass(ABCMeta, BaseSuiteContributor)):
     section = None
 
     @abstractmethod
@@ -33,9 +30,7 @@ class SuiteContributorByModule(BaseSuiteContributor):
         return []
 
 
-class PostProcessor(BaseSuiteContributor):
-    __metaclass__ = ABCMeta
-
+class PostProcessor(with_metaclass(ABCMeta, BaseSuiteContributor)):
     @abstractmethod
     def update_suite(self):
         pass

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.models import ReportModule, ReportGraphConfig, \
     MobileSelectFilter
@@ -126,7 +128,7 @@ def _get_summary_details(config, domain):
                         y_function="column[@id='{}']".format(column),
                         configuration=ConfigurationGroup(configs=[
                             ConfigurationItem(id=key, xpath_function=value)
-                            for key, value in graph_config.series_configs.get(column, {}).items()
+                            for key, value in list(graph_config.series_configs.get(column, {}).items())
                         ])
                     )
                 yield Field(
@@ -138,7 +140,7 @@ def _get_summary_details(config, domain):
                             series=[_column_to_series(c.column_id) for c in chart_config.y_axis_columns],
                             configuration=ConfigurationGroup(configs=[
                                 ConfigurationItem(id=key, xpath_function=value)
-                                for key, value in graph_config.config.items()
+                                for key, value in list(graph_config.config.items())
                             ]),
                         ),
                     )
@@ -221,7 +223,7 @@ def _get_data_detail(config, domain):
 
             def _get_word_eval(word_translations, default_value):
                 word_eval = default_value
-                for lang, translation in word_translations.items():
+                for lang, translation in list(word_translations.items()):
                     word_eval = _get_conditional(
                         "$lang = '{lang}'".format(
                             lang=lang,
@@ -237,7 +239,7 @@ def _get_data_detail(config, domain):
             if transform.get('type') == 'translation':
                 default_val = "column[@id='{column_id}']"
                 xpath_function = default_val
-                for word, translations in transform['translations'].items():
+                for word, translations in list(transform['translations'].items()):
                     if isinstance(translations, basestring):
                         # This is a flat mapping, not per-language translations
                         word_eval = "'{}'".format(translations)
@@ -297,7 +299,7 @@ class _MobileSelectFilterHelpers(object):
 
     @staticmethod
     def get_filters(config, domain):
-        return [(slug, f) for slug, f in config.filters.items()
+        return [(slug, f) for slug, f in list(config.filters.items())
                 if isinstance(f, MobileSelectFilter)
                 and is_valid_mobile_select_filter_type(config.report(domain).get_ui_filter(slug))]
 

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -1,5 +1,6 @@
-from past.builtins import basestring
 from builtins import object
+from past.builtins import basestring
+
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.models import ReportModule, ReportGraphConfig, \
     MobileSelectFilter
@@ -128,7 +129,7 @@ def _get_summary_details(config, domain):
                         y_function="column[@id='{}']".format(column),
                         configuration=ConfigurationGroup(configs=[
                             ConfigurationItem(id=key, xpath_function=value)
-                            for key, value in list(graph_config.series_configs.get(column, {}).items())
+                            for key, value in graph_config.series_configs.get(column, {}).items()
                         ])
                     )
                 yield Field(
@@ -140,7 +141,7 @@ def _get_summary_details(config, domain):
                             series=[_column_to_series(c.column_id) for c in chart_config.y_axis_columns],
                             configuration=ConfigurationGroup(configs=[
                                 ConfigurationItem(id=key, xpath_function=value)
-                                for key, value in list(graph_config.config.items())
+                                for key, value in graph_config.config.items()
                             ]),
                         ),
                     )
@@ -223,7 +224,7 @@ def _get_data_detail(config, domain):
 
             def _get_word_eval(word_translations, default_value):
                 word_eval = default_value
-                for lang, translation in list(word_translations.items()):
+                for lang, translation in word_translations.items():
                     word_eval = _get_conditional(
                         "$lang = '{lang}'".format(
                             lang=lang,
@@ -239,7 +240,7 @@ def _get_data_detail(config, domain):
             if transform.get('type') == 'translation':
                 default_val = "column[@id='{column_id}']"
                 xpath_function = default_val
-                for word, translations in list(transform['translations'].items()):
+                for word, translations in transform['translations'].items():
                     if isinstance(translations, basestring):
                         # This is a flat mapping, not per-language translations
                         word_eval = "'{}'".format(translations)
@@ -299,7 +300,7 @@ class _MobileSelectFilterHelpers(object):
 
     @staticmethod
     def get_filters(config, domain):
-        return [(slug, f) for slug, f in list(config.filters.items())
+        return [(slug, f) for slug, f in config.filters.items()
                 if isinstance(f, MobileSelectFilter)
                 and is_valid_mobile_select_filter_type(config.report(domain).get_ui_filter(slug))]
 

--- a/corehq/apps/app_manager/suite_xml/features/scheduler.py
+++ b/corehq/apps/app_manager/suite_xml/features/scheduler.py
@@ -28,8 +28,9 @@ class SchedulerFixtureContributor(SectionContributor):
             schedule = form.schedule
 
             if schedule is None:
-                raise ScheduleError(_("There is no schedule for form {form_id}")
-                                     .format(form_id=form.unique_id))
+                raise ScheduleError(
+                    _("There is no schedule for form {form_id}")
+                    .format(form_id=form.unique_id))
 
             visits = [ScheduleFixtureVisit(id=visit.id,
                                            due=visit.due,

--- a/corehq/apps/app_manager/suite_xml/features/scheduler.py
+++ b/corehq/apps/app_manager/suite_xml/features/scheduler.py
@@ -28,7 +28,8 @@ class SchedulerFixtureContributor(SectionContributor):
             schedule = form.schedule
 
             if schedule is None:
-                raise ScheduleError
+                raise ScheduleError(_("There is no schedule for form {form_id}")
+                                     .format(form_id=form.unique_id))
 
             visits = [ScheduleFixtureVisit(id=visit.id,
                                            due=visit.due,

--- a/corehq/apps/app_manager/suite_xml/features/scheduler.py
+++ b/corehq/apps/app_manager/suite_xml/features/scheduler.py
@@ -28,8 +28,7 @@ class SchedulerFixtureContributor(SectionContributor):
             schedule = form.schedule
 
             if schedule is None:
-                raise (ScheduleError(_("There is no schedule for form {form_id}")
-                                     .format(form_id=form.unique_id)))
+                raise ScheduleError
 
             visits = [ScheduleFixtureVisit(id=visit.id,
                                            due=visit.due,

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,8 +1,9 @@
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object
+
 import urllib.request, urllib.parse, urllib.error
 
+from builtins import object
 from django.core.urlresolvers import reverse
 
 from corehq.apps.app_manager.exceptions import MediaResourceError
@@ -109,7 +110,7 @@ class MediaSuiteGenerator(object):
             for lang in self.build_profile.langs:
                 media_list += self.app.media_language_map[lang].media_refs
             requested_media = set(media_list)
-        for path, m in sorted(list(self.app.multimedia_map.items()), key=lambda item: item[0]):
+        for path, m in sorted(self.app.multimedia_map.items(), key=lambda item: item[0]):
             if filter_multimedia and m.form_media and path not in requested_media:
                 continue
             unchanged_path = path

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,8 +1,9 @@
 from future import standard_library
 standard_library.install_aliases()
 
-import urllib.request, urllib.parse, urllib.error
-
+import urllib.request
+import urllib.parse
+import urllib.error
 from builtins import object
 from django.core.urlresolvers import reverse
 

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,4 +1,7 @@
-import urllib
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+import urllib.request, urllib.parse, urllib.error
 
 from django.core.urlresolvers import reverse
 
@@ -106,7 +109,7 @@ class MediaSuiteGenerator(object):
             for lang in self.build_profile.langs:
                 media_list += self.app.media_language_map[lang].media_refs
             requested_media = set(media_list)
-        for path, m in sorted(self.app.multimedia_map.items(), key=lambda item: item[0]):
+        for path, m in sorted(list(self.app.multimedia_map.items()), key=lambda item: item[0]):
             if filter_multimedia and m.form_media and path not in requested_media:
                 continue
             unchanged_path = path
@@ -148,5 +151,5 @@ class MediaSuiteGenerator(object):
                 remote=self.app.url_base + reverse(
                     'hqmedia_download',
                     args=[m.media_type, m.multimedia_id]
-                ) + urllib.quote(name.encode('utf-8')) if name else name
+                ) + urllib.parse.quote(name.encode('utf-8')) if name else name
             )

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,3 +1,4 @@
+from builtins import object
 from collections import defaultdict
 import re
 from corehq import toggles
@@ -119,7 +120,7 @@ INSTANCE_BY_ID = {
 }
 
 
-@register_factory(*INSTANCE_BY_ID.keys())
+@register_factory(*list(INSTANCE_BY_ID.keys()))
 def preset_instances(domain, instance_name):
     return INSTANCE_BY_ID.get(instance_name, None)
 
@@ -167,7 +168,7 @@ def get_all_instances_referenced_in_xpaths(domain, xpaths):
             if instance:
                 instances.add(instance)
             else:
-                class UnicodeWithContext(unicode):
+                class UnicodeWithContext(str):
                     pass
                 instance_name = UnicodeWithContext(instance_name)
                 instance_name.xpath = xpath

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,6 +1,7 @@
-from builtins import object
-from collections import defaultdict
 import re
+from builtins import object
+from builtins import str
+from collections import defaultdict
 from corehq import toggles
 from corehq.apps.app_manager.exceptions import DuplicateInstanceIdError
 from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
@@ -120,7 +121,7 @@ INSTANCE_BY_ID = {
 }
 
 
-@register_factory(*list(INSTANCE_BY_ID.keys()))
+@register_factory(*list(INSTANCE_BY_ID))
 def preset_instances(domain, instance_name):
     return INSTANCE_BY_ID.get(instance_name, None)
 

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -29,7 +29,7 @@ class WorkflowHelper(PostProcessor):
         root_modules = [module for module in self.modules if getattr(module, 'put_in_root', False)]
         return [
             datum for module in root_modules
-            for datum in list(self.get_module_datums(u'm{}'.format(module.id)).values())
+            for datum in self.get_module_datums(u'm{}'.format(module.id)).values()
         ]
 
     def update_suite(self):
@@ -147,8 +147,8 @@ class WorkflowHelper(PostProcessor):
                 for d in e.datums:
                     datums[module_id][form_id].append(WorkflowDatumMeta.from_session_datum(d))
 
-        for module_id, form_datum_map in list(datums.items()):
-            for form_id, entry_datums in list(form_datum_map.items()):
+        for module_id, form_datum_map in datums.items():
+            for form_id, entry_datums in form_datum_map.items():
                 self._add_missing_case_types(module_id, form_id, entry_datums)
 
         return entries, datums

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from builtins import filter
+from builtins import object
 from collections import defaultdict, namedtuple
 from functools import total_ordering
 from os.path import commonprefix
@@ -27,7 +29,7 @@ class WorkflowHelper(PostProcessor):
         root_modules = [module for module in self.modules if getattr(module, 'put_in_root', False)]
         return [
             datum for module in root_modules
-            for datum in self.get_module_datums(u'm{}'.format(module.id)).values()
+            for datum in list(self.get_module_datums(u'm{}'.format(module.id)).values())
         ]
 
     def update_suite(self):
@@ -82,7 +84,7 @@ class WorkflowHelper(PostProcessor):
         if module_command == id_strings.ROOT:
             datums_list = self.root_module_datums
         else:
-            datums_list = module_datums.values()  # [ [datums for f0], [datums for f1], ...]
+            datums_list = list(module_datums.values())  # [ [datums for f0], [datums for f1], ...]
 
         common_datums = commonprefix(datums_list)
         remaining_datums = form_datums[len(common_datums):]
@@ -96,7 +98,7 @@ class WorkflowHelper(PostProcessor):
         return frame_children
 
     def create_workflow_stack(self, form_command, frame_metas):
-        frames = filter(None, [meta.to_frame() for meta in frame_metas])
+        frames = [_f for _f in [meta.to_frame() for meta in frame_metas] if _f]
         if not frames:
             return
 
@@ -145,8 +147,8 @@ class WorkflowHelper(PostProcessor):
                 for d in e.datums:
                     datums[module_id][form_id].append(WorkflowDatumMeta.from_session_datum(d))
 
-        for module_id, form_datum_map in datums.items():
-            for form_id, entry_datums in form_datum_map.items():
+        for module_id, form_datum_map in list(datums.items()):
+            for form_id, entry_datums in list(form_datum_map.items()):
                 self._add_missing_case_types(module_id, form_id, entry_datums)
 
         return entries, datums

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import object
 from collections import namedtuple
 import os
 from xml.sax.saxutils import escape
@@ -406,7 +407,7 @@ def get_instances_for_module(app, module, additional_xpaths=None):
     detail_ids = [helper.get_detail_id_safe(module, detail_type)
                   for detail_type, detail, enabled in module.get_details()
                   if enabled]
-    detail_ids = filter(None, detail_ids)
+    detail_ids = [_f for _f in detail_ids if _f]
     xpaths = set()
 
     if additional_xpaths:

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -1,5 +1,6 @@
+from builtins import object
 from collections import namedtuple, defaultdict
-from itertools import izip_longest
+from itertools import zip_longest
 from django.utils.translation import ugettext as _
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
 
@@ -775,7 +776,7 @@ class EntriesHelper(object):
             datum_ids = {d.datum.id: d for d in datums}
             index = 0
             changed_ids_by_case_tag = defaultdict(list)
-            for this_datum_meta, parent_datum_meta in list(izip_longest(datums, parent_datums)):
+            for this_datum_meta, parent_datum_meta in list(zip_longest(datums, parent_datums)):
                 if this_datum_meta:
                     update_refs(this_datum_meta, changed_ids_by_case_tag)
                 if not parent_datum_meta:

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -1,3 +1,4 @@
+from builtins import next
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import (ScheduleError, CaseXPathValidationError,
     UserCaseXPathValidationError)

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -1,3 +1,4 @@
+from builtins import object
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
 from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -44,7 +44,7 @@ def get_select_chain_meta(app, module):
 
 
 def validate_suite(suite):
-    if isinstance(suite, unicode):
+    if isinstance(suite, str):
         suite = suite.encode('utf8')
     if isinstance(suite, str):
         suite = etree.fromstring(suite)

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -1,4 +1,5 @@
 from lxml import etree
+from builtins import str
 from django.utils.translation import ugettext as _
 from corehq.apps.app_manager.exceptions import SuiteValidationError
 from corehq.apps.app_manager.suite_xml.xml_models import Suite
@@ -46,7 +47,7 @@ def get_select_chain_meta(app, module):
 def validate_suite(suite):
     if isinstance(suite, str):
         suite = suite.encode('utf8')
-    if isinstance(suite, str):
+    if isinstance(suite, bytes):
         suite = etree.fromstring(suite)
     if isinstance(suite, etree._Element):
         suite = Suite(suite)

--- a/corehq/apps/app_manager/templatetags/url_extras.py
+++ b/corehq/apps/app_manager/templatetags/url_extras.py
@@ -1,5 +1,6 @@
 from future import standard_library
 standard_library.install_aliases()
+from builtins import str
 from django import template
 import urllib.request, urllib.parse, urllib.error
 
@@ -53,7 +54,7 @@ class URLEncodeNode(template.Node):
             params[key] = [v.encode('utf-8') if isinstance(v, str) else v
                            for v in val]
 
-        for key,val in list(self.extra_params.items()):
+        for key,val in self.extra_params.items():
             key = template.Variable(key).resolve(context)
             val = template.Variable(val).resolve(context)
             params[key] = val

--- a/corehq/apps/app_manager/templatetags/url_extras.py
+++ b/corehq/apps/app_manager/templatetags/url_extras.py
@@ -1,8 +1,10 @@
 from future import standard_library
 standard_library.install_aliases()
+import urllib.request
+import urllib.parse
+import urllib.error
 from builtins import str
 from django import template
-import urllib.request, urllib.parse, urllib.error
 
 register = template.Library()
 
@@ -34,14 +36,15 @@ def urlencode(parser, token):
             except:
                 raise template.TemplateSyntaxError("%r tag has incomplete 'without'" % tag_name)
         else:
-            raise template.TemplateSyntaxError("%r tag found '%s'; expected 'with...as' or 'without'" % (tag_name, cmd))
+            raise template.TemplateSyntaxError(
+                "%r tag found '%s'; expected 'with...as' or 'without'" % (tag_name, cmd))
 
     return URLEncodeNode(path_var, params_var, params, delete)
 
 
 class URLEncodeNode(template.Node):
 
-    def __init__(self, path_var,  params_var, extra_params, delete_params):
+    def __init__(self, path_var, params_var, extra_params, delete_params):
         self.path_var = template.Variable(path_var)
         self.params_var = template.Variable(params_var)
         self.extra_params = extra_params
@@ -54,7 +57,7 @@ class URLEncodeNode(template.Node):
             params[key] = [v.encode('utf-8') if isinstance(v, str) else v
                            for v in val]
 
-        for key,val in self.extra_params.items():
+        for key, val in self.extra_params.items():
             key = template.Variable(key).resolve(context)
             val = template.Variable(val).resolve(context)
             params[key] = val

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -125,7 +125,7 @@ def _input_trans(template, name, langs=None, allow_blank=True):
                 options['placeholder'] = name[lang] if (allow_blank or name[lang] != '') else placeholder
                 options['lang'] = lang
             break
-    options = {key: html.escapejs(value) for (key, value) in options.iteritems()}
+    options = {key: html.escapejs(value) for (key, value) in options.items()}
     return mark_safe(template % options)
 
 

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -1,3 +1,6 @@
+from builtins import next
+from past.builtins import basestring
+from builtins import object
 import uuid
 from corehq.apps.app_manager.const import AUTO_SELECT_USERCASE
 from corehq.apps.app_manager.models import AdvancedModule, Module, UpdateCaseAction, LoadUpdateAction, \

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -1,7 +1,8 @@
-from builtins import next
-from past.builtins import basestring
-from builtins import object
 import uuid
+from builtins import next
+from builtins import object
+from past.builtins import basestring
+
 from corehq.apps.app_manager.const import AUTO_SELECT_USERCASE
 from corehq.apps.app_manager.models import AdvancedModule, Module, UpdateCaseAction, LoadUpdateAction, \
     FormActionCondition, OpenSubCaseAction, OpenCaseAction, AdvancedOpenCaseAction, Application, AdvancedForm, \

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+from builtins import zip
+from builtins import range
 import json
 from mock import patch
 from corehq.apps.app_manager.tests.util import add_build, patch_default_builds
@@ -108,7 +110,7 @@ class AppManagerTest(TestCase):
     @patch_default_builds
     def _test_import_app(self, app_id_or_source):
         new_app = import_app(app_id_or_source, self.domain)
-        self.assertEqual(set(new_app.blobs.keys()).intersection(self.app.blobs.keys()), set())
+        self.assertEqual(set(new_app.blobs.keys()).intersection(list(self.app.blobs.keys())), set())
         new_forms = list(new_app.get_forms())
         old_forms = list(self.app.get_forms())
         for new_form, old_form in zip(new_forms, old_forms):

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -1,7 +1,7 @@
 # coding: utf-8
+import json
 from builtins import zip
 from builtins import range
-import json
 from mock import patch
 from corehq.apps.app_manager.tests.util import add_build, patch_default_builds
 from corehq.apps.app_manager.util import (add_odk_profile_after_build,
@@ -110,7 +110,7 @@ class AppManagerTest(TestCase):
     @patch_default_builds
     def _test_import_app(self, app_id_or_source):
         new_app = import_app(app_id_or_source, self.domain)
-        self.assertEqual(set(new_app.blobs.keys()).intersection(list(self.app.blobs.keys())), set())
+        self.assertEqual(set(new_app.blobs).intersection(self.app.blobs), set())
         new_forms = list(new_app.get_forms())
         old_forms = list(self.app.get_forms())
         for new_form, old_form in zip(new_forms, old_forms):

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -1,9 +1,13 @@
 # coding=utf-8
+from future import standard_library
+standard_library.install_aliases()
+from builtins import next
+from builtins import zip
 import codecs
 import tempfile
 
 from django.test import SimpleTestCase
-from StringIO import StringIO
+from io import StringIO
 
 from mock import patch
 
@@ -358,7 +362,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
 
         actual_workbook = [
             {'name': title,
-             'rows': [dict(zip(headers, row)) for row in actual_rows[title]]}
+             'rows': [dict(list(zip(headers, row))) for row in actual_rows[title]]}
             for title, headers in actual_headers
         ]
 

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -1,10 +1,11 @@
 # coding=utf-8
 from future import standard_library
 standard_library.install_aliases()
-from builtins import next
-from builtins import zip
+
 import codecs
 import tempfile
+from builtins import next
+from builtins import zip
 
 from django.test import SimpleTestCase
 from io import StringIO
@@ -362,7 +363,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
 
         actual_workbook = [
             {'name': title,
-             'rows': [dict(list(zip(headers, row))) for row in actual_rows[title]]}
+             'rows': [dict(zip(headers, row)) for row in actual_rows[title]]}
             for title, headers in actual_headers
         ]
 

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -1,5 +1,7 @@
+from future import standard_library
+standard_library.install_aliases()
 from django.test import SimpleTestCase
-from StringIO import StringIO
+from io import StringIO
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.views.translations import process_ui_translation_upload,\
     get_default_translations_for_download
@@ -18,7 +20,7 @@ class BulkUiTranslation(SimpleTestCase):
         if data is None:
             data = []
             translations = get_default_translations_for_download(self.app)
-            for translation_key, translation_value in translations.iteritems():
+            for translation_key, translation_value in translations.items():
                 data.append((translation_key, translation_value))
 
         data = (('translations', tuple(data)),)

--- a/corehq/apps/app_manager/tests/test_case_detail_distance.py
+++ b/corehq/apps/app_manager/tests/test_case_detail_distance.py
@@ -141,8 +141,8 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
 
     def test_long_detail_xml(self):
         long = self.case_details.long
-        long.display = 'long'
-        long_column = long.get_column(0)
+        int.display = 'long'
+        long_column = int.get_column(0)
         long_column.format = 'distance'
 
         suite = self.factory.app.create_suite()

--- a/corehq/apps/app_manager/tests/test_case_detail_distance.py
+++ b/corehq/apps/app_manager/tests/test_case_detail_distance.py
@@ -141,8 +141,8 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
 
     def test_long_detail_xml(self):
         long = self.case_details.long
-        int.display = 'long'
-        long_column = int.get_column(0)
+        long.display = 'long'
+        long_column = long.get_column(0)
         long_column.format = 'distance'
 
         suite = self.factory.app.create_suite()

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -1,3 +1,4 @@
+from builtins import range
 from collections import defaultdict
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.commcare_settings import (

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -160,15 +160,15 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         app_build_versions = get_all_built_app_ids_and_versions(self.domain)
 
         self.assertEqual(len(app_build_versions), 3)
-        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id == '1234']), 1)
-        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id == self.apps[0]._id]), 2)
+        self.assertEqual(len([abv for abv in app_build_versions if abv.app_id == '1234']), 1)
+        self.assertEqual(len([abv for abv in app_build_versions if abv.app_id == self.apps[0]._id]), 2)
 
     def test_get_all_built_app_ids_and_versions_by_app(self):
         app_build_versions = get_all_built_app_ids_and_versions(self.domain, app_id='1234')
 
         self.assertEqual(len(app_build_versions), 1)
-        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id == '1234']), 1)
-        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id != '1234']), 0)
+        self.assertEqual(len([abv for abv in app_build_versions if abv.app_id == '1234']), 1)
+        self.assertEqual(len([abv for abv in app_build_versions if abv.app_id != '1234']), 0)
 
 
 class TestAppGetters(TestCase):

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -160,15 +160,15 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         app_build_versions = get_all_built_app_ids_and_versions(self.domain)
 
         self.assertEqual(len(app_build_versions), 3)
-        self.assertEqual(len(filter(lambda abv: abv.app_id == '1234', app_build_versions)), 1)
-        self.assertEqual(len(filter(lambda abv: abv.app_id == self.apps[0]._id, app_build_versions)), 2)
+        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id == '1234']), 1)
+        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id == self.apps[0]._id]), 2)
 
     def test_get_all_built_app_ids_and_versions_by_app(self):
         app_build_versions = get_all_built_app_ids_and_versions(self.domain, app_id='1234')
 
         self.assertEqual(len(app_build_versions), 1)
-        self.assertEqual(len(filter(lambda abv: abv.app_id == '1234', app_build_versions)), 1)
-        self.assertEqual(len(filter(lambda abv: abv.app_id != '1234', app_build_versions)), 0)
+        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id == '1234']), 1)
+        self.assertEqual(len([abv for abv in app_build_verions if abv.app_id != '1234']), 0)
 
 
 class TestAppGetters(TestCase):

--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -1,3 +1,5 @@
+from builtins import next
+from builtins import str
 from corehq.apps.app_manager.exceptions import CaseError
 from corehq.apps.app_manager.models import (
     Application,

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from builtins import str
 from corehq.apps.app_manager.const import CAREPLAN_GOAL, CAREPLAN_TASK
 from corehq.apps.app_manager.exceptions import XFormException, XFormValidationError
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -1,3 +1,5 @@
+from builtins import filter
+from builtins import str
 import os
 import uuid
 

--- a/corehq/apps/app_manager/tests/test_profile.py
+++ b/corehq/apps/app_manager/tests/test_profile.py
@@ -36,8 +36,8 @@ class ProfileTest(SimpleTestCase, TestXmlMixin):
             'features': self._test_feature,
             'properties': self._test_property,
         }
-        for p_type, test_method in types.items():
-            for key, value in app.profile.get(p_type, {}).items():
+        for p_type, test_method in list(types.items()):
+            for key, value in list(app.profile.get(p_type, {}).items()):
                 setting = get_commcare_settings_lookup()[p_type][key]
                 test_method(profile_xml, key, value, setting)
 

--- a/corehq/apps/app_manager/tests/test_profile.py
+++ b/corehq/apps/app_manager/tests/test_profile.py
@@ -36,8 +36,8 @@ class ProfileTest(SimpleTestCase, TestXmlMixin):
             'features': self._test_feature,
             'properties': self._test_property,
         }
-        for p_type, test_method in list(types.items()):
-            for key, value in list(app.profile.get(p_type, {}).items()):
+        for p_type, test_method in types.items():
+            for key, value in app.profile.get(p_type, {}).items():
                 setting = get_commcare_settings_lookup()[p_type][key]
                 test_method(profile_xml, key, value, setting)
 

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -1,3 +1,4 @@
+from past.builtins import basestring
 import os
 from xml.etree import ElementTree
 from django.test import SimpleTestCase, TestCase

--- a/corehq/apps/app_manager/tests/test_schedule.py
+++ b/corehq/apps/app_manager/tests/test_schedule.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from builtins import next
 from mock import patch
 import copy
 from django.test import SimpleTestCase

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -340,7 +340,7 @@ class SchemaTest(SimpleTestCase):
         Key/value pairs in `test_dict` but not present in
         `expected_dict` will be ignored.
         """
-        for key, value in expected_dict.items():
+        for key, value in list(expected_dict.items()):
             self.assertEqual(test_dict[key], value)
 
     def add_form(self, case_type=None, case_updates=None):

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -340,7 +340,7 @@ class SchemaTest(SimpleTestCase):
         Key/value pairs in `test_dict` but not present in
         `expected_dict` will be ignored.
         """
-        for key, value in list(expected_dict.items()):
+        for key, value in expected_dict.items():
             self.assertEqual(test_dict[key], value)
 
     def add_form(self, case_type=None, case_updates=None):

--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -16,7 +16,7 @@ class XFormParsingTest(SimpleTestCase, TestXmlMixin):
             self.xforms[filename] = XForm(xml)
 
     def test_properties(self):
-        for _, xform in list(self.xforms.items()):
+        for _, xform in self.xforms.items():
             xform.data_node
             xform.model_node
             xform.instance_node

--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from builtins import str
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.xform import XForm, XFormException, ItextValue, \
@@ -15,7 +16,7 @@ class XFormParsingTest(SimpleTestCase, TestXmlMixin):
             self.xforms[filename] = XForm(xml)
 
     def test_properties(self):
-        for _, xform in self.xforms.items():
+        for _, xform in list(self.xforms.items()):
             xform.data_node
             xform.model_node
             xform.instance_node

--- a/corehq/apps/app_manager/tests/test_xml_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xml_parsing.py
@@ -1,3 +1,4 @@
+from builtins import str
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.models import _parse_xml
 import os
@@ -15,6 +16,6 @@ class XMLParsingTest(SimpleTestCase):
         except:    
             self.fail("Parsing normal string data shouldn't fail!")
         try:
-            _parse_xml(unicode(xml_data))
+            _parse_xml(str(xml_data))
         except:    
             self.fail("Parsing unicode data shouldn't fail!")

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -88,7 +88,7 @@ def normalize_attributes(xml):
     """Sort XML attributes to make it easier to find differences"""
     for node in xml.iterfind(".//*"):
         if node.attrib:
-            attrs = sorted(node.attrib.iteritems())
+            attrs = sorted(node.attrib.items())
             node.attrib.clear()
             node.attrib.update(attrs)
     return xml

--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -1,15 +1,15 @@
 # coding=utf-8
-from builtins import zip
+import copy
+import re
 from builtins import next
 from builtins import str
-from past.builtins import basestring
+from builtins import zip
 from collections import defaultdict, OrderedDict
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from lxml import etree
-import copy
-import re
 from lxml.etree import XMLSyntaxError, Element
+from past.builtins import basestring
 
 from corehq.apps.app_manager.exceptions import (
     FormNotFoundException,
@@ -634,10 +634,10 @@ def update_form_translations(sheet, rows, missing_cols, app):
                     # has already been logged as unrecoginzed column
                     continue
 
-            keep_value_node = any(v for k, v in list(translations.items()))
+            keep_value_node = any(v for k, v in translations.items())
 
             # Add or remove translations
-            for trans_type, new_translation in list(translations.items()):
+            for trans_type, new_translation in translations.items():
                 if not new_translation and col_key not in missing_cols:
                     # If the cell corresponding to the label for this question
                     # in this language is empty, fall back to another language

--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -1,4 +1,8 @@
 # coding=utf-8
+from builtins import zip
+from builtins import next
+from builtins import str
+from past.builtins import basestring
 from collections import defaultdict, OrderedDict
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
@@ -33,11 +37,11 @@ def get_unicode_dicts(iterable):
 
     """
     def none_or_unicode(val):
-        return unicode(val) if val is not None else val
+        return str(val) if val is not None else val
 
     rows = []
     for row in iterable:
-        rows.append({unicode(k): none_or_unicode(v) for k, v in row.iteritems()})
+        rows.append({str(k): none_or_unicode(v) for k, v in row.items()})
     return rows
 
 
@@ -318,7 +322,7 @@ def expected_bulk_app_sheet_rows(app):
 
                     # Add rows for graph configuration
                     if detail.format == "graph":
-                        for key, val in detail.graph_configuration.locale_specific_config.iteritems():
+                        for key, val in detail.graph_configuration.locale_specific_config.items():
                             rows[module_string].append(
                                 (
                                     key + " (graph config)",
@@ -326,7 +330,7 @@ def expected_bulk_app_sheet_rows(app):
                                 ) + tuple(val.get(lang, "") for lang in app.langs)
                             )
                         for i, series in enumerate(detail.graph_configuration.series):
-                            for key, val in series.locale_specific_config.iteritems():
+                            for key, val in series.locale_specific_config.items():
                                 rows[module_string].append(
                                     (
                                         "{} {} (graph series config)".format(key, i),
@@ -389,7 +393,7 @@ def expected_bulk_app_sheet_rows(app):
                                     value += mark_safe(force_text(part).replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;'))
                             itext_items[text_id][(lang, value_form)] = value
 
-                for text_id, values in itext_items.iteritems():
+                for text_id, values in itext_items.items():
                     row = [text_id]
                     for value_form in ["default", "audio", "image", "video"]:
                         # Get the fallback value for this form
@@ -630,10 +634,10 @@ def update_form_translations(sheet, rows, missing_cols, app):
                     # has already been logged as unrecoginzed column
                     continue
 
-            keep_value_node = any(v for k, v in translations.items())
+            keep_value_node = any(v for k, v in list(translations.items()))
 
             # Add or remove translations
-            for trans_type, new_translation in translations.items():
+            for trans_type, new_translation in list(translations.items()):
                 if not new_translation and col_key not in missing_cols:
                     # If the cell corresponding to the label for this question
                     # in this language is empty, fall back to another language
@@ -813,7 +817,7 @@ def update_case_list_translations(sheet, rows, app):
             ))
 
     for row, detail in \
-            zip(list_rows, short_details) + zip(detail_rows, long_details):
+            list(zip(list_rows, short_details)) + list(zip(detail_rows, long_details)):
 
         # Check that names match (user is not allowed to change property in the
         # upload). Mismatched names indicate the user probably botched the sheet.
@@ -879,7 +883,7 @@ def has_at_least_one_translation(row, prefix, langs):
     :param langs:
     :return:
     """
-    return bool(filter(None, [row.get(prefix + '_' + l) for l in langs]))
+    return bool([_f for _f in [row.get(prefix + '_' + l) for l in langs] if _f])
 
 
 def get_col_key(translation_type, language):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -309,7 +309,7 @@ class ParentCasePropertyBuilder(object):
             for parent_type, relationship in parent_types:
                 rel_map[relationship].append(parent_type)
 
-            for relationship, types in list(rel_map.items()):
+            for relationship, types in rel_map.items():
                 if allow_multiple_parents:
                     parent_map[case_type][relationship] = types
                 else:
@@ -836,7 +836,7 @@ def get_sort_and_sort_only_columns(detail, sort_elements):
 
     sort_only_elements = [
         SortOnlyElement(field, element, element_order)
-        for field, (element, element_order) in list(sort_elements.items())
+        for field, (element, element_order) in sort_elements.items()
     ]
     return sort_only_elements, sort_columns
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -1,3 +1,4 @@
+from builtins import object
 from collections import defaultdict, namedtuple, OrderedDict
 from copy import deepcopy
 import functools
@@ -308,7 +309,7 @@ class ParentCasePropertyBuilder(object):
             for parent_type, relationship in parent_types:
                 rel_map[relationship].append(parent_type)
 
-            for relationship, types in rel_map.items():
+            for relationship, types in list(rel_map.items()):
                 if allow_multiple_parents:
                     parent_map[case_type][relationship] = types
                 else:
@@ -587,14 +588,14 @@ def all_case_properties_by_domain(domain, include_parent_properties=True):
         property_map = get_case_properties(app, app.get_case_types(),
             defaults=('name',), include_parent_properties=include_parent_properties)
 
-        for case_type, properties in property_map.iteritems():
+        for case_type, properties in property_map.items():
             if case_type in result:
                 result[case_type].extend(properties)
             else:
                 result[case_type] = properties
 
     cleaned_result = {}
-    for case_type, properties in result.iteritems():
+    for case_type, properties in result.items():
         properties = list(set(properties))
         properties.sort()
         cleaned_result[case_type] = properties
@@ -835,7 +836,7 @@ def get_sort_and_sort_only_columns(detail, sort_elements):
 
     sort_only_elements = [
         SortOnlyElement(field, element, element_order)
-        for field, (element, element_order) in sort_elements.items()
+        for field, (element, element_order) in list(sort_elements.items())
     ]
     return sort_only_elements, sort_columns
 

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -1,5 +1,9 @@
+from builtins import next
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 from copy import copy
-from StringIO import StringIO
+from io import StringIO
 from collections import namedtuple
 
 from django.core.urlresolvers import reverse
@@ -108,7 +112,7 @@ class AppSummaryView(JSONResponseMixin, LoginAndDomainMixin, BasePageView, Appli
                     form_meta['questions'] = [FormQuestionResponse(q).to_json() for q in questions]
                 except XFormException as e:
                     form_meta['error'] = {
-                        'details': unicode(e),
+                        'details': str(e),
                         'edit_url': reverse('form_source', args=[self.domain, self.app_id, module.id, form.id])
                     }
                     form_meta['module'] = copy(module_meta)
@@ -143,7 +147,7 @@ def _translate_name(names, language):
     try:
         return names[language]
     except KeyError:
-        first_name = names.iteritems().next()
+        first_name = next(iter(names.items()))
         return u"{} [{}]".format(first_name[1], first_name[0])
 
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -37,7 +37,6 @@ from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.tour import tours
 from corehq.apps.translations.models import Translation
 from corehq.apps.app_manager.const import (
-    APP_V2,
     MAJOR_RELEASE_TO_VERSION,
     AUTO_SELECT_USERCASE,
     DEFAULT_FETCH_LIMIT,
@@ -136,7 +135,7 @@ def default_new_app(request, domain):
         # APP MANAGER V2 is completely blank on new app
         module = Module.new_module(_("Untitled Module"), lang)
         app.add_module(module)
-        form = app.new_form(0, "Untitled Form", lang)
+        app.new_form(0, "Untitled Form", lang)
 
     if request.project.secure_submissions:
         app.secure_submissions = True
@@ -195,10 +194,11 @@ def get_app_view_context(request, app):
             builds["default"] = build_config.get_default(app_ver).to_string()
 
     if context['settings_layout']:
-        settings = [setting for section in context['settings_layout']
-                            for setting in section['settings']]
-        (build_spec_setting,) = [x for x in settings if x['type'] == 'hq' and
-                                                        x['id'] == 'build_spec']
+        settings = [setting
+            for section in context['settings_layout']
+            for setting in section['settings']]
+        (build_spec_setting,) = [x
+            for x in settings if x['type'] == 'hq' and x['id'] == 'build_spec']
     else:
         build_spec_setting = None
     if build_spec_setting:
@@ -618,7 +618,6 @@ def edit_app_attr(request, domain, app_id, attr):
 
     """
     app = get_app(domain, app_id)
-    lang = request.COOKIES.get('lang', (app.langs or ['en'])[0])
 
     try:
         hq_settings = json.loads(request.body)['hq']

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -171,7 +171,8 @@ def get_app_view_context(request, app):
         section['settings'] = new_settings
 
     if toggles.CUSTOM_PROPERTIES.enabled(request.domain) and 'custom_properties' in app.profile:
-        custom_properties_array = [{'key': p[0], 'value': p[1]} for p in list(app.profile.get('custom_properties').items())]
+        custom_properties_array = [{'key': p[0], 'value': p[1]}
+            for p in app.profile.get('custom_properties').items()]
         context.update({'custom_properties': custom_properties_array})
 
     context.update({
@@ -193,8 +194,13 @@ def get_app_view_context(request, app):
             app_ver = MAJOR_RELEASE_TO_VERSION[option.build.major_release()]
             builds["default"] = build_config.get_default(app_ver).to_string()
 
-    (build_spec_setting,) = [x for x in [setting for section in context['settings_layout']
-            for setting in section['settings']] if x['type'] == 'hq' and x['id'] == 'build_spec'] if context['settings_layout'] else (None,)
+    if context['settings_layout']:
+        settings = [setting for section in context['settings_layout']
+                            for setting in section['settings']]
+        (build_spec_setting,) = [x for x in settings if x['type'] == 'hq' and
+                                                        x['id'] == 'build_spec']
+    else:
+        build_spec_setting = None
     if build_spec_setting:
         build_spec_setting['options_map'] = options_map
         build_spec_setting['default_app_version'] = app.application_version
@@ -531,7 +537,7 @@ def edit_app_langs(request, domain, app_id):
         return HttpResponse(status=400)
 
     # now do it
-    for old, new in list(rename.items()):
+    for old, new in rename.items():
         if old != new:
             app.rename_lang(old, new)
 
@@ -583,7 +589,7 @@ def get_app_ui_translations(request, domain):
     one = params.get('one', False)
     translations = Translation.get_translations(lang, key, one)
     if isinstance(translations, dict):
-        translations = {k: v for k, v in list(translations.items())
+        translations = {k: v for k, v in translations.items()
                         if not id_strings.is_custom_app_string(k)
                         and '=' not in k}
     return json_response(translations)
@@ -804,7 +810,7 @@ def formdefs(request, domain, app_id):
             [
                 FormattedRow([
                     cell for (_, cell) in
-                    sorted(list(row.items()), key=lambda item: sheet['columns'].index(item[0]))
+                    sorted(row.items(), key=lambda item: sheet['columns'].index(item[0]))
                 ])
                 for row in sheet['rows']
             ]

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -1,3 +1,4 @@
+from builtins import map
 from django.utils.text import slugify
 from django.template.loader import render_to_string
 
@@ -38,7 +39,7 @@ def list_apps(request, domain):
     applications = Domain.get_by_name(domain).applications()
     return json_response({
         'status': 'success',
-        'applications': map(app_to_json, applications),
+        'applications': list(map(app_to_json, applications)),
     })
 
 

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -1,5 +1,6 @@
 from future import standard_library
 standard_library.install_aliases()
+from builtins import str
 import json
 import logging
 import os
@@ -251,7 +252,7 @@ def download_file(request, domain, app_id, path):
                         raise
                 else:
                     raise
-            if type(payload) is str:
+            if isinstance(payload, str):
                 payload = payload.encode('utf-8')
             buffer = StringIO(payload)
             metadata = {'content_type': content_type}
@@ -423,7 +424,7 @@ def download_index_files(app, build_profile_id=None):
         files = [(path[len(prefix):], app.fetch_attachment(path))
                  for path in app.blobs if needed_for_CCZ(path)]
     else:
-        files = list(app.create_all_files().items())
+        files = app.create_all_files().items()
     return sorted(files)
 
 

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -1,7 +1,9 @@
+from future import standard_library
+standard_library.install_aliases()
 import json
 import logging
 import os
-from StringIO import StringIO
+from io import StringIO
 
 from couchdbkit import ResourceConflict, ResourceNotFound
 from django.contrib import messages
@@ -249,7 +251,7 @@ def download_file(request, domain, app_id, path):
                         raise
                 else:
                     raise
-            if type(payload) is unicode:
+            if type(payload) is str:
                 payload = payload.encode('utf-8')
             buffer = StringIO(payload)
             metadata = {'content_type': content_type}
@@ -421,7 +423,7 @@ def download_index_files(app, build_profile_id=None):
         files = [(path[len(prefix):], app.fetch_attachment(path))
                  for path in app.blobs if needed_for_CCZ(path)]
     else:
-        files = app.create_all_files().items()
+        files = list(app.create_all_files().items())
     return sorted(files)
 
 

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -1,3 +1,4 @@
+from builtins import next
 import json
 import logging
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -166,7 +166,7 @@ def edit_advanced_form_actions(request, domain, app_id, module_id, form_id):
     actions = AdvancedFormActions.wrap(json_loads)
     form.actions = actions
     for action in actions.load_update_cases:
-        add_properties_to_data_dictionary(domain, action.case_type, list(action.case_properties.keys()))
+        add_properties_to_data_dictionary(domain, action.case_type, list(action.case_properties))
     if advanced_actions_use_usercase(form.actions) and not is_usercase_in_use(domain):
         enable_usercase(domain)
     response_json = {}
@@ -183,7 +183,7 @@ def edit_form_actions(request, domain, app_id, module_id, form_id):
     form = module.get_form(form_id)
     old_load_from_form = form.actions.load_from_form
     form.actions = FormActions.wrap(json.loads(request.POST['actions']))
-    add_properties_to_data_dictionary(domain, module.case_type, list(form.actions.update_case.update.keys()))
+    add_properties_to_data_dictionary(domain, module.case_type, list(form.actions.update_case.update))
     if old_load_from_form:
         form.actions.load_from_form = old_load_from_form
 
@@ -194,7 +194,7 @@ def edit_form_actions(request, domain, app_id, module_id, form_id):
     if actions_use_usercase(form.actions):
         if not is_usercase_in_use(domain):
             enable_usercase(domain)
-        add_properties_to_data_dictionary(domain, USERCASE_TYPE, list(form.actions.usercase_update.update.keys()))
+        add_properties_to_data_dictionary(domain, USERCASE_TYPE, list(form.actions.usercase_update.update))
 
     response_json = {}
     app.save(response_json)
@@ -618,10 +618,10 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
             'mode': form.mode,
             'fixed_questions': form.get_fixed_questions(),
             'custom_case_properties': [
-                {'key': key, 'path': path} for key, path in list(form.custom_case_updates.items())
+                {'key': key, 'path': path} for key, path in form.custom_case_updates.items()
             ],
             'case_preload': [
-                {'key': key, 'path': path} for key, path in list(form.case_preload.items())
+                {'key': key, 'path': path} for key, path in form.case_preload.items()
             ],
         })
         template = get_app_manager_template(
@@ -753,7 +753,7 @@ def _get_case_references(data):
         # old/deprecated format
         preload = json.loads(data['references'])["preload"]
         refs = {
-            "load": {k: [v] for k, v in list(preload.items())}
+            "load": {k: [v] for k, v in preload.items()}
         }
     else:
         refs = json.loads(data.get('case_references', '{}'))

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -1,3 +1,6 @@
+from builtins import zip
+from builtins import str
+from past.builtins import basestring
 import logging
 import hashlib
 import re
@@ -163,7 +166,7 @@ def edit_advanced_form_actions(request, domain, app_id, module_id, form_id):
     actions = AdvancedFormActions.wrap(json_loads)
     form.actions = actions
     for action in actions.load_update_cases:
-        add_properties_to_data_dictionary(domain, action.case_type, action.case_properties.keys())
+        add_properties_to_data_dictionary(domain, action.case_type, list(action.case_properties.keys()))
     if advanced_actions_use_usercase(form.actions) and not is_usercase_in_use(domain):
         enable_usercase(domain)
     response_json = {}
@@ -180,7 +183,7 @@ def edit_form_actions(request, domain, app_id, module_id, form_id):
     form = module.get_form(form_id)
     old_load_from_form = form.actions.load_from_form
     form.actions = FormActions.wrap(json.loads(request.POST['actions']))
-    add_properties_to_data_dictionary(domain, module.case_type, form.actions.update_case.update.keys())
+    add_properties_to_data_dictionary(domain, module.case_type, list(form.actions.update_case.update.keys()))
     if old_load_from_form:
         form.actions.load_from_form = old_load_from_form
 
@@ -191,7 +194,7 @@ def edit_form_actions(request, domain, app_id, module_id, form_id):
     if actions_use_usercase(form.actions):
         if not is_usercase_in_use(domain):
             enable_usercase(domain)
-        add_properties_to_data_dictionary(domain, USERCASE_TYPE, form.actions.usercase_update.update.keys())
+        add_properties_to_data_dictionary(domain, USERCASE_TYPE, list(form.actions.usercase_update.update.keys()))
 
     response_json = {}
     app.save(response_json)
@@ -248,7 +251,7 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
         form = app.get_form(unique_form_id)
     except FormNotFoundException as e:
         if ajax:
-            return HttpResponseBadRequest(unicode(e))
+            return HttpResponseBadRequest(str(e))
         else:
             messages.error(request, _("There was an error saving, please try again!"))
             return back_to_main(request, domain, app_id=app_id)
@@ -276,7 +279,7 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
                 xform = request.POST.get('xform')
             else:
                 try:
-                    xform = unicode(xform, encoding="utf-8")
+                    xform = str(xform, encoding="utf-8")
                 except Exception:
                     raise Exception("Error uploading form: Please make sure your form is encoded in UTF-8")
             if request.POST.get('cleanup', False):
@@ -293,11 +296,11 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
                 save_xform(app, form, xform)
             else:
                 raise Exception("You didn't select a form to upload")
-        except Exception, e:
+        except Exception as e:
             if ajax:
-                return HttpResponseBadRequest(unicode(e))
+                return HttpResponseBadRequest(str(e))
             else:
-                messages.error(request, unicode(e))
+                messages.error(request, str(e))
     if should_edit("references") or should_edit("case_references"):
         form.case_references = _get_case_references(request.POST)
     if should_edit("show_count"):
@@ -317,14 +320,14 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
     if (should_edit("form_links_xpath_expressions") and
             should_edit("form_links_form_ids") and
             toggles.FORM_LINK_WORKFLOW.enabled(domain)):
-        form_links = zip(
+        form_links = list(zip(
             request.POST.getlist('form_links_xpath_expressions'),
             request.POST.getlist('form_links_form_ids'),
             [
                 json.loads(datum_json) if datum_json else []
                 for datum_json in request.POST.getlist('datums_json')
             ],
-        )
+        ))
         form.form_links = [FormLink(
             xpath=link[0],
             form_id=link[1],
@@ -515,11 +518,11 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
             except CaseError as e:
                 messages.error(request, u"Error in Case Management: %s" % e)
             except XFormException as e:
-                messages.error(request, unicode(e))
+                messages.error(request, str(e))
             except Exception as e:
                 if settings.DEBUG:
                     raise
-                logging.exception(unicode(e))
+                logging.exception(str(e))
                 messages.error(request, u"Unexpected Error: %s" % e)
 
     try:
@@ -592,7 +595,7 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
             star = '* ' if auto_link else '  '
             return u"{}{} -> {}".format(star, module_name, form_name)
 
-        modules = filter(lambda m: m.case_type == module.case_type, all_modules)
+        modules = [m for m in all_modules if m.case_type == module.case_type]
         if getattr(module, 'root_module_id', None) and module.root_module not in modules:
             modules.append(module.root_module)
         auto_linkable_forms = list(itertools.chain.from_iterable(list(m.get_forms()) for m in modules))
@@ -615,10 +618,10 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
             'mode': form.mode,
             'fixed_questions': form.get_fixed_questions(),
             'custom_case_properties': [
-                {'key': key, 'path': path} for key, path in form.custom_case_updates.items()
+                {'key': key, 'path': path} for key, path in list(form.custom_case_updates.items())
             ],
             'case_preload': [
-                {'key': key, 'path': path} for key, path in form.case_preload.items()
+                {'key': key, 'path': path} for key, path in list(form.case_preload.items())
             ],
         })
         template = get_app_manager_template(
@@ -750,7 +753,7 @@ def _get_case_references(data):
         # old/deprecated format
         preload = json.loads(data['references'])["preload"]
         refs = {
-            "load": {k: [v] for k, v in preload.items()}
+            "load": {k: [v] for k, v in list(preload.items())}
         }
     else:
         refs = json.loads(data.get('case_references', '{}'))

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from builtins import next
+from builtins import map
 import os
 from collections import OrderedDict, namedtuple
 import json
@@ -750,7 +752,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
 
     lang = request.COOKIES.get('lang', app.langs[0])
     if short is not None:
-        detail.short.columns = map(DetailColumn.from_json, short)
+        detail.short.columns = list(map(DetailColumn.from_json, short))
         if persist_case_context is not None:
             detail.short.persist_case_context = persist_case_context
             detail.short.persistent_case_context_xml = persistent_case_context_xml
@@ -763,10 +765,10 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         if case_list_lookup is not None:
             _save_case_list_lookup_params(detail.short, case_list_lookup, lang)
 
-    if long is not None:
-        detail.long.columns = map(DetailColumn.from_json, long)
+    if int is not None:
+        detail.long.columns = list(map(DetailColumn.from_json, int))
         if tabs is not None:
-            detail.long.tabs = map(DetailTab.wrap, tabs)
+            detail.long.tabs = list(map(DetailTab.wrap, tabs))
     if filter != ():
         # Note that we use the empty tuple as the sentinel because a filter
         # value of None represents clearing the filter.

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -765,8 +765,8 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         if case_list_lookup is not None:
             _save_case_list_lookup_params(detail.short, case_list_lookup, lang)
 
-    if int is not None:
-        detail.long.columns = list(map(DetailColumn.from_json, int))
+    if long is not None:
+        detail.long.columns = list(map(DetailColumn.from_json, long))
         if tabs is not None:
             detail.long.tabs = list(map(DetailTab.wrap, tabs))
     if filter != ():

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -374,7 +374,7 @@ def _get_app_diffs(first_app, second_app):
     """
     file_pairs = _get_file_pairs(first_app, second_app)
     diffs = []
-    for name, files in file_pairs.iteritems():
+    for name, files in file_pairs.items():
         diff_html = ghdiff.diff(files[0], files[1], n=4, css=False)
         additions, deletions = _get_change_counts(diff_html)
         if additions == 0 and deletions == 0:

--- a/corehq/apps/app_manager/views/schedules.py
+++ b/corehq/apps/app_manager/views/schedules.py
@@ -1,3 +1,4 @@
+from builtins import str
 import json
 
 from django.http import HttpResponseBadRequest
@@ -30,7 +31,7 @@ def edit_schedule_phases(request, domain, app_id, module_id):
         module.update_schedule_phases(all_anchors)
         module.has_schedule = enabled
     except ScheduleError as e:
-        return HttpResponseBadRequest(unicode(e))
+        return HttpResponseBadRequest(str(e))
 
     response_json = {}
     app.save(response_json)
@@ -53,7 +54,7 @@ def edit_visit_schedule(request, domain, app_id, module_id, form_id):
         try:
             phase, is_new_phase = module.get_or_create_schedule_phase(anchor=anchor)
         except ScheduleError as e:
-            return HttpResponseBadRequest(unicode(e))
+            return HttpResponseBadRequest(str(e))
         form.schedule_form_id = schedule_form_id
         form.schedule = FormSchedule.wrap(json_loads)
         phase.add_form(form)

--- a/corehq/apps/app_manager/views/settings.py
+++ b/corehq/apps/app_manager/views/settings.py
@@ -58,7 +58,7 @@ def edit_commcare_profile(request, domain, app_id):
     for settings_type in types:
         if settings_type == "custom_properties":
             app.profile[settings_type] = {}
-        for name, value in settings.get(settings_type, {}).items():
+        for name, value in list(settings.get(settings_type, {}).items()):
             if settings_type not in app.profile:
                 app.profile[settings_type] = {}
             app.profile[settings_type][name] = value

--- a/corehq/apps/app_manager/views/settings.py
+++ b/corehq/apps/app_manager/views/settings.py
@@ -58,7 +58,7 @@ def edit_commcare_profile(request, domain, app_id):
     for settings_type in types:
         if settings_type == "custom_properties":
             app.profile[settings_type] = {}
-        for name, value in list(settings.get(settings_type, {}).items()):
+        for name, value in settings.get(settings_type, {}).items():
             if settings_type not in app.profile:
                 app.profile[settings_type] = {}
             app.profile[settings_type][name] = value

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -1,6 +1,9 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 from collections import defaultdict
 import re
-from StringIO import StringIO
+from io import StringIO
 
 from django.contrib import messages
 from django.core.urlresolvers import reverse
@@ -86,7 +89,7 @@ def download_bulk_app_translations(request, domain, app_id):
     headers = expected_bulk_app_sheet_headers(app)
     rows = expected_bulk_app_sheet_rows(app)
     temp = StringIO()
-    data = [(k, v) for k, v in rows.iteritems()]
+    data = [(k, v) for k, v in rows.items()]
     export_raw(headers, data, temp)
     return export_response(temp, Format.XLS_2007, "bulk_app_translations")
 
@@ -113,7 +116,7 @@ def process_ui_translation_upload(app, trans_file):
     workbook = WorkbookJSONReader(trans_file)
     translations = workbook.get_worksheet(title='translations')
 
-    commcare_ui_strings = load_translations('en', 2).keys()
+    commcare_ui_strings = list(load_translations('en', 2).keys())
     default_trans = get_default_translations_for_download(app)
     lang_with_defaults = app.langs[get_index_for_defaults(app.langs)]
 
@@ -149,14 +152,14 @@ def build_ui_translation_download_file(app):
     for i, lang in enumerate(app.langs):
         index = i + 1
         trans_dict = app.translations.get(lang, {})
-        for prop, trans in trans_dict.iteritems():
+        for prop, trans in trans_dict.items():
             if prop not in row_dict:
                 row_dict[prop] = [prop]
             num_to_fill = index - len(row_dict[prop])
             row_dict[prop].extend(["" for i in range(num_to_fill)] if num_to_fill > 0 else [])
             row_dict[prop].append(trans)
 
-    rows = row_dict.values()
+    rows = list(row_dict.values())
     all_prop_trans = get_default_translations_for_download(app)
     rows.extend([[t] for t in sorted(all_prop_trans.keys()) if t not in row_dict])
 

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -116,7 +116,7 @@ def process_ui_translation_upload(app, trans_file):
     workbook = WorkbookJSONReader(trans_file)
     translations = workbook.get_worksheet(title='translations')
 
-    commcare_ui_strings = list(load_translations('en', 2).keys())
+    commcare_ui_strings = list(load_translations('en', 2))
     default_trans = get_default_translations_for_download(app)
     lang_with_defaults = app.langs[get_index_for_defaults(app.langs)]
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -1,5 +1,7 @@
+from future import standard_library
+standard_library.install_aliases()
 import json
-from urllib import urlencode
+from urllib.parse import urlencode
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
@@ -92,7 +94,7 @@ def bail(request, domain, app_id, not_found=""):
 
 
 def encode_if_unicode(s):
-    return s.encode('utf-8') if isinstance(s, unicode) else s
+    return s.encode('utf-8') if isinstance(s, str) else s
 
 
 def validate_langs(request, existing_langs):
@@ -103,9 +105,9 @@ def validate_langs(request, existing_langs):
     assert set(rename.keys()).issubset(existing_langs)
     assert set(rename.values()).issubset(langs)
     # assert that there are no repeats in the values of rename
-    assert len(set(rename.values())) == len(rename.values())
+    assert len(set(rename.values())) == len(list(rename.values()))
     # assert that no lang is renamed to an already existing lang
-    for old, new in rename.items():
+    for old, new in list(rename.items()):
         if old != new:
             assert(new not in existing_langs)
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -1,5 +1,6 @@
 from future import standard_library
 standard_library.install_aliases()
+from builtins import str
 import json
 from urllib.parse import urlencode
 from django.contrib import messages
@@ -107,7 +108,7 @@ def validate_langs(request, existing_langs):
     # assert that there are no repeats in the values of rename
     assert len(set(rename.values())) == len(list(rename.values()))
     # assert that no lang is renamed to an already existing lang
-    for old, new in list(rename.items()):
+    for old, new in rename.items():
         if old != new:
             assert(new not in existing_langs)
 

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -253,7 +253,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
     context['latest_commcare_version'] = get_commcare_versions(request.user)[-1]
 
     if app and app.doc_type == 'Application' and has_privilege(request, privileges.COMMCARE_LOGO_UPLOADER):
-        uploader_slugs = list(ANDROID_LOGO_PROPERTY_MAPPING.keys())
+        uploader_slugs = list(ANDROID_LOGO_PROPERTY_MAPPING)
         from corehq.apps.hqmedia.controller import MultimediaLogoUploadController
         from corehq.apps.hqmedia.views import ProcessLogoFileUploadView
         context.update({

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -253,7 +253,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
     context['latest_commcare_version'] = get_commcare_versions(request.user)[-1]
 
     if app and app.doc_type == 'Application' and has_privilege(request, privileges.COMMCARE_LOGO_UPLOADER):
-        uploader_slugs = ANDROID_LOGO_PROPERTY_MAPPING.keys()
+        uploader_slugs = list(ANDROID_LOGO_PROPERTY_MAPPING.keys())
         from corehq.apps.hqmedia.controller import MultimediaLogoUploadController
         from corehq.apps.hqmedia.views import ProcessLogoFileUploadView
         context.update({

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -19,6 +19,9 @@ seem to be a good fit.
 
 
 """
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 import re
 import uuid
 from lxml import etree
@@ -245,7 +248,7 @@ class XFormBuilder(object):
                 get_text_node(name, params['hint'], group, label_safe_=label_safe, is_hint=True)
             )
         if choices:
-            for choice_name, choice_label in choices.items():
+            for choice_name, choice_label in list(choices.items()):
                 self._translation1.append(get_text_node(name, choice_label, group, choice_name, label_safe))
 
     def _append_to_model(self, name, data_type, group=None, **params):
@@ -253,7 +256,7 @@ class XFormBuilder(object):
             attrs = {'nodeset': self.get_data_ref(name, group)}
             if data_type in XSD_TYPES:
                 attrs['type'] = 'xsd:' + data_type
-            for param, value in params.items():
+            for param, value in list(params.items()):
                 if param in QUESTION_PARAMS:
                     ns_param = self.get_namespaced(param)
                     attrs[ns_param] = value
@@ -351,7 +354,7 @@ class XFormBuilder(object):
                 node_.append(
                     E.hint({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, is_hint=True))})
                 )
-            for choice_name in choices_.keys():
+            for choice_name in list(choices_.keys()):
                 node_.append(
                     E.item(
                         E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, choice_name))}),

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -19,13 +19,13 @@ seem to be a good fit.
 
 
 """
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import re
 import uuid
+from builtins import object
+from builtins import str
 from lxml import etree
 from lxml.builder import E
+from past.builtins import basestring
 
 EMPTY_XFORM = """<?xml version="1.0"?>
 <h:html xmlns:h="http://www.w3.org/1999/xhtml"
@@ -248,7 +248,7 @@ class XFormBuilder(object):
                 get_text_node(name, params['hint'], group, label_safe_=label_safe, is_hint=True)
             )
         if choices:
-            for choice_name, choice_label in list(choices.items()):
+            for choice_name, choice_label in choices.items():
                 self._translation1.append(get_text_node(name, choice_label, group, choice_name, label_safe))
 
     def _append_to_model(self, name, data_type, group=None, **params):
@@ -256,7 +256,7 @@ class XFormBuilder(object):
             attrs = {'nodeset': self.get_data_ref(name, group)}
             if data_type in XSD_TYPES:
                 attrs['type'] = 'xsd:' + data_type
-            for param, value in list(params.items()):
+            for param, value in params.items():
                 if param in QUESTION_PARAMS:
                     ns_param = self.get_namespaced(param)
                     attrs[ns_param] = value
@@ -354,7 +354,7 @@ class XFormBuilder(object):
                 node_.append(
                     E.hint({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, is_hint=True))})
                 )
-            for choice_name in list(choices_.keys()):
+            for choice_name in choices_:
                 node_.append(
                     E.item(
                         E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, choice_name))}),

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import re
 from corehq.apps.app_manager.const import (
     USERCASE_TYPE,
@@ -92,7 +94,7 @@ def interpolate_xpath(string, case_xpath=None, fixture_xpath=None, module=None, 
         replacements['#parent'] = CaseIDXPath(case_xpath + '/index/parent').case()
         replacements['#host'] = CaseIDXPath(case_xpath + '/index/host').case()
 
-    for pattern, repl in replacements.items():
+    for pattern, repl in list(replacements.items()):
         string = string.replace(pattern, repl)
 
     if case_xpath:
@@ -109,7 +111,7 @@ def session_var(var, path=u'data'):
     return session.slash(var)
 
 
-class XPath(unicode):
+class XPath(str):
 
     def __new__(cls, string=u'', compound=False):
         return super(XPath, cls).__new__(cls, string)
@@ -118,7 +120,7 @@ class XPath(unicode):
         self.compound = compound
 
     def paren(self, force=False):
-        return unicode(self) if not (force or self.compound) else u'({})'.format(self)
+        return str(self) if not (force or self.compound) else u'({})'.format(self)
 
     def slash(self, xpath):
         if self:

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -1,6 +1,6 @@
-from builtins import str
-from builtins import object
 import re
+from builtins import object
+from builtins import str
 from corehq.apps.app_manager.const import (
     USERCASE_TYPE,
     SCHEDULE_PHASE,
@@ -94,7 +94,7 @@ def interpolate_xpath(string, case_xpath=None, fixture_xpath=None, module=None, 
         replacements['#parent'] = CaseIDXPath(case_xpath + '/index/parent').case()
         replacements['#host'] = CaseIDXPath(case_xpath + '/index/host').case()
 
-    for pattern, repl in list(replacements.items()):
+    for pattern, repl in replacements.items():
         string = string.replace(pattern, repl)
 
     if case_xpath:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,6 +22,7 @@ elasticsearch==1.9.0
 #egenix-mx-base==3.2.8
 eulxml==0.18.0
 feedparser==5.1.3
+future==0.16.0
 ghdiff==0.4
 gunicorn==19.4
 lxml==3.4.4


### PR DESCRIPTION
Used `python-future`'s `futurize` script to do most of this, and then hand-edited (in separate commits) changes that were unnecessary or wrong. Probably best to review commits individually.

Things to discuss:
- Do we want to standardize on use of `future` vs `six`? I had previously thought `future` depended on `six`, but on a subsequent reading of the docs I see it doesn't. See the [`future` FAQ on this topic](http://python-future.org/faq.html#what-is-the-relationship-between-future-and-six). I personally think `future` is better because it "[allows] standard Py3 code to run with almost no modification on both Py3 and Py2."
- Are we going to try to make all code written from now on Python 3 compatible? I think it's a good idea, and if others agree we should make @dimagimon enforce it.
- String types are going to require special care. `future` uses `from builtins import str` to make `str` act like `unicode` in Python 2. This can cause confusion if you're not expecting it. Also, I think there may be a bug where `futurize` forgets to add that import in some cases, but that's a separate issue.

@emord @nickpell 