### PR TITLE
Move urllib.js and initial_page_data.js to base template

### DIFF
--- a/corehq/apps/accounting/templates/accounting/accounts.html
+++ b/corehq/apps/accounting/templates/accounting/accounts.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'accounting/js/credits-tab.js' %}"></script>
     <script src="{% static 'accounting/js/stay-on-tab.js' %}"></script>
     <script src="{% static 'accounting/js/accounting.billing_account_form.ko.js' %}"></script>

--- a/corehq/apps/accounting/templates/accounting/plans.html
+++ b/corehq/apps/accounting/templates/accounting/plans.html
@@ -5,7 +5,6 @@
 
 {% block js %}{{ block.super }}
     <script src="{% static 'accounting/js/stay-on-tab.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'accounting/js/accounting.software_plan_version_handler.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/accounting/templates/accounting/subscriptions.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions.html
@@ -6,7 +6,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'accounting/js/stay-on-tab.js' %}"></script>
         <script src="{% static 'accounting/js/adjust-balance-modal.js' %}"></script>
         <script src="{% static 'accounting/js/subscriptions.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/v1/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/apps_base.html
@@ -64,8 +64,6 @@
     <script src="{% static 'style/js/ui-element.js' %}"></script>
     <script src="{% static 'langcodes/js/langcodes.js' %}"></script>
     <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     {% if show_live_preview %}
     <script src="{% static 'app_manager/js/preview_app.js' %}"></script>
     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/import_app.html
@@ -5,8 +5,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
         <script src="{% static 'hqwebapp/js/lib/compression.js' %}"></script>
         <script src="{% static 'app_manager/js/import_app.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/source_files.html
@@ -56,8 +56,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
         <script src="{% static 'app_manager/js/source_files.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/apps_base.html
@@ -81,8 +81,6 @@ appmanager-main-container{% if formdesigner %} formdesigner-content-wrapper{% en
     <script src="{% static 'style/js/ui-element.js' %}"></script>
     <script src="{% static 'langcodes/js/langcodes.js' %}"></script>
     <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
 
 
     <script src="{% static 'app_manager/js/preview_app.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/v2/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/import_app.html
@@ -5,8 +5,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
         <script src="{% static 'hqwebapp/js/lib/compression.js' %}"></script>
         <script src="{% static 'app_manager/js/import_app.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/source_files.html
@@ -56,8 +56,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
         <script src="{% static 'app_manager/js/source_files.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/apps_base.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/apps_base.html.diff.txt
@@ -74,10 +74,10 @@
    {% endif %}
  
  {% endblock %}
-@@ -66,37 +83,23 @@
+@@ -64,37 +81,23 @@
+     <script src="{% static 'style/js/ui-element.js' %}"></script>
+     <script src="{% static 'langcodes/js/langcodes.js' %}"></script>
      <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
-     <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
-     <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
 -    {% if show_live_preview %}
 +
 +
@@ -120,7 +120,7 @@
       id="js-appmanager-body">
      {% if app %}
          {% if error %}
-@@ -121,7 +124,7 @@
+@@ -119,7 +122,7 @@
                  {% endblocktrans %}
              </p>
              <br>

--- a/corehq/apps/appstore/templates/appstore/appstore_base.html
+++ b/corehq/apps/appstore/templates/appstore/appstore_base.html
@@ -171,7 +171,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'appstore/js/facet_sidebar.js' %}"></script>
         <script src="{% static 'appstore/js/appstore_base.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -5,7 +5,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'builds/js/edit-builds.js' %}"></script>
     {% endcompress %}
 {% endblock %}

--- a/corehq/apps/case_importer/templates/case_importer/partials/import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/import_history.html
@@ -5,7 +5,6 @@
 {% registerurl 'case_importer_update_upload_comment' domain '---' %}
 
 {% addtoblock js %}
-<script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
 <script src="{% static 'case_importer/js/import_history.js' %}"></script>
 {% endaddtoblock %}
 

