### PR TITLE
Conditionally run both backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - TEST=python NOSE_DIVIDED_WE_RUN=04 JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=59 JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=af JS_SETUP=yes
-    - TEST=python-sharded-and-javascript JS_SETUP=yes
+    - TEST=python-sharded-and-javascript JS_SETUP=yes USE_SQL_BACKEND_ONLY=1
   global:
     # TRAVIS_HQ_USERNAME
     - secure: "LuT0vvsY6RjlEX8Gje74Xl0jcuEfaiN/fOOXpfZd1tf8zC3Xd9E8mNn5vlup/3PBBBv1yIAUmw9LTc03ifWBGzaazqIVAgTfgBoW7XAd8G/lx0/eeZFqheSdpP8wSZwn72Z/XrIhQczFCreZRJHlZA9GopRv7Lfs1SfNEbnMoac="

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - TEST=python NOSE_DIVIDED_WE_RUN=04 JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=59 JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=af JS_SETUP=yes
-    - TEST=python-sharded-and-javascript JS_SETUP=yes USE_SQL_BACKEND_ONLY=1
+    - TEST=python-sharded-and-javascript JS_SETUP=yes USE_SQL_BACKEND_ONLY=yes
   global:
     # TRAVIS_HQ_USERNAME
     - secure: "LuT0vvsY6RjlEX8Gje74Xl0jcuEfaiN/fOOXpfZd1tf8zC3Xd9E8mNn5vlup/3PBBBv1yIAUmw9LTc03ifWBGzaazqIVAgTfgBoW7XAd8G/lx0/eeZFqheSdpP8wSZwn72Z/XrIhQczFCreZRJHlZA9GopRv7Lfs1SfNEbnMoac="

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -51,7 +51,7 @@ from custom.ilsgateway.resources.v0_1 import ILSLocationResource
 from custom.ewsghana.resources.v0_1 import EWSLocationResource
 from corehq.apps.users.analytics import update_analytics_indexes
 from corehq.apps.users.models import CommCareUser, WebUser, UserRole, Permissions
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.pillows.reportxform import transform_xform_for_report_forms_index
 from corehq.pillows.xform import transform_xform_for_elasticsearch
 from custom.hope.models import CC_BIHAR_PREGNANCY
@@ -361,7 +361,7 @@ class TestXFormInstanceResource(APIResourceTest):
         ]
         self._test_es_query({'include_archived': 'true'}, expected)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fetching_xform_cases(self):
         fake_xform_es = FakeXFormES(ESXFormInstance)
         v0_4.MOCK_XFORM_ES = fake_xform_es
@@ -425,7 +425,7 @@ class TestCommCareCaseResource(APIResourceTest):
         api_case = api_cases[0]
         self.assertEqual(api_case['server_date_modified'], json_format_datetime(backend_case.server_modified_on))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_parent_and_child_cases(self):
         fake_case_es = FakeXFormES(ESCase)
         v0_4.MOCK_CASE_ES = fake_case_es

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -20,7 +20,7 @@ from django.test import TestCase
 from django.core import cache
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 from corehq.sql_db.connections import connection_manager
 from corehq.sql_db.tests.utils import temporary_database
 
