### PR TITLE
nikshay patient registration repeater to pick non-test submissions

### DIFF
--- a/corehq/apps/cleanup/management/commands/fire_repeaters.py
+++ b/corehq/apps/cleanup/management/commands/fire_repeaters.py
@@ -19,5 +19,4 @@ class Command(BaseCommand):
         records = RepeatRecord.all(domain=domain, due_before=next_year)
         for record in records:
             record.fire(post_fn=simple_post)
-            record.save()
             print('{} {}'.format(record._id, 'successful' if record.succeeded else 'failed'))

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -558,6 +558,7 @@ class RepeatRecord(Document):
             tries = 0
             post_info = PostInfo(self.get_payload(), headers, force_send, max_tries)
             self.post(post_info, tries=tries)
+            self.save()
 
     def post(self, post_info, tries=0):
         tries += 1

--- a/corehq/apps/repeaters/tasks.py
+++ b/corehq/apps/repeaters/tasks.py
@@ -62,8 +62,7 @@ def process_repeat_record(repeat_record):
             if not repeat_record.doc_type.endswith(DELETED_SUFFIX):
                 repeat_record.doc_type += DELETED_SUFFIX
                 repeat_record.save()
-        else:
-            if repeat_record.state == RECORD_PENDING_STATE or repeat_record.state == RECORD_FAILURE_STATE:
+        elif repeat_record.state == RECORD_PENDING_STATE or repeat_record.state == RECORD_FAILURE_STATE:
                 repeat_record.fire()
     except Exception:
         logging.exception('Failed to process repeat record: {}'.format(repeat_record._id))

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -139,7 +139,6 @@ class RepeaterTest(BaseRepeaterTest):
                     return_value=MockResponse(status_code=404, reason='Not Found')) as mock_post:
                 repeat_record.fire()
                 self.assertEqual(mock_post.call_count, 3)
-            repeat_record.save()
 
         next_check_time = now() + timedelta(minutes=60)
 
@@ -186,7 +185,6 @@ class RepeaterTest(BaseRepeaterTest):
                     force_send=False,
                     timeout=POST_TIMEOUT,
                 )
-            repeat_record.save()
 
         # The following is pretty fickle and depends on which of
         #   - corehq.apps.repeaters.signals

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -248,7 +248,6 @@ class RepeaterTest(BaseRepeaterTest):
             for repeat_record in RepeatRecord.all():
                 self.assertEqual(repeat_record.state, RECORD_SUCCESS_STATE)
 
-
     @run_with_all_backends
     def test_process_repeat_record_locking(self):
         self.assertEqual(len(RepeatRecord.all()), 2)

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -18,7 +18,7 @@ from corehq.apps.repeaters.models import (
     FormRepeater,
     RepeatRecord,
 )
-from corehq.apps.repeaters.const import MIN_RETRY_WAIT, POST_TIMEOUT
+from corehq.apps.repeaters.const import MIN_RETRY_WAIT, POST_TIMEOUT, RECORD_SUCCESS_STATE
 from corehq.apps.repeaters.dbaccessors import delete_all_repeat_records
 from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
@@ -215,6 +215,39 @@ class RepeaterTest(BaseRepeaterTest):
         with patch('corehq.apps.repeaters.models.simple_post_with_cached_timeout') as mock_fire:
             check_repeaters()
             self.assertEqual(mock_fire.call_count, 0)
