### PR TITLE
pass object ID's to tasks rather than the full objects

### DIFF
--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -86,16 +86,16 @@ def _get_export_instance(cls, key):
     return [cls.wrap(result['doc']) for result in results]
 
 
-def get_all_daily_saved_export_instances():
+def get_all_daily_saved_export_instance_ids():
     from .models import ExportInstance
     results = ExportInstance.get_db().view(
         "export_instances_by_is_daily_saved/view",
         startkey=[True],
         endkey=[True, {}],
-        include_docs=True,
+        include_docs=False,
         reduce=False,
     ).all()
-    return [_properly_wrap_export_instance(result['doc']) for result in results]
+    return [result['id'] for result in results]
 
 
 def get_properly_wrapped_export_instance(doc_id):

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -3,7 +3,7 @@ from celery.task import task
 
 from corehq.apps.data_dictionary.util import add_properties_to_data_dictionary
 from corehq.apps.export.export import get_export_file, rebuild_export
-from corehq.apps.export.dbaccessors import get_case_inferred_schema
+from corehq.apps.export.dbaccessors import get_case_inferred_schema, get_properly_wrapped_export_instance
 from corehq.apps.export.system_properties import MAIN_CASE_TABLE_PROPERTIES
 from corehq.util.decorators import serial_task
 from corehq.util.files import safe_filename_header
