### PR TITLE
BubbleGraphSeries should inherit from XYGraphSeries

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/graph-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/graph-config.js
@@ -583,7 +583,7 @@ hqDefine('app_manager/js/graph-config.js', function () {
 
     // private
     var BubbleGraphSeries = function(original, childCaseTypes, fixtures, lang, langs){
-        GraphSeries.apply(this, [original, childCaseTypes, fixtures, lang, langs]);
+        XYGraphSeries.apply(this, [original, childCaseTypes, fixtures, lang, langs]);
         var self = this;
 
         self.radiusFunction = ko.observable(original.radiusFunction === undefined ? "" : original.radiusFunction);


### PR DESCRIPTION
Bubble graphs weren't displaying the autocomplete option and hints for `is-data`, `point-style`, `secondary-y`.

@gcapalbo / @NoahCarnahan 