### PR TITLE
allow property_name to accept expressions

### DIFF
--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -38,6 +38,14 @@ _property_path_expression = functools.partial(_simple_expression_generator, Prop
 _iteration_number_expression = functools.partial(_simple_expression_generator, IterationNumberExpressionSpec)
 
 
+def _property_name_expression(spec, context):
+    expression = PropertyNameGetterSpec.wrap(spec)
+    expression.configure(
+        ExpressionFactory.from_spec(expression.property_name, context=context)
+    )
+    return expression
+
+
 def _named_expression(spec, context):
     expression = NamedExpressionSpec.wrap(spec)
     expression.configure(context=context)

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -47,11 +47,14 @@ class ConstantGetterSpec(JsonObject):
 
 class PropertyNameGetterSpec(JsonObject):
     type = TypeProperty('property_name')
-    property_name = StringProperty(required=True)
+    property_name = DefaultProperty(required=True)
     datatype = DataTypeProperty(required=False)
 
+    def configure(self, property_name_expression):
+        self._property_name_expression = property_name_expression
+
     def __call__(self, item, context=None):
-        raw_value = item.get(self.property_name, None) if isinstance(item, dict) else None
+        raw_value = item.get(self._property_name_expression(item, context)) if isinstance(item, dict) else None
         return transform_from_datatype(self.datatype)(raw_value)
 
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import json
 from simpleeval import InvalidExpression
 from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 from corehq.apps.userreports.document_stores import get_document_store
@@ -15,7 +14,6 @@ from corehq.apps.userreports.specs import TypeProperty, EvaluationContext
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from pillowtop.dao.exceptions import DocumentNotFoundError
 from .utils import eval_statements
-from corehq.util.quickcache import quickcache
 import six
 
 

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -178,6 +178,26 @@ class ExpressionFromSpecTest(SimpleTestCase):
                 })
 
 
+class PropertyNameExpressionTest(SimpleTestCase):
+    def test_basic(self):
+        wrapped_expression = ExpressionFactory.from_spec({
+            'type': 'property_name',
+            'property_name': 'foo'
+        })
+        self.assertEqual(wrapped_expression({'foo': 'foo_value'}), 'foo_value')
+        self.assertEqual(wrapped_expression({'no': 'value'}), None)
+
+    def test_property_name_expression_with_expression(self):
+        wrapped_expression = ExpressionFactory.from_spec({
+            'type': 'property_name',
+            'property_name': {
+                'type': 'constant',
+                'constant': 'foo',
+            }
+        })
+        self.assertEqual(wrapped_expression({'foo': 'foo_value'}), 'foo_value')
+
+
 class PropertyPathExpressionTest(SimpleTestCase):
 
     def test_datatype(self):


### PR DESCRIPTION
this supports a relatively obscure use case for base item expression doing fancy stuff using a property name expression based on the iterator value.

should hopefully be backwards compatible though.

@calellowitz 