### PR TITLE
Move debugger out of drag scroll dominion

### DIFF
--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -168,15 +168,15 @@
                       afterRender: afterRender
                   }">
               </section>
-              {% if request.couch_user.can_edit_data %}
-              <section id="cloudcare-debugger" data-bind="
-                  template: {
-                      name: 'instance-viewer-ko-template',
-                      afterRender: adjustWidth
-                  }
-              "></section>
-              {% endif %}
             </div>
+            {% if request.couch_user.can_edit_data %}
+            <section id="cloudcare-debugger" data-bind="
+                template: {
+                    name: 'instance-viewer-ko-template',
+                    afterRender: adjustWidth
+                }
+            "></section>
+            {% endif %}
         </div>
 
         {% include 'form_entry/templates.html' %}


### PR DESCRIPTION
@biyeun this moves the debugger out of the dominion of the dragscroll so you can select things again. I tried `nochilddrag` with no luck. I still find that library terribly uncooperative

http://manage.dimagi.com/default.asp?247674

cc: @kaapstorm 