### PR TITLE
Kill CommTrackTest

### DIFF
--- a/corehq/apps/commtrack/tests/test_programs.py
+++ b/corehq/apps/commtrack/tests/test_programs.py
@@ -1,22 +1,22 @@
-from corehq.apps.commtrack.tests.util import CommTrackTest
+from django.test import TestCase
+from corehq.apps.commtrack.tests.util import bootstrap_domain, bootstrap_products, TEST_DOMAIN
 from corehq.apps.programs.models import Program
 from corehq.apps.products.models import Product, SQLProduct
 from corehq.apps.commtrack.util import make_program
 from couchdbkit import ResourceNotFound
 
 
-class ProgramsTest(CommTrackTest):
-
-    def setUp(self):
-        super(ProgramsTest, self).setUp()
+class ProgramsTest(TestCase):
+    def test_programs(self):
+        self.domain = bootstrap_domain(TEST_DOMAIN)
+        bootstrap_products(self.domain.name)
+        self.products = sorted(Product.by_domain(self.domain.name), key=lambda p: p._id)
         self.default_program = Program.by_domain(self.domain.name, wrap=True).one()
         self.new_program = make_program(
             self.domain.name,
             'new program',
             'newprogram'
         )
-
-    def test_defaults(self):
         self.assertTrue(self.default_program.default)
         self.assertFalse(self.new_program.default)
 
@@ -25,7 +25,6 @@ class ProgramsTest(CommTrackTest):
 
         self.assertEqual(context.exception.message, 'You cannot delete the default program')
 
-    def test_delete(self):
         # assign some product to the new program
         self.products[0].program_id = self.new_program._id
         self.products[0].save()
@@ -63,3 +62,4 @@ class ProgramsTest(CommTrackTest):
             self.default_program._id,
             SQLProduct.objects.get(product_id=self.products[0]._id).program_id
         )
+        self.domain.delete()

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -1,22 +1,52 @@
+from datetime import datetime
 from decimal import Decimal
 import functools
 
+from django.test import TestCase
+
 from corehq.apps.commtrack.consumption import recalculate_domain_consumption
-from corehq.apps.commtrack.models import StockState
-from corehq.apps.products.models import SQLProduct
+from corehq.apps.commtrack.models import StockState, CommtrackConfig, ConsumptionConfig
+from corehq.apps.commtrack.tests import util
+from corehq.apps.consumption.models import DefaultConsumption
+from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
+from corehq.apps.products.models import Product, SQLProduct
 from casexml.apps.stock.models import DocDomainMapping
 from casexml.apps.stock.tests.base import _stock_report
-from corehq.apps.commtrack.tests.util import CommTrackTest
-from datetime import datetime
-from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
 from testapps.test_pillowtop.utils import process_kafka_changes
 
 
-class StockStateTest(CommTrackTest):
+class StockStateTest(TestCase):
+    domain = 'stock-state-test'
+
+    @classmethod
+    def setUpClass(cls):
+        super(StockStateTest, cls).setUpClass()
+        cls.domain_obj = util.bootstrap_domain(cls.domain)
+        util.bootstrap_location_types(cls.domain)
+        util.bootstrap_products(cls.domain)
+        cls.ct_settings = CommtrackConfig.for_domain(cls.domain)
+        cls.ct_settings.use_auto_consumption = True
+        cls.ct_settings.consumption_config = ConsumptionConfig(
+            min_transactions=0,
+            min_window=0,
+            optimal_window=60,
+            min_periods=0,
+        )
+        cls.ct_settings.save()
+
+        cls.loc = util.make_loc('loc1', domain=cls.domain)
+        cls.sp = cls.loc.linked_supply_point()
+        cls.products = sorted(Product.by_domain(cls.domain), key=lambda p: p._id)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super(StockStateTest, cls).tearDownClass()
+
 
     def report(self, amount, days_ago):
         return _stock_report(
-            self.domain.name,
+            self.domain,
             self.sp.case_id,
             self.products[0]._id,
             amount,
@@ -25,11 +55,6 @@ class StockStateTest(CommTrackTest):
 
 
 class StockStateBehaviorTest(StockStateTest):
-
-    def setUp(self):
-        super(StockStateBehaviorTest, self).setUp()
-        self.ct_settings.use_auto_consumption = True
-        self.ct_settings.save()
 
     def test_stock_state(self):
         with process_kafka_changes('LedgerToElasticsearchPillow'):
@@ -136,12 +161,18 @@ class StockStateBehaviorTest(StockStateTest):
         ).save()
 
         self.assertEqual(
-            self.domain.name,
+            self.domain,
             DocDomainMapping.objects.get(doc_id=self.sp.case_id).domain_name
         )
 
 
 class StockStateConsumptionTest(StockStateTest):
