### PR TITLE
cleaning up accounting tests

### DIFF
--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -115,12 +115,6 @@ def arbitrary_contact_info(account, web_user_creator):
 
 
 @unit_testing_only
-def delete_all_accounts():
-    BillingContactInfo.objects.all().delete()
-    BillingAccount.objects.all().delete()
-
-
-@unit_testing_only
 def subscribable_plan(edition=SoftwarePlanEdition.STANDARD):
     return DefaultProductPlan.get_default_plan_version(edition)
 

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -67,7 +67,7 @@ def unique_name():
 
 
 @unit_testing_only
-def arbitrary_web_user(save=True, is_dimagi=False):
+def arbitrary_web_user(is_dimagi=False):
     domain = Domain(name=unique_name()[:25])
     domain.save()
     username = "%s@%s.com" % (unique_name(), 'dimagi' if is_dimagi else 'gmail')
@@ -76,8 +76,7 @@ def arbitrary_web_user(save=True, is_dimagi=False):
     except Exception:
         web_user = WebUser.get_by_username(username)
     web_user.is_active = True
-    if save:
-        web_user.save()
+    web_user.save()
     return web_user
 
 

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -293,9 +293,6 @@ class TestCreditTransfers(BaseAccountingTest):
 
     @classmethod
     def tearDownClass(cls):
-        CreditAdjustment.objects.all().delete()
-        CreditLine.objects.all().delete()
-        generator.delete_all_subscriptions()
         cls.web_user.delete()
         super(TestCreditTransfers, cls).tearDownClass()
 

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -58,8 +58,6 @@ class BaseInvoiceTestCase(BaseAccountingTest):
             date_end=subscription_end_date,
         )
 
-        cls.community_plan = DefaultProductPlan.get_default_plan_version()
-
     def tearDown(self):
         for user in self.domain.all_users():
             user.delete()
@@ -465,7 +463,8 @@ class TestUserLineItem(BaseInvoiceTestCase):
         self.assertIsNone(user_line_item.base_description)
         self.assertEqual(user_line_item.base_cost, Decimal('0.0000'))
 
-        num_to_charge = num_active - self.community_plan.user_limit
+        community_plan = DefaultProductPlan.get_default_plan_version()
+        num_to_charge = num_active - community_plan.user_limit
         self.assertIsNotNone(user_line_item.unit_description)
         self.assertEqual(user_line_item.quantity, num_to_charge)
         self.assertEqual(user_line_item.unit_cost, self.user_rate.per_excess_fee)

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -65,16 +65,6 @@ class BaseInvoiceTestCase(BaseAccountingTest):
 
     @classmethod
     def tearDownClass(cls):
-        CreditAdjustment.objects.all().delete()
-        CreditLine.objects.all().delete()
-
-        BillingRecord.objects.all().delete()
-        LineItem.objects.all().delete()
-        SubscriptionAdjustment.objects.all().delete()
-        Invoice.objects.all().delete()
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
-
         cls.billing_contact.delete()
         cls.dimagi_user.delete()
         cls.domain.delete()

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import random
+import uuid
 from datetime import date, timedelta
 
 from django.test import TestCase
@@ -24,13 +25,7 @@ class TestExplicitCommunitySubscriptions(TestCase):
     def setUpClass(cls):
         super(TestExplicitCommunitySubscriptions, cls).setUpClass()
 
-        # TODO - remove once messy tests are cleaned up
-        for domain in Domain.get_all():
-            domain.delete()
-
-        assert len(list(Domain.get_all())) == 0
-
-        cls.domain = Domain(name='test')
+        cls.domain = Domain(name=str(uuid.uuid4()))
         cls.domain.save()
         cls.from_date = date.today()
 

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -39,11 +39,6 @@ class TestExplicitCommunitySubscriptions(TestCase):
         cls.domain.delete()
         super(TestExplicitCommunitySubscriptions, cls).tearDownClass()
 
-    def tearDown(self):
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
-        super(TestExplicitCommunitySubscriptions, self).tearDown()
-
     def test_no_preexisting_subscription(self):
         self._assign_community_subscriptions()
 

--- a/corehq/apps/accounting/tests/test_model_validation.py
+++ b/corehq/apps/accounting/tests/test_model_validation.py
@@ -17,14 +17,6 @@ from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 
 class TestCreditAdjustmentValidation(BaseAccountingTest):
 
