### PR TITLE
Catch exceptions when generating schemas

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -17,6 +17,7 @@ from corehq.apps.export.esaccessors import get_ledger_section_entry_combinations
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.daterange import get_daterange_start_end_dates
 from corehq.util.timezones.utils import get_timezone_for_domain
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.decorators.memoized import memoized
 from couchdbkit import SchemaListProperty, SchemaProperty, BooleanProperty, DictProperty
 
@@ -1309,11 +1310,16 @@ class ExportDataSchema(Document):
                 continue
 
             app = Application.wrap(app_doc)
-            current_schema = cls._process_app_build(
-                current_schema,
-                app,
-                identifier,
-            )
+            try:
+                current_schema = cls._process_app_build(
+                    current_schema,
+                    app,
+                    identifier,
+                )
+            except Exception as e:
+                _soft_assert = soft_assert('{}@{}'.format('brudolph', 'dimagi.com'))
+                _soft_assert(False, 'Failed to process app {}. {}'.format(app._id, e))
+                continue
 
             # Only record the version of builds on the schema. We don't care about
             # whether or not the schema has seen the current build because that always

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -7,6 +7,7 @@ from corehq.apps.export.models.new import MAIN_TABLE, \
     PathNode, _question_path_to_path_nodes
 
 from corehq.util.context_managers import drop_connected_signals
+from corehq.util.test_utils import softer_assert
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.models import (
@@ -593,6 +594,21 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         )
 
         self.assertEqual(len(schema.group_schemas), 1)
+
+    @softer_assert()
+    def test_process_app_failure(self):
+        '''
+        This ensures that the schema generated will not fail if there is an error processing one of the
+        applications.
+        '''
+        with patch(
+                'corehq.apps.export.models.new.FormExportDataSchema._process_app_build',
+                side_effect=Exception('boom')):
+            FormExportDataSchema.generate_schema_from_builds(
+                self.current_app.domain,
+                self.current_app._id,
+                'my_sweet_xmlns'
+            )
 
     def test_build_from_saved_schema(self):
         app = self.current_app


### PR DESCRIPTION
@gcapalbo @emord not in love with this solution, but when migrating exports, some app builds are borked and processing them generates an error. I don't think this actually fails to often, but just in case i've added a soft assert. This falls into the category of "nice to be notified but not always an actionable error"