### PR TITLE
Mark chevrons HTML safe for Django 1.9

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -419,9 +419,9 @@ def chevron(value):
     Displays a green up chevron if value > 0, and a red down chevron if value < 0
     """
     if value > 0:
-        return '<span class="fa fa-chevron-up" style="color: #006400;"></span>'
+        return format_html('<span class="fa fa-chevron-up" style="color: #006400;"></span>')
     elif value < 0:
-        return '<span class="fa fa-chevron-down" style="color: #8b0000;"> </span>'
+        return format_html('<span class="fa fa-chevron-down" style="color: #8b0000;"> </span>')
     else:
         return ''
 
@@ -432,9 +432,9 @@ def reverse_chevron(value):
     Displays a red up chevron if value > 0, and a green down chevron if value < 0
     """
     if value > 0:
-        return '<span class="fa fa-chevron-up" style="color: #8b0000;"></span>'
+        return format_html('<span class="fa fa-chevron-up" style="color: #8b0000;"></span>')
     elif value < 0:
-        return '<span class="fa fa-chevron-down" style="color: #006400;"> </span>'
+        return format_html('<span class="fa fa-chevron-down" style="color: #006400;"> </span>')
     else:
         return ''
 


### PR DESCRIPTION
Context: [FB 247175](http://manage.dimagi.com/default.asp?247175)

![chevrons](https://cloud.githubusercontent.com/assets/708421/22740729/7c01e02a-ee19-11e6-9f4a-0341427a0f6a.png)
^^^ Chevrons are back (despite poor example because nothing happened to my local domain.)

@sravfeyn @czue cc @benrudolph 
