### PR TITLE
remove sniffing

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -38,12 +38,7 @@ def get_es_new():
             }
             for host in es_hosts
         ]
-        get_es_new._es_client = Elasticsearch(
-            hosts,
-            sniff_on_start=True,
-            sniff_on_connection_fail=True,
-            sniffer_timeout=60
-        )
+        get_es_new._es_client = Elasticsearch(hosts)
     return get_es_new._es_client
 
 


### PR DESCRIPTION
@NoahCarnahan @snopoke 

sounds like this is causing more issues than helping? thread starts here: https://github.com/dimagi/commcare-hq/pull/15124#issuecomment-282340245

I've also noticed some 500s `ERROR: ESError: TransportError(N/A, 'Unable to sniff hosts.')`

@benrudolph @gcapalbo 