### PR TITLE
Force translated strings to be strings

### DIFF
--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -31,11 +31,11 @@ def trans(name, langs=None, include_lang=True, use_delim=True, prefix=False):
     for lang in langs:
         if lang in name and name[lang]:
             affix = ("" if langs and lang == langs[0] else tag(lang))
-            return affix + str(name[lang]) if prefix else str(name[lang]) + affix
+            return affix + unicode(name[lang]) if prefix else unicode(name[lang]) + affix
         # ok, nothing yet... just return anything in name
     for lang, n in sorted(name.items()):
         affix = tag(lang)
-        return affix + str(n) if prefix else str(n) + affix
+        return affix + unicode(n) if prefix else unicode(n) + affix
     return ""
 
 

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -31,11 +31,11 @@ def trans(name, langs=None, include_lang=True, use_delim=True, prefix=False):
     for lang in langs:
         if lang in name and name[lang]:
             affix = ("" if langs and lang == langs[0] else tag(lang))
-            return affix + name[lang] if prefix else name[lang] + affix
+            return affix + str(name[lang]) if prefix else str(name[lang]) + affix
         # ok, nothing yet... just return anything in name
     for lang, n in sorted(name.items()):
         affix = tag(lang)
-        return affix + n if prefix else n + affix
+        return affix + str(n) if prefix else str(n) + affix
     return ""
 
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?247798

This causes a build error because the value `3.0` is interpreted as a decimal:
<img width="615" alt="screen shot 2017-02-17 at 4 27 25 pm" src="https://cloud.githubusercontent.com/assets/1486591/23083929/12f02cd8-f52e-11e6-9e3f-c3d1a6ea86b0.png">

Noticed this also affects graphing configuration (setting a series name to `1.0` will break the app), decided fixing it in `trans` was safe and more straightforward than figuring out what other app config might behave this way and fixing each area.

@gcapalbo 