### PR TITLE
add option to purge existing custom data fields from users when saving

### DIFF
--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -165,6 +165,8 @@ class CustomDataModelMixin(object):
     def post(self, request, *args, **kwargs):
         if self.form.is_valid():
             self.save_custom_fields()
+            if self.show_purge_existing and self.form.cleaned_data['purge_existing']:
+                self.update_existing_models()
             msg = _(u"{} fields saved successfully").format(
                 unicode(self.entity_string)
             )
@@ -172,3 +174,9 @@ class CustomDataModelMixin(object):
             return self.get(request, success=True, *args, **kwargs)
         else:
             return self.get(request, *args, **kwargs)
+
+    def update_existing_models(self):
+        """
+        Subclasses with show_purge_exiting set to True should override this to update existing models
+        """
+        raise NotImplementedError()

--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -97,6 +97,7 @@ class CustomDataModelMixin(object):
     urlname = None
     template_name = "custom_data_fields/custom_data_fields.html"
     field_type = None
+    show_purge_existing = False
     entity_string = None  # User, Group, Location, Product...
 
     @use_jquery_ui
@@ -148,6 +149,7 @@ class CustomDataModelMixin(object):
         return {
             "custom_fields": json.loads(self.form.data['data_fields']),
             "custom_fields_form": self.form,
+            "show_purge_existing": self.show_purge_existing,
         }
 
     @property