@@ -39,7 +39,8 @@ def populate_export_download_task(export_instances, filters, download_id, filena
 
 
 @task(queue='background_queue', ignore_result=True)
-def rebuild_export_task(export_instance, last_access_cutoff=None, filter=None):
+def rebuild_export_task(export_instance_id, last_access_cutoff=None, filter=None):
+    export_instance = get_properly_wrapped_export_instance(export_instance_id)
     rebuild_export(export_instance, last_access_cutoff, filter)
 
 

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -14,7 +14,7 @@ from corehq.apps.export.dbaccessors import (
     get_latest_form_export_schema,
     get_form_export_instances,
     get_case_export_instances,
-    get_all_daily_saved_export_instances,
+    get_all_daily_saved_export_instance_ids,
     get_properly_wrapped_export_instance,
     get_case_inferred_schema,
     get_form_inferred_schema,
@@ -161,8 +161,11 @@ class TestExportInstanceDBAccessors(TestCase):
         self.assertEqual(len(instances), 0)
 
     def test_get_daily_saved_exports(self):
-        instances = get_all_daily_saved_export_instances()
-        self.assertEqual(len(instances), 2)
+        instance_ids = get_all_daily_saved_export_instance_ids()
+        self.assertEqual(
+            set(instance_ids),
+            {self.form_instance_daily_saved._id, self.case_instance_daily_saved._id}
+        )
 
     def test_get_properly_wrapped_export_instance(self):
         instance = get_properly_wrapped_export_instance(self.form_instance_daily_saved._id)

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1216,8 +1216,7 @@ class BaseExportListView(ExportsPermissionsMixin, JSONResponseMixin, BaseProject
     def update_emailed_es_export_data(self, in_data):
         from corehq.apps.export.tasks import rebuild_export_task
         export_instance_id = in_data['export']['id']
-        export_instance = get_properly_wrapped_export_instance(export_instance_id)
-        rebuild_export_task.delay(export_instance)
+        rebuild_export_task.delay(export_instance_id)
         return format_angular_success({})
 
     @allow_remote_invocation
@@ -1432,7 +1431,7 @@ class DailySavedExportListView(BaseExportListView):
                     export.filters = filters
                     export.save()
                     from corehq.apps.export.tasks import rebuild_export_task
-                    rebuild_export_task.delay(export)
+                    rebuild_export_task.delay(export_id)
                 return format_angular_success()
             else:
                 return format_angular_error("Problem saving dashboard feed filters: Invalid form")
@@ -2345,7 +2344,7 @@ def download_daily_saved_export(req, domain, export_instance_id):
     if should_update_export(export_instance.last_accessed):
         try:
             from corehq.apps.export.tasks import rebuild_export_task
-            rebuild_export_task.delay(export_instance)
+            rebuild_export_task.delay(export_instance_id)
         except Exception:
             notify_exception(
                 req,

--- a/corehq/apps/reports/dbaccessors.py
+++ b/corehq/apps/reports/dbaccessors.py
@@ -1,10 +1,8 @@
-from itertools import imap
 import json
 
 from django.conf import settings
 
 from corehq.apps.domain.dbaccessors import get_docs_in_domain_by_class
-from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
 
 
 def _get_exports(domain, include_docs=True, reduce=False, **kwargs):
@@ -47,14 +45,3 @@ def touch_exports(domain):
 def hq_group_export_configs_by_domain(domain):
     from corehq.apps.reports.models import HQGroupExportConfiguration
     return get_docs_in_domain_by_class(domain, HQGroupExportConfiguration)
-
-
-def get_all_hq_group_export_configs():
-    from corehq.apps.reports.models import HQGroupExportConfiguration
-    return imap(
-        HQGroupExportConfiguration.wrap,
-        get_all_docs_with_doc_types(
-            HQGroupExportConfiguration.get_db(),
-            ('HQGroupExportConfiguration',)
-        )
-    )

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -17,7 +17,7 @@ from celery.task import task
 from celery.utils.log import get_task_logger
 
 from casexml.apps.case.xform import extract_case_blocks
-from corehq.apps.export.dbaccessors import get_all_daily_saved_export_instances
+from corehq.apps.export.dbaccessors import get_all_daily_saved_export_instance_ids
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.util.dates import iso_string_to_datetime
 from couchexport.files import Temp
@@ -142,10 +142,10 @@ def saved_exports():
     for group_config in get_all_hq_group_export_configs():
         export_for_group_async.delay(group_config)
 
-    for daily_saved_export in get_all_daily_saved_export_instances():
+    for daily_saved_export_id in get_all_daily_saved_export_instance_ids():
         from corehq.apps.export.tasks import rebuild_export_task
         last_access_cutoff = datetime.utcnow() - timedelta(days=settings.SAVED_EXPORT_ACCESS_CUTOFF)
-        rebuild_export_task.delay(daily_saved_export, last_access_cutoff)
+        rebuild_export_task.delay(daily_saved_export_id, last_access_cutoff)
 
 
 @task(queue='background_queue', ignore_result=True)

--- a/corehq/apps/reports/tests/test_dbaccessors.py
+++ b/corehq/apps/reports/tests/test_dbaccessors.py
@@ -4,13 +4,12 @@ from django.test.utils import override_settings
 from couchexport.models import SavedExportSchema
 
 from corehq.apps.reports.dbaccessors import (
-    get_all_hq_group_export_configs,
     hq_group_export_configs_by_domain,
     stale_get_exports_json,
     stale_get_export_count,
 )
 from corehq.apps.reports.models import HQGroupExportConfiguration
-from corehq.dbaccessors.couchapps.all_docs import delete_all_docs_by_doc_type
+from corehq.dbaccessors.couchapps.all_docs import delete_all_docs_by_doc_type, get_doc_ids_by_class
 
 
 class HQGroupExportConfigurationDbAccessorsTest(TestCase):
@@ -32,7 +31,7 @@ class HQGroupExportConfigurationDbAccessorsTest(TestCase):
         self.assertEqual(len(hq_group_export_configs_by_domain('domain2')), 2)
 
     def test_get_all_hq_group_export_configs(self):
-        self.assertEqual(len(list(get_all_hq_group_export_configs())), 3)
+        self.assertEqual(len(get_doc_ids_by_class(HQGroupExportConfiguration)), 3)
 
 
 @override_settings(COUCH_STALE_QUERY=None)


### PR DESCRIPTION
Should have better memory profile than passing full objects. Also just best practice.