### PR TITLE
use email instead of WebUser in test_autopay

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -14,7 +14,6 @@ from django.utils.translation import ugettext
 
 from celery.schedules import crontab
 from celery.task import periodic_task, task
-from couchdbkit import ResourceNotFound
 
 from couchexport.export import export_from_tables
 from couchexport.models import Format
@@ -389,12 +388,11 @@ def send_purchase_receipt(payment_record, domain,
                           template_html, template_plaintext,
                           additional_context):
     username = payment_record.payment_method.web_user
-
-    try:
-        web_user = WebUser.get_by_username(username)
+    web_user = WebUser.get_by_username(username)
+    if web_user:
         email = web_user.get_email()
         name = web_user.first_name
-    except ResourceNotFound:
+    else:
         log_accounting_error(
             "Strange. A payment attempt was made by a user that "
             "we can't seem to find! %s" % username,
@@ -427,9 +425,10 @@ def send_autopay_failed(invoice, payment_method):
     auto_payer = subscription.account.auto_pay_user
     payment_method = StripePaymentMethod.objects.get(web_user=auto_payer)
     autopay_card = payment_method.get_autopay_card(subscription.account)
-    try:
-        recipient = WebUser.get_by_username(auto_payer).get_email()
-    except ResourceNotFound:
+    web_user = WebUser.get_by_username(auto_payer)
+    if web_user:
+        recipient = web_user.get_email()
+    else:
         recipient = auto_payer
     domain = invoice.get_domain()
 

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -67,10 +67,14 @@ def unique_name():
 
 
 @unit_testing_only
+def create_arbitrary_web_user_name(is_dimagi=False):
+    return "%s@%s.com" % (unique_name(), 'dimagi' if is_dimagi else 'gmail')
+
+
+@unit_testing_only
 def arbitrary_web_user(is_dimagi=False):
-    domain = Domain(name=unique_name()[:25])
-    domain.save()
-    username = "%s@%s.com" % (unique_name(), 'dimagi' if is_dimagi else 'gmail')
+    domain = arbitrary_domain()
+    username = create_arbitrary_web_user_name(is_dimagi=is_dimagi)
     try:
         web_user = WebUser.create(domain.name, username, 'test123')
     except Exception:
@@ -86,7 +90,7 @@ def billing_account(web_user_creator, web_user_contact, currency=None, save=True
     currency = currency or Currency.objects.get(code=settings.DEFAULT_CURRENCY)
     billing_account = BillingAccount(
         name=account_name,
-        created_by=web_user_creator.username,
+        created_by=web_user_creator.username if isinstance(web_user_creator, WebUser) else web_user_creator,
         currency=currency,
     )
     if save:
@@ -102,7 +106,7 @@ def arbitrary_contact_info(account, web_user_creator):
         account=account,
         first_name=data_gen.arbitrary_firstname(),
         last_name=data_gen.arbitrary_lastname(),
-        email_list=[web_user_creator.username],
+        email_list=[web_user_creator.username if isinstance(web_user_creator, WebUser) else web_user_creator],
         phone_number="+15555555",
         company_name="Company Name",
         first_line="585 Mass Ave",

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -33,10 +33,10 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         cls.autopay_account = cls.account
         cls.autopay_account.created_by_domain = cls.domain
         cls.autopay_account.save()
-        cls.autopay_user = generator.arbitrary_web_user()
+        cls.autopay_user_email = generator.create_arbitrary_web_user_name()
         cls.fake_card = FakeStripeCard()
         cls.fake_stripe_customer = FakeStripeCustomer(cards=[cls.fake_card])
-        cls.autopay_account.update_autopay_user(cls.autopay_user.username, cls.domain)
+        cls.autopay_account.update_autopay_user(cls.autopay_user_email, cls.domain)
 
     @classmethod
     def _generate_non_autopayable_entities(cls):
@@ -44,8 +44,8 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         Create account, domain, and subscription linked to the autopay user, but that don't have autopay enabled
         """
         cls.non_autopay_account = generator.billing_account(
-            web_user_creator=generator.arbitrary_web_user(is_dimagi=True),
-            web_user_contact=cls.autopay_user
+            web_user_creator=generator.create_arbitrary_web_user_name(is_dimagi=True),
+            web_user_contact=cls.autopay_user_email
         )
         cls.non_autopay_domain = generator.arbitrary_domain()
         # Non-autopay subscription has same parameters as the autopayable subscription
@@ -105,7 +105,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
 
     def _create_autopay_method(self, fake_customer):
         fake_customer.__get__ = mock.Mock(return_value=self.fake_stripe_customer)
-        self.payment_method = StripePaymentMethod(web_user=self.autopay_user.username,
+        self.payment_method = StripePaymentMethod(web_user=self.autopay_user_email,
                                                   customer_id=self.fake_stripe_customer.id)
         self.payment_method.set_autopay(self.fake_card, self.autopay_account, self.domain)
         self.payment_method.save()


### PR DESCRIPTION
First steps to stop creating ```WebUser```s and ```Domain```s (and having to clean them up) unnecessarily in accounting tests.

@esoergel @biyeun 