### PR TITLE
Use server environment

### DIFF
--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -136,7 +136,7 @@ class DomainDashboardView(JSONResponseMixin, BaseDashboardView):
                 'slug': d.slug,
                 'ng_directive': d.ng_directive,
             } for d in self.tile_configs],
-            'is_icds': settings.HQ_INSTANCE == 'icds',
+            'is_icds': settings.SERVER_ENVIRONMENT == 'icds',
         }
 
     def make_tile(self, slug, in_data):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?248801#1297075

I had done this before. but I think at some point we moved from HQ_INSTANCE to SERVER_ENVIRONMENT?

looks like HQ_INSTANCE is only used for analytics

@gcapalbo @benrudolph 
