### PR TITLE
Prepare user model for app status

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -771,9 +771,17 @@ class DeviceIdLastUsed(DocumentSchema):
         return all(getattr(self, p) == getattr(other, p) for p in self.properties())
 
 
+class LastSubmission(DocumentSchema):
+    submission_date = DateTimeProperty()
+    app_id = StringProperty()
+    build_id = StringProperty()
+    build_version = IntegerProperty()
+    commcare_version = StringProperty()
+
+
 class ReportingMetadata(DocumentSchema):
 
-    last_submission_date = DateTimeProperty()
+    last_submission = SchemaProperty(LastSubmission)
 
 
 class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMixin):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -774,7 +774,6 @@ class DeviceIdLastUsed(DocumentSchema):
 class ReportingMetadata(DocumentSchema):
 
     last_submission_date = DateTimeProperty()
-    last_sync_date = DateTimeProperty()
 
 
 class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMixin):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -782,7 +782,7 @@ class LastSubmission(DocumentSchema):
 
 class ReportingMetadata(DocumentSchema):
 
-    last_submission = SchemaProperty(LastSubmission)
+    last_submissions = SchemaListProperty(LastSubmission)
 
 
 class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMixin):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -806,7 +806,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
     assigned_location_ids = StringListProperty()
     has_built_app = BooleanProperty(default=False)
 
-    reporting_metadata = SchemaDictProperty(ReportingMetadata)
+    reporting_metadata = SchemaProperty(ReportingMetadata)
 
     _user = None
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -771,6 +771,12 @@ class DeviceIdLastUsed(DocumentSchema):
         return all(getattr(self, p) == getattr(other, p) for p in self.properties())
 
 
+class ReportingMetadata(DocumentSchema):
+
+    last_submission_date = DateTimeProperty()
+    last_sync_date = DateTimeProperty()
+
+
 class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMixin):
     """
     A user (for web and commcare)
@@ -799,6 +805,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
     location_id = StringProperty()
     assigned_location_ids = StringListProperty()
     has_built_app = BooleanProperty(default=False)
+
+    reporting_metadata = SchemaDictProperty(ReportingMetadata)
 
     _user = None
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -775,6 +775,7 @@ class LastSubmission(DocumentSchema):
     submission_date = DateTimeProperty()
     app_id = StringProperty()
     build_id = StringProperty()
+    device_id = StringProperty()
     build_version = IntegerProperty()
     commcare_version = StringProperty()
 

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -1,12 +1,7 @@
 from dateutil import parser
 
-from django.http import Http404
-
-from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.users.models import CouchUser
-from corehq.util.quickcache import quickcache
-
 from .interface import PillowProcessor
+from .utils import mark_has_submission, mark_latest_submission
 
 
 class AppFormSubmissionTrackerProcessor(PillowProcessor):
@@ -31,39 +26,10 @@ class AppFormSubmissionTrackerProcessor(PillowProcessor):
             # and build_id so that there is no need to fetch the app again after this
             # is called. Any subsequent calls with the same arguments will result in
             # the same effect, an app having has_submissions set to True.
-            self._mark_has_submission(domain, build_id)
+            mark_has_submission(domain, build_id)
 
         user_id = doc.get('user_id')
         received_on = doc.get('received_on')
 
         if user_id and domain and received_on:
-            self._mark_latest_submission(domain, user_id, received_on)
-
-    @quickcache(['domain', 'build_id'], timeout=60 * 60)
-    def _mark_has_submission(self, domain, build_id):
-        app = None
-        try:
-            app = get_app(domain, build_id)
-        except Http404:
-            pass
-
-        if app and not app.has_submissions:
-            app.has_submissions = True
-            app.save()
-
-    def _mark_latest_submission(domain, user_id, received_on):
-        user = CouchUser.get_by_user_id(user_id, domain)
-
-        try:
-            received_on_datetime = parser.parse(received_on)
-        except ValueError:
-            return
-
-        if not user:
-            return
-
-        current_last_submission = user.reporting_metadata.last_submission_date
-
-        if current_last_submission is None or current_last_submission < received_on_datetime:
-            user.reporting_metadata.last_submission_date = received_on
-            user.save()
+            mark_latest_submission(domain, user_id, received_on)

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -1,6 +1,6 @@
-from dateutil import parser
-
 from django.http import Http404
+
+from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.users.models import CouchUser
@@ -60,12 +60,12 @@ def mark_latest_submission(domain, user_id, received_on):
         return
 
     try:
-        received_on_datetime = parser.parse(received_on)
+        received_on_datetime = string_to_utc_datetime(received_on)
     except ValueError:
         return
 
     current_last_submission = user.reporting_metadata.last_submission_date
 
     if current_last_submission is None or current_last_submission < received_on_datetime:
-        user.reporting_metadata.last_submission_date = received_on
+        user.reporting_metadata.last_submission_date = received_on_datetime
         user.save()

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -83,6 +83,7 @@ def mark_latest_submission(domain, user_id, app_id, build_id, version, metadata,
 
     if current_last_submission is None or current_last_submission < received_on_datetime:
         user.reporting_metadata.last_submission.submission_date = received_on_datetime
+        user.reporting_metadata.last_submission.device_id = metadata.get('deviceID')
         user.reporting_metadata.last_submission.app_id = app_id
         user.reporting_metadata.last_submission.build_id = build_id
         user.reporting_metadata.last_submission.build_version = app_version_info.build_version

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -1,10 +1,8 @@
-from dateutil import parser
-
 from .interface import PillowProcessor
 from .utils import mark_has_submission, mark_latest_submission
 
 
-class AppFormSubmissionTrackerProcessor(PillowProcessor):
+class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
     """
     Processor used to process each form and mark the corresponding application as
     having submissions (has_submissions = True).

