### PR TITLE
Dynamically generate sql backend test cases

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -16,8 +16,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
-    run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, generate_sql_backend_test_case
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from corehq.util.test_utils import flag_enabled
 from casexml.apps.case.tests.util import (
@@ -159,13 +158,13 @@ class SyncBaseTest(TestCase):
             self._testUpdate(migrated_sync_log, case_id_map, dependent_case_id_map)
 
 
+@generate_sql_backend_test_case
 class SyncTokenUpdateTest(SyncBaseTest):
     """
     Tests sync token updates on submission related to the list of cases
     on the phone and the footprint.
     """
 
-    @run_with_all_backends
     def testInitialEmpty(self):
         """
         Tests that a newly created sync token has no cases attached to it.
@@ -173,7 +172,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_exactly_one_wrapped_sync_log()
         self._testUpdate(sync_log.get_id, {}, {})
 
-    @run_with_all_backends
     def testOwnUpdatesDontSync(self):
         case_id = "own_updates_dont_sync"
         self._createCaseStubs([case_id])
@@ -189,7 +187,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         )
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
     def test_change_index_type(self):
         """
         Test that changing an index type updates the sync log
@@ -206,7 +203,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [],
                                                 child_id: [parent_ref]})
 
-    @run_with_all_backends
     def test_change_index_id(self):
         """
         Test that changing an index ID updates the sync log
@@ -228,7 +224,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [],
                                                 child_id: [parent_ref]})
 
-    @run_with_all_backends
     def test_add_multiple_indices(self):
         """
         Test that adding multiple indices works as expected
@@ -253,7 +248,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], new_case_id: [],
                                                 child_id: [parent_ref, new_index_ref]})
 
-    @run_with_all_backends
     def test_delete_only_index(self):
         child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # delete the first index
@@ -263,7 +257,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: []})
 
-    @run_with_all_backends
     def test_delete_one_of_multiple_indices(self):
         # make IDs both human readable and globally unique to this test
         uid = uuid.uuid4().hex
@@ -324,7 +317,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: [parent_ref]})
         return (child_id, parent_id, index_id, parent_ref)
 
-    @run_with_all_backends
     def testClosedParentIndex(self):
         """
         Tests that things work properly when you have a reference to the parent
@@ -361,7 +353,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # try a clean restore again
         assert_user_has_cases(self, self.user, [parent_id, child_id])
 
-    @run_with_all_backends
     def testAssignToNewOwner(self):
         # create parent and child
         parent_id = "mommy"
@@ -396,7 +387,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # child should be moved, parent should still be there
         self._testUpdate(self.sync_log.get_id, {parent_id: []}, {})
 
-    @run_with_all_backends
     def testArchiveUpdates(self):
         """
         Tests that archiving a form (and changing a case) causes the
@@ -418,7 +408,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         form.archive()
         assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id, purge_restore_cache=True)
 
-    @run_with_all_backends
     def testUserLoggedIntoMultipleDevices(self):
         # test that a child case created by the same user from a different device
         # gets included in the sync
