### PR TITLE
pull rebuild to the right

### DIFF
--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -19,7 +19,7 @@
   {% endif %}
   <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
     {% csrf_token %}
-    <button type="submit" class="btn btn-default disable-on-submit">
+    <button type="submit" class="btn btn-default disable-on-submit pull-right">
       {% trans 'Rebuild Data Source'%}
     </button>
     <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview data' %}</a>


### PR DESCRIPTION
Move the rebuild data source next to delete data source instead of next to preview data, and view the report data source. It's a little too easy to hit rebuild data source when you're trying to preview data. not that i've done that....

@benrudolph @gcapalbo 