### PR TITLE
Allow reg from case list in CLMI-only modules

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -384,6 +384,8 @@ class CaseListFormWorkflow(object):
         :param source_form_datums: List of datums from the source form.
         """
         ids_on_stack = stack_frames.ids_on_stack
+        if not len(target_module.forms):
+            return
         target_frame_children = self.helper.get_frame_children(target_module.get_form(0), module_only=True)
         remaining_target_frame_children = [fc for fc in target_frame_children if fc.id not in ids_on_stack]
         frame_children = WorkflowHelper.get_datums_matched_to_source(

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -234,7 +234,9 @@ class DetailContributor(SectionContributor):
         frame.add_command(XPath.string(id_strings.form_command(form)))
 
         target_form_dm = self.entries_helper.get_datums_meta_for_form_generic(form)
-        source_form_dm = self.entries_helper.get_datums_meta_for_form_generic(module.get_form(0))
+        source_form_dm = []
+        if len(module.forms):
+            source_form_dm = self.entries_helper.get_datums_meta_for_form_generic(module.get_form(0))
         for target_meta in target_form_dm:
             if target_meta.requires_selection:
                 # This is true for registration forms where the case being created is a subcase


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?247629

Tested on staging that the build succeeds and that the app behaves as expected on the phone. When you register a case from a CLMI-only module, you get sent to the home screen afterwards, which I think is fine.

@snopoke 
cc @gcapalbo 