+
+    @run_with_all_backends
+    def test_repeat_record_status_check(self):
+        self.assertEqual(len(RepeatRecord.all()), 2)
+
+        # Do not trigger cancelled records
+        for repeat_record in RepeatRecord.all():
+            repeat_record.cancelled = True
+            repeat_record.save()
+        with patch('corehq.apps.repeaters.models.simple_post_with_cached_timeout') as mock_fire:
+            check_repeaters()
+            self.assertEqual(mock_fire.call_count, 0)
+
+        # trigger force send records if not cancelled and tries not exhausted
+        for repeat_record in RepeatRecord.all():
+            with patch('corehq.apps.repeaters.models.simple_post_with_cached_timeout',
+                       return_value=MockResponse(status_code=200, reason='')
+                       ) as mock_fire:
+                repeat_record.fire(force_send=True)
+                self.assertEqual(mock_fire.call_count, 1)
+
+        # all records should be in SUCCESS state after force try
+        for repeat_record in RepeatRecord.all():
+                self.assertEqual(repeat_record.state, RECORD_SUCCESS_STATE)
+                self.assertEqual(repeat_record.overall_tries, 1)
+
+        # not trigger records succeeded triggered after cancellation
+        with patch('corehq.apps.repeaters.models.simple_post_with_cached_timeout') as mock_fire:
+            check_repeaters()
+            self.assertEqual(mock_fire.call_count, 0)
+            for repeat_record in RepeatRecord.all():
+                self.assertEqual(repeat_record.state, RECORD_SUCCESS_STATE)
+
 
     @run_with_all_backends
     def test_process_repeat_record_locking(self):

--- a/corehq/apps/repeaters/views.py
+++ b/corehq/apps/repeaters/views.py
@@ -64,7 +64,6 @@ class RepeatRecordView(View):
         # Retriggers a repeat record
         record = RepeatRecord.get(request.POST.get('record_id'))
         record.fire(max_tries=1, force_send=True)
-        record.save()
         return json_response({
             'success': record.succeeded,
             'failure_reason': record.failure_reason,

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -50,7 +50,7 @@ def test_submission(episode_case):
     except SQLLocation.DoesNotExist:
         raise NikshayLocationNotFound(
             "Location with id {location_id} not found. This is the owner for person with id: {person_id}"
-                .format(location_id=person_case.owner_id, person_id=person_case.case_id)
+            .format(location_id=person_case.owner_id, person_id=person_case.case_id)
         )
     return phi_location.metadata.get('is_test', "yes") == "yes"
 

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -1,5 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
+
+from corehq.apps.locations.models import SQLLocation
 from corehq.apps.repeaters.models import CaseRepeater
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.toggles import NIKSHAY_INTEGRATION
@@ -8,6 +10,8 @@ from casexml.apps.case.xform import get_case_updates
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.signals import case_post_save
 from corehq.apps.repeaters.signals import create_repeat_records
+from custom.enikshay.case_utils import get_person_case_from_episode
+from custom.enikshay.exceptions import NikshayLocationNotFound
 
 
 class NikshayRegisterPatientRepeater(CaseRepeater):
@@ -34,8 +38,21 @@ class NikshayRegisterPatientRepeater(CaseRepeater):
         return allowed_case_types_and_users and (
             not episode_case_properties.get('nikshay_registered', 'false') == 'true' and
             not episode_case_properties.get('nikshay_id', False) and
-            episode_pending_registration_changed(episode_case)
+            episode_pending_registration_changed(episode_case) and
+            not test_submission(episode_case)
         )
+
+
+def test_submission(episode_case):
+    person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
+    try:
+        phi_location = SQLLocation.objects.get(location_id=person_case.owner_id)
+    except SQLLocation.DoesNotExist:
+        raise NikshayLocationNotFound(
+            "Location with id {location_id} not found. This is the owner for person with id: {person_id}"
+                .format(location_id=person_case.owner_id, person_id=person_case.case_id)
+        )
+    return phi_location.metadata.get('is_test', "yes") == "yes"
 
 
 def episode_pending_registration_changed(case):

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -196,6 +196,7 @@ class ENikshayLocationStructureMixin(object):
         self.phi = locations['PHI']
         self.phi.metadata = {
             'nikshay_code': '2',
+            'is_test': 'no',
         }
         self.phi.save()
         super(ENikshayLocationStructureMixin, self).setUp()


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?248743

1. Send patients registrations to nikshay only when submitted by non-test location
2. update repeaters to fire only when state is pending or failure. This is needed coz the repeat records are getting fired even in cancelled state. Not the best fix though.

Best reviewed 🐟 / 🐟 