### PR TITLE
Save last sent date on repeat records that will not be retried

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -607,6 +607,7 @@ class RepeatRecord(Document):
         if self.repeater.allow_retries(response) and self.overall_tries < self.max_possible_tries:
             self.set_next_try()
         else:
+            self.last_checked = datetime.utcnow()
             self.cancel()
         self.failure_reason = reason
         log_counter(REPEATER_ERROR_COUNT, {


### PR DESCRIPTION
This change will make the repeat_record_report more useful for canceled repeat records.
https://manage.dimagi.com/default.asp?248041
cc @kaapstorm 