--- a/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
+++ b/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block js %}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'dashboard/js/dashboard_new_user.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -28,7 +28,7 @@
 
                 if (jsonResp.success) {
                     $testResult.addClass("text-success");
-                    $testResult.text(gettext('Success! Response is: ' + message);
+                    $testResult.text("{% trans 'Success! Response is' %}: " + message);
                 } else {
                     $testResult.addClass("text-danger");
                     $testResult.text(gettext('Failed! Response is: ') + message);
@@ -43,7 +43,7 @@
                 $testResult
                     .removeClass("hide text-success")
                     .addClass("text-danger");
-                $testResult.text(gettext('HQ was unable to make the request: ' + resp.statusText);
+                $testResult.text("{% trans 'HQ was unable to make the request' %}: " + resp.statusText);
             };
 
             $testLinkButton.click(function () {

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -28,10 +28,10 @@
 
                 if (jsonResp.success) {
                     $testResult.addClass("text-success");
-                    $testResult.text("{% trans 'Success! Response is' %}: " + message);
+                    $testResult.text(gettext('Success! Response is: ' + message);
                 } else {
                     $testResult.addClass("text-danger");
-                    $testResult.text("{% trans 'Failed! Response is' %}: " + message);
+                    $testResult.text(gettext('Failed! Response is: ') + message);
                 }
             };
 
@@ -43,7 +43,7 @@
                 $testResult
                     .removeClass("hide text-success")
                     .addClass("text-danger");
-                $testResult.text("{% trans 'HQ was unable to make the request' %}: " + resp.statusText);
+                $testResult.text(gettext('HQ was unable to make the request: ' + resp.statusText);
             };
 
             $testLinkButton.click(function () {

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -31,7 +31,7 @@
                     $testResult.text("{% trans 'Success! Response is' %}: " + message);
                 } else {
                     $testResult.addClass("text-danger");
-                    $testResult.text(gettext('Failed! Response is: ') + message);
+                    $testResult.text("{% trans 'Failed! Response is' %}: " + message);
                 }
             };
 

--- a/corehq/apps/domain/templates/domain/admin/media_manager.html
+++ b/corehq/apps/domain/templates/domain/admin/media_manager.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 
 {% block js %} {{ block.super }}
-<script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
 <script src="{% static 'domain/js/media_manager.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/create_snapshot.html
+++ b/corehq/apps/domain/templates/domain/create_snapshot.html
@@ -18,7 +18,6 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'domain/js/create_snapshot.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/internal_calculations.html
+++ b/corehq/apps/domain/templates/domain/internal_calculations.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
     <script src="{% static 'domain/js/internal_calculations.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/internal_settings.html
+++ b/corehq/apps/domain/templates/domain/internal_settings.html
@@ -23,6 +23,5 @@
 {% endblock %}
 
 {% block js %} {{ block.super }}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'domain/js/internal_settings.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -22,7 +22,6 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'accounting/js/accounting.pricing_table.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/snapshot_settings.html
+++ b/corehq/apps/domain/templates/domain/snapshot_settings.html
@@ -4,8 +4,6 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'domain/js/snapshot_settings.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -4,7 +4,6 @@
 
 {% block js %}
     {{ block.super }}
-    <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
     <script src="{% static 'export/js/const.js' %}"></script>
     <script src="{% static 'export/js/utils.js' %}"></script>
     <script src="{% static 'export/js/models.js' %}"></script>

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-<script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
 <script src="{% static 'fixtures/js/lookup-manage.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -17,7 +17,6 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'fixtures/js/view-table.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
     <script src="{% static 'locations/js/location_types.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/products/templates/products/manage/products.html
+++ b/corehq/apps/products/templates/products/manage/products.html
@@ -5,7 +5,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'hqwebapp/js/base_list_view_model.js' %}"></script>
         <script src="{% static 'commtrack/js/products_and_programs.async.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/programs/templates/programs/manage/program.html
+++ b/corehq/apps/programs/templates/programs/manage/program.html
@@ -10,7 +10,6 @@
         <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
         <script src="{% static 'style/js/ui-element.js' %}"></script>
         <script src="{% static 'hqwebapp/js/base_list_view_model.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'commtrack/js/products_and_programs.async.js' %}"></script>
     {% endcompress %}
 {% endblock %}

--- a/corehq/apps/programs/templates/programs/manage/programs.html
+++ b/corehq/apps/programs/templates/programs/manage/programs.html
@@ -5,7 +5,6 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'hqwebapp/js/base_list_view_model.js' %}"></script>
         <script src="{% static 'commtrack/js/products_and_programs.async.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -13,8 +13,6 @@
         <script src="{% static 'zxcvbn/dist/zxcvbn.js' %}"></script>
         <script src="{% static 'style/js/password_validators.ko.js' %}"></script>
         <script src="{% static 'intl-tel-input/build/js/intlTelInput.min.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
         <script src="{% static 'registration/js/new_user.ko.js' %}"></script>
         <script src="{% static 'registration/js/register_new_user.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -378,6 +378,8 @@
         <script src="{% static 'style/js/hq.helpers.js' %}"></script>
         <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
         <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
         <script src="{% static 'style/js/main.js' %}"></script>
         {% endcompress %}
 

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -9,8 +9,6 @@
 {% block js %}{{ block.super }}
     {% compress js %}
         <script src="{% static 'style/js/main.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/urllib.js' %}"></script>
         <script src="{% static 'toggle_ui/js/edit-flag.js' %}"></script>
     {% endcompress %}
 {% endblock %}


### PR DESCRIPTION
It's been getting more annoying to trace whether or not these have already been included in a parent template. They're used in enough places to justify adding them to `style/base.html` - and they're small.

@millerdev 