### PR TITLE
don't pass RequestContext to render

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -67,7 +67,7 @@ def csrf_inline(request):
     """
     from django.template import Template, RequestContext
     node = "{% csrf_token %}"
-    return Template(node).render(RequestContext(request))
+    return Template(node).render(RequestContext(request).dicts[0])
 
 
 def aliased_language_name(lang_code):

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -65,9 +65,9 @@ def csrf_inline(request):
 
     Useful for adding inline forms in messages for e.g. while showing an "'undo' Archive Form" message
     """
-    from django.template import Template, RequestContext
+    from django.template import Template
     node = "{% csrf_token %}"
-    return Template(node).render(RequestContext(request).dicts[0])
+    return Template(node).render(request=request)
 
 
 def aliased_language_name(lang_code):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -93,12 +93,14 @@ def server_error(request, template_name='500.html'):
     traceback_key = uuid.uuid4().hex
     cache.cache.set(traceback_key, traceback_text, 60*60)
 
-    return HttpResponseServerError(t.render(RequestContext(request,
-        {'MEDIA_URL': settings.MEDIA_URL,
-         'STATIC_URL': settings.STATIC_URL,
-         'domain': domain,
-         '500traceback': traceback_key,
-        })))
+    return HttpResponseServerError(t.render(
+        RequestContext(request, {
+            'MEDIA_URL': settings.MEDIA_URL,
+            'STATIC_URL': settings.STATIC_URL,
+            'domain': domain,
+            '500traceback': traceback_key,
+        }).dicts[0]
+    ))
 
 
 def not_found(request, template_name='404.html'):
@@ -106,10 +108,12 @@ def not_found(request, template_name='404.html'):
     404 error handler.
     """
     t = loader.get_template(template_name)
-    return HttpResponseNotFound(t.render(RequestContext(request,
-        {'MEDIA_URL': settings.MEDIA_URL,
-         'STATIC_URL': settings.STATIC_URL
-        })))
+    return HttpResponseNotFound(t.render(
+        RequestContext(request, {
+            'MEDIA_URL': settings.MEDIA_URL,
+            'STATIC_URL': settings.STATIC_URL,
+        }).dicts[0]
+    ))
 
 
 @require_GET
@@ -268,21 +272,23 @@ def no_permissions(request, redirect_to=None, template_name="403.html", message=
     403 error handler.
     """
     t = loader.get_template(template_name)
-    return HttpResponseForbidden(t.render(RequestContext(request, {
-        'MEDIA_URL': settings.MEDIA_URL,
-        'STATIC_URL': settings.STATIC_URL,
-        'message': message,
-    })))
+    return HttpResponseForbidden(t.render(
+        RequestContext(request, {
+            'MEDIA_URL': settings.MEDIA_URL,
+            'STATIC_URL': settings.STATIC_URL,
+            'message': message,
+        }).dicts[0]
+    ))
 
 
 def csrf_failure(request, reason=None, template_name="csrf_failure.html"):
     t = loader.get_template(template_name)
-    return HttpResponseForbidden(
-        t.render(RequestContext(
-            request,
-            {'MEDIA_URL': settings.MEDIA_URL,
-             'STATIC_URL': settings.STATIC_URL
-             })))
+    return HttpResponseForbidden(t.render(
+        RequestContext(request, {
+            'MEDIA_URL': settings.MEDIA_URL,
+            'STATIC_URL': settings.STATIC_URL,
+        }).dicts[0]
+    ))
 
 
 @sensitive_post_parameters('auth-password')

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -22,7 +22,6 @@ from django.http import HttpResponseRedirect, HttpResponse, Http404,\
     HttpResponseForbidden
 from django.shortcuts import redirect, render
 from django.template import loader
-from django.template.context import RequestContext
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
@@ -94,12 +93,13 @@ def server_error(request, template_name='500.html'):
     cache.cache.set(traceback_key, traceback_text, 60*60)
 
     return HttpResponseServerError(t.render(
-        RequestContext(request, {
+        context={
             'MEDIA_URL': settings.MEDIA_URL,
             'STATIC_URL': settings.STATIC_URL,
             'domain': domain,
             '500traceback': traceback_key,
-        }).dicts[0]
+        },
+        request=request,
     ))
 
 
@@ -109,10 +109,11 @@ def not_found(request, template_name='404.html'):
     """
     t = loader.get_template(template_name)
     return HttpResponseNotFound(t.render(
-        RequestContext(request, {
+        context={
             'MEDIA_URL': settings.MEDIA_URL,
             'STATIC_URL': settings.STATIC_URL,
-        }).dicts[0]
+        },
+        request=request,
     ))
 
 
@@ -273,21 +274,23 @@ def no_permissions(request, redirect_to=None, template_name="403.html", message=
     """
     t = loader.get_template(template_name)
     return HttpResponseForbidden(t.render(
-        RequestContext(request, {
+        context={
             'MEDIA_URL': settings.MEDIA_URL,
             'STATIC_URL': settings.STATIC_URL,
             'message': message,
-        }).dicts[0]
+        },
+        request=request,
     ))
 
 
 def csrf_failure(request, reason=None, template_name="csrf_failure.html"):
     t = loader.get_template(template_name)
     return HttpResponseForbidden(t.render(
-        RequestContext(request, {
+        context={
             'MEDIA_URL': settings.MEDIA_URL,
             'STATIC_URL': settings.STATIC_URL,
-        }).dicts[0]
+        },
+        request=request,
     ))
 
 


### PR DESCRIPTION
passing ```RequestContext``` instead of ```dict``` to ```render```  becomes problematic in django 1.10

testing on staging