### PR TITLE
Module case type tooltip

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
@@ -119,7 +119,7 @@
                             {% elif module.module_type == 'shadow' %}class="fa fa-folder-open-o appmanager-icon-type"
                             {% else %}class="fa fa-folder-open"{% endif %}
 
-                            {% if module.case_type and request|toggle_enabled:"SUPPORT" %}
+                            {% if module.case_type and app.get_case_types|length > 1 %}
                             title="Case Type: {{ module.case_type }}"
                             data-toggle="tooltip"
                             data-placement="top"

--- a/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
@@ -110,12 +110,22 @@
                     <li class="edit-module-li {% ifequal module.id selected_module.id %}{% if not form %}
                         active{% endif %}{% endifequal %}"
                         data-index="{{ module.id }}">
-                        <a href="{% url "view_module" domain app.id module.id %}">
+                        <a href="{% url "view_module" domain app.id module.id %}"
+                            >
                             <i class="drag_handle"></i>
-                            {% if module.module_type == 'advanced' %}<i class="fa fa-flask appmanager-icon-type"></i>
-                            {% elif module.module_type == 'report' %}<i class="fa fa-bar-chart appmanager-icon-type"></i>
-                            {% elif module.module_type == 'shadow' %}<i class="fa fa-folder-open-o appmanager-icon-type"></i>
-                            {% else %}<i class="fa fa-folder-open"></i>{% endif %}
+                            <i
+                            {% if module.module_type == 'advanced' %}class="fa fa-flask appmanager-icon-type"
+                            {% elif module.module_type == 'report' %}class="fa fa-bar-chart appmanager-icon-type"
+                            {% elif module.module_type == 'shadow' %}class="fa fa-folder-open-o appmanager-icon-type"
+                            {% else %}class="fa fa-folder-open"{% endif %}
+
+                            {% if module.case_type and request|toggle_enabled:"SUPPORT" %}
+                            title="Case Type: {{ module.case_type }}"
+                            data-toggle="tooltip"
+                            data-placement="top"
+                            {% endif %}
+                            ></i>
+
                             <span {% if module.id == selected_module.id %}class="variable-module_name"{% endif %}>
                                 {{ module.name|html_trans:langs }}
 

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
@@ -6,7 +6,7 @@
  {% load xforms_extras %}
  {% load url_extras %}
  {% load hq_shared_tags %}
-@@ -25,241 +25,77 @@
+@@ -25,251 +25,77 @@
  {% endblock %}
  
  {% block page_navigation %}
@@ -129,15 +129,25 @@
 -                    <li class="edit-module-li {% ifequal module.id selected_module.id %}{% if not form %}
 -                        active{% endif %}{% endifequal %}"
 -                        data-index="{{ module.id }}">
--                        <a href="{% url "view_module" domain app.id module.id %}">
+-                        <a href="{% url "view_module" domain app.id module.id %}"
+-                            >
 -                            <i class="drag_handle"></i>
--                            {% if module.module_type == 'advanced' %}<i class="fa fa-flask appmanager-icon-type"></i>
--                            {% elif module.module_type == 'report' %}<i class="fa fa-bar-chart appmanager-icon-type"></i>
--                            {% elif module.module_type == 'shadow' %}<i class="fa fa-folder-open-o appmanager-icon-type"></i>
--                            {% else %}<i class="fa fa-folder-open"></i>{% endif %}
+-                            <i
+-                            {% if module.module_type == 'advanced' %}class="fa fa-flask appmanager-icon-type"
+-                            {% elif module.module_type == 'report' %}class="fa fa-bar-chart appmanager-icon-type"
+-                            {% elif module.module_type == 'shadow' %}class="fa fa-folder-open-o appmanager-icon-type"
+-                            {% else %}class="fa fa-folder-open"{% endif %}
+ 
+-                            {% if module.case_type and app.get_case_types|length > 1 %}
+-                            title="Case Type: {{ module.case_type }}"
+-                            data-toggle="tooltip"
+-                            data-placement="top"
+-                            {% endif %}
+-                            ></i>
+-
 -                            <span {% if module.id == selected_module.id %}class="variable-module_name"{% endif %}>
 -                                {{ module.name|html_trans:langs }}
- 
+-
 -                            </span>
 -                        </a>
 -                        <ul class="nav nav-hq-sidebar {% ifequal module.id selected_module.id %}selected{% endifequal %} sortable-forms sortable">


### PR DESCRIPTION
<img width="287" alt="screen shot 2017-02-16 at 11 19 31 am" src="https://cloud.githubusercontent.com/assets/918514/23014976/d5dfb4a2-f439-11e6-8b7b-02ce32df0618.png">

Similar to the form icon tooltip this displays what case type the module is without having to open it. I find this very useful in the current app manager. I put it behind the support toggle.

cc: @kaapstorm 