### PR TITLE
Add REUSE_DB=wipe option to clean database

### DIFF
--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -22,6 +22,7 @@ from couchdbkit.ext.django import loading
 from django.core.management import call_command
 from mock import patch, Mock
 from nose.plugins import Plugin
+from nose.tools import nottest
 from django.conf import settings
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.db.utils import OperationalError
@@ -276,6 +277,7 @@ def print_imports_until_thread_change():
     sys.meta_path.append(InfoImporter())
 
 
+@nottest
 @unit_testing_only
 def get_all_test_dbs():
     all_dbs = couch_config.all_dbs_by_db_name.values()

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -26,6 +26,7 @@ from django.conf import settings
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.db.utils import OperationalError
 from django_nose.plugin import DatabaseContext
+from dimagi.utils.parsing import string_to_boolean
 
 from corehq.tests.noseplugins.cmdline_params import CmdLineParametersPlugin
 from corehq.util.couchdb_management import couch_config
@@ -180,7 +181,7 @@ class HqdbContext(DatabaseContext):
     """
 
     def __init__(self, tests, runner):
-        reuse_db = CmdLineParametersPlugin.get('db_action') or os.environ.get("REUSE_DB")
+        reuse_db = CmdLineParametersPlugin.get('db_action') or string_to_boolean(os.environ.get("REUSE_DB"))
         self.reuse_db = reuse_db
         self.skip_setup_for_reuse_db = reuse_db and reuse_db != "reset_db"
         self.skip_teardown_for_reuse_db = reuse_db and reuse_db != "teardown_db"

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -171,13 +171,9 @@ class HqdbContext(DatabaseContext):
     database in `settings.DATABASES` all databases will be re-created
     and migrated.
 
-    Other supported `REUSE_DB` values:
-
-    The following flags are also useful in conjunction with REUSE_DB=1:
-        --reset-db
-        --flush-db
-        --migrate-db
-        --teardown-db
+    When using REUSE_DB=1, you may also want to provide a value for the
+    --reuse_db option, either reset, flush, migrate, or teardown.
+    ./manage.py test --help will give you a description of these.
     """
 
     def __init__(self, tests, runner):

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -181,10 +181,10 @@ class HqdbContext(DatabaseContext):
     """
 
     def __init__(self, tests, runner):
-        reuse_db = CmdLineParametersPlugin.get('db_action') or string_to_boolean(os.environ.get("REUSE_DB"))
+        reuse_db = CmdLineParametersPlugin.get('reuse_db') or string_to_boolean(os.environ.get("REUSE_DB"))
         self.reuse_db = reuse_db
-        self.skip_setup_for_reuse_db = reuse_db and reuse_db != "reset_db"
-        self.skip_teardown_for_reuse_db = reuse_db and reuse_db != "teardown_db"
+        self.skip_setup_for_reuse_db = reuse_db and reuse_db != "reset"
+        self.skip_teardown_for_reuse_db = reuse_db and reuse_db != "teardown"
         super(HqdbContext, self).__init__(tests, runner)
 
     def should_skip_test_setup(self):
@@ -198,13 +198,13 @@ class HqdbContext(DatabaseContext):
         self.blob_db = TemporaryFilesystemBlobDB()
 
         if self.skip_setup_for_reuse_db and self._databases_ok():
-            if self.reuse_db == "migrate_db":
+            if self.reuse_db == "migrate":
                 call_command('migrate_multi', interactive=False)
-            if self.reuse_db == "flush_db":
+            if self.reuse_db == "flush":
                 flush_databases()
             return  # skip remaining setup
 
-        if self.reuse_db == "reset_db":
+        if self.reuse_db == "reset":
             self.delete_couch_databases()
 
         sys.__stdout__.write("\n")  # newline for creating database message

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -177,7 +177,8 @@ class HqdbContext(DatabaseContext):
     """
 
     def __init__(self, tests, runner):
-        reuse_db = CmdLineParametersPlugin.get('reuse_db') or string_to_boolean(os.environ.get("REUSE_DB"))
+        reuse_db = (CmdLineParametersPlugin.get('reusedb')
+                    or string_to_boolean(os.environ.get("REUSE_DB") or "0"))
         self.reuse_db = reuse_db
         self.skip_setup_for_reuse_db = reuse_db and reuse_db != "reset"
         self.skip_teardown_for_reuse_db = reuse_db and reuse_db != "teardown"

--- a/corehq/tests/noseplugins/cmdline_params.py
+++ b/corehq/tests/noseplugins/cmdline_params.py
@@ -11,7 +11,7 @@ reset: Drop existing test dbs, then create and migrate new ones, but do not
 flush: Flush all objects from the old test databases before running tests.
     Much faster than `reset`.
 migrate: Migrate the test databases before running tests.
-    teardown: Skip database setup; do normal teardown after running tests.
+teardown: Skip database setup; do normal teardown after running tests.
 """
 
 
@@ -24,7 +24,7 @@ class CmdLineParametersPlugin(Plugin):
 
     def options(self, parser, env):
         parser.add_option(
-            '--reuse_db',
+            '--reusedb',
             default=None,
             choices=['reset', 'flush', 'migrate', 'teardown'],
             help=REUSE_DB_HELP,
@@ -36,7 +36,7 @@ class CmdLineParametersPlugin(Plugin):
         )
 
     def configure(self, options, conf):
-        for option in ['reuse_db', 'collect_only']:
+        for option in ['reusedb', 'collect_only']:
             type(self).parameters[option] = getattr(options, option)
 
     @classmethod

--- a/corehq/tests/noseplugins/cmdline_params.py
+++ b/corehq/tests/noseplugins/cmdline_params.py
@@ -3,6 +3,17 @@ A plugin to accept parameters used for various test runner operations.
 """
 from nose.plugins import Plugin
 