@@ -443,7 +432,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # ensure child case is included in sync using original sync log ID
         assert_user_has_case(self, self.user, child_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
     def test_tiered_parent_closing(self):
         all_ids = [uuid.uuid4().hex for i in range(3)]
         [grandparent_id, parent_id, child_id] = all_ids
@@ -482,7 +470,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
             # once the child is closed, all three are no longer relevant
             self.assertFalse(sync_log.phone_is_holding_case(id))
 
-    @run_with_all_backends
     def test_create_immediately_irrelevant_parent_case(self):
         """
         Make a case that is only relevant through a dependency at the same
@@ -507,7 +494,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
                                       referenced_id=parent_id)
         self._testUpdate(self.sync_log._id, {child_id: [index_ref]}, {parent_id: []})
 
-    @run_with_all_backends
     def test_closed_case_not_in_next_sync(self):
         # create a case
         case_id = self.factory.create_case().case_id
@@ -529,7 +515,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         last_sync = synclog_from_restore_payload(restore_config.get_payload().as_string())
         self.assertFalse(last_sync.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_sync_by_user_id(self):
         # create a case with an empty owner but valid user id
         case_id = self.factory.create_case(owner_id='', user_id=self.user_id).case_id
@@ -539,12 +524,10 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = synclog_from_restore_payload(payload)
         self.assertTrue(sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_irrelevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': 'irrelevant_2'}, strict=False)
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_relevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': self.user_id}, strict=False)
@@ -555,20 +538,17 @@ class SyncTokenUpdateTest(SyncBaseTest):
         if isinstance(sync_log, SimplifiedSyncLog):
             self.assertTrue(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_relevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id=self.user_id, update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         if isinstance(sync_log, SimplifiedSyncLog):
             self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_relevant_owner_then_submit_again_with_no_owner(self):
         case = self.factory.create_case()
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
@@ -580,7 +560,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertTrue(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_then_submit_again_with_no_owner(self):
         case = self.factory.create_case(owner_id='irrelevant_1')
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
@@ -592,7 +571,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case().case_id
@@ -617,7 +595,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # they should both be gone
         self._testUpdate(self.sync_log._id, {}, {})
 
-    @run_with_all_backends
     def test_create_closed_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case().case_id
@@ -643,12 +620,10 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # they should both be gone
         self._testUpdate(self.sync_log._id, {}, {})
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_close_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', close=True)
 
-    @run_with_all_backends
     def test_reassign_and_close_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         case_id = self.factory.create_case().case_id
@@ -659,7 +634,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
             )
         )
 
-    @run_with_all_backends
     def test_index_after_close(self):
         parent_id = self.factory.create_case().case_id
         case_id = uuid.uuid4().hex
@@ -677,7 +651,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # before this test was written, the case stayed on the sync log even though it was closed
         self.assertFalse(sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_index_chain_with_closed_parents(self):
         grandparent = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -721,7 +694,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
              grandparent.case_id: []}
         )
 
-    @run_with_all_backends
     def test_reassign_case_and_sync(self):
         case = self.factory.create_case()
         # reassign from an empty sync token, simulating a web-reassignment on HQ
@@ -737,7 +709,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         next_sync_log = synclog_from_restore_payload(payload)
         self.assertFalse(next_sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_cousins(self):
         """http://manage.dimagi.com/default.asp?189528
         """
@@ -776,15 +747,14 @@ class SyncTokenUpdateTest(SyncBaseTest):
         ])
 
 
+@generate_sql_backend_test_case
 class SyncDeletedCasesTest(SyncBaseTest):
 
-    @run_with_all_backends
     def test_deleted_case_doesnt_sync(self):
         case = self.factory.create_case()
         case.soft_delete()
         assert_user_doesnt_have_case(self, self.user, case.case_id)
 
-    @run_with_all_backends
     def test_deleted_parent_doesnt_sync(self):
         parent_id = uuid.uuid4().hex
         child_id = uuid.uuid4().hex
@@ -807,11 +777,11 @@ class SyncDeletedCasesTest(SyncBaseTest):
         assert_user_has_case(self, self.user, child_id)
 
 
+@generate_sql_backend_test_case
 class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
     """Makes sure the extension case trees are propertly updated
     """
 
-    @run_with_all_backends
     def test_create_extension(self):
         """creating an extension should add it to the extension_index_tree
         """
@@ -838,7 +808,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
 
-    @run_with_all_backends
     def test_create_multiple_indices(self):
         """creating multiple indices should add to the right tree
         """
@@ -868,7 +837,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {'host': host.case_id}})
 
-    @run_with_all_backends
     def test_create_extension_with_extension(self):
         """creating multiple extensions should be added to the right tree
         """
@@ -903,7 +871,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.index_tree.indices, {})
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
 
-    @run_with_all_backends
     def test_create_extension_then_delegate(self):
         """A delegated extension should still remain on the phone with the host
         """
@@ -931,7 +898,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
 
-    @run_with_all_backends
     def test_create_delegated_extension(self):
         case_type = 'case'
         host = CaseStructure(case_id='host',
@@ -953,7 +919,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
         self.assertEqual(sync_log.case_ids_on_phone, set([host.case_id, extension.case_id]))
 
-    @run_with_all_backends
     def test_close_host(self):
         """closing a host should update the appropriate trees
         """
@@ -984,7 +949,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([]))
         self.assertEqual(sync_log.case_ids_on_phone, set([]))
 
-    @run_with_all_backends
     def test_long_chain_with_children(self):
         """
                   +----+
@@ -1047,6 +1011,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.case_ids_on_phone, all_ids)
 
 
+@generate_sql_backend_test_case
 class ExtensionCasesFirstSync(SyncBaseTest):
 
     def setUp(self):
@@ -1054,7 +1019,6 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.restore_config = RestoreConfig(project=self.project, restore_user=self.user)
         self.restore_state = self.restore_config.restore_state
 
-    @run_with_all_backends
     def test_is_first_extension_sync(self):
         """Before any syncs, this should return true when the toggle is enabled, otherwise false"""
         with flag_enabled('EXTENSION_CASES_SYNC_ENABLED'):
@@ -1062,7 +1026,6 @@ class ExtensionCasesFirstSync(SyncBaseTest):
 
         self.assertFalse(self.restore_state.is_first_extension_sync)
 
-    @run_with_all_backends
     def test_is_first_extension_sync_after_sync(self):
         """After a sync with the extension code in place, this should be false"""
         self.factory.create_case()
