### PR TITLE
don't re-create the ES client on every call

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -26,7 +26,7 @@ def get_es_new():
     Get a handle to the configured elastic search DB.
     Returns an elasticsearch.Elasticsearch instance.
     """
-    if not get_es_new._es_client:
+    if not getattr(get_es_new, '_es_client', None):
         es_hosts = getattr(settings, 'ELASTICSEARCH_HOSTS', None)
         if not es_hosts:
             es_hosts = [settings.ELASTICSEARCH_HOST]

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -21,7 +21,7 @@ from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 
 
-def get_es_new(**kwargs):
+def get_es_new():
     """
     Get a handle to the configured elastic search DB.
     Returns an elasticsearch.Elasticsearch instance.

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -38,7 +38,12 @@ def get_es_new():
             }
             for host in es_hosts
         ]
-        get_es_new._es_client = Elasticsearch(hosts, **kwargs)
+        get_es_new._es_client = Elasticsearch(
+            hosts,
+            sniff_on_start=True,
+            sniff_on_connection_fail=True,
+            sniffer_timeout=60
+        )
     return get_es_new._es_client
 
 

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -26,18 +26,20 @@ def get_es_new(**kwargs):
     Get a handle to the configured elastic search DB.
     Returns an elasticsearch.Elasticsearch instance.
     """
-    es_hosts = getattr(settings, 'ELASTICSEARCH_HOSTS', None)
-    if not es_hosts:
-        es_hosts = [settings.ELASTICSEARCH_HOST]
+    if not get_es_new._es_client:
+        es_hosts = getattr(settings, 'ELASTICSEARCH_HOSTS', None)
+        if not es_hosts:
+            es_hosts = [settings.ELASTICSEARCH_HOST]
 
-    hosts = [
-        {
-            'host': host,
-            'port': settings.ELASTICSEARCH_PORT,
-        }
-        for host in es_hosts
-    ]
-    return Elasticsearch(hosts, **kwargs)
+        hosts = [
+            {
+                'host': host,
+                'port': settings.ELASTICSEARCH_PORT,
+            }
+            for host in es_hosts
+        ]
+        get_es_new._es_client = Elasticsearch(hosts, **kwargs)
+    return get_es_new._es_client
 
 
 def doc_exists_in_es(index_info, doc_id_or_dict):


### PR DESCRIPTION
From what I can tell this is how the ES client is supposed to be used (since it has connection pools etc inside it).