### PR TITLE
Add some hqDefines

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/import_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/import_app.js
@@ -1,9 +1,5 @@
-$(function () {
-    $(".historyBack").click(function () {
-        history.back();
-        return false;
-    });
-
+/* globals hqDefine */
+hqDefine('app_manager/js/import_app.js', function () {
     function CompressionViewModel(source, post_url){
         var self = this;
         self.name = ko.observable("");
@@ -16,7 +12,15 @@ $(function () {
             return false;
         };
     }
-    var source = hqImport('hqwebapp/js/initial_page_data.js').get('export_json');
-    var post_url = hqImport('hqwebapp/js/urllib.js').reverse('import_app');
-    $('#app-import-form').koApplyBindings(new CompressionViewModel(source, post_url));
+
+    $(function () {
+        $(".historyBack").click(function () {
+            history.back();
+            return false;
+        });
+ 
+        var source = hqImport('hqwebapp/js/initial_page_data.js').get('export_json');
+        var post_url = hqImport('hqwebapp/js/urllib.js').reverse('import_app');
+        $('#app-import-form').koApplyBindings(new CompressionViewModel(source, post_url));
+    });
 });

--- a/corehq/apps/appstore/static/appstore/js/appstore_base.js
+++ b/corehq/apps/appstore/static/appstore/js/appstore_base.js
@@ -1,4 +1,5 @@
-$(function(){
+/* globals hqDefine */
+hqDefine('appstore/js/appstore_base.js', function () {
     // This assures that all the result elements are the same height
     function assure_correct_spacing() {
         $('.results').each(function(){
@@ -17,8 +18,10 @@ $(function(){
     }
     $(window).resize(assure_correct_spacing);
 
-    var app_ids = hqImport('hqwebapp/js/initial_page_data.js').get('app_ids');
-    _.each(app_ids, function(id) {
-        gaTrackLink($('#view_button_' + id), 'Exchange', 'View button', id);
+    $(function(){
+        var app_ids = hqImport('hqwebapp/js/initial_page_data.js').get('app_ids');
+        _.each(app_ids, function(id) {
+            gaTrackLink($('#view_button_' + id), 'Exchange', 'View button', id);
+        });
     });
 });

--- a/corehq/apps/appstore/static/appstore/js/project_info.js
+++ b/corehq/apps/appstore/static/appstore/js/project_info.js
@@ -1,39 +1,42 @@
-$(function(){
+/* globals hqDefine */
+hqDefine('appstore/js/project_info.js', function () {
     function update_import_into_button() {
         var project = $('#project_select option:selected').text();
         $("#import-into-button").text("Import into " + project);
     }
 
-    update_import_into_button();
-
-    $("#import-app-button").click(function() {
-        $('#import-app').removeClass('hide');
-    });
-
-    $('#project_select').change(update_import_into_button);
-
-    $('[data-target="#licenseAgreement"]').click(function() {
-        var new_form = $(this).attr('data-form');
-        $('#agree-button').attr('data-form', new_form);
-    });
-    $('#agree-button').click(function() {
-        $('#agree-button').unbind()
-                          .addClass('disabled');
-        $('#download-new-project').removeProp('data-toggle');
-        $('#download-new-project').removeProp('href');
-        $('#import-into-button').removeProp('data-toggle');
-        $('#import-into-button').removeProp('href');
-        var form = $("#" + $(this).attr('data-form'));
-        form.submit();
-    });
-
-    // Analytics
-    var project = hqImport('hqwebapp/js/initial_page_data.js').get('project');
-    $('#download-new-project').click(function() {
-        ga_track_event('Exchange', 'Download As New Project', project);
-    });
-
-    $('#import-app-button').click(function() {
-        ga_track_event('Exchange', 'Download to Existing Project', project);
+    $(function(){
+        update_import_into_button();
+    
+        $("#import-app-button").click(function() {
+            $('#import-app').removeClass('hide');
+        });
+    
+        $('#project_select').change(update_import_into_button);
+    
+        $('[data-target="#licenseAgreement"]').click(function() {
+            var new_form = $(this).attr('data-form');
+            $('#agree-button').attr('data-form', new_form);
+        });
+        $('#agree-button').click(function() {
+            $('#agree-button').unbind()
+                              .addClass('disabled');
+            $('#download-new-project').removeProp('data-toggle');
+            $('#download-new-project').removeProp('href');
+            $('#import-into-button').removeProp('data-toggle');
+            $('#import-into-button').removeProp('href');
+            var form = $("#" + $(this).attr('data-form'));
+            form.submit();
+        });
+    
+        // Analytics
+        var project = hqImport('hqwebapp/js/initial_page_data.js').get('project');
+        $('#download-new-project').click(function() {
+            ga_track_event('Exchange', 'Download As New Project', project);
+        });
+    
+        $('#import-app-button').click(function() {
+            ga_track_event('Exchange', 'Download to Existing Project', project);
+        });
     });
 });

--- a/corehq/apps/builds/static/builds/js/edit-builds.js
+++ b/corehq/apps/builds/static/builds/js/edit-builds.js
@@ -1,4 +1,5 @@
-(function () {
+/* globals hqDefine */
+hqDefine('builds/js/edit-builds.js', function () {
     var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get,
         doc = initial_page_data('doc'),
         pretty_doc = JSON.stringify(doc, undefined, 2);
@@ -106,4 +107,4 @@
             {'doc': JSON.stringify(outputJSON(buildsMenu))}
         );
     });
-})();
+});

--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs.async.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs.async.js
@@ -1,103 +1,106 @@
-var CommtrackProductsProgramsViewModel = function (o) {
-    var view_model = BaseListViewModel(o);
+/* globals hqDefine */
+hqDefine('commtrack/js/products_and_programs.async.js', function () {
+    var CommtrackProductsProgramsViewModel = function (o) {
+        var view_model = BaseListViewModel(o);
 
-    view_model.currently_searching = ko.observable(false);
+        view_model.currently_searching = ko.observable(false);
 
-    view_model.colspan = ko.computed(function () {
-        return 7;
-    });
-
-    view_model.init = function () {
-        $(function () {
-            view_model.change_page(view_model.current_page);
+        view_model.colspan = ko.computed(function () {
+            return 7;
         });
-    };
 
-    view_model.change_page = function (page, next_or_last) {
-        page = ko.utils.unwrapObservable(page);
+        view_model.init = function () {
+            $(function () {
+                view_model.change_page(view_model.current_page);
+            });
+        };
 
-        if (page) {
-            view_model.currently_searching(true);
-            $.ajax({
-                url: format_url(page),
-                dataType: 'json',
-                error: function () {
+        view_model.change_page = function (page, next_or_last) {
+            page = ko.utils.unwrapObservable(page);
+
+            if (page) {
+                view_model.currently_searching(true);
+                $.ajax({
+                    url: format_url(page),
+                    dataType: 'json',
+                    error: function () {
+                        view_model.initial_load(true);
+                        $('.hide-until-load').fadeIn();
+                        $('#user-list-notification').text(gettext('Sorry, there was an problem contacting the server ' +
+                            'to fetch the data. Please, try again in a little bit.'));
+                        view_model.currently_searching(false);
+                    },
+                    success: reloadList
+                });
+            }
+
+            return false;
+        };
+
+        view_model.unsuccessful_archive_action = function (button, index) {
+            return function (data) {
+                if (data.message && data.product_id) {
+                    var alert_container = $('#alert_' + data.product_id);
+                    alert_container.text(data.message);
+                    alert_container.show();
+                }
+                $(button).button('unsuccessful');
+            };
+        };
+
+        var reloadList = function(data) {
+            view_model.currently_searching(false);
+            if (data.success) {
+                if (!view_model.initial_load()) {
                     view_model.initial_load(true);
                     $('.hide-until-load').fadeIn();
-                    $('#user-list-notification').text(gettext('Sorry, there was an problem contacting the server ' +
-                        'to fetch the data. Please, try again in a little bit.'));
-                    view_model.currently_searching(false);
-                },
-                success: reloadList
-            });
-        }
-
-        return false;
-    };
-
-    view_model.unsuccessful_archive_action = function (button, index) {
-        return function (data) {
-            if (data.message && data.product_id) {
-                var alert_container = $('#alert_' + data.product_id);
-                alert_container.text(data.message);
-                alert_container.show();
+                }
+                view_model.current_page(data.current_page);
+                view_model.data_list(data.data_list);
+                view_model.archive_action_items([]);
             }
-            $(button).button('unsuccessful');
         };
-    };
-
-    var reloadList = function(data) {
-        view_model.currently_searching(false);
-        if (data.success) {
-            if (!view_model.initial_load()) {
-                view_model.initial_load(true);
-                $('.hide-until-load').fadeIn();
+        var format_url = function(page) {
+            if (!page) {
+                return "#";
             }
-            view_model.current_page(data.current_page);
-            view_model.data_list(data.data_list);
-            view_model.archive_action_items([]);
-        }
-    };
-    var format_url = function(page) {
-        if (!page) {
-            return "#";
-        }
-        return view_model.list_url +'?page=' + page +
-            "&limit=" + view_model.page_limit() +
-            "&show_inactive=" + view_model.show_inactive;
+            return view_model.list_url +'?page=' + page +
+                "&limit=" + view_model.page_limit() +
+                "&show_inactive=" + view_model.show_inactive;
+        };
+
+        return view_model;
     };
 
-    return view_model;
-};
-
-ko.bindingHandlers.isPrevNextDisabled = {
-    update: function(element, valueAccessor) {
-        var value = valueAccessor()();
-        if (value === undefined) {
-            $(element).parent().addClass('disabled');
-        } else {
-            $(element).parent().removeClass('disabled');
+    ko.bindingHandlers.isPrevNextDisabled = {
+        update: function(element, valueAccessor) {
+            var value = valueAccessor()();
+            if (value === undefined) {
+                $(element).parent().addClass('disabled');
+            } else {
+                $(element).parent().removeClass('disabled');
+            }
         }
-    }
-};
+    };
 
-ko.bindingHandlers.isPaginationActive = {
-    update: function(element, valueAccessor, allBindingsAccessor) {
-        var current_page = parseInt(valueAccessor()());
-        var current_item = parseInt(allBindingsAccessor()['text']);
-        if (current_page === current_item) {
-            $(element).parent().addClass('active');
-        } else {
-            $(element).parent().removeClass('active');
+    ko.bindingHandlers.isPaginationActive = {
+        update: function(element, valueAccessor, allBindingsAccessor) {
+            var current_page = parseInt(valueAccessor()());
+            var current_item = parseInt(allBindingsAccessor()['text']);
+            if (current_page === current_item) {
+                $(element).parent().addClass('active');
+            } else {
+                $(element).parent().removeClass('active');
+            }
         }
-    }
-};
+    };
 
-$(function(){
-    var options = hqImport('hqwebapp/js/initial_page_data.js').get('program_product_options');
-    _.each($('.ko-program-product-list'), function(list) {
-        var viewModel = new CommtrackProductsProgramsViewModel(options);
-        $(list).koApplyBindings(viewModel);
-        viewModel.init();
+    $(function(){
+        var options = hqImport('hqwebapp/js/initial_page_data.js').get('program_product_options');
+        _.each($('.ko-program-product-list'), function(list) {
+            var viewModel = new CommtrackProductsProgramsViewModel(options);
+            $(list).koApplyBindings(viewModel);
+            viewModel.init();
+        });
     });
 });

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -1,5 +1,5 @@
-/* globals django, COMMCAREHQ */
-(function ($, _) {
+/* globals django, COMMCAREHQ, hqDefine */
+hqDefine('data_dictionary/js/data_dictionary.js', function () {
 
     var CaseType = function (name) {
         var self = this;
@@ -171,4 +171,4 @@
             window.analytics.usage('Data Dictionary', 'downloaded data dictionary');
         });
     });
-})($, _);
+});

--- a/corehq/apps/domain/static/domain/js/pro-bono.js
+++ b/corehq/apps/domain/static/domain/js/pro-bono.js
@@ -1,26 +1,29 @@
-$(function () {
+/* globals hqDefine */
+hqDefine('domain/js/pro-bono.js', function () {
     var _validateEmail = function (email) {
         // from http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
         var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return re.test(email);
     };
 
-    $('#id_contact_email').select2({
-        createSearchChoice: function (term, data) {
-            var matchedData = $(data).filter(function() {
-                return this.text.localeCompare(term) === 0;
-            });
-
-            var isEmailValid = _validateEmail(term);
-
-            if (matchedData.length === 0 && isEmailValid) {
-                return { id: term, text: term };
-            }
-        },
-        multiple: true,
-        data: [],
-        formatNoMatches: function () {
-            return gettext("Please enter a valid email.");
-        },
+    $(function () {
+        $('#id_contact_email').select2({
+            createSearchChoice: function (term, data) {
+                var matchedData = $(data).filter(function() {
+                    return this.text.localeCompare(term) === 0;
+                });
+    
+                var isEmailValid = _validateEmail(term);
+    
+                if (matchedData.length === 0 && isEmailValid) {
+                    return { id: term, text: term };
+                }
+            },
+            multiple: true,
+            data: [],
+            formatNoMatches: function () {
+                return gettext("Please enter a valid email.");
+            },
+        });
     });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
@@ -1,16 +1,19 @@
-$(function() {
-    var payloadElement = document.getElementById('payload');
-    var myCodeMirror = CodeMirror(function(elt) {
-        payloadElement.parentNode.replaceChild(elt, payloadElement);
-    }, {
-        value: payloadElement.textContent,
-        readOnly: true,
-        lineNumbers: true,
-        mode: {name: "text/xml", json: true},
-        viewportMargin: Infinity,
-        foldGutter: true,
-        gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
-    });
+/* globals hqDefine */
+hqDefine('hqadmin/js/admin_restore.js', function () {
+    $(function() {
+        var payloadElement = document.getElementById('payload');
+        var myCodeMirror = CodeMirror(function(elt) {
+            payloadElement.parentNode.replaceChild(elt, payloadElement);
+        }, {
+            value: payloadElement.textContent,
+            readOnly: true,
+            lineNumbers: true,
+            mode: {name: "text/xml", json: true},
+            viewportMargin: Infinity,
+            foldGutter: true,
+            gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+        });
 
-    $("#timingTable").treetable();
+        $("#timingTable").treetable();
+    });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/authenticate_as.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/authenticate_as.js
@@ -1,13 +1,16 @@
-$(function() {
-    $('#id_username, #id_domain').change(function() {
-        var username = $('#id_username').val(),
-            domain = $('#id_domain').val();
-
-        var action = hqImport('hqwebapp/js/initial_page_data.js').get('url') + username + '/';
-        if (domain) {
-            action += domain + '/';
-        }
-
-        $('#auth-as-form').attr('action', action);
+/* globals hqDefine */
+hqDefine('hqadmin/js/authenticate_as.js', function () {
+    $(function() {
+        $('#id_username, #id_domain').change(function() {
+            var username = $('#id_username').val(),
+                domain = $('#id_domain').val();
+    
+            var action = hqImport('hqwebapp/js/initial_page_data.js').get('url') + username + '/';
+            if (domain) {
+                action += domain + '/';
+            }
+    
+            $('#auth-as-form').attr('action', action);
+        });
     });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/couch_changes.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/couch_changes.js
@@ -1,23 +1,26 @@
-$(function () {
-    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get,
-        domain_data = initial_page_data('domain_data'),
-        doc_type_data = initial_page_data('doc_type_data');
-    var addGraph = function (data, divId) {
-        nv.addGraph(function() {
-            var chart = nv.models.discreteBarChart()
-                .x(function(d) { return d.label })
-                .y(function(d) { return d.value })
-                .staggerLabels(true)    //Too many bars and not enough room? Try staggering labels.
-                .tooltips(false)        //Don't show tooltips
-                .showValues(true)       //...instead, show the bar value right on top of each bar.
-            ;
-            d3.select('#' + divId + ' svg')
-              .datum(data)
-              .call(chart);
-            nv.utils.windowResize(chart.update);
-            return chart;
-        });
-    };
-    addGraph([domain_data], 'domain-info');
-    addGraph([doc_type_data], 'doc-type-info');
+/* globals hqDefine */
+hqDefine('hqadmin/js/couch_changes.js', function () {
+    $(function () {
+        var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get,
+            domain_data = initial_page_data('domain_data'),
+            doc_type_data = initial_page_data('doc_type_data');
+        var addGraph = function (data, divId) {
+            nv.addGraph(function() {
+                var chart = nv.models.discreteBarChart()
+                    .x(function(d) { return d.label })
+                    .y(function(d) { return d.value })
+                    .staggerLabels(true)    //Too many bars and not enough room? Try staggering labels.
+                    .tooltips(false)        //Don't show tooltips
+                    .showValues(true)       //...instead, show the bar value right on top of each bar.
+                ;
+                d3.select('#' + divId + ' svg')
+                  .datum(data)
+                  .call(chart);
+                nv.utils.windowResize(chart.update);
+                return chart;
+            });
+        };
+        addGraph([domain_data], 'domain-info');
+        addGraph([doc_type_data], 'doc-type-info');
+    });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/dimagisphere_helper.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/dimagisphere_helper.js
@@ -1,365 +1,368 @@
-var dimagisphere = (function() {
-    var self = {};
-
-    self.formData = {
-        totalFormsByCountry: {},  // keeps track of totals per country
-        recentFormsByCountry: {},  // keeps track of "active" per country - from the last second
-        maxFormsByCountry: 0, // most forms that any single country has submitted
-        totalFormsByDomain: {}, // keeps track of totals per domain
-        domainToCountry: {}
-    };
-
-    self.addData = function (dataItem) {
-        /**
-         * Adds data to self.formData. Returns whether anything was done.
-         */
-        dimagisphere.formData.domainToCountry[dataItem.domain] = dataItem.country;
-        var currentDomainCount = dimagisphere.formData.totalFormsByDomain[dataItem.domain] || 0;
-        currentDomainCount += 1;
-        dimagisphere.formData.totalFormsByDomain[dataItem.domain] = currentDomainCount;
-        if (dataItem.country) {
-            // update totals
-            var currentCount = self.formData.totalFormsByCountry[dataItem.country] || 0;
-            currentCount += 1;
-            self.formData.totalFormsByCountry[dataItem.country] = currentCount;
-            if (currentCount > self.formData.maxFormsByCountry) {
-                self.formData.maxFormsByCountry = currentCount;
-            }
-            // update active
-            var activeCount = self.formData.recentFormsByCountry[dataItem.country] || 0;
-            self.formData.recentFormsByCountry[dataItem.country] = activeCount + 1;
-            return true;
-        }
-        return false;
-    };
-
-    var FAKE_DOMAINS = {
-        'dimagi': 'United States of America',
-        'unicef': 'Nigeria',
-        'mvp': 'Ethiopia',
-        'dsi': 'India',
-        'icds': 'India',
-        'tula': 'Guatemala'
-    };
-
-    self.generateRandomItem = function () {
-        // just return a random item from FAKE_DOMAINS
-        // http://stackoverflow.com/questions/2532218/pick-random-property-from-a-javascript-object
-        var domains = Object.keys(FAKE_DOMAINS);
-        var randomDomain = domains[domains.length * Math.random() << 0];
-        return {
-            domain: randomDomain,
-            country: FAKE_DOMAINS[randomDomain]
+/* globals hqDefine */
+hqDefine('hqadmin/js/dimagisphere_helper.js', function () {
+    var dimagisphere = (function() {
+        var self = {};
+    
+        self.formData = {
+            totalFormsByCountry: {},  // keeps track of totals per country
+            recentFormsByCountry: {},  // keeps track of "active" per country - from the last second
+            maxFormsByCountry: 0, // most forms that any single country has submitted
+            totalFormsByDomain: {}, // keeps track of totals per domain
+            domainToCountry: {}
         };
-    };
-    return self;
-})();
-
-$(function() {
-    var filter = {},
-        initial_page_data = $("body").data();
-
-    // courtesy of http://colorbrewer2.org/
-    var COUNTRY_COLORS = ['#edf8fb','#b2e2e2','#66c2a4','#2ca25f','#006d2c'];
-    var COUNTRY_ACTIVE_COLORS = ['#fef0d9','#fdcc8a','#fc8d59','#e34a33','#b30000'];
-    var ws4redis = WS4Redis({
-        uri: initial_page_data.uri + 'form-feed?subscribe-broadcast',
-        receive_message: receiveMessage,
-        heartbeat_msg: initial_page_data.heartbeatMessage,
-    });
-
-    // in tv mode we don't show domains in the graph but just countries
-    var tvmode = initial_page_data.tvmode;
-    var chartSourceData = tvmode ? dimagisphere.formData.totalFormsByCountry : dimagisphere.formData.totalFormsByDomain;
-
-    function addDataToMap(msgObj) {
-        colorAll();
-        // this removes from active after a bit of time
-        window.setTimeout(function () {
-            dimagisphere.formData.recentFormsByCountry[msgObj.country] -= 1;
-        }, 1000);
-    }
-
-    // receive a message though the Websocket from the server
-    function receiveMessage(msg) {
-        var msgObj = JSON.parse(msg);
-        // var renderedMsg = '<strong>' + msgObj.username + '</strong>: ' + msgObj.message;
-
-        dimagisphere.addData(msgObj);
-        if (msgObj.country) {
-            addDataToMap(msgObj);
-        }
-        // add data to chart
-        if (chart !== undefined) {
-            chartData.datum(formatChartData(chartSourceData)).call(chart);
-
-            // when the bar for a domain is clicked on, we can filter on that domain
-            // isn't in use with just this one chart and the map, but maybe if there are other charts added
-            d3.selectAll(".discreteBar").on('click', function(d) {
-                if (filter.domain && filter.domain === d.domain) {
-                    filter.domain = null;
-                } else {
-                    filter.domain = d.domain;
+    
+        self.addData = function (dataItem) {
+            /**
+             * Adds data to self.formData. Returns whether anything was done.
+             */
+            dimagisphere.formData.domainToCountry[dataItem.domain] = dataItem.country;
+            var currentDomainCount = dimagisphere.formData.totalFormsByDomain[dataItem.domain] || 0;
+            currentDomainCount += 1;
+            dimagisphere.formData.totalFormsByDomain[dataItem.domain] = currentDomainCount;
+            if (dataItem.country) {
+                // update totals
+                var currentCount = self.formData.totalFormsByCountry[dataItem.country] || 0;
+                currentCount += 1;
+                self.formData.totalFormsByCountry[dataItem.country] = currentCount;
+                if (currentCount > self.formData.maxFormsByCountry) {
+                    self.formData.maxFormsByCountry = currentCount;
                 }
-            });
-            try {
-                nv.utils.windowResize(chart.update);
-            } catch (err) {
-                // if the chart is being updated frequently then this can fail so just ignore it for now
-            }
-        }
-    }
-
-    // charts
-    var chart, chartData;
-    nv.addGraph(function() {
-        chart = nv.models.discreteBarChart()
-          .x(function(d) { return d.domain })
-          .y(function(d) { return d.count })
-          .staggerLabels(true)
-          .tooltips(false)
-          .showValues(true)
-          .transitionDuration(350)
-        ;
-        chartData = d3.select('#chart svg').datum(formatChartData(chartSourceData));
-        chartData.call(chart);
-        nv.utils.windowResize(chart.update);
-        return chart;
-    });
-    function formatChartData(data) {
-        var values = $.map(data, function (count, domain) { return {'domain': domain, 'count': count}; });
-        if (filter.country) {
-            values = values.filter(function(obj) {
-                if (tvmode) {
-                    return obj.domain === filter.country;
-                } else {
-                    return dimagisphere.formData.domainToCountry[obj.domain] === filter.country;
-                }
-            });
-        }
-        // can uncomment the below line to sort by descending count (this causes colors to change over time)
-        // values.sort(function (a, b) { return b.count - a.count; });
-        return [{
-            key: "Submissions by Domain",
-            values: values
-        }];
-    }
-
-    var countriesGeo;
-    // A lot of the styling work here is modeled after http://leafletjs.com/examples/choropleth.html
-    var map = L.map('map').setView([0, 0], 2);
-    var mapId = 'mapbox.dark';
-    L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
-        maxZoom: 10,
-        id: mapId,
-        accessToken: initial_page_data.token,
-    }).addTo(map);
-
-    function getColor(featureId) {
-        var count = dimagisphere.formData.totalFormsByCountry[featureId];
-        if (!count) {
-            return COUNTRY_COLORS[0];
-        }
-        var activeCount = dimagisphere.formData.recentFormsByCountry[featureId];
-        if (!activeCount) {
-            var pct = count / dimagisphere.formData.maxFormsByCountry;
-            var index = Math.min(Math.floor(pct * COUNTRY_COLORS.length), COUNTRY_COLORS.length - 1);
-
-            return COUNTRY_COLORS[index];
-        }
-        else {
-            // these values are adjusted slightly to use all 5 colors, not leaving out the first color
-            var activeIndex = Math.min(activeCount, COUNTRY_ACTIVE_COLORS.length);
-            return COUNTRY_ACTIVE_COLORS[activeIndex - 1]
-        }
-    }
-
-    function getOpacity(featureId) {
-        if (dimagisphere.formData.totalFormsByCountry[featureId]) {
-            if (filter.country != null) {
-                if (featureId === filter.country) {
-                    return .9;
-                } else {
-                    return .3;
-                }
-            }
-            return .9;
-        } else {
-            return 0;
-        }
-    }
-
-    function style(feature) {
-        return {
-            fillColor: getColor(feature.properties.name),
-            weight: 2,
-            opacity: 1,
-            color: 'white',
-            dashArray: '3',
-            fillOpacity: getOpacity(feature.properties.name)
-        };
-    }
-
-    // highlights
-    function highlightFeature(e) {
-        var layer = e.target;
-        layer.setStyle({
-            weight: 4,
-            color: '#002c5f',
-            dashArray: ''
-        });
-        if (!L.Browser.ie && !L.Browser.opera) {
-            layer.bringToFront();
-        }
-        info.update(layer.feature.properties);
-    }
-
-    function resetHighlight(e) {
-        countriesGeo.resetStyle(e.target);
-        info.update();
-    }
-
-    function onEachFeature(feature, layer) {
-        layer.on({
-            mouseover: highlightFeature,
-            mouseout: resetHighlight,
-            click: function() {
-                // when a country is clicked on, we filter by country name
-                if (filter.country === layer.feature.properties.name) {
-                    filter.country = null;
-                } else {
-                    filter.country = layer.feature.properties.name;
-                    // show the name in text somewhere to avoid scanning the map? maybe in the top right?
-                }
-                chartData.datum(formatChartData(chartSourceData)).call(chart);
-                countriesGeo.setStyle(style);
-            }
-        });
-    }
-
-    // info control
-    var info = L.control();
-    info.onAdd = function (map) {
-        this._div = L.DomUtil.create('div', 'map-info');
-        this.update();
-        return this._div;
-    };
-
-    // method that we will use to update the control based on feature properties passed in
-    info.update = function (props) {
-        function _getInfoContent(countryName) {
-            var formCount = dimagisphere.formData.totalFormsByCountry[countryName];
-            var message = formCount ? formCount + ' forms' : 'no data yet';
-            return '<b>' + countryName + '</b>: ' + message;
-        }
-        this._div.innerHTML = (props ? _getInfoContent(props.name) : 'Hover over a country');
-    };
-    info.addTo(map);
-
-    // todo: should probably be getting this from somewhere else and possibly not on every page load.
-    $.getJSON('https://raw.githubusercontent.com/dimagi/world.geo.json/master/countries.geo.json', function (data) {
-        countriesGeo = L.geoJson(data, {style: style, onEachFeature: onEachFeature}).addTo(map);
-    });
-
-    function colorAll() {
-        if (countriesGeo !== undefined) {
-            countriesGeo.setStyle(style);
-            map.removeControl(legend);
-            legend.addTo(map);
-        }
-    }
-
-    // update all every 5 seconds in case no activity (this is just to clear active state)
-    window.setInterval(colorAll, 5000);
-
-    // add a legend
-    var legend = L.control({position: 'bottomleft'});
-
-    var createLegend = function (map) {
-        var div = L.DomUtil.create('div', 'info legend');
-
-        var activeCountValues = COUNTRY_ACTIVE_COLORS.map(function(e, i) {
-            return i+1;
-        });
-
-        // get the upper bounds for each bucket
-        var countValues = COUNTRY_COLORS.map(function(e, i) {
-            var bound = dimagisphere.formData.maxFormsByCountry * (i+1) / COUNTRY_COLORS.length;
-            return Math.max(0, (i < COUNTRY_COLORS.length -1 && Math.floor(bound) === bound) ? bound - 1 : Math.floor(bound));
-        });
-
-        // only include legend items that are actually used right now
-        // when there is a low number of maxForms, they may not all be included
-        var indicesToRemove = [];
-        var colors = COUNTRY_COLORS.filter(function(elem, index) {
-            if (countValues[index] <= 0 || (index > 0 && countValues[index] == countValues[index-1])) {
-                indicesToRemove.push(index);
-                return false;
-            } else {
+                // update active
+                var activeCount = self.formData.recentFormsByCountry[dataItem.country] || 0;
+                self.formData.recentFormsByCountry[dataItem.country] = activeCount + 1;
                 return true;
             }
+            return false;
+        };
+    
+        var FAKE_DOMAINS = {
+            'dimagi': 'United States of America',
+            'unicef': 'Nigeria',
+            'mvp': 'Ethiopia',
+            'dsi': 'India',
+            'icds': 'India',
+            'tula': 'Guatemala'
+        };
+    
+        self.generateRandomItem = function () {
+            // just return a random item from FAKE_DOMAINS
+            // http://stackoverflow.com/questions/2532218/pick-random-property-from-a-javascript-object
+            var domains = Object.keys(FAKE_DOMAINS);
+            var randomDomain = domains[domains.length * Math.random() << 0];
+            return {
+                domain: randomDomain,
+                country: FAKE_DOMAINS[randomDomain]
+            };
+        };
+        return self;
+    })();
+    
+    $(function() {
+        var filter = {},
+            initial_page_data = $("body").data();
+    
+        // courtesy of http://colorbrewer2.org/
+        var COUNTRY_COLORS = ['#edf8fb','#b2e2e2','#66c2a4','#2ca25f','#006d2c'];
+        var COUNTRY_ACTIVE_COLORS = ['#fef0d9','#fdcc8a','#fc8d59','#e34a33','#b30000'];
+        var ws4redis = WS4Redis({
+            uri: initial_page_data.uri + 'form-feed?subscribe-broadcast',
+            receive_message: receiveMessage,
+            heartbeat_msg: initial_page_data.heartbeatMessage,
         });
-
-        countValues = countValues.filter(function(elem, index) {
-            return indicesToRemove.indexOf(index) <= -1;
-        });
-
-        div.innerHTML += '<p>Recent Forms</p>';
-
-        // loop through our active form values and generate a label with a colored square for each value
-        for (var i = 0; i < activeCountValues.length; i++) {
-            div.innerHTML +=
-                '<i style="background:' + COUNTRY_ACTIVE_COLORS[i] + '"></i> ' +
-                activeCountValues[i] + (activeCountValues[i + 1] ? '<br>' : "+");
+    
+        // in tv mode we don't show domains in the graph but just countries
+        var tvmode = initial_page_data.tvmode;
+        var chartSourceData = tvmode ? dimagisphere.formData.totalFormsByCountry : dimagisphere.formData.totalFormsByDomain;
+    
+        function addDataToMap(msgObj) {
+            colorAll();
+            // this removes from active after a bit of time
+            window.setTimeout(function () {
+                dimagisphere.formData.recentFormsByCountry[msgObj.country] -= 1;
+            }, 1000);
         }
-
-        div.innerHTML += '<div class="padding"></div>'
-
-        div.innerHTML += '<p>All Forms Since Opening</p>' +
-                         '<i style="background:' + 'black' + '"></i> ' + '0' + '<br>'; 
-
-        // loop through our form count intervals and generate a label with a colored square for each interval
-        for (var i = 0; i < countValues.length; i++) {
-            div.innerHTML += '<i style="background:' + colors[i] + '"></i> ';
-            if (countValues[i-1] !==  undefined) {
-                if (countValues[i-1] +1 < countValues[i]) {
-                    div.innerHTML += (countValues[i-1] + 1) + '&ndash;'
-                }
-            } else if (countValues[i] > 1) {
-                div.innerHTML += '1&ndash;'
+    
+        // receive a message though the Websocket from the server
+        function receiveMessage(msg) {
+            var msgObj = JSON.parse(msg);
+            // var renderedMsg = '<strong>' + msgObj.username + '</strong>: ' + msgObj.message;
+    
+            dimagisphere.addData(msgObj);
+            if (msgObj.country) {
+                addDataToMap(msgObj);
             }
-            div.innerHTML += countValues[i] + '<br>';
+            // add data to chart
+            if (chart !== undefined) {
+                chartData.datum(formatChartData(chartSourceData)).call(chart);
+    
+                // when the bar for a domain is clicked on, we can filter on that domain
+                // isn't in use with just this one chart and the map, but maybe if there are other charts added
+                d3.selectAll(".discreteBar").on('click', function(d) {
+                    if (filter.domain && filter.domain === d.domain) {
+                        filter.domain = null;
+                    } else {
+                        filter.domain = d.domain;
+                    }
+                });
+                try {
+                    nv.utils.windowResize(chart.update);
+                } catch (err) {
+                    // if the chart is being updated frequently then this can fail so just ignore it for now
+                }
+            }
         }
-
-        return div;
-    };
-
-    legend.onAdd = createLegend;
-    legend.addTo(map);
-
-    // simulation controls
-    var simulationOn = false;
-    var controlButton = $('#controlButton');
-    function setPauseButton() {
-        controlButton.children('span').removeClass('glyphicon-play').addClass('glyphicon-pause');
-    }
-    function setPlayButton() {
-        controlButton.children('span').removeClass('glyphicon-pause').addClass('glyphicon-play');
-    }
-    function simulateForms() {
-        if (simulationOn) {
-            receiveMessage(JSON.stringify(dimagisphere.generateRandomItem()));
-            window.setTimeout(simulateForms, 1200);
+    
+        // charts
+        var chart, chartData;
+        nv.addGraph(function() {
+            chart = nv.models.discreteBarChart()
+              .x(function(d) { return d.domain })
+              .y(function(d) { return d.count })
+              .staggerLabels(true)
+              .tooltips(false)
+              .showValues(true)
+              .transitionDuration(350)
+            ;
+            chartData = d3.select('#chart svg').datum(formatChartData(chartSourceData));
+            chartData.call(chart);
+            nv.utils.windowResize(chart.update);
+            return chart;
+        });
+        function formatChartData(data) {
+            var values = $.map(data, function (count, domain) { return {'domain': domain, 'count': count}; });
+            if (filter.country) {
+                values = values.filter(function(obj) {
+                    if (tvmode) {
+                        return obj.domain === filter.country;
+                    } else {
+                        return dimagisphere.formData.domainToCountry[obj.domain] === filter.country;
+                    }
+                });
+            }
+            // can uncomment the below line to sort by descending count (this causes colors to change over time)
+            // values.sort(function (a, b) { return b.count - a.count; });
+            return [{
+                key: "Submissions by Domain",
+                values: values
+            }];
         }
-    }
-    controlButton.click(function () {
-        if (!simulationOn) {
-            simulationOn = true;
-            setPauseButton()
-            simulateForms();
-        } else {
-            simulationOn = false;
-            setPlayButton();
+    
+        var countriesGeo;
+        // A lot of the styling work here is modeled after http://leafletjs.com/examples/choropleth.html
+        var map = L.map('map').setView([0, 0], 2);
+        var mapId = 'mapbox.dark';
+        L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+            maxZoom: 10,
+            id: mapId,
+            accessToken: initial_page_data.token,
+        }).addTo(map);
+    
+        function getColor(featureId) {
+            var count = dimagisphere.formData.totalFormsByCountry[featureId];
+            if (!count) {
+                return COUNTRY_COLORS[0];
+            }
+            var activeCount = dimagisphere.formData.recentFormsByCountry[featureId];
+            if (!activeCount) {
+                var pct = count / dimagisphere.formData.maxFormsByCountry;
+                var index = Math.min(Math.floor(pct * COUNTRY_COLORS.length), COUNTRY_COLORS.length - 1);
+    
+                return COUNTRY_COLORS[index];
+            }
+            else {
+                // these values are adjusted slightly to use all 5 colors, not leaving out the first color
+                var activeIndex = Math.min(activeCount, COUNTRY_ACTIVE_COLORS.length);
+                return COUNTRY_ACTIVE_COLORS[activeIndex - 1]
+            }
         }
+    
+        function getOpacity(featureId) {
+            if (dimagisphere.formData.totalFormsByCountry[featureId]) {
+                if (filter.country != null) {
+                    if (featureId === filter.country) {
+                        return .9;
+                    } else {
+                        return .3;
+                    }
+                }
+                return .9;
+            } else {
+                return 0;
+            }
+        }
+    
+        function style(feature) {
+            return {
+                fillColor: getColor(feature.properties.name),
+                weight: 2,
+                opacity: 1,
+                color: 'white',
+                dashArray: '3',
+                fillOpacity: getOpacity(feature.properties.name)
+            };
+        }
+    
+        // highlights
+        function highlightFeature(e) {
+            var layer = e.target;
+            layer.setStyle({
+                weight: 4,
+                color: '#002c5f',
+                dashArray: ''
+            });
+            if (!L.Browser.ie && !L.Browser.opera) {
+                layer.bringToFront();
+            }
+            info.update(layer.feature.properties);
+        }
+    
+        function resetHighlight(e) {
+            countriesGeo.resetStyle(e.target);
+            info.update();
+        }
+    
+        function onEachFeature(feature, layer) {
+            layer.on({
+                mouseover: highlightFeature,
+                mouseout: resetHighlight,
+                click: function() {
+                    // when a country is clicked on, we filter by country name
+                    if (filter.country === layer.feature.properties.name) {
+                        filter.country = null;
+                    } else {
+                        filter.country = layer.feature.properties.name;
+                        // show the name in text somewhere to avoid scanning the map? maybe in the top right?
+                    }
+                    chartData.datum(formatChartData(chartSourceData)).call(chart);
+                    countriesGeo.setStyle(style);
+                }
+            });
+        }
+    
+        // info control
+        var info = L.control();
+        info.onAdd = function (map) {
+            this._div = L.DomUtil.create('div', 'map-info');
+            this.update();
+            return this._div;
+        };
+    
+        // method that we will use to update the control based on feature properties passed in
+        info.update = function (props) {
+            function _getInfoContent(countryName) {
+                var formCount = dimagisphere.formData.totalFormsByCountry[countryName];
+                var message = formCount ? formCount + ' forms' : 'no data yet';
+                return '<b>' + countryName + '</b>: ' + message;
+            }
+            this._div.innerHTML = (props ? _getInfoContent(props.name) : 'Hover over a country');
+        };
+        info.addTo(map);
+    
+        // todo: should probably be getting this from somewhere else and possibly not on every page load.
+        $.getJSON('https://raw.githubusercontent.com/dimagi/world.geo.json/master/countries.geo.json', function (data) {
+            countriesGeo = L.geoJson(data, {style: style, onEachFeature: onEachFeature}).addTo(map);
+        });
+    
+        function colorAll() {
+            if (countriesGeo !== undefined) {
+                countriesGeo.setStyle(style);
+                map.removeControl(legend);
+                legend.addTo(map);
+            }
+        }
+    
+        // update all every 5 seconds in case no activity (this is just to clear active state)
+        window.setInterval(colorAll, 5000);
+    
+        // add a legend
+        var legend = L.control({position: 'bottomleft'});
+    
+        var createLegend = function (map) {
+            var div = L.DomUtil.create('div', 'info legend');
+    
+            var activeCountValues = COUNTRY_ACTIVE_COLORS.map(function(e, i) {
+                return i+1;
+            });
+    
+            // get the upper bounds for each bucket
+            var countValues = COUNTRY_COLORS.map(function(e, i) {
+                var bound = dimagisphere.formData.maxFormsByCountry * (i+1) / COUNTRY_COLORS.length;
+                return Math.max(0, (i < COUNTRY_COLORS.length -1 && Math.floor(bound) === bound) ? bound - 1 : Math.floor(bound));
+            });
+    
+            // only include legend items that are actually used right now
+            // when there is a low number of maxForms, they may not all be included
+            var indicesToRemove = [];
+            var colors = COUNTRY_COLORS.filter(function(elem, index) {
+                if (countValues[index] <= 0 || (index > 0 && countValues[index] == countValues[index-1])) {
+                    indicesToRemove.push(index);
+                    return false;
+                } else {
+                    return true;
+                }
+            });
+    
+            countValues = countValues.filter(function(elem, index) {
+                return indicesToRemove.indexOf(index) <= -1;
+            });
+    
+            div.innerHTML += '<p>Recent Forms</p>';
+    
+            // loop through our active form values and generate a label with a colored square for each value
+            for (var i = 0; i < activeCountValues.length; i++) {
+                div.innerHTML +=
+                    '<i style="background:' + COUNTRY_ACTIVE_COLORS[i] + '"></i> ' +
+                    activeCountValues[i] + (activeCountValues[i + 1] ? '<br>' : "+");
+            }
+    
+            div.innerHTML += '<div class="padding"></div>'
+    
+            div.innerHTML += '<p>All Forms Since Opening</p>' +
+                             '<i style="background:' + 'black' + '"></i> ' + '0' + '<br>'; 
+    
+            // loop through our form count intervals and generate a label with a colored square for each interval
+            for (var i = 0; i < countValues.length; i++) {
+                div.innerHTML += '<i style="background:' + colors[i] + '"></i> ';
+                if (countValues[i-1] !==  undefined) {
+                    if (countValues[i-1] +1 < countValues[i]) {
+                        div.innerHTML += (countValues[i-1] + 1) + '&ndash;'
+                    }
+                } else if (countValues[i] > 1) {
+                    div.innerHTML += '1&ndash;'
+                }
+                div.innerHTML += countValues[i] + '<br>';
+            }
+    
+            return div;
+        };
+    
+        legend.onAdd = createLegend;
+        legend.addTo(map);
+    
+        // simulation controls
+        var simulationOn = false;
+        var controlButton = $('#controlButton');
+        function setPauseButton() {
+            controlButton.children('span').removeClass('glyphicon-play').addClass('glyphicon-pause');
+        }
+        function setPlayButton() {
+            controlButton.children('span').removeClass('glyphicon-pause').addClass('glyphicon-play');
+        }
+        function simulateForms() {
+            if (simulationOn) {
+                receiveMessage(JSON.stringify(dimagisphere.generateRandomItem()));
+                window.setTimeout(simulateForms, 1200);
+            }
+        }
+        controlButton.click(function () {
+            if (!simulationOn) {
+                simulationOn = true;
+                setPauseButton()
+                simulateForms();
+            } else {
+                simulationOn = false;
+                setPlayButton();
+            }
+        });
     });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/domain_faceted_report.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/domain_faceted_report.js
@@ -1,4 +1,5 @@
-$(function() {
+/* globals hqDefine */
+hqDefine('hqadmin/js/domain_faceted_report.js', function () {
     var visualizations = {
         forms: {name: "forms", xaxis_label: "# form submissions", viz: null},
         cases: {name: "cases", xaxis_label: "# case creations", viz: null},
@@ -23,32 +24,34 @@ $(function() {
     }
     var url_params = parse_url_params();
     
-    for (var key in visualizations) {
-        if (visualizations.hasOwnProperty(key)) {
-            visualizations[key].viz = new HQVisualizations({
-                chart_name: key,
-                histogram_type: key,
-                xaxis_label: visualizations[key].xaxis_label,
-                ajax_url: hqImport("hqwebapp/js/urllib.js").reverse("admin_stats_data"),
-                data: url_params,
-                interval: hqImport("hqwebapp/js/initial_page_data.js").get("interval"),
-            });
-            visualizations[key].viz.init();
-        }
-}
-
-    $("#all-charts-filter").on("submit", function() {
-        var $this = $(this);
-        var startdate = $this.find('[name="startdate"]').val();
-        var enddate = $this.find('[name="enddate"]').val();
-        var interval = $this.find('[name="interval"]').val();
-
-        $('.startdate-input').val(startdate);
-        $('.enddate-input').val(enddate);
-        $('.interval-input').val(interval);
-
-        $('.reload-graph-form').submit();
-
-        return false;
+    $(function() {
+        for (var key in visualizations) {
+            if (visualizations.hasOwnProperty(key)) {
+                visualizations[key].viz = new HQVisualizations({
+                    chart_name: key,
+                    histogram_type: key,
+                    xaxis_label: visualizations[key].xaxis_label,
+                    ajax_url: hqImport("hqwebapp/js/urllib.js").reverse("admin_stats_data"),
+                    data: url_params,
+                    interval: hqImport("hqwebapp/js/initial_page_data.js").get("interval"),
+                });
+                visualizations[key].viz.init();
+            }
+    }
+    
+        $("#all-charts-filter").on("submit", function() {
+            var $this = $(this);
+            var startdate = $this.find('[name="startdate"]').val();
+            var enddate = $this.find('[name="enddate"]').val();
+            var interval = $this.find('[name="interval"]').val();
+    
+            $('.startdate-input').val(startdate);
+            $('.enddate-input').val(enddate);
+            $('.interval-input').val(interval);
+    
+            $('.reload-graph-form').submit();
+    
+            return false;
+        });
     });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/hqadmin_base_report.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/hqadmin_base_report.js
@@ -1,9 +1,12 @@
-$(function() {
-    var aoColumns = hqImport('hqwebapp/js/initial_page_data.js').get('aoColumns');
-    if (aoColumns) {
-        var reportTables = new HQReportDataTables({
-            aoColumns: aoColumns,
-        });
-        reportTables.render();
-    }
+/* globals hqDefine */
+hqDefine('hqadmin/js/hqadmin_base_report.js', function () {
+    $(function() {
+        var aoColumns = hqImport('hqwebapp/js/initial_page_data.js').get('aoColumns');
+        if (aoColumns) {
+            var reportTables = new HQReportDataTables({
+                aoColumns: aoColumns,
+            });
+            reportTables.render();
+        }
+    });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -1,366 +1,369 @@
-$(function() {
-    // courtesy of http://colorbrewer2.org/
-    var COUNTRY_COLORS = ['#fef0d9','#fdd49e','#fdbb84','#fc8d59','#e34a33','#b30000'];
-    var PROJECT_COUNTS_THRESHOLD = [10, 20, 30, 40, 50];
-    var USER_COUNTS_THRESHOLD = [10, 100, 500, 1000, 4000];
-    var mapboxAccessToken = $("#map").data("token");
+/* globals hqDefine */
+hqDefine('hqadmin/js/project_map.js', function () {
+    $(function() {
+        // courtesy of http://colorbrewer2.org/
+        var COUNTRY_COLORS = ['#fef0d9','#fdd49e','#fdbb84','#fc8d59','#e34a33','#b30000'];
+        var PROJECT_COUNTS_THRESHOLD = [10, 20, 30, 40, 50];
+        var USER_COUNTS_THRESHOLD = [10, 100, 500, 1000, 4000];
+        var mapboxAccessToken = $("#map").data("token");
 
-    var selectionModel;
+        var selectionModel;
 
-    function colorAll() {
-        if (countriesGeo !== undefined) {
-            countriesGeo.setStyle(style);
-            map.removeControl(legend);
-            legend.addTo(map);
-        }
-    }
-
-    var dataController = function() {
-        var that = {};
-        var maxNumProjects = 0;
-        var maxNumUsers = 0;
-        var totalNumUsers = 0;
-        var totalNumProjects = 0;
-        var projects_per_country = {};
-        var users_per_country = {};
-        var is_project_count_map = true;
-
-        that.refreshProjectData = function (filter, callback) {
-            $.ajax({
-                url: '/hq/admin/json/project_map/' + window.location.search,
-                dataType: 'json',
-            }).done(function (data) {
-
-                projects_per_country = data.country_projs_count;
-                users_per_country = data.users_per_country;
-                totalNumProjects = data.total_num_projects;
-
-                Object.keys(projects_per_country).map(function(country) {
-                    if (projects_per_country[country] > maxNumProjects) {
-                        maxNumProjects = projects_per_country[country];
-                    }
-                });
-
-                Object.keys(users_per_country).map(function(country) {
-                    if (users_per_country[country] > maxNumUsers) {
-                        maxNumUsers = users_per_country[country];
-                    }
-                    totalNumUsers += users_per_country[country];
-                });
-
-                colorAll();
-                callback();
-            });
-        };
-
-        that.getCount = function (countryName) {
-            countryName = countryName.toUpperCase();
-            if (is_project_count_map) {
-                return projects_per_country[countryName] || 0;
-            } else {
-                return users_per_country[countryName] || 0;
-            }
-        };
-
-        that.toggleMap = function () {
-            is_project_count_map = !is_project_count_map;
-        };
-
-        that.getUnit = function (count) {
-            if (is_project_count_map) {
-                return count > 1 ? 'active projects' : 'active project';
-            } else {
-                return count > 1 ? 'active users' : 'active user';
-            }
-        };
-
-        that.getNumActiveCountries = function () {
-            return Object.keys(projects_per_country).length;
-        };
-
-        that.getMax = function () {
-            if (is_project_count_map) {
-                return maxNumProjects;
-            } else {
-                return maxNumUsers;
-            }
-        };
-
-        that.getNumProjects = function () {
-            return totalNumProjects;
-        };
-
-        that.getNumUsers = function () {
-            return totalNumUsers;
-        };
-
-        that.isProjectCountMap = function (){
-            return is_project_count_map;
-        };
-
-        var SelectionModel = function () {
-            var self = this;
-            self.selectedCountry = ko.observable('country name');
-            self.selectedProject = ko.observable('project name');
-            self.internalTableProperties = ['Name', 'Organization', 'Notes', 'Sector', 'Sub-Sector', 'Active Users', 'Countries'];
-            self.externalTableProperties = ['Sector', 'Sub-Sector', 'Active Users', 'Countries'];
-            self.topFiveProjects = ko.observableArray();
-        };
-
-        selectionModel = new SelectionModel();
-        $('#modal').koApplyBindings(selectionModel);
-
-        Object.freeze(that);
-        return that;
-    }();
-
-    var modalController = function(){
-        var that = {};
-
-        that.showProjectsTable = function(countryName) {
-            var modalContent = $('.modal-content');
-            modalContent.addClass('show-table');
-            modalContent.removeClass('show-project-info');
-
-            window.location.hash = countryName;
-        };
-
-        Object.freeze(that);
-        return that;
-    }();
-
-    var countriesGeo;
-    // A lot of the styling work here is modeled after http://leafletjs.com/examples/choropleth.html
-    var map = L.map('map').setView([0, 0], 3);
-    var mapId = 'dimagi/cirqobc2w0000g4ksj9dochrm';
-
-    // copied from dimagisphere
-    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/256/{z}/{x}/{y}?access_token={accessToken}', {
-        maxZoom: 6,
-        minZoom: 2,
-        id: mapId,
-        accessToken: mapboxAccessToken,
-        noWrap: true,
-    }).addTo(map);
-
-    var southWest = L.latLng(-85.0, -180.0),
-        northEast = L.latLng(85.0, 180.0),
-        bounds = L.latLngBounds(southWest, northEast);
-
-    map.setMaxBounds(bounds);
-    map.on('drag', function(){
-        map.panInsideBounds(bounds, {animate:false});
-    });
-
-    function getColor(featureId) {
-        var thresholdScales;
-        var count = dataController.getCount(featureId);
-        var isProjectCountMap = dataController.isProjectCountMap();
-        if (isProjectCountMap) {
-            thresholdScales = PROJECT_COUNTS_THRESHOLD;
-        } else {
-            thresholdScales = USER_COUNTS_THRESHOLD;
-        }
-        var index = getColorScaleIndex(count, thresholdScales);
-        return COUNTRY_COLORS[index];
-    }
-
-    function getColorScaleIndex(count, scales) {
-        for (var i = 0; i < scales.length; i++){
-            if (count < scales[i]){
-                return i;
+        function colorAll() {
+            if (countriesGeo !== undefined) {
+                countriesGeo.setStyle(style);
+                map.removeControl(legend);
+                legend.addTo(map);
             }
         }
-        return scales.length;
-    }
 
-    function getOpacity(featureId) {
-        if (dataController.getCount(featureId)) {
-            return 0.9;
-        } else {
-            return 0;
-        }
-    }
-
-    function style(feature) {
-        return {
-            fillColor: getColor(feature.properties.name),
-            weight: 2,
-            opacity: 1,
-            color: 'white',
-            dashArray: '3',
-            fillOpacity: getOpacity(feature.properties.name),
-        };
-    }
-
-    // highlights
-    function highlightFeature(e) {
-        var layer = e.target;
-        layer.setStyle({
-            weight: 4,
-            color: '#002c5f',
-            dashArray: '',
-        });
-        if (!L.Browser.ie && !L.Browser.opera) {
-            layer.bringToFront();
-        }
-        info.update(layer.feature.properties);
-    }
-
-    function resetHighlight(e) {
-        countriesGeo.resetStyle(e.target);
-        info.update();
-    }
-
-    function formatCountryNames(countries) {
-        return countries.map(function(country) {
-            var formattedCountryName = country.charAt(0).toUpperCase();
-            if (country.indexOf(",") > -1) {
-                formattedCountryName += country.substring(1, country.indexOf(",")).toLowerCase();
-            } else {
-                formattedCountryName += country.substring(1).toLowerCase();
-            }
-            return formattedCountryName;
-        });
-    }
-
-    function onEachFeature(feature, layer) {
-        layer.on({
-            mouseover: highlightFeature,
-            mouseout: resetHighlight,
-            click: function(e) {
-                if (dataController.getCount(feature.properties.name)){
-                    selectionModel.selectedCountry(feature.properties.name);
-                    modalController.showProjectsTable(selectionModel.selectedCountry());
-                    var country = (feature.properties.name).toUpperCase();
-                    selectionModel.topFiveProjects.removeAll();
-                    $.ajax({
-                        url: "/hq/admin/top_five_projects_by_country/?country=" + country,
-                        datatype: "json",
-                    }).done(function(data){
-                        if (data.internal) {
-                            data[country].forEach(function(project){
-                                selectionModel.topFiveProjects.push({
-                                    name: project['name'],
-                                    organization: project['organization_name'],
-                                    description: project['internal']['notes'],
-                                    sector: project['internal']['area'],
-                                    sub_sector: project['internal']['sub_area'],
-                                    active_users: project['cp_n_active_cc_users'],
-                                    countries: formatCountryNames(project['deployment']['countries']).join(', '),
-                                });
-                            });
-                        } else {
-                            data[country].forEach(function(project){
-                                selectionModel.topFiveProjects.push({
-                                    sector: project['internal']['area'],
-                                    sub_sector: project['internal']['sub_area'],
-                                    active_users: project['cp_n_active_cc_users'],
-                                    countries: formatCountryNames(project['deployment']['countries']).join(', '),
-                                });
-                            });
+        var dataController = function() {
+            var that = {};
+            var maxNumProjects = 0;
+            var maxNumUsers = 0;
+            var totalNumUsers = 0;
+            var totalNumProjects = 0;
+            var projects_per_country = {};
+            var users_per_country = {};
+            var is_project_count_map = true;
+    
+            that.refreshProjectData = function (filter, callback) {
+                $.ajax({
+                    url: '/hq/admin/json/project_map/' + window.location.search,
+                    dataType: 'json',
+                }).done(function (data) {
+    
+                    projects_per_country = data.country_projs_count;
+                    users_per_country = data.users_per_country;
+                    totalNumProjects = data.total_num_projects;
+    
+                    Object.keys(projects_per_country).map(function(country) {
+                        if (projects_per_country[country] > maxNumProjects) {
+                            maxNumProjects = projects_per_country[country];
                         }
-
                     });
-                    $('#modal').modal();
-                };
-            },
-        });
-    }
-
-    // info control
-    var info = L.control();
-    info.onAdd = function (map) {
-        this._div = L.DomUtil.create('div', 'map-info');
-        this.update();
-        return this._div;
-    };
-
-    // method that we will use to update the control based on feature properties passed in
-    info.update = function (props) {
-        function _getInfoContent(countryName) {
-            var count = dataController.getCount(countryName);
-            var unit = dataController.getUnit(count);
-            var message = count ? count + ' ' + unit : 'no ' + unit + 's';
-            return '<b>' + countryName + '</b>: ' + message;
-        }
-        this._div.innerHTML = (props ? _getInfoContent(props.name) : 'Hover over a country');
-    };
-    info.addTo(map);
-
-    // add a legend
-    var legend = L.control({position: 'bottomleft'});
-
-    legend.onAdd = function (map) {
-        var div = L.DomUtil.create('div', 'info legend');
-        var thresholds;
-        div.innerHTML += '<i style="background:' + 'black' + '"></i> ' + '0' + '<br>';
-        var is_project_count_map = dataController.isProjectCountMap();
-        if (is_project_count_map) {
-            thresholds = PROJECT_COUNTS_THRESHOLD;
-        } else {
-            thresholds = USER_COUNTS_THRESHOLD;
-        }
-        for (var i = 0; i < thresholds.length; i++) {
-            div.innerHTML += '<i style="background:' + COUNTRY_COLORS[i] + '"></i> ';
-            if (thresholds[i-1] !==  undefined) {
-                if (thresholds[i-1] +1 < thresholds[i]) {
-                    div.innerHTML += (thresholds[i-1] + 1) + '&ndash;';
+    
+                    Object.keys(users_per_country).map(function(country) {
+                        if (users_per_country[country] > maxNumUsers) {
+                            maxNumUsers = users_per_country[country];
+                        }
+                        totalNumUsers += users_per_country[country];
+                    });
+    
+                    colorAll();
+                    callback();
+                });
+            };
+    
+            that.getCount = function (countryName) {
+                countryName = countryName.toUpperCase();
+                if (is_project_count_map) {
+                    return projects_per_country[countryName] || 0;
+                } else {
+                    return users_per_country[countryName] || 0;
                 }
-            } else if (thresholds[i] > 1) {
-                div.innerHTML += '1&ndash;';
-            }
-            div.innerHTML += thresholds[i] + '<br>';
-        }
-        div.innerHTML += '<i style="background:' + COUNTRY_COLORS[thresholds.length] + '"></i> '
-                         + (thresholds[thresholds.length-1] + 1)+ '+';
-
-        return div;
-    };
-
-    legend.addTo(map);
-
-
-    var stats = L.control({position: 'bottomright'});
-
-    stats.onAdd = function (map) {
-        var div = L.DomUtil.create('div', 'info legend');
-        div.innerHTML += '<p><b>Statistics</b></p>';
-        div.innerHTML += '<p>Number of Active Countries: ' + dataController.getNumActiveCountries() +  '</p>';
-        div.innerHTML += '<p>Number of Active Mobile Users: ' + dataController.getNumUsers() +  '</p>';
-        div.innerHTML += '<p>Number of Active Projects: ' + dataController.getNumProjects() +  '</p>';
-        div.innerHTML += '<br><p><em> Active: A project or user submitted a form in past 30 days.</em></p>';
-        return div;
-    };
-
-    // copied from dimagisphere
-    // todo: should probably be getting this from somewhere else and possibly not on every page load.
-    $.getJSON('https://raw.githubusercontent.com/dimagi/world.geo.json/master/countries.geo.json', function (data) {
-        countriesGeo = L.geoJson(data, {style: style, onEachFeature: onEachFeature}).addTo(map);
-        dataController.refreshProjectData({}, function() {
-
-            stats.addTo(map);
-
-            var references = window.location.hash.substring(1).split('#');
-            if (references.length === 2) {
-                // country, then project
-                selectionModel.selectedCountry(references[0]);
-                selectionModel.selectedProject(references[1]);
-                modalController.showProjectInfo(references[0], references[1]);
-                $('#modal').modal();
-            } else if (references.length === 1 && references[0].length > 0) {
-                // just a country
-                selectionModel.selectedCountry(references[0]);
-                modalController.showProjectsTable(references[0]);
-                $('#modal').modal();
-            }
+            };
+    
+            that.toggleMap = function () {
+                is_project_count_map = !is_project_count_map;
+            };
+    
+            that.getUnit = function (count) {
+                if (is_project_count_map) {
+                    return count > 1 ? 'active projects' : 'active project';
+                } else {
+                    return count > 1 ? 'active users' : 'active user';
+                }
+            };
+    
+            that.getNumActiveCountries = function () {
+                return Object.keys(projects_per_country).length;
+            };
+    
+            that.getMax = function () {
+                if (is_project_count_map) {
+                    return maxNumProjects;
+                } else {
+                    return maxNumUsers;
+                }
+            };
+    
+            that.getNumProjects = function () {
+                return totalNumProjects;
+            };
+    
+            that.getNumUsers = function () {
+                return totalNumUsers;
+            };
+    
+            that.isProjectCountMap = function (){
+                return is_project_count_map;
+            };
+    
+            var SelectionModel = function () {
+                var self = this;
+                self.selectedCountry = ko.observable('country name');
+                self.selectedProject = ko.observable('project name');
+                self.internalTableProperties = ['Name', 'Organization', 'Notes', 'Sector', 'Sub-Sector', 'Active Users', 'Countries'];
+                self.externalTableProperties = ['Sector', 'Sub-Sector', 'Active Users', 'Countries'];
+                self.topFiveProjects = ko.observableArray();
+            };
+    
+            selectionModel = new SelectionModel();
+            $('#modal').koApplyBindings(selectionModel);
+    
+            Object.freeze(that);
+            return that;
+        }();
+    
+        var modalController = function(){
+            var that = {};
+    
+            that.showProjectsTable = function(countryName) {
+                var modalContent = $('.modal-content');
+                modalContent.addClass('show-table');
+                modalContent.removeClass('show-project-info');
+    
+                window.location.hash = countryName;
+            };
+    
+            Object.freeze(that);
+            return that;
+        }();
+    
+        var countriesGeo;
+        // A lot of the styling work here is modeled after http://leafletjs.com/examples/choropleth.html
+        var map = L.map('map').setView([0, 0], 3);
+        var mapId = 'dimagi/cirqobc2w0000g4ksj9dochrm';
+    
+        // copied from dimagisphere
+        L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/256/{z}/{x}/{y}?access_token={accessToken}', {
+            maxZoom: 6,
+            minZoom: 2,
+            id: mapId,
+            accessToken: mapboxAccessToken,
+            noWrap: true,
+        }).addTo(map);
+    
+        var southWest = L.latLng(-85.0, -180.0),
+            northEast = L.latLng(85.0, 180.0),
+            bounds = L.latLngBounds(southWest, northEast);
+    
+        map.setMaxBounds(bounds);
+        map.on('drag', function(){
+            map.panInsideBounds(bounds, {animate:false});
         });
-    });
+    
+        function getColor(featureId) {
+            var thresholdScales;
+            var count = dataController.getCount(featureId);
+            var isProjectCountMap = dataController.isProjectCountMap();
+            if (isProjectCountMap) {
+                thresholdScales = PROJECT_COUNTS_THRESHOLD;
+            } else {
+                thresholdScales = USER_COUNTS_THRESHOLD;
+            }
+            var index = getColorScaleIndex(count, thresholdScales);
+            return COUNTRY_COLORS[index];
+        }
+    
+        function getColorScaleIndex(count, scales) {
+            for (var i = 0; i < scales.length; i++){
+                if (count < scales[i]){
+                    return i;
+                }
+            }
+            return scales.length;
+        }
+    
+        function getOpacity(featureId) {
+            if (dataController.getCount(featureId)) {
+                return 0.9;
+            } else {
+                return 0;
+            }
+        }
+    
+        function style(feature) {
+            return {
+                fillColor: getColor(feature.properties.name),
+                weight: 2,
+                opacity: 1,
+                color: 'white',
+                dashArray: '3',
+                fillOpacity: getOpacity(feature.properties.name),
+            };
+        }
+    
+        // highlights
+        function highlightFeature(e) {
+            var layer = e.target;
+            layer.setStyle({
+                weight: 4,
+                color: '#002c5f',
+                dashArray: '',
+            });
+            if (!L.Browser.ie && !L.Browser.opera) {
+                layer.bringToFront();
+            }
+            info.update(layer.feature.properties);
+        }
+    
+        function resetHighlight(e) {
+            countriesGeo.resetStyle(e.target);
+            info.update();
+        }
+    
+        function formatCountryNames(countries) {
+            return countries.map(function(country) {
+                var formattedCountryName = country.charAt(0).toUpperCase();
+                if (country.indexOf(",") > -1) {
+                    formattedCountryName += country.substring(1, country.indexOf(",")).toLowerCase();
+                } else {
+                    formattedCountryName += country.substring(1).toLowerCase();
+                }
+                return formattedCountryName;
+            });
+        }
+    
+        function onEachFeature(feature, layer) {
+            layer.on({
+                mouseover: highlightFeature,
+                mouseout: resetHighlight,
+                click: function(e) {
+                    if (dataController.getCount(feature.properties.name)){
+                        selectionModel.selectedCountry(feature.properties.name);
+                        modalController.showProjectsTable(selectionModel.selectedCountry());
+                        var country = (feature.properties.name).toUpperCase();
+                        selectionModel.topFiveProjects.removeAll();
+                        $.ajax({
+                            url: "/hq/admin/top_five_projects_by_country/?country=" + country,
+                            datatype: "json",
+                        }).done(function(data){
+                            if (data.internal) {
+                                data[country].forEach(function(project){
+                                    selectionModel.topFiveProjects.push({
+                                        name: project['name'],
+                                        organization: project['organization_name'],
+                                        description: project['internal']['notes'],
+                                        sector: project['internal']['area'],
+                                        sub_sector: project['internal']['sub_area'],
+                                        active_users: project['cp_n_active_cc_users'],
+                                        countries: formatCountryNames(project['deployment']['countries']).join(', '),
+                                    });
+                                });
+                            } else {
+                                data[country].forEach(function(project){
+                                    selectionModel.topFiveProjects.push({
+                                        sector: project['internal']['area'],
+                                        sub_sector: project['internal']['sub_area'],
+                                        active_users: project['cp_n_active_cc_users'],
+                                        countries: formatCountryNames(project['deployment']['countries']).join(', '),
+                                    });
+                                });
+                            }
+    
+                        });
+                        $('#modal').modal();
+                    };
+                },
+            });
+        }
+    
+        // info control
+        var info = L.control();
+        info.onAdd = function (map) {
+            this._div = L.DomUtil.create('div', 'map-info');
+            this.update();
+            return this._div;
+        };
+    
+        // method that we will use to update the control based on feature properties passed in
+        info.update = function (props) {
+            function _getInfoContent(countryName) {
+                var count = dataController.getCount(countryName);
+                var unit = dataController.getUnit(count);
+                var message = count ? count + ' ' + unit : 'no ' + unit + 's';
+                return '<b>' + countryName + '</b>: ' + message;
+            }
+            this._div.innerHTML = (props ? _getInfoContent(props.name) : 'Hover over a country');
+        };
+        info.addTo(map);
+    
+        // add a legend
+        var legend = L.control({position: 'bottomleft'});
+    
+        legend.onAdd = function (map) {
+            var div = L.DomUtil.create('div', 'info legend');
+            var thresholds;
+            div.innerHTML += '<i style="background:' + 'black' + '"></i> ' + '0' + '<br>';
+            var is_project_count_map = dataController.isProjectCountMap();
+            if (is_project_count_map) {
+                thresholds = PROJECT_COUNTS_THRESHOLD;
+            } else {
+                thresholds = USER_COUNTS_THRESHOLD;
+            }
+            for (var i = 0; i < thresholds.length; i++) {
+                div.innerHTML += '<i style="background:' + COUNTRY_COLORS[i] + '"></i> ';
+                if (thresholds[i-1] !==  undefined) {
+                    if (thresholds[i-1] +1 < thresholds[i]) {
+                        div.innerHTML += (thresholds[i-1] + 1) + '&ndash;';
+                    }
+                } else if (thresholds[i] > 1) {
+                    div.innerHTML += '1&ndash;';
+                }
+                div.innerHTML += thresholds[i] + '<br>';
+            }
+            div.innerHTML += '<i style="background:' + COUNTRY_COLORS[thresholds.length] + '"></i> '
+                             + (thresholds[thresholds.length-1] + 1)+ '+';
+    
+            return div;
+        };
+    
+        legend.addTo(map);
+    
+    
+        var stats = L.control({position: 'bottomright'});
+    
+        stats.onAdd = function (map) {
+            var div = L.DomUtil.create('div', 'info legend');
+            div.innerHTML += '<p><b>Statistics</b></p>';
+            div.innerHTML += '<p>Number of Active Countries: ' + dataController.getNumActiveCountries() +  '</p>';
+            div.innerHTML += '<p>Number of Active Mobile Users: ' + dataController.getNumUsers() +  '</p>';
+            div.innerHTML += '<p>Number of Active Projects: ' + dataController.getNumProjects() +  '</p>';
+            div.innerHTML += '<br><p><em> Active: A project or user submitted a form in past 30 days.</em></p>';
+            return div;
+        };
 
-    $('.btn-toggle').click(function() {
-        dataController.toggleMap();
-        dataController.refreshProjectData({}, function(){});
-        $(this).find('.btn').toggleClass('btn-primary');
-        $(this).find('.btn').toggleClass('btn-default');
+        // copied from dimagisphere
+        // todo: should probably be getting this from somewhere else and possibly not on every page load.
+        $.getJSON('https://raw.githubusercontent.com/dimagi/world.geo.json/master/countries.geo.json', function (data) {
+            countriesGeo = L.geoJson(data, {style: style, onEachFeature: onEachFeature}).addTo(map);
+            dataController.refreshProjectData({}, function() {
+    
+                stats.addTo(map);
+    
+                var references = window.location.hash.substring(1).split('#');
+                if (references.length === 2) {
+                    // country, then project
+                    selectionModel.selectedCountry(references[0]);
+                    selectionModel.selectedProject(references[1]);
+                    modalController.showProjectInfo(references[0], references[1]);
+                    $('#modal').modal();
+                } else if (references.length === 1 && references[0].length > 0) {
+                    // just a country
+                    selectionModel.selectedCountry(references[0]);
+                    modalController.showProjectsTable(references[0]);
+                    $('#modal').modal();
+                }
+            });
+        });
+    
+        $('.btn-toggle').click(function() {
+            dataController.toggleMap();
+            dataController.refreshProjectData({}, function(){});
+            $(this).find('.btn').toggleClass('btn-primary');
+            $(this).find('.btn').toggleClass('btn-default');
+        });
     });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/raw_couch.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/raw_couch.js
@@ -1,19 +1,22 @@
-$(function() {
-    // don't break if offline (Also why I left it as a <pre/>)
-    if (window.CodeMirror) {
-        var couchDocElement = document.getElementById('couch-document');
-        if (couchDocElement) {
-            var myCodeMirror = CodeMirror(function(elt) {
-                couchDocElement.parentNode.replaceChild(elt, couchDocElement);
-            }, {
-                value: couchDocElement.textContent,
-                readOnly: true,
-                lineNumbers: true,
-                mode: {name: "javascript", json: true},
-                viewportMargin: Infinity,
-                foldGutter: true,
-                gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
-            });
+/* globals hqDefine */
+hqDefine('hqadmin/js/raw_couch.js', function () {
+    $(function() {
+        // don't break if offline (Also why I left it as a <pre/>)
+        if (window.CodeMirror) {
+            var couchDocElement = document.getElementById('couch-document');
+            if (couchDocElement) {
+                var myCodeMirror = CodeMirror(function(elt) {
+                    couchDocElement.parentNode.replaceChild(elt, couchDocElement);
+                }, {
+                    value: couchDocElement.textContent,
+                    readOnly: true,
+                    lineNumbers: true,
+                    mode: {name: "javascript", json: true},
+                    viewportMargin: Infinity,
+                    foldGutter: true,
+                    gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+                });
+            }
         }
-    }
+    });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/system_info.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/system_info.js
@@ -1,373 +1,376 @@
-function format_date(datestring) {
-    //parse and format the date timestamps - seconds since epoch into date object
-    var date = new Date(datestring * 1000);
-    // hours part from the timestamp
-    var hours = date.getHours();
-    // minutes part from the timestamp
-    var minutes = date.getMinutes();
-    // seconds part from the timestamp
-    var seconds = date.getSeconds();
-    if (seconds < 10) {
-        var second_str = "0"+ seconds;
-    } else {
-        var second_str = seconds;
-    }
-
-    var year = date.getFullYear();
-    var month = date.getMonth() + 1;
-    var day = date.getDate();
-
-    return  year + '/' + month + '/' + day + ' ' + hours + ':' + minutes + ':' +  second_str;
-
-}
-
-function number_fix(num) {
-    if (num !== null) {
-        if (num.toFixed) {
-            return num.toFixed(2)
-        }
-        if (num.toPrecision) {
-            return num.toPrecision(2);
-        }
-        return num;
-    }
-}
-
-function RefreshableViewModel(url, model, interval, sort_by) {
-    var self = this;
-    self.error = ko.observable();
-    self.models = ko.observableArray();
-    self.autoRefresh = ko.observable(false);
-    self.loading = ko.observable(false);
-    self.timer = null;
-    self.interval = interval;
-
-    self.autoRefresh.subscribe(function (newVal) {
-        if (newVal) {
-            self.refresh();
+/* globals hqDefine */
+hqDefine('hqadmin/js/system_info.js', function () {
+    function format_date(datestring) {
+        //parse and format the date timestamps - seconds since epoch into date object
+        var date = new Date(datestring * 1000);
+        // hours part from the timestamp
+        var hours = date.getHours();
+        // minutes part from the timestamp
+        var minutes = date.getMinutes();
+        // seconds part from the timestamp
+        var seconds = date.getSeconds();
+        if (seconds < 10) {
+            var second_str = "0"+ seconds;
         } else {
-            self.clearTimer();
+            var second_str = seconds;
         }
-    });
-
-    self.clearTimer = function () {
-        if (self.timer) {
-            clearTimeout(self.timer);
-            self.timer = null;
-        }
-    };
-
-    self.refresh = function () {
-        self.clearTimer();
-        self.loading(true);
-        $.getJSON(url, function (data) {
-            self.error(null);
-            var objects = _(data).map(function (item) {
-                return new model(item);
-            });
-            if (sort_by) {
-                objects = _(objects).sortBy(function (x) { return x[sort_by]; })
+    
+        var year = date.getFullYear();
+        var month = date.getMonth() + 1;
+        var day = date.getDate();
+    
+        return  year + '/' + month + '/' + day + ' ' + hours + ':' + minutes + ':' +  second_str;
+    
+    }
+    
+    function number_fix(num) {
+        if (num !== null) {
+            if (num.toFixed) {
+                return num.toFixed(2)
             }
-            self.models(objects);
-            if (self.autoRefresh()) {
-                self.timer = setTimeout(self.refresh, self.interval);
+            if (num.toPrecision) {
+                return num.toPrecision(2);
             }
-        })
-        .fail(function (jqxhr, textStatus, error) {
-            var err = 'Unknown server error';
-            try {
-                err = JSON.parse(jqxhr.responseText).error;
-            } catch (e) {}
-            self.error("Error: " + err);
-            self.autoRefresh(false);
-            self.timer = null;
-        })
-        .always(function (){
-            self.loading(false);
-        });
-    };
-}
-
-function ActiveTaskModel(data) {
-
-    this.pid = ko.observable(data.pid);
-    this.type = ko.observable(data.type);
-    this.database = ko.observable(data.database);
-    this.progress = ko.observable(data.progress + "%");
-    this.design_document = ko.observable(data.design_document);
-    this.started_on = ko.observable(format_date(data.started_on));
-    this.updated_on = ko.observable(format_date(data.updated_on));
-    this.total_changes = ko.observable(data.total_changes);
-    this.changes_done = ko.observable(data.changes_done);
-    this.progress_contribution = ko.observable(data.progress_contribution);
-}
-
-function DesignDocModel(data) {
-    var self = this;
-    self.design_document = ko.observable(data.design_document);
-    self.details_id = self.design_document() + '_details';
-    var tasks = _(data.tasks).map(function (task) {
-        return new ActiveTaskModel(task);
-    });
-    self.tasks = ko.observableArray(tasks);
-
-    self.showDetails = function () {
-        $('#' + self.details_id).toggle();
-    };
-}
-
-function CeleryTaskModel(data) {
-    var self = this;
-    this.name = ko.observable(data.name);
-    this.uuid = ko.observable(data.uuid);
-    this.state = ko.observable(data.state);
-    this.received = ko.observable(format_date(data.received));
-    this.started = ko.observable(format_date(data.started));
-    this.timestamp = ko.observable(format_date(data.timestamp));
-    this.succeeded = ko.observable(format_date(data.succeeded));
-    this.retries = ko.observable(data.retries);
-    this.args = ko.observable(data.args);
-    this.kwargs = ko.observable(data.kwargs);
-    this.runtime = ko.observable(number_fix(data.runtime));
-
-    this.toggleArgs = function () {
-        $('#' + self.uuid()).toggle();
+            return num;
+        }
     }
-}
-
-function PillowOperationViewModel(pillow_model, operation) {
-    var self = this;
-    self.pillow_model = pillow_model;
-    self.operation = operation;
-    self.title = operation + ' for ' + pillow_model.name();
-
-    self.go = function () {
-        self.pillow_model.perform_operation(operation);
-    }
-}
-
-function PillowProgress(name, db_offset, seq) {
-    var self = this;
-    self.name = name;
-    self.db_offset = db_offset;
-    self.seq = seq;
-
-    self.width = function() {
-        return (self.seq * 100) / self.db_offset;
-    };
-
-    self.status = function() {
-        if (self.width() > 98) {
-            return 'progress-bar-success';
-        } else if (self.width() < 50) {
-            return 'progress-bar-danger';
-        } else if (self.width() < 75) {
-            return 'progress-bar-warning';
-        }
-    };
-}
-
-function PillowModel(pillow) {
-    var self = this;
-    self.name = ko.observable();
-    self.seq_format = ko.observable();
-    self.seq = ko.observable();
-    self.offsets = ko.observable();
-    self.time_since_last = ko.observable();
-    self.show_supervisor_info = ko.observable();
-    self.supervisor_state = ko.observable();
-    self.supervisor_message = ko.observable();
-    self.operation_in_progress = ko.observable(false);
-    self.progress = ko.observableArray();
-
-    self.update = function (data) {
-        self.name(data.name);
-        self.seq_format(data.seq_format);
-        self.seq(data.seq);
-        self.offsets(data.offsets);
-        self.time_since_last(data.time_since_last);
-        self.show_supervisor_info(!!data.supervisor_state);
-        self.supervisor_state(data.supervisor_state||'(unavailable)');
-        self.supervisor_message(data.supervisor_message);
-
-        self.progress([]);
-        if (self.seq_format() === 'json') {
-            _.each(self.offsets(), function(db_offset, key) {
-                var value;
-                if (self.seq() === null || !self.seq().hasOwnProperty(key)) {
-                    value = 0;
-                } else {
-                    value = self.seq()[key];
-                }
-                self.progress.push(new PillowProgress(key, db_offset, value));
-            })
-        } else {
-            var key = _.keys(self.offsets())[0];
-            self.progress.push(new PillowProgress(key, self.offsets()[key], self.seq()));
-        }
-    };
-
-    self.update(pillow);
-
-    self.process_running = ko.computed(function () {
-        return self.supervisor_state() === 'RUNNING';
-    });
-
-    self.start_stop_text = ko.computed(function () {
-        return self.process_running() ? gettext("Stop") : gettext("Start");
-    });
-
-    self.disabled = ko.computed(function() {
-        return self.operation_in_progress() || (self.supervisor_state() !== 'RUNNING' && self.supervisor_state() !== 'STOPPED');
-    });
-
-    self.supervisor_state_css = ko.computed(function() {
-        switch (self.supervisor_state()) {
-            case ('(unavailable)'):
-                return '';
-            case ('RUNNING'):
-                return 'label-success';
-            case ('STOPPED'):
-                return 'label-warning';
-            default:
-                return 'label-danger';
-        }
-    });
-
-    self.checkpoint_status_css = ko.computed(function() {
-        var hours = pillow.hours_since_last;
-        switch (true) {
-            case (hours <= 1):
-                return 'label-success';
-            case (hours <= 6):
-                return 'label-info';
-            case (hours <= 12):
-                return 'label-warning';
-            default:
-                return 'label-danger';
-        }
-    });
-
-    self.overall_status = ko.computed(function() {
-        var status_combined = self.checkpoint_status_css() + self.supervisor_state_css();
-        if (status_combined.indexOf('important') !== -1) {
-            return 'error';
-        } else if (status_combined.indexOf('warning') !== -1) {
-            return 'warning';
-        } else if (status_combined.indexOf('info') !== -1) {
-            return 'info';
-        } else if (status_combined.indexOf('success') !== -1) {
-            return 'success';
-        }
-    });
-
-    self.show_pillow_dialog = function (operation) {
-        var element = $('#pillow_operation_modal').get(0);
-        ko.cleanNode(element);
-        $(element).koApplyBindings(new PillowOperationViewModel(self, operation));
-        $('#pillow_operation_modal').modal({
-            backdrop: 'static',
-            keyboard: false,
-            show: true
-        });
-    };
-
-    self.reset_checkpoint = function () {
-        self.show_pillow_dialog('reset_checkpoint');
-    };
-
-    self.start_stop = function () {
-        self.show_pillow_dialog(self.process_running() ? 'stop' : 'start');
-    };
-
-    self.refresh = function () {
-        self.perform_operation('refresh');
-    };
-
-    self.perform_operation = function(operation) {
-        self.operation_in_progress(true);
-        $.post(hqImport("hqwebapp/js/urllib.js").reverse("pillow_operation_api"), {
-            'pillow_name': self.name,
-            'operation': operation
-        }, function( data ) {
-            self.operation_in_progress(false);
-            self.update(data);
-
-            if (!data.success) {
-                alert_user("Operation failed: " + data.operation + " on "
-                        + data.pillow_name + ', ' + data.message, 'error');
-            }
-        }, "json")
-        .fail(function (jqxhr, textStatus, error) {
-            var err = 'Unknown server error';
-            try {
-                err = JSON.parse(jqxhr.responseText).error;
-            } catch (e) {}
-            self.operation_in_progress(false);
-            self.supervisor_state('(unavailable)');
-            self.supervisor_message(err);
-        }).always(function() {
-            $('#pillow_operation_modal').modal('hide');
-            $("#" + self.name() +" td").fadeTo( "fast" , 0.5).fadeTo( "fast" , 1);
-        });
-    }
-}
-
-function DbComparisons(data) {
-    var self = this;
-    self.description = data.description;
-    self.es_docs = data.es_docs;
-    self.couch_docs = data.couch_docs;
-    self.sql_rows = data.sql_rows;
-}
-
-$(function () {
-    var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get,
-        celery_update = initial_page_data("celery_update"),
-        couch_update = initial_page_data("couch_update"),
-        system_ajax_url = hqImport("hqwebapp/js/urllib.js").reverse("system_ajax");
-    var celeryViewModel = new RefreshableViewModel(system_ajax_url + "?api=flower_poll", CeleryTaskModel, celery_update);
-    var couchViewModel;
-    if (initial_page_data("is_bigcouch")) {
-        var couchViewModel = new RefreshableViewModel(system_ajax_url + "?api=_active_tasks", DesignDocModel, couch_update, 'design_document');
-    } else {
-        var couchViewModel = new RefreshableViewModel(system_ajax_url + "?api=_active_tasks", ActiveTaskModel, couch_update);
-    }
-    var pillowtopViewModel = new RefreshableViewModel(system_ajax_url + "?api=pillowtop", PillowModel, couch_update, 'name');
-
-    var AutoRefreshModel = function () {
+    
+    function RefreshableViewModel(url, model, interval, sort_by) {
         var self = this;
-        self.refreshStatus = ko.observable(false);
-        self.refreshStatusText = ko.observable('off');
-        self.models = [];
-
-        self.addModel = function (model) {
-            self.models.push(model);
+        self.error = ko.observable();
+        self.models = ko.observableArray();
+        self.autoRefresh = ko.observable(false);
+        self.loading = ko.observable(false);
+        self.timer = null;
+        self.interval = interval;
+    
+        self.autoRefresh.subscribe(function (newVal) {
+            if (newVal) {
+                self.refresh();
+            } else {
+                self.clearTimer();
+            }
+        });
+    
+        self.clearTimer = function () {
+            if (self.timer) {
+                clearTimeout(self.timer);
+                self.timer = null;
+            }
         };
-
-        self.toggleRefresh = function () {
-            self.refreshStatus(!self.refreshStatus());
-            self.refreshStatusText(self.refreshStatus() ? 'on' : 'off');
-            $.each(self.models, function (index, model) {
-                model.autoRefresh(self.refreshStatus());
+    
+        self.refresh = function () {
+            self.clearTimer();
+            self.loading(true);
+            $.getJSON(url, function (data) {
+                self.error(null);
+                var objects = _(data).map(function (item) {
+                    return new model(item);
+                });
+                if (sort_by) {
+                    objects = _(objects).sortBy(function (x) { return x[sort_by]; })
+                }
+                self.models(objects);
+                if (self.autoRefresh()) {
+                    self.timer = setTimeout(self.refresh, self.interval);
+                }
+            })
+            .fail(function (jqxhr, textStatus, error) {
+                var err = 'Unknown server error';
+                try {
+                    err = JSON.parse(jqxhr.responseText).error;
+                } catch (e) {}
+                self.error("Error: " + err);
+                self.autoRefresh(false);
+                self.timer = null;
+            })
+            .always(function (){
+                self.loading(false);
             });
         };
-
-        self.refreshAll = function () {
-            $.each(self.models, function (index, model) {
-                model.refresh();
+    }
+    
+    function ActiveTaskModel(data) {
+    
+        this.pid = ko.observable(data.pid);
+        this.type = ko.observable(data.type);
+        this.database = ko.observable(data.database);
+        this.progress = ko.observable(data.progress + "%");
+        this.design_document = ko.observable(data.design_document);
+        this.started_on = ko.observable(format_date(data.started_on));
+        this.updated_on = ko.observable(format_date(data.updated_on));
+        this.total_changes = ko.observable(data.total_changes);
+        this.changes_done = ko.observable(data.changes_done);
+        this.progress_contribution = ko.observable(data.progress_contribution);
+    }
+    
+    function DesignDocModel(data) {
+        var self = this;
+        self.design_document = ko.observable(data.design_document);
+        self.details_id = self.design_document() + '_details';
+        var tasks = _(data.tasks).map(function (task) {
+            return new ActiveTaskModel(task);
+        });
+        self.tasks = ko.observableArray(tasks);
+    
+        self.showDetails = function () {
+            $('#' + self.details_id).toggle();
+        };
+    }
+    
+    function CeleryTaskModel(data) {
+        var self = this;
+        this.name = ko.observable(data.name);
+        this.uuid = ko.observable(data.uuid);
+        this.state = ko.observable(data.state);
+        this.received = ko.observable(format_date(data.received));
+        this.started = ko.observable(format_date(data.started));
+        this.timestamp = ko.observable(format_date(data.timestamp));
+        this.succeeded = ko.observable(format_date(data.succeeded));
+        this.retries = ko.observable(data.retries);
+        this.args = ko.observable(data.args);
+        this.kwargs = ko.observable(data.kwargs);
+        this.runtime = ko.observable(number_fix(data.runtime));
+    
+        this.toggleArgs = function () {
+            $('#' + self.uuid()).toggle();
+        }
+    }
+    
+    function PillowOperationViewModel(pillow_model, operation) {
+        var self = this;
+        self.pillow_model = pillow_model;
+        self.operation = operation;
+        self.title = operation + ' for ' + pillow_model.name();
+    
+        self.go = function () {
+            self.pillow_model.perform_operation(operation);
+        }
+    }
+    
+    function PillowProgress(name, db_offset, seq) {
+        var self = this;
+        self.name = name;
+        self.db_offset = db_offset;
+        self.seq = seq;
+    
+        self.width = function() {
+            return (self.seq * 100) / self.db_offset;
+        };
+    
+        self.status = function() {
+            if (self.width() > 98) {
+                return 'progress-bar-success';
+            } else if (self.width() < 50) {
+                return 'progress-bar-danger';
+            } else if (self.width() < 75) {
+                return 'progress-bar-warning';
+            }
+        };
+    }
+    
+    function PillowModel(pillow) {
+        var self = this;
+        self.name = ko.observable();
+        self.seq_format = ko.observable();
+        self.seq = ko.observable();
+        self.offsets = ko.observable();
+        self.time_since_last = ko.observable();
+        self.show_supervisor_info = ko.observable();
+        self.supervisor_state = ko.observable();
+        self.supervisor_message = ko.observable();
+        self.operation_in_progress = ko.observable(false);
+        self.progress = ko.observableArray();
+    
+        self.update = function (data) {
+            self.name(data.name);
+            self.seq_format(data.seq_format);
+            self.seq(data.seq);
+            self.offsets(data.offsets);
+            self.time_since_last(data.time_since_last);
+            self.show_supervisor_info(!!data.supervisor_state);
+            self.supervisor_state(data.supervisor_state||'(unavailable)');
+            self.supervisor_message(data.supervisor_message);
+    
+            self.progress([]);
+            if (self.seq_format() === 'json') {
+                _.each(self.offsets(), function(db_offset, key) {
+                    var value;
+                    if (self.seq() === null || !self.seq().hasOwnProperty(key)) {
+                        value = 0;
+                    } else {
+                        value = self.seq()[key];
+                    }
+                    self.progress.push(new PillowProgress(key, db_offset, value));
+                })
+            } else {
+                var key = _.keys(self.offsets())[0];
+                self.progress.push(new PillowProgress(key, self.offsets()[key], self.seq()));
+            }
+        };
+    
+        self.update(pillow);
+    
+        self.process_running = ko.computed(function () {
+            return self.supervisor_state() === 'RUNNING';
+        });
+    
+        self.start_stop_text = ko.computed(function () {
+            return self.process_running() ? gettext("Stop") : gettext("Start");
+        });
+    
+        self.disabled = ko.computed(function() {
+            return self.operation_in_progress() || (self.supervisor_state() !== 'RUNNING' && self.supervisor_state() !== 'STOPPED');
+        });
+    
+        self.supervisor_state_css = ko.computed(function() {
+            switch (self.supervisor_state()) {
+                case ('(unavailable)'):
+                    return '';
+                case ('RUNNING'):
+                    return 'label-success';
+                case ('STOPPED'):
+                    return 'label-warning';
+                default:
+                    return 'label-danger';
+            }
+        });
+    
+        self.checkpoint_status_css = ko.computed(function() {
+            var hours = pillow.hours_since_last;
+            switch (true) {
+                case (hours <= 1):
+                    return 'label-success';
+                case (hours <= 6):
+                    return 'label-info';
+                case (hours <= 12):
+                    return 'label-warning';
+                default:
+                    return 'label-danger';
+            }
+        });
+    
+        self.overall_status = ko.computed(function() {
+            var status_combined = self.checkpoint_status_css() + self.supervisor_state_css();
+            if (status_combined.indexOf('important') !== -1) {
+                return 'error';
+            } else if (status_combined.indexOf('warning') !== -1) {
+                return 'warning';
+            } else if (status_combined.indexOf('info') !== -1) {
+                return 'info';
+            } else if (status_combined.indexOf('success') !== -1) {
+                return 'success';
+            }
+        });
+    
+        self.show_pillow_dialog = function (operation) {
+            var element = $('#pillow_operation_modal').get(0);
+            ko.cleanNode(element);
+            $(element).koApplyBindings(new PillowOperationViewModel(self, operation));
+            $('#pillow_operation_modal').modal({
+                backdrop: 'static',
+                keyboard: false,
+                show: true
             });
         };
-    };
-
-    var autoRefresh = new AutoRefreshModel();
-    $("#celeryblock").koApplyBindings(celeryViewModel);
-    $("#couchblock").koApplyBindings(couchViewModel);
-    $('#pillowtop-status').koApplyBindings(pillowtopViewModel);
-    autoRefresh.addModel(celeryViewModel);
-    autoRefresh.addModel(couchViewModel);
-    autoRefresh.addModel(pillowtopViewModel);
-
-    autoRefresh.refreshAll();
-    $('#autorefresh').koApplyBindings(autoRefresh);
+    
+        self.reset_checkpoint = function () {
+            self.show_pillow_dialog('reset_checkpoint');
+        };
+    
+        self.start_stop = function () {
+            self.show_pillow_dialog(self.process_running() ? 'stop' : 'start');
+        };
+    
+        self.refresh = function () {
+            self.perform_operation('refresh');
+        };
+    
+        self.perform_operation = function(operation) {
+            self.operation_in_progress(true);
+            $.post(hqImport("hqwebapp/js/urllib.js").reverse("pillow_operation_api"), {
+                'pillow_name': self.name,
+                'operation': operation
+            }, function( data ) {
+                self.operation_in_progress(false);
+                self.update(data);
+    
+                if (!data.success) {
+                    alert_user("Operation failed: " + data.operation + " on "
+                            + data.pillow_name + ', ' + data.message, 'error');
+                }
+            }, "json")
+            .fail(function (jqxhr, textStatus, error) {
+                var err = 'Unknown server error';
+                try {
+                    err = JSON.parse(jqxhr.responseText).error;
+                } catch (e) {}
+                self.operation_in_progress(false);
+                self.supervisor_state('(unavailable)');
+                self.supervisor_message(err);
+            }).always(function() {
+                $('#pillow_operation_modal').modal('hide');
+                $("#" + self.name() +" td").fadeTo( "fast" , 0.5).fadeTo( "fast" , 1);
+            });
+        }
+    }
+    
+    function DbComparisons(data) {
+        var self = this;
+        self.description = data.description;
+        self.es_docs = data.es_docs;
+        self.couch_docs = data.couch_docs;
+        self.sql_rows = data.sql_rows;
+    }
+    
+    $(function () {
+        var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get,
+            celery_update = initial_page_data("celery_update"),
+            couch_update = initial_page_data("couch_update"),
+            system_ajax_url = hqImport("hqwebapp/js/urllib.js").reverse("system_ajax");
+        var celeryViewModel = new RefreshableViewModel(system_ajax_url + "?api=flower_poll", CeleryTaskModel, celery_update);
+        var couchViewModel;
+        if (initial_page_data("is_bigcouch")) {
+            var couchViewModel = new RefreshableViewModel(system_ajax_url + "?api=_active_tasks", DesignDocModel, couch_update, 'design_document');
+        } else {
+            var couchViewModel = new RefreshableViewModel(system_ajax_url + "?api=_active_tasks", ActiveTaskModel, couch_update);
+        }
+        var pillowtopViewModel = new RefreshableViewModel(system_ajax_url + "?api=pillowtop", PillowModel, couch_update, 'name');
+    
+        var AutoRefreshModel = function () {
+            var self = this;
+            self.refreshStatus = ko.observable(false);
+            self.refreshStatusText = ko.observable('off');
+            self.models = [];
+    
+            self.addModel = function (model) {
+                self.models.push(model);
+            };
+    
+            self.toggleRefresh = function () {
+                self.refreshStatus(!self.refreshStatus());
+                self.refreshStatusText(self.refreshStatus() ? 'on' : 'off');
+                $.each(self.models, function (index, model) {
+                    model.autoRefresh(self.refreshStatus());
+                });
+            };
+    
+            self.refreshAll = function () {
+                $.each(self.models, function (index, model) {
+                    model.refresh();
+                });
+            };
+        };
+    
+        var autoRefresh = new AutoRefreshModel();
+        $("#celeryblock").koApplyBindings(celeryViewModel);
+        $("#couchblock").koApplyBindings(couchViewModel);
+        $('#pillowtop-status').koApplyBindings(pillowtopViewModel);
+        autoRefresh.addModel(celeryViewModel);
+        autoRefresh.addModel(couchViewModel);
+        autoRefresh.addModel(pillowtopViewModel);
+    
+        autoRefresh.refreshAll();
+        $('#autorefresh').koApplyBindings(autoRefresh);
+    });
 });

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -18,6 +18,7 @@
             <script src="{% static 'codemirror/addon/fold/foldcode.js' %}"></script>
             <script src="{% static 'codemirror/addon/fold/foldgutter.js' %}"></script>
             <script src="{% static 'codemirror/addon/fold/xml-fold.js' %}"></script>
+            <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
             <script src="{% static 'hqadmin/js/admin_restore.js' %}"></script>
         {% endcompress %}
 

--- a/corehq/apps/hqadmin/templates/hqadmin/dimagisphere/form_feed.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/dimagisphere/form_feed.html
@@ -99,6 +99,7 @@
         <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
         <script src="{% static 'js/ws4redis.js' %}"></script>
         <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
         <script src="{% static 'hqadmin/js/dimagisphere_helper.js' %}"></script>
     {% endcompress %}
 </body>

--- a/corehq/apps/hqadmin/templates/hqadmin/project_map.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/project_map.html
@@ -37,6 +37,7 @@
   <script src="{% static 'knockout/dist/knockout.js' %}"></script>
   <script src="{% static 'style/js/hq.helpers.js' %}"></script>
   <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
+  <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
   <script src="{% static 'hqadmin/js/project_map.js' %}"></script>
   <script src="{% static 'appstore/js/facet_sidebar.js' %}"></script>
   {% endcompress %}

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
@@ -24,6 +24,7 @@
         <script src="{% static 'codemirror/addon/fold/foldcode.js' %}"></script>
         <script src="{% static 'codemirror/addon/fold/foldgutter.js' %}"></script>
         <script src="{% static 'codemirror/addon/fold/brace-fold.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
         <script src="{% static 'hqadmin/js/raw_couch.js' %}"></script>
         {% endif %}
 

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -1,4 +1,5 @@
-$(function(){
+/* globals hqDefine */
+hqDefine('toggle_ui/js/edit-flag.js', function () {
     var PAD_CHAR = '&nbsp;';
     function ToggleView() {
         var self = this;
@@ -84,14 +85,16 @@ $(function(){
 
     }
 
-    var $home = $('#toggle_editing_ko');
-    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get,
-        view = new ToggleView();
-    view.init({
-        items: initial_page_data('items'),
-        namespaces: initial_page_data('namespaces'),
-        last_used: initial_page_data('last_used'),
+    $(function(){
+        var $home = $('#toggle_editing_ko');
+        var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get,
+            view = new ToggleView();
+        view.init({
+            items: initial_page_data('items'),
+            namespaces: initial_page_data('namespaces'),
+            last_used: initial_page_data('last_used'),
+        });
+        $home.koApplyBindings(view);
+        $home.on('change', 'input', view.change);
     });
-    $home.koApplyBindings(view);
-    $home.on('change', 'input', view.change);
 });

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -1,4 +1,5 @@
-$(function(){
+/* globals hqDefine */
+hqDefine('toggle_ui/js/flags.js', function () {
     var dataTableElem = '.datatable';
     var viewModel = {
         tagFilter: ko.observable(null)

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -1,4 +1,5 @@
-$(function () {
+/* globals hqDefine */
+hqDefine('users/js/edit_commcare_user.js', function () {
     var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get,
         couch_user_id = initial_page_data('couch_user_id'),
         activeTabCookie = 'active_tab',


### PR DESCRIPTION
@millerdev 

Needed a short & brainless task to do at the end of the day.  `hqDefine` wrapping to the rescue.

Musing on this work (feel free to ignore)...

This uses `hqDefine` a bit non-traditionally. As documented in the js-guide, an `hqDefine` call typically returns an object that acts as that module's api, and then those functions are then called from other modules. But many of our modules aren't reusable functionality that other js depends on, they're widgets: single-use chunks of code that define the behavior for a piece of UI (whether a small piece or an entire page). For these, I've created `hqDefine` modules that return nothing and instead contain a document ready handler that sets up some event handlers and/or calls `koApplyBindings`. I'm not sure this is going to become our best practice for defining widgets, but it's a step forward: the js is external, the `hqDefine` call acts as a namespace, and the codebase is getting more consistent.

The js I've touched recently is lengthy and has a lot of stylistic variation, but the dependencies aren't particularly complex. Which might mean that a module system won't be a big of a win as I've been thinking it is...Or maybe I haven't hit the more complex areas yet...Or maybe our js could be much more modular but that hasn't been apparent for any number of reasons, so we haven't refactored out the right reusable pieces yet.