### PR TITLE
soft delete ucr data sources / reports

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -44,7 +44,7 @@ from corehq.pillows.utils import get_deleted_doc_types
 from corehq.util.couch import get_document_or_not_found, DocumentNotFound
 from dimagi.utils.couch.bulk import get_docs
 from dimagi.utils.couch.database import iter_docs
-from dimagi.utils.couch.undo import DELETED_SUFFIX
+from dimagi.utils.couch.undo import get_deleted_doc_type
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.mixins import UnicodeMixIn
 from django.conf import settings
@@ -108,7 +108,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         super(DataSourceConfiguration, self).save(**params)
 
     def soft_delete(self):
-        self.doc_type += DELETED_SUFFIX
+        self.doc_type = get_deleted_doc_type(self)
         self.save()
 
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -44,6 +44,7 @@ from corehq.pillows.utils import get_deleted_doc_types
 from corehq.util.couch import get_document_or_not_found, DocumentNotFound
 from dimagi.utils.couch.bulk import get_docs
 from dimagi.utils.couch.database import iter_docs
+from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.mixins import UnicodeMixIn
 from django.conf import settings
@@ -105,6 +106,11 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     def save(self, **params):
         self.last_modified = datetime.utcnow()
         super(DataSourceConfiguration, self).save(**params)
+
+    def soft_delete(self):
+        self.doc_type += DELETED_SUFFIX
+        self.save()
+
 
     def filter(self, document):
         filter_fn = self._get_main_filter()

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -44,7 +44,6 @@ from corehq.pillows.utils import get_deleted_doc_types
 from corehq.util.couch import get_document_or_not_found, DocumentNotFound
 from dimagi.utils.couch.bulk import get_docs
 from dimagi.utils.couch.database import iter_docs
-from dimagi.utils.couch.undo import get_deleted_doc_type
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.mixins import UnicodeMixIn
 from django.conf import settings
@@ -106,11 +105,6 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     def save(self, **params):
         self.last_modified = datetime.utcnow()
         super(DataSourceConfiguration, self).save(**params)
-
-    def soft_delete(self):
-        self.doc_type = get_deleted_doc_type(self)
-        self.save()
-
 
     def filter(self, document):
         filter_fn = self._get_main_filter()

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -50,10 +50,6 @@
             adjustToggleAppearance();
         });
         {% endif %}
