### PR TITLE
remove code that depends on classes removed in django 1.11

### DIFF
--- a/corehq/apps/style/forms/widgets.py
+++ b/corehq/apps/style/forms/widgets.py
@@ -5,16 +5,11 @@ from django.forms.utils import flatatt
 from django.forms.widgets import (
     CheckboxInput,
     Input,
-    RadioChoiceInput,
-    RadioSelect,
-    RadioFieldRenderer,
     TextInput,
     MultiWidget,
-    Widget,
 )
 from django.template.loader import render_to_string
 from django.utils.encoding import force_unicode
-from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 import json
 from django.utils.translation import ugettext_noop
@@ -40,32 +35,6 @@ class BootstrapCheckboxInput(CheckboxInput):
             final_attrs['value'] = force_unicode(value)
         return mark_safe(u'<label class="checkbox"><input%s /> %s</label>' %
                          (flatatt(final_attrs), self.inline_label))
-
-
-class BootstrapRadioInput(RadioChoiceInput):
-
-    def __unicode__(self):
-        if 'id' in self.attrs:
-            label_for = ' for="%s_%s"' % (self.attrs['id'], self.index)
-        else:
-            label_for = ''
-        choice_label = conditional_escape(force_unicode(self.choice_label))
-        return mark_safe(u'<label class="radio"%s>%s %s</label>' % (label_for, self.tag(), choice_label))
-
-
-class BootstrapRadioFieldRenderer(RadioFieldRenderer):
-
-    def render(self):
-        return mark_safe(u'\n'.join([u'%s'
-                                      % force_unicode(w) for w in self]))
-
-    def __iter__(self):
-        for i, choice in enumerate(self.choices):
-            yield BootstrapRadioInput(self.name, self.value, self.attrs.copy(), choice, i)
-
-
-class BootstrapRadioSelect(RadioSelect):
-    renderer = BootstrapRadioFieldRenderer
 
 
 class BootstrapAddressField(MultiValueField):


### PR DESCRIPTION
```RadioChoiceInput``` and ```RadioFieldRenderer``` [are being removed](https://docs.djangoproject.com/en/dev/releases/1.11/#changes-due-to-the-introduction-of-template-based-widget-rendering) from django.  I couldn't find any uses of ```BootstrapRadioSelect``` in HQ, so seemed safe to remove.

@biyeun 