### PR TITLE
avoid rendering 30 day trial message by default as its better self-re…

### DIFF
--- a/corehq/apps/style/templates/style/includes/modal_report_issue.html
+++ b/corehq/apps/style/templates/style/includes/modal_report_issue.html
@@ -144,11 +144,4 @@
             </form>
         </div>
     </div>
-    {% addtoblock js-inline %}
-    <script>
-        $(window).on('load', function(){
-            $('#modalTrial30Day').modal('show');
-        });
-    </script>
-    {% endaddtoblock %}
 {% endif %}


### PR DESCRIPTION
…ndered only when needed by the template

This is silently ignored by chrome but causes JS error in say, safari