### PR TITLE
check for conflicting dates when neither subscription has an end date

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1127,16 +1127,9 @@ class Subscription(models.Model):
         ).exclude(id=self.id).all():
             related_has_no_end = sub.date_end is None
             current_has_no_end = date_end is None
-            start_before_related_end = (
-                date_start is not None and sub.date_end is not None
-                and date_start < sub.date_end
-            )
-            start_before_related_start = (
-                date_start is not None and date_start < sub.date_start
-            )
-            start_after_related_start = (
-                date_start is not None and date_start > sub.date_start
-            )
+            start_before_related_end = sub.date_end is not None and date_start < sub.date_end
+            start_before_related_start = date_start < sub.date_start
+            start_after_related_start = date_start > sub.date_start
             end_before_related_end = (
                 date_end is not None and sub.date_end is not None
                 and date_end < sub.date_end
@@ -1145,9 +1138,7 @@ class Subscription(models.Model):
                 date_end is not None and sub.date_end is not None
                 and date_end > sub.date_end
             )
-            end_after_related_start = (
-                date_end is not None and date_end > sub.date_start
-            )
+            end_after_related_start = date_end is not None and date_end > sub.date_start
 
             if (
                 (start_before_related_end and start_after_related_start)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1121,6 +1121,7 @@ class Subscription(models.Model):
         """Raises a subscription Adjustment error if the specified date range
         conflicts with other subscriptions related to this subscriber.
         """
+        assert date_start is not None
         for sub in Subscription.objects.filter(
             subscriber=self.subscriber
         ).exclude(id=self.id).all():

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1155,6 +1155,7 @@ class Subscription(models.Model):
                 or (end_after_related_start and related_has_no_end)
                 or (start_before_related_start and end_after_related_end)
                 or (start_before_related_end and current_has_no_end)
+                or (current_has_no_end and related_has_no_end)
             ):
                 raise SubscriptionAdjustmentError(
                     "The start date of %(start_date)s conflicts with the "


### PR DESCRIPTION
Fixes the root cause of http://manage.dimagi.com/default.asp?247845 by preventing creating multiple subscriptions that don't have an end date.  Also does some cleanup by asserting that ```date_start``` is always set.

code buddy @sravfeyn 