### PR TITLE
Always install ipython on prod environments

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -15,7 +15,7 @@ fixture
 sniffer
 psutil  # for memory profiling
 django-extensions
-ipython==4.2.1
+ipython==5.2.2
 ipdb==0.9.4
 wheel==0.29.0
 

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -3,3 +3,4 @@ newrelic
 errand-boy==0.3.8
 setproctitle==1.1.9
 uWSGI==2.0.11.2
+ipython==5.2.2


### PR DESCRIPTION
If I ever want to run a django shell, I want ipython available.  I don't
think there's a real downside to this, but interested to hear if anyone
disagrees.