### PR TITLE
Export migration tweaks

### DIFF
--- a/corehq/apps/export/management/commands/migrate_exports.py
+++ b/corehq/apps/export/management/commands/migrate_exports.py
@@ -52,26 +52,27 @@ class Command(BaseCommand):
             domain = doc['key']
 
             if not use_new_exports(domain):
-                try:
-                    metas = migrate_domain(domain, dryrun=True, force_convert_columns=force_convert_columns)
-                except Exception:
-                    print('Migration raised an exception, skipping.')
-                    traceback.print_exc()
-                    skipped_domains.append(domain)
-                    continue
+                if not force_convert_columns:
+                    try:
+                        metas = migrate_domain(domain, dryrun=True, force_convert_columns=force_convert_columns)
+                    except Exception:
+                        print('Migration raised an exception, skipping.')
+                        traceback.print_exc()
+                        skipped_domains.append(domain)
+                        continue
 
-                has_skipped_tables = any(map(lambda meta: bool(meta.skipped_tables), metas))
-                has_skipped_columns = any(map(lambda meta: bool(meta.skipped_columns), metas))
-                is_remote_app_migration = any(map(lambda meta: bool(meta.is_remote_app_migration), metas))
-                if has_skipped_tables or has_skipped_columns:
-                    print('Skipping {} because we would have skipped columns'.format(domain))
-                    skipped_domains.append(domain)
-                    continue
+                    has_skipped_tables = any(map(lambda meta: bool(meta.skipped_tables), metas))
+                    has_skipped_columns = any(map(lambda meta: bool(meta.skipped_columns), metas))
+                    is_remote_app_migration = any(map(lambda meta: bool(meta.is_remote_app_migration), metas))
+                    if has_skipped_tables or has_skipped_columns:
+                        print('Skipping {} because we would have skipped columns'.format(domain))
+                        skipped_domains.append(domain)
+                        continue
 
-                if is_remote_app_migration:
-                    print('Skipping {} because it contains remote apps'.format(domain))
-                    skipped_domains.append(domain)
-                    continue
+                    if is_remote_app_migration:
+                        print('Skipping {} because it contains remote apps'.format(domain))
+                        skipped_domains.append(domain)
+                        continue
 
                 if not dryrun:
                     print('Migrating {}'.format(domain))

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from datetime import datetime
-import sys
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.modules import to_function
@@ -609,8 +608,7 @@ def migrate_domain(domain, dryrun=False, force_convert_columns=False):
                 )
             except Exception as e:
                 print('Failed parsing {}: {}'.format(old_export['_id'], e))
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                raise exc_type, exc_value, exc_traceback
+                raise
             else:
                 metas.append(migration_meta)
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from datetime import datetime
+import sys
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.modules import to_function
@@ -608,7 +609,8 @@ def migrate_domain(domain, dryrun=False, force_convert_columns=False):
                 )
             except Exception as e:
                 print('Failed parsing {}: {}'.format(old_export['_id'], e))
-                raise e
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                raise exc_type, exc_value, exc_traceback
             else:
                 metas.append(migration_meta)
 


### PR DESCRIPTION
@emord @gcapalbo first commit improves trackback readability, second commit skips the first migration if we are forcing the conversion. before it would do a dryrun migration to ensure we didn't skip any columns, however this is not necessary when we force the column convert