### PR TITLE
Atwho items indicator

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -385,8 +385,7 @@ function ComboboxEntry(question, options) {
                     });
                     $atwhoView = $('.atwho-container .atwho-view');
                     $atwhoView.attr({
-                        'data-showing': Math.min(limit, results.length),
-                        'data-total': results.length,
+                        'data-message': 'Showing ' + Math.min(limit, results.length) + ' of ' + results.length,
                     });
                     return results;
                 },

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -91,6 +91,7 @@ EntrySingleAnswer = function(question, options) {
     Entry.call(self, question, options);
     self.valueUpdate = undefined;
     self.rawAnswer = ko.observable(question.answer() || Formplayer.Const.NO_ANSWER);
+    self.placeholderText = '';
 
     self.rawAnswer.subscribe(self.onPreProcess.bind(self));
 
@@ -341,6 +342,7 @@ function ComboboxEntry(question, options) {
     self.matchType = options.matchType;
     self.lengthLimit = Infinity;
     self.templateType = 'str';
+    self.placeholderText = gettext('Type to filter answers');
 
     self.options = ko.computed(function() {
         return _.map(question.choices(), function(choice, idx) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -366,7 +366,9 @@ function ComboboxEntry(question, options) {
     }
 
     self.renderAtwho = function() {
-        var $input = $('#' + self.entryId);
+        var $input = $('#' + self.entryId),
+            limit = 5,
+            $atwhoView;
         $input.atwho('destroy');
         $input.atwho('setIframe', window.frameElement, true);
         $input.atwho({
@@ -374,13 +376,19 @@ function ComboboxEntry(question, options) {
             data: self.options(),
             maxLen: Infinity,
             tabSelectsMatch: false,
-            limit: 10,
+            limit: limit,
             suffix: '',
             callbacks: {
                 filter: function(query, data) {
-                    return _.filter(data, function(item) {
+                    var results = _.filter(data, function(item) {
                         return ComboboxEntry.filter(query, item, self.matchType);
                     });
+                    $atwhoView = $('.atwho-container .atwho-view');
+                    $atwhoView.attr({
+                        'data-showing': Math.min(limit, results.length),
+                        'data-total': results.length,
+                    });
+                    return results;
                 },
                 matcher: function() {
                     return $input.val();

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -386,12 +386,13 @@
 </script>
 
 <script type="text/html" id="str-entry-ko-template">
-    <input type="text" class="form-control" data-bind="
+    <input autocomplete="off" type="text" class="form-control" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
         attr: {
             maxlength: lengthLimit,
             id: entryId,
+            placeholder: placeholderText
         }
     "/>
     <span class="help-block type" data-bind="

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -13,4 +13,5 @@
   height: 20px;
   display: block;
   text-align: center;
+  margin-top: 4px;
 }

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -9,9 +9,8 @@
 
 .atwho-view:after {
   text-align: center;
-  content: "Showing " attr(data-showing) " of " attr(data-total);
-  height: 20px;
+  content: attr(data-message);
   display: block;
   text-align: center;
-  margin-top: 4px;
+  line-height: 20px;
 }

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -6,3 +6,11 @@
   text-decoration: none;
   outline: 0;
 }
+
+.atwho-view:after {
+  text-align: center;
+  content: "Showing " attr(data-showing) " of " attr(data-total);
+  height: 20px;
+  display: block;
+  text-align: center;
+}


### PR DESCRIPTION
@czue @dimagi/ux made some adjustments to address the usability of the combobox in web apps.

first commit adds place holder text:

<img width="441" alt="screen shot 2017-03-01 at 10 18 12 am" src="https://cloud.githubusercontent.com/assets/918514/23452112/a982d722-fe6b-11e6-9f31-79c20f498aa5.png">

second commit adds an indicator of how many items are showing (i also dropped the number of items showing down to 5 from 10 because i didn't like the scroll bar that was being created)

<img width="758" alt="screen shot 2017-03-01 at 10 40 14 am" src="https://cloud.githubusercontent.com/assets/918514/23452132/c06c91bc-fe6b-11e6-885b-5ce537ead060.png">

cc: @snopoke 