### PR TITLE
call center case owner

### DIFF
--- a/corehq/apps/callcenter/const.py
+++ b/corehq/apps/callcenter/const.py
@@ -83,3 +83,5 @@ PER_DOMAIN_FORM_INDICATORS = {
         'HomeVisitForms': {'type': TYPE_SUM, 'xmlns': CDC_NormalVisit},
     },
 }
+
+CALLCENTER_USER = 'callcenter-system'

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -14,11 +14,10 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.signals import commcare_domain_post_save
 from corehq.apps.users.models import CommCareUser
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase, SimpleTestCase, override_settings
 
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted
@@ -29,50 +28,48 @@ TEST_DOMAIN = 'cc_util_test'
 CASE_TYPE = 'cc_flw'
 
 
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
 class CallCenterUtilsTests(TestCase):
-
     @classmethod
     def setUpClass(cls):
+        super(CallCenterUtilsTests, cls).setUpClass()
         cls.domain = create_domain(TEST_DOMAIN)
-        user = CommCareUser.create(TEST_DOMAIN, 'user1', '***')
-        cls.user_id = user.user_id
+        cls.user = CommCareUser.create(TEST_DOMAIN, 'user1', '***')
+        cls.user_id = cls.user.user_id
 
         cls.domain.call_center_config.enabled = True
-        cls.domain.call_center_config.case_owner_id = user.user_id
+        cls.domain.call_center_config.case_owner_id = cls.user.user_id
         cls.domain.call_center_config.case_type = CASE_TYPE
         cls.domain.save()
 
     @classmethod
     def tearDownClass(cls):
-        CommCareUser.get(cls.user_id).delete()
+        cls.user.delete()
         cls.domain.delete()
-
-    def setUp(self):
-        self.user = CommCareUser.get(self.user_id)
+        super(CallCenterUtilsTests, cls).tearDownClass()
 
     def tearDown(self):
         delete_all_cases()
 
