### PR TITLE
Skip some location upload validation

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext as _
 
 from dimagi.utils.decorators.memoized import memoized
 
+from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import SQLLocation, LocationType
 from .tree_utils import BadParentError, CycleError, assert_no_cycles, expansion_validators
@@ -400,7 +401,7 @@ class NewLocationImporter(object):
         return cls(domain, type_rows, location_rows)
 
     def run(self):
-        tree_validator = LocationTreeValidator(self.type_rows, self.location_rows, self.old_collection)
+        tree_validator = LocationTreeValidator(self.domain, self.type_rows, self.location_rows, self.old_collection)
         self.result.errors = tree_validator.errors
         self.result.warnings = tree_validator.warnings
         if self.result.errors:
@@ -446,11 +447,12 @@ class LocationTreeValidator(object):
     """
     Validates the given type and location stubs
     """
-    def __init__(self, type_rows, location_rows, old_collection=None):
+    def __init__(self, domain, type_rows, location_rows, old_collection=None):
 
         _to_be_deleted = lambda items: filter(lambda i: i.do_delete, items)
         _not_to_be_deleted = lambda items: filter(lambda i: not i.do_delete, items)
 
+        self.domain = domain
         self.all_listed_types = type_rows
         self.location_types = _not_to_be_deleted(type_rows)
         self.types_to_be_deleted = _to_be_deleted(type_rows)
@@ -489,7 +491,7 @@ class LocationTreeValidator(object):
                                self._check_unknown_location_ids() + self._validate_geodata())
 
         unknown_or_missing_errors = []
-        if self.old_collection:
+        if not toggles.STUPIDLY_DANGEROUS_UPLOAD.enabled(self.domain) and self.old_collection:
             # all old types/locations should be listed in excel
             unknown_or_missing_errors = (self._check_unlisted_type_codes() +
                                          self._check_unlisted_location_ids())

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -624,9 +624,8 @@ class TestBulkManagement(TestCase):
     @flag_enabled('STUPIDLY_DANGEROUS_UPLOAD')
     def test_dangerous_upload(self):
         lt_by_code = self.create_location_types(FLAT_LOCATION_TYPES)
-        locations_by_code = self.create_locations(self.basic_tree, lt_by_code)
+        self.create_locations(self.basic_tree, lt_by_code)
 
-        _loc_id = lambda x: locations_by_code[x].location_id
         add_new_stuff = [
             ('S3', 's3', 'state', '', '', False) + extra_stub_args,
             ('County33', 'county33', 'county', 's3', '', False) + extra_stub_args,

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from django.test import SimpleTestCase, TestCase
 from mock import MagicMock
 
+from corehq.util.test_utils import flag_enabled
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.locations.tree_utils import TreeError, assert_no_cycles, expansion_validators
@@ -204,6 +205,7 @@ class MockLocationStub(LocationStub):
 
 def get_validator(location_types, locations, old_collection=None):
     validator = LocationTreeValidator(
+        'fake-domain',
         [LocationTypeStub(*loc_type) for loc_type in location_types],
         [MockLocationStub(*loc) for loc in locations],
         old_collection=old_collection
@@ -617,6 +619,28 @@ class TestBulkManagement(TestCase):
         self.assertEqual(result.errors, [])
         self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
         self.assertLocationsMatch(self.as_pairs(delete_county11))
+        self.assertCouchSync()
+
+    @flag_enabled('STUPIDLY_DANGEROUS_UPLOAD')
+    def test_dangerous_upload(self):
+        lt_by_code = self.create_location_types(FLAT_LOCATION_TYPES)
+        locations_by_code = self.create_locations(self.basic_tree, lt_by_code)
+
+        _loc_id = lambda x: locations_by_code[x].location_id
+        add_new_stuff = [
+            ('S3', 's3', 'state', '', '', False) + extra_stub_args,
+            ('County33', 'county33', 'county', 's3', '', False) + extra_stub_args,
+            ('City233', 'city233', 'city', 'county33', '', False) + extra_stub_args,
+        ]
+
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            add_new_stuff,
+        )
+
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch(self.as_pairs(self.basic_tree + add_new_stuff))
         self.assertCouchSync()
 
     def test_invalid_tree(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -673,6 +673,13 @@ CUSTOM_MENU_BAR = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+STUPIDLY_DANGEROUS_UPLOAD = StaticToggle(
+    'stupidly_dangerous_upload',
+    'Enable a stupidly dangerous locations upload',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN]
+)
+
 ICDS_REPORTS = StaticToggle(
     'icds_reports',
     'Enable access to the Tableau dashboard for ICDS',


### PR DESCRIPTION
This is strictly to be used for a bulk upload Sri needs to do.  This will allow him to upload segments at a time without reprocessing existing locations.  Once that's done, I'd like to revert this.  Sravan, can you take a look at this and see if there's any way this could backfire?  Does it seem safe enough for Sri's purpose, or should we require them to wait until your feature is done?  You're more familiar with this validation than I am, so I'd defer to your judgement.
@sheelio @sravfeyn