### PR TITLE
The slow march to tagging sql backend tests

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -34,13 +34,13 @@ class CaseBugTestCouchOnly(TestCase, TestFileMixin):
 
     @classmethod
     def setUpClass(cls):
-        super(CaseBugTestCouch, cls).setUpClass()
+        super(CaseBugTestCouchOnly, cls).setUpClass()
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()
 
     @classmethod
     def tearDownClass(cls):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()
-        super(CaseBugTestCouch, cls).tearDownClass()
+        super(CaseBugTestCouchOnly, cls).tearDownClass()
 
     def test_conflicting_ids(self):
         """

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -14,7 +14,7 @@ from casexml.apps.case.xml import V2, V1
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
-    sql_backend_case,
+    use_sql_backend,
 )
 from corehq.util.test_utils import TestFileMixin, softer_assert
 
@@ -188,7 +188,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertEqual(cases[1].get_case_property('p'), '2')
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseBugTestSQL(CaseBugTest):
     pass
 
@@ -306,6 +306,6 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual(1, len(hierarchy['child_cases'][0]['child_cases']))
 
 
-@sql_backend_case
+@use_sql_backend
 class TestCaseHierarchySQL(TestCaseHierarchy):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -27,7 +27,7 @@ class SimpleCaseBugTests(SimpleTestCase):
             CommCareCase(_id='test').to_xml(version)
 
 
-class CaseBugTestCouch(TestCase, TestFileMixin):
+class CaseBugTestCouchOnly(TestCase, TestFileMixin):
 
     file_path = ('data', 'bugs')
     root = os.path.dirname(__file__)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -14,7 +14,7 @@ from casexml.apps.case.xml import V2, V1
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
-    sql_backend_test_case,
+    sql_backend_case,
 )
 from corehq.util.test_utils import TestFileMixin, softer_assert
 
@@ -29,15 +29,18 @@ class SimpleCaseBugTests(SimpleTestCase):
 
 class CaseBugTestCouch(TestCase, TestFileMixin):
 
+    file_path = ('data', 'bugs')
+    root = os.path.dirname(__file__)
+
     @classmethod
     def setUpClass(cls):
-        super(CaseBugTest, cls).setUpClass()
+        super(CaseBugTestCouch, cls).setUpClass()
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()
 
     @classmethod
     def tearDownClass(cls):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()
-        super(CaseBugTest, cls).tearDownClass()
+        super(CaseBugTestCouch, cls).tearDownClass()
 
     def test_conflicting_ids(self):
         """
@@ -185,7 +188,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertEqual(cases[1].get_case_property('p'), '2')
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseBugTestSQL(CaseBugTest):
     pass
 
@@ -303,6 +306,6 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual(1, len(hierarchy['child_cases'][0]['child_cases']))
 
 
-@sql_backend_test_case
+@sql_backend_case
 class TestCaseHierarchySQL(TestCaseHierarchy):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -27,13 +27,7 @@ class SimpleCaseBugTests(SimpleTestCase):
             CommCareCase(_id='test').to_xml(version)
 
 
-@override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
-class CaseBugTest(TestCase, TestFileMixin):
-    """
-    Tests bugs that come up in case processing
-    """
-    file_path = ('data', 'bugs')
-    root = os.path.dirname(__file__)
+class CaseBugTestCouch(TestCase, TestFileMixin):
 
     @classmethod
     def setUpClass(cls):
@@ -52,6 +46,25 @@ class CaseBugTest(TestCase, TestFileMixin):
         xml_data = self.get_xml('id_conflicts')
         with self.assertRaises(BulkSaveError):
             submit_form_locally(xml_data, 'test-domain')
+
+
+@override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
+class CaseBugTest(TestCase, TestFileMixin):
+    """
+    Tests bugs that come up in case processing
+    """
+    file_path = ('data', 'bugs')
+    root = os.path.dirname(__file__)
+
+    @classmethod
+    def setUpClass(cls):
+        super(CaseBugTest, cls).setUpClass()
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+        super(CaseBugTest, cls).tearDownClass()
 
     def test_empty_case_id(self):
         """

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -6,7 +6,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.xform import get_extensions_to_close
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
@@ -101,7 +101,6 @@ class AutoCloseExtensionsTest(TestCase):
         )
         return self.factory.create_or_update_cases([extension_2])
 
-    @run_with_all_backends
     def test_get_extension_chain_simple(self):
         host = CaseStructure(case_id=self.host_id, attrs={'create': True})
         extension = CaseStructure(
@@ -118,7 +117,6 @@ class AutoCloseExtensionsTest(TestCase):
             CaseAccessors(self.domain).get_extension_chain([self.host_id])
         )
 
-    @run_with_all_backends
     def test_get_extension_chain_multiple(self):
         created_cases = self._create_extension_chain()
         self.assertEqual(
@@ -126,7 +124,6 @@ class AutoCloseExtensionsTest(TestCase):
             CaseAccessors(self.domain).get_extension_chain([created_cases[-1].case_id])
         )
 
-    @run_with_all_backends
     def test_get_extension_chain_circular_ref(self):
         """If there is a circular reference, this should not hang forever
         """
@@ -139,7 +136,6 @@ class AutoCloseExtensionsTest(TestCase):
         )
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_get_extension_to_close(self):
         """should return empty if case is not a host, otherwise should return full chain"""
         created_cases = self._create_extension_chain()
@@ -161,7 +157,6 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertEqual(set(), no_cases)
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_get_extension_to_close_child_host(self):
         """should still return extension chain if outgoing index is a child index"""
         created_cases = self._create_host_is_subcase_chain()
@@ -186,7 +181,6 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertEqual(set(self.extension_ids[0:2]), full_chain)
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_close_cases_host(self):
         """Closing a host should close all the extensions"""
         self._create_extension_chain()
@@ -222,7 +216,6 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertTrue(cases[self.extension_ids[2]])
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_close_cases_child(self):
         """Closing a host that is also a child should close all the extensions"""
         self._create_host_is_subcase_chain()
@@ -246,3 +239,8 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertTrue(cases[self.host_id])
         self.assertTrue(cases[self.extension_ids[0]])
         self.assertTrue(cases[self.extension_ids[1]])
+
+
+@sql_backend_test_case
+class AutoCloseExtensionsTestSQL(AutoCloseExtensionsTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -6,7 +6,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.xform import get_extensions_to_close
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
@@ -241,6 +241,6 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertTrue(cases[self.extension_ids[1]])
 
 
-@sql_backend_test_case
+@sql_backend_case
 class AutoCloseExtensionsTestSQL(AutoCloseExtensionsTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -6,7 +6,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.xform import get_extensions_to_close
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
@@ -241,6 +241,6 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertTrue(cases[self.extension_ids[1]])
 
 
-@sql_backend_case
+@use_sql_backend
 class AutoCloseExtensionsTestSQL(AutoCloseExtensionsTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
 from django.test import TestCase
 
 
@@ -23,7 +23,6 @@ class TestExtensionCaseIds(TestCase):
         FormProcessorTestUtils.delete_all_xforms()
         super(TestExtensionCaseIds, self).tearDown()
 
-    @run_with_all_backends
     def test_no_extensions(self):
         """ Returns empty when there are other index types """
         parent_id = uuid.uuid4().hex
@@ -42,7 +41,6 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([parent_id])
         self.assertEqual(returned_cases, [])
 
-    @run_with_all_backends
     def test_simple_extension_returned(self):
         """ Should return extension if it exists """
         host_id = uuid.uuid4().hex
@@ -61,7 +59,6 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id])
         self.assertItemsEqual(returned_cases, [extension_id])
 
-    @run_with_all_backends
     def test_extension_of_multiple_hosts_returned(self):
         """ Should return an extension from any host if there are multiple indices """
         host_id = uuid.uuid4().hex
@@ -89,7 +86,6 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id])
         self.assertItemsEqual(returned_cases, [extension_id])
 
-    @run_with_all_backends
     def test_host_with_multiple_extensions(self):
         """ Return all extensions from a single host """
         host_id = uuid.uuid4().hex
@@ -119,7 +115,6 @@ class TestExtensionCaseIds(TestCase):
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id])
         self.assertItemsEqual(returned_cases, [extension_id, extension_2_id])
 
-    @run_with_all_backends
     def test_extensions_from_list(self):
         """ Given a list of hosts, should return all extensions """
         host_id = uuid.uuid4().hex
@@ -151,6 +146,11 @@ class TestExtensionCaseIds(TestCase):
         self.assertItemsEqual(returned_cases, [extension_id, extension_2_id])
 
 
+@sql_backend_test_case
+class TestExtensionCaseIdsSQL(TestExtensionCaseIds):
+    pass
+
+
 class TestIndexedCaseIds(TestCase):
 
     def setUp(self):
@@ -163,7 +163,6 @@ class TestIndexedCaseIds(TestCase):
         FormProcessorTestUtils.delete_all_xforms()
         super(TestIndexedCaseIds, self).tearDown()
 
-    @run_with_all_backends
     def test_indexed_case_ids_returns_extensions(self):
         """ When getting indices, also return extensions """
         host_id = uuid.uuid4().hex
@@ -181,6 +180,11 @@ class TestIndexedCaseIds(TestCase):
         )
         returned_cases = CaseAccessors(self.domain).get_indexed_case_ids([extension_id])
         self.assertItemsEqual(returned_cases, [host_id])
+
+
+@sql_backend_test_case
+class TestIndexedCaseIdsSQL(TestIndexedCaseIds):
+    pass
 
 
 class TestReverseIndexedCases(TestCase):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
 from django.test import TestCase
 
 
@@ -146,7 +146,7 @@ class TestExtensionCaseIds(TestCase):
         self.assertItemsEqual(returned_cases, [extension_id, extension_2_id])
 
 
-@sql_backend_test_case
+@sql_backend_case
 class TestExtensionCaseIdsSQL(TestExtensionCaseIds):
     pass
 
@@ -182,7 +182,7 @@ class TestIndexedCaseIds(TestCase):
         self.assertItemsEqual(returned_cases, [host_id])
 
 
-@sql_backend_test_case
+@sql_backend_case
 class TestIndexedCaseIdsSQL(TestIndexedCaseIds):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
 from django.test import TestCase
 
 
@@ -146,7 +146,7 @@ class TestExtensionCaseIds(TestCase):
         self.assertItemsEqual(returned_cases, [extension_id, extension_2_id])
 
 
-@sql_backend_case
+@use_sql_backend
 class TestExtensionCaseIdsSQL(TestExtensionCaseIds):
     pass
 
@@ -182,7 +182,7 @@ class TestIndexedCaseIds(TestCase):
         self.assertItemsEqual(returned_cases, [host_id])
 
 
-@sql_backend_case
+@use_sql_backend
 class TestIndexedCaseIdsSQL(TestIndexedCaseIds):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
@@ -7,7 +7,7 @@ from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
 from corehq.apps.change_feed import topics
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 from corehq.form_processor.utils.general import should_use_sql_backend
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
 
@@ -18,7 +18,6 @@ class TestHardDelete(TestCase):
         self.casedb = CaseAccessors(TEST_DOMAIN_NAME)
         self.formdb = FormAccessors(TEST_DOMAIN_NAME)
 
-    @run_with_all_backends
     def test_simple_delete(self):
         factory = CaseFactory()
         case = factory.create_case()
@@ -47,7 +46,6 @@ class TestHardDelete(TestCase):
             with self.assertRaises(XFormNotFound):
                 self.formdb.get_form(form_id)
 
-    @run_with_all_backends
     def test_delete_with_related(self):
         factory = CaseFactory()
         parent = factory.create_case()
@@ -66,7 +64,6 @@ class TestHardDelete(TestCase):
         with self.assertRaises(CaseNotFound):
             self.casedb.get_case(child.case_id)
 
-    @run_with_all_backends
     def test_delete_sharing_form(self):
         factory = CaseFactory()
         c1, c2 = factory.create_or_update_cases([
@@ -81,3 +78,8 @@ class TestHardDelete(TestCase):
 
         self.assertIsNotNone(self.casedb.get_case(c1.case_id))
         self.assertIsNotNone(self.casedb.get_case(c2.case_id))
+
+
+@sql_backend_test_case
+class TestHardDeleteSQL(TestHardDelete):
+    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
@@ -7,7 +7,7 @@ from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
 from corehq.apps.change_feed import topics
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.form_processor.utils.general import should_use_sql_backend
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
 
@@ -80,6 +80,6 @@ class TestHardDelete(TestCase):
         self.assertIsNotNone(self.casedb.get_case(c2.case_id))
 
 
-@sql_backend_case
+@use_sql_backend
 class TestHardDeleteSQL(TestHardDelete):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_delete.py
@@ -7,7 +7,7 @@ from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
 from corehq.apps.change_feed import topics
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from corehq.form_processor.utils.general import should_use_sql_backend
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
 
@@ -80,6 +80,6 @@ class TestHardDelete(TestCase):
         self.assertIsNotNone(self.casedb.get_case(c2.case_id))
 
 
-@sql_backend_test_case
+@sql_backend_case
 class TestHardDeleteSQL(TestHardDelete):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 ALICE_XML = """<?xml version='1.0' ?>
 <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D95E58BD-A228-414F-83E6-EEE716F0B3AD">