-    @run_with_all_backends
     def test_sync(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
         self.assertIsNotNone(case)
-        self.assertEquals(case.name, self.user.username)
-        self.assertEquals(case.get_case_property('username'), self.user.raw_username)
+        self.assertEqual(case.name, self.user.username)
+        self.assertEqual(case.get_case_property('username'), self.user.raw_username)
         self.assertIsNotNone(case.get_case_property('language'))
         self.assertIsNotNone(case.get_case_property('phone_number'))
 
-    @run_with_all_backends
     def test_sync_full_name(self):
+        other_user = CommCareUser.create(TEST_DOMAIN, 'user7', '***')
+        self.addCleanup(other_user.delete)
         name = 'Ricky Bowwood'
-        self.user.set_full_name(name)
-        sync_call_center_user_case(self.user)
-        case = self._get_user_case()
+        other_user.set_full_name(name)
+        sync_call_center_user_case(other_user)
+        case = self._get_user_case(other_user._id)
         self.assertIsNotNone(case)
-        self.assertEquals(case.name, name)
+        self.assertEqual(case.name, name)
 
-    @run_with_all_backends
     def test_sync_inactive(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
@@ -83,7 +80,6 @@ class CallCenterUtilsTests(TestCase):
         case = self._get_user_case()
         self.assertTrue(case.closed)
 
-    @run_with_all_backends
     def test_sync_retired(self):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
@@ -94,20 +90,20 @@ class CallCenterUtilsTests(TestCase):
         case = self._get_user_case()
         self.assertTrue(case.closed)
 
-    @run_with_all_backends
     def test_sync_update_update(self):
-        sync_call_center_user_case(self.user)
-        case = self._get_user_case()
+        other_user = CommCareUser.create(TEST_DOMAIN, 'user2', '***')
+        self.addCleanup(other_user.delete)
+        sync_call_center_user_case(other_user)
+        case = self._get_user_case(other_user._id)
         self.assertIsNotNone(case)
-        self.assertEquals(case.name, self.user.username)
+        self.assertEqual(case.name, other_user.username)
 
         name = 'Ricky Bowwood'
-        self.user.set_full_name(name)
-        sync_call_center_user_case(self.user)
-        case = self._get_user_case()
-        self.assertEquals(case.name, name)
+        other_user.set_full_name(name)
+        sync_call_center_user_case(other_user)
+        case = self._get_user_case(other_user._id)
+        self.assertEqual(case.name, name)
 
-    @run_with_all_backends
     def test_sync_custom_user_data(self):
         self.user.user_data = {
             '': 'blank_key',
@@ -121,10 +117,9 @@ class CallCenterUtilsTests(TestCase):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
         self.assertIsNotNone(case)
-        self.assertEquals(case.get_case_property('blank_val'), '')
-        self.assertEquals(case.get_case_property('ok'), 'good')
+        self.assertEqual(case.get_case_property('blank_val'), '')
+        self.assertEqual(case.get_case_property('ok'), 'good')
 
-    @run_with_all_backends
     def test_get_call_center_cases_for_user(self):
         factory = CaseFactory(domain=TEST_DOMAIN, case_defaults={
             'user_id': self.user_id,
@@ -144,7 +139,6 @@ class CallCenterUtilsTests(TestCase):
         self.assertEqual(case_ids, set([c1.case_id, c2.case_id]))
         self.assertEqual(user_ids, set([self.user_id]))
 
-    @run_with_all_backends
     def test_get_call_center_cases_all(self):
         factory = CaseFactory(domain=TEST_DOMAIN, case_defaults={
             'user_id': self.user_id,
@@ -160,7 +154,6 @@ class CallCenterUtilsTests(TestCase):
         cases = get_call_center_cases(TEST_DOMAIN, CASE_TYPE)
         self.assertEqual(len(cases), 3)
 
-    @run_with_all_backends
     def test_call_center_not_default_case_owner(self):
         """
         call center case owner should not change on sync
@@ -178,23 +171,36 @@ class CallCenterUtilsTests(TestCase):
         case = self._get_user_case()
         self.assertEqual(case.owner_id, cases[0].owner_id)
 
-    def _get_user_case(self):
-        return CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, CASE_TYPE)
+    def _get_user_case(self, user_id=None):
+        return CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(user_id or self.user._id, CASE_TYPE)
 
 
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+class CallCenterUtilsTestsSQL(CallCenterUtilsTests):
+    pass
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
 class CallCenterUtilsUserCaseTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(CallCenterUtilsUserCaseTests, cls).setUpClass()
+        cls.domain = create_domain(TEST_DOMAIN)
+        cls.domain.usercase_enabled = True
+        cls.domain.save()
 
     def setUp(self):
-        self.domain = create_domain(TEST_DOMAIN)
-        self.domain.usercase_enabled = True
-        self.domain.save()
         self.user = CommCareUser.create(TEST_DOMAIN, 'user1', '***', commit=False)  # Don't commit yet
 
     def tearDown(self):
-        delete_all_cases()
-        self.domain.delete()
+        self.user.delete()
 
-    @run_with_all_backends
+    @classmethod
+    def tearDownClass(cls):
+        delete_all_cases()
+        cls.domain.delete()
+        super(CallCenterUtilsUserCaseTests, cls).tearDownClass()
+
     def test_sync_usercase_custom_user_data_on_create(self):
         """
         Custom user data should be synced when the user is created
@@ -205,9 +211,8 @@ class CallCenterUtilsUserCaseTests(TestCase):
         self.user.save()
         case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
         self.assertIsNotNone(case)
-        self.assertEquals(case.dynamic_case_properties()['completed_training'], 'yes')
+        self.assertEqual(case.dynamic_case_properties()['completed_training'], 'yes')
 
-    @run_with_all_backends
     def test_sync_usercase_custom_user_data_on_update(self):
         """
         Custom user data should be synced when the user is updated
@@ -221,9 +226,8 @@ class CallCenterUtilsUserCaseTests(TestCase):
         }
         sync_usercase(self.user)
         case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
-        self.assertEquals(case.dynamic_case_properties()['completed_training'], 'yes')
+        self.assertEqual(case.dynamic_case_properties()['completed_training'], 'yes')
 
-    @run_with_all_backends
     def test_reactivate_user(self):
         """Confirm that reactivating a user re-opens its user case."""
         self.user.save()
@@ -240,7 +244,6 @@ class CallCenterUtilsUserCaseTests(TestCase):
         user_case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
         self.assertFalse(user_case.closed)
 
-    @run_with_all_backends
     def test_update_deactivated_user(self):
         """
         Confirm that updating a deactivated user also updates the user case.
@@ -258,9 +261,8 @@ class CallCenterUtilsUserCaseTests(TestCase):
         self.user.save()
         user_case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
         self.assertTrue(user_case.closed)
-        self.assertEquals(user_case.dynamic_case_properties()['foo'], 'bar')
+        self.assertEqual(user_case.dynamic_case_properties()['foo'], 'bar')
 
-    @run_with_all_backends
     def test_update_and_reactivate_in_one_save(self):
         """
         Confirm that a usercase can be updated and reactived in a single save of the user model
@@ -282,7 +284,12 @@ class CallCenterUtilsUserCaseTests(TestCase):
         self.user.save()
         user_case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
         self.assertFalse(user_case.closed)
-        self.assertEquals(user_case.dynamic_case_properties()['foo'], 'bar')
+        self.assertEqual(user_case.dynamic_case_properties()['foo'], 'bar')
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+class CallCenterUtilsUserCaseTestsSQL(CallCenterUtilsUserCaseTests):
+    pass
 
 
 class DomainTimezoneTests(SimpleTestCase):

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.app_manager.const import USERCASE_TYPE
+from corehq.apps.callcenter.const import CALLCENTER_USER
 from corehq.apps.callcenter.utils import (
     sync_call_center_user_case,
     is_midnight_for_domain,
@@ -170,6 +171,11 @@ class CallCenterUtilsTests(TestCase):
         sync_call_center_user_case(self.user)
         case = self._get_user_case()
         self.assertEqual(case.owner_id, cases[0].owner_id)
+
+    def test_opened_by_id_is_system(self):
+        sync_call_center_user_case(self.user)
+        case = self._get_user_case()
+        self.assertEqual(case.opened_by, CALLCENTER_USER)
 
     def _get_user_case(self, user_id=None):
         return CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(user_id or self.user._id, CASE_TYPE)

--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -6,6 +6,7 @@ from casexml.apps.case.mock import CaseBlock
 import uuid
 from xml.etree import ElementTree
 from corehq.apps.app_manager.const import USERCASE_TYPE
+from corehq.apps.callcenter.const import CALLCENTER_USER
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.domains import DomainES
 from corehq.apps.es import filters
@@ -62,7 +63,7 @@ class _UserCaseHelper(object):
             create=True,
             case_id=uuid.uuid4().hex,
             owner_id=self.owner_id,
-            user_id=self.owner_id,
+            user_id=CALLCENTER_USER,
             case_type=case_type,
             case_name=fields.pop('name', None),
             update=fields


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?248322

Callcenter makes the opened by the same as the owner id which causes issues when the owner should be a group (and likely locations as well).

Used the same format for the user as we use for commtrack (`commtrack-system`)

@gcapalbo @benrudolph 