### PR TITLE
Coerce integer custom location data to strings

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -143,7 +143,7 @@ class LocationStub(object):
         self.do_delete = do_delete
         self.external_id = str(external_id) if isinstance(external_id, int) else external_id
         self.index = index
-        self.custom_data = custom_data or {}
+        self.custom_data = {key: unicode(value) for key, value in custom_data.items()} if custom_data else {}
         self.uncategorized_data = uncategorized_data or {}
         if not self.location_id and not self.site_code:
             raise LocationExcelSheetError(

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -926,8 +926,8 @@ class TestBulkManagement(TestCase):
 
     def test_custom_data(self):
         tree = [
-            ('State 1', 's1', 'state', '', '', False, '', '', '', {'a': 1}, {}, 0),
-            ('County 11', 'c1', 'county', 's1', '', False, '', '', '', {'b': 'test'}, {}, 0),
+            ('State 1', 's1', 'state', '', '', False, '', '', '', {u'a': 1}, {}, 0),
+            ('County 11', 'c1', 'county', 's1', '', False, '', '', '', {u'b': u'test'}, {}, 0),
         ]
         result = self.bulk_update_locations(
             FLAT_LOCATION_TYPES,
@@ -936,4 +936,8 @@ class TestBulkManagement(TestCase):
         self.assertEqual(result.errors, [])
         self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
         self.assertLocationsMatch(self.as_pairs(tree))
+
+        locations = SQLLocation.objects.all()
+        self.assertEqual(locations[0].metadata, {u'a': u'1'})  # test that ints are coerced to strings
+        self.assertEqual(locations[1].metadata, {u'b': u'test'})
         self.assertCouchSync()


### PR DESCRIPTION
Yipes.
When doing a bulk upload with integers as custom data, it was breaking restores with `ERROR: TypeError: cannot serialize 9 (type int)`, because `ElementTree` [doesn't do it for you](http://stackoverflow.com/questions/19534288/can-xml-etree-elementtree-write-integer-values-for-a-given-element).

@esoergel @nickpell @emord 