### PR TITLE
Move where metrics are being recorded

### DIFF
--- a/corehq/ex-submodules/pillowtop/feed/couch.py
+++ b/corehq/ex-submodules/pillowtop/feed/couch.py
@@ -36,6 +36,10 @@ class CouchChangeFeed(ChangeFeed):
     def get_checkpoint_value(self):
         return str(self.get_latest_change_id())
 
+    @property
+    def couch_db(self):
+        return self._couch_db
+
 
 def change_from_couch_row(couch_change, document_store=None):
     return Change(

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -124,17 +124,24 @@ class PillowBase(object):
     def fire_change_processed_event(self, change, context):
         pass
 
-    def _record_checkpoint_in_datadog(self):
+    def _normalize_checkpoint_sequence(self):
         sequence = self.get_last_checkpoint_sequence()
         change_feed = self.get_change_feed()
+
         if not isinstance(sequence, dict):
             topics = change_feed.topics
             assert len(topics) == 1
             sequence = {topics[0]: int(sequence)}
+        return sequence
 
+    def _record_checkpoint_in_datadog(self):
         datadog_counter('commcare.change_feed.change_feed.checkpoint', tags=[
             'pillow_name:{}'.format(self.get_name()),
         ])
+
+    def _record_change_in_datadog(self, change):
+        change_feed = self.get_change_feed()
+        sequence = self._normalize_checkpoint_sequence()
 
         for topic, value in sequence.iteritems():
             datadog_gauge('commcare.change_feed.processed_offsets'.format(topic), value, tags=[
@@ -148,7 +155,6 @@ class PillowBase(object):
                 'topic:{}'.format(topic),
             ])
 
-    def _record_change_in_datadog(self, change):
         self.__record_change_metric_in_datadog('commcare.change_feed.changes.count', change)
 
     def _record_change_success_in_datadog(self, change):

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -128,6 +128,9 @@ class PillowBase(object):
         from pillowtop.feed.couch import CouchChangeFeed
         from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 
+        if self.checkpoint is None:
+            return {}
+
         sequence = self.get_last_checkpoint_sequence()
         change_feed = self.get_change_feed()
 


### PR DESCRIPTION
It seems that the checkpoint doesn't get called too often, so i've moved where we record the current_offsets to be updated every time we process a change. Edit: this might've been erroring more than I had thought which might've caused the metrics not to be recorded