-        $('.btn-danger').click(function (e) {
-            var warning = "{% trans 'Are you sure you want to do this? Deleting things is permanent and not undoable!' %}";
-            return window.confirm(warning);
-        })
     });
 </script>
 {% endblock %}

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -21,8 +21,8 @@ from corehq.apps.userreports.views import (
     data_source_status,
     choice_list_api,
     ExpressionDebuggerView,
-    evaluate_expression
-)
+    evaluate_expression,
+    undelete_data_source)
 
 urlpatterns = [
     url(r'^$', UserConfigReportsHomeView.as_view(),
@@ -44,6 +44,8 @@ urlpatterns = [
     url(r'^data_sources/source/(?P<config_id>[\w-]+)/$', data_source_json, name='configurable_data_source_json'),
     url(r'^data_sources/delete/(?P<config_id>[\w-]+)/$', delete_data_source,
         name='delete_configurable_data_source'),
+    url(r'^data_sources/undelete/(?P<config_id>[\w-]+)/$', undelete_data_source,
+        name='undo_delete_data_source'),
     url(r'^data_sources/rebuild/(?P<config_id>[\w-]+)/$', rebuild_data_source,
         name='rebuild_configurable_data_source'),
     url(r'^data_sources/resume/(?P<config_id>[\w-]+)/$', resume_building_data_source,

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -22,7 +22,7 @@ from corehq.apps.userreports.views import (
     choice_list_api,
     ExpressionDebuggerView,
     evaluate_expression,
-    undelete_data_source)
+    undelete_data_source, undelete_report)
 
 urlpatterns = [
     url(r'^$', UserConfigReportsHomeView.as_view(),
@@ -35,6 +35,7 @@ urlpatterns = [
         name=EditConfigReportView.urlname),
     url(r'^reports/source/(?P<report_id>[\w-]+)/$', report_source_json, name='configurable_report_json'),
     url(r'^reports/delete/(?P<report_id>[\w-]+)/$', delete_report, name='delete_configurable_report'),
+    url(r'^reports/undelete/(?P<report_id>[\w-]+)/$', undelete_report, name='undo_delete_configurable_report'),
     url(r'^data_sources/create/$', CreateDataSourceView.as_view(),
         name=CreateDataSourceView.urlname),
     url(r'^data_sources/create_from_app/$', CreateDataSourceFromAppView.as_view(),

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -40,7 +40,7 @@ from couchexport.export import export_from_tables
 from couchexport.files import Temp
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
-from dimagi.utils.couch.undo import get_deleted_doc_type, is_deleted, undo_delete
+from dimagi.utils.couch.undo import get_deleted_doc_type, is_deleted, undo_delete, soft_delete
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
@@ -1063,7 +1063,7 @@ def delete_data_source_shared(domain, config_id, request=None):
     config = get_document_or_404(DataSourceConfiguration, domain, config_id)
     adapter = get_indicator_adapter(config)
     adapter.drop_table()
-    config.soft_delete()
+    soft_delete(config)
     if request:
         messages.success(
             request,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -787,13 +787,16 @@ class ConfigureMapReport(ConfigureChartReport):
         return ConfigureMapReportForm
 
 
-def delete_report(request, domain, report_id):
+def _assert_report_delete_privileges(request):
     if not (toggle_enabled(request, toggles.USER_CONFIGURABLE_REPORTS)
             or toggle_enabled(request, toggles.REPORT_BUILDER)
             or toggle_enabled(request, toggles.REPORT_BUILDER_BETA_GROUP)
             or has_report_builder_add_on_privilege(request)):
         raise Http404()
 
+
+def delete_report(request, domain, report_id):
+    _assert_report_delete_privileges(request)
     config = get_document_or_404(ReportConfiguration, domain, report_id)
 
     # Delete the data source too if it's not being used by any other reports.

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1062,7 +1062,7 @@ def delete_data_source_shared(domain, config_id, request=None):
     config = get_document_or_404(DataSourceConfiguration, domain, config_id)
     adapter = get_indicator_adapter(config)
     adapter.drop_table()
-    config.delete()
+    config.soft_delete()
     if request:
         messages.success(
             request,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -807,7 +807,7 @@ def delete_report(request, domain, report_id):
             # No other reports reference this data source.
             data_source.deactivate()
 
-    config.delete()
+    soft_delete(config)
     did_purge_something = purge_report_from_mobile_ucr(config)
 
     messages.success(request, _(u'Report "{}" deleted!').format(config.title))

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -813,12 +813,14 @@ def delete_report(request, domain, report_id):
     soft_delete(config)
     did_purge_something = purge_report_from_mobile_ucr(config)
 
-    messages.success(request, _(u'Report "{name}" has been deleted. <a href="{url}" class="post-link">Undo</a>').format(
-                name=config.title,
-                url=reverse('undo_delete_configurable_report', args=[domain, config._id]),
-            ),
-            extra_tags='html'
-        )
+    messages.success(
+        request,
+        _(u'Report "{name}" has been deleted. <a href="{url}" class="post-link">Undo</a>').format(
+            name=config.title,
+            url=reverse('undo_delete_configurable_report', args=[domain, config._id]),
+        ),
+        extra_tags='html'
+    )
     if did_purge_something:
         messages.warning(
             request,
@@ -1097,6 +1099,7 @@ def delete_data_source_shared(domain, config_id, request=None):
             ),
             extra_tags='html'
         )
+
 
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 @require_POST

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1080,7 +1080,6 @@ def delete_data_source_shared(domain, config_id, request=None):
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 @require_POST
 def undelete_data_source(request, domain, config_id):
-    print get_deleted_doc_type(DataSourceConfiguration)
     config = get_document_or_404(DataSourceConfiguration, domain, config_id, additional_doc_types=[
         get_deleted_doc_type(DataSourceConfiguration)
     ])


### PR DESCRIPTION
this seems way better in case you accidentally delete something you put a lot of work into.

@NoahCarnahan saw this on my todo list and after our conversation yesterday decided to just do it.

also works with report builder

cc @calellowitz review by commit

cross: https://github.com/dimagi/dimagi-utils/pull/397