### PR TITLE
Test refactoring sync_mode

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1882,20 +1882,22 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
     Test that doing multiple clean syncs with extensions does what we think it will
     """
 
-    def setUp(self):
-        super(SteadyStateExtensionSyncTest, self).setUp()
-        self.other_user = create_restore_user(
-            self.project.name,
+    @classmethod
+    def setUpClass(cls):
+        super(SteadyStateExtensionSyncTest, cls).setUpClass()
+        cls.other_user = create_restore_user(
+            cls.project.name,
             username=OTHER_USERNAME,
         )
-        self.other_user_id = self.other_user.user_id
-        self._create_ownership_cleanliness(self.user_id)
-        self._create_ownership_cleanliness(self.other_user_id)
+        cls.other_user_id = cls.other_user.user_id
+        cls._create_ownership_cleanliness(cls.user_id)
+        cls._create_ownership_cleanliness(cls.other_user_id)
 
-    def _create_ownership_cleanliness(self, user_id):
+    @classmethod
+    def _create_ownership_cleanliness(cls, user_id):
         OwnershipCleanlinessFlag.objects.get_or_create(
-            owner_id=self.user_id,
-            domain=self.project.name,
+            owner_id=cls.user_id,
+            domain=cls.project.name,
             defaults={'is_clean': True}
         )
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1896,7 +1896,7 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
     @classmethod
     def _create_ownership_cleanliness(cls, user_id):
         OwnershipCleanlinessFlag.objects.get_or_create(
-            owner_id=cls.user_id,
+            owner_id=user_id,
             domain=cls.project.name,
             defaults={'is_clean': True}
         )


### PR DESCRIPTION
Taking a stab at getting casexml tests down. This one refactors sync_mode just a bit by moving things that can be done in SetUpClass to there instead of setUp.

Before:
```

----------------------------------------------------------------------
Ran 68 tests in 108.208s
```
After:
```

----------------------------------------------------------------------
Ran 68 tests in 54.738s
```
@dimagi/test-team 