--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -19,6 +19,7 @@ class CustomDataFieldsForm(forms.Form):
     The main form for editing a custom data definition
     """
     data_fields = forms.CharField(widget=forms.HiddenInput)
+    purge_existing = forms.BooleanField(widget=forms.HiddenInput, required=False, initial=False)
 
     def verify_no_duplicates(self, data_fields):
         errors = set()

--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -58,6 +58,7 @@ function CustomDataField () {
 function CustomDataFieldsModel () {
     var self = this;
     self.data_fields = ko.observableArray();
+    self.purge_existing = ko.observable(false);
     // The data field that the "remove field modal" currently refers to.
     self.modalField = ko.observable();
 
@@ -120,6 +121,11 @@ function CustomDataFieldsModel () {
         $('<input type="hidden">')
             .attr('name', 'data_fields')
             .attr('value', JSON.stringify(self.serialize()))
+            .appendTo(customDataFieldsForm);
+
+        $('<input type="hidden">')
+            .attr('name', 'purge_existing')
+            .attr('value', self.purge_existing())
             .appendTo(customDataFieldsForm);
         customDataFieldsForm.appendTo("body");
         customDataFieldsForm.submit();

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -186,7 +186,7 @@
 
         <div class="form-actions">
             <div class="col-sm-4 col-md-5 col-lg-3 col-sm-offset-3 col-md-offset-4 col-lg-offset-2">
-                <button id="save-custom-fields" class="btn btn-primary disable-on-submit" type="submit" disabled>Save Fields</button>
+                <button id="save-custom-fields" class="btn btn-primary disable-on-submit" type="submit" disabled>{% trans "Save Fields" %}</button>
             </div>
         </div>
 

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -183,6 +183,7 @@
                 </div>
             </div>
         </fieldset>
+        {% if show_purge_existing %}
         <fieldset>
             <div class="col-sm-10 col-sm-offset-2">
                 <div class="checkbox">
@@ -199,6 +200,7 @@
                 </div>
             </div>
         </fieldset>
+        {% endif %}
         <div class="form-actions">
             <div class="col-sm-4 col-md-5 col-lg-3 col-sm-offset-3 col-md-offset-4 col-lg-offset-2">
                 <button id="save-custom-fields" class="btn btn-primary disable-on-submit" type="submit" disabled>{% trans "Save Fields" %}</button>

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -192,8 +192,8 @@
                         <span class="hq-help-template"
                               data-title="{% trans "Remove Unused Fields" %}"
                               data-content="{% blocktrans with entity_string=view.entity_string|lower %}
-                                  If checked, this will remove any extra information from any existing {{ entity_string }}
-                                  that has data fields that are no longer used.
+                                  If checked, this will remove any other fields from every {{ entity_string }}.
+                                  This could break existing applications if they rely on these other fields.
                               {% endblocktrans %}">
                         </span>
                     </label>

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -183,7 +183,22 @@
                 </div>
             </div>
         </fieldset>
-
+        <fieldset>
+            <div class="col-sm-10 col-sm-offset-2">
+                <div class="checkbox">
+                    <label>
+                        <input name="remove-existing" type="checkbox" data-bind="checked: purge_existing">{% trans "Remove unused fields from existing data."%}
+                        <span class="hq-help-template"
+                              data-title="{% trans "Remove Unused Fields" %}"
+                              data-content="{% blocktrans with entity_string=view.entity_string|lower %}
+                                  If checked, this will remove any extra information from any existing {{ entity_string }}
+                                  that has data fields that are no longer used.
+                              {% endblocktrans %}">
+                        </span>
+                    </label>
+                </div>
+            </div>
+        </fieldset>
         <div class="form-actions">
             <div class="col-sm-4 col-md-5 col-lg-3 col-sm-offset-3 col-md-offset-4 col-lg-offset-2">
                 <button id="save-custom-fields" class="btn btn-primary disable-on-submit" type="submit" disabled>{% trans "Save Fields" %}</button>

--- a/corehq/apps/users/custom_data.py
+++ b/corehq/apps/users/custom_data.py
@@ -1,0 +1,23 @@
+from corehq.apps.custom_data_fields.models import is_system_key
+from corehq.apps.users.dbaccessors import get_all_commcare_users_by_domain
+from corehq.apps.custom_data_fields.dbaccessors import get_by_domain_and_type
+
+
+def remove_unused_custom_fields_from_users(domain):
+    """
+    Removes all unused custom data fields from all users in the domain
+    """
+    from corehq.apps.users.views.mobile.custom_data_fields import CUSTOM_USER_DATA_FIELD_TYPE
+    fields_definition = get_by_domain_and_type(domain, CUSTOM_USER_DATA_FIELD_TYPE)
+    assert fields_definition, 'remove_unused_custom_fields_from_users called without a valid CustomDataFieldsDefinition'
+    configured_field_keys = set([f.slug for f in fields_definition.get_fields()])
+    for user in get_all_commcare_users_by_domain(domain):
+        keys_to_delete = _get_invalid_user_data_fields(user, configured_field_keys)
+        if keys_to_delete:
+            for key in keys_to_delete:
+                del user.user_data[key]
+            user.save()
+
+
+def _get_invalid_user_data_fields(user, configured_field_keys):
+    return [key for key in user.user_data if not is_system_key(key) and not key in configured_field_keys]

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -171,3 +171,9 @@ def reset_demo_user_restore_task(couch_user, domain):
 
     DownloadBase.set_progress(reset_demo_user_restore_task, 100, 100)
     return {'messages': results}
+
+
+@task
+def remove_unused_custom_fields_from_users_task(domain):
+    from corehq.apps.users.custom_data import remove_unused_custom_fields_from_users
+    remove_unused_custom_fields_from_users(domain)

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -13,7 +13,6 @@ from corehq.util.log import SensitiveErrorMail
 from couchforms.exceptions import UnexpectedDeletedXForm
 from corehq.apps.domain.models import Domain
 from dimagi.utils.logging import notify_exception
-from dimagi.utils.parsing import json_format_datetime
 from soil import DownloadBase
 from casexml.apps.case.xform import get_case_ids_from_form
 

--- a/corehq/apps/users/tests/test_remove_unused_custom_fields.py
+++ b/corehq/apps/users/tests/test_remove_unused_custom_fields.py
@@ -1,0 +1,23 @@
+from django.test import SimpleTestCase
+from corehq.apps.users.custom_data import _get_invalid_user_data_fields
+from corehq.apps.users.models import CommCareUser
+
+
+class RemoveUnusedFieldsTestCase(SimpleTestCase):
+
+    def test_empty(self):
+        user_with_no_fields = CommCareUser(user_data={})
+        self.assertEqual([], _get_invalid_user_data_fields(user_with_no_fields, set()))
+        self.assertEqual([], _get_invalid_user_data_fields(user_with_no_fields, set(['a', 'b'])))
+
+    def test_normal_behavior(self):
+        user_with_fields = CommCareUser(user_data={'a': 'foo', 'b': 'bar', 'c': 'baz'})
+        self.assertEqual(set(['a', 'b', 'c']), set(_get_invalid_user_data_fields(user_with_fields, set())))
+        self.assertEqual(set(['c']), set(_get_invalid_user_data_fields(user_with_fields, set(['a', 'b']))))
+        self.assertEqual(set(['a', 'b', 'c']),
+                         set(_get_invalid_user_data_fields(user_with_fields, set(['e', 'f']))))
+
+    def test_system_fields_not_removed(self):
+        user_with_system_fields = CommCareUser(user_data={'commcare_location_id': 'foo'})
+        self.assertEqual([], _get_invalid_user_data_fields(user_with_system_fields, set()))
+        self.assertEqual([], _get_invalid_user_data_fields(user_with_system_fields, set(['a', 'b'])))

--- a/corehq/apps/users/views/mobile/custom_data_fields.py
+++ b/corehq/apps/users/views/mobile/custom_data_fields.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from corehq.apps.custom_data_fields import CustomDataModelMixin
 from corehq.apps.users.decorators import require_can_edit_commcare_users
+from corehq.apps.users.tasks import remove_unused_custom_fields_from_users_task
 from corehq.apps.users.views import BaseUserSettingsView
 
 CUSTOM_USER_DATA_FIELD_TYPE = 'UserFields'
@@ -12,7 +13,11 @@ class UserFieldsView(CustomDataModelMixin, BaseUserSettingsView):
     urlname = 'user_fields_view'
     field_type = CUSTOM_USER_DATA_FIELD_TYPE
     entity_string = _("User")
+    show_purge_existing = True
 
     @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, request, *args, **kwargs):
         return super(UserFieldsView, self).dispatch(request, *args, **kwargs)
+
+    def update_existing_models(self):
+        remove_unused_custom_fields_from_users_task.delay(self.domain)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -46,14 +46,13 @@ from corehq.apps.custom_data_fields import CustomDataEditor
 from corehq.apps.custom_data_fields.models import CUSTOM_DATA_FIELD_PREFIX
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_class
 from corehq.apps.domain.decorators import domain_admin_required
-from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.analytics import users_have_locations
-from corehq.apps.locations.models import Location, SQLLocation
+from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe, user_can_access_location_id
 from corehq.apps.ota.utils import turn_off_demo_mode, demo_restore_date_created
 from corehq.apps.sms.models import SelfRegistrationInvitation
@@ -79,13 +78,12 @@ from corehq.apps.users.forms import (
     MultipleSelectionForm, ConfirmExtraUserChargesForm, NewMobileWorkerForm,
     SelfRegistrationForm, SetUserPasswordForm,
 )
-from corehq.apps.users.models import CommCareUser, UserRole, CouchUser
+from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.tasks import bulk_upload_async, turn_on_demo_mode_task, reset_demo_user_restore_task
 from corehq.apps.users.util import can_add_extra_mobile_workers, format_username
 from corehq.apps.users.views import BaseUserSettingsView, BaseEditUserView, get_domain_languages
 from corehq.const import USER_DATE_FORMAT, GOOGLE_PLAY_STORE_COMMCARE_URL
 from corehq.toggles import SUPPORT
-from corehq.util.couch import get_document_or_404
 from corehq.util.workbook_json.excel import JSONReaderError, HeaderValueError, \
     WorksheetNotFound, WorkbookJSONReader, enforce_string_type, StringTypeRequiredError, \
     InvalidExcelFileException


### PR DESCRIPTION
was going to implement this as a management command but then seemed easy enough to do in the UI.

![image](https://cloud.githubusercontent.com/assets/66555/22703188/f0d6c7b6-ed6b-11e6-8fde-8d60aad635be.png)

@dimagi/product / @sheelio do you see any issues with adding this? i can obviously flag it if needed but seems helpful to me.

I think @esoergel has the most context on this feature? cc @proteusvacuum @kaapstorm buddies. review how you like. :fish: / :classical_building: 
