### PR TITLE
fix errors in query using columns that contain ")" char

### DIFF
--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -87,7 +87,11 @@ class ChoiceListColumnDbTest(TestCase):
             "display_name": "practicing_lessons",
             "property_name": "long_column",
             "choices": [
-                "duplicate_choice_1",
+                # test for regression:
+                # with sqlalchemy paramstyle='pyformat' (default)
+                # some queries that included columns with ')' in the column name
+                # would fail with a very cryptic message
+                "duplicate_choice_1(s)",
                 "duplicate_choice_2",
             ],
             "select_style": "multiple",
@@ -109,7 +113,7 @@ class ChoiceListColumnDbTest(TestCase):
             '_id': uuid.uuid4().hex,
             'domain': 'test',
             'doc_type': 'CommCareCase',
-            'long_column': 'duplicate_choice_1',
+            'long_column': 'duplicate_choice_1(s)',
         })
         adapter.refresh_table()
         # and query it back

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -12,9 +12,11 @@ ICDS_UCR_ENGINE_ID = 'icds-ucr'
 
 
 def create_engine(connection_string=None):
-    # todo: this function is just a proxy for the sqlalchemy version and should be removed
     connection_string = connection_string or settings.SQL_REPORTING_DATABASE_URL
-    return sqlalchemy.create_engine(connection_string)
+    # paramstyle='format' allows you to use column names that include the ')' character
+    # otherwise queries will sometimes be misformated/error when formatting
+    # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
+    return sqlalchemy.create_engine(connection_string, paramstyle='format')
 
 
 class SessionHelper(object):


### PR DESCRIPTION
Man this was an annoying bug with a really satisfying resolution! https://manage.dimagi.com/default.asp?248511

Basically, postgres (and sqlachemy) support column names that include the character ')' (among other things), but if you then form an insert query using that column, such as

```python
query = table.insert().values({'relative(s)': 0})  # 'relative(s)' is the column name
connection.execute(query)
```

then the execute command will fail with `KeyError('relative(s')` (_sic_, missing closing paren).

@emord and I were finally able trace it back to the fact that there's an intermediate representation that is basically `'INSERT INTO table ("relative(s)") VALUES (%(relative(s))s)'` that gets interpolated with`{'relative(s)': 0}`. The formatter then can't parse `%(relative(s))s` and takes the first closing paren as the matching paren rather than the second.

After figuring that out, we found https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173, which explains exactly this problem and how to get around it. I chose the method of globally setting `paramstyle='format'` on connections, which that documentation did not mention any drawbacks for. If tests pass, then I think it's fair to assume that it works the way I think it does and that it doesn't have drawbacks (other than readability of the intermediate format). As far as I understand there are two values you can use for that param: 'pyformat' which works often, and 'format' which works always. Working often was the default.