### PR TITLE
update logging to prevent duplicate error reports

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1076,7 +1076,7 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': False,
         },
-        'django.request': {
+        'django': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
             'propagate': True,


### PR DESCRIPTION
anyone

Tested this locally and prior to this change 2 emails get sent for every 500. After the change only one (the correct one).

See https://docs.djangoproject.com/en/1.10/releases/1.9/#changes-to-the-default-logging-configuration