### PR TITLE
Remove redundant get_app call

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -25,14 +25,12 @@ class CopyApplicationForm(forms.Form):
     # Toggles to enable when copying the app
     toggles = forms.CharField(required=False, widget=forms.HiddenInput, max_length=5000)
 
-    def __init__(self, from_domain, app_id, *args, **kwargs):
+    def __init__(self, from_domain, app, *args, **kwargs):
         export_zipped_apps_enabled = kwargs.pop('export_zipped_apps_enabled', False)
         super(CopyApplicationForm, self).__init__(*args, **kwargs)
         fields = ['domain', 'name', 'toggles']
-        if app_id:
-            app = get_app(from_domain, app_id)
-            if app:
-                self.fields['name'].initial = app.name
+        if app:
+            self.fields['name'].initial = app.name
         if export_zipped_apps_enabled:
             self.fields['gzip'] = forms.FileField(required=False)
             fields.append('gzip')
@@ -47,7 +45,7 @@ class CopyApplicationForm(forms.Form):
                 _('Copy Application'),
                 *fields
             ),
-            Hidden('app', app_id),
+            Hidden('app', app.get_id),
             hqcrispy.FormActions(
                 StrictButton(_('Copy'), type='button', css_class='btn-primary')
             )

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -297,8 +297,9 @@ def app_source(request, domain, app_id):
 @require_can_edit_apps
 def copy_app(request, domain):
     app_id = request.POST.get('app')
+    app = get_app(domain, app_id)
     form = CopyApplicationForm(
-        domain, app_id, request.POST,
+        domain, app, request.POST,
         export_zipped_apps_enabled=toggles.EXPORT_ZIPPED_APPS.enabled(request.user.username)
     )
     if form.is_valid():
@@ -319,7 +320,6 @@ def copy_app(request, domain):
             if data.get('linked'):
                 extra_properties['master'] = app_id
                 extra_properties['doc_type'] = 'LinkedApplication'
-                app = get_app(None, app_id)
                 if domain not in app.linked_whitelist:
                     app.linked_whitelist.append(domain)
                     app.save()

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -250,7 +250,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
     domain_names.sort()
     if app and copy_app_form is None:
         toggle_enabled = toggles.EXPORT_ZIPPED_APPS.enabled(request.user.username)
-        copy_app_form = CopyApplicationForm(domain, app_id, export_zipped_apps_enabled=toggle_enabled)
+        copy_app_form = CopyApplicationForm(domain, app, export_zipped_apps_enabled=toggle_enabled)
         context.update({
             'domain_names': domain_names,
         })


### PR DESCRIPTION
Noticed that most `view_generic` calls have an unnecessary extra `get_app`.

@millerdev 