--- a/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from dimagi.utils.parsing import string_to_utc_datetime
 
-from corehq.apps.users.models import CommCareUser, CouchUser, LastSubmission
+from corehq.apps.users.models import CommCareUser, CouchUser
 
 from pillowtop.processors.form import mark_latest_submission
 
@@ -163,4 +163,3 @@ class MarkLatestSubmissionTest(TestCase):
         )
         user = CouchUser.get_by_user_id(self.user._id, self.domain)
         self.assertEqual(len(user.reporting_metadata.last_submissions), 2)
-

--- a/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+from dimagi.utils.parsing import string_to_utc_datetime
+
+from corehq.apps.users.models import CommCareUser, CouchUser
+
+from pillowtop.processors.form import mark_latest_submission
+
+
+class MarkLatestSubmissionTest(TestCase):
+
+    domain = 'tracker-domain'
+    username = 'tracker-user'
+    password = '***'
+
+    @classmethod
+    def setUpClass(cls):
+        super(MarkLatestSubmissionTest, cls).setUpClass()
+        cls.user = CommCareUser.create(
+            cls.domain,
+            cls.username,
+            cls.password
+        )
+
+    def tearDown(self):
+        self.user.reporting_metadata.last_submission_date = None
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete()
+        super(MarkLatestSubmissionTest, cls).tearDownClass()
+
+    def test_mark_latest_submission_basic(self):
+        submission_date = "2017-02-05T00:00:00.000000Z"
+        mark_latest_submission(self.domain, self.user._id, submission_date)
+        user = CouchUser.get_by_user_id(self.user._id, self.domain)
+
+        self.assertEqual(
+            user.reporting_metadata.last_submission_date,
+            string_to_utc_datetime(submission_date),
+        )
+
+    def test_mark_latest_submission_do_not_update(self):
+        '''
+        Ensures we do not update the user if the received_on date is after the one saved
+        '''
+        submission_date = "2017-02-05T00:00:00.000000Z"
+        previous_date = "2017-02-04T00:00:00.000000Z"
+
+        mark_latest_submission(self.domain, self.user._id, submission_date)
+        user = CouchUser.get_by_user_id(self.user._id, self.domain)
+        rev = user._rev
+
+        mark_latest_submission(self.domain, self.user._id, previous_date)
+        user = CouchUser.get_by_user_id(self.user._id, self.domain)
+        new_rev = user._rev
+
+        self.assertEqual(rev, new_rev)
+
+    def test_mark_latest_submission_error_parsing(self):
+        submission_date = "bad-date"
+        mark_latest_submission(self.domain, self.user._id, submission_date)
+        self.assertIsNone(self.user.reporting_metadata.last_submission_date)
+
+        submission_date = "2017-02-05T00:00:00.000000Z"
+        mark_latest_submission('bad-domain', self.user._id, submission_date)
+        self.assertIsNone(self.user.reporting_metadata.last_submission_date)
+
+        mark_latest_submission(self.domain, 'bad-user', submission_date)
+        self.assertIsNone(self.user.reporting_metadata.last_submission_date)

--- a/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
@@ -14,7 +14,9 @@ class MarkLatestSubmissionTest(TestCase):
     app_id = 'app-id'
     build_id = 'build-id'
     version = '2'
-    metadata = {}
+    metadata = {
+        'deviceID': 'device-id'
+    }
 
     @classmethod
     def setUpClass(cls):
@@ -59,6 +61,10 @@ class MarkLatestSubmissionTest(TestCase):
         self.assertEqual(
             user.reporting_metadata.last_submission.build_id,
             self.build_id,
+        )
+        self.assertEqual(
+            user.reporting_metadata.last_submission.device_id,
+            self.metadata['deviceID'],
         )
         self.assertEqual(user.reporting_metadata.last_submission.build_version, 2)
 

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import sys
 
 import simplejson
