### PR TITLE
Redo soft rollout modal

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
@@ -166,8 +166,7 @@
 {% block modals %}
     {{ block.super }}
     {% with slug="vellum_beta" name="New Form Builder" %}
-    {% initial_page_data "toggle_item" toggle_item %}
-    {% initial_page_data "toggle_url" toggle_url %}
+    {% registerurl "enable_vellum_beta" %}
     {% if not request|toggle_enabled:'VELLUM_BETA' %}
         <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
         <div class="modal rollout-modal" data-slug="{{ slug }}">

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
@@ -279,8 +279,7 @@
 {% block modals %}
     {{ block.super }}
     {% with slug="vellum_beta" name="New Form Builder" %}
-    {% initial_page_data "toggle_item" toggle_item %}
-    {% initial_page_data "toggle_url" toggle_url %}
+    {% registerurl "enable_vellum_beta" %}
     {% if not request|toggle_enabled:'VELLUM_BETA' %}
         <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
         <div class="modal rollout-modal" data-slug="{{ slug }}">

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -9,7 +9,6 @@ from django.shortcuts import render
 from django.views.decorators.http import require_GET
 from django.conf import settings
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from corehq.apps.app_manager.views.apps import get_apps_base_context
 from corehq.apps.app_manager.views.notifications import get_facility_for_form, notify_form_opened
 
@@ -39,7 +38,6 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.analytics.tasks import track_entered_form_builder_on_hubspot
 from corehq.apps.analytics.utils import get_meta
-from corehq.apps.toggle_ui.views import ToggleEditView
 from corehq.apps.tour import tours
 from corehq.apps.analytics import ab_tests
 from corehq.apps.domain.models import Domain
@@ -156,8 +154,6 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
         'include_fullstory': include_fullstory,
         'notifications_enabled': request.user.is_superuser,
         'notify_facility': get_facility_for_form(domain, app_id, form.unique_id),
-        'toggle_url': reverse(ToggleEditView.urlname, args=["vellum_beta"]),
-        'toggle_item': request.user.username,
     })
     notify_form_opened(domain, request.couch_user, app_id, form.unique_id)
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/rollout_modal.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/rollout_modal.js
@@ -4,8 +4,7 @@ hqDefine("hqwebapp/js/rollout_modal.js", function() {
         var $modal = $(".rollout-modal"),
             slug = $modal.data("slug"),
             cookie_name = "snooze_" + slug;
-        if (false && $modal.length && !$.cookie(cookie_name)) {
-            var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
+        if ($modal.length && !$.cookie(cookie_name)) {
             $modal.modal({
                 backdrop: 'static',
                 keyboard: false,
@@ -13,11 +12,7 @@ hqDefine("hqwebapp/js/rollout_modal.js", function() {
             });
             $modal.on('click', '.flag-enable', function() {
                 $.post({
-                    url: initial_page_data("toggle_url"),
-                    data: {
-                        item_list: JSON.stringify([initial_page_data("toggle_item")]),
-                        append: 1,
-                    },
+                    url: hqImport("hqwebapp/js/urllib.js").reverse("enable_vellum_beta"),
                     success: function() {
                         window.location.reload(true);
                     },

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url
 
-from corehq.apps.toggle_ui.views import ToggleListView, ToggleEditView
+from corehq.apps.toggle_ui.views import ToggleListView, ToggleEditView, enable_vellum_beta
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
+    url(r'^enable_vellum_beta/$', enable_vellum_beta, name="enable_vellum_beta"),
 ]

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -119,9 +119,7 @@ class ToggleEditView(ToggleBaseView):
         """
         Returns the corresponding toggle definition from corehq/toggles.py
         """
-        for toggle in all_toggles():
-            if toggle.slug == self.toggle_slug:
-                return toggle
+        return _find_static_toggle(self.toggle_slug)
 
     def get_toggle(self):
         if not self.static_toggle:
@@ -157,39 +155,20 @@ class ToggleEditView(ToggleBaseView):
             context['last_used'] = _get_usage_info(toggle)
         return context
 
-    def call_save_fn_and_clear_cache(self, toggle_slug, changed_entries, currently_enabled):
-        for entry in changed_entries:
-            enabled = entry in currently_enabled
-            namespace, entry = parse_toggle(entry)
-            if namespace == NAMESPACE_DOMAIN:
-                domain = entry
-                if self.static_toggle.save_fn is not None:
-                    self.static_toggle.save_fn(domain, enabled)
-                toggle_js_domain_cachebuster.clear(domain)
-            else:
-                # these are sent down with no namespace
-                assert ':' not in entry, entry
-                username = entry
-                toggle_js_user_cachebuster.clear(username)
-
-            clear_toggle_cache(toggle_slug, entry, namespace=namespace)
-
     def post(self, request, *args, **kwargs):
         toggle = self.get_toggle()
         item_list = request.POST.get('item_list', [])
         if item_list:
             item_list = json.loads(item_list)
             item_list = [u.strip() for u in item_list if u and u.strip()]
-            if request.POST.get('append', None):
-                item_list.extend(toggle.enabled_users)
 
         previously_enabled = set(toggle.enabled_users)
         currently_enabled = set(item_list)
-        toggle.enabled_users = list(currently_enabled)
+        toggle.enabled_users = item_list
         toggle.save()
 
         changed_entries = previously_enabled ^ currently_enabled  # ^ means XOR
-        self.call_save_fn_and_clear_cache(toggle.slug, changed_entries, currently_enabled)
+        _call_save_fn_and_clear_cache(toggle.slug, changed_entries, currently_enabled, self.static_toggle)
 
         data = {
             'items': item_list
@@ -197,6 +176,44 @@ class ToggleEditView(ToggleBaseView):
         if self.usage_info:
             data['last_used'] = _get_usage_info(toggle)
         return HttpResponse(json.dumps(data), content_type="application/json")
+
+
+def enable_vellum_beta(request):
+    slug = "vellum_beta"
+    toggle = Toggle.get(slug)
+
+    changed_entries = []
+    if request.user.username not in toggle.enabled_users:
+        changed_entries.append(request.user.username)
+        toggle.enabled_users.append(request.user.username)
+        toggle.save()
+        _call_save_fn_and_clear_cache(slug, changed_entries, toggle.enabled_users, _find_static_toggle(slug))
+
+    return HttpResponse(json.dumps({'success': True}), content_type="application/json")
+
+
+def _find_static_toggle(slug):
+    for toggle in all_toggles():
+        if toggle.slug == slug:
+            return toggle
+
+
+def _call_save_fn_and_clear_cache(toggle_slug, changed_entries, currently_enabled, static_toggle):
+    for entry in changed_entries:
+        enabled = entry in currently_enabled
+        namespace, entry = parse_toggle(entry)
+        if namespace == NAMESPACE_DOMAIN:
+            domain = entry
+            if static_toggle.save_fn is not None:
+                static_toggle.save_fn(domain, enabled)
+            toggle_js_domain_cachebuster.clear(domain)
+        else:
+            # these are sent down with no namespace
+            assert ':' not in entry, entry
+            username = entry
+            toggle_js_user_cachebuster.clear(username)
+
+        clear_toggle_cache(toggle_slug, entry, namespace=namespace)
 
 
 def _get_usage_info(toggle):


### PR DESCRIPTION
@millerdev / @emord 

https://github.com/dimagi/commcare-hq/pull/15207 didn't work because it turned on the `vellum_beta` flag by issuing a POST to the standard edit feature flags url, which 403s for non-admins. This makes a separate view that's publicly available but only has the ability to enable the `vellum_beta` flag.

Would like to get this into today's deploy.