### PR TITLE
upgrade django-celery for 1.10 compatibility

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ celery==3.1.18
 decorator==4.0.4
 django==1.9.12
 django-braces==1.8.1
-django-celery==3.1.17
+django-celery==3.2.1
 django-crispy-forms==1.6.0
 jsonfield==1.0.3
 dropbox==7.1.1


### PR DESCRIPTION
Currently running on staging with django 1.9, no problems observed.

@snopoke @emord cc: @sravfeyn 