### PR TITLE
Remove poster from reqs

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,6 @@ mock==0.8.0
 openpyxl==2.2.5
 Pillow==2.7.0
 phonenumberslite==7.1.0
-poster==0.8.1
 psycopg2==2.6.1
 psycogreen==1.0
 pycrypto==2.6.1


### PR DESCRIPTION
Ran `ag --py poster` and got no results. I don't think we've used this for a while. (hasn't even been updated in 6 years)

buddies @czue @millerdev