### PR TITLE
test docs + tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,17 @@ To avoid having to run the databse setup for each test run you can specify the `
     
 See `corehq.tests.nose.HqdbContext` for full description of `REUSE_DB`.
 
+### Running tests by tag
+You can run all tests with a certain tag as follows:
+
+    $ ./manage.py test --attr=tag
+
+Available tags:
+
+  * dual_backend: all tests decorated with `run_with_all_backeds`
+
+See http://nose.readthedocs.io/en/latest/plugins/attrib.html for more details.
+
 ## Javascript tests
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ To run a particular test or subset of tests
 If database tests are failing because of a `permission denied` error, give your postgres user permissions to create a database.
 In the postgres shell, run the following as a superuser: `ALTER USER commcarehq CREATEDB;`
 
+### REUSE DB
 To avoid having to run the databse setup for each test run you can specify the `REUSE_DB` environment variable
  which will use an existing test database if one exists:
  
@@ -346,6 +347,9 @@ Available tags:
   * dual_backend: all tests decorated with `run_with_all_backeds`
 
 See http://nose.readthedocs.io/en/latest/plugins/attrib.html for more details.
+
+### Running only failed tests
+See https://github.com/nose-devs/nose/blob/master/nose/plugins/testid.py
 
 ## Javascript tests
 

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -165,7 +165,8 @@ run_with_all_backends = functools.partial(
             },
             pre_run=lambda *args, **kwargs: args[0].setUp(),
         ),
-    ]
+    ],
+    nose_tags={'dual_backend': True}
 )
 
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -256,10 +256,12 @@ def call_with_settings(fn, settings_dict, args, kwargs):
             setattr(settings, key, value)
 
 
-def run_with_multiple_configs(fn, run_configs):
+def run_with_multiple_configs(fn, run_configs, nose_tags=None):
+    from nose.plugins.attrib import attr
     helper = RunWithMultipleConfigs(fn, run_configs)
 
     @functools.wraps(fn)
+    @attr(**(nose_tags or {}))
     def inner(*args, **kwargs):
         return helper(*args, **kwargs)
 


### PR DESCRIPTION
Wanted to run all tests that use the `run_with_both_backends` decorator and found the nose attr plugin useful for it. Might be other uses too.

@dimagi/test-team 