### PR TITLE
Don't error if export table configuration has empty label

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -75,7 +75,10 @@ class _Writer(object):
                     (t, (t.get_headers(split_columns=instance.split_multiselects),))
                     for t in instance.selected_tables
                 ]
-                table_titles.update({t: t.label for t in instance.selected_tables})
+                table_titles.update({
+                    t: t.label or "Sheet{}".format(i+1)
+                    for i, t in enumerate(instance.selected_tables)
+                })
             self.writer.open(headers, file, table_titles=table_titles, archive_basepath=name)
             yield
             self.writer.close()

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -513,6 +513,43 @@ class WriterTest(SimpleTestCase):
                 }
             )
 
+    def test_empty_table_label(self):
+        export_instance = FormExportInstance(
+            export_format=Format.JSON,
+            domain=DOMAIN,
+            case_type=DEFAULT_CASE_TYPE,
+            split_multiselects=True,
+            tables=[TableConfiguration(
+                label="",
+                selected=True,
+                path=[],
+                columns=[
+                    ExportColumn(
+                        label="Q1",
+                        item=ScalarItem(
+                            path=[PathNode(name='form'), PathNode(name='q1')],
+                        ),
+                        selected=True
+                    ),
+                ]
+            )]
+        )
+        writer = _get_writer([export_instance])
+        with writer.open([export_instance]):
+            _write_export_instance(writer, export_instance, self.docs)
+
+        with ExportFile(writer.path, writer.format) as export:
+            self.assertEqual(
+                json.loads(export),
+                {
+                    u'Sheet1': {
+                        u'headers': [u'Q1'],
+                        u'rows': [[u'foo'], [u'bip']],
+
+                    }
+                }
+            )
+
 
 class ExportTest(SimpleTestCase):
 


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?246861
If the label was falsey, the writer would attempt to use the TableConfiguration for the label, but as the configuration is not a string, it would 500. This ensures that every TableConfiguration has a truthy label when we attempt to write the table.
cc @esoergel 
fyi @kaapstorm (who also worked on this bug)