-
 from django.conf import settings
 
 from dimagi.utils.chunked import chunked

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -6,9 +6,7 @@ import sys
 
 import simplejson
 
-from django.http import Http404
 from django.conf import settings
-from dateutil import parser
 
 from dimagi.utils.chunked import chunked
 from dimagi.utils.modules import to_function
@@ -16,10 +14,6 @@ from dimagi.utils.modules import to_function
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.logger import pillow_logging
 from pillowtop.dao.exceptions import DocumentMismatchError, DocumentNotFoundError
-
-from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.util.quickcache import quickcache
-from corehq.apps.users.models import CouchUser
 
 
 def _get_pillow_instance(full_class_str):
@@ -268,34 +262,3 @@ def ensure_document_exists(change):
     if doc is None:
         pillow_logging.warning("Unable to get document from change: {}".format(change))
         raise DocumentNotFoundError()  # force a retry
-
-
-@quickcache(['domain', 'build_id'], timeout=60 * 60)
-def mark_has_submission(domain, build_id):
-    app = None
-    try:
-        app = get_app(domain, build_id)
-    except Http404:
-        pass
-
-    if app and not app.has_submissions:
-        app.has_submissions = True
-        app.save()
-
-
-def mark_latest_submission(domain, user_id, received_on):
-    user = CouchUser.get_by_user_id(user_id, domain)
-
-    if not user:
-        return
-
-    try:
-        received_on_datetime = parser.parse(received_on)
-    except ValueError:
-        return
-
-    current_last_submission = user.reporting_metadata.last_submission_date
-
-    if current_last_submission is None or current_last_submission < received_on_datetime:
-        user.reporting_metadata.last_submission_date = received_on
-        user.save()

--- a/corehq/pillows/app_submission_tracker.py
+++ b/corehq/pillows/app_submission_tracker.py
@@ -13,18 +13,18 @@ from couchforms.models import XFormInstance, XFormArchived, XFormError, XFormDep
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
-from pillowtop.processors.form import AppFormSubmissionTrackerProcessor
+from pillowtop.processors.form import FormSubmissionMetadataTrackerProcessor
 from pillowtop.reindexer.reindexer import Reindexer
 
 
-def get_app_form_submission_tracker_pillow(pillow_id='AppFormSubmissionTrackerPillow'):
+def get_form_submission_metadata_tracker_pillow(pillow_id='FormSubmissionMetadataTrackerProcessor'):
     """
     This gets a pillow which iterates through all forms and marks the corresponding app
     as having submissions. This could be expanded to be more generic and include
     other processing that needs to happen on each form
     """
-    checkpoint = PillowCheckpoint('app-form-submission-tracker')
-    form_processor = AppFormSubmissionTrackerProcessor()
+    checkpoint = PillowCheckpoint('form-submission-metadata-tracker')
+    form_processor = FormSubmissionMetadataTrackerProcessor()
     change_feed = KafkaChangeFeed(topics=[topics.FORM, topics.FORM_SQL], group_id='form-processsor')
     return ConstructedPillow(
         name=pillow_id,
@@ -85,7 +85,7 @@ class AppFormSubmissionReindexer(Reindexer):
         self.doc_provider = doc_provider
         self.chunk_size = chunk_size
         self.doc_processor = AppFormSubmissionReindexDocProcessor(
-            AppFormSubmissionTrackerProcessor(),
+            FormSubmissionMetadataTrackerProcessor(),
             data_source_type,
             data_source_name,
         )

--- a/settings.py
+++ b/settings.py
@@ -1529,9 +1529,9 @@ PILLOWTOPS = {
             'instance': 'corehq.pillows.domain.get_domain_kafka_to_elasticsearch_pillow',
         },
         {
-            'name': 'AppFormSubmissionTrackerPillow',
+            'name': 'FormSubmissionMetadataTrackerPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.pillows.app_submission_tracker.get_app_form_submission_tracker_pillow',
+            'instance': 'corehq.pillows.app_submission_tracker.get_form_submission_metadata_tracker_pillow',
         },
     ],
     'core_ext': [


### PR DESCRIPTION
@dimagi/scale-team working on the user model for the app status report by including the last_submission in the user model. still have some open questions.

if we want to support the filter by application dropdown, we'll need to change the model to support `SchemaListProperty` so that we can have the last submission for each application.

I talked to a few GS folk and most seemed to think that it was less important to be able to filter by application and often used it as a way to filter users. some of the primary use cases were:

1. To be able to tell which users haven't updated their phones (with this addition we should be able to sort by build number)
2. Be able to tell which users are not submitting data. This should be possible with last_submission date
3. Be able to tell which users are not syncing. I punted on being able to sort by last sync time, but wouldn't be too hard to add

🐟 or 🏠 