### PR TITLE
Drop inline js on confirmation_sent.html

### DIFF
--- a/corehq/apps/registration/templates/registration/confirmation_sent.html
+++ b/corehq/apps/registration/templates/registration/confirmation_sent.html
@@ -1,17 +1,6 @@
 {% extends "registration/base.html" %}
 {% load i18n %}
 
-{% if track_domain_registration %}
-{% block js-inline %}{{ block.super }}
-<script>
-    $(function () {
-        analytics.workflow("Created new project");
-        _kmq.push(["trackClick", "create_account_success", "Account Creation was Successful (old)"]);
-    });
-</script>
-{% endblock js-inline %}
-{% endif %}
-
 {% block title %}{% trans "Confirmation Email Sent" %}{% endblock title %}
 
 {% block registration-content %}

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -256,9 +256,9 @@ class RegisterDomainView(TemplateView):
             if self.is_new_user:
                 context.update({
                     'requested_domain': domain_name,
-                    'track_domain_registration': True,
                     'current_page': {'page_name': _('Confirm Account')},
                 })
+                track_workflow(self.request.user.email, "Created new project")
                 return render(request, 'registration/confirmation_sent.html', context)
             else:
                 if nextpage:


### PR DESCRIPTION
@krsdimagi confirmed that `"Account Creation was Successful (old)"` is no longer needed

@gcapalbo / @calellowitz 