### PR TITLE
Convert timestamp in UCR metadata to domain's timzone

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -5,6 +5,8 @@ from StringIO import StringIO
 
 from datetime import datetime
 
+import pytz
+
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.reports.util import \
     DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER
@@ -18,6 +20,7 @@ from corehq.apps.style.decorators import (
 )
 from corehq.apps.userreports.const import REPORT_BUILDER_EVENTS_KEY, \
     DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE, UCR_LABORATORY_BACKEND
+from corehq.util.timezones.utils import get_timezone_for_domain
 from couchexport.shortcuts import export_response
 
 from corehq.toggles import DISABLE_COLUMN_LIMIT_IN_UCR, INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS
@@ -524,11 +527,12 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
         ]
 
         if INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS.enabled(self.domain):
+            time_zone = get_timezone_for_domain(self.domain)
             export_table.append([
                 'metadata',
                 [
                     [_('Report Name'), self.title],
-                    [_('Generated On'), datetime.utcnow().strftime('%Y-%m-%d %H:%M')],
+                    [_('Generated On'), datetime.now(pytz.UTC).astimezone(time_zone).strftime('%Y-%m-%d %H:%M')],
                 ] + list(self._get_filter_values())
             ])
         return export_table


### PR DESCRIPTION
A feature flag allows UCRs that are exported to excel to include a sheet of metadata, including the time at which the report was generated. This time was in UTC, but this converts the time to the domain's timezone.
@kaapstorm 