### PR TITLE
Include export name in sheet names for bulk exports

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -72,15 +72,19 @@ class _Writer(object):
             # open the ExportWriter
             headers = []
             table_titles = {}
-            for instance in export_instances:
+            for instance_index, instance in enumerate(export_instances):
                 headers += [
                     (t, (t.get_headers(split_columns=instance.split_multiselects),))
                     for t in instance.selected_tables
                 ]
-                table_titles.update({
-                    t: t.label or "Sheet{}".format(i+1)
-                    for i, t in enumerate(instance.selected_tables)
-                })
+                for table_index, table in enumerate(instance.selected_tables):
+                    sheet_name = table.label or "Sheet{}".format(table_index+1)
+                    if len(export_instances) > 1:
+                        sheet_name = "{}-{}".format(
+                            instance.name or "Export{}".format(instance_index+1),
+                            sheet_name
+                        )
+                    table_titles[table] = sheet_name
             self.writer.open(headers, file, table_titles=table_titles, archive_basepath=name)
             yield
             self.writer.close()

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -78,10 +78,10 @@ class _Writer(object):
                     for t in instance.selected_tables
                 ]
                 for table_index, table in enumerate(instance.selected_tables):
-                    sheet_name = table.label or "Sheet{}".format(table_index+1)
+                    sheet_name = table.label or "Sheet{}".format(table_index + 1)
                     if len(export_instances) > 1:
                         sheet_name = "{}-{}".format(
-                            instance.name or "Export{}".format(instance_index+1),
+                            instance.name or "Export{}".format(instance_index + 1),
                             sheet_name
                         )
                     table_titles[table] = sheet_name

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -80,7 +80,7 @@ class _Writer(object):
                 for table_index, table in enumerate(instance.selected_tables):
                     sheet_name = table.label or "Sheet{}".format(table_index + 1)
                     if len(export_instances) > 1:
-                        sheet_name = "{}-{}".format(
+                        sheet_name = u"{}-{}".format(
                             instance.name or "Export{}".format(instance_index + 1),
                             sheet_name
                         )

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -501,12 +501,12 @@ class WriterTest(SimpleTestCase):
             self.assertEqual(
                 json.loads(export),
                 {
-                    u'My table': {
+                    u'Export1-My table': {
                         u'headers': [u'Q3'],
                         u'rows': [[u'baz'], [u'bop']],
 
                     },
-                    u'My other table': {
+                    u'Export2-My other table': {
                         u'headers': [u'Q4'],
                         u'rows': [[u'bar'], [u'boop']],
                     }
@@ -795,13 +795,13 @@ class ExportTest(SimpleTestCase):
         )
 
         expected = {
-            'My table': {
+            'Export1-My table': {
                 "A1": "Foo column",
                 "A2": "apple",
                 "A3": "apple",
                 "A4": "apple",
             },
-            "My table1": {
+            "Export2-My table": {
                 "A1": "Bar column",
                 "A2": "banana",
                 "A3": "banana",
@@ -811,7 +811,7 @@ class ExportTest(SimpleTestCase):
 
         with export_file as export:
             wb = load_workbook(StringIO(export))
-            self.assertEqual(wb.get_sheet_names(), ["My table", "My table1"])
+            self.assertEqual(wb.get_sheet_names(), ["Export1-My table", "Export2-My table"])
 
             for sheet in expected.keys():
                 for cell in expected[sheet].keys():


### PR DESCRIPTION
Addresses: http://manage.dimagi.com/default.asp?247678

Makes it easier to figure out which sheets correspond to which exports, otherwise they will just be named "Forms1", "Forms2", etc.