### PR TITLE
use same table for ucr

### DIFF
--- a/corehq/apps/userreports/adapter.py
+++ b/corehq/apps/userreports/adapter.py
@@ -21,6 +21,9 @@ class IndicatorAdapter(object):
     def refresh_table(self):
         raise NotImplementedError
 
+    def clear_table(self):
+        raise NotImplementedError
+
     def get_query_object(self):
         raise NotImplementedError
 

--- a/corehq/apps/userreports/adapter.py
+++ b/corehq/apps/userreports/adapter.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.logging import notify_exception
+from corehq.util.test_utils import unit_testing_only
 
 
 class IndicatorAdapter(object):
@@ -21,6 +22,7 @@ class IndicatorAdapter(object):
     def refresh_table(self):
         raise NotImplementedError
 
+    @unit_testing_only
     def clear_table(self):
         raise NotImplementedError
 

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -7,6 +7,7 @@ from corehq.apps.userreports.adapter import IndicatorAdapter
 from corehq.apps.es.es_query import HQESQuery
 from corehq.apps.es.aggregations import MissingAggregation
 from corehq.elastic import get_es_new, ESError
+from corehq.util.test_utils import unit_testing_only
 from dimagi.utils.decorators.memoized import memoized
 from pillowtop.es_utils import (
     set_index_reindex_settings,
@@ -164,6 +165,7 @@ class IndicatorESAdapter(IndicatorAdapter):
     def refresh_table(self):
         self.es.indices.refresh(index=self.table_name)
 
+    @unit_testing_only
     def clear_table(self):
         self.rebuild_table()
 

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -164,6 +164,9 @@ class IndicatorESAdapter(IndicatorAdapter):
     def refresh_table(self):
         self.es.indices.refresh(index=self.table_name)
 
+    def clear_table(self):
+        self.rebuild_table()
+
     def get_query_object(self):
         return ESAlchemy(self.table_name, self.config)
 

--- a/corehq/apps/userreports/laboratory/adapter.py
+++ b/corehq/apps/userreports/laboratory/adapter.py
@@ -34,6 +34,10 @@ class IndicatorLaboratoryAdapter(IndicatorAdapter):
         self.es_adapter.refresh_table()
         self.sql_adapter.refresh_table()
 
+    def clear_table(self):
+        self.es_adapter.clear_table()
+        self.sql_adapter.clear_table()
+
     def get_query_object(self):
         raise NotImplementedError
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -59,6 +59,12 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         # SQL is always fresh
         pass
 
+    def clear_table(self):
+        table = self.get_table()
+        with self.engine.begin() as connection:
+            delete = table.delete()
+            connection.execute(delete)
+
     def get_query_object(self):
         """
         Get a sqlalchemy query object ready to query this table

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -9,6 +9,7 @@ from corehq.apps.userreports.sql.columns import column_to_sql
 from corehq.apps.userreports.sql.connection import get_engine_id
 from corehq.apps.userreports.util import get_table_name
 from corehq.sql_db.connections import connection_manager
+from corehq.util.test_utils import unit_testing_only
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.logging import notify_exception
 
@@ -59,6 +60,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         # SQL is always fresh
         pass
 
+    @unit_testing_only
     def clear_table(self):
         table = self.get_table()
         with self.engine.begin() as connection:


### PR DESCRIPTION
@dimagi/test-team I looked at this briefly for the test team day, but it's pretty complicated to do this on most tests. Most tests are currently creating different data sources for each test, but some look like they could be combined as one.

There are really big gains per test if we can decrease the amount of rebuilding we do

before: `Ran 4 tests in 26.804s`
after: `Ran 8 tests in 8.489s`

@gcapalbo @benrudolph 