+
+    def tearDown(self):
+        default = DefaultConsumption.get_domain_default(self.domain)
+        if default:
+            default.delete()
+        super(StockStateConsumptionTest, self).tearDown()
 
     def test_none_with_no_defaults(self):
         # need to submit something to have a state initialized
@@ -157,7 +188,7 @@ class StockStateConsumptionTest(StockStateTest):
         self.assertEqual(None, state.get_daily_consumption())
 
     def test_pre_set_defaults(self):
-        set_default_monthly_consumption_for_domain(self.domain.name, 5 * 30)
+        set_default_monthly_consumption_for_domain(self.domain, 5 * 30)
         with process_kafka_changes('LedgerToElasticsearchPillow'):
             self.report(25, 0)
         state = StockState.objects.get(
@@ -171,7 +202,7 @@ class StockStateConsumptionTest(StockStateTest):
     def test_defaults_set_after_report(self):
         with process_kafka_changes('LedgerToElasticsearchPillow'):
             self.report(25, 0)
-        set_default_monthly_consumption_for_domain(self.domain.name, 5 * 30)
+        set_default_monthly_consumption_for_domain(self.domain, 5 * 30)
 
         state = StockState.objects.get(
             section_id='stock',
@@ -187,7 +218,7 @@ class StockStateConsumptionTest(StockStateTest):
         self.report(10, 0)
         expected_result = Decimal(3)
 
-        commtrack_settings = self.domain.commtrack_settings
+        commtrack_settings = self.domain_obj.commtrack_settings
 
         def _update_consumption_config(min_transactions, min_window, optimal_window):
             commtrack_settings.consumption_config.min_transactions = min_transactions
@@ -206,7 +237,7 @@ class StockStateConsumptionTest(StockStateTest):
         )
         for consumption_params, test_result in tests:
             _reset()
-            recalculate_domain_consumption(self.domain.name)
+            recalculate_domain_consumption(self.domain)
             state = StockState.objects.get(section_id='stock', case_id=self.sp.case_id, product_id=self.products[0]._id)
             self.assertEqual(
                 expected_result,
@@ -226,7 +257,7 @@ class StockStateConsumptionTest(StockStateTest):
             )
 
             # recalculating should though
-            recalculate_domain_consumption(self.domain.name)
+            recalculate_domain_consumption(self.domain)
             state = StockState.objects.get(section_id='stock', case_id=self.sp.case_id, product_id=self.products[0]._id)
             self.assertEqual(
                 test_result,

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from django.test import TestCase
 from django.test.utils import override_settings
 from lxml import etree
 import os
@@ -21,8 +22,8 @@ from dimagi.utils.parsing import json_format_datetime, json_format_date
 from casexml.apps.stock import const as stockconst
 from casexml.apps.stock.models import StockReport, StockTransaction
 from corehq.apps.commtrack import const
-from corehq.apps.commtrack.tests.util import CommTrackTest, get_ota_balance_xml, FIXED_USER, extract_balance_xml, \
-    get_single_balance_block, get_single_transfer_block
+from corehq.apps.commtrack.models import CommtrackConfig
+from corehq.apps.commtrack.tests import util
 from casexml.apps.case.tests.util import check_xml_line_by_line, check_user_has_case
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.commtrack.tests.util import make_loc
@@ -39,24 +40,50 @@ from corehq.apps.commtrack.tests.data.balances import (
     receipts_enumerated,
     balance_enumerated,
     products_xml, SohReport)
+from corehq.apps.groups.models import Group
+from corehq.apps.products.models import Product
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from testapps.test_pillowtop.utils import process_kafka_changes
 
 
-class CommTrackOTATest(CommTrackTest):
-    user_definitions = [FIXED_USER]
+class XMLTest(TestCase):
+    user_definitions = [util.FIXED_USER]
 
     def setUp(self):
-        super(CommTrackOTATest, self).setUp()
+        super(XMLTest, self).setUp()
+        self.domain = util.bootstrap_domain(util.TEST_DOMAIN)
+        util.bootstrap_location_types(self.domain.name)
+        util.bootstrap_products(self.domain.name)
+        self.products = sorted(Product.by_domain(self.domain.name), key=lambda p: p._id)
+        self.ct_settings = CommtrackConfig.for_domain(self.domain.name)
+        self.ct_settings.consumption_config = ConsumptionConfig(
+            min_transactions=0,
+            min_window=0,
+            optimal_window=60,
+            min_periods=0,
+        )
+        self.ct_settings.save()
+        self.domain = Domain.get(self.domain._id)
+
+        self.loc = make_loc('loc1')
+        self.sp = self.loc.linked_supply_point()
+        self.users = [util.bootstrap_user(self, **user_def) for user_def in self.user_definitions]
         self.user = self.users[0]
+
+    def tearDown(self):
+        delete_all_users()
+        self.domain.delete()
+        super(XMLTest, self).tearDown()
+
+
+class CommTrackOTATest(XMLTest):
 
     @run_with_all_backends
     def test_ota_blank_balances(self):
-        user = self.user
-        self.assertFalse(get_ota_balance_xml(self.domain, user))
+        self.assertFalse(util.get_ota_balance_xml(self.domain, self.user))
 
     @run_with_all_backends
     def test_ota_basic(self):
-        user = self.user
         amounts = [
             SohReport(section_id='stock', product_id=p._id, amount=i*10)
             for i, p in enumerate(self.products)
@@ -70,12 +97,11 @@ class CommTrackOTATest(CommTrackTest):
                 amounts,
                 datestring=report_date,
             ),
-            get_ota_balance_xml(self.domain, user)[0],
+            util.get_ota_balance_xml(self.domain, self.user)[0],
         )
 
     @run_with_all_backends
     def test_ota_multiple_stocks(self):
-        user = self.user
         section_ids = sorted(('stock', 'losses', 'consumption'))
         amounts = [
             SohReport(section_id=section_id, product_id=p._id, amount=i * 10)
@@ -83,7 +109,7 @@ class CommTrackOTATest(CommTrackTest):
             for i, p in enumerate(self.products)
         ]
         report_date = _report_soh(amounts, self.sp.case_id, self.domain.name)
-        balance_blocks = get_ota_balance_xml(self.domain, user)
+        balance_blocks = util.get_ota_balance_xml(self.domain, self.user)
         self.assertEqual(3, len(balance_blocks))
         for i, section_id in enumerate(section_ids):
             reports = [
@@ -183,12 +209,10 @@ class CommTrackOTATest(CommTrackTest):
         self.domain = Domain.get(self.domain._id)
 
 
-class CommTrackSubmissionTest(CommTrackTest):
-    user_definitions = [FIXED_USER]
+class CommTrackSubmissionTest(XMLTest):
 
     def setUp(self):
         super(CommTrackSubmissionTest, self).setUp()
-        self.user = self.users[0]
         loc2 = make_loc('loc2')
         self.sp2 = loc2.linked_supply_point()
 
@@ -427,7 +451,11 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
     @run_with_all_backends
     def test_blank_case_id_in_balance(self):
         form = submit_case_blocks(
-            case_blocks=get_single_balance_block(case_id='', product_id=self.products[0]._id, quantity=100),
+            case_blocks=util.get_single_balance_block(
+                case_id='',
+                product_id=self.products[0]._id,
+                quantity=100
+            ),
             domain=self.domain.name,
         )[0]
         instance = FormAccessors(self.domain.name).get_form(form.form_id)
@@ -437,7 +465,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
     @run_with_all_backends
     def test_blank_case_id_in_transfer(self):
         form = submit_case_blocks(
-            case_blocks=get_single_transfer_block(
+            case_blocks=util.get_single_transfer_block(
                 src_id='', dest_id='', product_id=self.products[0]._id, quantity=100,
             ),
             domain=self.domain.name,
@@ -538,23 +566,15 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
 
     def setUp(self):
         super(CommTrackSyncTest, self).setUp()
-        # reused stuff
+        self.group = Group(domain=util.TEST_DOMAIN, name='commtrack-folks',
+                           users=[self.user._id], case_sharing=True)
+        self.group._id = self.sp.owner_id
+        self.group.save()
+
         self.restore_user = self.user.to_ota_restore_user()
         self.sp_block = CaseBlock(
             case_id=self.sp.case_id,
         ).as_xml()
-
-        # bootstrap ota stuff
-        self.ct_settings.consumption_config = ConsumptionConfig(
-            min_transactions=0,
-            min_window=0,
-            optimal_window=60,
-        )
-        self.ct_settings.ota_restore_config = StockRestoreConfig(
-            section_to_consumption_types={'stock': 'consumption'}
-        )
-        set_default_monthly_consumption_for_domain(self.domain.name, 5)
-        self.ota_settings = self.ct_settings.get_ota_restore_settings()
 
         # get initial restore token
         restore_config = RestoreConfig(
@@ -685,7 +705,7 @@ class CommTrackArchiveSubmissionTest(CommTrackSubmissionTest):
 def _report_soh(soh_reports, case_id, domain):
     report_date = json_format_datetime(datetime.utcnow())
     balance_blocks = [
-        get_single_balance_block(
+        util.get_single_balance_block(
             case_id,
             report.product_id,
             report.amount,
@@ -704,4 +724,4 @@ def _get_ota_balance_blocks(project, user):
         restore_user=user.to_ota_restore_user(),
         params=RestoreParams(version=V2),
     )
-    return extract_balance_xml(restore_config.get_payload().as_string())
+    return util.extract_balance_xml(restore_config.get_payload().as_string())

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -145,14 +145,6 @@ class CommTrackTest(TestCase):
 
     def setUp(self):
         super(CommTrackTest, self).setUp()
-        # might as well clean house before doing anything
-        delete_all_xforms()
-        delete_all_cases()
-        delete_all_sync_logs()
-
-        StockReport.objects.all().delete()
-        StockTransaction.objects.all().delete()
-
         self.backend, self.backend_mapping = setup_default_sms_test_backend()
 
         self.domain = bootstrap_domain(TEST_DOMAIN)

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -140,7 +140,6 @@ def make_loc(code, name=None, domain=TEST_DOMAIN, type=TEST_LOCATION_TYPE, paren
 
 
 class CommTrackTest(TestCase):
-    requisitions_enabled = False  # can be overridden
     user_definitions = []
 
     def setUp(self):
@@ -157,10 +156,6 @@ class CommTrackTest(TestCase):
             optimal_window=60,
             min_periods=0,
         )
-        # todo: remove?
-        if self.requisitions_enabled:
-            self.ct_settings.requisition_config = get_default_requisition_config()
-
         self.ct_settings.save()
 
         self.domain = Domain.get(self.domain._id)

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -121,8 +121,6 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
 
     @classmethod
     def setUpClass(cls):
-        delete_all_locations()
-        delete_all_users()
         super(LocationChoiceProviderTest, cls).setUpClass()
         report = ReportConfiguration(domain=cls.domain)
         choice_tuples = [
@@ -148,6 +146,7 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
     def tearDownClass(cls):
         cls.domain_obj.delete()
         delete_all_locations()
+        delete_all_users()
 
     def test_query_search(self):
         # Searching for something common to all locations gets you all locations


### PR DESCRIPTION
This class was essentially a dumping ground for the `setUp` needs of bunch of vaguely related tests.  Much of that wasn't necessary at all, and in most cases could go in `setUpClass`.  I cut down on a bunch of this needless `setUp`.  The `test_xml.py` tests still take around 135s (down from 220s), it wasn't trivial to pull stuff out in to a `setUpClass`, but I'm confident that could be improved further.  All told, this brings the total runtime of these tests from 407s to 225s - a savings of 3:02.
@dimagi/test-team 