### PR TITLE
cache report_class_name

### DIFF
--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext
 from django.views.generic.base import View
 
 from dimagi.utils.decorators.datespan import datespan_in_request
+from dimagi.utils.modules import to_function
 
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
@@ -17,6 +18,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import get_domain_module_map
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.reports.exceptions import BadRequestError
+from corehq.util.quickcache import quickcache
 
 
 datespan_default = datespan_in_request(
@@ -119,6 +121,11 @@ class ReportDispatcher(View):
         """
         return self.get_reports_dict(domain).get(report_slug, None)
 
+    @quickcache(['domain', 'report_slug'], timeout=60)
+    def get_report_class_name(self, domain, report_slug):
+        report_cls = self.get_report(domain, report_slug)
+        return report_cls.__module__ + '.' + report_cls.__name__ if report_cls else ''
+
     def _redirect_slug(self, slug):
         return self.slug_aliases.get(slug) is not None
 
@@ -145,8 +152,8 @@ class ReportDispatcher(View):
 
         report_kwargs = kwargs.copy()
 
-        cls = self.get_report(domain, report_slug)
-        class_name = cls.__module__ + '.' + cls.__name__ if cls else ''
+        class_name = self.get_report_class_name(domain, report_slug)
+        cls = to_function(class_name)
 
         permissions_check = permissions_check or self.permissions_check
         if (

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -153,7 +153,7 @@ class ReportDispatcher(View):
         report_kwargs = kwargs.copy()
 
         class_name = self.get_report_class_name(domain, report_slug)
-        cls = to_function(class_name)
+        cls = to_function(class_name) if class_name else None
 
         permissions_check = permissions_check or self.permissions_check
         if (

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -121,7 +121,7 @@ class ReportDispatcher(View):
         """
         return self.get_reports_dict(domain).get(report_slug, None)
 
-    @quickcache(['domain', 'report_slug'], timeout=60)
+    @quickcache(['domain', 'report_slug'], timeout=300)
     def get_report_class_name(self, domain, report_slug):
         report_cls = self.get_report(domain, report_slug)
         return report_cls.__module__ + '.' + report_cls.__name__ if report_cls else ''


### PR DESCRIPTION
@snopoke during my dive in the report dispatcher, i noticed it took 4 seconds to call `get_report`. that function gets called at least 2, sometimes 3 times per report load. i switched around the function return value so that we can cache it. here's the prof data:

```
loading profile stats for get_report_class_name-20170207T120127706584
         4248460 function calls (3478542 primitive calls) in 4.230 seconds

   Ordered by: cumulative time, call count
   List reduced from 531 to 200 due to restriction <200>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    4.230    4.230 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/reports/dispatcher.py:125(get_report_class_name)
        1    0.000    0.000    4.230    4.230 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/reports/dispatcher.py:117(get_report)
        1    0.000    0.000    4.230    4.230 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/reports/dispatcher.py:112(get_reports_dict)
        1    0.000    0.000    4.230    4.230 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/reports/dispatcher.py:79(get_reports)
        1    0.000    0.000    4.227    4.227 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/reports/dispatcher.py:87(process)
        1    0.000    0.000    4.227    4.227 /Users/benrudolph/Dimagi/commcare-hq/corehq/reports.py:63(REPORTS)
        2    0.000    0.000    4.218    2.109 /Users/benrudolph/Dimagi/commcare-hq/corehq/reports.py:182(_safely_get_report_configs)
        2    0.034    0.017    4.209    2.105 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/userreports/models.py:605(by_domain)
      840    0.007    0.000    4.170    0.005 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/userreports/models.py:599(all)
      838    0.008    0.000    3.691    0.004 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/userreports/models.py:671(_get_report_config)
```
cc: @emord 

