### PR TITLE
Include style for edit forms

### DIFF
--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -1,6 +1,41 @@
 {% extends "style/two_column.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
+{% load compress %}
+
+{% block stylesheets %}
+
+{% if less_debug %}
+<link type="text/less"
+    rel="stylesheet"
+    media="all"
+    href="{% static 'cloudcare/less/font-formplayer.less' %}" />
+<link type="text/less"
+    rel="stylesheet"
+    media="all"
+    href="{% static 'cloudcare/less/formplayer-common.debug.less' %}" />
+<link type="text/less"
+    rel="stylesheet"
+    media="all"
+    href="{% static 'cloudcare/less/formplayer-webapp.debug.less' %}" />
+{% else %}
+{% compress css %}
+  <link type="text/less"
+        rel="stylesheet"
+        media="all"
+        href="{% static 'cloudcare/less/font-formplayer.less' %}" />
+  <link type="text/less"
+        rel="stylesheet"
+        media="all"
+        href="{% static 'cloudcare/less/formplayer-common.less' %}"/>
+  <link type="text/less"
+        rel="stylesheet"
+        media="all"
+        href="{% static 'cloudcare/less/formplayer-webapp.less' %}"/>
+{% endcompress %}
+{% endif %}
+
+{% endblock %}
 
 {% block js-inline %}{{ block.super }}
     {% include 'cloudcare/includes/touchforms-inline.html' %}


### PR DESCRIPTION
@wpride http://manage.dimagi.com/default.asp?247788 this doesn't address the full ticket, but this will handle the issue of unwanted "Sorry this question is required" showing up. I think there is some discrepancy between old edit forms and new edit forms (will offline with you). tested on both old and new backend

![screen shot 2017-02-17 at 10 46 45 am](https://cloud.githubusercontent.com/assets/918514/23058593/6524b79c-f4fe-11e6-9bc1-c320abefdfae.png)

cc: @kaapstorm (also @dimagi/ux not sure if you have input, but this is drastically changing the look of edit forms to match web apps)