### PR TITLE
Externalize js: Signup

### DIFF
--- a/corehq/apps/domain/templates/domain/create_snapshot.html
+++ b/corehq/apps/domain/templates/domain/create_snapshot.html
@@ -18,8 +18,6 @@
 {% endblock %}
 
 {% block js-inline %} {{ block.super }}
-{% url "cda_basic" as cda_url %}
-{% include 'style/includes/load_into_modal.html' with modal_id="cda-modal" load_from=cda_url %}
 <script>
     $(function(){
         var ids = [];

--- a/corehq/apps/domain/templates/domain/partials/cda_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/cda_modal.html
@@ -2,7 +2,7 @@
 {% blocktrans %}
 I have read and agree to the <a data-toggle="modal" data-target="#cda-modal" href="#cda-modal">CommCare HQ Content Distribution Agreement</a>.
 {% endblocktrans %}
-<div class="modal fade" id="cda-modal">
+<div class="modal fade remote-modal" id="cda-modal" data-url="{% url "cda_basic" %}">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -100,6 +100,7 @@ except (ImportError, SyntaxError):
     resource_versions = {}
 
 
+@register.filter
 @register.simple_tag
 def static(url):
     resource_url = url

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -7,6 +7,7 @@ $(function () {
         $('.reg-form-column').css('min-height', Math.max(newHeight, minHeight) + 'px');
     });
 
+    // Link up with registration form ko model
     var reg = hqImport('registration/js/new_user.ko.js');
     reg.onModuleLoad = function () {
         $('.loading-form-step').fadeOut(500, function () {
@@ -24,21 +25,25 @@ $(function () {
     );
     $('#registration-form-container').koApplyBindings(regForm);
 
+    // Email validation feedback
     reg.setResetEmailFeedbackFn(function (isValidating) {
-        // separating form and function
+        var $email = $('#div_id_email');
         if (isValidating) {
-            $('#div_id_email').removeClass('has-error has-success')
-                              .addClass('has-warning')
-                              .find('.form-control-feedback').removeClass('fa-check fa-remove')
-                                                             .addClass('fa-spinner fa-spin');
+            $email.removeClass('has-error has-success').addClass('has-warning');
+            $email.find('.form-control-feedback').removeClass('fa-check fa-remove').addClass('fa-spinner fa-spin');
         } else {
-            $('#div_id_email').removeClass('has-warning')
-                              .addClass((regForm.emailDelayed.isValid() && regForm.email.isValid()) ? 'has-success' : 'has-error')
-                              .find('.form-control-feedback').removeClass('fa-spinner fa-spin')
-                              .addClass((regForm.emailDelayed.isValid() && regForm.email.isValid()) ? 'fa-check' : 'fa-remove');
+            var inputClass = 'has-error',
+                iconClass = 'fa-remove';
+            if (regForm.emailDelayed.isValid() && regForm.email.isValid()) {
+                inputClass = 'has-success';
+                iconClass = 'fa-check';
+            }
+            $email.removeClass('has-warning').addClass(inputClass);
+            $email.find('.form-control-feedback').removeClass('fa-spinner fa-spin').addClass(iconClass);
         }
     });
 
+    // Analytics
     reg.setSubmitAttemptFn(function () {
         _kmq.push(["trackClick", "create_account_clicked", "Clicked Create Account"]);
     });
@@ -46,6 +51,7 @@ $(function () {
         _kmq.push(["trackClick", "create_account_success", "Account Creation was Successful"]);
     });
 
+    // Handle phone number input
     if (initial_page_data('show_number')) {
         var $number = $('#id_phone_number');
         $number.intlTelInput({

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -1,0 +1,90 @@
+$(function () {
+    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
+
+    $(window).on('resize load', function () {
+        var newHeight = $(window).height() - $('#hq-navigation').outerHeight() - $('#hq-footer').outerHeight() - 1;  // -1 for rounding errors
+        var minHeight = initial_page_data('show_number') ? 600 : 450;
+        $('.reg-form-column').css('min-height', Math.max(newHeight, minHeight) + 'px');
+    });
+
+    var reg = hqImport('registration/js/new_user.ko.js');
+    reg.onModuleLoad = function () {
+        $('.loading-form-step').fadeOut(500, function () {
+            $('.step-1').fadeIn(500);
+        });
+    };
+    reg.initRMI(hqImport('hqwebapp/js/urllib.js').reverse('process_registration'));
+    if (!initial_page_data('hide_password_feedback')) {
+        reg.showPasswordFeedback();
+    }
+    var regForm = new reg.FormViewModel(
+        initial_page_data('reg_form_defaults'),
+        '#registration-form-container',
+        ['step-1', 'step-2', 'final-step']
+    );
+    $('#registration-form-container').koApplyBindings(regForm);
+
+    reg.setResetEmailFeedbackFn(function (isValidating) {
+        // separating form and function
+        if (isValidating) {
+            $('#div_id_email').removeClass('has-error has-success')
+                              .addClass('has-warning')
+                              .find('.form-control-feedback').removeClass('fa-check fa-remove')
+                                                             .addClass('fa-spinner fa-spin');
+        } else {
+            $('#div_id_email').removeClass('has-warning')
+                              .addClass((regForm.emailDelayed.isValid() && regForm.email.isValid()) ? 'has-success' : 'has-error')
+                              .find('.form-control-feedback').removeClass('fa-spinner fa-spin')
+                              .addClass((regForm.emailDelayed.isValid() && regForm.email.isValid()) ? 'fa-check' : 'fa-remove');
+        }
+    });
+
+    reg.setSubmitAttemptFn(function () {
+        _kmq.push(["trackClick", "create_account_clicked", "Clicked Create Account"]);
+    });
+    reg.setSubmitSuccessFn(function () {
+        _kmq.push(["trackClick", "create_account_success", "Account Creation was Successful"]);
+    });
+
+    if (initial_page_data('show_number')) {
+        var $number = $('#id_phone_number');
+        $number.intlTelInput({
+            nationalMode: true,
+            utilsScript: initial_page_data('number_utils_script'),
+        });
+        $number.keydown(function (e) {
+            // prevents non-numeric numbers from being entered.
+            // from http://stackoverflow.com/questions/995183/how-to-allow-only-numeric-0-9-in-html-inputbox-using-jquery
+            // Allow: backspace, delete, tab, escape, enter and .
+            if ($.inArray(e.keyCode, [46, 8, 9, 27, 13, 110, 190]) !== -1 ||
+                // Allow: Ctrl+A, Command+A
+                (e.keyCode === 65 && (e.ctrlKey === true || e.metaKey === true)) ||
+                // Allow: home, end, left, right, down, up
+                (e.keyCode >= 35 && e.keyCode <= 40)
+            ) {
+                   // let it happen, don't do anything
+                   return;
+            }
+
+            // Ensure that it is a number and stop the keypress
+            if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
+                e.preventDefault();
+            }
+        });
+        reg.setGetPhoneNumberFn(function () {
+            var phoneNumber = $number.intlTelInput("getNumber");
+            if (phoneNumber) {
+                _kmq.push(["trackClick", "submitted_phone_number", "Phone Number Field Filled Out"]);
+            }
+            return phoneNumber;
+        });
+    }
+
+    // A/B test setup
+    var ab_test = hqImport('hqwebapp/js/initial_page_data.js').get('ab_test');
+    if (ab_test) {
+        var options = {};
+        options[ab_test.name] = ab_test.version;
+        _kmq.push(["set", options]);
+    }
+});

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -20,20 +20,19 @@
 {% endblock %}
 
 {% block js-inline  %}{{ block.super }}
-  <script>
-    $(function () {
-      $(window).on('resize load', function () {
-        var newHeight = $(window).height() - $('#hq-navigation').outerHeight() - $('#hq-footer').outerHeight() - 1;  // -1 for rounding errors
-        $('.reg-form-column').css('min-height', Math.max(newHeight, {% if show_number %}600{% else %}450{% endif %}) + 'px');
-      });
-    });
-  </script>
   {% url "eula_basic" as eula_url %}
   {% include 'style/includes/load_into_modal.html' with modal_id="eulaModal" load_from=eula_url %}
   <script>
     $(function () {
-      var reg = hqImport('registration/js/new_user.ko.js')
-          initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
+      var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
+
+      $(window).on('resize load', function () {
+        var newHeight = $(window).height() - $('#hq-navigation').outerHeight() - $('#hq-footer').outerHeight() - 1;  // -1 for rounding errors
+        var minHeight = initial_page_data('show_number') ? 600 : 450;
+        $('.reg-form-column').css('min-height', Math.max(newHeight, minHeight) + 'px');
+      });
+
+      var reg = hqImport('registration/js/new_user.ko.js');
       reg.onModuleLoad = function () {
         $('.loading-form-step').fadeOut(500, function () {
           $('.step-1').fadeIn(500);

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -13,111 +13,16 @@
         <script src="{% static 'zxcvbn/dist/zxcvbn.js' %}"></script>
         <script src="{% static 'style/js/password_validators.ko.js' %}"></script>
         <script src="{% static 'intl-tel-input/build/js/intlTelInput.min.js' %}"></script>
-        <script src="{% static 'registration/js/new_user.ko.js' %}"></script>
         <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
+        <script src="{% static 'registration/js/new_user.ko.js' %}"></script>
+        <script src="{% static 'registration/js/register_new_user.js' %}"></script>
     {% endcompress %}
 {% endblock %}
 
 {% block js-inline  %}{{ block.super }}
   {% url "eula_basic" as eula_url %}
   {% include 'style/includes/load_into_modal.html' with modal_id="eulaModal" load_from=eula_url %}
-  <script>
-    $(function () {
-      var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
-
-      $(window).on('resize load', function () {
-        var newHeight = $(window).height() - $('#hq-navigation').outerHeight() - $('#hq-footer').outerHeight() - 1;  // -1 for rounding errors
-        var minHeight = initial_page_data('show_number') ? 600 : 450;
-        $('.reg-form-column').css('min-height', Math.max(newHeight, minHeight) + 'px');
-      });
-
-      var reg = hqImport('registration/js/new_user.ko.js');
-      reg.onModuleLoad = function () {
-        $('.loading-form-step').fadeOut(500, function () {
-          $('.step-1').fadeIn(500);
-        });
-      };
-      reg.initRMI(hqImport('hqwebapp/js/urllib.js').reverse('process_registration'));
-      if (!initial_page_data('hide_password_feedback')) {
-        reg.showPasswordFeedback();
-      }
-      var regForm = new reg.FormViewModel(
-        initial_page_data('reg_form_defaults'),
-        '#registration-form-container',
-        ['step-1', 'step-2', 'final-step']
-      );
-      $('#registration-form-container').koApplyBindings(regForm);
-
-      reg.setResetEmailFeedbackFn(function (isValidating) {
-        // separating form and function
-        if (isValidating) {
-          $('#div_id_email')
-            .removeClass('has-error has-success')
-            .addClass('has-warning')
-            .find('.form-control-feedback')
-              .removeClass('fa-check fa-remove')
-              .addClass('fa-spinner fa-spin');
-        } else {
-          $('#div_id_email')
-            .removeClass('has-warning')
-            .addClass((regForm.emailDelayed.isValid() && regForm.email.isValid()) ? 'has-success' : 'has-error')
-            .find('.form-control-feedback')
-              .removeClass('fa-spinner fa-spin')
-              .addClass((regForm.emailDelayed.isValid() && regForm.email.isValid()) ? 'fa-check' : 'fa-remove');
-        }
-      });
-
-      reg.setSubmitAttemptFn(function () {
-        _kmq.push(["trackClick", "create_account_clicked", "Clicked Create Account"]);
-      });
-
-      reg.setSubmitSuccessFn(function () {
-        _kmq.push(["trackClick", "create_account_success", "Account Creation was Successful"]);
-      });
-
-      if (initial_page_data('show_number')) {
-        var $number = $('#id_phone_number');
-        $number.intlTelInput({
-          nationalMode: true,
-          utilsScript: initial_page_data('number_utils_script'),
-        });
-        $number.keydown(function (e) {
-          // prevents non-numeric numbers from being entered.
-          // from http://stackoverflow.com/questions/995183/how-to-allow-only-numeric-0-9-in-html-inputbox-using-jquery
-          // Allow: backspace, delete, tab, escape, enter and .
-          if ($.inArray(e.keyCode, [46, 8, 9, 27, 13, 110, 190]) !== -1 ||
-               // Allow: Ctrl+A, Command+A
-              (e.keyCode === 65 && (e.ctrlKey === true || e.metaKey === true)) ||
-               // Allow: home, end, left, right, down, up
-              (e.keyCode >= 35 && e.keyCode <= 40)) {
-                   // let it happen, don't do anything
-                   return;
-          }
-          // Ensure that it is a number and stop the keypress
-          if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
-              e.preventDefault();
-          }
-        });
-        reg.setGetPhoneNumberFn(function () {
-          var phoneNumber = $number.intlTelInput("getNumber");
-          if (phoneNumber) {
-            _kmq.push(["trackClick", "submitted_phone_number", "Phone Number Field Filled Out"]);
-          }
-          return phoneNumber;
-        });
-      }
-    });
-
-      $(function () {
-        var ab_test = hqImport('hqwebapp/js/initial_page_data.js').get('ab_test');
-        if (ab_test) {
-            var options = {};
-            options[ab_test.name] = ab_test.version;
-            _kmq.push(["set", options]);
-        }
-      })
-    </script>
 {% endblock %}
 
 {% block stylesheets %}

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -20,11 +20,6 @@
     {% endcompress %}
 {% endblock %}
 
-{% block js-inline  %}{{ block.super }}
-  {% url "eula_basic" as eula_url %}
-  {% include 'style/includes/load_into_modal.html' with modal_id="eulaModal" load_from=eula_url %}
-{% endblock %}
-
 {% block stylesheets %}
 <link type="text/css"
       rel="stylesheet"

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -6,6 +6,19 @@
 
 {% block title %}{% trans "Create an Account" %}{% endblock title %}
 
+{% block js %}{{ block.super }}
+    {% compress js %}
+        <script src="{% static 'jquery-ui/ui/effect.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/effect-slide.js' %}"></script>
+        <script src="{% static 'zxcvbn/dist/zxcvbn.js' %}"></script>
+        <script src="{% static 'style/js/password_validators.ko.js' %}"></script>
+        <script src="{% static 'intl-tel-input/build/js/intlTelInput.min.js' %}"></script>
+        <script src="{% static 'registration/js/new_user.ko.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
+    {% endcompress %}
+{% endblock %}
+
 {% block js-inline  %}{{ block.super }}
   <script>
     $(function () {
@@ -17,25 +30,24 @@
   </script>
   {% url "eula_basic" as eula_url %}
   {% include 'style/includes/load_into_modal.html' with modal_id="eulaModal" load_from=eula_url %}
-  <script src="{% static 'jquery-ui/ui/effect.js' %}"></script>
-  <script src="{% static 'jquery-ui/ui/effect-slide.js' %}"></script>
-  <script src="{% static 'zxcvbn/dist/zxcvbn.js' %}"></script>
-  <script src="{% static 'style/js/password_validators.ko.js' %}"></script>
-  <script src="{% static 'intl-tel-input/build/js/intlTelInput.min.js' %}"></script>
-  <script src="{% static 'registration/js/new_user.ko.js' %}"></script>
   <script>
     $(function () {
-      var reg = hqImport('registration/js/new_user.ko.js');
+      var reg = hqImport('registration/js/new_user.ko.js')
+          initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
       reg.onModuleLoad = function () {
         $('.loading-form-step').fadeOut(500, function () {
           $('.step-1').fadeIn(500);
         });
       };
-      reg.initRMI('{% url 'process_registration' %}');
-      {% if not hide_password_feedback %}
+      reg.initRMI(hqImport('hqwebapp/js/urllib.js').reverse('process_registration'));
+      if (!initial_page_data('hide_password_feedback')) {
         reg.showPasswordFeedback();
-      {% endif %}
-      var regForm = new reg.FormViewModel({{ reg_form_defaults|JSON }}, '#registration-form-container', ['step-1', 'step-2', 'final-step']);
+      }
+      var regForm = new reg.FormViewModel(
+        initial_page_data('reg_form_defaults'),
+        '#registration-form-container',
+        ['step-1', 'step-2', 'final-step']
+      );
       $('#registration-form-container').koApplyBindings(regForm);
 
       reg.setResetEmailFeedbackFn(function (isValidating) {
@@ -65,11 +77,11 @@
         _kmq.push(["trackClick", "create_account_success", "Account Creation was Successful"]);
       });
 
-      {% if show_number %}
+      if (initial_page_data('show_number')) {
         var $number = $('#id_phone_number');
         $number.intlTelInput({
           nationalMode: true,
-          utilsScript: "{% static 'intl-tel-input/build/js/utils.js' %}"
+          utilsScript: initial_page_data('number_utils_script'),
         });
         $number.keydown(function (e) {
           // prevents non-numeric numbers from being entered.
@@ -95,17 +107,18 @@
           }
           return phoneNumber;
         });
-      {% endif %}
-
+      }
     });
-  </script>
-  {% if ab_test %}
-    <script>
+
       $(function () {
-        _kmq.push(["set", {"{{ ab_test.name }}": "{{ ab_test.version }}"}]);
+        var ab_test = hqImport('hqwebapp/js/initial_page_data.js').get('ab_test');
+        if (ab_test) {
+            var options = {};
+            options[ab_test.name] = ab_test.version;
+            _kmq.push(["set", options]);
+        }
       })
     </script>
-  {% endif %}
 {% endblock %}
 
 {% block stylesheets %}
@@ -137,6 +150,12 @@
 {% endblock %}
 
 {% block content %}
+{% initial_page_data 'hide_password_feedback' hide_password_feedback %}
+{% initial_page_data 'show_number' show_number %}
+{% initial_page_data 'number_utils_script' 'intl-tel-input/build/js/utils.js'|static %}
+{% initial_page_data 'reg_form_defaults' reg_form_defaults %}
+{% initial_page_data 'ab_test' ab_test %}
+{% registerurl 'process_registration' %}
 <div class="container">
   <div class="row">
     <div class="col-xs-8 col-xs-offset-4 col-md-7 col-md-offset-5 reg-form-column animate-height" style="min-height: 450px">

--- a/corehq/apps/style/static/style/js/remote-modals.js
+++ b/corehq/apps/style/static/style/js/remote-modals.js
@@ -1,0 +1,7 @@
+$(function() {
+    _.each($(".remote-modal"), function(modal) {
+        $(modal).on("show show.bs.modal", function() {
+            $(this).find(".fetched-data").load($(this).data("url"));
+        });
+    });
+});

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -602,6 +602,11 @@
         {# Report Issue #}
         {% include 'style/includes/modal_report_issue.html' %}
 
+        {# Remote modals (EULA and CDA) #}
+        {% compress js %}
+            <script src="{% static 'style/js/remote-modals.js' %}"></script>
+        {% endcompress %}
+
         {# EULA #}
         {% if request.couch_user and not request.couch_user.is_eula_signed %}
             {% include 'style/includes/modal_eula.html' with needs_agreement=True %}

--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -30,9 +30,11 @@
         ga('set', 'dimension3', '{% if request.couch_user.is_commcare_user %}yes{% else %}no{% endif %}');
         ga('set', 'dimension4', '{% if domain %}{{ domain|escapejs }}{% else %}none{% endif %}');
         ga('set', 'dimension5', '{% if request.couch_user.has_built_app %}yes{% else %}no{% endif %}');
+        {% if request.couch_user %}
         var daysOld = {{ request.couch_user.days_since_created }};
         ga('set', 'dimension6', daysOld < 1 ? 'yes' : 'no');
         ga('set', 'dimension7', daysOld >= 1 && daysOld < 7 ? 'yes' : 'no');
+        {% endif %}
         ga('send', 'pageview');
 
 

--- a/corehq/apps/style/templates/style/includes/load_into_modal.html
+++ b/corehq/apps/style/templates/style/includes/load_into_modal.html
@@ -1,7 +1,0 @@
-<script>
-    $(function() {
-        $("#{{ modal_id }}").on("show show.bs.modal", function() {
-            $(this).find(".fetched-data").load("{{ load_from }}");
-        });
-    });
-</script>

--- a/corehq/apps/style/templates/style/includes/modal_eula.html
+++ b/corehq/apps/style/templates/style/includes/modal_eula.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="modal fade" id="eulaModal">
+<div class="modal fade remote-modal" id="eulaModal" data-url="{% url "eula_basic" %}">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
@@ -31,8 +31,6 @@
             </div>
     </div>
 </div>
-{% url "eula_basic" as eula_url %}
-{% include 'style/includes/load_into_modal.html' with modal_id="eulaModal" load_from=eula_url %}
 {% if needs_agreement %}
     <script>
         $(function(){

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -6,8 +6,6 @@
 {% block title %}{% trans "Invitation to join the " %}{{ invite_to }} {{ invite_type }}{% endblock title %}
 
 {% block js-inline  %}{{ block.super }}
-    {% url "eula_basic" as eula_url %}
-    {% include 'style/includes/load_into_modal.html' with modal_id="eulaModal" load_from=eula_url %}
     {% if not hide_password_feedback %}
     <script src="{% static 'zxcvbn/dist/zxcvbn.js' %}"></script>
     <script src="{% static 'registration/js/password.js' %}"></script>

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -68,7 +68,7 @@
                             {{ global_error }}
                         </div>
                     {% endfor %}
-                    <fieldset>
+                    <fieldset class="check-password">
                         {% if create_domain %}
                             <legend>{% trans 'New user information' %}</legend>
                         {% endif %}


### PR DESCRIPTION
Review commits individually.

The one mildly interesting thing about this one is it makes `static` available as a filter, so that I can use it more easily with inital_page_data: `{% initial_page_data 'path' 'this/is/my/path'|static %}`

@gcapalbo 