### PR TITLE
fix deprecation for serializers without fields or exclude

### DIFF
--- a/corehq/form_processor/serializers.py
+++ b/corehq/form_processor/serializers.py
@@ -84,6 +84,7 @@ class XFormInstanceSQLRawDocSerializer(JsonFieldSerializerMixin, DeletableModelS
 
     class Meta:
         model = XFormInstanceSQL
+        fields = '__all__'
 
 
 class CommCareCaseIndexSQLSerializer(serializers.ModelSerializer):
@@ -118,6 +119,7 @@ class CommCareCaseSQLRawDocSerializer(JsonFieldSerializerMixin, DeletableModelSe
 
     class Meta:
         model = CommCareCaseSQL
+        fields = '__all__'
 
 
 class CaseAttachmentSQLSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?247565

*Deprecation error:*
"Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit `fields = '__all__'` to the XFormInstanceSQLRawDocSerializer serializer"
Done the same for `CommCareCaseSQLRawDocSerializer`