@@ -75,7 +75,6 @@ EVE_DOMAIN = 'domain2'
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=True)
 class DomainTest(TestCase):
 
-    @run_with_all_backends
     def test_cant_own_case(self):
         _, _, [case] = submit_form_locally(ALICE_XML, ALICE_DOMAIN)
         response, form, cases = submit_form_locally(EVE_XML, EVE_DOMAIN)
@@ -85,3 +84,8 @@ class DomainTest(TestCase):
 
         _, _, [case] = submit_form_locally(ALICE_UPDATE_XML, ALICE_DOMAIN)
         self.assertEqual(case.dynamic_case_properties()['plan_to_buy_gun'], 'no')
+
+
+@sql_backend_test_case
+class DomainTestSQL(DomainTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 ALICE_XML = """<?xml version='1.0' ?>
 <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D95E58BD-A228-414F-83E6-EEE716F0B3AD">
@@ -86,6 +86,6 @@ class DomainTest(TestCase):
         self.assertEqual(case.dynamic_case_properties()['plan_to_buy_gun'], 'no')
 
 
-@sql_backend_case
+@use_sql_backend
 class DomainTestSQL(DomainTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 ALICE_XML = """<?xml version='1.0' ?>
 <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D95E58BD-A228-414F-83E6-EEE716F0B3AD">
@@ -86,6 +86,6 @@ class DomainTest(TestCase):
         self.assertEqual(case.dynamic_case_properties()['plan_to_buy_gun'], 'no')
 
 
-@sql_backend_test_case
+@sql_backend_case
 class DomainTestSQL(DomainTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 TEST_DOMAIN = 'test-domain'
 
@@ -19,7 +19,6 @@ class CaseExclusionTest(TestCase):
         super(CaseExclusionTest, self).setUp()
         delete_all_cases()
 
-    @run_with_all_backends
     def testTopLevelExclusion(self):
         """
         Entire forms tagged as device logs should be excluded
@@ -31,7 +30,6 @@ class CaseExclusionTest(TestCase):
         submit_form_locally(xml_data, TEST_DOMAIN)
         self.assertEqual(0, len(CaseAccessors(TEST_DOMAIN).get_case_ids_in_domain()))
 
-    @run_with_all_backends
     def testNestedExclusion(self):
         """
         Blocks inside forms tagged as device logs should be excluded
@@ -42,3 +40,8 @@ class CaseExclusionTest(TestCase):
         _, _, [case] = submit_form_locally(xml_data, TEST_DOMAIN)
         self.assertEqual(['case_in_form'], CaseAccessors(TEST_DOMAIN).get_case_ids_in_domain())
         self.assertEqual("form case", case.name)
+
+
+@sql_backend_test_case
+class CaseExclusionTestSQL(CaseExclusionTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 TEST_DOMAIN = 'test-domain'
 
@@ -42,6 +42,6 @@ class CaseExclusionTest(TestCase):
         self.assertEqual("form case", case.name)
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseExclusionTestSQL(CaseExclusionTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 TEST_DOMAIN = 'test-domain'
 
@@ -42,6 +42,6 @@ class CaseExclusionTest(TestCase):
         self.assertEqual("form case", case.name)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseExclusionTestSQL(CaseExclusionTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -159,7 +159,7 @@ class CaseFactoryTest(TestCase):
         [regular, child, parent] = cases
         self.assertEqual(1, len(child.indices))
         self.assertEqual(parent_case_id, child.indices[0].referenced_id)
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(2, len(regular.actions))  # create + update
             self.assertEqual(2, len(parent.actions))  # create + update
             self.assertEqual(3, len(child.actions))  # create + update + index

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from casexml.apps.case.mock import CaseStructure, CaseIndex, CaseFactory
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 
 
@@ -205,6 +205,6 @@ class CaseFactoryTest(TestCase):
         self.assertEqual('differenttoken', form.last_sync_token)
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseFactoryTestSQL(CaseFactoryTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from casexml.apps.case.mock import CaseStructure, CaseIndex, CaseFactory
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 
 
@@ -103,41 +103,35 @@ class CaseStructureTest(SimpleTestCase):
 
 class CaseFactoryTest(TestCase):
 
-    @run_with_all_backends
     def test_simple_create(self):
         factory = CaseFactory()
         case = factory.create_case()
         self.assertIsNotNone(CaseAccessors().get_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_overrides(self):
         factory = CaseFactory()
         case = factory.create_case(owner_id='somebody', update={'custom_prop': 'custom_value'})
         self.assertEqual('somebody', case.owner_id)
         self.assertEqual('custom_value', case.dynamic_case_properties()['custom_prop'])
 
-    @run_with_all_backends
     def test_domain(self):
         domain = uuid.uuid4().hex
         factory = CaseFactory(domain=domain)
         case = factory.create_case()
         self.assertEqual(domain, case.domain)
 
-    @run_with_all_backends
     def test_factory_defaults(self):
         owner_id = uuid.uuid4().hex
         factory = CaseFactory(case_defaults={'owner_id': owner_id})
         case = factory.create_case()
         self.assertEqual(owner_id, case.owner_id)
 
-    @run_with_all_backends
     def test_override_defaults(self):
         owner_id = uuid.uuid4().hex
         factory = CaseFactory(case_defaults={'owner_id': owner_id})
         case = factory.create_case(owner_id='notthedefault')
         self.assertEqual('notthedefault', case.owner_id)
 
-    @run_with_all_backends
     def test_create_from_structure(self):
         owner_id = uuid.uuid4().hex
         factory = CaseFactory(case_defaults={
@@ -170,7 +164,6 @@ class CaseFactoryTest(TestCase):
             self.assertEqual(2, len(parent.actions))  # create + update
             self.assertEqual(3, len(child.actions))  # create + update + index
 
-    @run_with_all_backends
     def test_no_walk_related(self):
         factory = CaseFactory()
         parent = factory.create_case()
@@ -182,7 +175,6 @@ class CaseFactoryTest(TestCase):
         self.assertEqual(1, len(child_updates))
         self.assertEqual(parent.case_id, child_updates[0].indices[0].referenced_id)
 
-    @run_with_all_backends
     def test_form_extras(self):
         domain = uuid.uuid4().hex
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
@@ -192,7 +184,6 @@ class CaseFactoryTest(TestCase):
         form = FormAccessors(domain).get_form(case.xform_ids[0])
         self.assertEqual(token_id, form.last_sync_token)
 
-    @run_with_all_backends
     def test_form_extras_default(self):
         domain = uuid.uuid4().hex
         # have to enable loose sync token validation for the domain or create actual SyncLog documents.
@@ -204,7 +195,6 @@ class CaseFactoryTest(TestCase):
         form = FormAccessors(domain).get_form(case.xform_ids[0])
         self.assertEqual(token_id, form.last_sync_token)
 
-    @run_with_all_backends
     def test_form_extras_override_defaults(self):
         domain = uuid.uuid4().hex
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
@@ -213,3 +203,8 @@ class CaseFactoryTest(TestCase):
         [case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}), form_extras={'last_sync_token': 'differenttoken'})
         form = FormAccessors(domain).get_form(case.xform_ids[0])
         self.assertEqual('differenttoken', form.last_sync_token)
+
+
+@sql_backend_test_case
+class CaseFactoryTestSQL(CaseFactoryTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from casexml.apps.case.mock import CaseStructure, CaseIndex, CaseFactory
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 
 
@@ -205,6 +205,6 @@ class CaseFactoryTest(TestCase):
         self.assertEqual('differenttoken', form.last_sync_token)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseFactoryTestSQL(CaseFactoryTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
@@ -8,7 +8,7 @@ from casexml.apps.case.tests.util import bootstrap_case_from_xml
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CaseTransaction, CommCareCaseSQL
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.form_processor.backends.couch.update_strategy import coerce_to_datetime
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -131,6 +131,6 @@ class CaseFromXFormTest(TestCase):
             self.assertFalse(transaction.revoked)
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseFromXFormTestSQL(CaseFromXFormTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
@@ -8,7 +8,7 @@ from casexml.apps.case.tests.util import bootstrap_case_from_xml
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CaseTransaction, CommCareCaseSQL
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 from corehq.form_processor.backends.couch.update_strategy import coerce_to_datetime
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -17,7 +17,6 @@ class CaseFromXFormTest(TestCase):
     def setUp(self):
         self.interface = FormProcessorInterface()
 
-    @run_with_all_backends
     def testCreate(self):
         xform, case = bootstrap_case_from_xml(self, "create.xml")
         self._check_static_properties(case)
@@ -34,7 +33,6 @@ class CaseFromXFormTest(TestCase):
             self.assertEqual(xform.form_id, create_action.xform_id)
             self.assertEqual("test create", create_action.xform_name)
 
-    @run_with_all_backends
     def testCreateThenUpdateInSeparateForms(self):
         # recycle our previous test's form
         xform1, original_case = bootstrap_case_from_xml(self, "create_update.xml")
@@ -84,7 +82,6 @@ class CaseFromXFormTest(TestCase):
         # case should have a new modified date
         self.assertEqual(MODIFY_DATE, case.modified_on)
         
-    @run_with_all_backends
     def testCreateThenClose(self):
         xform1, case = bootstrap_case_from_xml(self, "create.xml")
 
@@ -132,3 +129,8 @@ class CaseFromXFormTest(TestCase):
             self.assertTrue(CaseTransaction.is_form_transaction)
             self.assertEqual(xform.form_id, transaction.form_id)
             self.assertFalse(transaction.revoked)
+
+
+@sql_backend_test_case
+class CaseFromXFormTestSQL(CaseFromXFormTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
@@ -22,7 +22,7 @@ class CaseFromXFormTest(TestCase):
         self._check_static_properties(case)
         self.assertEqual(False, case.closed)
 
-        if settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self._check_transactions(case, [xform])
             self.assertTrue(case.transactions[0].is_case_create)
         else:
@@ -46,7 +46,7 @@ class CaseFromXFormTest(TestCase):
         case = CaseAccessors().get_case(case.case_id)
         self.assertEqual(False, case.closed)
 
-        if settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self._check_transactions(case, [xform1, xform2])
             self.assertTrue(case.transactions[0].is_case_create)
         else:
@@ -89,7 +89,7 @@ class CaseFromXFormTest(TestCase):
         xform2, case = bootstrap_case_from_xml(self, "close.xml", case.case_id)
         self.assertEqual(True, case.closed)
 
-        if settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self._check_transactions(case, [xform1, xform2])
             self.assertTrue(case.transactions[0].is_case_create)
             self.assertTrue(case.transactions[1].is_case_close)
@@ -110,7 +110,7 @@ class CaseFromXFormTest(TestCase):
         self.assertEqual(CLOSE_DATE, case.modified_on)
 
     def _check_static_properties(self, case):
-        if settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(CommCareCaseSQL, type(case))
         else:
             self.assertEqual(CommCareCase, type(case))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
@@ -8,7 +8,7 @@ from casexml.apps.case.tests.util import bootstrap_case_from_xml
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CaseTransaction, CommCareCaseSQL
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from corehq.form_processor.backends.couch.update_strategy import coerce_to_datetime
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -131,6 +131,6 @@ class CaseFromXFormTest(TestCase):
             self.assertFalse(transaction.revoked)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseFromXFormTestSQL(CaseFromXFormTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -12,7 +12,7 @@ from casexml.apps.phone.tests.utils import create_restore_user
 from django.test import TestCase, SimpleTestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
 
 
 class IndexSimpleTest(SimpleTestCase):
@@ -167,7 +167,7 @@ class IndexTest(TestCase):
         check_user_has_case(self, self.user, create_index)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class IndexTestSQL(IndexTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -12,7 +12,7 @@ from casexml.apps.phone.tests.utils import create_restore_user
 from django.test import TestCase, SimpleTestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
 
 
 class IndexSimpleTest(SimpleTestCase):
@@ -167,7 +167,7 @@ class IndexTest(TestCase):
         check_user_has_case(self, self.user, create_index)
 
 
-@sql_backend_case
+@use_sql_backend
 class IndexTestSQL(IndexTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -12,7 +12,7 @@ from casexml.apps.phone.tests.utils import create_restore_user
 from django.test import TestCase, SimpleTestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
 
 
 class IndexSimpleTest(SimpleTestCase):
@@ -150,7 +150,6 @@ class IndexTest(TestCase):
 
         check_user_has_case(self, self.user, update_index_expected)
 
-    @run_with_all_backends
     def testRelationshipGetsSet(self):
         parent_case_id = uuid.uuid4().hex
         post_case_blocks(
@@ -166,6 +165,11 @@ class IndexTest(TestCase):
         ).as_xml()
         post_case_blocks([create_index], domain=self.project.name)
         check_user_has_case(self, self.user, create_index)
+
+
+@sql_backend_test_case
+class IndexTestSQL(IndexTest):
+    pass
 
 
 class CaseBlockIndexRelationshipTests(SimpleTestCase):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -20,7 +20,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_test_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
 from corehq.util.test_utils import TestFileMixin, trap_extra_setup
 
 TEST_CASE_ID = "EOL9FIAKIQWOFXFOH0QAMWU64"
@@ -295,7 +295,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
                                            sync_token=sync_log._id)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseMultimediaTestSQL(CaseMultimediaTest):
     pass
 
@@ -330,7 +330,7 @@ class CaseMultimediaS3DBTest(BaseCaseMultimediaTest):
         )
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseMultimediaS3DBTestSQL(CaseMultimediaS3DBTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -333,4 +333,3 @@ class CaseMultimediaS3DBTest(BaseCaseMultimediaTest):
 @use_sql_backend
 class CaseMultimediaS3DBTestSQL(CaseMultimediaS3DBTest):
     pass
-

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -20,7 +20,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sql_backend_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
 from corehq.util.test_utils import TestFileMixin, trap_extra_setup
 
 TEST_CASE_ID = "EOL9FIAKIQWOFXFOH0QAMWU64"
@@ -295,7 +295,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
                                            sync_token=sync_log._id)
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseMultimediaTestSQL(CaseMultimediaTest):
     pass
 
@@ -330,7 +330,7 @@ class CaseMultimediaS3DBTest(BaseCaseMultimediaTest):
         )
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseMultimediaS3DBTestSQL(CaseMultimediaS3DBTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -183,7 +183,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
             self._calc_file_hash(single_attach),
             hashlib.md5(case.get_attachment(single_attach)).hexdigest()
         )
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(1, len(filter(lambda x: x['action_type'] == 'attachment', case.actions)))
 
     def testArchiveAfterAttach(self):
@@ -209,7 +209,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         self.assertEqual(0, len(case.case_attachments))
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
             self.assertEqual(2, len(attach_actions))
             last_action = attach_actions[-1]
@@ -224,7 +224,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         self.assertEqual(sorted(new_attachments), sorted(case.case_attachments.keys()))
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
             self.assertEqual(2, len(attach_actions))
 
@@ -268,7 +268,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         # 1 plus the 2 we had
         self.assertEqual(len(new_attachments) + 1, len(case.case_attachments))
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
             self.assertEqual(2, len(attach_actions))
             last_action = attach_actions[-1]

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -44,6 +44,7 @@ def _post_util(create=False, case_id=None, user_id=None, owner_id=None,
     post_case_blocks([block], form_extras)
     return case_id
 
+
 class CaseRebuildTestMixin(object):
 
     def _assertListEqual(self, l1, l2, include_ordering=True):
@@ -258,7 +259,11 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         delete_all_cases()
 
     def test_rebuild_empty(self):
-        self.assertEqual(None, rebuild_case_from_forms('anydomain', 'notarealid', RebuildWithReason(reason='test')))
+        self.assertEqual(
+            None,
+            rebuild_case_from_forms('anydomain', 'notarealid', RebuildWithReason(reason='test'))
+        )
+
     def test_archiving_only_form(self):
         """
         Checks that archiving the only form associated with the case archives

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -15,7 +15,7 @@ from corehq.form_processor.backends.couch.update_strategy import CouchCaseUpdate
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import RebuildWithReason
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from corehq.form_processor.utils.general import should_use_sql_backend
 from couchforms.models import XFormInstance
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
@@ -68,7 +68,7 @@ class CouchCaseRebuildTest(TestCase, CaseRebuildTestMixin):
 
     @classmethod
     def setUpClass(cls):
-        super(CaseRebuildTest, cls).setUpClass()
+        super(CouchCaseRebuildTest, cls).setUpClass()
 
     def test_couch_action_equality(self):
         case_id = _post_util(create=True)
@@ -461,7 +461,7 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         self.assertTrue(case.is_deleted)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CaseRebuildTestSQL(CaseRebuildTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -67,8 +67,9 @@ class CaseRebuildTestMixin(object):
 class CouchCaseRebuildTest(TestCase, CaseRebuildTestMixin):
 
     @classmethod
-    def setUpClass(cls):
-        super(CouchCaseRebuildTest, cls).setUpClass()
+    def tearDownClass(cls):
+        delete_all_cases()
+        super(CouchCaseRebuildTest, cls).tearDownClass()
 
     def test_couch_action_equality(self):
         case_id = _post_util(create=True)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -15,7 +15,7 @@ from corehq.form_processor.backends.couch.update_strategy import CouchCaseUpdate
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import RebuildWithReason
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.form_processor.utils.general import should_use_sql_backend
 from couchforms.models import XFormInstance
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
@@ -462,7 +462,7 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         self.assertTrue(case.is_deleted)
 
 
-@sql_backend_case
+@use_sql_backend
 class CaseRebuildTestSQL(CaseRebuildTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -256,10 +256,8 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         super(CaseRebuildTest, cls).setUpClass()
         delete_all_cases()
 
-    @run_with_all_backends
     def test_rebuild_empty(self):
         self.assertEqual(None, rebuild_case_from_forms('anydomain', 'notarealid', RebuildWithReason(reason='test')))
-    @run_with_all_backends
     def test_archiving_only_form(self):
         """
         Checks that archiving the only form associated with the case archives
@@ -291,7 +289,6 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         self.assertEqual(3, len(case.actions))
         self.assertTrue(case.actions[-1].is_case_rebuild)
 
-    @run_with_all_backends
     def test_form_archiving(self):
         now = datetime.utcnow()
         # make sure we timestamp everything so they have the right order
@@ -420,7 +417,6 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         self.assertFalse('p5' in case.dynamic_case_properties())  # should disappear entirely
         _reset(f3)
 
-    @run_with_all_backends
     def test_archie_modified_on(self):
         case_id = uuid.uuid4().hex
         now = datetime.utcnow().replace(microsecond=0)
@@ -445,7 +441,6 @@ class CaseRebuildTest(TestCase, CaseRebuildTestMixin):
         case = case_accessors.get_case(case_id)
         self.assertEqual(way_earlier, case.modified_on)
 
-    @run_with_all_backends
     def test_archive_against_deleted_case(self):
         now = datetime.utcnow()
         # make sure we timestamp everything so they have the right order

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
@@ -5,7 +5,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.case.xform import process_cases_with_casedb
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.form import process_xform_xml
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 CASE_ID = 'a0cd5e6c5fb84695a4f729d3b1996a93'
@@ -41,7 +41,7 @@ class StrictDatetimesTest(TestCase):
                     process_cases_with_casedb(xforms, case_db)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class StrictDatetimesTestSQL(StrictDatetimesTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
@@ -5,7 +5,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.case.xform import process_cases_with_casedb
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.form import process_xform_xml
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 CASE_ID = 'a0cd5e6c5fb84695a4f729d3b1996a93'
@@ -32,7 +32,6 @@ class StrictDatetimesTest(TestCase):
         cls.domain = 'strict-datetimes-test-domain'
         cls.interface = FormProcessorInterface(cls.domain)
 
-    @run_with_all_backends
     def test(self):
         form = _make_form_from_case_blocks([ElementTree.fromstring(CASE_BLOCK)])
         result = process_xform_xml(self.domain, form)
@@ -40,6 +39,11 @@ class StrictDatetimesTest(TestCase):
             with self.interface.casedb_cache(domain=self.domain) as case_db:
                 with self.assertRaises(PhoneDateValueError):
                     process_cases_with_casedb(xforms, case_db)
+
+
+@sql_backend_test_case
+class StrictDatetimesTestSQL(StrictDatetimesTest):
+    pass
 
 
 def _make_form_from_case_blocks(case_blocks):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
@@ -5,7 +5,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.case.xform import process_cases_with_casedb
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.form import process_xform_xml
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 CASE_ID = 'a0cd5e6c5fb84695a4f729d3b1996a93'
@@ -41,7 +41,7 @@ class StrictDatetimesTest(TestCase):
                     process_cases_with_casedb(xforms, case_db)
 
 
-@sql_backend_case
+@use_sql_backend
 class StrictDatetimesTestSQL(StrictDatetimesTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from casexml.apps.case.xml import V2, V2_NAMESPACE
 from casexml.apps.case import const
 from casexml.apps.phone import xml
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -31,7 +31,6 @@ class Version2CaseParsingTest(TestCase):
         delete_all_cases()
         super(Version2CaseParsingTest, cls).tearDownClass()
 
-    @run_with_all_backends
     def testParseCreate(self):
         self._test_parse_create()
 
@@ -57,7 +56,6 @@ class Version2CaseParsingTest(TestCase):
             self.assertEqual("v2 create", action.xform_name)
             self.assertEqual("bar-user-id", case.actions[0].user_id)
 
-    @run_with_all_backends
     def testParseUpdate(self):
         self._test_parse_create()
         
@@ -77,7 +75,6 @@ class Version2CaseParsingTest(TestCase):
             self.assertEqual(2, len(case.actions))
             self.assertEqual("bar-user-id", case.actions[1].user_id)
 
-    @run_with_all_backends
     def testParseNoop(self):
         self._test_parse_create()
 
@@ -96,7 +93,6 @@ class Version2CaseParsingTest(TestCase):
 
         self.assertEqual(2, len(case.xform_ids))
 
-    @run_with_all_backends
     def testParseClose(self):
         self._test_parse_create()
         
@@ -108,7 +104,6 @@ class Version2CaseParsingTest(TestCase):
         self.assertTrue(case.closed)
         self.assertEqual("bar-user-id", case.closed_by)
 
-    @run_with_all_backends
     def testParseNamedNamespace(self):
         file_path = os.path.join(os.path.dirname(__file__), "data", "v2", "named_namespace.xml")
         with open(file_path, "rb") as f:
@@ -124,7 +119,6 @@ class Version2CaseParsingTest(TestCase):
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual(2, len(case.actions))
 
-    @run_with_all_backends
     def testParseWithIndices(self):
         self._test_parse_create()
 
@@ -175,6 +169,11 @@ class Version2CaseParsingTest(TestCase):
                 </index>
             </case>"""
         check_xml_line_by_line(self, expected_v2_response, v2response)
+
+
+@sql_backend_test_case
+class Version2CaseParsingTestSQL(Version2CaseParsingTest):
+    pass
 
 
 class SimpleParsingTests(SimpleTestCase):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from casexml.apps.case.xml import V2, V2_NAMESPACE
 from casexml.apps.case import const
 from casexml.apps.phone import xml
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -171,7 +171,7 @@ class Version2CaseParsingTest(TestCase):
         check_xml_line_by_line(self, expected_v2_response, v2response)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class Version2CaseParsingTestSQL(Version2CaseParsingTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -49,7 +49,7 @@ class Version2CaseParsingTest(TestCase):
         self.assertEqual("v2_case_type", case.type)
         self.assertEqual("test case name", case.name)
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(1, len(case.actions))
             [action] = case.actions
             self.assertEqual("http://openrosa.org/case/test/create", action.xform_xmlns)
@@ -71,7 +71,7 @@ class Version2CaseParsingTest(TestCase):
         self.assertEqual("updated case name", case.name)
         self.assertEqual("something dynamic", case.dynamic_case_properties()['dynamic'])
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(2, len(case.actions))
             self.assertEqual("bar-user-id", case.actions[1].user_id)
 
@@ -87,7 +87,7 @@ class Version2CaseParsingTest(TestCase):
         self.assertEqual("bar-user-id", case.user_id)
         self.assertEqual(datetime(2011, 12, 7, 13, 44, 50), case.modified_on)
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(2, len(case.actions))
             self.assertEqual("bar-user-id", case.actions[1].user_id)
 
@@ -116,7 +116,7 @@ class Version2CaseParsingTest(TestCase):
         self.assertEqual("cc_bihar_pregnancy", case.type)
         self.assertEqual("TEST", case.name)
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(2, len(case.actions))
 
     def testParseWithIndices(self):
@@ -144,7 +144,7 @@ class Version2CaseParsingTest(TestCase):
         self.assertEqual("bop", case.get_index("baz_ref").referenced_type)
         self.assertEqual("some_other_referenced_id", case.get_index("baz_ref").referenced_id)
 
-        if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             # check the action
             self.assertEqual(2, len(case.actions))
             [_, index_action] = case.actions

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from casexml.apps.case.xml import V2, V2_NAMESPACE
 from casexml.apps.case import const
 from casexml.apps.phone import xml
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -171,7 +171,7 @@ class Version2CaseParsingTest(TestCase):
         check_xml_line_by_line(self, expected_v2_response, v2response)
 
 
-@sql_backend_case
+@use_sql_backend
 class Version2CaseParsingTestSQL(Version2CaseParsingTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -12,7 +12,7 @@ from casexml.apps.case.tests.util import (
     delete_all_sync_logs,
 )
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from casexml.apps.phone.restore import (
     RestoreConfig,
     RestoreParams,
@@ -236,7 +236,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         self.assertTrue(cache.delete.called)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class AsyncRestoreTestSQL(AsyncRestoreTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -12,7 +12,7 @@ from casexml.apps.case.tests.util import (
     delete_all_sync_logs,
 )
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from casexml.apps.phone.restore import (
     RestoreConfig,
     RestoreParams,
@@ -236,7 +236,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         self.assertTrue(cache.delete.called)
 
 
-@sql_backend_case
+@use_sql_backend
 class AsyncRestoreTestSQL(AsyncRestoreTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
@@ -9,7 +9,7 @@ from casexml.apps.phone.exceptions import SyncLogCachingError
 from casexml.apps.phone.models import SimplifiedSyncLog, get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.dummy import dummy_restore_xml
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 class CacheUtilsTest(SimpleTestCase):
@@ -75,7 +75,7 @@ class CacheUtilsDbTest(TestCase):
         self.assertEqual(updated_log.case_ids_on_phone, sync_log.case_ids_on_phone)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CacheUtilsDbTestSQL(CacheUtilsDbTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
@@ -9,7 +9,7 @@ from casexml.apps.phone.exceptions import SyncLogCachingError
 from casexml.apps.phone.models import SimplifiedSyncLog, get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.dummy import dummy_restore_xml
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 class CacheUtilsTest(SimpleTestCase):
@@ -55,7 +55,6 @@ class CacheUtilsTest(SimpleTestCase):
 
 class CacheUtilsDbTest(TestCase):
 
-    @run_with_all_backends
     def test_copy_payload(self):
         sync_log = SimplifiedSyncLog(case_ids_on_phone=set(['case-1', 'case-2']))
         sync_log.save()
@@ -74,6 +73,11 @@ class CacheUtilsDbTest(TestCase):
         self.assertFalse(sync_log._id in updated_payload)
         updated_log = get_properly_wrapped_sync_log(updated_id)
         self.assertEqual(updated_log.case_ids_on_phone, sync_log.case_ids_on_phone)
+
+
+@sql_backend_test_case
+class CacheUtilsDbTestSQL(CacheUtilsDbTest):
+    pass
 
 
 def _restore_id_block(sync_id):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
@@ -9,7 +9,7 @@ from casexml.apps.phone.exceptions import SyncLogCachingError
 from casexml.apps.phone.models import SimplifiedSyncLog, get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.dummy import dummy_restore_xml
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 class CacheUtilsTest(SimpleTestCase):
@@ -75,7 +75,7 @@ class CacheUtilsDbTest(TestCase):
         self.assertEqual(updated_log.case_ids_on_phone, sync_log.case_ids_on_phone)
 
 
-@sql_backend_case
+@use_sql_backend
 class CacheUtilsDbTestSQL(CacheUtilsDbTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.data_providers.case.clean_owners import pop_ids
 from casexml.apps.phone.exceptions import InvalidDomainError, InvalidOwnerIdError
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=None)
@@ -483,7 +483,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags()
 
 
-@sql_backend_test_case
+@sql_backend_case
 class OwnerCleanlinessTestSQL(OwnerCleanlinessTest):
     pass
 
@@ -503,7 +503,7 @@ class SetCleanlinessFlagsTest(TestCase):
                 set_cleanliness_flags('whatever', invalid_owner)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SetCleanlinessFlagsTestSQL(SetCleanlinessFlagsTest):
     pass
 
@@ -669,7 +669,7 @@ class GetCaseFootprintInfoTest(TestCase):
         )
 
 
-@sql_backend_test_case
+@sql_backend_case
 class GetCaseFootprintInfoTestSQL(GetCaseFootprintInfoTest):
     pass
 
@@ -759,6 +759,6 @@ class GetDependentCasesTest(TestCase):
                          get_dependent_case_info(self.domain, [parent.case_id]).extension_ids)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class GetDependentCasesTestSQL(GetDependentCasesTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.data_providers.case.clean_owners import pop_ids
 from casexml.apps.phone.exceptions import InvalidDomainError, InvalidOwnerIdError
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=None)
@@ -483,7 +483,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags()
 
 
-@sql_backend_case
+@use_sql_backend
 class OwnerCleanlinessTestSQL(OwnerCleanlinessTest):
     pass
 
@@ -503,7 +503,7 @@ class SetCleanlinessFlagsTest(TestCase):
                 set_cleanliness_flags('whatever', invalid_owner)
 
 
-@sql_backend_case
+@use_sql_backend
 class SetCleanlinessFlagsTestSQL(SetCleanlinessFlagsTest):
     pass
 
@@ -669,7 +669,7 @@ class GetCaseFootprintInfoTest(TestCase):
         )
 
 
-@sql_backend_case
+@use_sql_backend
 class GetCaseFootprintInfoTestSQL(GetCaseFootprintInfoTest):
     pass
 
@@ -759,6 +759,6 @@ class GetDependentCasesTest(TestCase):
                          get_dependent_case_info(self.domain, [parent.case_id]).extension_ids)
 
 
-@sql_backend_case
+@use_sql_backend
 class GetDependentCasesTestSQL(GetDependentCasesTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.data_providers.case.clean_owners import pop_ids
 from casexml.apps.phone.exceptions import InvalidDomainError, InvalidOwnerIdError
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=None)
@@ -103,14 +103,12 @@ class OwnerCleanlinessTest(SyncBaseTest):
         )[0]
         self.assertEqual(owner_id, case.owner_id)
 
-    @run_with_all_backends
     def test_add_normal_case_stays_clean(self):
         """Owned case with no indices remains clean"""
         self.factory.create_case()
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_change_owner_stays_clean(self):
         """change the owner ID of a normal case, should remain clean"""
         new_owner = uuid.uuid4().hex
@@ -118,7 +116,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_temporarily_dirty()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_change_owner_child_case_stays_clean(self):
         """change the owner ID of a child case, should remain clean"""
         new_owner = uuid.uuid4().hex
@@ -126,14 +123,12 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_temporarily_dirty()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_add_clean_parent_stays_clean(self):
         """add a parent with the same owner, should remain clean"""
         self.factory.create_or_update_case(CaseStructure(indices=[CaseIndex()]))
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_create_dirty_makes_dirty(self):
         """create a case and a parent case with a different owner at the same time
         make sure the owner becomes dirty.
@@ -150,7 +145,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(child.case_id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_add_dirty_parent_makes_dirty(self):
         """add parent with a different owner and make sure the owner becomes dirty"""
         new_owner = uuid.uuid4().hex
@@ -166,7 +160,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(child.case_id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_change_parent_owner_makes_dirty(self):
         """change the owner id of a parent case and make sure the owner becomes dirty"""
         new_owner = uuid.uuid4().hex
@@ -175,7 +168,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(self.child.case_id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_change_host_owner_remains_clean(self):
         """change owner for unowned extension, owner remains clean"""
         new_owner = uuid.uuid4().hex
@@ -186,7 +178,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(self._owner_cleanliness_for_id(new_owner).is_clean)
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_change_host_owner_makes_both_owners_dirty(self):
         """change owner for extension, both owners dirty"""
         new_owner = uuid.uuid4().hex
@@ -195,13 +186,11 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_dirty()
         self.assertFalse(self._owner_cleanliness_for_id(new_owner).is_clean)
 
-    @run_with_all_backends
     def test_set_flag_clean_no_data(self):
         unused_owner_id = uuid.uuid4().hex
         set_cleanliness_flags(self.domain, unused_owner_id)
         self.assertTrue(OwnershipCleanlinessFlag.objects.get(owner_id=unused_owner_id).is_clean)
 
-    @run_with_all_backends
     def test_hint_invalidation(self):
         new_owner = uuid.uuid4().hex
         self._set_owner(self.parent.case_id, new_owner)
@@ -216,7 +205,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_clean()
         self.assertEqual(None, self.owner_cleanliness.hint)
 
-    @run_with_all_backends
     def test_hint_invalidation_extensions(self):
         other_owner_id = uuid.uuid4().hex
         [extension, host] = self.factory.create_or_update_case(
@@ -237,7 +225,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._set_owner(extension.case_id, UNOWNED_EXTENSION_OWNER_ID)
         self.assertFalse(hint_still_valid(self.domain, self.owner_cleanliness.hint))
 
-    @run_with_all_backends
     def test_hint_invalidation_extension_chain(self):
         other_owner_id = uuid.uuid4().hex
         self._owner_cleanliness_for_id(other_owner_id)
@@ -268,7 +255,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._set_owner(extension_2.case_id, UNOWNED_EXTENSION_OWNER_ID)
         self.assertFalse(hint_still_valid(self.domain, self.owner_cleanliness.hint))
 
-    @run_with_all_backends
     def test_cross_domain_on_submission(self):
         """create a form that makes a dirty owner with the same ID but in a different domain
         make sure the original owner stays clean"""
@@ -289,7 +275,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
             OwnershipCleanlinessFlag.objects.get(owner_id=self.owner_id, domain=new_domain).is_clean,
         )
 
-    @run_with_all_backends
     def test_cross_domain_both_clean(self):
         new_domain = uuid.uuid4().hex
         self.factory.domain = new_domain
@@ -304,7 +289,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(get_cleanliness_flag_from_scratch(self.domain, self.owner_id).is_clean)
         self.assertTrue(get_cleanliness_flag_from_scratch(new_domain, self.owner_id).is_clean)
 
-    @run_with_all_backends
     def test_cross_domain_dirty(self):
         new_domain = uuid.uuid4().hex
         new_owner = uuid.uuid4().hex
@@ -320,7 +304,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(get_cleanliness_flag_from_scratch(self.domain, self.owner_id).is_clean)
         self.assertFalse(get_cleanliness_flag_from_scratch(new_domain, self.owner_id).is_clean)
 
-    @run_with_all_backends
     def test_non_existent_parent(self):
         self.factory.create_or_update_case(
             CaseStructure(
@@ -333,7 +316,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertTrue(get_cleanliness_flag_from_scratch(self.domain, self.owner_id).is_clean)
 
     @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=False)
-    @run_with_all_backends
     def test_autocreate_flag_off(self):
         new_owner = uuid.uuid4().hex
         self.factory.create_or_update_case(
@@ -342,7 +324,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertFalse(OwnershipCleanlinessFlag.objects.filter(domain=self.domain, owner_id=new_owner).exists())
 
     @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=True)
-    @run_with_all_backends
     def test_autocreate_flag_on(self):
         new_owner = uuid.uuid4().hex
         self.factory.create_or_update_case(
@@ -351,7 +332,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         flag = OwnershipCleanlinessFlag.objects.get(domain=self.domain, owner_id=new_owner)
         self.assertEqual(True, flag.is_clean)
 
-    @run_with_all_backends
     def test_simple_unowned_extension(self):
         """Simple unowned extensions should be clean"""
         self.factory.create_or_update_case(
@@ -369,7 +349,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
-    @run_with_all_backends
     def test_owned_extension(self):
         """Extension owned by another owner should be dirty"""
         other_owner_id = uuid.uuid4().hex
@@ -393,7 +372,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags(self.owner_id)
         self._verify_set_cleanliness_flags(other_owner_id)
 
-    @run_with_all_backends
     def test_extension_chain_with_other_owner_makes_dirty(self):
         """An extension chain of unowned extensions that ends at a case owned by a different owner is dirty"""
         other_owner_id = uuid.uuid4().hex
@@ -428,7 +406,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags(self.owner_id)
         self._verify_set_cleanliness_flags(other_owner_id)
 
-    @run_with_all_backends
     def test_multiple_indices_multiple_owners(self):
         """Extension that indexes a case with another owner should make all owners dirty"""
         other_owner_id = uuid.uuid4().hex
@@ -461,7 +438,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags(self.owner_id)
         self._verify_set_cleanliness_flags(other_owner_id)
 
-    @run_with_all_backends
     def test_long_extension_chain_with_branches(self):
         """An extension chain of unowned extensions that ends at an owned case is dirty"""
         owner_1 = uuid.uuid4().hex
@@ -507,21 +483,29 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags()
 
 
+@sql_backend_test_case
+class OwnerCleanlinessTestSQL(OwnerCleanlinessTest):
+    pass
+
+
 class SetCleanlinessFlagsTest(TestCase):
 
-    @run_with_all_backends
     def test_set_bad_domains(self):
         test_cases = [None, '', 'something-too-long' * 10]
         for invalid_domain in test_cases:
             with self.assertRaises(InvalidDomainError):
                 set_cleanliness_flags(invalid_domain, 'whatever')
 
-    @run_with_all_backends
     def test_set_bad_owner_ids(self):
         test_cases = [None, '', 'something-too-long' * 10]
         for invalid_owner in test_cases:
             with self.assertRaises(InvalidOwnerIdError):
                 set_cleanliness_flags('whatever', invalid_owner)
+
+
+@sql_backend_test_case
+class SetCleanlinessFlagsTestSQL(SetCleanlinessFlagsTest):
+    pass
 
 
 class CleanlinessUtilitiesTest(SimpleTestCase):
@@ -555,7 +539,6 @@ class GetCaseFootprintInfoTest(TestCase):
         self.other_owner_id = uuid.uuid4().hex
         self.factory = CaseFactory(self.domain)
 
-    @run_with_all_backends
     def test_simple_footprint(self):
         """ should only return open cases from user """
         case = CaseStructure(case_id=uuid.uuid4().hex, attrs={'owner_id': self.owner_id, 'create': True})
@@ -566,7 +549,6 @@ class GetCaseFootprintInfoTest(TestCase):
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)
         self.assertEqual(footprint_info.all_ids, set([case.case_id]))
 
-    @run_with_all_backends
     def test_footprint_with_parent(self):
         """ should return open cases with parents """
         parent = CaseStructure(
@@ -585,7 +567,6 @@ class GetCaseFootprintInfoTest(TestCase):
         self.assertEqual(footprint_info.all_ids, set([child.case_id, parent.case_id]))
         self.assertEqual(footprint_info.base_ids, set([child.case_id]))
 
-    @run_with_all_backends
     def test_footprint_with_extension(self):
         """
         Extensions are brought in if the host case is owned;
@@ -610,7 +591,6 @@ class GetCaseFootprintInfoTest(TestCase):
         self.assertEqual(footprint_info.all_ids, set([extension.case_id, host.case_id]))
         self.assertEqual(footprint_info.base_ids, set([extension.case_id]))
 
-    @run_with_all_backends
     def test_footprint_with_extension_of_parent(self):
         """ Extensions of parents should be included """
         parent = CaseStructure(
@@ -631,7 +611,6 @@ class GetCaseFootprintInfoTest(TestCase):
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)
         self.assertEqual(footprint_info.all_ids, set([extension.case_id, parent.case_id, child.case_id]))
 
-    @run_with_all_backends
     def test_footprint_with_extension_of_child(self):
         """ Extensions of children should be included """
         parent = CaseStructure(
@@ -652,7 +631,6 @@ class GetCaseFootprintInfoTest(TestCase):
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)
         self.assertEqual(footprint_info.all_ids, set([extension.case_id, parent.case_id, child.case_id]))
 
-    @run_with_all_backends
     def test_cousins(self):
         # http://manage.dimagi.com/default.asp?189528
         grandparent = CaseStructure(
@@ -691,6 +669,11 @@ class GetCaseFootprintInfoTest(TestCase):
         )
 
 
+@sql_backend_test_case
+class GetCaseFootprintInfoTestSQL(GetCaseFootprintInfoTest):
+    pass
+
+
 class GetDependentCasesTest(TestCase):
 
     @classmethod
@@ -705,12 +688,10 @@ class GetDependentCasesTest(TestCase):
         self.other_owner_id = uuid.uuid4().hex
         self.factory = CaseFactory(self.domain)
 
-    @run_with_all_backends
     def test_returns_nothing_with_no_dependencies(self):
         case = self.factory.create_case()
         self.assertEqual(set(), get_dependent_case_info(self.domain, [case.case_id]).all_ids)
 
-    @run_with_all_backends
     def test_returns_simple_extension(self):
         host = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -729,7 +710,6 @@ class GetDependentCasesTest(TestCase):
         self.assertEqual(set([extension.case_id]),
                          get_dependent_case_info(self.domain, [host.case_id]).extension_ids)
 
-    @run_with_all_backends
     def test_returns_extension_of_extension(self):
         host = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -754,7 +734,6 @@ class GetDependentCasesTest(TestCase):
         self.assertEqual(set([extension.case_id, extension_2.case_id]),
                          get_dependent_case_info(self.domain, [host.case_id]).extension_ids)
 
-    @run_with_all_backends
     def test_children_and_extensions(self):
         parent = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -778,3 +757,8 @@ class GetDependentCasesTest(TestCase):
                          get_dependent_case_info(self.domain, [child.case_id]).extension_ids)
         self.assertEqual(set([]),
                          get_dependent_case_info(self.domain, [parent.case_id]).extension_ids)
+
+
+@sql_backend_test_case
+class GetDependentCasesTestSQL(GetDependentCasesTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -9,7 +9,7 @@ from casexml.apps.case.tests.util import assert_user_doesnt_have_cases, \
     assert_user_has_cases
 from casexml.apps.phone.models import get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from corehq.util.test_utils import softer_assert
 
 
@@ -140,6 +140,6 @@ class IndexTreeTest(SyncBaseTest):
         self.factory.create_or_update_cases(case_structures)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class IndexTreeTestSQL(IndexTreeTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -9,7 +9,7 @@ from casexml.apps.case.tests.util import assert_user_doesnt_have_cases, \
     assert_user_has_cases
 from casexml.apps.phone.models import get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 from corehq.util.test_utils import softer_assert
 
 
@@ -44,7 +44,7 @@ def test_generator(test_name, skip=False):
         assert_user_doesnt_have_cases(self, self.user, undesired_cases)
 
     test.__name__ = get_test_name(test_name)
-    return run_with_all_backends(test)
+    return test
 
 
 class TestSequenceMeta(type):
@@ -138,3 +138,8 @@ class IndexTreeTest(SyncBaseTest):
             ))
 
         self.factory.create_or_update_cases(case_structures)
+
+
+@sql_backend_test_case
+class IndexTreeTestSQL(IndexTreeTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -9,7 +9,7 @@ from casexml.apps.case.tests.util import assert_user_doesnt_have_cases, \
     assert_user_has_cases
 from casexml.apps.phone.models import get_properly_wrapped_sync_log
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.util.test_utils import softer_assert
 
 
@@ -140,6 +140,6 @@ class IndexTreeTest(SyncBaseTest):
         self.factory.create_or_update_cases(case_structures)
 
 
-@sql_backend_case
+@use_sql_backend
 class IndexTreeTestSQL(IndexTreeTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog, LOG_FORMAT_SIM
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_from_restore_payload, create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 from corehq.toggles import LEGACY_SYNC_SUPPORT
 from corehq.util.global_request.api import set_request
 
@@ -139,7 +139,6 @@ class TestNewSyncSpecifics(TestCase):
         )
         cls.user_id = cls.user.user_id
 
-    @run_with_all_backends
     def test_legacy_support_toggle(self):
         restore_config = RestoreConfig(self.project, restore_user=self.user)
         factory = CaseFactory(domain=self.project.name, case_defaults={'owner_id': self.user_id})
@@ -185,3 +184,8 @@ class TestNewSyncSpecifics(TestCase):
             CaseStructure(case_id=child_id, attrs={'owner_id': 'different'}),
             CaseStructure(case_id=parent_id, attrs={'owner_id': 'different'}),
         ], form_extras={'last_sync_token': sync_log._id})
+
+
+@sql_backend_test_case
+class TestNewSyncSpecificsSQL(TestNewSyncSpecifics):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog, LOG_FORMAT_SIM
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_from_restore_payload, create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.toggles import LEGACY_SYNC_SUPPORT
 from corehq.util.global_request.api import set_request
 
@@ -186,6 +186,6 @@ class TestNewSyncSpecifics(TestCase):
         ], form_extras={'last_sync_token': sync_log._id})
 
 
-@sql_backend_case
+@use_sql_backend
 class TestNewSyncSpecificsSQL(TestNewSyncSpecifics):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog, LOG_FORMAT_SIM
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_from_restore_payload, create_restore_user
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from corehq.toggles import LEGACY_SYNC_SUPPORT
 from corehq.util.global_request.api import set_request
 
@@ -186,6 +186,6 @@ class TestNewSyncSpecifics(TestCase):
         ], form_extras={'last_sync_token': sync_log._id})
 
 
-@sql_backend_test_case
+@sql_backend_case
 class TestNewSyncSpecificsSQL(TestNewSyncSpecifics):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -12,7 +12,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from casexml.apps.case.tests.util import check_xml_line_by_line
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 DOMAIN = 'fixture-test'
 SA_PROVINCES = 'sa_provinces'
@@ -38,7 +38,7 @@ class OtaWebUserFixtureTest(TestCase):
         self.assertEqual(fixture_xml[0].findall('./groups/group'), [])
 
 
-@sql_backend_test_case
+@sql_backend_case
 class OtaWebUserFixtureTestSQL(OtaWebUserFixtureTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -12,7 +12,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from casexml.apps.case.tests.util import check_xml_line_by_line
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 DOMAIN = 'fixture-test'
 SA_PROVINCES = 'sa_provinces'
@@ -37,7 +37,7 @@ class OtaWebUserFixtureTest(TestCase):
         self.assertEqual(fixture_xml[0].findall('./groups/group'), [])
 
 
-@sql_backend_case
+@use_sql_backend
 class OtaWebUserFixtureTestSQL(OtaWebUserFixtureTest):
     pass
 
@@ -126,7 +126,7 @@ class OtaFixtureTest(TestCase):
         self.assertIsNone(fixture_xml)
 
 
-@sql_backend_case
+@use_sql_backend
 class OtaFixtureTestSQL(OtaFixtureTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -12,7 +12,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from casexml.apps.case.tests.util import check_xml_line_by_line
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 DOMAIN = 'fixture-test'
 SA_PROVINCES = 'sa_provinces'
@@ -36,6 +36,11 @@ class OtaWebUserFixtureTest(TestCase):
         fixture_xml = list(generator.get_fixtures(self.restore_user, version=V2))
         self.assertEqual(len(fixture_xml), 1)
         self.assertEqual(fixture_xml[0].findall('./groups/group'), [])
+
+
+@sql_backend_test_case
+class OtaWebUserFixtureTestSQL(OtaWebUserFixtureTest):
+    pass
 
 
 class OtaFixtureTest(TestCase):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -31,7 +31,6 @@ class OtaWebUserFixtureTest(TestCase):
         cls.domain.delete()
         delete_all_users()
 
-    @run_with_all_backends
     def test_basic_fixture_generation(self):
         fixture_xml = list(generator.get_fixtures(self.restore_user, version=V2))
         self.assertEqual(len(fixture_xml), 1)
@@ -95,17 +94,14 @@ class OtaFixtureTest(TestCase):
                 expected = _get_item_list_fixture(self.user.get_id, data_type.tag, data_item)
                 check_xml_line_by_line(self, expected, item_list_xml[0])
 
-    @run_with_all_backends
     def test_fixture_gen_v1(self):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V1)
         self.assertEqual(list(fixture_xml), [])
 
-    @run_with_all_backends
     def test_basic_fixture_generation(self):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V2)
         self._check_fixture(fixture_xml, item_lists=[SA_PROVINCES, FR_PROVINCES])
 
-    @run_with_all_backends
     def test_fixtures_by_group(self):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V2, group='case')
         self.assertEqual(list(fixture_xml), [])
@@ -113,7 +109,6 @@ class OtaFixtureTest(TestCase):
         fixture_xml = generator.get_fixtures(self.restore_user, version=V2, group='standalone')
         self._check_fixture(fixture_xml, item_lists=[SA_PROVINCES, FR_PROVINCES])
 
-    @run_with_all_backends
     def test_fixtures_by_id(self):
         fixture_xml = generator.get_fixture_by_id('user-groups', self.restore_user, version=V2)
         self._check_fixture([fixture_xml])
@@ -129,6 +124,11 @@ class OtaFixtureTest(TestCase):
 
         fixture_xml = generator.get_fixture_by_id('bad ID', self.restore_user, version=V2)
         self.assertIsNone(fixture_xml)
+
+
+@sql_backend_case
+class OtaFixtureTestSQL(OtaFixtureTest):
+    pass
 
 
 def _get_group_fixture(user_id, groups):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -16,7 +16,7 @@ from casexml.apps.phone.tests.utils import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -104,6 +104,6 @@ class StateHashTest(TestCase):
 
 
 
-@sql_backend_case
+@use_sql_backend
 class StateHashTestSQL(StateHashTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -103,7 +103,6 @@ class StateHashTest(TestCase):
             self.assertTrue("123abc" in e.case_ids)
 
 
-
 @use_sql_backend
 class StateHashTestSQL(StateHashTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -16,7 +16,7 @@ from casexml.apps.phone.tests.utils import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -104,6 +104,6 @@ class StateHashTest(TestCase):
 
 
 
-@sql_backend_test_case
+@sql_backend_case
 class StateHashTestSQL(StateHashTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -16,7 +16,7 @@ from casexml.apps.phone.tests.utils import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
@@ -45,7 +45,6 @@ class StateHashTest(TestCase):
         delete_all_users()
         super(StateHashTest, cls).tearDownClass()
 
-    @run_with_all_backends
     def testEmpty(self):
         empty_hash = CaseStateHash(EMPTY_HASH)
         wrong_hash = CaseStateHash("thisisntright")
@@ -73,7 +72,6 @@ class StateHashTest(TestCase):
                                              state_hash=str(wrong_hash))
         self.assertEqual(412, response.status_code)
 
-    @run_with_all_backends
     def testMismatch(self):
         self.assertEqual(CaseStateHash(EMPTY_HASH), self.sync_log.get_state_hash())
         
@@ -103,3 +101,9 @@ class StateHashTest(TestCase):
             self.assertEqual(2, len(e.case_ids))
             self.assertTrue("abc123" in e.case_ids)
             self.assertTrue("123abc" in e.case_ids)
+
+
+
+@sql_backend_test_case
+class StateHashTestSQL(StateHashTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -5,7 +5,7 @@ from casexml.apps.case.const import CASE_ACTION_UPDATE
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.phone.models import SyncLog, CaseState, SimplifiedSyncLog
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 from couchforms.models import XFormInstance
 
 
@@ -53,6 +53,6 @@ class SyncLogAssertionTest(TestCase):
                 self.assertIn(dependent_case_state, log.test_only_get_dependent_cases_on_phone())
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SyncLogAssertionTestSQL(SyncLogAssertionTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -5,7 +5,7 @@ from casexml.apps.case.const import CASE_ACTION_UPDATE
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.phone.models import SyncLog, CaseState, SimplifiedSyncLog
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 from couchforms.models import XFormInstance
 
 
@@ -53,6 +53,6 @@ class SyncLogAssertionTest(TestCase):
                 self.assertIn(dependent_case_state, log.test_only_get_dependent_cases_on_phone())
 
 
-@sql_backend_case
+@use_sql_backend
 class SyncLogAssertionTestSQL(SyncLogAssertionTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -5,13 +5,12 @@ from casexml.apps.case.const import CASE_ACTION_UPDATE
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.phone.models import SyncLog, CaseState, SimplifiedSyncLog
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 from couchforms.models import XFormInstance
 
 
 class SyncLogAssertionTest(TestCase):
 
-    @run_with_all_backends
     def test_update_dependent_case(self):
         sync_log = SyncLog(
             cases_on_phone=[
@@ -32,7 +31,6 @@ class SyncLogAssertionTest(TestCase):
             for log in [sync_log, SimplifiedSyncLog.from_other_format(sync_log)]:
                 log.update_phone_lists(xform, [parent_case])
 
-    @run_with_all_backends
     def test_update_dependent_case_owner_still_present(self):
         dependent_case_state = CaseState(case_id="d1", indices=[])
         sync_log = SyncLog(
@@ -53,3 +51,8 @@ class SyncLogAssertionTest(TestCase):
             for log in [sync_log, SimplifiedSyncLog.from_other_format(sync_log)]:
                 log.update_phone_lists(xform, [parent_case])
                 self.assertIn(dependent_case_state, log.test_only_get_dependent_cases_on_phone())
+
+
+@sql_backend_test_case
+class SyncLogAssertionTestSQL(SyncLogAssertionTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.restore import RestoreParams, RestoreConfig
 from casexml.apps.phone.tests.utils import create_restore_user, generate_restore_payload
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 class PhoneFootprintTest(SimpleTestCase):
@@ -79,7 +79,6 @@ class PhoneFootprintTest(SimpleTestCase):
 
 class CachingReponseTest(TestCase):
 
-    @run_with_all_backends
     def testCachingResponse(self):
         log = SyncLog()
         log.save()
@@ -109,6 +108,11 @@ class CachingReponseTest(TestCase):
         self.assertFalse(log.has_cached_payload(V2))
         self.assertEqual(None, log.get_cached_payload(V1))
         self.assertEqual(None, log.get_cached_payload(V2))
+
+
+@sql_backend_test_case
+class CachingReponseTestSQL(CachingReponseTest):
+    pass
 
 
 class SyncLogModelTest(TestCase):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.restore import RestoreParams, RestoreConfig
 from casexml.apps.phone.tests.utils import create_restore_user, generate_restore_payload
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 class PhoneFootprintTest(SimpleTestCase):
@@ -110,7 +110,7 @@ class CachingReponseTest(TestCase):
         self.assertEqual(None, log.get_cached_payload(V2))
 
 
-@sql_backend_case
+@use_sql_backend
 class CachingReponseTestSQL(CachingReponseTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.restore import RestoreParams, RestoreConfig
 from casexml.apps.phone.tests.utils import create_restore_user, generate_restore_payload
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 class PhoneFootprintTest(SimpleTestCase):
@@ -110,7 +110,7 @@ class CachingReponseTest(TestCase):
         self.assertEqual(None, log.get_cached_payload(V2))
 
 
-@sql_backend_test_case
+@sql_backend_case
 class CachingReponseTestSQL(CachingReponseTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -18,7 +18,7 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
-    sql_backend_case,
+    use_sql_backend,
 )
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from corehq.util.test_utils import flag_enabled
@@ -749,7 +749,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         ])
 
 
-@sql_backend_case
+@use_sql_backend
 class SyncTokenUpdateTestSQL(SyncTokenUpdateTest):
     pass
 
@@ -783,7 +783,7 @@ class SyncDeletedCasesTest(SyncBaseTest):
         assert_user_has_case(self, self.user, child_id)
 
 
-@sql_backend_case
+@use_sql_backend
 class SyncDeletedCasesTestSQL(SyncDeletedCasesTest):
     pass
 
@@ -1048,7 +1048,7 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.assertFalse(config.restore_state.is_first_extension_sync)
 
 
-@sql_backend_case
+@use_sql_backend
 class ExtensionCasesFirstSyncSQL(ExtensionCasesFirstSync):
     pass
 
@@ -1122,7 +1122,7 @@ class ChangingOwnershipTest(SyncBaseTest):
         return synclog_from_restore_payload(incremental_restore_config.get_payload().as_string())
 
 
-@sql_backend_case
+@use_sql_backend
 class ChangingOwnershipTestSQL(ChangingOwnershipTest):
     pass
 
@@ -1269,7 +1269,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertNotEqual(original_payload.get_filename(), next_file.get_filename())
 
 
-@sql_backend_case
+@use_sql_backend
 class SyncTokenCachingTestSQL(SyncTokenCachingTest):
     pass
 
@@ -1845,7 +1845,7 @@ class MultiUserSyncTest(SyncBaseTest):
         })
 
 
-@sql_backend_case
+@use_sql_backend
 class MultiUserSyncTestSQL(MultiUserSyncTest):
     pass
 
@@ -1968,7 +1968,7 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         self.assertItemsEqual(third_sync_log.case_ids_on_phone, ['host', 'extension'])
 
 
-@sql_backend_case
+@use_sql_backend
 class SteadyStateExtensionSyncTestSQL(SteadyStateExtensionSyncTest):
     pass
 
@@ -2066,7 +2066,7 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             pass
 
 
-@sql_backend_case
+@use_sql_backend
 class SyncTokenReprocessingTestSQL(SyncTokenReprocessingTest):
     pass
 
@@ -2133,6 +2133,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
             _test()
 
 
-@sql_backend_case
+@use_sql_backend
 class LooseSyncTokenValidationTestSQL(LooseSyncTokenValidationTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -16,8 +16,10 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
-    run_with_all_backends
+from corehq.form_processor.tests.utils import (
+    FormProcessorTestUtils,
+    sql_backend_test_case,
+)
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from corehq.util.test_utils import flag_enabled
 from casexml.apps.case.tests.util import (
@@ -165,7 +167,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
     on the phone and the footprint.
     """
 
-    @run_with_all_backends
     def testInitialEmpty(self):
         """
         Tests that a newly created sync token has no cases attached to it.
@@ -173,7 +174,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_exactly_one_wrapped_sync_log()
         self._testUpdate(sync_log.get_id, {}, {})
 
-    @run_with_all_backends
     def testOwnUpdatesDontSync(self):
         case_id = "own_updates_dont_sync"
         self._createCaseStubs([case_id])
@@ -189,7 +189,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         )
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
     def test_change_index_type(self):
         """
         Test that changing an index type updates the sync log
@@ -206,7 +205,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [],
                                                 child_id: [parent_ref]})
 
-    @run_with_all_backends
     def test_change_index_id(self):
         """
         Test that changing an index ID updates the sync log
@@ -228,7 +226,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [],
                                                 child_id: [parent_ref]})
 
-    @run_with_all_backends
     def test_add_multiple_indices(self):
         """
         Test that adding multiple indices works as expected
@@ -253,7 +250,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], new_case_id: [],
                                                 child_id: [parent_ref, new_index_ref]})
 
-    @run_with_all_backends
     def test_delete_only_index(self):
         child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # delete the first index
@@ -263,7 +259,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: []})
 
-    @run_with_all_backends
     def test_delete_one_of_multiple_indices(self):
         # make IDs both human readable and globally unique to this test
         uid = uuid.uuid4().hex
@@ -324,7 +319,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: [parent_ref]})
         return (child_id, parent_id, index_id, parent_ref)
 
-    @run_with_all_backends
     def testClosedParentIndex(self):
         """
         Tests that things work properly when you have a reference to the parent
@@ -361,7 +355,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # try a clean restore again
         assert_user_has_cases(self, self.user, [parent_id, child_id])
 
-    @run_with_all_backends
     def testAssignToNewOwner(self):
         # create parent and child
         parent_id = "mommy"
@@ -396,7 +389,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # child should be moved, parent should still be there
         self._testUpdate(self.sync_log.get_id, {parent_id: []}, {})
 
-    @run_with_all_backends
     def testArchiveUpdates(self):
         """
         Tests that archiving a form (and changing a case) causes the
@@ -418,7 +410,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         form.archive()
         assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id, purge_restore_cache=True)
 
-    @run_with_all_backends
     def testUserLoggedIntoMultipleDevices(self):
         # test that a child case created by the same user from a different device
         # gets included in the sync
@@ -443,7 +434,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # ensure child case is included in sync using original sync log ID
         assert_user_has_case(self, self.user, child_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
     def test_tiered_parent_closing(self):
         all_ids = [uuid.uuid4().hex for i in range(3)]
         [grandparent_id, parent_id, child_id] = all_ids
@@ -482,7 +472,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
             # once the child is closed, all three are no longer relevant
             self.assertFalse(sync_log.phone_is_holding_case(id))
 
-    @run_with_all_backends
     def test_create_immediately_irrelevant_parent_case(self):
         """
         Make a case that is only relevant through a dependency at the same
@@ -507,7 +496,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
                                       referenced_id=parent_id)
         self._testUpdate(self.sync_log._id, {child_id: [index_ref]}, {parent_id: []})
 
-    @run_with_all_backends
     def test_closed_case_not_in_next_sync(self):
         # create a case
         case_id = self.factory.create_case().case_id
@@ -529,7 +517,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         last_sync = synclog_from_restore_payload(restore_config.get_payload().as_string())
         self.assertFalse(last_sync.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_sync_by_user_id(self):
         # create a case with an empty owner but valid user id
         case_id = self.factory.create_case(owner_id='', user_id=self.user_id).case_id
@@ -539,12 +526,10 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = synclog_from_restore_payload(payload)
         self.assertTrue(sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_irrelevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': 'irrelevant_2'}, strict=False)
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_relevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': self.user_id}, strict=False)
@@ -555,20 +540,17 @@ class SyncTokenUpdateTest(SyncBaseTest):
         if isinstance(sync_log, SimplifiedSyncLog):
             self.assertTrue(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_relevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id=self.user_id, update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         if isinstance(sync_log, SimplifiedSyncLog):
             self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_relevant_owner_then_submit_again_with_no_owner(self):
         case = self.factory.create_case()
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
@@ -580,7 +562,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertTrue(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_then_submit_again_with_no_owner(self):
         case = self.factory.create_case(owner_id='irrelevant_1')
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
@@ -592,7 +573,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_create_irrelevant_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case().case_id
@@ -617,7 +597,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # they should both be gone
         self._testUpdate(self.sync_log._id, {}, {})
 
-    @run_with_all_backends
     def test_create_closed_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case().case_id
@@ -643,12 +622,10 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # they should both be gone
         self._testUpdate(self.sync_log._id, {}, {})
 
-    @run_with_all_backends
     def test_create_irrelevant_owner_and_close_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', close=True)
 
-    @run_with_all_backends
     def test_reassign_and_close_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         case_id = self.factory.create_case().case_id
@@ -659,7 +636,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
             )
         )
 
-    @run_with_all_backends
     def test_index_after_close(self):
         parent_id = self.factory.create_case().case_id
         case_id = uuid.uuid4().hex
@@ -677,7 +653,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # before this test was written, the case stayed on the sync log even though it was closed
         self.assertFalse(sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_index_chain_with_closed_parents(self):
         grandparent = CaseStructure(
             case_id=uuid.uuid4().hex,
@@ -721,7 +696,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
              grandparent.case_id: []}
         )
 
-    @run_with_all_backends
     def test_reassign_case_and_sync(self):
         case = self.factory.create_case()
         # reassign from an empty sync token, simulating a web-reassignment on HQ
@@ -737,7 +711,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         next_sync_log = synclog_from_restore_payload(payload)
         self.assertFalse(next_sync_log.phone_is_holding_case(case.case_id))
 
-    @run_with_all_backends
     def test_cousins(self):
         """http://manage.dimagi.com/default.asp?189528
         """
@@ -776,15 +749,18 @@ class SyncTokenUpdateTest(SyncBaseTest):
         ])
 
 
+@sql_backend_test_case
+class SyncTokenUpdateTestSQL(SyncTokenUpdateTest):
+    pass
+
+
 class SyncDeletedCasesTest(SyncBaseTest):
 
-    @run_with_all_backends
     def test_deleted_case_doesnt_sync(self):
         case = self.factory.create_case()
         case.soft_delete()
         assert_user_doesnt_have_case(self, self.user, case.case_id)
 
-    @run_with_all_backends
     def test_deleted_parent_doesnt_sync(self):
         parent_id = uuid.uuid4().hex
         child_id = uuid.uuid4().hex
@@ -807,11 +783,15 @@ class SyncDeletedCasesTest(SyncBaseTest):
         assert_user_has_case(self, self.user, child_id)
 
 
+@sql_backend_test_case
+class SyncDeletedCasesTestSQL(SyncDeletedCasesTest):
+    pass
+
+
 class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
     """Makes sure the extension case trees are propertly updated
     """
 
-    @run_with_all_backends
     def test_create_extension(self):
         """creating an extension should add it to the extension_index_tree
         """
@@ -838,7 +818,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
 
-    @run_with_all_backends
     def test_create_multiple_indices(self):
         """creating multiple indices should add to the right tree
         """
@@ -868,7 +847,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {'host': host.case_id}})
 
-    @run_with_all_backends
     def test_create_extension_with_extension(self):
         """creating multiple extensions should be added to the right tree
         """
@@ -903,7 +881,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.index_tree.indices, {})
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
 
-    @run_with_all_backends
     def test_create_extension_then_delegate(self):
         """A delegated extension should still remain on the phone with the host
         """
@@ -931,7 +908,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
 
-    @run_with_all_backends
     def test_create_delegated_extension(self):
         case_type = 'case'
         host = CaseStructure(case_id='host',
@@ -953,7 +929,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
         self.assertEqual(sync_log.case_ids_on_phone, set([host.case_id, extension.case_id]))
 
-    @run_with_all_backends
     def test_close_host(self):
         """closing a host should update the appropriate trees
         """
@@ -984,7 +959,6 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([]))
         self.assertEqual(sync_log.case_ids_on_phone, set([]))
 
-    @run_with_all_backends
     def test_long_chain_with_children(self):
         """
                   +----+
@@ -1054,7 +1028,6 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.restore_config = RestoreConfig(project=self.project, restore_user=self.user)
         self.restore_state = self.restore_config.restore_state
 
-    @run_with_all_backends
     def test_is_first_extension_sync(self):
         """Before any syncs, this should return true when the toggle is enabled, otherwise false"""
         with flag_enabled('EXTENSION_CASES_SYNC_ENABLED'):
@@ -1062,7 +1035,6 @@ class ExtensionCasesFirstSync(SyncBaseTest):
 
         self.assertFalse(self.restore_state.is_first_extension_sync)
 
-    @run_with_all_backends
     def test_is_first_extension_sync_after_sync(self):
         """After a sync with the extension code in place, this should be false"""
         self.factory.create_case()
@@ -1076,12 +1048,16 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.assertFalse(config.restore_state.is_first_extension_sync)
 
 
+@sql_backend_test_case
+class ExtensionCasesFirstSyncSQL(ExtensionCasesFirstSync):
+    pass
+
+
 class ChangingOwnershipTest(SyncBaseTest):
 
     def setUp(self):
         super(ChangingOwnershipTest, self).setUp()
 
-    @run_with_all_backends
     def test_remove_user_from_group(self):
         group = Group(
             domain=self.project.name,
@@ -1115,7 +1091,6 @@ class ChangingOwnershipTest(SyncBaseTest):
         self.assertFalse(group._id in incremental_sync_log.owner_ids_on_phone)
         self.assertFalse(incremental_sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def test_add_user_to_group(self):
         group = Group(
             domain=self.project.name,
@@ -1147,9 +1122,13 @@ class ChangingOwnershipTest(SyncBaseTest):
         return synclog_from_restore_payload(incremental_restore_config.get_payload().as_string())
 
 
+@sql_backend_test_case
+class ChangingOwnershipTestSQL(ChangingOwnershipTest):
+    pass
+
+
 class SyncTokenCachingTest(SyncBaseTest):
 
-    @run_with_all_backends
     def testCaching(self):
         self.assertFalse(self.sync_log.has_cached_payload(V2))
         # first request should populate the cache
@@ -1190,7 +1169,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         versioned_sync_log = synclog_from_restore_payload(versioned_payload)
         self.assertNotEqual(next_sync_log._id, versioned_sync_log._id)
 
-    @run_with_all_backends
     def test_initial_cache(self):
         restore_config = RestoreConfig(
             project=self.project,
@@ -1204,7 +1182,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         cached_payload = restore_config.get_payload()
         self.assertIsInstance(cached_payload, CachedResponse)
 
-    @run_with_all_backends
     def testCacheInvalidation(self):
         original_payload = RestoreConfig(
             project=self.project,
@@ -1241,7 +1218,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         # we can be explicit about why this is the case
         self.assertTrue(self.sync_log.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def testCacheNonInvalidation(self):
         original_payload = RestoreConfig(
             project=self.project,
@@ -1275,7 +1251,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertEqual(original_payload, next_payload)
         self.assertFalse(case_id in next_payload)
 
-    @run_with_all_backends
     def testCacheInvalidationAfterFileDelete(self):
         # first request should populate the cache
         original_payload = RestoreConfig(
@@ -1292,6 +1267,11 @@ class SyncTokenCachingTest(SyncBaseTest):
         next_file = RestoreConfig(project=self.project, restore_user=self.user).get_payload()
         self.assertNotIsInstance(next_file, CachedResponse)
         self.assertNotEqual(original_payload.get_filename(), next_file.get_filename())
+
+
+@sql_backend_test_case
+class SyncTokenCachingTestSQL(SyncTokenCachingTest):
+    pass
 
 
 class MultiUserSyncTest(SyncBaseTest):
@@ -1337,7 +1317,6 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue(self.shared_group._id in self.sync_log.owner_ids_on_phone)
         self.assertTrue(self.user_id in self.sync_log.owner_ids_on_phone)
 
-    @run_with_all_backends
     def testSharedCase(self):
         # create a case by one user
         case_id = "shared_case"
@@ -1345,7 +1324,6 @@ class MultiUserSyncTest(SyncBaseTest):
         # should sync to the other owner
         assert_user_has_case(self, self.other_user, case_id, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
     def testOtherUserEdits(self):
         # create a case by one user
         case_id = "other_user_edits"
@@ -1369,7 +1347,6 @@ class MultiUserSyncTest(SyncBaseTest):
         _, match = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
         self.assertTrue("Hello!" in match.to_string())
 
-    @run_with_all_backends
     def testOtherUserAddsIndex(self):
         time = datetime.utcnow()
 
@@ -1429,7 +1406,6 @@ class MultiUserSyncTest(SyncBaseTest):
         _, orig = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
         self.assertTrue("index" in orig.to_string())
 
-    @run_with_all_backends
     def testMultiUserEdits(self):
         time = datetime.utcnow()
 
@@ -1496,7 +1472,6 @@ class MultiUserSyncTest(SyncBaseTest):
         check_user_has_case(self, self.user, joint_change, restore_id=main_sync_log.get_id)
         check_user_has_case(self, self.other_user, joint_change, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
     def testOtherUserCloses(self):
         # create a case from one user
         case_id = "other_user_closes"
@@ -1527,7 +1502,6 @@ class MultiUserSyncTest(SyncBaseTest):
         )
         self.assertFalse(next_synclog.phone_is_holding_case(case_id))
 
-    @run_with_all_backends
     def testOtherUserUpdatesUnowned(self):
         # create a case from one user and assign ownership elsewhere
         case_id = "other_user_updates_unowned"
@@ -1552,7 +1526,6 @@ class MultiUserSyncTest(SyncBaseTest):
         # make sure there are no new changes
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
-    @run_with_all_backends
     def testIndexesSync(self):
         # create a parent and child case (with index) from one user
         parent_id = "indexes_sync_parent"
@@ -1586,7 +1559,6 @@ class MultiUserSyncTest(SyncBaseTest):
                              purge_restore_cache=True)
         assert_user_has_case(self, self.other_user, case_id, restore_id=self.other_sync_log.get_id)
 
-    @run_with_all_backends
     def testOtherUserUpdatesIndex(self):
         # create a parent and child case (with index) from one user
         parent_id = "other_updates_index_parent"
@@ -1638,7 +1610,6 @@ class MultiUserSyncTest(SyncBaseTest):
         assert_user_has_case(self, self.user, parent_id, restore_id=latest_sync_log.get_id,
                              purge_restore_cache=True)
 
-    @run_with_all_backends
     def testOtherUserReassignsIndexed(self):
         # create a parent and child case (with index) from one user
         parent_id = "other_reassigns_index_parent"
@@ -1759,7 +1730,6 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue("something different" in payload)
         self.assertTrue("hi changed!" in payload)
 
-    @run_with_all_backends
     def testComplicatedGatesBug(self):
         # found this bug in the wild, used the real (test) forms to fix it
         # just running through this test used to fail hard, even though there
@@ -1773,7 +1743,6 @@ class MultiUserSyncTest(SyncBaseTest):
                 generate_restore_payload(self.project, self.user, version="2.0")
             )
 
-    @run_with_all_backends
     def test_dependent_case_becomes_relevant_at_sync_time(self):
         """
         Make a case that is only relevant through a dependency.
@@ -1816,7 +1785,6 @@ class MultiUserSyncTest(SyncBaseTest):
         )
         self._testUpdate(latest_sync_log._id, {child_id: [index_ref], parent_id: []})
 
-    @run_with_all_backends
     def test_index_tree_conflict_handling(self):
         """
         Test that if another user changes the index tree, the original user
@@ -1877,6 +1845,11 @@ class MultiUserSyncTest(SyncBaseTest):
         })
 
 
+@sql_backend_test_case
+class MultiUserSyncTestSQL(MultiUserSyncTest):
+    pass
+
+
 class SteadyStateExtensionSyncTest(SyncBaseTest):
     """
     Test that doing multiple clean syncs with extensions does what we think it will
@@ -1919,7 +1892,6 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         return host, extension
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_delegating_extensions(self):
         """Make an extension, delegate it, send it back, see what happens"""
         host, extension = self._create_extension()
@@ -1979,7 +1951,6 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         # Hooray!
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
-    @run_with_all_backends
     def test_multiple_syncs(self):
         host, extension = self._create_extension()
         assert_user_has_case(self, self.user, host.case_id)
@@ -1997,12 +1968,16 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         self.assertItemsEqual(third_sync_log.case_ids_on_phone, ['host', 'extension'])
 
 
+@sql_backend_test_case
+class SteadyStateExtensionSyncTestSQL(SteadyStateExtensionSyncTest):
+    pass
+
+
 class SyncTokenReprocessingTest(SyncBaseTest):
     """
     Tests sync token logic for fixing itself when it gets into a bad state.
     """
 
-    @run_with_all_backends
     def testUpdateNonExisting(self):
         case_id = 'non_existent'
         caseblock = CaseBlock(
@@ -2019,7 +1994,6 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             # this should fail because it's a true error
             pass
 
-    @run_with_all_backends
     def testShouldHaveCase(self):
         case_id = "should_have"
         self._createCaseStubs([case_id])
@@ -2046,7 +2020,6 @@ class SyncTokenReprocessingTest(SyncBaseTest):
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(getattr(sync_log, 'has_assert_errors', False))
 
-    @run_with_all_backends
     def testCodependencies(self):
 
         case_id1 = 'bad1'
@@ -2093,9 +2066,13 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             pass
 
 
+@sql_backend_test_case
+class SyncTokenReprocessingTestSQL(SyncTokenReprocessingTest):
+    pass
+
+
 class LooseSyncTokenValidationTest(SyncBaseTest):
 
-    @run_with_all_backends
     def test_submission_with_bad_log_default(self):
         with self.assertRaises(ResourceNotFound):
             post_case_blocks(
@@ -2104,7 +2081,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 domain='some-domain-without-toggle',
             )
 
-    @run_with_all_backends
     def test_submission_with_bad_log_toggle_enabled(self):
         domain = 'submission-domain-with-toggle'
 
@@ -2123,7 +2099,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
         # this is just asserting that an exception is not raised after the toggle is set
         _test()
 
-    @run_with_all_backends
     def test_restore_with_bad_log_default(self):
         with self.assertRaises(MissingSyncLog):
             RestoreConfig(
@@ -2135,7 +2110,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 ),
             ).get_payload()
 
-    @run_with_all_backends
     def test_restore_with_bad_log_toggle_enabled(self):
         domain = 'restore-domain-with-toggle'
 
@@ -2157,3 +2131,8 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
         # when the toggle is set the exception should be a RestoreException instead
         with self.assertRaises(RestoreException):
             _test()
+
+
+@sql_backend_test_case
+class LooseSyncTokenValidationTestSQL(LooseSyncTokenValidationTest):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -18,7 +18,7 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
-    sql_backend_test_case,
+    sql_backend_case,
 )
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from corehq.util.test_utils import flag_enabled
@@ -749,7 +749,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         ])
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SyncTokenUpdateTestSQL(SyncTokenUpdateTest):
     pass
 
@@ -783,7 +783,7 @@ class SyncDeletedCasesTest(SyncBaseTest):
         assert_user_has_case(self, self.user, child_id)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SyncDeletedCasesTestSQL(SyncDeletedCasesTest):
     pass
 
@@ -1048,7 +1048,7 @@ class ExtensionCasesFirstSync(SyncBaseTest):
         self.assertFalse(config.restore_state.is_first_extension_sync)
 
 
-@sql_backend_test_case
+@sql_backend_case
 class ExtensionCasesFirstSyncSQL(ExtensionCasesFirstSync):
     pass
 
@@ -1122,7 +1122,7 @@ class ChangingOwnershipTest(SyncBaseTest):
         return synclog_from_restore_payload(incremental_restore_config.get_payload().as_string())
 
 
-@sql_backend_test_case
+@sql_backend_case
 class ChangingOwnershipTestSQL(ChangingOwnershipTest):
     pass
 
@@ -1269,7 +1269,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertNotEqual(original_payload.get_filename(), next_file.get_filename())
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SyncTokenCachingTestSQL(SyncTokenCachingTest):
     pass
 
@@ -1845,7 +1845,7 @@ class MultiUserSyncTest(SyncBaseTest):
         })
 
 
-@sql_backend_test_case
+@sql_backend_case
 class MultiUserSyncTestSQL(MultiUserSyncTest):
     pass
 
@@ -1968,7 +1968,7 @@ class SteadyStateExtensionSyncTest(SyncBaseTest):
         self.assertItemsEqual(third_sync_log.case_ids_on_phone, ['host', 'extension'])
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SteadyStateExtensionSyncTestSQL(SteadyStateExtensionSyncTest):
     pass
 
@@ -2066,7 +2066,7 @@ class SyncTokenReprocessingTest(SyncBaseTest):
             pass
 
 
-@sql_backend_test_case
+@sql_backend_case
 class SyncTokenReprocessingTestSQL(SyncTokenReprocessingTest):
     pass
 
@@ -2133,6 +2133,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
             _test()
 
 
-@sql_backend_test_case
+@sql_backend_case
 class LooseSyncTokenValidationTestSQL(LooseSyncTokenValidationTest):
     pass

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
@@ -2,7 +2,7 @@ from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_da
     compute_consumption_or_default)
 from casexml.apps.stock.tests.mock_consumption import now
 from casexml.apps.stock.tests.base import StockTestBase
-from corehq.form_processor.tests.utils import sql_backend_test_case
+from corehq.form_processor.tests.utils import sql_backend_case
 
 
 class ConsumptionCaseTest(StockTestBase):
@@ -44,7 +44,7 @@ class ConsumptionCaseTest(StockTestBase):
         ))
 
 
-@sql_backend_test_case
+@sql_backend_case
 class ConsumptionCaseTestSQL(ConsumptionCaseTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
@@ -2,31 +2,27 @@ from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_da
     compute_consumption_or_default)
 from casexml.apps.stock.tests.mock_consumption import now
 from casexml.apps.stock.tests.base import StockTestBase
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import sql_backend_test_case
 
 
 class ConsumptionCaseTest(StockTestBase):
 
-    @run_with_all_backends
     def testNoConsumption(self):
         self._stock_report(25, 5)
         self._stock_report(25, 0)
         self.assertAlmostEqual(0., self._compute_consumption())
 
-    @run_with_all_backends
     def testNoConsumptionWithReceipts(self):
         self._stock_report(25, 5)
         self._receipt_report(10, 3)
         self._stock_report(35, 0)
         self.assertAlmostEqual(0., self._compute_consumption())
 
-    @run_with_all_backends
     def testSimpleConsumption(self):
         self._stock_report(25, 5)
         self._stock_report(10, 0)
         self.assertAlmostEqual(3., self._compute_consumption())
 
-    @run_with_all_backends
     def testDefaultValue(self):
         self._stock_report(25, 5)
         self._stock_report(10, 0)
@@ -46,3 +42,9 @@ class ConsumptionCaseTest(StockTestBase):
                 default_monthly_consumption_function=_ten
             )
         ))
+
+
+@sql_backend_test_case
+class ConsumptionCaseTestSQL(ConsumptionCaseTest):
+    pass
+

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
@@ -2,7 +2,7 @@ from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_da
     compute_consumption_or_default)
 from casexml.apps.stock.tests.mock_consumption import now
 from casexml.apps.stock.tests.base import StockTestBase
-from corehq.form_processor.tests.utils import sql_backend_case
+from corehq.form_processor.tests.utils import use_sql_backend
 
 
 class ConsumptionCaseTest(StockTestBase):
@@ -44,7 +44,7 @@ class ConsumptionCaseTest(StockTestBase):
         ))
 
 
-@sql_backend_case
+@use_sql_backend
 class ConsumptionCaseTestSQL(ConsumptionCaseTest):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
@@ -47,4 +47,3 @@ class ConsumptionCaseTest(StockTestBase):
 @use_sql_backend
 class ConsumptionCaseTestSQL(ConsumptionCaseTest):
     pass
-

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -172,7 +172,7 @@ run_with_all_backends = functools.partial(
 )
 
 
-def sql_backend_test_case(cls):
+def sql_backend_case(cls):
     return attr(sql_backend=True)(override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)(cls))
 
 

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -172,7 +172,7 @@ run_with_all_backends = functools.partial(
 )
 
 
-def sql_backend_case(cls):
+def use_sql_backend(cls):
     return attr(sql_backend=True)(override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)(cls))
 
 

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -5,7 +5,9 @@ from uuid import uuid4
 
 from couchdbkit import ResourceNotFound
 from django.conf import settings
+from django.test.utils import override_settings
 from nose.tools import nottest
+from nose.plugins.attrib import attr
 
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.phone.models import SyncLog
@@ -168,6 +170,10 @@ run_with_all_backends = functools.partial(
     ],
     nose_tags={'all_backends': True}
 )
+
+
+def sql_backend_test_case(cls):
+    return attr(sql_backend=True)(override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)(cls))
 
 
 @unit_testing_only

--- a/testsettings.py
+++ b/testsettings.py
@@ -73,8 +73,6 @@ ENABLE_PRELOGIN_SITE = True
 # override dev_settings
 CACHE_REPORTS = True
 
-TESTS_SHOULD_USE_SQL_BACKEND = False
-
 
 def _set_logging_levels(levels):
     import logging

--- a/testsettings.py
+++ b/testsettings.py
@@ -73,6 +73,9 @@ ENABLE_PRELOGIN_SITE = True
 # override dev_settings
 CACHE_REPORTS = True
 
+TESTS_SHOULD_USE_SQL_BACKEND = False
+
+
 def _set_logging_levels(levels):
     import logging
     for path, level in levels.items():


### PR DESCRIPTION
@dimagi/test-team Still need to figure out how to properly run these in travis, but this now splits out couch and sql tests so we can run them more easily. Should shave ~2 mins off the python sharded tests. Thank god for macros

cc: @kaapstorm 