### PR TITLE
fix archive forms

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -65,9 +65,9 @@ def csrf_inline(request):
 
     Useful for adding inline forms in messages for e.g. while showing an "'undo' Archive Form" message
     """
-    from django.template import Template
+    from django.template import Template, RequestContext
     node = "{% csrf_token %}"
-    return Template(node).render(request=request)
+    return Template(node).render(RequestContext(request))
 
 
 def aliased_language_name(lang_code):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?248250

Introduced in https://github.com/dimagi/commcare-hq/pull/15111/

This is pretty weird. The default instantiation of `Template` actually has a [different api](https://github.com/django/django/blob/stable/1.9.x/django/template/base.py#L199) for this function. I think it only exists to [support this use case](https://github.com/django/django/blob/stable/1.9.x/django/template/base.py#L176), but at first blush I would argue this is a bug in django 1.9.

@nickpell cc @calellowitz 