### PR TITLE
Don't 500 on remote apps

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4628,6 +4628,12 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     case_sharing = BooleanProperty(default=False)
     vellum_case_management = BooleanProperty(default=False)
 
+    # legacy property; kept around to be able to identify (deprecated) v1 apps
+    application_version = StringProperty(default=APP_V2, choices=[APP_V1, APP_V2], required=False)
+
+    def assert_app_v2(self):
+        assert self.application_version == APP_V2
+
     build_profiles = SchemaDictProperty(BuildProfile)
 
     # each language is a key and the value is a list of multimedia referenced in that language
@@ -5239,12 +5245,6 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     use_grid_menus = BooleanProperty(default=False)
     grid_form_menus = StringProperty(default='none',
                                      choices=['none', 'all', 'some'])
-
-    # legacy property; kept around to be able to identify (deprecated) v1 apps
-    application_version = StringProperty(default=APP_V2, choices=[APP_V1, APP_V2], required=False)
-
-    def assert_app_v2(self):
-        assert self.application_version == APP_V2
 
     @property
     @memoized

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/vellum_case_management_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/vellum_case_management_warning.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% if not app.vellum_case_management %}
+{% if not app.vellum_case_management and not app.is_remote_app %}
     <div class="alert alert-danger">
         {% blocktrans %}
             This application uses an outdated form of case management and may behave unexpectedly.

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -263,7 +263,7 @@ def get_apps_base_context(request, domain, app):
         'app_subset': {
             'commcare_minor_release': app.commcare_minor_release,
             'doc_type': app.get_doc_type(),
-            'form_counts_by_module': [len(m.forms) for m in app.modules] if app.get_doc_type() != "RemoteApp" else [],
+            'form_counts_by_module': [len(m.forms) for m in app.modules] if not app.is_remote_app() else [],
             'version': app.version,
         } if app else {},
         'timezone': timezone,

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -263,7 +263,7 @@ def get_apps_base_context(request, domain, app):
         'app_subset': {
             'commcare_minor_release': app.commcare_minor_release,
             'doc_type': app.get_doc_type(),
-            'form_counts_by_module': [len(m.forms) for m in app.modules],
+            'form_counts_by_module': [len(m.forms) for m in app.modules] if app.get_doc_type() != "RemoteApp" else [],
             'version': app.version,
         } if app else {},
         'timezone': timezone,

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -150,7 +150,7 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
     context.update({
         'show_live_preview': should_show_preview_app(
             request,
-            domain_obj,
+            app,
             request.couch_user.username,
         ),
         'can_preview_form': request.couch_user.has_permission(domain, 'edit_data')

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -113,8 +113,6 @@ def get_releases_context(request, domain, app_id):
     build_profile_access = domain_has_privilege(domain, privileges.BUILD_PROFILES)
 
     context.update({
-        'intro_only': len(
-            app.modules) == 0 and toggles.APP_MANAGER_V2.enabled(domain),
         'release_manager': True,
         'can_send_sms': can_send_sms,
         'has_mobile_workers': get_doc_count_in_domain_by_class(domain, CommCareUser) > 0,
@@ -127,6 +125,8 @@ def get_releases_context(request, domain, app_id):
         'fetchLimit': request.GET.get('limit', DEFAULT_FETCH_LIMIT),
     })
     if not app.is_remote_app():
+        if toggles.APP_MANAGER_V2.enabled(domain) and len(app.modules) == 0:
+            context.update({'intro_only', True})
         # Multimedia is not supported for remote applications at this time.
         try:
             multimedia_state = app.check_media_state()

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -91,7 +91,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
                 'domain': domain,
                 'app': app,
             })
-        if not app.vellum_case_management:
+        if not app.vellum_case_management and not app.is_remote_app():
             # Soft assert but then continue rendering; template will contain a user-facing warning
             _assert = soft_assert(['jschweers' + '@' + 'dimagi.com'])
             _assert(False, 'vellum_case_management=False', {'domain': domain, 'app_id': app_id})

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -293,9 +293,9 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
 
     domain_obj = Domain.get_by_name(domain)
     context.update({
-        'show_live_preview': should_show_preview_app(
+        'show_live_preview': app and should_show_preview_app(
             request,
-            domain_obj,
+            app,
             request.couch_user.username
         ),
         'can_preview_form': request.couch_user.has_permission(domain, 'edit_data')

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -2,5 +2,5 @@ from corehq.toggles import PREVIEW_APP
 from corehq.apps.analytics import ab_tests
 
 
-def should_show_preview_app(request, domain_obj, username):
-    return PREVIEW_APP.enabled(domain_obj.name) or PREVIEW_APP.enabled(username)
+def should_show_preview_app(request, app, username):
+    return (PREVIEW_APP.enabled(app.domain) or PREVIEW_APP.enabled(username)) and not app.is_remote_app()


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?248127

The wrapping bug I think was a side effect of https://github.com/dimagi/commcare-hq/pull/12915 (fyi @dannyroberts ), and then there were a couple of places I wrote app manager v2 code that didn't account for remote apps.

@millerdev 