### PR TITLE
case block ordering

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/id_conflicts.xml
+++ b/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/id_conflicts.xml
@@ -6,10 +6,10 @@
 		<timeEnd>2011-02-15T22:01:18.957</timeEnd>
 		<username>user1</username>
 		<chw_id>82WS6S0JPCKFK82SPGF6W023L</chw_id>
-		<uid>3A6B9P0AYZD0OGC3U5XQ3HN45</uid>
+		<uid>3A6B9P0AYZD0OGC3U5XQ3HN46</uid>
 	</Meta>
 	<case>
-		<case_id>3A6B9P0AYZD0OGC3U5XQ3HN45</case_id>
+		<case_id>3A6B9P0AYZD0OGC3U5XQ3HN46</case_id>
 		<date_modified>2011-02-15T22:01:18.957</date_modified>
 		<create>
 			<case_type_id>care_anc</case_type_id>

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -161,6 +161,17 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertEqual('not_bar', case.dynamic_case_properties()['foo'])
         self.assertTrue(case.is_deleted)
 
+    @run_with_all_backends
+    def test_case_block_ordering(self):
+        case_id = uuid.uuid4().hex
+        blocks = [
+            CaseBlock(create=False, case_id=case_id, update={'p': '2'}).as_xml(),  # update before create
+            CaseBlock(create=True, case_id=case_id, update={'p': '1'}).as_xml()
+        ]
+
+        xform, cases = post_case_blocks(blocks)
+        self.assertEqual(cases[0].get_case_property('p'), '2')
+
 
 class TestCaseHierarchy(TestCase):
     @classmethod

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -12,7 +12,7 @@ from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2, V1
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
 from corehq.util.test_utils import TestFileMixin, softer_assert
 
 
@@ -32,10 +32,15 @@ class CaseBugTest(TestCase, TestFileMixin):
     file_path = ('data', 'bugs')
     root = os.path.dirname(__file__)
 
