### PR TITLE
share hierarchical fixtures for domains that were on flat fixture and…

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -143,13 +143,23 @@ class FlatLocationSerializer(object):
 
 
 def should_sync_hierarchical_fixture(project):
+    # Sync hierarchical fixture for domains that have moved to flat fixture but
+    # still need hierarchical fixture for older versions or other references and hence have
+    # not deliberately chosen to NOT sync hierarchical fixture
     # Sync hierarchical fixture for domains with fixture toggle enabled for migration and
     # configuration set to use hierarchical fixture
     # Even if both fixtures are set up, this one takes priority for domains with toggle enabled
     return (
-        project.uses_locations and
-        toggles.HIERARCHICAL_LOCATION_FIXTURE.enabled(project.name) and
-        LocationFixtureConfiguration.for_domain(project.name).sync_hierarchical_fixture
+        (
+            project.uses_locations and
+            toggles.FLAT_LOCATION_FIXTURE.enabled(project.name) and
+            LocationFixtureConfiguration.for_domain(project.name).sync_hierarchical_fixture
+        ) or
+        (
+            project.uses_locations and
+            toggles.HIERARCHICAL_LOCATION_FIXTURE.enabled(project.name) and
+            LocationFixtureConfiguration.for_domain(project.name).sync_hierarchical_fixture
+        )
     )
 
 


### PR DESCRIPTION
… have NOT chosen to remove hierarchical fixture from restores

This should fix issues with domains on flat fixture needing hierarchical location fixture to be synced as well, mirroring the behaviour that was there earlier.