@@ -1076,12 +1039,12 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.assertFalse(config.restore_state.is_first_extension_sync)
 
 
+@generate_sql_backend_test_case
 class ChangingOwnershipTest(SyncBaseTest):
 
     def setUp(self):
         super(ChangingOwnershipTest, self).setUp()
 
-    @run_with_all_backends
     def test_remove_user_from_group(self):
         group = Group(
             domain=self.project.name,
@@ -1115,7 +1078,6 @@ class ChangingOwnershipTest(SyncBaseTest):
         self.assertFalse(group._id in incremental_sync_log.owner_ids_on_phone)
         self.assertFalse(incremental_sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_add_user_to_group(self):
         group = Group(
             domain=self.project.name,
@@ -1147,9 +1109,9 @@ class ChangingOwnershipTest(SyncBaseTest):
         return synclog_from_restore_payload(incremental_restore_config.get_payload().as_string())
 
 
+@generate_sql_backend_test_case
 class SyncTokenCachingTest(SyncBaseTest):
 
-    @run_with_all_backends
     def testCaching(self):
         self.assertFalse(self.sync_log.has_cached_payload(V2))
         # first request should populate the cache
@@ -1190,7 +1152,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         versioned_sync_log = synclog_from_restore_payload(versioned_payload)
         self.assertNotEqual(next_sync_log._id, versioned_sync_log._id)
 
-    @run_with_all_backends
     def test_initial_cache(self):
         restore_config = RestoreConfig(
             project=self.project,
@@ -1204,7 +1165,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         cached_payload = restore_config.get_payload()
         self.assertIsInstance(cached_payload, CachedResponse)
 
-    @run_with_all_backends
     def testCacheInvalidation(self):
         original_payload = RestoreConfig(
             project=self.project,
@@ -1241,7 +1201,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         # we can be explicit about why this is the case
         self.assertTrue(self.sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def testCacheNonInvalidation(self):
         original_payload = RestoreConfig(
             project=self.project,
@@ -1275,7 +1234,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertEqual(original_payload, next_payload)
         self.assertFalse(case_id in next_payload)
 
-    @run_with_all_backends
     def testCacheInvalidationAfterFileDelete(self):
         # first request should populate the cache
         original_payload = RestoreConfig(
@@ -1294,6 +1252,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertNotEqual(original_payload.get_filename(), next_file.get_filename())
 
 
+@generate_sql_backend_test_case
 class MultiUserSyncTest(SyncBaseTest):
     """
     Tests the interaction of two users in sync mode doing various things
@@ -1337,7 +1296,6 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue(self.shared_group._id in self.sync_log.owner_ids_on_phone)
         self.assertTrue(self.user_id in self.sync_log.owner_ids_on_phone)
 
-    @run_with_all_backends
     def testSharedCase(self):
         # create a case by one user
         case_id = "shared_case"
@@ -1345,7 +1303,6 @@ class MultiUserSyncTest(SyncBaseTest):
         # should sync to the other owner
         assert_user_has_case(self, self.other_user, case_id, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
     def testOtherUserEdits(self):
         # create a case by one user
         case_id = "other_user_edits"
@@ -1369,7 +1326,6 @@ class MultiUserSyncTest(SyncBaseTest):
         _, match = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
         self.assertTrue("Hello!" in match.to_string())
 
-    @run_with_all_backends
     def testOtherUserAddsIndex(self):
         time = datetime.utcnow()
 
@@ -1429,7 +1385,6 @@ class MultiUserSyncTest(SyncBaseTest):
         _, orig = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
         self.assertTrue("index" in orig.to_string())
 
-    @run_with_all_backends
     def testMultiUserEdits(self):
         time = datetime.utcnow()
 
@@ -1496,7 +1451,6 @@ class MultiUserSyncTest(SyncBaseTest):
         check_user_has_case(self, self.user, joint_change, restore_id=main_sync_log.get_id)
         check_user_has_case(self, self.other_user, joint_change, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
     def testOtherUserCloses(self):
         # create a case from one user
         case_id = "other_user_closes"
@@ -1527,7 +1481,6 @@ class MultiUserSyncTest(SyncBaseTest):
         )
         self.assertFalse(next_synclog.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def testOtherUserUpdatesUnowned(self):
         # create a case from one user and assign ownership elsewhere
         case_id = "other_user_updates_unowned"
@@ -1552,7 +1505,6 @@ class MultiUserSyncTest(SyncBaseTest):
         # make sure there are no new changes
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
     def testIndexesSync(self):
         # create a parent and child case (with index) from one user
         parent_id = "indexes_sync_parent"
@@ -1586,7 +1538,6 @@ class MultiUserSyncTest(SyncBaseTest):
                              purge_restore_cache=True)
         assert_user_has_case(self, self.other_user, case_id, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
     def testOtherUserUpdatesIndex(self):
         # create a parent and child case (with index) from one user
         parent_id = "other_updates_index_parent"
@@ -1638,7 +1589,6 @@ class MultiUserSyncTest(SyncBaseTest):
         assert_user_has_case(self, self.user, parent_id, restore_id=latest_sync_log.get_id,
                              purge_restore_cache=True)
 
-    @run_with_all_backends
     def testOtherUserReassignsIndexed(self):
         # create a parent and child case (with index) from one user
         parent_id = "other_reassigns_index_parent"
@@ -1759,7 +1709,6 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue("something different" in payload)
         self.assertTrue("hi changed!" in payload)
 
-    @run_with_all_backends
     def testComplicatedGatesBug(self):
         # found this bug in the wild, used the real (test) forms to fix it
         # just running through this test used to fail hard, even though there
@@ -1773,7 +1722,6 @@ class MultiUserSyncTest(SyncBaseTest):
                 generate_restore_payload(self.project, self.user, version="2.0")
             )
 
-    @run_with_all_backends
     def test_dependent_case_becomes_relevant_at_sync_time(self):
         """
         Make a case that is only relevant through a dependency.
@@ -1816,7 +1764,6 @@ class MultiUserSyncTest(SyncBaseTest):
         )
         self._testUpdate(latest_sync_log._id, {child_id: [index_ref], parent_id: []})
 
-    @run_with_all_backends
     def test_index_tree_conflict_handling(self):
         """
         Test that if another user changes the index tree, the original user
@@ -1877,6 +1824,7 @@ class MultiUserSyncTest(SyncBaseTest):
         })
 
 
+@generate_sql_backend_test_case
 class SteadyStateExtensionSyncTest(SyncBaseTest):
     """
     Test that doing multiple clean syncs with extensions does what we think it will
@@ -1919,7 +1867,6 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         return host, extension
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_delegating_extensions(self):
         """Make an extension, delegate it, send it back, see what happens"""
         host, extension = self._create_extension()
@@ -1979,7 +1926,6 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         # Hooray!
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_multiple_syncs(self):
         host, extension = self._create_extension()
         assert_user_has_case(self, self.user, host.case_id)
@@ -1997,12 +1943,12 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         self.assertItemsEqual(third_sync_log.case_ids_on_phone, ['host', 'extension'])
 
 
+@generate_sql_backend_test_case
 class SyncTokenReprocessingTest(SyncBaseTest):
     """
     Tests sync token logic for fixing itself when it gets into a bad state.
     """
 
-    @run_with_all_backends
     def testUpdateNonExisting(self):
         case_id = 'non_existent'
         caseblock = CaseBlock(
@@ -2019,7 +1965,6 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             # this should fail because it's a true error
             pass
 
-    @run_with_all_backends
     def testShouldHaveCase(self):
         case_id = "should_have"
         self._createCaseStubs([case_id])
@@ -2046,7 +1991,6 @@ class SyncTokenReprocessingTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(getattr(sync_log, 'has_assert_errors', False))
 
-    @run_with_all_backends
     def testCodependencies(self):
 
         case_id1 = 'bad1'
@@ -2093,9 +2037,9 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             pass
 
 
+@generate_sql_backend_test_case
 class LooseSyncTokenValidationTest(SyncBaseTest):
 
-    @run_with_all_backends
     def test_submission_with_bad_log_default(self):
         with self.assertRaises(ResourceNotFound):
             post_case_blocks(
@@ -2104,7 +2048,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 domain='some-domain-without-toggle',
             )
 
-    @run_with_all_backends
     def test_submission_with_bad_log_toggle_enabled(self):
         domain = 'submission-domain-with-toggle'
 
@@ -2123,7 +2066,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
         # this is just asserting that an exception is not raised after the toggle is set
         _test()
 
-    @run_with_all_backends
     def test_restore_with_bad_log_default(self):
         with self.assertRaises(MissingSyncLog):
             RestoreConfig(
@@ -2135,7 +2077,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 ),
             ).get_payload()
 
-    @run_with_all_backends
     def test_restore_with_bad_log_toggle_enabled(self):
         domain = 'restore-domain-with-toggle'
 


### PR DESCRIPTION
@dimagi/test-team in light of my failure to not run couch tests on travis by modifying the `run_with_all_backends`, I've developed a new strategy. It might be too sneaky, but curious to hear your thoughts. Essentially this decorator will create a new class by subclassing the decorated class and then override its settings. Then we can tag that new class as `sql_backend`. Once we've tagged all tests that are sql_backend, we can change the travis config to just run `--attr=sql_backend`

cc: @kaapstorm 