-    def tearDown(self):
-        CreditAdjustment.objects.all().delete()
-        LineItem.objects.all().delete()
-        Invoice.objects.all().delete()
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
-        super(TestCreditAdjustmentValidation, self).tearDown()
-
     def test_clean(self):
         account = BillingAccount.objects.create(
             name='Test Account',

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -154,8 +154,6 @@ class TestSubscription(BaseAccountingTest):
         self.dimagi_user.delete()
         self.domain.delete()
 
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
         super(TestSubscription, self).tearDown()
 
 

--- a/corehq/apps/accounting/tests/test_renew_subscription.py
+++ b/corehq/apps/accounting/tests/test_renew_subscription.py
@@ -47,8 +47,6 @@ class TestRenewSubscriptions(BaseAccountingTest):
         self.subscription.save()
 
     def tearDown(self):
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
         super(TestRenewSubscriptions, self).tearDown()
         self.admin_user.delete()
 

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -161,8 +161,6 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
     def tearDown(self):
         self.domain.delete()
         self.admin_user.delete()
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
         super(TestUserRoleSubscriptionChanges, self).tearDown()
 
 

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -196,6 +196,4 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
     def tearDown(self):
         self.project.delete()
         self.admin_user.delete()
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
         super(TestSubscriptionPermissionsChanges, self).tearDown()

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -21,9 +21,6 @@ class TestWireInvoice(BaseInvoiceTestCase):
         self.invoices = Invoice.objects.all()
         self.domain_name = self.invoices[0].get_domain()
 
-    def tearDown(self):
-        super(TestWireInvoice, self).tearDown()
-
     def test_factory(self):
         factory = DomainWireInvoiceFactory(
             self.domain_name,

--- a/corehq/apps/analytics/tests/test_subscription_properties.py
+++ b/corehq/apps/analytics/tests/test_subscription_properties.py
@@ -56,8 +56,6 @@ class TestSubscriptionProperties(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        generator.delete_all_subscriptions()
-        generator.delete_all_accounts()
         cls.base_domain.delete()
         cls.user.delete()
         super(TestSubscriptionProperties, cls).tearDownClass()

--- a/custom/ewsghana/tests/handlers/utils.py
+++ b/custom/ewsghana/tests/handlers/utils.py
@@ -31,7 +31,6 @@ class EWSTestCase(TestCase):
     def tearDownClass(cls):
         cls.sms_backend_mapping.delete()
         cls.backend.delete()
-        generator.delete_all_subscriptions()
         super(EWSTestCase, cls).tearDownClass()
 
 

--- a/custom/ilsgateway/tests/handlers/utils.py
+++ b/custom/ilsgateway/tests/handlers/utils.py
@@ -135,7 +135,6 @@ class ILSTestScript(TestScript):
             if location:
                 location.delete()
         SQLLocation.objects.all().delete()
-        generator.delete_all_subscriptions()
         test_domain = Domain.get_by_name(TEST_DOMAIN)
         if test_domain:
             test_domain.delete()

--- a/custom/ilsgateway/tests/test_reminders.py
+++ b/custom/ilsgateway/tests/test_reminders.py
@@ -24,6 +24,7 @@ class TestReminders(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(TestReminders, cls).setUpClass()
         cls.sms_backend, cls.sms_backend_mapping = setup_default_sms_test_backend()
         domain = prepare_domain(TEST_DOMAIN)
         mohsw = make_loc(code="moh1", name="Test MOHSW 1", type="MOHSW", domain=domain.name)
@@ -65,6 +66,7 @@ class TestReminders(TestCase):
     def tearDown(self):
         SMS.objects.all().delete()
         SupplyPointStatus.objects.all().delete()
+        super(TestReminders, self).tearDown()
 
     def test_randr_reminder_facility(self):
         date = datetime(2015, 5, 1)

--- a/custom/ilsgateway/tests/test_reminders.py
+++ b/custom/ilsgateway/tests/test_reminders.py
@@ -60,7 +60,7 @@ class TestReminders(TestCase):
         cls.sms_backend_mapping.delete()
         cls.sms_backend.delete()
         Domain.get_by_name(TEST_DOMAIN).delete()
-        generator.delete_all_subscriptions()
+        super(TestReminders, cls).tearDownClass()
 
     def tearDown(self):
         SMS.objects.all().delete()

--- a/custom/ilsgateway/tests/test_report_runner.py
+++ b/custom/ilsgateway/tests/test_report_runner.py
@@ -24,7 +24,6 @@ class TestReportRunner(TestCase):
         SupplyPointStatus.objects.all().delete()
         StockTransaction.objects.all().delete()
         StockReport.objects.all().delete()
-        generator.delete_all_subscriptions()
         cls.domain.delete()
         super(TestReportRunner, cls).tearDownClass()
 


### PR DESCRIPTION
Some first steps.  One of the next things I'd like to do is stop creating a new domain every time we create a ```WebUser``` for accounting tests.