+REUSE_DB_HELP = """
+To be used in conjunction with the environment variable REUSE_DB=1.
+reset: Drop existing test dbs, then create and migrate new ones, but do not
+    teardown after running tests. This is convenient when the existing databases
+    are outdated and need to be rebuilt.
+flush: Flush all objects from the old test databases before running tests.
+    Much faster than `reset`.
+migrate: Migrate the test databases before running tests.
+    teardown: Skip database setup; do normal teardown after running tests.
+"""
+
 
 class CmdLineParametersPlugin(Plugin):
     """Accept and store misc test runner flags for later reference
@@ -12,33 +23,11 @@ class CmdLineParametersPlugin(Plugin):
     parameters = {}
 
     def options(self, parser, env):
-        reuse_msg = " To be used in conjunction with REUSE_DB=1."
         parser.add_option(
-            '--reset-db',
-            action="store_true",
-            default=False,
-            help=("Drop existing test dbs, then create and migrate new ones, but do not teardown "
-                  "after running tests. This is convenient when the existing databases are "
-                  "outdated and need to be rebuilt." + reuse_msg),
-        )
-        parser.add_option(
-            '--flush-db',
-            action="store_true",
-            default=False,
-            help=("Flush all objects from the old test databases before running tests.  Much "
-                  "faster than `--reset-db`." + reuse_msg),
-        )
-        parser.add_option(
-            '--migrate-db',
-            action="store_true",
-            default=False,
-            help="Migrate the test databases before running tests." + reuse_msg,
-        )
-        parser.add_option(
-            '--teardown-db',
-            action="store_true",
-            default=False,
-            help="Skip database setup; do normal teardown after running tests." + reuse_msg,
+            '--reuse_db',
+            default=None,
+            choices=['reset', 'flush', 'migrate', 'teardown'],
+            help=REUSE_DB_HELP,
         )
         parser.add_option(
             "--collect-only",
@@ -47,12 +36,8 @@ class CmdLineParametersPlugin(Plugin):
         )
 
     def configure(self, options, conf):
-        db_action = None
-        for action in ['reset_db', 'flush_db', 'migrate_db', 'teardown_db']:
-            if getattr(options, action):
-                db_action = action
-        type(self).parameters['db_action'] = db_action
-        type(self).parameters['collect_only'] = options.collect_only
+        for option in ['reuse_db', 'collect_only']:
+            type(self).parameters[option] = getattr(options, option)
 
     @classmethod
     def get(cls, parameter):

--- a/corehq/tests/noseplugins/cmdline_params.py
+++ b/corehq/tests/noseplugins/cmdline_params.py
@@ -1,0 +1,59 @@
+"""
+A plugin to accept parameters used for various test runner operations.
+"""
+from nose.plugins import Plugin
+
+
+class CmdLineParametersPlugin(Plugin):
+    """Accept and store misc test runner flags for later reference
+    """
+    name = "cmdline-parameters"
+    enabled = True
+    parameters = {}
+
+    def options(self, parser, env):
+        reuse_msg = " To be used in conjunction with REUSE_DB=1."
+        parser.add_option(
+            '--reset-db',
+            action="store_true",
+            default=False,
+            help=("Drop existing test dbs, then create and migrate new ones, but do not teardown "
+                  "after running tests. This is convenient when the existing databases are "
+                  "outdated and need to be rebuilt." + reuse_msg),
+        )
+        parser.add_option(
+            '--flush-db',
+            action="store_true",
+            default=False,
+            help=("Flush all objects from the old test databases before running tests.  Much "
+                  "faster than `--reset-db`." + reuse_msg),
+        )
+        parser.add_option(
+            '--migrate-db',
+            action="store_true",
+            default=False,
+            help="Migrate the test databases before running tests." + reuse_msg,
+        )
+        parser.add_option(
+            '--teardown-db',
+            action="store_true",
+            default=False,
+            help="Skip database setup; do normal teardown after running tests." + reuse_msg,
+        )
+        parser.add_option(
+            "--collect-only",
+            action="store_true",
+            default=False,
+        )
+
+    def configure(self, options, conf):
+        db_action = None
+        for action in ['reset_db', 'flush_db', 'migrate_db', 'teardown_db']:
+            if getattr(options, action):
+                db_action = action
+        type(self).parameters['db_action'] = db_action
+        type(self).parameters['collect_only'] = options.collect_only
+
+    @classmethod
+    def get(cls, parameter):
+        return cls.parameters[parameter]

--- a/testsettings.py
+++ b/testsettings.py
@@ -21,6 +21,7 @@ NOSE_PLUGINS = [
     'corehq.tests.nose.HqTestFinderPlugin',
     'corehq.tests.noseplugins.dividedwerun.DividedWeRunPlugin',
     'corehq.tests.noseplugins.djangomigrations.DjangoMigrationsPlugin',
+    'corehq.tests.noseplugins.cmdline_params.CmdLineParametersPlugin',
 
     # The following are not enabled by default
     'corehq.tests.noseplugins.logfile.LogFilePlugin',


### PR DESCRIPTION
You ever find yourself not properly cleaning up after something and forced with a `REUSE_DB=reset`?  Perhaps you had a bug in your `setUpClass`, so it never tore down some stuff and now you get a CouchUser with username blah already exists".  Fear no more - this deletes all docs in Couch and SQL, letting you keep testing without deleting the test dbs and rebuilding and migrating them.

@dimagi/test-team looking for feedback, then I'll ping the HQ team to notify once we're happy with it.