@@ -467,7 +467,7 @@ class CallCenterSupervisorGroupTest(BaseCCTests):
         self.domain.delete()
         super(CallCenterSupervisorGroupTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_users_assigned_via_group(self):
         """
         Ensure that users who are assigned to the supervisor via a group are also included
@@ -526,7 +526,7 @@ class CallCenterCaseSharingTest(BaseCCTests):
         clear_data(self.domain.name)
         self.domain.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cases_owned_by_group(self):
         """
         Ensure that indicators include cases owned by a case sharing group the user is part of.
@@ -572,7 +572,7 @@ class CallCenterTestOpenedClosed(BaseCCTests):
         clear_data(self.domain.name)
         self.domain.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_opened_closed(self):
         """
         Test that cases_closed and cases_opened indicators count based on the user that
@@ -619,7 +619,7 @@ class TestSavingToUCRDatabase(BaseCCTests):
         connection_manager.dispose_engine('ucr')
         self.db_context.__exit__(None, None, None)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_standard_indicators(self):
         with override_settings(UCR_DATABASE_URL=self.ucr_db_url):
             load_data(self.cc_domain.name, self.cc_user.user_id)

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -20,7 +20,7 @@ from django.test import TestCase
 from django.core import cache
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.sql_db.connections import connection_manager
 from corehq.sql_db.tests.utils import temporary_database
 

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -18,7 +18,7 @@ from django.test import TestCase, SimpleTestCase
 
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted
@@ -53,7 +53,7 @@ class CallCenterUtilsTests(TestCase):
     def tearDown(self):
         delete_all_cases()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
@@ -63,7 +63,7 @@ class CallCenterUtilsTests(TestCase):
         self.assertIsNotNone(case.get_case_property('language'))
         self.assertIsNotNone(case.get_case_property('phone_number'))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_full_name(self):
         name = 'Ricky Bowwood'
         self.user.set_full_name(name)
@@ -72,7 +72,7 @@ class CallCenterUtilsTests(TestCase):
         self.assertIsNotNone(case)
         self.assertEquals(case.name, name)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_inactive(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
@@ -83,7 +83,7 @@ class CallCenterUtilsTests(TestCase):
         case = self._get_user_case()
         self.assertTrue(case.closed)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_retired(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
@@ -94,7 +94,7 @@ class CallCenterUtilsTests(TestCase):
         case = self._get_user_case()
         self.assertTrue(case.closed)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_update_update(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
@@ -107,7 +107,7 @@ class CallCenterUtilsTests(TestCase):
         case = self._get_user_case()
         self.assertEquals(case.name, name)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_custom_user_data(self):
         self.user.user_data = {
             '': 'blank_key',
@@ -124,7 +124,7 @@ class CallCenterUtilsTests(TestCase):
         self.assertEquals(case.get_case_property('blank_val'), '')
         self.assertEquals(case.get_case_property('ok'), 'good')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_call_center_cases_for_user(self):
         factory = CaseFactory(domain=TEST_DOMAIN, case_defaults={
             'user_id': self.user_id,
@@ -144,7 +144,7 @@ class CallCenterUtilsTests(TestCase):
         self.assertEqual(case_ids, set([c1.case_id, c2.case_id]))
         self.assertEqual(user_ids, set([self.user_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_call_center_cases_all(self):
         factory = CaseFactory(domain=TEST_DOMAIN, case_defaults={
             'user_id': self.user_id,
@@ -160,7 +160,7 @@ class CallCenterUtilsTests(TestCase):
         cases = get_call_center_cases(TEST_DOMAIN, CASE_TYPE)
         self.assertEqual(len(cases), 3)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_call_center_not_default_case_owner(self):
         """
         call center case owner should not change on sync
@@ -194,7 +194,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
         delete_all_cases()
         self.domain.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_usercase_custom_user_data_on_create(self):
         """
         Custom user data should be synced when the user is created
@@ -207,7 +207,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
         self.assertIsNotNone(case)
         self.assertEquals(case.dynamic_case_properties()['completed_training'], 'yes')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_usercase_custom_user_data_on_update(self):
         """
         Custom user data should be synced when the user is updated
@@ -223,7 +223,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
         case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
         self.assertEquals(case.dynamic_case_properties()['completed_training'], 'yes')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reactivate_user(self):
         """Confirm that reactivating a user re-opens its user case."""
         self.user.save()
@@ -240,7 +240,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
         user_case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
         self.assertFalse(user_case.closed)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_deactivated_user(self):
         """
         Confirm that updating a deactivated user also updates the user case.
@@ -260,7 +260,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
         self.assertTrue(user_case.closed)
         self.assertEquals(user_case.dynamic_case_properties()['foo'], 'bar')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_and_reactivate_in_one_save(self):
         """
         Confirm that a usercase can be updated and reactived in a single save of the user model

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -18,7 +18,7 @@ from django.test import TestCase, SimpleTestCase
 
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -12,7 +12,7 @@ from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 from corehq.util.workbook_reading import make_worksheet
 
 
@@ -53,14 +53,14 @@ class ImporterTest(TestCase):
             create_new_cases=create_new_cases,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testImportNone(self):
         res = bulk_import_async(self._config(['anything']), self.domain, None)
         self.assertEqual('Sorry, your session has expired. Please start over and try again.',
                          unicode(res['errors']))
         self.assertEqual(0, len(get_case_ids_in_domain(self.domain)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testImportBasic(self):
         config = self._config(['case_id', 'age', 'sex', 'location'])
         file = make_worksheet_wrapper(
@@ -89,7 +89,7 @@ class ImporterTest(TestCase):
                 self.assertFalse(case.get_case_property(prop) in properties_seen)
                 properties_seen.add(case.get_case_property(prop))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testImportNamedColumns(self):
         config = self._config(['case_id', 'age', 'sex', 'location'])
         file = make_worksheet_wrapper(
@@ -104,7 +104,7 @@ class ImporterTest(TestCase):
         self.assertEqual(4, res['created_count'])
         self.assertEqual(4, len(self.accessor.get_case_ids_in_domain()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testImportTrailingWhitespace(self):
         cols = ['case_id', 'age', u'sex\xa0', 'location']
         config = self._config(cols)
@@ -120,7 +120,7 @@ class ImporterTest(TestCase):
         case = self.accessor.get_case(case_ids[0])
         self.assertTrue(bool(case.get_case_property('sex')))  # make sure the value also got properly set
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCaseIdMatching(self):
         # bootstrap a stub case
         [case] = self.factory.create_or_update_case(CaseStructure(attrs={
@@ -151,7 +151,7 @@ class ImporterTest(TestCase):
         # shouldn't touch existing properties
         self.assertEqual('foo', case.get_case_property('importer_test_prop'))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCaseLookupTypeCheck(self):
         [case] = self.factory.create_or_update_case(CaseStructure(attrs={
             'create': True,
@@ -171,7 +171,7 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['match_count'])
         self.assertEqual(4, len(self.accessor.get_case_ids_in_domain()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCaseLookupDomainCheck(self):
         self.factory.domain = 'wrong-domain'
         [case] = self.factory.create_or_update_case(CaseStructure(attrs={
@@ -192,7 +192,7 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['match_count'])
         self.assertEqual(3, len(self.accessor.get_case_ids_in_domain()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testExternalIdMatching(self):
         # bootstrap a stub case
         external_id = 'importer-test-external-id'
@@ -220,7 +220,7 @@ class ImporterTest(TestCase):
         # shouldn't create any more cases, just the one
         self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_external_id_matching_on_create_with_custom_column_name(self):
         headers = ['id_column', 'age', 'sex', 'location']
         external_id = 'external-id-test'
@@ -288,7 +288,7 @@ class ImporterTest(TestCase):
         self.assertEqual(5, res['created_count'])
         self.assertEqual(5, len(get_case_ids_in_domain(self.domain)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testExternalIdChunking(self):
         # bootstrap a stub case
         external_id = 'importer-test-external-id'
@@ -317,7 +317,7 @@ class ImporterTest(TestCase):
         for prop in ['age', 'sex', 'location']:
             self.assertTrue(prop in case.get_case_property(prop))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParentCase(self):
         headers = ['parent_id', 'name', 'case_id']
         config = self._config(headers, create_new_cases=True, search_column='case_id')
@@ -354,7 +354,7 @@ class ImporterTest(TestCase):
         xls_file = make_worksheet_wrapper(*rows)
         return do_import(xls_file, config, self.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testLocationOwner(self):
         # This is actually testing several different things, but I figure it's
         # worth it, as each of these tests takes a non-trivial amount of time.

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -12,7 +12,7 @@ from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.workbook_reading import make_worksheet
 
 

--- a/corehq/apps/commtrack/tests/test_dbaccessors.py
+++ b/corehq/apps/commtrack/tests/test_dbaccessors.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.commtrack.dbaccessors import get_supply_point_ids_in_domain_by_location

--- a/corehq/apps/commtrack/tests/test_dbaccessors.py
+++ b/corehq/apps/commtrack/tests/test_dbaccessors.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.commtrack.dbaccessors import get_supply_point_ids_in_domain_by_location
@@ -36,7 +36,7 @@ class SupplyPointDBAccessorsTest(TestCase):
         }
         self.assertEqual(actual, expected)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_supply_point_by_location_id(self):
         actual = self.interface.get_closed_and_open_by_location_id_and_domain(
             self.domain,

--- a/corehq/apps/commtrack/tests/test_locations.py
+++ b/corehq/apps/commtrack/tests/test_locations.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseBlock
 from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc, FIXED_USER
 from corehq.toggles import MULTIPLE_LOCATIONS_PER_USER, NAMESPACE_DOMAIN
 from corehq.form_processor.interfaces.supply import SupplyInterface
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 
 
 def _count_locations(domain):
@@ -25,7 +25,7 @@ class LocationsTest(CommTrackTest):
         self.accessor = SupplyInterface(self.domain.name)
         self.user = self.users[0]
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync(self):
         test_state = make_loc(
             'teststate',
@@ -49,7 +49,7 @@ class LocationsTest(CommTrackTest):
         except SQLLocation.DoesNotExist:
             self.fail("Synced SQL object does not exist")
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive(self):
         test_state = make_loc(
             'teststate',
@@ -86,7 +86,7 @@ class LocationsTest(CommTrackTest):
             1
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_flips_sp_cases(self):
         loc = make_loc('someloc').sql_location
         sp = loc.linked_supply_point()
@@ -100,7 +100,7 @@ class LocationsTest(CommTrackTest):
         sp = loc.linked_supply_point()
         self.assertFalse(sp.closed)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_full_delete(self):
         test_loc = make_loc(
             'test_loc',
@@ -129,7 +129,7 @@ class LocationsTest(CommTrackTest):
             0
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_closes_sp_cases(self):
         loc = make_loc('test_loc').sql_location
         sp = loc.linked_supply_point()

--- a/corehq/apps/commtrack/tests/test_locations.py
+++ b/corehq/apps/commtrack/tests/test_locations.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseBlock
 from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc, FIXED_USER
 from corehq.toggles import MULTIPLE_LOCATIONS_PER_USER, NAMESPACE_DOMAIN
 from corehq.form_processor.interfaces.supply import SupplyInterface
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 def _count_locations(domain):

--- a/corehq/apps/commtrack/tests/test_rebuild.py
+++ b/corehq/apps/commtrack/tests/test_rebuild.py
@@ -9,7 +9,7 @@ from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors, CaseAc
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import RebuildWithReason
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 
 LEDGER_BLOCKS_SIMPLE = """
 <transfer xmlns="http://commcarehq.org/ledger/v1" dest="{case_id}" date="2000-01-02" section-id="stock">
@@ -62,7 +62,7 @@ class RebuildStockStateTest(TestCase):
         return submit_case_blocks(
             ledger_blocks.format(**self._stock_state_key), self.domain)[0].form_id
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple(self):
         self._submit_ledgers(LEDGER_BLOCKS_SIMPLE)
         self._assert_stats(2, 100, 100)
@@ -88,7 +88,7 @@ class RebuildStockStateTest(TestCase):
 
         self._assert_stats(2, 150, 150)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_actions(self):
         # make sure that when a case is rebuilt (using rebuild_case)
         # stock transactions show up as well
@@ -99,7 +99,7 @@ class RebuildStockStateTest(TestCase):
         self.assertEqual(case.xform_ids[1:], [form_id])
         self.assertTrue(form_id in [action.form_id for action in case.actions])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_edit_submissions_simple(self):
         initial_quantity = 100
         form = submit_case_blocks(

--- a/corehq/apps/commtrack/tests/test_rebuild.py
+++ b/corehq/apps/commtrack/tests/test_rebuild.py
@@ -9,7 +9,7 @@ from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors, CaseAc
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import RebuildWithReason
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 LEDGER_BLOCKS_SIMPLE = """
 <transfer xmlns="http://commcarehq.org/ledger/v1" dest="{case_id}" date="2000-01-02" section-id="stock">

--- a/corehq/apps/commtrack/tests/test_stock_report.py
+++ b/corehq/apps/commtrack/tests/test_stock_report.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.ledgers.helpers import StockReportHelper, StockTransactionHelper
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 from corehq.form_processor.utils import get_simple_wrapped_form
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.form_processor.utils.xform import TestFormMetadata
@@ -107,7 +107,7 @@ class StockReportDomainTest(TestCase):
         self.assertEquals(stock_report.form_id, self.form._id)
         self.assertEquals(stock_report.domain, self.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_case_ledger_state(self):
         for case_id in self.case_ids:
             state = LedgerAccessors(self.domain).get_case_ledger_state(case_id)
@@ -153,7 +153,7 @@ class StockReportDomainTest(TestCase):
 
         tester_fn(new_trans)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_case_ledger_state_1(self):
         def test_transactions(expected):
             for case_id in self.case_ids:
@@ -164,7 +164,7 @@ class StockReportDomainTest(TestCase):
 
         self.assertEqual({}, LedgerAccessors(self.domain).get_case_ledger_state('non-existent'))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_current_ledger_state(self):
         def test_transactions(expected):
             state = LedgerAccessors(self.domain).get_current_ledger_state(self.case_ids.keys())

--- a/corehq/apps/commtrack/tests/test_stock_report.py
+++ b/corehq/apps/commtrack/tests/test_stock_report.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.ledgers.helpers import StockReportHelper, StockTransactionHelper
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils import get_simple_wrapped_form
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.form_processor.utils.xform import TestFormMetadata

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -15,7 +15,7 @@ from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_fo
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors, FormAccessors, CaseAccessors
 from corehq.form_processor.models import LedgerTransaction
-from corehq.form_processor.tests.utils import
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils.general import should_use_sql_backend
 from dimagi.utils.parsing import json_format_datetime, json_format_date
 from casexml.apps.stock import const as stockconst

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -15,7 +15,7 @@ from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_fo
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors, FormAccessors, CaseAccessors
 from corehq.form_processor.models import LedgerTransaction
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import
 from corehq.form_processor.utils.general import should_use_sql_backend
 from dimagi.utils.parsing import json_format_datetime, json_format_date
 from casexml.apps.stock import const as stockconst
@@ -49,12 +49,12 @@ class CommTrackOTATest(CommTrackTest):
         super(CommTrackOTATest, self).setUp()
         self.user = self.users[0]
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ota_blank_balances(self):
         user = self.user
         self.assertFalse(get_ota_balance_xml(self.domain, user))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ota_basic(self):
         user = self.user
         amounts = [
@@ -73,7 +73,7 @@ class CommTrackOTATest(CommTrackTest):
             get_ota_balance_xml(self.domain, user)[0],
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ota_multiple_stocks(self):
         user = self.user
         section_ids = sorted(('stock', 'losses', 'consumption'))
@@ -100,7 +100,7 @@ class CommTrackOTATest(CommTrackTest):
                 balance_blocks[i],
             )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ota_consumption(self):
         self.ct_settings.sync_consumption_fixtures = True
         self.ct_settings.consumption_config = ConsumptionConfig(
@@ -143,7 +143,7 @@ class CommTrackOTATest(CommTrackTest):
             consumption_block,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_force_consumption(self):
         self.ct_settings.sync_consumption_fixtures = True
         self.ct_settings.consumption_config = ConsumptionConfig(
@@ -235,28 +235,28 @@ class CommTrackSubmissionTest(CommTrackTest):
 
 class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_submit(self):
         amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
         self.submit_xml_form(balance_submission(amounts))
         for product, amt in amounts:
             self.check_product_stock(self.sp, product, amt, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_submit_date(self):
         amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
         self.submit_xml_form(balance_submission(amounts), date_formatter=json_format_date)
         for product, amt in amounts:
             self.check_product_stock(self.sp, product, amt, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_enumerated(self):
         amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
         self.submit_xml_form(balance_enumerated(amounts))
         for product, amt in amounts:
             self.check_product_stock(self.sp, product, amt, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_consumption(self):
         initial = float(100)
         initial_amounts = [(p._id, initial) for p in self.products]
@@ -280,7 +280,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
                 self.assertEqual(Decimal(str(amt)), inferred_txn.stock_on_hand)
                 self.assertEqual(stockconst.TRANSACTION_TYPE_CONSUMPTION, inferred_txn.type)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_consumption_with_date(self):
         initial = float(100)
         initial_amounts = [(p._id, initial) for p in self.products]
@@ -291,7 +291,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in final_amounts:
             self.check_product_stock(self.sp, product, amt, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archived_product_submissions(self):
         """
         This is basically the same as above, but separated to be
@@ -310,7 +310,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in final_amounts:
             self.check_product_stock(self.sp, product, amt, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_submit_multiple_stocks(self):
         def _random_amounts():
             return [(p._id, float(random.randint(0, 100))) for i, p in enumerate(self.products)]
@@ -324,14 +324,14 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
             for product, amt in amounts:
                 self.check_product_stock(self.sp, product, amt, 0, section_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_dest_only(self):
         amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
         self.submit_xml_form(transfer_dest_only(amounts))
         for product, amt in amounts:
             self.check_product_stock(self.sp, product, amt, amt)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_source_only(self):
         initial = float(100)
         initial_amounts = [(p._id, initial) for p in self.products]
@@ -342,7 +342,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in deductions:
             self.check_product_stock(self.sp, product, initial-amt, -amt)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_both(self):
         initial = float(100)
         initial_amounts = [(p._id, initial) for p in self.products]
@@ -354,14 +354,14 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
             self.check_product_stock(self.sp, product, initial-amt, -amt)
             self.check_product_stock(self.sp2, product, amt, amt)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_with_date(self):
         amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
         self.submit_xml_form(transfer_dest_only(amounts), date_formatter=json_format_date)
         for product, amt in amounts:
             self.check_product_stock(self.sp, product, amt, amt)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_enumerated(self):
         initial = float(100)
         initial_amounts = [(p._id, initial) for p in self.products]
@@ -372,7 +372,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in receipts:
             self.check_product_stock(self.sp, product, initial + amt, amt)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_first_doc_order(self):
         initial = float(100)
         balance_amounts = [(p._id, initial) for p in self.products]
@@ -381,7 +381,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in transfers:
             self.check_product_stock(self.sp, product, initial + amt, amt)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_first_doc_order(self):
         # first set to 100
         initial = float(100)
@@ -397,7 +397,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in transfers:
             self.check_product_stock(self.sp, product, final, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_blank_quantities(self):
         # submitting a bunch of blank data shouldn't submit transactions
         # so lets submit some initial data and make sure we don't modify it
@@ -415,7 +415,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product in self.products:
             self.check_product_stock(self.sp, product._id, 100, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_blank_product_id(self):
         initial = float(100)
         balances = [('', initial)]
@@ -424,7 +424,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         self.assertTrue(instance.is_error)
         self.assertTrue('MissingProductId' in instance.problem)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_blank_case_id_in_balance(self):
         form = submit_case_blocks(
             case_blocks=get_single_balance_block(case_id='', product_id=self.products[0]._id, quantity=100),
@@ -434,7 +434,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         self.assertTrue(instance.is_error)
         self.assertTrue('IllegalCaseId' in instance.problem)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_blank_case_id_in_transfer(self):
         form = submit_case_blocks(
             case_blocks=get_single_transfer_block(
@@ -449,7 +449,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
 
 class BugSubmissionsTest(CommTrackSubmissionTest):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @override_settings(ALLOW_FORM_PROCESSING_QUERIES=True)
     def test_device_report_submissions_ignored(self):
         """
@@ -483,7 +483,7 @@ class BugSubmissionsTest(CommTrackSubmissionTest):
 
         _assert_no_stock_transactions()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_xform_id_added_to_case_xform_list(self):
         initial_amounts = [(p._id, float(100)) for p in self.products]
         submissions = [balance_submission([amount]) for amount in initial_amounts]
@@ -495,7 +495,7 @@ class BugSubmissionsTest(CommTrackSubmissionTest):
         case = CaseAccessors(self.domain.name).get_case(self.sp.case_id)
         self.assertIn(instance_id, case.xform_ids)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_xform_id_added_to_case_xform_list_only_once(self):
         initial_amounts = [(p._id, float(100)) for p in self.products]
         submissions = [balance_submission([amount]) for amount in initial_amounts]
@@ -515,7 +515,7 @@ class BugSubmissionsTest(CommTrackSubmissionTest):
         # make sure the ID only got added once
         self.assertEqual(len(case.xform_ids), len(set(case.xform_ids)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archived_form_gets_removed_from_case_xform_ids(self):
         initial_amounts = [(p._id, float(100)) for p in self.products]
         instance_id = self.submit_xml_form(
@@ -564,7 +564,7 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
         )
         self.sync_log_id = synclog_id_from_restore_payload(restore_config.get_payload().as_string())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testStockSyncToken(self):
         # first restore should not have the updated case
         check_user_has_case(self, self.restore_user, self.sp_block, should_have=False,
@@ -586,7 +586,7 @@ class CommTrackArchiveSubmissionTest(CommTrackSubmissionTest):
         self.ct_settings.use_auto_consumption = True
         self.ct_settings.save()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_last_form(self):
         initial_amounts = [(p._id, float(100)) for p in self.products]
         self.submit_xml_form(
@@ -642,7 +642,7 @@ class CommTrackArchiveSubmissionTest(CommTrackSubmissionTest):
             form.unarchive()
         _assert_initial_state()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_only_form(self):
         # check no data in stock states
         ledger_accessors = LedgerAccessors(self.domain.name)

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -11,7 +11,7 @@ from datetime import datetime, date
 
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import (run_with_all_backends, FormProcessorTestUtils,
+from corehq.form_processor.tests.utils import (conditionally_run_with_all_backends, FormProcessorTestUtils,
     set_case_property_directly)
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.form_processor.signals import sql_case_post_save
@@ -154,7 +154,7 @@ class AutomaticCaseUpdateTest(TestCase):
             doc = self._get_case()
             self.assertTrue(doc['_rev'].startswith('%s-' % rev_number))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_rule(self):
         now = datetime(2015, 10, 22, 0, 0)
         with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.get_case_ids', new=self._get_case_ids):
@@ -206,7 +206,7 @@ class AutomaticCaseUpdateTest(TestCase):
             self.assertEqual(case.get_case_property('update_flag'), 'C')
             self.assertEqual(case.closed, True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_match_days_after(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
             AutomaticUpdateRuleCriteria.objects.create(
@@ -229,7 +229,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'last_visit_date', '2015-11-01')
             self.assertTrue(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_match_days_before(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
             AutomaticUpdateRuleCriteria.objects.create(
@@ -256,7 +256,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'last_visit_date', '2016-03-01')
             self.assertTrue(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_match_equal(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
             AutomaticUpdateRuleCriteria.objects.create(
@@ -273,7 +273,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'property1', 'value1')
             self.assertTrue(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_match_not_equal(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
             AutomaticUpdateRuleCriteria.objects.create(
@@ -290,7 +290,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'property2', 'x')
             self.assertTrue(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_date_case_properties_for_equality(self):
         """
         Date case properties are automatically converted from string to date
@@ -311,7 +311,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'property1', '2016-02-25')
             self.assertFalse(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_date_case_properties_for_inequality(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
             AutomaticUpdateRuleCriteria.objects.create(
@@ -327,7 +327,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'property1', '2016-02-25')
             self.assertTrue(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_match_has_value(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
             AutomaticUpdateRuleCriteria.objects.create(
@@ -343,7 +343,7 @@ class AutomaticCaseUpdateTest(TestCase):
             set_case_property_directly(case, 'property3', '')
             self.assertFalse(self.rule2.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_and_criteria(self):
         with _with_case(self.domain, 'test-case-type-2', datetime(2015, 1, 1)) as case:
 
@@ -427,7 +427,7 @@ class AutomaticCaseUpdateTest(TestCase):
             rules_by_case_type['test-case-type-2'], datetime(2016, 1, 1))
         self.assertEqual(boundary_date, datetime(2015, 12, 2))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_parent_cases(self):
         with _with_case(self.domain, 'test-child-case-type', datetime(2016, 1, 1)) as child, \
                 _with_case(self.domain, 'test-parent-case-type', datetime(2016, 1, 1), case_name='abc') as parent:
@@ -483,13 +483,13 @@ class AutomaticCaseUpdateTest(TestCase):
 
             self.assertFalse(rule.rule_matches_case(child, datetime(2016, 3, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_server_boundary(self):
         with _with_case(self.domain, 'test-case-type-3', datetime(2016, 1, 1), case_name='signal') as case:
             # no filtering on server modified date so same day matches
             self.assertTrue(self.rule5.rule_matches_case(case, datetime(2016, 1, 1)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_run_on_save(self):
         with _with_case(self.domain, 'test-case-type-3', datetime(2016, 1, 1), case_name='signal') as case:
             with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.apply_rule') as apply:
@@ -497,7 +497,7 @@ class AutomaticCaseUpdateTest(TestCase):
                 update_case(self.domain, case.case_id, {})
                 apply.assert_called_once()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_early_task_exit(self):
         with _with_case(self.domain, 'test-case-type-3', datetime(2016, 1, 1), case_name='signal') as case:
             with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.apply_rule') as apply:

--- a/corehq/apps/data_interfaces/tests/tests.py
+++ b/corehq/apps/data_interfaces/tests/tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.test import Client
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils.xform import TestFormMetadata, get_simple_wrapped_form
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.workbook_json.excel import WorkbookJSONReader
@@ -123,7 +123,7 @@ class BulkArchiveFormsUnit(TestCase):
     def tearDown(self):
         FormProcessorTestUtils.delete_all_xforms(DOMAIN_NAME)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_forms_basic(self):
         uploaded_file = WorkbookJSONReader(join(BASE_PATH, BASIC_XLSX))
 
@@ -137,7 +137,7 @@ class BulkArchiveFormsUnit(TestCase):
 
         self.assertEqual(len(response['success']), len(self.xforms))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_forms_missing(self):
         uploaded_file = WorkbookJSONReader(join(BASE_PATH, MISSING_XLSX))
 
@@ -151,7 +151,7 @@ class BulkArchiveFormsUnit(TestCase):
         self.assertEqual(len(response['errors']), 1,
                          "One error for trying to archive a missing form")
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_forms_wrong_domain(self):
         uploaded_file = WorkbookJSONReader(join(BASE_PATH, BASIC_XLSX))
 

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -16,7 +16,7 @@ from corehq.apps.hqcase.utils import make_creating_casexml, submit_case_blocks
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 TESTS = (
@@ -130,7 +130,7 @@ class ExplodeCasesDbTest(TestCase):
         cls.user.delete()
         cls.domain.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple(self):
         caseblock = CaseBlock(
             create=True,
@@ -149,7 +149,7 @@ class ExplodeCasesDbTest(TestCase):
         for case in cases_back:
             self.assertEqual(self.user_id, case.owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_skip_user_case(self):
         caseblock = CaseBlock(
             create=True,
@@ -168,7 +168,7 @@ class ExplodeCasesDbTest(TestCase):
         for case in cases_back:
             self.assertEqual(self.user_id, case.owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_parent_child(self):
         parent_id = uuid.uuid4().hex
         parent_type = 'exploder-parent-type'

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -6,7 +6,7 @@ from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.toggles import ENABLE_LOADTEST_USERS
 
 
@@ -30,7 +30,7 @@ class LoadtestUserTest(TestCase):
         cls.user.delete()
         cls.domain.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_factor_set(self):
         self.user.loadtest_factor = None
         self.user.save()
@@ -45,7 +45,7 @@ class LoadtestUserTest(TestCase):
         self.assertEqual(1, len(caseblocks))
         self.assertEqual(caseblocks[0].get_case_id(), case.case_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple_factor(self):
         self.user.loadtest_factor = 3
         self.user.save()
@@ -64,7 +64,7 @@ class LoadtestUserTest(TestCase):
         self.assertEqual(3, len(filter(lambda cb: case1.name in cb.get_case_name(), caseblocks)))
         self.assertEqual(3, len(filter(lambda cb: case2.name in cb.get_case_name(), caseblocks)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_parent_child(self):
         self.user.loadtest_factor = 3
         self.user.save()

--- a/corehq/apps/ivr/tests/util.py
+++ b/corehq/apps/ivr/tests/util.py
@@ -1,6 +1,6 @@
 from corehq.apps.ivr.models import Call
 from corehq.apps.sms.models import INCOMING
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import create_test_case
 from django.test import TestCase
 
@@ -52,7 +52,7 @@ class LogCallTestCase(TestCase):
         return create_test_case(self.domain, 'contact', 'test',
             case_properties=case_properties, drop_signals=False)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_log_call(self):
         with self.create_case() as case:
             if self.__class__ == LogCallTestCase:

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -17,7 +17,7 @@ from corehq.form_processor.utils.xform import (
     TestFormMetadata,
     get_simple_wrapped_form,
 )
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from casexml.apps.case.tests.util import delete_all_xforms
 
 from ..views import LocationsListView, EditLocationView
@@ -41,20 +41,20 @@ class FormEditRestrictionsMixin(object):
         ])
     ]
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_can_edit_form_in_county(self):
         self.assertCanEdit(self.middlesex_web_user, self.cambridge_form)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cant_edit_out_of_county(self):
         self.assertCannotEdit(self.middlesex_web_user, self.boston_form)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_can_edit_any_form(self):
         self.assertCanEdit(self.massachusetts_web_user, self.cambridge_form)
         self.assertCanEdit(self.massachusetts_web_user, self.boston_form)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_project_admin_can_edit_anything(self):
         self.project_admin.get_domain_membership(self.domain).is_admin = True
         self.project_admin.save()
@@ -62,13 +62,13 @@ class FormEditRestrictionsMixin(object):
         self.assertCanEdit(self.project_admin, self.cambridge_form)
         self.assertCanEdit(self.project_admin, self.boston_form)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unassigned_web_user_cant_edit_anything(self):
         self.assertCannotEdit(self.locationless_web_user, self.cambridge_form)
         self.assertCannotEdit(self.locationless_web_user, self.boston_form)
 
     @flag_enabled('MULTIPLE_LOCATIONS_PER_USER')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_locations_per_user(self):
         # Note also that location types must not be administrative for multiple
         # locations per domain to work.  This was a pain to figure out...

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -7,7 +7,7 @@ from corehq.apps.case_search.models import CLAIM_CASE_TYPE
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 DOMAIN = 'test_domain'
 USERNAME = 'lina.stern@ras.ru'
@@ -62,7 +62,7 @@ class CaseClaimTests(TestCase):
             'relationship': 'extension',
         }])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_claim_case(self):
         """
         claim_case should create an extension case
@@ -71,7 +71,7 @@ class CaseClaimTests(TestCase):
                               host_type=self.host_case_type, host_name=self.host_case_name)
         self.assert_claim(claim_id=claim_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_claim_case_id_only(self):
         """
         claim_case should look up host case details if only ID is passed
@@ -79,7 +79,7 @@ class CaseClaimTests(TestCase):
         claim_id = claim_case(DOMAIN, self.user.user_id, self.host_case_id)
         self.assert_claim(claim_id=claim_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_first_claim_one(self):
         """
         get_first_claim should return one claim
@@ -89,7 +89,7 @@ class CaseClaimTests(TestCase):
         claim = get_first_claim(DOMAIN, self.user.user_id, self.host_case_id)
         self.assert_claim(claim, claim_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_first_claim_none(self):
         """
         get_first_claim should return None if not found
@@ -97,7 +97,7 @@ class CaseClaimTests(TestCase):
         claim = get_first_claim(DOMAIN, self.user.user_id, self.host_case_id)
         self.assertIsNone(claim)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_closed_claim(self):
         """
         get_first_claim should return None if claim case is closed

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.pillows.case_search import get_case_search_reindexer
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO, CASE_SEARCH_INDEX
 from corehq.util.elastic import ensure_index_deleted
@@ -63,7 +63,7 @@ class CaseClaimEndpointTests(TestCase):
         for query_addition in CaseSearchQueryAddition.objects.all():
             query_addition.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_claim_case(self):
         """
         A claim case request should create an extension case
@@ -81,7 +81,7 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(claim.owner_id, self.user.get_id)
         self.assertEqual(claim.name, CASE_NAME)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_duplicate_client_claim(self):
         """
         Server should not allow the same client to claim the same case more than once
@@ -97,7 +97,7 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content, 'You have already claimed that case')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_duplicate_user_claim(self):
         """
         Server should not allow the same user to claim the same case more than once
@@ -115,7 +115,7 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content, 'You have already claimed that case')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_search_endpoint(self):
         known_result = (
             '<results id="case">'  # ("case" is not the case type)

--- a/corehq/apps/receiverwrapper/tests/test_app_id.py
+++ b/corehq/apps/receiverwrapper/tests/test_app_id.py
@@ -4,7 +4,7 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.util import get_version_from_build_id, get_submit_url
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from couchforms.util import spoof_submission
 
 
@@ -32,7 +32,7 @@ class TestAppId(TestCase):
         cls.project.delete()
         super(TestAppId, cls).tearDownClass()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test(self):
         self._test(self.build_id, self.app_id, self.build_id)
         self._test(self.app_id, self.app_id, None)

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -5,7 +5,7 @@ from urllib import urlencode
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.submission_post import SubmissionPost
 import django_digest.test
 from django.test import TestCase
@@ -117,7 +117,7 @@ class _AuthTest(TestCase):
             self.assertEqual(xform.auth_context, expected_auth_context)
             return xform
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_digest(self):
         client = django_digest.test.Client()
         client.set_authorization(self.user.username, '1234',
@@ -171,7 +171,7 @@ class _AuthTest(TestCase):
             expected_response=accepted_response
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic(self):
         client = django_digest.test.Client()
         client.set_authorization(self.user.username, '1234',
@@ -197,7 +197,7 @@ class _AuthTest(TestCase):
             expected_auth_context=expected_auth_context
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_noauth_nometa(self):
         self._test_post(
             file_path=self.bare_form,
@@ -205,7 +205,7 @@ class _AuthTest(TestCase):
             expected_status=403,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_noauth_demomode(self):
         self._test_post(
             file_path=self.bare_form,
@@ -215,7 +215,7 @@ class _AuthTest(TestCase):
             expected_response=SubmissionPost.submission_ignored_response().content,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_noauth_devicelog(self):
         self._test_post(
             file_path=self.device_log,
@@ -223,7 +223,7 @@ class _AuthTest(TestCase):
             expected_status=201,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_bad_noauth(self):
         """
         if someone submits a form in noauth mode, but it creates or updates
@@ -236,7 +236,7 @@ class _AuthTest(TestCase):
             expected_status=403,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_noauth(self):
         self._test_post(
             file_path=self.form_with_demo_case,

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 import os
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 
 
 class SubmissionTest(TestCase):
@@ -76,35 +76,35 @@ class SubmissionTest(TestCase):
         expected = self._get_expected_json(xform_id, xmlns)
         self.assertEqual(foo, expected)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submit_simple_form(self):
         self._test(
             form='simple_form.xml',
             xmlns='http://commcarehq.org/test/submit',
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submit_bare_form(self):
         self._test(
             form='bare_form.xml',
             xmlns='http://commcarehq.org/test/submit',
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submit_user_registration(self):
         self._test(
             form='user_registration.xml',
             xmlns='http://openrosa.org/user/registration',
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submit_with_case(self):
         self._test(
             form='form_with_case.xml',
             xmlns='http://commcarehq.org/test/submit',
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submit_with_namespaced_meta(self):
         self._test(
             form='namespace_in_meta.xml',

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -7,7 +7,7 @@ from django.core.urlresolvers import reverse
 import os
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 from corehq.util.test_utils import flag_enabled
 from dimagi.utils.post import tmpfile
 from couchforms.signals import successful_form_received
@@ -38,7 +38,7 @@ class SubmissionErrorTest(TestCase):
             })
             return file_path, res
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSubmitBadAttachmentType(self):
         res = self.client.post(self.url, {
                 "xml_submission_file": "this isn't a file"
@@ -46,7 +46,7 @@ class SubmissionErrorTest(TestCase):
         self.assertEqual(400, res.status_code)
         #self.assertIn("xml_submission_file", res.content)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSubmitDuplicate(self):
         file, res = self._submit('simple_form.xml')
         self.assertEqual(201, res.status_code)
@@ -64,7 +64,7 @@ class SubmissionErrorTest(TestCase):
         with open(file) as f:
             self.assertEqual(f.read(), log.get_xml())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSubmissionError(self):
         evil_laugh = "mwa ha ha!"
 
@@ -89,7 +89,7 @@ class SubmissionErrorTest(TestCase):
         finally:
             successful_form_received.disconnect(fail)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSubmitBadXML(self):
         f, path = tmpfile()
         with f:
@@ -109,7 +109,7 @@ class SubmissionErrorTest(TestCase):
         self.assertEqual("this isn't even close to xml", log.get_xml())
         self.assertEqual(log.form_data, {})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_missing_xmlns(self):
         file, res = self._submit('missing_xmlns.xml')
         self.assertEqual(500, res.status_code)
@@ -124,7 +124,7 @@ class SubmissionErrorTest(TestCase):
         with open(file) as f:
             self.assertEqual(f.read(), log.get_xml())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @flag_enabled('DATA_MIGRATION')
     def test_data_migration(self):
         file, res = self._submit('simple_form.xml')

--- a/corehq/apps/reminders/tests/test_message_formatting.py
+++ b/corehq/apps/reminders/tests/test_message_formatting.py
@@ -5,7 +5,7 @@ from corehq.apps.reminders.event_handlers import get_message_template_params
 from corehq.apps.reminders.models import Message
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import create_test_case, set_parent_case
 from datetime import datetime, timedelta
 from django.test import TestCase
@@ -127,7 +127,7 @@ class MessageTestCase(TestCase):
             'site_code': self.location.site_code,
         }
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_template_params(self):
         with self.create_child_case() as child_case, self.create_parent_case() as parent_case:
             set_parent_case(self.domain, child_case, parent_case)
@@ -145,7 +145,7 @@ class MessageTestCase(TestCase):
             parent_expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(parent_case), parent_expected_result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_owner_template_params(self):
         with self.create_parent_case(owner=self.mobile_user) as case:
             expected_result = {'case': case.to_json()}
@@ -171,7 +171,7 @@ class MessageTestCase(TestCase):
             expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(case), expected_result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_modified_by_template_params(self):
         with self.create_parent_case(modified_by=self.mobile_user, owner=self.location) as case:
             expected_result = {'case': case.to_json()}

--- a/corehq/apps/reminders/tests/test_recipient.py
+++ b/corehq/apps/reminders/tests/test_recipient.py
@@ -4,7 +4,7 @@ from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.reminders.models import (CaseReminder, CaseReminderHandler,
     RECIPIENT_CASE_OWNER_LOCATION_PARENT)
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import create_test_case
 from mock import patch
 
@@ -37,7 +37,7 @@ class ReminderRecipientTest(TestCase):
         self.user.delete()
         self.domain_obj.delete()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_recipient_case_owner_location_parent(self):
         parent_location = SQLLocation.objects.create(
             domain=self.domain,

--- a/corehq/apps/reminders/tests/test_responsiveness.py
+++ b/corehq/apps/reminders/tests/test_responsiveness.py
@@ -5,7 +5,7 @@ from corehq.util.test_utils import set_parent_case
 from corehq.apps.reminders.models import (CaseReminderHandler, CaseReminder, MATCH_EXACT,
     MATCH_REGEX, MATCH_ANY_VALUE, REPEAT_SCHEDULE_INDEFINITELY, FIRE_TIME_CASE_PROPERTY,
     DAY_MON, DAY_TUE)
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import create_test_case
 from datetime import datetime, date, time
 from django.test import TestCase
@@ -32,7 +32,7 @@ class ReminderResponsivenessTest(TestCase):
         self.assertEqual(len(reminder_instances), 1)
         return reminder_instances[0]
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_match_equal(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -70,7 +70,7 @@ class ReminderResponsivenessTest(TestCase):
             update_case(self.domain, case.case_id, case_properties={'status': 'red'})
             self.assertEqual(self.get_reminders(), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_match_regex(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -110,7 +110,7 @@ class ReminderResponsivenessTest(TestCase):
             update_case(self.domain, case.case_id, case_properties={'status': 'red'})
             self.assertEqual(self.get_reminders(), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_match_any_value(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -147,7 +147,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertIsNone(reminder_instance.start_condition_datetime)
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_start_date(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -244,7 +244,7 @@ class ReminderResponsivenessTest(TestCase):
             update_case(self.domain, case.case_id, case_properties={'start_date': ''})
             self.assertEqual(self.get_reminders(), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_start_date_with_blank_option(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -351,7 +351,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertIsNone(reminder_instance.start_condition_datetime)
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_type_match(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -394,7 +394,7 @@ class ReminderResponsivenessTest(TestCase):
             reminder.save()
             self.assertEqual(self.get_reminders(), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_parent_case_property_criteria(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -441,7 +441,7 @@ class ReminderResponsivenessTest(TestCase):
             update_case(self.domain, parent_case.case_id, case_properties={'status': 'red'})
             self.assertEqual(self.get_reminders(), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reminder_delete(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -475,7 +475,7 @@ class ReminderResponsivenessTest(TestCase):
         self.assertEqual(r2.doc_type, 'CaseReminder')
         self.assertEqual(r3.doc_type, 'CaseReminder')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_reminder_time(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -511,7 +511,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.current_event_sequence_num, 0)
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_reminder_time_default(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -546,7 +546,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.current_event_sequence_num, 0)
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_time_zone(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -582,7 +582,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.current_event_sequence_num, 0)
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_start_date_with_start_offset(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -639,7 +639,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.start_condition_datetime, datetime(2016, 1, 8))
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_property_start_date_with_start_day_of_week(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -696,7 +696,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.start_condition_datetime, datetime(2016, 1, 8))
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_user_recipient(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -751,7 +751,7 @@ class ReminderResponsivenessTest(TestCase):
             )
             self.assertEqual(self.get_reminders(), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_until_condition(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
@@ -826,7 +826,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.current_event_sequence_num, 0)
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_datetime_condition(self):
         with create_test_case(self.domain, 'participant', 'bob', drop_signals=False) as case, \
                 patch('corehq.apps.reminders.models.CaseReminderHandler.get_now') as now_mock:

--- a/corehq/apps/reminders/tests/test_send_reminders.py
+++ b/corehq/apps/reminders/tests/test_send_reminders.py
@@ -7,7 +7,7 @@ from corehq.apps.reminders.tests.utils import BaseReminderTestCase
 from corehq.apps.sms.models import ExpectedCallback, CALLBACK_RECEIVED, CALLBACK_PENDING, CALLBACK_MISSED
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import create_test_case, update_case
 from datetime import datetime, date, time, timedelta
 from django.test import TestCase
@@ -51,7 +51,7 @@ class ReminderTestCase(BaseReminderTestCase):
         self.user.delete()
         super(ReminderTestCase, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ok(self):
         with create_test_case(self.domain, self.case_type, 'test-case', drop_signals=False,
                 user_id=self.user.get_id) as case:
@@ -177,7 +177,7 @@ class ReminderIrregularScheduleTestCase(BaseReminderTestCase):
         self.user.delete()
         super(ReminderIrregularScheduleTestCase, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ok(self):
 
         with create_test_case(self.domain, self.case_type, 'test-case', drop_signals=False,
@@ -336,7 +336,7 @@ class ReminderCallbackTestCase(BaseReminderTestCase):
             date
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ok(self):
         with create_test_case(self.domain, self.case_type, 'test-case', drop_signals=False,
                 user_id=self.user.get_id) as case:
@@ -640,7 +640,7 @@ class CaseTypeReminderTestCase(BaseReminderTestCase):
             domain=self.domain
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ok(self):
         with self.create_case_1() as case1, self.create_case_2() as case2:
 
@@ -780,7 +780,7 @@ class StartConditionReminderTestCase(BaseReminderTestCase):
         self.user.delete()
         super(StartConditionReminderTestCase, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ok(self):
         with create_test_case(self.domain, 'case_type_a', 'test-case', drop_signals=False,
                 user_id=self.user.get_id) as case:
@@ -905,7 +905,7 @@ class ReminderDefinitionCalculationsTestCase(TestCase):
     def setUp(self):
         self.domain = 'reminder-calculation-test'
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_calculate_start_date_without_today_option(self):
         now = datetime.utcnow()
 
@@ -968,7 +968,7 @@ class ReminderDefinitionCalculationsTestCase(TestCase):
                 (datetime(2016, 1, 12), True, False)
             )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_calculate_start_date_with_today_option(self):
         now = datetime.utcnow()
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.models import CommCareCaseSQL, CaseTransaction
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
 from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
 from corehq.pillows.mappings.ledger_mapping import LEDGER_INDEX_INFO
@@ -129,7 +129,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.es.indices.refresh(GROUP_INDEX_INFO.index)
         return group
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_forms(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -157,7 +157,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(paged_result.hits[0]['form']['meta']['userID'], user_id)
         self.assertEqual(paged_result.hits[0]['received_on'], '2013-07-02T00:00:00.000000Z')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_ids_having_multimedia(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -192,7 +192,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(len(form_ids), 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_ids_having_multimedia_with_user_types(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -252,7 +252,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(len(form_ids), 2)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_ids_having_multimedia_with_group(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -294,7 +294,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(len(form_ids), 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_forms_multiple_apps_xmlnss(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -361,7 +361,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(paged_result.total, 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_completed_by_user(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -371,7 +371,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         results = get_completed_counts_by_user(self.domain, DateSpan(start, end))
         self.assertEquals(results['cruella_deville'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_completed_out_of_range_by_user(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -392,7 +392,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         results = get_completed_counts_by_user(self.domain, DateSpan(start, end))
         self.assertEquals(results['cruella_deville'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_submission_by_user(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -403,7 +403,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         results = get_submission_counts_by_user(self.domain, DateSpan(start, end))
         self.assertEquals(results['cruella_deville'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_last_form_submission_by_xmlns(self):
         xmlns = 'http://a.b.org'
         kwargs = {
@@ -426,11 +426,11 @@ class TestFormESAccessors(BaseESAccessorsTest):
         form = get_last_form_submission_for_xmlns(self.domain, 'missing')
         self.assertIsNone(form)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_guess_form_name_from_xmlns_not_found(self):
         self.assertEqual(None, guess_form_name_from_submissions_using_xmlns('missing', 'missing'))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_guess_form_name_from_xmlns(self):
         form_name = 'my cool form'
         xmlns = 'http://a.b.org'
@@ -440,7 +440,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(form_name, guess_form_name_from_submissions_using_xmlns(self.domain, xmlns))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submission_out_of_range_by_user(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -452,7 +452,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         results = get_submission_counts_by_user(self.domain, DateSpan(start, end))
         self.assertEquals(results['cruella_deville'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submission_different_domain_by_user(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -464,7 +464,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         results = get_submission_counts_by_user(self.domain, DateSpan(start, end))
         self.assertEquals(results['cruella_deville'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_submission_by_date(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
@@ -481,7 +481,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEquals(results['2013-07-15'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_paged_forms_by_type(self):
         self._send_form_to_es()
         self._send_form_to_es()
@@ -490,7 +490,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(len(paged_result.hits), 1)
         self.assertEqual(paged_result.total, 2)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_timezone_differences(self):
         """
         Our received_on dates are always in UTC, so if we submit a form right at midnight UTC, then the report
@@ -511,7 +511,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEquals(results['2013-07-14'], 1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_last_form_submission_for_user_for_app(self):
         kwargs_u1 = {
             'user_id': 'u1',
@@ -556,7 +556,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(result['u1'][0]['xmlns'], 'third')
         self.assertEqual(result[None][0]['xmlns'], 'third')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_counts_by_user_xmlns(self):
         user1, user2 = 'u1', 'u2'
         app1, app2 = '123', '567'
@@ -603,7 +603,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
             (None, app2, xmlns2): 1,
         })
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_duration_stats_by_user(self):
         """
         Tests the get_form_duration_stats_by_user basic ability to get duration stats
@@ -658,7 +658,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(results[MISSING_KEY]['count'], 1)
         self.assertEqual(timedelta(milliseconds=results[MISSING_KEY]['max']), completion_time - time_start)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_duration_stats_by_user_decoys(self):
         """
         Tests the get_form_duration_stats_by_user ability to filter out forms that
@@ -729,7 +729,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(timedelta(milliseconds=results[user1]['max']), completion_time - time_start)
         self.assertIsNone(results.get('user2'))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_duration_stats_for_users(self):
         """
         Tests the get_form_duration_stats_for_users basic ability to get duration stats
@@ -779,7 +779,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(results['count'], 3)
         self.assertEqual(timedelta(milliseconds=results['max']), completion_time - time_start)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_duration_stats_for_users_decoys(self):
         """
         Tests the get_form_duration_stats_for_users ability to filter out forms that
@@ -849,7 +849,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(results['count'], 1)
         self.assertEqual(timedelta(milliseconds=results['max']), completion_time - time_start)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_all_user_ids_submitted_without_app_id(self):
         user1, user2 = 'u1', 'u2'
         app1, app2 = '123', '567'
@@ -863,7 +863,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         user_ids = get_all_user_ids_submitted(self.domain)
         self.assertEqual(user_ids, ['u1', 'u2'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_all_user_ids_submitted_with_app_id(self):
         user1, user2 = 'u1', 'u2'
         app1, app2 = '123', '567'
@@ -879,7 +879,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         user_ids = get_all_user_ids_submitted(self.domain, app2)
         self.assertEqual(user_ids, ['u2'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_username_in_last_form_submitted(self):
         user1, user2 = 'u1', 'u2'
         app1 = '123'

--- a/corehq/apps/reports/tests/test_supply_accessors.py
+++ b/corehq/apps/reports/tests/test_supply_accessors.py
@@ -26,7 +26,7 @@ class TestSupplyAccessors(TestCase):
                                                               case_id='missing', section_id='stock',
                                                               as_of=datetime.utcnow()))
 
-    # @run_with_all_backends
+    # @conditionally_run_with_all_backends
     def test_get_ledger_values_for_case_as_of(self):
         case_id = uuid.uuid4().hex
         form_xml = get_simple_form_xml(uuid.uuid4().hex, case_id)

--- a/corehq/apps/sms/tests/opt_tests.py
+++ b/corehq/apps/sms/tests/opt_tests.py
@@ -6,7 +6,7 @@ from corehq.apps.sms.messages import MSG_OPTED_IN, MSG_OPTED_OUT, get_message
 from corehq.apps.sms.models import PhoneBlacklist, SMS, PhoneNumber
 from corehq.apps.sms.tests.util import setup_default_sms_test_backend, delete_domain_phone_numbers
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 
 
 class OptTestCase(BaseAccountingTest, DomainSubscriptionMixin):
@@ -25,7 +25,7 @@ class OptTestCase(BaseAccountingTest, DomainSubscriptionMixin):
     def get_last_sms(self, phone_number):
         return SMS.objects.filter(domain=self.domain, phone_number=phone_number).order_by('-date')[0]
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_opt_out_and_opt_in(self):
         self.assertEqual(PhoneBlacklist.objects.count(), 0)
 
@@ -57,7 +57,7 @@ class OptTestCase(BaseAccountingTest, DomainSubscriptionMixin):
         self.assertEqual(sms.direction, 'O')
         self.assertEqual(sms.text, get_message(MSG_OPTED_IN, context=('STOP',)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sending_to_opted_out_number(self):
         self.assertEqual(PhoneBlacklist.objects.count(), 0)
 

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -11,7 +11,7 @@ from corehq.apps.sms.models import (SMS, QueuedSMS,
 from corehq.apps.sms.tasks import handle_outgoing
 from corehq.apps.sms.tests.util import BaseSMSTest, delete_domain_phone_numbers
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.messaging.smsbackends.apposit.models import SQLAppositBackend
 from corehq.messaging.smsbackends.grapevine.models import SQLGrapevineBackend
 from corehq.messaging.smsbackends.http.models import SQLHttpBackend
@@ -275,14 +275,14 @@ class AllBackendTest(BaseSMSTest):
         self._test_outbound_backend(self.push_backend, 'push test', push_send)
         self._test_outbound_backend(self.icds_backend, 'icds test', icds_send)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unicel_inbound_sms(self):
         self._simulate_inbound_request('/unicel/in/', phone_param=InboundParams.SENDER,
             msg_param=InboundParams.MESSAGE, msg_text='unicel test')
 
         self._verify_inbound_request(self.unicel_backend.get_api_id(), 'unicel test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_tropo_inbound_sms(self):
         tropo_data = {'session': {'from': {'id': self.test_phone_number}, 'initialText': 'tropo test'}}
         self._simulate_inbound_request_with_payload('/tropo/sms/',
@@ -290,7 +290,7 @@ class AllBackendTest(BaseSMSTest):
 
         self._verify_inbound_request(self.tropo_backend.get_api_id(), 'tropo test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_telerivet_inbound_sms(self):
         additional_params = {
             'event': 'incoming_message',
@@ -303,7 +303,7 @@ class AllBackendTest(BaseSMSTest):
 
         self._verify_inbound_request(self.telerivet_backend.get_api_id(), 'telerivet test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @override_settings(SIMPLE_API_KEYS={'grapevine-test': 'grapevine-api-key'})
     def test_grapevine_inbound_sms(self):
         xml = """
@@ -320,7 +320,7 @@ class AllBackendTest(BaseSMSTest):
 
         self._verify_inbound_request(self.grapevine_backend.get_api_id(), 'grapevine test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_twilio_inbound_sms(self):
         url = '/twilio/sms/%s' % self.twilio_backend.inbound_api_key
         self._simulate_inbound_request(url, phone_param='From',
@@ -329,7 +329,7 @@ class AllBackendTest(BaseSMSTest):
         self._verify_inbound_request(self.twilio_backend.get_api_id(), 'twilio test',
             backend_couch_id=self.twilio_backend.couch_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_twilio_401_response(self):
         start_count = SMS.objects.count()
 
@@ -341,28 +341,28 @@ class AllBackendTest(BaseSMSTest):
 
         self.assertEqual(start_count, end_count)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_megamobile_inbound_sms(self):
         self._simulate_inbound_request('/megamobile/sms/', phone_param='cel',
             msg_param='msg', msg_text='megamobile test', is_megamobile=True)
 
         self._verify_inbound_request(self.megamobile_backend.get_api_id(), 'megamobile test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sislog_inbound_sms(self):
         self._simulate_inbound_request('/sislog/in/', phone_param='sender',
             msg_param='msgdata', msg_text='sislog test')
 
         self._verify_inbound_request(self.sislog_backend.get_api_id(), 'sislog test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_yo_inbound_sms(self):
         self._simulate_inbound_request('/yo/sms/', phone_param='sender',
             msg_param='message', msg_text='yo test')
 
         self._verify_inbound_request(self.yo_backend.get_api_id(), 'yo test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_smsgh_inbound_sms(self):
         self._simulate_inbound_request(
             '/smsgh/sms/{}/'.format(self.smsgh_backend.inbound_api_key),
@@ -373,7 +373,7 @@ class AllBackendTest(BaseSMSTest):
 
         self._verify_inbound_request('SMSGH', 'smsgh test')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_apposit_inbound_sms(self):
         self._simulate_inbound_request_with_payload(
             '/apposit/in/%s/' % self.apposit_backend.inbound_api_key,
@@ -386,7 +386,7 @@ class AllBackendTest(BaseSMSTest):
         self._verify_inbound_request('APPOSIT', 'apposit test',
             backend_couch_id=self.apposit_backend.couch_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_push_inbound_sms(self):
         xml = """<?xml version="1.0" encoding="UTF-8"?>
         <bspostevent>

--- a/corehq/apps/sms/tests/test_chat.py
+++ b/corehq/apps/sms/tests/test_chat.py
@@ -3,7 +3,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sms.models import SMS, SQLLastReadMessage, OUTGOING, INCOMING
 from corehq.apps.sms.views import ChatMessageHistory
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import softer_assert, create_test_case
 from datetime import datetime
 from dimagi.utils.parsing import json_format_datetime
@@ -213,7 +213,7 @@ class ChatHistoryTestCase(TestCase):
     def create_contact2(self):
         return create_test_case('another-domain', 'contact', 'test-case2', case_id=self.contact2_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_contact(self):
         with self.create_contact1() as contact1, self.create_contact2() as contact2:
             with self.patch_contact_id(contact1.case_id):
@@ -222,7 +222,7 @@ class ChatHistoryTestCase(TestCase):
             with self.patch_contact_id(contact2.case_id):
                 self.assertIsNone(self.new_view.contact)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_contact_name(self):
         with self.create_contact1() as contact1:
             self.set_custom_case_username(None)
@@ -309,7 +309,7 @@ class ChatHistoryTestCase(TestCase):
         self.assertEqual(lrm.message_id, sms.couch_id)
         self.assertEqual(lrm.message_timestamp, sms.date)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_response_data(self):
         with self.create_contact1() as contact1:
             with self.patch_contact_id(contact1.case_id):
@@ -355,7 +355,7 @@ class ChatHistoryTestCase(TestCase):
 
                 self.set_survey_filter_option(False, False)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_last_read_message(self):
         SQLLastReadMessage.objects.all().delete()
         self.assertEqual(self.get_last_read_message_count(), 0)

--- a/corehq/apps/sms/tests/test_phone_numbers.py
+++ b/corehq/apps/sms/tests/test_phone_numbers.py
@@ -11,7 +11,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from datetime import datetime, timedelta
 from django.test import TestCase
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils import is_commcarecase
 from corehq.util.test_utils import create_test_case
 from mock import patch
@@ -120,7 +120,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
         if pk:
             self.assertEqual(v.pk, pk)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_phone_number_updates(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -177,7 +177,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_close_case(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -202,7 +202,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_soft_delete(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -227,7 +227,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_zero_phone_number(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -252,7 +252,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_invalid_phone_format(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -277,7 +277,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_phone_number_already_in_use(self):
         self.assertEqual(PhoneNumber.count_by_domain(self.domain), 0)
 
@@ -302,7 +302,7 @@ class CaseContactPhoneNumberTestCase(TestCase):
             self.assertPhoneNumberDetails(case1, '99987658765', None, None, True, False, True)
             self.assertPhoneNumberDetails(case2, '99987658765', None, None, False, False, False)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_entries(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -376,7 +376,7 @@ class SQLPhoneNumberTestCase(TestCase):
         number.backend_id = '  '
         self.assertEqual(number.backend, backend1)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_owner(self):
         with create_test_case(self.domain, 'participant', 'test') as case:
             number = PhoneNumber(owner_doc_type='CommCareCase', owner_id=case.case_id)
@@ -637,7 +637,7 @@ class SQLPhoneNumberTestCase(TestCase):
             drop_signals=False
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_phone_numbers_for_owners(self):
         with self.create_case_contact('9990001') as case1, \
                 self.create_case_contact('9990002') as case2, \

--- a/corehq/apps/sms/tests/test_util.py
+++ b/corehq/apps/sms/tests/test_util.py
@@ -4,7 +4,7 @@ from corehq.apps.sms.mixin import apply_leniency
 from corehq.apps.sms.util import (clean_phone_number,
     get_contact, ContactNotFoundException, is_contact_active)
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils import is_commcarecase
 from corehq.util.test_utils import create_test_case
 from django.test import TestCase
@@ -24,7 +24,7 @@ class UtilTestCase(TestCase):
         cleaned = clean_phone_number(phone_number)
         self.assertEquals(cleaned, "+3242323421241")
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_contact_for_case(self):
         with create_test_case(self.domain, 'contact', 'test-case') as case:
             contact = get_contact(self.domain, case.case_id)
@@ -46,7 +46,7 @@ class UtilTestCase(TestCase):
         with self.assertRaises(ContactNotFoundException):
             get_contact(self.domain, 'this-id-should-not-be-found')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_is_contact_active_for_case(self):
         with create_test_case(self.domain, 'contact', 'test-case') as case:
             self.assertTrue(is_contact_active(self.domain, 'CommCareCase', case.case_id))

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -21,7 +21,7 @@ from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.groups.models import Group
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import generate_cases, create_and_save_a_form, create_and_save_a_case
 
 
@@ -758,14 +758,14 @@ class RelatedDocExpressionTest(SimpleTestCase):
 class RelatedDocExpressionDbTest(TestCase):
     domain = 'related-doc-db-test-domain'
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_lookups(self):
         form = create_and_save_a_form(domain=self.domain)
         expression = self._get_expression('XFormInstance')
         doc = self._get_doc(form.form_id)
         self.assertEqual(form.form_id, expression(doc, EvaluationContext(doc, 0)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_lookups(self):
         case_id = uuid.uuid4().hex
         create_and_save_a_case(domain=self.domain, case_id=case_id, case_name='related doc test case')
@@ -773,7 +773,7 @@ class RelatedDocExpressionDbTest(TestCase):
         doc = self._get_doc(case_id)
         self.assertEqual(case_id, expression(doc, EvaluationContext(doc, 0)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_other_lookups(self):
         user_id = uuid.uuid4().hex
         CommCareUser.get_db().save_doc({'_id': user_id, 'domain': self.domain})
@@ -994,7 +994,7 @@ class TestFormsExpressionSpec(TestCase):
         delete_all_cases()
         super(TestFormsExpressionSpec, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_evaluation(self):
         context = EvaluationContext({"domain": self.domain}, 0)
         forms = self.expression(self.case.to_json(), context)
@@ -1002,7 +1002,7 @@ class TestFormsExpressionSpec(TestCase):
         self.assertEqual(len(forms), 1)
         self.assertEqual(forms, self.forms)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_wrong_domain(self):
         context = EvaluationContext({"domain": "wrong-domain"}, 0)
         forms = self.expression(self.case.to_json(), context)
@@ -1029,13 +1029,13 @@ class TestGetSubcasesExpression(TestCase):
         delete_all_cases()
         super(TestGetSubcasesExpression, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_subcases(self):
         case = self.factory.create_case()
         subcases = self.expression(case.to_json(), self.context)
         self.assertEqual(len(subcases), 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_single_child(self):
         parent_id = uuid.uuid4().hex
         child_id = uuid.uuid4().hex
@@ -1050,7 +1050,7 @@ class TestGetSubcasesExpression(TestCase):
         self.assertEqual(len(subcases), 1)
         self.assertEqual(child.case_id, subcases[0]['_id'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_single_extension(self):
         host_id = uuid.uuid4().hex
         extension_id = uuid.uuid4().hex
@@ -1093,13 +1093,13 @@ class TestGetCaseSharingGroupsExpression(TestCase):
             user.delete()
         super(TestGetCaseSharingGroupsExpression, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_groups(self):
         user = CommCareUser.create(domain=self.domain, username='test_no_group', password='123')
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(case_sharing_groups), 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_single_group(self):
         user = CommCareUser.create(domain=self.domain, username='test_single', password='123')
         group = Group(domain=self.domain, name='group_single', users=[user._id], case_sharing=True)
@@ -1109,7 +1109,7 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         self.assertEqual(len(case_sharing_groups), 1)
         self.assertEqual(group._id, case_sharing_groups[0]['_id'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_groups(self):
         user = CommCareUser.create(domain=self.domain, username='test_multiple', password='123')
         group1 = Group(domain=self.domain, name='group1', users=[user._id], case_sharing=True)
@@ -1120,7 +1120,7 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(case_sharing_groups), 2)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_wrong_domain(self):
         user = CommCareUser.create(domain=self.second_domain, username='test_wrong_domain', password='123')
         group = Group(domain=self.second_domain, name='group_wrong_domain', users=[user._id], case_sharing=True)
@@ -1154,13 +1154,13 @@ class TestGetReportingGroupsExpression(TestCase):
             user.delete()
         super(TestGetReportingGroupsExpression, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_groups(self):
         user = CommCareUser.create(domain=self.domain, username='test_no_group', password='123')
         reporting_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(reporting_groups), 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_groups(self):
         user = CommCareUser.create(domain=self.domain, username='test_multiple', password='123')
         group1 = Group(domain=self.domain, name='group1', users=[user._id])
@@ -1171,7 +1171,7 @@ class TestGetReportingGroupsExpression(TestCase):
         reporting_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(reporting_groups), 2)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_wrong_domain(self):
         user = CommCareUser.create(domain=self.second_domain, username='test_wrong_domain', password='123')
         group = Group(domain=self.second_domain, name='group_wrong_domain', users=[user._id], case_sharing=True)

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -20,7 +20,7 @@ from corehq.apps.userreports.specs import EvaluationContext
 from corehq.apps.products.models import SQLProduct
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.ledgers.helpers import StockReportHelper, StockTransactionHelper
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils import get_simple_wrapped_form
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.form_processor.utils.xform import TestFormMetadata
@@ -615,7 +615,7 @@ class TestGetValuesByProduct(TestCase):
         StockTransaction.objects.all().delete()
         super(TestGetValuesByProduct, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_soh_values_by_product(self):
         values = LedgerBalancesIndicator._get_values_by_product(
             'soh', self.case_id, ['coke', 'surge', 'new_coke'], self.domain_name
@@ -624,7 +624,7 @@ class TestGetValuesByProduct(TestCase):
         self.assertEqual(values['surge'], 85)
         self.assertEqual(values['new_coke'], 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_consumption_by_product(self):
         values = LedgerBalancesIndicator._get_values_by_product(
             'consumption', self.case_id, ['coke', 'surge', 'new_coke'], self.domain_name

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -12,7 +12,7 @@ from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from corehq.apps.users.tasks import remove_indices_from_deleted_cases
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import UserArchivedRebuild
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 class RetireUserTestCase(TestCase):
@@ -37,7 +37,7 @@ class RetireUserTestCase(TestCase):
         delete_all_xforms()
         super(RetireUserTestCase, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unretire_user(self):
         case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
 
@@ -67,7 +67,7 @@ class RetireUserTestCase(TestCase):
         form = FormAccessors(self.domain).get_form(xform.form_id)
         self.assertFalse(form.is_deleted)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_deleted_indices_removed(self):
         factory = CaseFactory(
             self.domain,
@@ -102,7 +102,7 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(0, len(child.indices))
         self.assertEqual(2, len(child.xform_ids))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_rebuild_cases_with_new_owner(self, rebuild_case):
         """
@@ -125,7 +125,7 @@ class RetireUserTestCase(TestCase):
         detail = UserArchivedRebuild(user_id=self.other_user.user_id)
         rebuild_case.assert_called_once_with(self.domain, case_id, detail)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_dont_rebuild(self, rebuild_case):
         """ Don't rebuild cases that are owned by other users """
@@ -144,7 +144,7 @@ class RetireUserTestCase(TestCase):
 
         self.assertEqual(rebuild_case.call_count, 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_multiple_case_blocks_all_rebuilt(self, rebuild_case):
         """ Rebuild all cases in forms with multiple case blocks """
@@ -168,7 +168,7 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(rebuild_case.call_count, len(case_ids))
         self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_multiple_case_blocks_some_deleted(self, rebuild_case):
         """ Don't rebuild deleted cases """

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -4,7 +4,7 @@ from django.test import TestCase, SimpleTestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.utils import get_simple_wrapped_form, TestFormMetadata
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 
 
 class UserModelTest(TestCase):
@@ -31,7 +31,7 @@ class UserModelTest(TestCase):
         self.domain_obj.delete()
         super(UserModelTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_form_ids(self):
         form_ids = list(self.user._get_form_ids())
         self.assertEqual(len(form_ids), 1)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -12,7 +12,7 @@ from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2, V1
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import TestFileMixin, softer_assert
 
 
@@ -45,7 +45,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         with self.assertRaises(BulkSaveError):
             submit_form_locally(xml_data, 'test-domain')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_empty_case_id(self):
         """
         Ensure that form processor fails on empty id
@@ -77,26 +77,26 @@ class CaseBugTest(TestCase, TestFileMixin):
         _test({'case_type': value})
         _test({'user_id': value})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testDateInCasePropertyBug(self):
         """
         Submits a case name/case type/user_id that looks like a date
         """
         self._testCornerCaseDatatypeBugs('2011-11-16')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testIntegerInCasePropertyBug(self):
         """
         Submits a case name/case type/user_id that looks like a number
         """
         self._testCornerCaseDatatypeBugs('42')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testDecimalInCasePropertyBug(self):
         # Submits a case name/case type/user_id that looks like a decimal
         self._testCornerCaseDatatypeBugs('4.06')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testDuplicateCasePropertiesBug(self):
         # Submit multiple values for the same property in an update block
         case_id = '061ecbae-d9be-4bb5-bdd4-e62abd5eaf7b'
@@ -111,7 +111,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         response, form, [case] = submit_form_locally(xml_data, 'test-domain')
         self.assertEqual("2", case.dynamic_case_properties()['bar'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testMultipleCaseBlocks(self):
         # How do we do when submitting a form with multiple blocks for the same case?
         case_id = 'MCLPZ69ON942EKNIBR5WF1G2L'
@@ -129,14 +129,14 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertEqual(2, len(ids))
         self.assertEqual([create_form.form_id, form.form_id], ids)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testLotsOfSubcases(self):
         # How do we do when submitting a form with multiple blocks for the same case?
         xml_data = self.get_xml('lots_of_subcases')
         response, form, cases = submit_form_locally(xml_data, 'test-domain')
         self.assertEqual(11, len(cases))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSubmitToDeletedCase(self):
         # submitting to a deleted case should succeed and affect the case
         case_id = uuid.uuid4().hex
@@ -163,7 +163,7 @@ class TestCaseHierarchy(TestCase):
         super(TestCaseHierarchy, self).setUp()
         delete_all_cases()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_normal_index(self):
         factory = CaseFactory()
         [cp] = factory.create_or_update_case(
@@ -181,7 +181,7 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual(2, len(hierarchy['case_list']))
         self.assertEqual(1, len(hierarchy['child_cases']))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_extension_index(self):
         factory = CaseFactory()
         [case] = factory.create_or_update_case(
@@ -207,7 +207,7 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual(2, len(hierarchy['case_list']))
         self.assertEqual(1, len(hierarchy['child_cases']))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_recursive_indexes(self):
         factory = CaseFactory()
         [case] = factory.create_or_update_case(CaseStructure(
@@ -221,7 +221,7 @@ class TestCaseHierarchy(TestCase):
         hierarchy = get_case_hierarchy(case, {})
         self.assertEqual(1, len(hierarchy['case_list']))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_complex_index(self):
         factory = CaseFactory()
         cp = factory.create_or_update_case(CaseStructure(case_id='parent', attrs={

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -6,7 +6,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.xform import get_extensions_to_close
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
@@ -99,7 +99,7 @@ class AutoCloseExtensionsTest(TestCase):
         )
         return self.factory.create_or_update_cases([extension_2])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_extension_chain_simple(self):
         host = CaseStructure(case_id=self.host_id, attrs={'create': True})
         extension = CaseStructure(
@@ -116,7 +116,7 @@ class AutoCloseExtensionsTest(TestCase):
             CaseAccessors(self.domain).get_extension_chain([self.host_id])
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_extension_chain_multiple(self):
         created_cases = self._create_extension_chain()
         self.assertEqual(
@@ -124,7 +124,7 @@ class AutoCloseExtensionsTest(TestCase):
             CaseAccessors(self.domain).get_extension_chain([created_cases[-1].case_id])
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_extension_chain_circular_ref(self):
         """If there is a circular reference, this should not hang forever
         """
@@ -137,7 +137,7 @@ class AutoCloseExtensionsTest(TestCase):
         )
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_extension_to_close(self):
         """should return empty if case is not a host, otherwise should return full chain"""
         created_cases = self._create_extension_chain()
@@ -159,7 +159,7 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertEqual(set(), no_cases)
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_extension_to_close_child_host(self):
         """should still return extension chain if outgoing index is a child index"""
         created_cases = self._create_host_is_subcase_chain()
@@ -184,7 +184,7 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertEqual(set(self.extension_ids[0:2]), full_chain)
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_close_cases_host(self):
         """Closing a host should close all the extensions"""
         self._create_extension_chain()
@@ -220,7 +220,7 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertTrue(cases[self.extension_ids[2]])
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_close_cases_child(self):
         """Closing a host that is also a child should close all the extensions"""
         self._create_host_is_subcase_chain()

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from django.test import TestCase
 
 
@@ -23,7 +23,7 @@ class TestExtensionCaseIds(TestCase):
         FormProcessorTestUtils.delete_all_xforms()
         super(TestExtensionCaseIds, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_extensions(self):
         """ Returns empty when there are other index types """
         parent_id = uuid.uuid4().hex
@@ -42,7 +42,7 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([parent_id])
         self.assertEqual(returned_cases, [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple_extension_returned(self):
         """ Should return extension if it exists """
         host_id = uuid.uuid4().hex
@@ -61,7 +61,7 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id])
         self.assertItemsEqual(returned_cases, [extension_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_extension_of_multiple_hosts_returned(self):
         """ Should return an extension from any host if there are multiple indices """
         host_id = uuid.uuid4().hex
@@ -89,7 +89,7 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id])
         self.assertItemsEqual(returned_cases, [extension_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_host_with_multiple_extensions(self):
         """ Return all extensions from a single host """
         host_id = uuid.uuid4().hex
@@ -119,7 +119,7 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id])
         self.assertItemsEqual(returned_cases, [extension_id, extension_2_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_extensions_from_list(self):
         """ Given a list of hosts, should return all extensions """
         host_id = uuid.uuid4().hex
@@ -163,7 +163,7 @@ class TestIndexedCaseIds(TestCase):
         FormProcessorTestUtils.delete_all_xforms()
         super(TestIndexedCaseIds, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_indexed_case_ids_returns_extensions(self):
         """ When getting indices, also return extensions """
         host_id = uuid.uuid4().hex

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
@@ -7,7 +7,7 @@ from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
 from corehq.apps.change_feed import topics
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils.general import should_use_sql_backend
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
 
@@ -18,7 +18,7 @@ class TestHardDelete(TestCase):
         self.casedb = CaseAccessors(TEST_DOMAIN_NAME)
         self.formdb = FormAccessors(TEST_DOMAIN_NAME)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple_delete(self):
         factory = CaseFactory()
         case = factory.create_case()
@@ -47,7 +47,7 @@ class TestHardDelete(TestCase):
             with self.assertRaises(XFormNotFound):
                 self.formdb.get_form(form_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_with_related(self):
         factory = CaseFactory()
         parent = factory.create_case()
@@ -66,7 +66,7 @@ class TestHardDelete(TestCase):
         with self.assertRaises(CaseNotFound):
             self.casedb.get_case(child.case_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_sharing_form(self):
         factory = CaseFactory()
         c1, c2 = factory.create_or_update_cases([

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 ALICE_XML = """<?xml version='1.0' ?>
 <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D95E58BD-A228-414F-83E6-EEE716F0B3AD">
@@ -75,7 +75,7 @@ EVE_DOMAIN = 'domain2'
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=True)
 class DomainTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cant_own_case(self):
         _, _, [case] = submit_form_locally(ALICE_XML, ALICE_DOMAIN)
         response, form, cases = submit_form_locally(EVE_XML, EVE_DOMAIN)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 TEST_DOMAIN = 'test-domain'
 
@@ -19,7 +19,7 @@ class CaseExclusionTest(TestCase):
         super(CaseExclusionTest, self).setUp()
         delete_all_cases()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testTopLevelExclusion(self):
         """
         Entire forms tagged as device logs should be excluded
@@ -31,7 +31,7 @@ class CaseExclusionTest(TestCase):
         submit_form_locally(xml_data, TEST_DOMAIN)
         self.assertEqual(0, len(CaseAccessors(TEST_DOMAIN).get_case_ids_in_domain()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testNestedExclusion(self):
         """
         Blocks inside forms tagged as device logs should be excluded

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from casexml.apps.case.mock import CaseStructure, CaseIndex, CaseFactory
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 
 
@@ -103,41 +103,41 @@ class CaseStructureTest(SimpleTestCase):
 
 class CaseFactoryTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple_create(self):
         factory = CaseFactory()
         case = factory.create_case()
         self.assertIsNotNone(CaseAccessors().get_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_overrides(self):
         factory = CaseFactory()
         case = factory.create_case(owner_id='somebody', update={'custom_prop': 'custom_value'})
         self.assertEqual('somebody', case.owner_id)
         self.assertEqual('custom_value', case.dynamic_case_properties()['custom_prop'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_domain(self):
         domain = uuid.uuid4().hex
         factory = CaseFactory(domain=domain)
         case = factory.create_case()
         self.assertEqual(domain, case.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_factory_defaults(self):
         owner_id = uuid.uuid4().hex
         factory = CaseFactory(case_defaults={'owner_id': owner_id})
         case = factory.create_case()
         self.assertEqual(owner_id, case.owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_override_defaults(self):
         owner_id = uuid.uuid4().hex
         factory = CaseFactory(case_defaults={'owner_id': owner_id})
         case = factory.create_case(owner_id='notthedefault')
         self.assertEqual('notthedefault', case.owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_from_structure(self):
         owner_id = uuid.uuid4().hex
         factory = CaseFactory(case_defaults={
@@ -170,7 +170,7 @@ class CaseFactoryTest(TestCase):
             self.assertEqual(2, len(parent.actions))  # create + update
             self.assertEqual(3, len(child.actions))  # create + update + index
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_walk_related(self):
         factory = CaseFactory()
         parent = factory.create_case()
@@ -182,7 +182,7 @@ class CaseFactoryTest(TestCase):
         self.assertEqual(1, len(child_updates))
         self.assertEqual(parent.case_id, child_updates[0].indices[0].referenced_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_extras(self):
         domain = uuid.uuid4().hex
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
@@ -192,7 +192,7 @@ class CaseFactoryTest(TestCase):
         form = FormAccessors(domain).get_form(case.xform_ids[0])
         self.assertEqual(token_id, form.last_sync_token)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_extras_default(self):
         domain = uuid.uuid4().hex
         # have to enable loose sync token validation for the domain or create actual SyncLog documents.
@@ -204,7 +204,7 @@ class CaseFactoryTest(TestCase):
         form = FormAccessors(domain).get_form(case.xform_ids[0])
         self.assertEqual(token_id, form.last_sync_token)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_extras_override_defaults(self):
         domain = uuid.uuid4().hex
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
@@ -8,7 +8,7 @@ from casexml.apps.case.tests.util import bootstrap_case_from_xml
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CaseTransaction, CommCareCaseSQL
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.backends.couch.update_strategy import coerce_to_datetime
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -17,7 +17,7 @@ class CaseFromXFormTest(TestCase):
     def setUp(self):
         self.interface = FormProcessorInterface()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCreate(self):
         xform, case = bootstrap_case_from_xml(self, "create.xml")
         self._check_static_properties(case)
@@ -34,7 +34,7 @@ class CaseFromXFormTest(TestCase):
             self.assertEqual(xform.form_id, create_action.xform_id)
             self.assertEqual("test create", create_action.xform_name)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCreateThenUpdateInSeparateForms(self):
         # recycle our previous test's form
         xform1, original_case = bootstrap_case_from_xml(self, "create_update.xml")
@@ -84,7 +84,7 @@ class CaseFromXFormTest(TestCase):
         # case should have a new modified date
         self.assertEqual(MODIFY_DATE, case.modified_on)
         
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCreateThenClose(self):
         xform1, case = bootstrap_case_from_xml(self, "create.xml")
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -12,7 +12,7 @@ from casexml.apps.phone.tests.utils import create_restore_user
 from django.test import TestCase, SimpleTestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 
 
 class IndexSimpleTest(SimpleTestCase):
@@ -143,7 +143,7 @@ class IndexTest(TestCase):
 
         check_user_has_case(self, self.user, update_index_expected)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testRelationshipGetsSet(self):
         parent_case_id = uuid.uuid4().hex
         post_case_blocks(

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -20,7 +20,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.util.test_utils import TestFileMixin, trap_extra_setup
 
 TEST_CASE_ID = "EOL9FIAKIQWOFXFOH0QAMWU64"
@@ -145,7 +145,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
     Tests new attachments for cases and case properties
     Spec: https://github.com/dimagi/commcare/wiki/CaseAttachmentAPI
     """
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testAttachInCreate(self):
         single_attach = 'fruity_file'
         xform, case = self._doCreateCaseWithMultimedia(attachments=[single_attach])
@@ -159,7 +159,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual(1, len(filter(lambda x: x['action_type'] == 'attachment', case.actions)))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testArchiveAfterAttach(self):
         single_attach = 'fruity_file'
         xform, case = self._doCreateCaseWithMultimedia(attachments=[single_attach])
@@ -175,7 +175,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
             form = self.formdb.get_form(xform_id)
             self.assertFalse(form.is_archived)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testAttachRemoveSingle(self):
         self._doCreateCaseWithMultimedia()
         new_attachments = []
@@ -190,7 +190,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
             last_action = attach_actions[-1]
             self.assertEqual(sorted(removes), sorted(last_action['attachments'].keys()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testAttachRemoveMultiple(self):
         self._doCreateCaseWithMultimedia()
 
@@ -204,13 +204,13 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
             attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
             self.assertEqual(2, len(attach_actions))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOTARestoreSingle(self):
         _, case = self._doCreateCaseWithMultimedia()
         restore_attachments = ['fruity_file']
         self._validateOTARestore(case.case_id, restore_attachments)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOTARestoreMultiple(self):
         _, case = self._doCreateCaseWithMultimedia()
         restore_attachments = ['commcare_logo_file', 'dimagi_logo_file']
@@ -238,7 +238,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         self.assertEqual(0, len(restore_attachments))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testAttachInUpdate(self):
         new_attachments = ['commcare_logo_file', 'dimagi_logo_file']
 
@@ -285,7 +285,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
         # and none of the attachments were re-saved in rebuild
         self.assertEqual(bulk_save_attachments, [{}])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_log_invalidation_bug(self):
         sync_log = FormProcessorInterface().sync_log_model(
             user_id='6dac4940-913e-11e0-9d4b-005056aa7fb5'
@@ -318,7 +318,7 @@ class CaseMultimediaS3DBTest(BaseCaseMultimediaTest):
         self.s3db.close()
         super(CaseMultimediaS3DBTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_attachment(self):
         single_attach = 'fruity_file'
         xform, case = self._doCreateCaseWithMultimedia(attachments=[single_attach])

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -15,7 +15,7 @@ from corehq.form_processor.backends.couch.update_strategy import CouchCaseUpdate
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import RebuildWithReason
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils.general import should_use_sql_backend
 from couchforms.models import XFormInstance
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
@@ -178,7 +178,7 @@ class CaseRebuildTest(TestCase):
         CouchCaseUpdateStrategy(case).soft_rebuild_case()
         _confirm_action_order(case, [a1, a2, a3])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_rebuild_empty(self):
         self.assertEqual(None, rebuild_case_from_forms('anydomain', 'notarealid', RebuildWithReason(reason='test')))
 
@@ -251,7 +251,7 @@ class CaseRebuildTest(TestCase):
         self._assertListEqual(original_actions, primary_actions(case))
         self._assertListEqual(original_form_ids, case.xform_ids)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archiving_only_form(self):
         """
         Checks that archiving the only form associated with the case archives
@@ -283,7 +283,7 @@ class CaseRebuildTest(TestCase):
         self.assertEqual(3, len(case.actions))
         self.assertTrue(case.actions[-1].is_case_rebuild)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_archiving(self):
         now = datetime.utcnow()
         # make sure we timestamp everything so they have the right order
@@ -412,7 +412,7 @@ class CaseRebuildTest(TestCase):
         self.assertFalse('p5' in case.dynamic_case_properties())  # should disappear entirely
         _reset(f3)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archie_modified_on(self):
         case_id = uuid.uuid4().hex
         now = datetime.utcnow().replace(microsecond=0)
@@ -437,7 +437,7 @@ class CaseRebuildTest(TestCase):
         case = case_accessors.get_case(case_id)
         self.assertEqual(way_earlier, case.modified_on)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_archive_against_deleted_case(self):
         now = datetime.utcnow()
         # make sure we timestamp everything so they have the right order

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
@@ -5,7 +5,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.case.xform import process_cases_with_casedb
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.form import process_xform_xml
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 CASE_ID = 'a0cd5e6c5fb84695a4f729d3b1996a93'
@@ -32,7 +32,7 @@ class StrictDatetimesTest(TestCase):
         cls.domain = 'strict-datetimes-test-domain'
         cls.interface = FormProcessorInterface(cls.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test(self):
         form = _make_form_from_case_blocks([ElementTree.fromstring(CASE_BLOCK)])
         result = process_xform_xml(self.domain, form)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from casexml.apps.case.xml import V2, V2_NAMESPACE
 from casexml.apps.case import const
 from casexml.apps.phone import xml
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -31,7 +31,7 @@ class Version2CaseParsingTest(TestCase):
         delete_all_cases()
         super(Version2CaseParsingTest, cls).tearDownClass()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParseCreate(self):
         self._test_parse_create()
 
@@ -57,7 +57,7 @@ class Version2CaseParsingTest(TestCase):
             self.assertEqual("v2 create", action.xform_name)
             self.assertEqual("bar-user-id", case.actions[0].user_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParseUpdate(self):
         self._test_parse_create()
         
@@ -77,7 +77,7 @@ class Version2CaseParsingTest(TestCase):
             self.assertEqual(2, len(case.actions))
             self.assertEqual("bar-user-id", case.actions[1].user_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParseNoop(self):
         self._test_parse_create()
 
@@ -96,7 +96,7 @@ class Version2CaseParsingTest(TestCase):
 
         self.assertEqual(2, len(case.xform_ids))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParseClose(self):
         self._test_parse_create()
         
@@ -108,7 +108,7 @@ class Version2CaseParsingTest(TestCase):
         self.assertTrue(case.closed)
         self.assertEqual("bar-user-id", case.closed_by)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParseNamedNamespace(self):
         file_path = os.path.join(os.path.dirname(__file__), "data", "v2", "named_namespace.xml")
         with open(file_path, "rb") as f:
@@ -124,7 +124,7 @@ class Version2CaseParsingTest(TestCase):
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual(2, len(case.actions))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testParseWithIndices(self):
         self._test_parse_create()
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -12,7 +12,7 @@ from casexml.apps.case.tests.util import (
     delete_all_sync_logs,
 )
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from casexml.apps.phone.restore import (
     RestoreConfig,
     RestoreParams,
@@ -146,7 +146,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         self.assertTrue(restore_config.force_cache)
 
     @flag_enabled('ASYNC_RESTORE')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_restore_in_progress_form_submitted_kills_old_jobs(self):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
@@ -180,7 +180,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
             self.assertIsNone(restore_config.cache.get(initial_sync_cache_id))
 
     @flag_enabled('ASYNC_RESTORE')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submit_form_no_userid(self):
         form = """
         <data xmlns="http://openrosa.org/formdesigner/blah">
@@ -191,7 +191,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         """
         submit_form_locally(form, self.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @mock.patch.object(CachedPayload, 'finalize')  # fake that a cached payload exists
     @mock.patch.object(RestoreConfig, 'cache')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
@@ -9,7 +9,7 @@ from casexml.apps.phone.exceptions import SyncLogCachingError
 from casexml.apps.phone.models import SimplifiedSyncLog, get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.dummy import dummy_restore_xml
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 class CacheUtilsTest(SimpleTestCase):
@@ -55,7 +55,7 @@ class CacheUtilsTest(SimpleTestCase):
 
 class CacheUtilsDbTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_copy_payload(self):
         sync_log = SimplifiedSyncLog(case_ids_on_phone=set(['case-1', 'case-2']))
         sync_log.save()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.data_providers.case.clean_owners import pop_ids
 from casexml.apps.phone.exceptions import InvalidDomainError, InvalidOwnerIdError
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=None)
@@ -103,14 +103,14 @@ class OwnerCleanlinessTest(SyncBaseTest):
         )[0]
         self.assertEqual(owner_id, case.owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_add_normal_case_stays_clean(self):
         """Owned case with no indices remains clean"""
         self.factory.create_case()
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_owner_stays_clean(self):
         """change the owner ID of a normal case, should remain clean"""
         new_owner = uuid.uuid4().hex
@@ -118,7 +118,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_temporarily_dirty()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_owner_child_case_stays_clean(self):
         """change the owner ID of a child case, should remain clean"""
         new_owner = uuid.uuid4().hex
@@ -126,14 +126,14 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_temporarily_dirty()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_add_clean_parent_stays_clean(self):
         """add a parent with the same owner, should remain clean"""
         self.factory.create_or_update_case(CaseStructure(indices=[CaseIndex()]))
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_dirty_makes_dirty(self):
         """create a case and a parent case with a different owner at the same time
         make sure the owner becomes dirty.
@@ -150,7 +150,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(child.case_id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_add_dirty_parent_makes_dirty(self):
         """add parent with a different owner and make sure the owner becomes dirty"""
         new_owner = uuid.uuid4().hex
@@ -166,7 +166,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(child.case_id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_parent_owner_makes_dirty(self):
         """change the owner id of a parent case and make sure the owner becomes dirty"""
         new_owner = uuid.uuid4().hex
@@ -175,7 +175,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(self.child.case_id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_host_owner_remains_clean(self):
         """change owner for unowned extension, owner remains clean"""
         new_owner = uuid.uuid4().hex
@@ -186,7 +186,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(self._owner_cleanliness_for_id(new_owner).is_clean)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_host_owner_makes_both_owners_dirty(self):
         """change owner for extension, both owners dirty"""
         new_owner = uuid.uuid4().hex
@@ -195,13 +195,13 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_dirty()
         self.assertFalse(self._owner_cleanliness_for_id(new_owner).is_clean)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_set_flag_clean_no_data(self):
         unused_owner_id = uuid.uuid4().hex
         set_cleanliness_flags(self.domain, unused_owner_id)
         self.assertTrue(OwnershipCleanlinessFlag.objects.get(owner_id=unused_owner_id).is_clean)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_hint_invalidation(self):
         new_owner = uuid.uuid4().hex
         self._set_owner(self.parent.case_id, new_owner)
@@ -216,7 +216,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_clean()
         self.assertEqual(None, self.owner_cleanliness.hint)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_hint_invalidation_extensions(self):
         other_owner_id = uuid.uuid4().hex
         [extension, host] = self.factory.create_or_update_case(
@@ -237,7 +237,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._set_owner(extension.case_id, UNOWNED_EXTENSION_OWNER_ID)
         self.assertFalse(hint_still_valid(self.domain, self.owner_cleanliness.hint))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_hint_invalidation_extension_chain(self):
         other_owner_id = uuid.uuid4().hex
         self._owner_cleanliness_for_id(other_owner_id)
@@ -268,7 +268,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._set_owner(extension_2.case_id, UNOWNED_EXTENSION_OWNER_ID)
         self.assertFalse(hint_still_valid(self.domain, self.owner_cleanliness.hint))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cross_domain_on_submission(self):
         """create a form that makes a dirty owner with the same ID but in a different domain
         make sure the original owner stays clean"""
@@ -289,7 +289,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
             OwnershipCleanlinessFlag.objects.get(owner_id=self.owner_id, domain=new_domain).is_clean,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cross_domain_both_clean(self):
         new_domain = uuid.uuid4().hex
         self.factory.domain = new_domain
@@ -304,7 +304,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(get_cleanliness_flag_from_scratch(self.domain, self.owner_id).is_clean)
         self.assertTrue(get_cleanliness_flag_from_scratch(new_domain, self.owner_id).is_clean)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cross_domain_dirty(self):
         new_domain = uuid.uuid4().hex
         new_owner = uuid.uuid4().hex
@@ -320,7 +320,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(get_cleanliness_flag_from_scratch(self.domain, self.owner_id).is_clean)
         self.assertFalse(get_cleanliness_flag_from_scratch(new_domain, self.owner_id).is_clean)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_non_existent_parent(self):
         self.factory.create_or_update_case(
             CaseStructure(
@@ -333,7 +333,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(get_cleanliness_flag_from_scratch(self.domain, self.owner_id).is_clean)
 
     @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=False)
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_autocreate_flag_off(self):
         new_owner = uuid.uuid4().hex
         self.factory.create_or_update_case(
@@ -342,7 +342,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertFalse(OwnershipCleanlinessFlag.objects.filter(domain=self.domain, owner_id=new_owner).exists())
 
     @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=True)
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_autocreate_flag_on(self):
         new_owner = uuid.uuid4().hex
         self.factory.create_or_update_case(
@@ -351,7 +351,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         flag = OwnershipCleanlinessFlag.objects.get(domain=self.domain, owner_id=new_owner)
         self.assertEqual(True, flag.is_clean)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple_unowned_extension(self):
         """Simple unowned extensions should be clean"""
         self.factory.create_or_update_case(
@@ -369,7 +369,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_owned_extension(self):
         """Extension owned by another owner should be dirty"""
         other_owner_id = uuid.uuid4().hex
@@ -393,7 +393,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags(self.owner_id)
         self._verify_set_cleanliness_flags(other_owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_extension_chain_with_other_owner_makes_dirty(self):
         """An extension chain of unowned extensions that ends at a case owned by a different owner is dirty"""
         other_owner_id = uuid.uuid4().hex
@@ -428,7 +428,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags(self.owner_id)
         self._verify_set_cleanliness_flags(other_owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_indices_multiple_owners(self):
         """Extension that indexes a case with another owner should make all owners dirty"""
         other_owner_id = uuid.uuid4().hex
@@ -461,7 +461,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags(self.owner_id)
         self._verify_set_cleanliness_flags(other_owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_long_extension_chain_with_branches(self):
         """An extension chain of unowned extensions that ends at an owned case is dirty"""
         owner_1 = uuid.uuid4().hex
@@ -509,14 +509,14 @@ class OwnerCleanlinessTest(SyncBaseTest):
 
 class SetCleanlinessFlagsTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_set_bad_domains(self):
         test_cases = [None, '', 'something-too-long' * 10]
         for invalid_domain in test_cases:
             with self.assertRaises(InvalidDomainError):
                 set_cleanliness_flags(invalid_domain, 'whatever')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_set_bad_owner_ids(self):
         test_cases = [None, '', 'something-too-long' * 10]
         for invalid_owner in test_cases:
@@ -555,7 +555,7 @@ class GetCaseFootprintInfoTest(TestCase):
         self.other_owner_id = uuid.uuid4().hex
         self.factory = CaseFactory(self.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_simple_footprint(self):
         """ should only return open cases from user """
         case = CaseStructure(case_id=uuid.uuid4().hex, attrs={'owner_id': self.owner_id, 'create': True})
@@ -566,7 +566,7 @@ class GetCaseFootprintInfoTest(TestCase):
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)
         self.assertEqual(footprint_info.all_ids, set([case.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_footprint_with_parent(self):
         """ should return open cases with parents """
         parent = CaseStructure(
@@ -585,7 +585,7 @@ class GetCaseFootprintInfoTest(TestCase):
         self.assertEqual(footprint_info.all_ids, set([child.case_id, parent.case_id]))
         self.assertEqual(footprint_info.base_ids, set([child.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_footprint_with_extension(self):
         """
         Extensions are brought in if the host case is owned;
@@ -610,7 +610,7 @@ class GetCaseFootprintInfoTest(TestCase):
         self.assertEqual(footprint_info.all_ids, set([extension.case_id, host.case_id]))
         self.assertEqual(footprint_info.base_ids, set([extension.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_footprint_with_extension_of_parent(self):
         """ Extensions of parents should be included """
         parent = CaseStructure(
@@ -631,7 +631,7 @@ class GetCaseFootprintInfoTest(TestCase):
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)
         self.assertEqual(footprint_info.all_ids, set([extension.case_id, parent.case_id, child.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_footprint_with_extension_of_child(self):
         """ Extensions of children should be included """
         parent = CaseStructure(
@@ -652,7 +652,7 @@ class GetCaseFootprintInfoTest(TestCase):
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)
         self.assertEqual(footprint_info.all_ids, set([extension.case_id, parent.case_id, child.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cousins(self):
         # http://manage.dimagi.com/default.asp?189528
         grandparent = CaseStructure(
@@ -705,12 +705,12 @@ class GetDependentCasesTest(TestCase):
         self.other_owner_id = uuid.uuid4().hex
         self.factory = CaseFactory(self.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_returns_nothing_with_no_dependencies(self):
         case = self.factory.create_case()
         self.assertEqual(set(), get_dependent_case_info(self.domain, [case.case_id]).all_ids)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_returns_simple_extension(self):
         host = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -729,7 +729,7 @@ class GetDependentCasesTest(TestCase):
         self.assertEqual(set([extension.case_id]),
                          get_dependent_case_info(self.domain, [host.case_id]).extension_ids)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_returns_extension_of_extension(self):
         host = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -754,7 +754,7 @@ class GetDependentCasesTest(TestCase):
         self.assertEqual(set([extension.case_id, extension_2.case_id]),
                          get_dependent_case_info(self.domain, [host.case_id]).extension_ids)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_children_and_extensions(self):
         parent = CaseStructure(
             case_id=uuid.uuid4().hex,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -9,7 +9,7 @@ from casexml.apps.case.tests.util import assert_user_doesnt_have_cases, \
     assert_user_has_cases
 from casexml.apps.phone.models import get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import softer_assert
 
 
@@ -44,7 +44,7 @@ def test_generator(test_name, skip=False):
         assert_user_doesnt_have_cases(self, self.user, undesired_cases)
 
     test.__name__ = get_test_name(test_name)
-    return run_with_all_backends(test)
+    return conditionally_run_with_all_backends(test)
 
 
 class TestSequenceMeta(type):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog, LOG_FORMAT_SIM
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_from_restore_payload, create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.toggles import LEGACY_SYNC_SUPPORT
 from corehq.util.global_request.api import set_request
 
@@ -139,7 +139,7 @@ class TestNewSyncSpecifics(TestCase):
         )
         cls.user_id = cls.user.user_id
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_legacy_support_toggle(self):
         restore_config = RestoreConfig(self.project, restore_user=self.user)
         factory = CaseFactory(domain=self.project.name, case_defaults={'owner_id': self.user_id})

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -12,7 +12,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from casexml.apps.case.tests.util import check_xml_line_by_line
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 DOMAIN = 'fixture-test'
 SA_PROVINCES = 'sa_provinces'
@@ -31,7 +31,7 @@ class OtaWebUserFixtureTest(TestCase):
         cls.domain.delete()
         delete_all_users()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_fixture_generation(self):
         fixture_xml = list(generator.get_fixtures(self.restore_user, version=V2))
         self.assertEqual(len(fixture_xml), 1)
@@ -90,17 +90,17 @@ class OtaFixtureTest(TestCase):
                 expected = _get_item_list_fixture(self.user.get_id, data_type.tag, data_item)
                 check_xml_line_by_line(self, expected, item_list_xml[0])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fixture_gen_v1(self):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V1)
         self.assertEqual(list(fixture_xml), [])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_fixture_generation(self):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V2)
         self._check_fixture(fixture_xml, item_lists=[SA_PROVINCES, FR_PROVINCES])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fixtures_by_group(self):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V2, group='case')
         self.assertEqual(list(fixture_xml), [])
@@ -108,7 +108,7 @@ class OtaFixtureTest(TestCase):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V2, group='standalone')
         self._check_fixture(fixture_xml, item_lists=[SA_PROVINCES, FR_PROVINCES])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fixtures_by_id(self):
         fixture_xml = generator.get_fixture_by_id('user-groups', self.restore_user, version=V2)
         self._check_fixture([fixture_xml])

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -16,7 +16,7 @@ from casexml.apps.phone.tests.utils import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -35,7 +35,7 @@ class StateHashTest(TestCase):
         generate_restore_payload(self.project, self.user)
         self.sync_log = get_exactly_one_wrapped_sync_log()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testEmpty(self):
         empty_hash = CaseStateHash(EMPTY_HASH)
         wrong_hash = CaseStateHash("thisisntright")
@@ -63,7 +63,7 @@ class StateHashTest(TestCase):
                                              state_hash=str(wrong_hash))
         self.assertEqual(412, response.status_code)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testMismatch(self):
         self.assertEqual(CaseStateHash(EMPTY_HASH), self.sync_log.get_state_hash())
         

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -5,13 +5,13 @@ from casexml.apps.case.const import CASE_ACTION_UPDATE
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.phone.models import SyncLog, CaseState, SimplifiedSyncLog
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from couchforms.models import XFormInstance
 
 
 class SyncLogAssertionTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_dependent_case(self):
         sync_log = SyncLog(
             cases_on_phone=[
@@ -32,7 +32,7 @@ class SyncLogAssertionTest(TestCase):
             for log in [sync_log, SimplifiedSyncLog.from_other_format(sync_log)]:
                 log.update_phone_lists(xform, [parent_case])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_dependent_case_owner_still_present(self):
         dependent_case_state = CaseState(case_id="d1", indices=[])
         sync_log = SyncLog(

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.restore import RestoreParams, RestoreConfig
 from casexml.apps.phone.tests.utils import create_restore_user, generate_restore_payload
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 class PhoneFootprintTest(SimpleTestCase):
@@ -79,7 +79,7 @@ class PhoneFootprintTest(SimpleTestCase):
 
 class CachingReponseTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCachingResponse(self):
         log = SyncLog()
         log.save()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -17,7 +17,7 @@ from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
-    run_with_all_backends
+    conditionally_run_with_all_backends
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from corehq.util.test_utils import flag_enabled
 from casexml.apps.case.tests.util import (
@@ -165,7 +165,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
     on the phone and the footprint.
     """
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testInitialEmpty(self):
         """
         Tests that a newly created sync token has no cases attached to it.
@@ -173,7 +173,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_exactly_one_wrapped_sync_log()
         self._testUpdate(sync_log.get_id, {}, {})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOwnUpdatesDontSync(self):
         case_id = "own_updates_dont_sync"
         self._createCaseStubs([case_id])
@@ -189,7 +189,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         )
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_index_type(self):
         """
         Test that changing an index type updates the sync log
@@ -206,7 +206,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [],
                                                 child_id: [parent_ref]})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_change_index_id(self):
         """
         Test that changing an index ID updates the sync log
@@ -228,7 +228,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [],
                                                 child_id: [parent_ref]})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_add_multiple_indices(self):
         """
         Test that adding multiple indices works as expected
@@ -253,7 +253,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], new_case_id: [],
                                                 child_id: [parent_ref, new_index_ref]})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_only_index(self):
         child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # delete the first index
@@ -263,7 +263,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: []})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_one_of_multiple_indices(self):
         # make IDs both human readable and globally unique to this test
         uid = uuid.uuid4().hex
@@ -324,7 +324,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: [parent_ref]})
         return (child_id, parent_id, index_id, parent_ref)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testClosedParentIndex(self):
         """
         Tests that things work properly when you have a reference to the parent
@@ -361,7 +361,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # try a clean restore again
         assert_user_has_cases(self, self.user, [parent_id, child_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testAssignToNewOwner(self):
         # create parent and child
         parent_id = "mommy"
@@ -396,7 +396,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # child should be moved, parent should still be there
         self._testUpdate(self.sync_log.get_id, {parent_id: []}, {})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testArchiveUpdates(self):
         """
         Tests that archiving a form (and changing a case) causes the
@@ -418,7 +418,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         form.archive()
         assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id, purge_restore_cache=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testUserLoggedIntoMultipleDevices(self):
         # test that a child case created by the same user from a different device
         # gets included in the sync
@@ -443,7 +443,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # ensure child case is included in sync using original sync log ID
         assert_user_has_case(self, self.user, child_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_tiered_parent_closing(self):
         all_ids = [uuid.uuid4().hex for i in range(3)]
         [grandparent_id, parent_id, child_id] = all_ids
@@ -482,7 +482,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
             # once the child is closed, all three are no longer relevant
             self.assertFalse(sync_log.phone_is_holding_case(id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_immediately_irrelevant_parent_case(self):
         """
         Make a case that is only relevant through a dependency at the same
@@ -507,7 +507,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
                                       referenced_id=parent_id)
         self._testUpdate(self.sync_log._id, {child_id: [index_ref]}, {parent_id: []})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_closed_case_not_in_next_sync(self):
         # create a case
         case_id = self.factory.create_case().case_id
@@ -529,7 +529,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         last_sync = synclog_from_restore_payload(restore_config.get_payload().as_string())
         self.assertFalse(last_sync.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_sync_by_user_id(self):
         # create a case with an empty owner but valid user id
         case_id = self.factory.create_case(owner_id='', user_id=self.user_id).case_id
@@ -539,12 +539,12 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = synclog_from_restore_payload(payload)
         self.assertTrue(sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_irrelevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': 'irrelevant_2'}, strict=False)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_relevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': self.user_id}, strict=False)
@@ -555,20 +555,20 @@ class SyncTokenUpdateTest(SyncBaseTest):
         if isinstance(sync_log, SimplifiedSyncLog):
             self.assertTrue(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_relevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id=self.user_id, update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         if isinstance(sync_log, SimplifiedSyncLog):
             self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_relevant_owner_then_submit_again_with_no_owner(self):
         case = self.factory.create_case()
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
@@ -580,7 +580,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertTrue(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_irrelevant_owner_then_submit_again_with_no_owner(self):
         case = self.factory.create_case(owner_id='irrelevant_1')
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
@@ -592,7 +592,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_irrelevant_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case().case_id
@@ -617,7 +617,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # they should both be gone
         self._testUpdate(self.sync_log._id, {}, {})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_closed_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case().case_id
@@ -643,12 +643,12 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # they should both be gone
         self._testUpdate(self.sync_log._id, {}, {})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_irrelevant_owner_and_close_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', close=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reassign_and_close_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         case_id = self.factory.create_case().case_id
@@ -659,7 +659,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
             )
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_index_after_close(self):
         parent_id = self.factory.create_case().case_id
         case_id = uuid.uuid4().hex
@@ -677,7 +677,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # before this test was written, the case stayed on the sync log even though it was closed
         self.assertFalse(sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_index_chain_with_closed_parents(self):
         grandparent = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -721,7 +721,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
              grandparent.case_id: []}
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reassign_case_and_sync(self):
         case = self.factory.create_case()
         # reassign from an empty sync token, simulating a web-reassignment on HQ
@@ -737,7 +737,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         next_sync_log = synclog_from_restore_payload(payload)
         self.assertFalse(next_sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cousins(self):
         """http://manage.dimagi.com/default.asp?189528
         """
@@ -778,13 +778,13 @@ class SyncTokenUpdateTest(SyncBaseTest):
 
 class SyncDeletedCasesTest(SyncBaseTest):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_deleted_case_doesnt_sync(self):
         case = self.factory.create_case()
         case.soft_delete()
         assert_user_doesnt_have_case(self, self.user, case.case_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_deleted_parent_doesnt_sync(self):
         parent_id = uuid.uuid4().hex
         child_id = uuid.uuid4().hex
@@ -811,7 +811,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
     """Makes sure the extension case trees are propertly updated
     """
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_extension(self):
         """creating an extension should add it to the extension_index_tree
         """
@@ -838,7 +838,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_multiple_indices(self):
         """creating multiple indices should add to the right tree
         """
@@ -868,7 +868,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {'host': host.case_id}})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_extension_with_extension(self):
         """creating multiple extensions should be added to the right tree
         """
@@ -903,7 +903,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.index_tree.indices, {})
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_extension_then_delegate(self):
         """A delegated extension should still remain on the phone with the host
         """
@@ -931,7 +931,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_delegated_extension(self):
         case_type = 'case'
         host = CaseStructure(case_id='host',
@@ -953,7 +953,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
         self.assertEqual(sync_log.case_ids_on_phone, set([host.case_id, extension.case_id]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_close_host(self):
         """closing a host should update the appropriate trees
         """
@@ -984,7 +984,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([]))
         self.assertEqual(sync_log.case_ids_on_phone, set([]))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_long_chain_with_children(self):
         """
                   +----+
@@ -1054,7 +1054,7 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.restore_config = RestoreConfig(project=self.project, restore_user=self.user)
         self.restore_state = self.restore_config.restore_state
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_is_first_extension_sync(self):
         """Before any syncs, this should return true when the toggle is enabled, otherwise false"""
         with flag_enabled('EXTENSION_CASES_SYNC_ENABLED'):
@@ -1062,7 +1062,7 @@ class ExtensionCasesFirstSync(SyncBaseTest):
 
         self.assertFalse(self.restore_state.is_first_extension_sync)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_is_first_extension_sync_after_sync(self):
         """After a sync with the extension code in place, this should be false"""
         self.factory.create_case()
@@ -1081,7 +1081,7 @@ class ChangingOwnershipTest(SyncBaseTest):
     def setUp(self):
         super(ChangingOwnershipTest, self).setUp()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_remove_user_from_group(self):
         group = Group(
             domain=self.project.name,
@@ -1115,7 +1115,7 @@ class ChangingOwnershipTest(SyncBaseTest):
         self.assertFalse(group._id in incremental_sync_log.owner_ids_on_phone)
         self.assertFalse(incremental_sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_add_user_to_group(self):
         group = Group(
             domain=self.project.name,
@@ -1149,7 +1149,7 @@ class ChangingOwnershipTest(SyncBaseTest):
 
 class SyncTokenCachingTest(SyncBaseTest):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCaching(self):
         self.assertFalse(self.sync_log.has_cached_payload(V2))
         # first request should populate the cache
@@ -1190,7 +1190,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         versioned_sync_log = synclog_from_restore_payload(versioned_payload)
         self.assertNotEqual(next_sync_log._id, versioned_sync_log._id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_initial_cache(self):
         restore_config = RestoreConfig(
             project=self.project,
@@ -1204,7 +1204,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         cached_payload = restore_config.get_payload()
         self.assertIsInstance(cached_payload, CachedResponse)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCacheInvalidation(self):
         original_payload = RestoreConfig(
             project=self.project,
@@ -1241,7 +1241,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         # we can be explicit about why this is the case
         self.assertTrue(self.sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCacheNonInvalidation(self):
         original_payload = RestoreConfig(
             project=self.project,
@@ -1275,7 +1275,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertEqual(original_payload, next_payload)
         self.assertFalse(case_id in next_payload)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCacheInvalidationAfterFileDelete(self):
         # first request should populate the cache
         original_payload = RestoreConfig(
@@ -1337,7 +1337,7 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue(self.shared_group._id in self.sync_log.owner_ids_on_phone)
         self.assertTrue(self.user_id in self.sync_log.owner_ids_on_phone)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSharedCase(self):
         # create a case by one user
         case_id = "shared_case"
@@ -1345,7 +1345,7 @@ class MultiUserSyncTest(SyncBaseTest):
         # should sync to the other owner
         assert_user_has_case(self, self.other_user, case_id, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOtherUserEdits(self):
         # create a case by one user
         case_id = "other_user_edits"
@@ -1369,7 +1369,7 @@ class MultiUserSyncTest(SyncBaseTest):
         _, match = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
         self.assertTrue("Hello!" in match.to_string())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOtherUserAddsIndex(self):
         time = datetime.utcnow()
 
@@ -1429,7 +1429,7 @@ class MultiUserSyncTest(SyncBaseTest):
         _, orig = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
         self.assertTrue("index" in orig.to_string())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testMultiUserEdits(self):
         time = datetime.utcnow()
 
@@ -1496,7 +1496,7 @@ class MultiUserSyncTest(SyncBaseTest):
         check_user_has_case(self, self.user, joint_change, restore_id=main_sync_log.get_id)
         check_user_has_case(self, self.other_user, joint_change, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOtherUserCloses(self):
         # create a case from one user
         case_id = "other_user_closes"
@@ -1527,7 +1527,7 @@ class MultiUserSyncTest(SyncBaseTest):
         )
         self.assertFalse(next_synclog.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOtherUserUpdatesUnowned(self):
         # create a case from one user and assign ownership elsewhere
         case_id = "other_user_updates_unowned"
@@ -1552,7 +1552,7 @@ class MultiUserSyncTest(SyncBaseTest):
         # make sure there are no new changes
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testIndexesSync(self):
         # create a parent and child case (with index) from one user
         parent_id = "indexes_sync_parent"
@@ -1586,7 +1586,7 @@ class MultiUserSyncTest(SyncBaseTest):
                              purge_restore_cache=True)
         assert_user_has_case(self, self.other_user, case_id, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOtherUserUpdatesIndex(self):
         # create a parent and child case (with index) from one user
         parent_id = "other_updates_index_parent"
@@ -1638,7 +1638,7 @@ class MultiUserSyncTest(SyncBaseTest):
         assert_user_has_case(self, self.user, parent_id, restore_id=latest_sync_log.get_id,
                              purge_restore_cache=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOtherUserReassignsIndexed(self):
         # create a parent and child case (with index) from one user
         parent_id = "other_reassigns_index_parent"
@@ -1759,7 +1759,7 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue("something different" in payload)
         self.assertTrue("hi changed!" in payload)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testComplicatedGatesBug(self):
         # found this bug in the wild, used the real (test) forms to fix it
         # just running through this test used to fail hard, even though there
@@ -1773,7 +1773,7 @@ class MultiUserSyncTest(SyncBaseTest):
                 generate_restore_payload(self.project, self.user, version="2.0")
             )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_dependent_case_becomes_relevant_at_sync_time(self):
         """
         Make a case that is only relevant through a dependency.
@@ -1816,7 +1816,7 @@ class MultiUserSyncTest(SyncBaseTest):
         )
         self._testUpdate(latest_sync_log._id, {child_id: [index_ref], parent_id: []})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_index_tree_conflict_handling(self):
         """
         Test that if another user changes the index tree, the original user
@@ -1919,7 +1919,7 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         return host, extension
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delegating_extensions(self):
         """Make an extension, delegate it, send it back, see what happens"""
         host, extension = self._create_extension()
@@ -1979,7 +1979,7 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         # Hooray!
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_syncs(self):
         host, extension = self._create_extension()
         assert_user_has_case(self, self.user, host.case_id)
@@ -2002,7 +2002,7 @@ class SyncTokenReprocessingTest(SyncBaseTest):
     Tests sync token logic for fixing itself when it gets into a bad state.
     """
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testUpdateNonExisting(self):
         case_id = 'non_existent'
         caseblock = CaseBlock(
@@ -2019,7 +2019,7 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             # this should fail because it's a true error
             pass
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testShouldHaveCase(self):
         case_id = "should_have"
         self._createCaseStubs([case_id])
@@ -2046,7 +2046,7 @@ class SyncTokenReprocessingTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(getattr(sync_log, 'has_assert_errors', False))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testCodependencies(self):
 
         case_id1 = 'bad1'
@@ -2095,7 +2095,7 @@ class SyncTokenReprocessingTest(SyncBaseTest):
 
 class LooseSyncTokenValidationTest(SyncBaseTest):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submission_with_bad_log_default(self):
         with self.assertRaises(ResourceNotFound):
             post_case_blocks(
@@ -2104,7 +2104,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 domain='some-domain-without-toggle',
             )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_submission_with_bad_log_toggle_enabled(self):
         domain = 'submission-domain-with-toggle'
 
@@ -2123,7 +2123,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
         # this is just asserting that an exception is not raised after the toggle is set
         _test()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_restore_with_bad_log_default(self):
         with self.assertRaises(MissingSyncLog):
             RestoreConfig(
@@ -2135,7 +2135,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 ),
             ).get_payload()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_restore_with_bad_log_toggle_enabled(self):
         domain = 'restore-domain-with-toggle'
 

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
@@ -2,31 +2,31 @@ from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_da
     compute_consumption_or_default)
 from casexml.apps.stock.tests.mock_consumption import now
 from casexml.apps.stock.tests.base import StockTestBase
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 class ConsumptionCaseTest(StockTestBase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testNoConsumption(self):
         self._stock_report(25, 5)
         self._stock_report(25, 0)
         self.assertAlmostEqual(0., self._compute_consumption())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testNoConsumptionWithReceipts(self):
         self._stock_report(25, 5)
         self._receipt_report(10, 3)
         self._stock_report(35, 0)
         self.assertAlmostEqual(0., self._compute_consumption())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSimpleConsumption(self):
         self._stock_report(25, 5)
         self._stock_report(10, 0)
         self.assertAlmostEqual(3., self._compute_consumption())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testDefaultValue(self):
         self._stock_report(25, 5)
         self._stock_report(10, 0)

--- a/corehq/ex-submodules/couchforms/tests/test_archive.py
+++ b/corehq/ex-submodules/couchforms/tests/test_archive.py
@@ -9,7 +9,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from corehq.util.context_managers import drop_connected_signals
 from couchforms.signals import xform_archived, xform_unarchived
 
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.util.test_utils import TestFileMixin
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
 
@@ -28,7 +28,7 @@ class TestFormArchiving(TestCase, TestFileMixin):
         FormProcessorTestUtils.delete_all_cases()
         super(TestFormArchiving, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testArchive(self):
         case_id = 'ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169'
         xml_data = self.get_xml('basic')
@@ -70,7 +70,7 @@ class TestFormArchiving(TestCase, TestFileMixin):
         self.assertEqual('unarchive', restoration.operation)
         self.assertEqual('mr. researcher', restoration.user)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSignal(self):
         global archive_counter, restore_counter
         archive_counter = 0

--- a/corehq/ex-submodules/couchforms/tests/test_auth.py
+++ b/corehq/ex-submodules/couchforms/tests/test_auth.py
@@ -5,14 +5,14 @@ from corehq.util.test_utils import TestFileMixin
 from couchforms.models import DefaultAuthContext
 import os
 
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 class AuthTest(TestCase, TestFileMixin):
     file_path = ('data', 'posts')
     root = os.path.dirname(__file__)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_auth_context(self):
         xml_data = self.get_xml('meta')
 

--- a/corehq/ex-submodules/couchforms/tests/test_devicelogs.py
+++ b/corehq/ex-submodules/couchforms/tests/test_devicelogs.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase, TestCase
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.util.test_utils import TestFileMixin
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.form_processor.utils import convert_xform_to_json
 from phonelog.models import UserEntry, DeviceReportEntry, UserErrorEntry, ForceCloseEntry
 from phonelog.utils import _get_logs
@@ -30,7 +30,7 @@ class DeviceLogTest(TestCase, TestFileMixin):
                    .format(obj.__class__.__name__, prop, value, actual))
             self.assertEqual(actual, value, msg)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_devicelog(self):
         xml = self.get_xml('devicelog')
         submit_form_locally(xml, 'test-domain')
@@ -107,7 +107,7 @@ class DeviceLogTest(TestCase, TestFileMixin):
         self.assertIsNotNone(force_closure.server_date)
         self.assertIn("java.lang.Exception: exception_text", force_closure.msg)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_subreports_that_shouldnt_fail(self):
         xml = self.get_xml('subreports_that_shouldnt_fail')
         submit_form_locally(xml, 'test-domain')

--- a/corehq/ex-submodules/couchforms/tests/test_duplicates.py
+++ b/corehq/ex-submodules/couchforms/tests/test_duplicates.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends, post_xform
 from corehq.util.test_utils import TestFileMixin
 
 
@@ -16,7 +16,7 @@ class DuplicateFormTest(TestCase, TestFileMixin):
     def tearDown(self):
         FormProcessorTestUtils.delete_all_xforms()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_duplicate(self):
         xml_data = self.get_xml('duplicate')
         xform = post_xform(xml_data)
@@ -31,7 +31,7 @@ class DuplicateFormTest(TestCase, TestFileMixin):
         if settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual(self.ID, xform.orig_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_wrong_doc_type(self):
         domain = 'test-domain'
         instance = self.get_xml('duplicate')
@@ -52,7 +52,7 @@ class DuplicateFormTest(TestCase, TestFileMixin):
 
         self.assertNotEqual(xform1.form_id, xform2.form_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_wrong_domain(self):
         domain = 'test-domain'
         instance = self.get_xml('duplicate')

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -13,7 +13,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from couchforms.models import UnfinishedSubmissionStub
 
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends, post_xform
 from corehq.util.test_utils import TestFileMixin
 
 
@@ -36,7 +36,7 @@ class EditFormTest(TestCase, TestFileMixin):
         UnfinishedSubmissionStub.objects.all().delete()
         super(EditFormTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_basic_edit(self):
         original_xml = self.get_xml('original')
         edit_xml = self.get_xml('edit')
@@ -72,7 +72,7 @@ class EditFormTest(TestCase, TestFileMixin):
         )
         self.assertEqual(xform.get_xml(), edit_xml)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_edit_an_error(self):
         form_id = uuid.uuid4().hex
         case_block = CaseBlock(
@@ -91,7 +91,7 @@ class EditFormTest(TestCase, TestFileMixin):
         self.assertFalse(form.is_error)
         self.assertEqual(None, getattr(form, 'problem', None))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_broken_save(self):
         """
         Test that if the second form submission terminates unexpectedly
@@ -131,7 +131,7 @@ class EditFormTest(TestCase, TestFileMixin):
             1
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_management(self):
         form_id = uuid.uuid4().hex
         case_id = uuid.uuid4().hex
@@ -180,7 +180,7 @@ class EditFormTest(TestCase, TestFileMixin):
             for a in case.actions:
                 self.assertEqual(form_id, a.xform_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_second_edit_fails(self):
         form_id = uuid.uuid4().hex
         case_id = uuid.uuid4().hex
@@ -205,7 +205,7 @@ class EditFormTest(TestCase, TestFileMixin):
         deprecated_xform = self.formdb.get_form(xform.deprecated_form_id)
         self.assertTrue(deprecated_xform.is_deprecated)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_management_ordering(self):
         case_id = uuid.uuid4().hex
         owner_id = uuid.uuid4().hex

--- a/corehq/ex-submodules/couchforms/tests/test_errors.py
+++ b/corehq/ex-submodules/couchforms/tests/test_errors.py
@@ -1,13 +1,13 @@
 from django.test import TestCase
 
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import softer_assert
 
 
 class CaseProcessingErrorsTest(TestCase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_case_id(self):
         """
         submit form with a case block that has no case_id
@@ -40,7 +40,7 @@ class CaseProcessingErrorsTest(TestCase):
         self.assertTrue(xform.is_error)
         self.assertEqual(xform.problem, 'IllegalCaseId: case_id must not be empty')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @softer_assert()
     def test_uses_referrals(self):
         # submit form with a case block that uses referrals

--- a/corehq/ex-submodules/couchforms/tests/test_meta.py
+++ b/corehq/ex-submodules/couchforms/tests/test_meta.py
@@ -8,7 +8,7 @@ from corehq.util.test_utils import TestFileMixin
 from couchforms.datatypes import GeoPoint
 from couchforms.models import XFormInstance
 
-from corehq.form_processor.tests.utils import run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, post_xform
 
 
 class TestMeta(TestCase, TestFileMixin):
@@ -25,7 +25,7 @@ class TestMeta(TestCase, TestFileMixin):
             del expected['deprecatedID']
         self.assertEqual(xform.metadata.to_json(), expected)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testClosed(self):
         xml_data = self.get_xml('meta')
         xform = post_xform(xml_data)
@@ -51,7 +51,7 @@ class TestMeta(TestCase, TestFileMixin):
         }
         self._check_metadata(xform, result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testDecimalAppVersion(self):
         '''
         Tests that an appVersion that looks like a decimal:
@@ -77,7 +77,7 @@ class TestMeta(TestCase, TestFileMixin):
         }
         self._check_metadata(xform, result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testMetaBadUsername(self):
         xml_data = self.get_xml('meta_bad_username')
         xform = post_xform(xml_data)
@@ -97,7 +97,7 @@ class TestMeta(TestCase, TestFileMixin):
         }
         self._check_metadata(xform, result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testMetaAppVersionDict(self):
         xml_data = self.get_xml('meta_dict_appversion')
         xform = post_xform(xml_data)
@@ -117,7 +117,7 @@ class TestMeta(TestCase, TestFileMixin):
         }
         self._check_metadata(xform, result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_gps_location(self):
         xml_data = self.get_xml('gps_location', override_path=('data',))
 
@@ -148,7 +148,7 @@ class TestMeta(TestCase, TestFileMixin):
         }
         self._check_metadata(xform, result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_empty_gps_location(self):
         xml_data = self.get_xml('gps_empty_location', override_path=('data',))
         xform = post_xform(xml_data)
@@ -160,7 +160,7 @@ class TestMeta(TestCase, TestFileMixin):
 
         self.assertEqual(xform.metadata.to_json()['location'], None)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testMetaDateInDatetimeFields(self):
         xml_data = self.get_xml('date_in_meta', override_path=('data',))
         xform = post_xform(xml_data)
@@ -168,7 +168,7 @@ class TestMeta(TestCase, TestFileMixin):
         self.assertEqual(datetime(2014, 7, 10), xform.metadata.timeStart)
         self.assertEqual(datetime(2014, 7, 11), xform.metadata.timeEnd)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_missing_meta_key(self):
         xml_data = self.get_xml('missing_date_in_meta', override_path=('data',))
         xform = post_xform(xml_data)

--- a/corehq/ex-submodules/couchforms/tests/test_namespaces.py
+++ b/corehq/ex-submodules/couchforms/tests/test_namespaces.py
@@ -1,7 +1,7 @@
 import os
 from django.test import TestCase
 
-from corehq.form_processor.tests.utils import run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, post_xform
 from corehq.util.test_utils import TestFileMixin
 
 
@@ -13,7 +13,7 @@ class TestNamespaces(TestCase, TestFileMixin):
         result = xform.get_data(xpath)
         self.assertEqual(xmlns, result['@xmlns'] if expect_xmlns_index else result)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testClosed(self):
         xml_data = self.get_xml('namespaces')
         xform = post_xform(xml_data)

--- a/corehq/ex-submodules/couchforms/tests/test_post.py
+++ b/corehq/ex-submodules/couchforms/tests/test_post.py
@@ -7,7 +7,7 @@ from corehq.apps.tzmigration.test_utils import \
     run_pre_and_post_timezone_migration
 
 from corehq.util.test_utils import TestFileMixin
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends, post_xform
 
 
 class PostTest(TestCase, TestFileMixin):
@@ -64,30 +64,30 @@ class PostTest(TestCase, TestFileMixin):
         self._test('cloudant-template', tz_differs=True)
         FormProcessorTestUtils.delete_all_xforms()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_decimalmeta(self):
         self._test('decimalmeta', any_id_ok=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_duplicate(self):
         self._test('duplicate')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_meta(self):
         self._test('meta', any_id_ok=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_meta_bad_username(self):
         self._test('meta_bad_username')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_meta_dict_appversion(self):
         self._test('meta_dict_appversion')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_namespaces(self):
         self._test('namespaces', any_id_ok=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unicode(self):
         self._test('unicode', any_id_ok=True)

--- a/corehq/ex-submodules/couchforms/tests/test_xml.py
+++ b/corehq/ex-submodules/couchforms/tests/test_xml.py
@@ -2,7 +2,7 @@
 import uuid
 import os
 from django.test import TestCase
-from corehq.form_processor.tests.utils import run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, post_xform
 from corehq.util.test_utils import TestFileMixin
 
 
@@ -10,7 +10,7 @@ class XMLElementTest(TestCase, TestFileMixin):
     file_path = ('data',)
     root = os.path.dirname(__file__)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_various_encodings(self):
         tests = (
             ('utf-8', u'हिन्दी चट्टानों'),

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -14,7 +14,7 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.backends.couch.update_strategy import coerce_to_datetime
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 
@@ -41,7 +41,7 @@ class FundamentalCaseTests(TestCase):
         self.interface = FormProcessorInterface()
         self.casedb = CaseAccessors()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_case(self):
         case_id = uuid.uuid4().hex
         modified_on = datetime.utcnow()
@@ -73,7 +73,7 @@ class FundamentalCaseTests(TestCase):
 
         self.assertEqual(case.dynamic_case_properties()['dynamic'], '123')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_case_unicode_name(self):
         """
         Submit case blocks with unicode names
@@ -93,7 +93,7 @@ class FundamentalCaseTests(TestCase):
         case = self.casedb.get_case(case_id)
         self.assertEqual(case.name, case_name)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_case(self):
         case_id = uuid.uuid4().hex
         opened_on = datetime.utcnow()
@@ -124,7 +124,7 @@ class FundamentalCaseTests(TestCase):
         self.assertIsNone(case.closed_on)
         self.assertEqual(case.dynamic_case_properties()['dynamic'], '1234')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_close_case(self):
         # same as update, closed, closed on, closed by
         case_id = uuid.uuid4().hex
@@ -148,7 +148,7 @@ class FundamentalCaseTests(TestCase):
         self.assertEqual(case.closed_by, 'user2')
         self.assertTrue(case.server_modified_on > modified_on)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_empty_update(self):
         case_id = uuid.uuid4().hex
         opened_on = datetime.utcnow()
@@ -167,7 +167,7 @@ class FundamentalCaseTests(TestCase):
         case = self.casedb.get_case(case_id)
         self.assertEqual(case.dynamic_case_properties(), {'dynamic': '123'})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_with_index(self):
         # same as update, indexes
         mother_case_id = uuid.uuid4().hex
@@ -192,7 +192,7 @@ class FundamentalCaseTests(TestCase):
         self.assertEqual(index.referenced_type, 'mother')
         self.assertEqual(index.relationship, 'child')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_index(self):
         mother_case_id = uuid.uuid4().hex
         _submit_case_block(
@@ -219,7 +219,7 @@ class FundamentalCaseTests(TestCase):
         case = self.casedb.get_case(child_case_id)
         self.assertEqual(case.indices[0].referenced_type, 'other_mother')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delete_index(self):
         mother_case_id = uuid.uuid4().hex
         _submit_case_block(
@@ -246,7 +246,7 @@ class FundamentalCaseTests(TestCase):
         case = self.casedb.get_case(child_case_id)
         self.assertEqual(len(case.indices), 0)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_invalid_index(self):
         invalid_case_id = uuid.uuid4().hex
         child_case_id = uuid.uuid4().hex
@@ -260,7 +260,7 @@ class FundamentalCaseTests(TestCase):
         self.assertTrue(form.is_error)
         self.assertTrue('InvalidCaseIndex' in form.problem)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_invalid_index_cross_domain(self):
         mother_case_id = uuid.uuid4().hex
         _submit_case_block(
@@ -285,7 +285,7 @@ class FundamentalCaseTests(TestCase):
         # same as update, attachments
         pass
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_date_opened_coercion(self):
         delete_all_users()
         self.project = Domain(name='some-domain')
@@ -307,7 +307,7 @@ class FundamentalCaseTests(TestCase):
         case.date_opened = case.date_opened.date()
         check_user_has_case(self, user, case.as_xml())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_restore_caches_cleared(self):
         cache = get_redis_default_cache()
         cache_key = restore_cache_key(RESTORE_CACHE_KEY_PREFIX, 'user_id', version="2.0")

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -12,7 +12,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseIndexInfo, CaseAcce
 from corehq.form_processor.interfaces.processor import ProcessedForms
 from corehq.form_processor.models import XFormInstanceSQL, CommCareCaseSQL, \
     CaseTransaction, CommCareCaseIndexSQL, CaseAttachmentSQL, SupplyPointCaseMixin
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.tests.test_basic_cases import _submit_case_block
 from corehq.sql_db.routers import db_for_read_write
 
@@ -669,7 +669,7 @@ class CaseAccessorsTests(TestCase):
         FormProcessorTestUtils.delete_all_xforms(DOMAIN)
         FormProcessorTestUtils.delete_all_cases(DOMAIN)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_soft_delete(self):
         _submit_case_block(True, 'c1', domain=DOMAIN)
         _submit_case_block(True, 'c2', domain=DOMAIN)

--- a/corehq/form_processor/tests/test_dbcache.py
+++ b/corehq/form_processor/tests/test_dbcache.py
@@ -8,7 +8,7 @@ from corehq.form_processor.backends.couch.casedb import CaseDbCacheCouch
 from corehq.form_processor.backends.sql.casedb import CaseDbCacheSQL
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 
 
 class CaseDbCacheTest(TestCase):
@@ -20,7 +20,7 @@ class CaseDbCacheTest(TestCase):
         super(CaseDbCacheTest, self).setUp()
         self.interface = FormProcessorInterface()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testDomainCheck(self):
         id = uuid.uuid4().hex
         post_case_blocks([
@@ -56,7 +56,7 @@ class CaseDbCacheTest(TestCase):
         except IllegalCaseId:
             pass
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testGetPopulatesCache(self):
         case_ids = _make_some_cases(3)
         cache = self.interface.casedb_cache()
@@ -70,7 +70,7 @@ class CaseDbCacheTest(TestCase):
         for id in case_ids:
             self.assertTrue(cache.in_cache(id))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testSetPopulatesCache(self):
         case_ids = _make_some_cases(3)
         cache = self.interface.casedb_cache()
@@ -85,7 +85,7 @@ class CaseDbCacheTest(TestCase):
             case = cache.get(id)
             self.assertEqual(str(i), case.dynamic_case_properties()['my_index'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testPopulate(self):
         case_ids = _make_some_cases(3)
         cache = self.interface.casedb_cache()

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -19,7 +19,7 @@ from corehq.form_processor.models import (XFormInstanceSQL, XFormOperationSQL,
     XFormAttachmentSQL, DisabledDbMixin)
 from corehq.form_processor.parsers.form import apply_deprecation
 from corehq.form_processor.tests.utils import (create_form_for_test,
-    FormProcessorTestUtils, run_with_all_backends)
+    FormProcessorTestUtils, conditionally_run_with_all_backends)
 from corehq.form_processor.utils import get_simple_form_xml, get_simple_wrapped_form
 from corehq.form_processor.utils.xform import TestFormMetadata
 from corehq.sql_db.routers import db_for_read_write
@@ -318,7 +318,7 @@ class FormAccessorsTests(TestCase):
         FormProcessorTestUtils.delete_all_xforms(DOMAIN)
         super(FormAccessorsTests, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_soft_delete(self):
         meta = TestFormMetadata(domain=DOMAIN)
         get_simple_wrapped_form('f1', metadata=meta)

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -7,7 +7,7 @@ from corehq.apps.commtrack.tests.util import get_single_balance_block
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils import get_simple_form_xml, should_use_sql_backend
 from corehq.util.test_utils import create_and_save_a_case, create_and_save_a_form
 from pillowtop.pillow.interface import ConstructedPillow
@@ -47,7 +47,7 @@ class KafkaPublishingTest(TestCase):
     def tearDown(self):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_is_published(self):
         with process_kafka_changes(self.form_pillow):
             with process_couch_changes('DefaultChangeFeedPillow'):
@@ -58,7 +58,7 @@ class KafkaPublishingTest(TestCase):
         self.assertEqual(form.form_id, change_meta.document_id)
         self.assertEqual(self.domain, change_meta.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_duplicate_form_published(self):
         form_id = uuid.uuid4().hex
         form_xml = get_simple_form_xml(form_id)
@@ -87,7 +87,7 @@ class KafkaPublishingTest(TestCase):
             self.assertEqual(self.domain, orig_form_meta.domain)
             self.assertEqual(dupe_form.domain, dupe_form.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_soft_deletions(self):
         form = create_and_save_a_form(self.domain)
         with process_kafka_changes(self.form_pillow):
@@ -99,7 +99,7 @@ class KafkaPublishingTest(TestCase):
         self.assertEqual(form.form_id, change_meta.document_id)
         self.assertTrue(change_meta.is_deletion)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_is_published(self):
         with process_kafka_changes(self.case_pillow):
             with process_couch_changes('DefaultChangeFeedPillow'):
@@ -110,7 +110,7 @@ class KafkaPublishingTest(TestCase):
         self.assertEqual(case.case_id, change_meta.document_id)
         self.assertEqual(self.domain, change_meta.domain)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_deletions(self):
         case = create_and_save_a_case(self.domain, case_id=uuid.uuid4().hex, case_name='test case')
         with process_kafka_changes(self.case_pillow):

--- a/corehq/form_processor/tests/test_ledgers.py
+++ b/corehq/form_processor/tests/test_ledgers.py
@@ -14,7 +14,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import LedgerTransaction
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils.general import should_use_sql_backend
 
 DOMAIN = 'ledger-tests'
@@ -67,7 +67,7 @@ class LedgerTests(TestCase):
             get_single_transfer_block(self.case.case_id, None, self.product_a._id, amount)
         ])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_submission(self):
         orignal_form_count = len(self.interface.get_case_forms(self.case.case_id))
         self._set_balance(100)
@@ -78,7 +78,7 @@ class LedgerTests(TestCase):
             self._expected_val(100, 100)
         ])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_submission_multiple(self):
         from corehq.apps.commtrack.tests.util import get_single_balance_block
         balances = {
@@ -105,7 +105,7 @@ class LedgerTests(TestCase):
 
         self._assert_transactions(expected_transactions, ignore_ordering=True)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_balance_submission_with_prior_balance(self):
         self._set_balance(100)
         self._assert_ledger_state(100)
@@ -120,7 +120,7 @@ class LedgerTests(TestCase):
             self._expected_val(100, 150),
         ])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_submission(self):
         orignal_form_count = len(self.interface.get_case_forms(self.case.case_id))
         self._transfer_in(100)
@@ -132,7 +132,7 @@ class LedgerTests(TestCase):
             self._expected_val(100, 100, type_=LedgerTransaction.TYPE_TRANSFER),
         ])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_transfer_submission_with_prior_balance(self):
         self._set_balance(100)
         self._transfer_in(100)
@@ -143,7 +143,7 @@ class LedgerTests(TestCase):
             self._expected_val(100, 200, type_=LedgerTransaction.TYPE_TRANSFER),
         ])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_full_combination(self):
         self._set_balance(100)
         self._transfer_in(100)
@@ -164,7 +164,7 @@ class LedgerTests(TestCase):
             self._expected_val(-30, 140, type_=LedgerTransaction.TYPE_TRANSFER),
         ])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ledger_update_with_case_update(self):
         from corehq.apps.commtrack.tests.util import get_single_balance_block
         submit_case_blocks([

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -160,7 +160,7 @@ def _conditionally_run_with_all_backends():
     to run couch backend as well.
     '''
 
-    should_run_sql_only = os.environ.get('USE_SQL_BACKEND_ONLY') == '1'
+    should_run_sql_only = os.environ.get('USE_SQL_BACKEND_ONLY') == 'yes'
     run_configs = [
         # run with default setting
         RunConfig(

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -161,11 +161,18 @@ def _conditionally_run_with_all_backends():
     '''
 
     should_run_sql_only = os.environ.get('USE_SQL_BACKEND_ONLY') == 'yes'
+
+    def sql_pre_run(*args, **kwargs):
+        # When running just SQL tests we need to tear down the couch setup and setup for sql
+        with args[0].settings(TESTS_SHOULD_USE_SQL_BACKEND=False):
+            args[0].tearDown()
+        args[0].setUp()
     run_configs = [
         # run with default setting
         RunConfig(
+            pre_run=sql_pre_run if should_run_sql_only else None,
             settings={
-                'TESTS_SHOULD_USE_SQL_BACKEND': True,
+                'TESTS_SHOULD_USE_SQL_BACKEND': should_run_sql_only,
             },
             post_run=lambda *args, **kwargs: args[0].tearDown() if not should_run_sql_only else None,
         ),

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -149,28 +149,6 @@ class FormProcessorTestUtils(object):
                     pass
 
 
-run_with_all_backends = functools.partial(
-    run_with_multiple_configs,
-    run_configs=[
-        # run with default setting
-        RunConfig(
-            settings={
-                'TESTS_SHOULD_USE_SQL_BACKEND': getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False),
-            },
-            post_run=lambda *args, **kwargs: args[0].tearDown()
-        ),
-        # run with inverse of default setting
-        RunConfig(
-            settings={
-                'TESTS_SHOULD_USE_SQL_BACKEND': not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False),
-            },
-            pre_run=lambda *args, **kwargs: args[0].setUp(),
-        ),
-    ],
-    nose_tags={'all_backends': True}
-)
-
-
 def _conditionally_run_with_all_backends():
     '''
     Conditionally runs both backends. By default will run both backends, if

--- a/corehq/messaging/ivrbackends/kookoo/tests/outbound.py
+++ b/corehq/messaging/ivrbackends/kookoo/tests/outbound.py
@@ -6,7 +6,7 @@ from corehq.apps.reminders.models import (CaseReminderHandler,
     CaseReminderEvent, FIRE_TIME_DEFAULT,
     EVENT_AS_SCHEDULE, MATCH_EXACT)
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 from corehq.messaging.ivrbackends.kookoo.models import SQLKooKooBackend
 from mock import patch
 from datetime import datetime, time
@@ -103,7 +103,7 @@ class KooKooTestCase(TouchformsTestCase):
         url = "%s/kookoo/ivr_finished/" % self.live_server_url
         return urllib2.urlopen(url, params).read()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def testOutbound(self):
         # Send an outbound call using self.reminder1 to self.case
         # and answer it

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -12,7 +12,7 @@ from custom.enikshay.integrations.nikshay.repeater_generator import (
     NikshayRegisterPatientPayloadGenerator,
     ENIKSHAY_ID,
 )
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from casexml.apps.case.mock import CaseStructure
 from corehq.apps.repeaters.models import RepeatRecord
 from corehq.apps.repeaters.dbaccessors import delete_all_repeat_records, delete_all_repeaters
@@ -95,7 +95,7 @@ class TestNikshayRegisterPatientRepeater(NikshayRepeaterTestBase):
     def test_available_for_domain(self):
         self.assertTrue(NikshayRegisterPatientRepeater.available_for_domain(self.domain))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger(self):
         # nikshay not enabled
         self.create_case(self.episode)
@@ -109,7 +109,7 @@ class TestNikshayRegisterPatientRepeater(NikshayRepeaterTestBase):
         self._create_nikshay_registered_case()
         self.assertEqual(1, len(self.repeat_records().all()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger_different_case_type(self):
         # different case type
         self.create_case(self.person)
@@ -123,7 +123,7 @@ class TestNikshayRegisterPatientPayloadGenerator(ENikshayLocationStructureMixin,
         self.cases = self.create_case_structure()
         self.assign_person_to_location(self.phi.location_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_payload_properties(self):
         episode_case = self._create_nikshay_enabled_case()
         payload = (json.loads(
@@ -175,7 +175,7 @@ class TestNikshayRegisterPatientPayloadGenerator(ENikshayLocationStructureMixin,
         self.assertEqual(payload['regBy'], username)
         self.assertEqual(payload['password'], password)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_success(self):
         nikshay_id = "NIKSHAY!"
         self._create_nikshay_enabled_case()
@@ -202,7 +202,7 @@ class TestNikshayRegisterPatientPayloadGenerator(ENikshayLocationStructureMixin,
         self._assert_case_property_equal(updated_episode_case, 'nikshay_id', nikshay_id)
         self.assertEqual(updated_episode_case.external_id, nikshay_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_bad_nikshay_response(self):
         self._create_nikshay_enabled_case()
         payload_generator = NikshayRegisterPatientPayloadGenerator(None)
@@ -231,7 +231,7 @@ class TestNikshayRegisterPatientPayloadGenerator(ENikshayLocationStructureMixin,
             'No Nikshay ID received: {}'.format(response)
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_duplicate(self):
         payload_generator = NikshayRegisterPatientPayloadGenerator(None)
         payload_generator.handle_failure(
@@ -254,7 +254,7 @@ class TestNikshayRegisterPatientPayloadGenerator(ENikshayLocationStructureMixin,
         self._assert_case_property_equal(updated_episode_case, 'nikshay_registered', 'true')
         self._assert_case_property_equal(updated_episode_case, 'nikshay_error', 'duplicate')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_failure(self):
         message = {
             "Nikshay_Message": "Success",

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_integration.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_integration.py
@@ -3,7 +3,7 @@ import pytz
 from django.test import SimpleTestCase, TestCase
 
 
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from custom.enikshay.integrations.ninetyninedots.views import (
@@ -40,7 +40,7 @@ class NinetyNineDotsCaseTests(ENikshayCaseStructureMixin, TestCase):
     def tearDown(self):
         FormProcessorTestUtils.delete_all_cases()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_adherence_cases(self):
         self.create_case_structure()
         case_accessor = CaseAccessors(self.domain)
@@ -82,7 +82,7 @@ class NinetyNineDotsCaseTests(ENikshayCaseStructureMixin, TestCase):
                 'high'
             )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_adherence_confidence(self):
         self.create_case_structure()
         case_accessor = CaseAccessors(self.domain)
@@ -116,7 +116,7 @@ class NinetyNineDotsCaseTests(ENikshayCaseStructureMixin, TestCase):
             'new_confidence_level',
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_default_confidence_level(self):
         self.create_case_structure()
         confidence_level = "new_confidence_level"

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.test import TestCase
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from casexml.apps.case.mock import CaseStructure
 from corehq.apps.repeaters.models import RepeatRecord
 from corehq.apps.repeaters.dbaccessors import delete_all_repeat_records, delete_all_repeaters
@@ -111,7 +111,7 @@ class TestRegisterPatientRepeater(ENikshayRepeaterTestBase):
         self.repeater.white_listed_case_types = ['episode']
         self.repeater.save()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger(self):
         # 99dots not enabled
         self.create_case(self.episode)
@@ -137,7 +137,7 @@ class TestUpdatePatientRepeater(ENikshayRepeaterTestBase):
         self.repeater.white_listed_case_types = ['person']
         self.repeater.save()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger(self):
         self.create_case_structure()
         self._update_case(self.person_id, {PRIMARY_PHONE_NUMBER: '999999999', })
@@ -152,7 +152,7 @@ class TestUpdatePatientRepeater(ENikshayRepeaterTestBase):
         self._update_case(self.person_id, {PRIMARY_PHONE_NUMBER: '999999999', })
         self.assertEqual(1, len(self.repeat_records().all()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger_multiple_cases(self):
         """Submitting a form with noop case blocks was throwing an exception
         """
@@ -173,7 +173,7 @@ class TestUpdatePatientRepeater(ENikshayRepeaterTestBase):
         self.factory.create_or_update_cases([empty_case, person_case])
         self.assertEqual(1, len(self.repeat_records().all()))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_create_person_no_episode(self):
         """On registration this was failing hard if a phone number was added but no episode was created
         http://manage.dimagi.com/default.asp?241290#1245284
@@ -193,7 +193,7 @@ class TestAdherenceRepeater(ENikshayRepeaterTestBase):
         self.repeater.white_listed_case_types = ['adherence']
         self.repeater.save()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger(self):
         self.create_case_structure()
         self._create_99dots_registered_case()
@@ -221,7 +221,7 @@ class TestTreatmentOutcomeRepeater(ENikshayRepeaterTestBase):
         self.repeater.white_listed_case_types = ['episode']
         self.repeater.save()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trigger(self):
         self.create_case_structure()
         self._create_99dots_registered_case()
@@ -276,7 +276,7 @@ class TestRegisterPatientPayloadGenerator(TestPayloadGeneratorBase):
     def _get_actual_payload(self, casedb):
         return RegisterPatientPayloadGenerator(None).get_payload(None, casedb[self.episode_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_payload(self):
         cases = self.create_case_structure()
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
@@ -287,7 +287,7 @@ class TestRegisterPatientPayloadGenerator(TestPayloadGeneratorBase):
         )
         self._assert_payload_equal(cases, expected_numbers)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_payload_no_numbers(self):
         self.primary_phone_number = None
         self.secondary_phone_number = None
@@ -295,14 +295,14 @@ class TestRegisterPatientPayloadGenerator(TestPayloadGeneratorBase):
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
         self._assert_payload_equal(cases, None)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_payload_secondary_number_only(self):
         self.primary_phone_number = None
         cases = self.create_case_structure()
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
         self._assert_payload_equal(cases, u"+91{}".format(self.secondary_phone_number.replace("0", "")))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_success(self):
         cases = self.create_case_structure()
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
@@ -318,7 +318,7 @@ class TestRegisterPatientPayloadGenerator(TestPayloadGeneratorBase):
             ''
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_failure(self):
         cases = self.create_case_structure()
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
@@ -343,7 +343,7 @@ class TestUpdatePatientPayloadGenerator(TestPayloadGeneratorBase):
     def _get_actual_payload(self, casedb):
         return UpdatePatientPayloadGenerator(None).get_payload(None, casedb[self.person_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_payload(self):
         cases = self.create_case_structure()
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
@@ -353,7 +353,7 @@ class TestUpdatePatientPayloadGenerator(TestPayloadGeneratorBase):
         )
         self._assert_payload_equal(cases, expected_numbers)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_success(self):
         cases = self.create_case_structure()
         self.factory.create_or_update_case(CaseStructure(
@@ -371,7 +371,7 @@ class TestUpdatePatientPayloadGenerator(TestPayloadGeneratorBase):
             ''
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_failure(self):
         cases = self.create_case_structure()
         payload_generator = UpdatePatientPayloadGenerator(None)
@@ -390,7 +390,7 @@ class TestAdherencePayloadGenerator(TestPayloadGeneratorBase):
     def _get_actual_payload(self, casedb):
         return AdherencePayloadGenerator(None).get_payload(None, casedb['adherence'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_payload(self):
         date = datetime(2017, 2, 20)
         cases = self.create_case_structure()
@@ -405,7 +405,7 @@ class TestAdherencePayloadGenerator(TestPayloadGeneratorBase):
         )
         self.assertEqual(self._get_actual_payload(cases), expected_payload)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_success(self):
         date = datetime(2017, 2, 20)
         cases = self.create_case_structure()
@@ -430,7 +430,7 @@ class TestAdherencePayloadGenerator(TestPayloadGeneratorBase):
             'true'
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_handle_failure(self):
         date = datetime(2017, 2, 20)
         cases = self.create_case_structure()
@@ -452,7 +452,7 @@ class TestTreatmentOutcomePayloadGenerator(TestPayloadGeneratorBase):
     def _get_actual_payload(self, casedb):
         return TreatmentOutcomePayloadGenerator(None).get_payload(None, casedb[self.episode_id])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_payload(self):
         cases = self.create_case_structure()
         cases[self.episode_id] = self.create_case(

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -9,7 +9,7 @@ from mock import patch
 from casexml.apps.case.const import ARCHIVED_CASE_OWNER_ID
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from custom.enikshay.nikshay_datamigration.models import Outcome, PatientDetail
 from custom.enikshay.tests.utils import ENikshayLocationStructureMixin
 
@@ -65,7 +65,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
 
         super(TestCreateEnikshayCases, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     @patch('custom.enikshay.nikshay_datamigration.factory.datetime')
     def test_case_creation(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2016, 9, 8, 1, 2, 3, 4123)
@@ -188,7 +188,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         drtb_hiv_referral_case_ids = self.case_accessor.get_case_ids_in_domain(type='drtb_hiv_referral')
         self.assertEqual(0, len(drtb_hiv_referral_case_ids))
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_drtb_hiv_referral(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
@@ -207,7 +207,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         self.assertEqual('A B C', drtb_hiv_referral_case.name)
         self.assertEqual(self.drtb_hiv.location_id, drtb_hiv_referral_case.owner_id)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_update(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
@@ -239,7 +239,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         episode_case = self.case_accessor.get_case(episode_case_ids[0])
         self.assertEqual(episode_case.dynamic_case_properties()['disease_classification'], 'extra_pulmonary')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_location_not_found(self):
         self.phi.delete()
         call_command('create_enikshay_cases', self.domain)
@@ -252,7 +252,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         self.assertEqual(person_case.dynamic_case_properties()['migration_error'], 'location_not_found')
         self.assertEqual(person_case.dynamic_case_properties()['migration_error_details'], 'MH-ABD-1-2')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_outcome_cured(self):
         self.outcome.Outcome = '1'
         self.outcome.OutcomeDate = '2/01/2017'
@@ -278,7 +278,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         self.assertEqual(episode_case.dynamic_case_properties()['treatment_outcome'], 'cured')
         self.assertEqual(episode_case.dynamic_case_properties()['treatment_outcome_date'], '2017-01-02')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_outcome_died(self):
         self.outcome.Outcome = '3'
         self.outcome.OutcomeDate = '2-01-2017'

--- a/custom/enikshay/tests/test_case_utils.py
+++ b/custom/enikshay/tests/test_case_utils.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from custom.enikshay.tests.utils import ENikshayCaseStructureMixin, ENikshayLocationStructureMixin
 from custom.enikshay.exceptions import NikshayLocationNotFound
-from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends, FormProcessorTestUtils
 
 from custom.enikshay.case_utils import (
     get_open_episode_case_from_person,
@@ -36,7 +36,7 @@ class ENikshayCaseUtilsTests(ENikshayCaseStructureMixin, TestCase):
         super(ENikshayCaseUtilsTests, self).tearDown()
         FormProcessorTestUtils.delete_all_cases()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_adherence_cases_between_dates(self):
         adherence_dates = [
             datetime(2005, 7, 10),
@@ -78,32 +78,32 @@ class ENikshayCaseUtilsTests(ENikshayCaseStructureMixin, TestCase):
             fetched_cases[0].case_id,
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_episode(self):
         self.assertEqual(get_open_episode_case_from_person(self.domain, 'person').case_id, 'episode')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_occurrence_case_from_episode(self):
         self.assertEqual(
             get_occurrence_case_from_episode(self.domain, self.episode_id).case_id,
             self.occurrence_id
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_person_case_from_occurrence(self):
         self.assertEqual(
             get_person_case_from_occurrence(self.domain, self.occurrence_id).case_id,
             self.person_id
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_person_case_from_episode(self):
         self.assertEqual(
             get_person_case_from_episode(self.domain, self.episode_id).case_id,
             self.person_id
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_update_case(self):
         update_properties = {'age': 99}
         self.factory.create_or_update_cases([self.person])
@@ -114,21 +114,21 @@ class ENikshayCaseUtilsTests(ENikshayCaseStructureMixin, TestCase):
         person_case = case_accessors.get_case(self.person_id)
         self.assertEqual(person_case.dynamic_case_properties()['age'], '99')
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_open_occurrence_case_from_person(self):
         self.assertEqual(
             get_open_occurrence_case_from_person(self.domain, self.person_id).case_id,
             self.occurrence_id
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_open_episode_case_from_occurrence(self):
         self.assertEqual(
             get_open_episode_case_from_occurrence(self.domain, self.occurrence_id).case_id,
             self.episode_id
         )
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_get_episode_case_from_adherence(self):
         adherence_case = self.create_adherence_cases([datetime(2017, 2, 17)])[0]
         self.assertEqual(

--- a/custom/icds_reports/ucr/tests/test_ccs_record_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_ccs_record_monthly.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, date
 from xml.etree import ElementTree
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseStructure, CaseIndex
 from custom.icds_reports.ucr.tests.base_test import BaseICDSDatasourceTest, add_element
@@ -202,7 +202,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
 
         submit_form_locally(ElementTree.tostring(form), self.domain, **{})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_open_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -223,7 +223,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_alive_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -243,7 +243,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_demographic_data(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -268,7 +268,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_thr_rations(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -306,7 +306,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_lactating_post(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -326,7 +326,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_preg_to_lactating(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -345,7 +345,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_pre_preg(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -364,7 +364,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_postnatal(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -384,7 +384,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_tt_complete_none(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -402,7 +402,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_tt_complete(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -421,7 +421,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_delivered_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -440,7 +440,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trimester_1_2(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -459,7 +459,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_trimester_3_none(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -478,7 +478,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_anc_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -507,7 +507,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anc1_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -536,7 +536,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anc2_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -565,7 +565,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anc3_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -594,7 +594,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anc4_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -623,7 +623,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reg_trimester_3_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -642,7 +642,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reg_trimester_2_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -662,7 +662,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases, start_date=start_date)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_reg_trimester_1_at_delivery(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -682,7 +682,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases, start_date=start_date)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_bp_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -705,7 +705,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_pnc_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -729,7 +729,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_bp_last_submitted_form(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -781,7 +781,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_bp_any_submitted_form(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -851,7 +851,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anemic_unknown(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -874,7 +874,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anemia_normal(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -920,7 +920,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anemia_moderate(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -966,7 +966,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_anemia_severe(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -1012,7 +1012,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_counsel_methods_pnc(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -1043,7 +1043,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_counsel_methods_ebf(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(
@@ -1074,7 +1074,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_bp_pnc_complete(self):
         case_id = uuid.uuid4().hex
         self._create_ccs_case(

--- a/custom/icds_reports/ucr/tests/test_child_health_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_child_health_monthly.py
@@ -3,7 +3,7 @@ from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from xml.etree import ElementTree
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseStructure, CaseIndex
 from custom.icds_reports.ucr.tests.base_test import BaseICDSDatasourceTest, add_element
@@ -428,7 +428,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
 
         submit_form_locally(ElementTree.tostring(form), self.domain, **{})
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_demographic_data(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -454,7 +454,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_open_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -474,7 +474,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_alive_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -493,7 +493,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_valid_in_month(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -512,7 +512,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_in_months(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -530,7 +530,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_0_to_6(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -547,7 +547,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_6_to_12(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -564,7 +564,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_12_to_24(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -580,7 +580,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_24_to_36(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -596,7 +596,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_36_to_48(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -612,7 +612,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_48_to_60(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -628,7 +628,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_60_to_72(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -644,7 +644,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_age_tranche_72_to_null(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -660,7 +660,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_wer_eligible(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -679,7 +679,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_thr_eligible_6mo(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -698,7 +698,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_thr_eligible_36mo(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -717,7 +717,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ebf_eligible(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -736,7 +736,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cf_eligible_6mo(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -755,7 +755,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cf_eligible_24mo(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -774,7 +774,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_pse_eligible_36mo(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -793,7 +793,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_pse_eligible_72mo(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -811,7 +811,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_nutrition_status_delivery(self):
         case_id = uuid.uuid4().hex
         case_id_2 = uuid.uuid4().hex
@@ -876,7 +876,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_nutrition_status_gmp(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -951,7 +951,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_thr_rations(self):
         case_id = uuid.uuid4().hex
         case_id_2 = uuid.uuid4().hex
@@ -995,7 +995,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_pse(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1030,7 +1030,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_born_in_month_positive(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1058,7 +1058,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_born_in_month_negative(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1084,7 +1084,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ebf_ebf_form(self):
         case_id = uuid.uuid4().hex
         case_id_2 = uuid.uuid4().hex
@@ -1190,7 +1190,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_pnc_form(self):
         case_id = uuid.uuid4().hex
         case_id_2 = uuid.uuid4().hex
@@ -1275,7 +1275,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ebf_no_ebf_reasons(self):
         case_id = uuid.uuid4().hex
         case_id_2 = uuid.uuid4().hex
@@ -1376,7 +1376,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_cf(self):
         case_id = uuid.uuid4().hex
         case_id_2 = uuid.uuid4().hex
@@ -1468,7 +1468,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fully_immunized_eligible(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1485,7 +1485,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fully_immunized_on_time(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1509,7 +1509,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_fully_immunized_late(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1536,7 +1536,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_immediate_breastfeeding(self):
         case_id = uuid.uuid4().hex
         self._create_case(
@@ -1557,7 +1557,7 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
                  ]
         self._run_iterative_monthly_test(case_id=case_id, cases=cases)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_yes_immediate_breastfeeding(self):
         case_id = uuid.uuid4().hex
         self._create_case(

--- a/custom/ucla/tests.py
+++ b/custom/ucla/tests.py
@@ -7,7 +7,7 @@ from corehq.apps.fixtures.models import (
     FixtureDataType, FixtureTypeField, FixtureDataItem, FieldList, FixtureItemField
 )
 from corehq.apps.users.models import WebUser
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import conditionally_run_with_all_backends
 from corehq.util.test_utils import create_test_case
 from custom.ucla.api import ucla_message_bank_content
 
@@ -103,12 +103,12 @@ class TestUCLACustomHandler(TestCase):
         data_item.save()
         self.addCleanup(data_item.delete)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_message_bank_doesnt_exist(self):
         with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
             self.assertRaises(AssertionError, ucla_message_bank_content, self._reminder(), self._handler(), case)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_message_bank_doesnt_have_correct_properties(self):
         data_type = FixtureDataType(
             domain=self.domain_name,
@@ -125,32 +125,32 @@ class TestUCLACustomHandler(TestCase):
         self._setup_fixture_type()
         self.assertRaises(AssertionError, ucla_message_bank_content, self._reminder(), self._handler(), None)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_passing_case_without_risk_profile(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
             self.assertRaises(AssertionError, ucla_message_bank_content, self._reminder(), self._handler(), case)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_relevant_message_invalid_risk(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk2'}) as case:
             self.assertRaises(AssertionError, ucla_message_bank_content, self._reminder(), self._handler(), case)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_no_relevant_message_invalid_seq_num(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
             self.assertRaises(AssertionError, ucla_message_bank_content, self._reminder(iteration_num=2), self._handler(), case)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_multiple_relevant_messages(self):
         self._setup_fixture_type()
         self._setup_data_item('risk1', '1', 'message2')
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
             self.assertRaises(AssertionError, ucla_message_bank_content, self._reminder(), self._handler(), case)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_correct_message(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -6,7 +6,7 @@ from elasticsearch.exceptions import ConnectionError
 from corehq.apps.es import CaseES
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup, create_and_save_a_case
@@ -31,7 +31,7 @@ class CasePillowTest(TestCase):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
         super(CasePillowTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_pillow(self):
         case_id, case_name = self._create_case_and_sync_to_es()
 
@@ -43,7 +43,7 @@ class CasePillowTest(TestCase):
         self.assertEqual(case_id, case_doc['_id'])
         self.assertEqual(case_name, case_doc['name'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_soft_deletion(self):
         case_id, case_name = self._create_case_and_sync_to_es()
 

--- a/testapps/test_pillowtop/tests/test_ledger_pillow.py
+++ b/testapps/test_pillowtop/tests/test_ledger_pillow.py
@@ -10,7 +10,7 @@ from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
 from corehq.apps.change_feed.topics import get_topic_offset
 from corehq.elastic import get_es_new
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.pillows.ledger import get_ledger_to_elasticsearch_pillow
 from corehq.pillows.mappings.ledger_mapping import LEDGER_INDEX_INFO
@@ -46,7 +46,7 @@ class LedgerPillowTest(TestCase):
         FormProcessorTestUtils.delete_all_cases(self.domain)
         super(LedgerPillowTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ledger_pillow(self):
         factory = CaseFactory(domain=self.domain)
         case = factory.create_case()
@@ -82,7 +82,7 @@ class LedgerPillowTest(TestCase):
         # confirm change made it to elasticserach
         self._assert_ledger_in_es(ref)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_ledger_reindexer(self):
         factory = CaseFactory(domain=self.domain)
         case = factory.create_case()

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -15,7 +15,7 @@ from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
-    run_with_all_backends
+    conditionally_run_with_all_backends
 from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX
@@ -59,7 +59,7 @@ class PillowtopReindexerTest(TestCase):
         self.assertEqual('Domain', domain_doc['doc_type'])
         delete_es_index(DOMAIN_INDEX)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_reindexer_v2(self):
         FormProcessorTestUtils.delete_all_cases()
         case = _create_and_save_a_case()
@@ -69,7 +69,7 @@ class PillowtopReindexerTest(TestCase):
 
         self._assert_case_is_in_es(case)
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_case_search_reindexer(self):
         es = get_es_new()
         FormProcessorTestUtils.delete_all_cases()
@@ -91,7 +91,7 @@ class PillowtopReindexerTest(TestCase):
         es.indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
         self._assert_case_is_in_es(case, esquery=CaseSearchES())
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_xform_reindexer_v2(self):
         FormProcessorTestUtils.delete_all_xforms()
         form = create_and_save_a_form(DOMAIN)

--- a/testapps/test_pillowtop/tests/test_report_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_case_pillow.py
@@ -5,7 +5,7 @@ from elasticsearch.exceptions import ConnectionError
 
 from corehq.apps.es import CaseES
 from corehq.elastic import get_es_new
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX_INFO
 from corehq.pillows.reportcase import get_report_case_reindexer
 from corehq.util.elastic import ensure_index_deleted
@@ -34,7 +34,7 @@ class ReportCasePillowTest(TestCase):
         FormProcessorTestUtils.delete_all_cases()
         super(ReportCasePillowTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_report_case_pillow(self):
         case_id, case_name = self._create_case_and_sync_to_es(DOMAIN)
 
@@ -46,7 +46,7 @@ class ReportCasePillowTest(TestCase):
         self.assertEqual(case_id, case_doc['_id'])
         self.assertEqual(case_name, case_doc['name'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unsupported_domain(self):
         self._create_case_and_sync_to_es('unsupported-domain')
 
@@ -80,7 +80,7 @@ class ReportCaseReindexerTest(TestCase):
         ensure_index_deleted(REPORT_CASE_INDEX_INFO.index)
         super(ReportCaseReindexerTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_report_case_reindexer(self):
         cases_included = set()
         for i in range(3):

--- a/testapps/test_pillowtop/tests/test_report_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_xform_pillow.py
@@ -4,7 +4,7 @@ from elasticsearch.exceptions import ConnectionError
 from corehq.apps.es import FormES
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.reportxform import get_report_xforms_reindexer
@@ -33,7 +33,7 @@ class ReportXformPillowTest(TestCase):
         ensure_index_deleted(REPORT_XFORM_INDEX_INFO.index)
         super(ReportXformPillowTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_report_xform_pillow(self):
         form, metadata = self._create_form_and_sync_to_es(DOMAIN)
 
@@ -46,7 +46,7 @@ class ReportXformPillowTest(TestCase):
         self.assertEqual('XFormInstance', form_doc['doc_type'])
         self.assertEqual(form.form_id, form_doc['_id'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unsupported_domain(self):
         form, metadata = self._create_form_and_sync_to_es('unsupported-domain')
 
@@ -79,7 +79,7 @@ class ReportXformReindexerTest(TestCase):
         ensure_index_deleted(REPORT_XFORM_INDEX_INFO.index)
         super(ReportXformReindexerTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_report_xform_reindexer(self):
         forms_included = set()
         for i in range(3):

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -13,7 +13,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.change_publishers import change_meta_from_sql_form
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.pillows.user import get_user_pillow, get_unknown_users_pillow
@@ -91,7 +91,7 @@ class UserPillowTest(UserPillowTestBase):
 
 class UnknownUserPillowTest(UserPillowTestBase):
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_unknown_user_pillow(self):
         FormProcessorTestUtils.delete_all_xforms()
         user_id = 'test-unknown-user'

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -8,7 +8,7 @@ from corehq.apps.es import FormES
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, conditionally_run_with_all_backends
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.pillows.xform import (
@@ -34,7 +34,7 @@ class XFormPillowTest(TestCase):
         ensure_index_deleted(XFORM_INDEX_INFO.index)
         super(XFormPillowTest, self).tearDown()
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_xform_pillow(self):
         form, metadata = self._create_form_and_sync_to_es()
 
@@ -47,7 +47,7 @@ class XFormPillowTest(TestCase):
         self.assertEqual(metadata.xmlns, form_doc['xmlns'])
         self.assertEqual('XFormInstance', form_doc['doc_type'])
 
-    @run_with_all_backends
+    @conditionally_run_with_all_backends
     def test_form_soft_deletion(self):
         form, metadata = self._create_form_and_sync_to_es()
 


### PR DESCRIPTION
@dimagi/test-team This makes it possible to _not_ run both backends for tests marked as `run_with_all_backends`. We run our `casexml` tests 4 times, twice during the normal run when tests are marked as `run_with_all_backends` and then again for the python sharded tests. It's redundant to run the Couch backend for testing the python sharding, and it's particularly painful because these are some of our slowest tests. I also think this'll just be generally useful, since there have been many times where i've been debugging something in a test not related to the backend and having the test run twice in a row is annoying. Big PR, but mainly it's find and replace. Best read 🐟 

cc: @kaapstorm 