-    def setUp(self):
-        super(CaseBugTest, self).setUp()
-        delete_all_cases()
-        delete_all_xforms()
+    @classmethod
+    def setUpClass(cls):
+        super(CaseBugTest, cls).setUpClass()
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+        super(CaseBugTest, cls).tearDownClass()
 
     def test_conflicting_ids(self):
         """
@@ -158,22 +163,29 @@ class CaseBugTest(TestCase, TestFileMixin):
 
 
 class TestCaseHierarchy(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestCaseHierarchy, cls).setUpClass()
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
 
-    def setUp(self):
-        super(TestCaseHierarchy, self).setUp()
-        delete_all_cases()
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+        super(TestCaseHierarchy, cls).tearDownClass()
 
     @run_with_all_backends
     def test_normal_index(self):
         factory = CaseFactory()
+        parent_id = uuid.uuid4().hex
         [cp] = factory.create_or_update_case(
-            CaseStructure(case_id='parent', attrs={'case_type': 'parent', 'create': True})
+            CaseStructure(case_id=parent_id, attrs={'case_type': 'parent', 'create': True})
         )
 
+        child_id = uuid.uuid4().hex
         factory.create_or_update_case(CaseStructure(
-            case_id='child',
+            case_id=child_id,
             attrs={'case_type': 'child', 'create': True},
-            indices=[CaseIndex(CaseStructure(case_id='parent'), related_type='parent')],
+            indices=[CaseIndex(CaseStructure(case_id=parent_id), related_type='parent')],
             walk_related=False
         ))
 
@@ -184,17 +196,19 @@ class TestCaseHierarchy(TestCase):
     @run_with_all_backends
     def test_extension_index(self):
         factory = CaseFactory()
+        standard_case_id = uuid.uuid4().hex
         [case] = factory.create_or_update_case(
-            CaseStructure(case_id="standard_case", attrs={'case_type': "standard_type", 'create': True})
+            CaseStructure(case_id=standard_case_id, attrs={'case_type': "standard_type", 'create': True})
         )
 
+        extension_case_id = uuid.uuid4().hex
         factory.create_or_update_case(
             CaseStructure(
-                case_id="extension_case",
+                case_id=extension_case_id,
                 attrs={'case_type': "extension_type", 'create': True},
                 indices=[
                     CaseIndex(
-                        CaseStructure(case_id="standard_case"),
+                        CaseStructure(case_id=standard_case_id),
                         related_type='standard_type',
                         relationship=CASE_INDEX_EXTENSION
                     )
@@ -224,25 +238,28 @@ class TestCaseHierarchy(TestCase):
     @run_with_all_backends
     def test_complex_index(self):
         factory = CaseFactory()
-        cp = factory.create_or_update_case(CaseStructure(case_id='parent', attrs={
+        parent_id = uuid.uuid4().hex
+        cp = factory.create_or_update_case(CaseStructure(case_id=parent_id, attrs={
             'case_type': 'parent', 'create': True
         }))[0]
 
         # cases processed according to ID order so ensure that this case is
         # processed after the task case by making its ID sort after task ID
+        goal_id = uuid.uuid4().hex
         factory.create_or_update_case(CaseStructure(
-            case_id='z_goal',
+            case_id=goal_id,
             attrs={'case_type': 'goal', 'create': True},
-            indices=[CaseIndex(CaseStructure(case_id='parent'), related_type='parent')],
+            indices=[CaseIndex(CaseStructure(case_id=parent_id), related_type='parent')],
             walk_related=False
         ))
 
+        task_id = uuid.uuid4().hex
         factory.create_or_update_case(CaseStructure(
-            case_id='task1',
+            case_id=task_id,
             attrs={'case_type': 'task', 'create': True},
             indices=[
-                CaseIndex(CaseStructure(case_id='z_goal'), related_type='goal', identifier='goal'),
-                CaseIndex(CaseStructure(case_id='parent'), related_type='parent')
+                CaseIndex(CaseStructure(case_id=goal_id), related_type='goal', identifier='goal'),
+                CaseIndex(CaseStructure(case_id=parent_id), related_type='parent')
             ],
             walk_related=False,
         ))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -576,7 +576,10 @@ class TestActionSortKey(SimpleTestCase):
 EMPTY_DATE = object()
 
 
-def _make_action(server_date, phone_date=EMPTY_DATE, action_type=const.CASE_ACTION_UPDATE, user_id='someuserid'):
+def _make_action(server_date, phone_date=EMPTY_DATE, action_type=const.CASE_ACTION_UPDATE, user_id='someuserid', form_id=None):
     if phone_date == EMPTY_DATE:
         phone_date = server_date
-    return CommCareCaseAction(action_type=action_type, server_date=server_date, date=phone_date, user_id=user_id)
+    form_id = form_id or uuid.uuid4().hex
+    return CommCareCaseAction(
+        action_type=action_type, server_date=server_date, date=phone_date, user_id=user_id, xform_id=form_id
+    )

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -560,6 +560,15 @@ class TestActionSortKey(SimpleTestCase):
         )
         self._test(expected_actions)
 
+    def test_type_order_in_same_form(self):
+        expected_actions = (
+            (3, _make_action(server_date=datetime(2001, 1, 1), action_type=const.CASE_ACTION_CLOSE, form_id='1')),
+            (1, _make_action(server_date=datetime(2001, 1, 1), action_type=const.CASE_ACTION_UPDATE, form_id='1')),
+            (0, _make_action(server_date=datetime(2001, 1, 1), action_type=const.CASE_ACTION_CREATE, form_id='1')),
+            (2, _make_action(server_date=datetime(2001, 1, 1), action_type=const.CASE_ACTION_UPDATE, form_id='1')),
+        )
+        self._test(expected_actions)
+
     def _test(self, action_tuples):
         """
         Takes in an iterable of tuples of the form: (expected_index, action).

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -393,8 +393,9 @@ def _action_sort_key_function(case):
                 if not action.server_date or not action.date:
                     raise MissingServerDate()
 
-                form_cmp = lambda form_id: (form_ids.index(form_id)
-                                            if form_id in form_ids else sys.maxint)
+                def form_cmp(form_id):
+                    return form_ids.index(form_id) if form_id in form_ids else sys.maxint
+
                 # if the user is the same you should compare with the special logic below
                 # if the user is not the same you should compare just using received_on
                 return (

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -382,6 +382,13 @@ def _action_sort_key_function(case):
         else:
             form_ids = list(case.xform_ids)
 
+            if first_action.xform_id == second_action.xform_id:
+                # short circuit if they are from the same form
+                return cmp(
+                    _type_sort(first_action.action_type),
+                    _type_sort(second_action.action_type)
+                )
+
             def _sortkey(action):
                 if not action.server_date or not action.date:
                     raise MissingServerDate()

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -394,7 +394,7 @@ def _action_sort_key_function(case):
                     raise MissingServerDate()
 
                 form_cmp = lambda form_id: (form_ids.index(form_id)
-                                            if form_id in form_ids else sys.maxint, form_id)
+                                            if form_id in form_ids else sys.maxint)
                 # if the user is the same you should compare with the special logic below
                 # if the user is not the same you should compare just using received_on
                 return (

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -382,7 +382,7 @@ def _action_sort_key_function(case):
         else:
             form_ids = list(case.xform_ids)
 
-            if first_action.xform_id == second_action.xform_id:
+            if first_action.xform_id and first_action.xform_id == second_action.xform_id:
                 # short circuit if they are from the same form
                 return cmp(
                     _type_sort(first_action.action_type),


### PR DESCRIPTION
The processing order for case blocks for the same case in a single form is currently the order they appear in the form. This means that an update block could get processed before a create block.

First commit is a test prefactor