### PR TITLE
Warn when saving to case property with a slash

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -26,6 +26,7 @@ hqDefine('app_manager/js/case-config-ui-2.js', function () {
         self.requires = params.requires;
         self.caseType = params.caseType;
         self.reserved_words = params.reserved_words;
+        self.valid_index_names = params.valid_index_names;
         self.moduleCaseTypes = params.moduleCaseTypes;
         self.allowUsercase = params.allowUsercase;
 
@@ -661,6 +662,12 @@ hqDefine('app_manager/js/case-config-ui-2.js', function () {
                         return '<strong>' + self.key() + '</strong> is a reserved word';
                     } else if (self.repeat_context() && self.repeat_context() !== case_transaction.repeat_context()) {
                         return gettext('Inside the wrong repeat!');
+                    } else if (_.difference(
+                                    _.initial(self.key().split(/\//)),
+                                    case_transaction.caseConfig.valid_index_names
+                                ).length) {
+                        return gettext('Property uses unrecognized prefix <strong>' +
+                                        self.key().replace(/\/[^\/]*$/, '') + '</strong>');
                     }
                 }
                 return null;

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view.html
@@ -17,6 +17,7 @@
         save_url: "{% url "edit_form_actions" app.domain app.id module.id nav_form.id %}",
         requires: form_requires,
         reserved_words: {{ case_reserved_words_json|JSON }},
+        valid_index_names: {{ valid_index_names|JSON }},
         moduleCaseTypes: {{ module_case_types|JSON }},
         caseType: {{ form.get_case_type|JSON }},
         allowUsercase: {{ allow_usercase|JSON }},

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_view.html
@@ -17,6 +17,7 @@
         save_url: "{% url "edit_form_actions" app.domain app.id module.id nav_form.id %}",
         requires: form_requires,
         reserved_words: {{ case_reserved_words_json|JSON }},
+        valid_index_names: {{ valid_index_names|JSON }},
         moduleCaseTypes: {{ module_case_types|JSON }},
         caseType: {{ form.get_case_type|JSON }},
         allowUsercase: {{ allow_usercase|JSON }},

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view.html.diff.txt
@@ -15,7 +15,7 @@
      var CaseConfig = hqImport('app_manager/js/case-config-ui-2.js').CaseConfig;
      var caseConfig = new CaseConfig({
          home: $('#casexml_home'),
-@@ -24,5 +24,73 @@
+@@ -25,5 +25,73 @@
          usercasePropertiesMap: {{ usercase_properties|JSON }},
      });
      caseConfig.init();

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -551,7 +551,7 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
                       and not toggles.USER_TESTING_SIMPLIFY.enabled(request.domain))
     valid_index_names = DEFAULT_CASE_INDEX_IDENTIFIERS.values()
     if allow_usercase:
-        valid_index_names.append(USERCASE_PREFIX[0:-1]) # strip trailing slash
+        valid_index_names.append(USERCASE_PREFIX[0:-1])     # strip trailing slash
 
     form_has_schedule = isinstance(form, AdvancedForm) and form.get_module().has_schedule
     context = {

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -550,8 +550,8 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
     allow_usercase = (domain_has_privilege(request.domain, privileges.USER_CASE)
                       and not toggles.USER_TESTING_SIMPLIFY.enabled(request.domain))
     valid_index_names = DEFAULT_CASE_INDEX_IDENTIFIERS.values()
-    if allow_usercase and USERCASE_PREFIX[-1] == "/":
-        valid_index_names.append(USERCASE_PREFIX[0:-1])
+    if allow_usercase:
+        valid_index_names.append(USERCASE_PREFIX[0:-1]) # strip trailing slash
 
     form_has_schedule = isinstance(form, AdvancedForm) and form.get_module().has_schedule
     context = {


### PR DESCRIPTION
Context in http://manage.dimagi.com/default.asp?247753

Only added to basic modules because it's not very intelligent validation, it's just mean to warn users who don't realize that `/` is special.

<img width="801" alt="screen shot 2017-02-17 at 6 43 34 pm" src="https://cloud.githubusercontent.com/assets/1486591/23087300/16cc12d2-f541-11e6-8ce9-3857998ad8fb.png">

@gcapalbo / @snopoke / @czue 