### PR TITLE
Reduce duplicate setup on location fixtures tests

### DIFF
--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -63,7 +63,7 @@ class FixtureHasLocationsMixin(TestXmlMixin):
 
 
 @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
-class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
+class LocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
     location_type_names = ['state', 'county', 'city']
     location_structure = [
         ('Massachusetts', [
@@ -91,6 +91,14 @@ class LocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
 
     def tearDown(self):
         self.user._couch_user.delete()
+        for lt in self.location_types.values():
+            lt.expand_to = None
+            lt._expand_from_root = False
+            lt._expand_from = None
+            lt.include_without_expanding = None
+            lt.save()
+        for loc in self.locations.values():
+            loc.location_type.refresh_from_db()
         super(LocationFixturesTest, self).tearDown()
 
     @flag_enabled('HIERARCHICAL_LOCATION_FIXTURE')

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -22,7 +22,6 @@ from casexml.apps.case.xml import V2
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
 from .util import (
-    LocationHierarchyPerTest,
     setup_location_types_with_structure,
     setup_locations_with_structure,
     LocationStructure,
@@ -370,7 +369,7 @@ class LocationFixturesDataTest(LocationHierarchyTestCase, FixtureHasLocationsMix
 
 
 @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
-class WebUserLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
+class WebUserLocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
 
     location_type_names = ['state', 'county', 'city']
     location_structure = [
@@ -427,7 +426,7 @@ class WebUserLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsM
 
 
 @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
-class ForkedHierarchyLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLocationsMixin):
+class ForkedHierarchyLocationFixturesTest(TestCase, FixtureHasLocationsMixin):
     """
     - State
         - County
@@ -435,6 +434,7 @@ class ForkedHierarchyLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLo
         - Region
             - Town
     """
+    domain = 'forked-hierarchy-domain'
     location_type_structure = [
         LocationTypeStructure('state', [
             LocationTypeStructure('county', [
@@ -470,6 +470,9 @@ class ForkedHierarchyLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLo
         self.user = create_restore_user(self.domain, 'user', '123')
         self.location_types = setup_location_types_with_structure(self.domain, self.location_type_structure)
         self.locations = setup_locations_with_structure(self.domain, self.location_structure)
+
+    def tearDown(self):
+        self.domain_obj.delete()
 
     def test_forked_locations(self, *args):
         self.user._couch_user.set_location(self.locations['Massachusetts'].couch_location)


### PR DESCRIPTION
I started this during the test crunch session but needed to put in the last bit of effort to get it ready.
This brings these tests from 64s to 30s