### PR TITLE
Better handle overflow in case history

### DIFF
--- a/corehq/apps/style/static/style/less/_hq/utils.less
+++ b/corehq/apps/style/static/style/less/_hq/utils.less
@@ -16,13 +16,6 @@
   display: none;
 }
 
-.overflow-container {
-    position: relative;
-
-    .overflow-content {
-        position: absolute;
-        width: 100%;
-        overflow-x: hidden;
-        text-overflow: ellipsis;
-    }
+.break-all-words {
+    word-break: break-all;
 }

--- a/corehq/apps/style/static/style/less/_hq/utils.less
+++ b/corehq/apps/style/static/style/less/_hq/utils.less
@@ -15,3 +15,14 @@
 .ko-template {
   display: none;
 }
+
+.overflow-container {
+    position: relative;
+
+    .overflow-content {
+        position: absolute;
+        width: 100%;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
@@ -114,7 +114,7 @@
                                     <td>
                                         <span data-bind="text: received_on"></span>
                                     <td>
-                                        <span data-bind="text: readable_name, css: { 'break-all-words': readable_name().match(/\s/) }"></span>
+                                        <span data-bind="text: readable_name, css: { 'break-all-words': !readable_name().match(/\s/) }"></span>
                                     </td>
                                     <td>
                                         <span data-bind="text: username"></span>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
@@ -114,7 +114,7 @@
                                     <td>
                                         <span data-bind="text: received_on"></span>
                                     <td>
-                                        <span data-bind="text: readable_name, css: { 'break-all-words': readable_name.match(/\s/) }"></span>
+                                        <span data-bind="text: readable_name, css: { 'break-all-words': readable_name().match(/\s/) }"></span>
                                     </td>
                                     <td>
                                         <span data-bind="text: username"></span>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
@@ -113,8 +113,8 @@
                                 <tr data-bind='click: $root.clickRow, css: { info: $data.id() == $root.selected_xform_doc_id() }'>
                                     <td>
                                         <span data-bind="text: received_on"></span>
-                                    <td class="overflow-container">
-                                        <span class="overflow-content" data-bind="text: readable_name"></span>
+                                    <td>
+                                        <span data-bind="text: readable_name, css: { 'break-all-words': readable_name.match(/\s/) }"></span>
                                     </td>
                                     <td>
                                         <span data-bind="text: username"></span>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
@@ -113,8 +113,8 @@
                                 <tr data-bind='click: $root.clickRow, css: { info: $data.id() == $root.selected_xform_doc_id() }'>
                                     <td>
                                         <span data-bind="text: received_on"></span>
-                                    <td>
-                                        <span data-bind="text: readable_name"></span>
+                                    <td class="overflow-container">
+                                        <span class="overflow-content" data-bind="text: readable_name"></span>
                                     </td>
                                     <td>
                                         <span data-bind="text: username"></span>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?247778

This will wrap long URLs onto multiple lines. Experimented with having the table cell scroll, or having the whole table scroll, but both of those were a bit ugly and annoying to interact with.

<img width="449" alt="screen shot 2017-02-17 at 5 19 49 pm" src="https://cloud.githubusercontent.com/assets/1486591/23085361/549102be-f535-11e6-953e-83d1f2dda506.png">

@gcapalbo 
