### PR TITLE
default sms export

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -506,6 +506,7 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
     show_date_range = False
     check_for_multimedia = False
     filter_form_class = None
+    sms_export = False
 
     @use_daterangepicker
     @use_select2


### PR DESCRIPTION
@NoahCarnahan would be good to get this in before deploy. It's a todo to get rid of this variable, but it's referenced here https://github.com/dimagi/commcare-hq/blob/96e847fa899ec2e16856b4530d8b096cf18ec9dc/corehq/apps/export/views.py#L609 and set for real in the new sms exports