### PR TITLE
avoid IntegrityError in tearDown

### DIFF
--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -223,6 +223,12 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
             post_json = serializers.serialize('python', [post])[0]
             self.assertDictEqual(pre_json, post_json)
 
+    def tearDown(self):
+        from corehq.apps.data_interfaces.models import AutomaticUpdateAction, AutomaticUpdateRuleCriteria
+        AutomaticUpdateAction.objects.all().delete()
+        AutomaticUpdateRuleCriteria.objects.all().delete()
+        super(TestSQLDumpLoad, self).tearDown()
+
     def test_case_search_config(self):
         from corehq.apps.case_search.models import CaseSearchConfig, CaseSearchConfigJSON
         expected_object_counts = Counter({


### PR DESCRIPTION
fixes

```
======================================================================
ERROR: test_auto_case_update_rules (corehq.apps.dump_reload.tests.test_sql_dump_load.TestSQLDumpLoad)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/test/testcases.py", line 216, in __call__
    self._post_teardown()
  File "/usr/local/lib/python2.7/site-packages/django/test/testcases.py", line 908, in _post_teardown
    self._fixture_teardown()
  File "/usr/local/lib/python2.7/site-packages/django/test/testcases.py", line 1064, in _fixture_teardown
    connections[db_name].check_constraints()
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/postgresql/base.py", line 224, in check_constraints
    self.cursor().execute('SET CONSTRAINTS ALL IMMEDIATE')
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 62, in execute
    return self.cursor.execute(sql)
IntegrityError: update or delete on table "data_interfaces_automaticupdaterule" violates foreign key constraint "data_rule_id_9e33ccca_fk_data_interfaces_automaticupdaterule_id" on table "data_interfaces_automaticupdateaction"
DETAIL:  Key (id)=(1) is still referenced from table "data_interfaces_automaticupdateaction".
```

in django 1.10

@snopoke cc: @esoergel @biyeun 