### PR TITLE
don't import from django.core.urlresolvers

### DIFF
--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -6,7 +6,7 @@ from functools import wraps
 from django import http
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse as _reverse
+from django.urls import reverse as _reverse
 from django.utils.encoding import smart_bytes
 from django.utils.http import urlencode
 


### PR DESCRIPTION
get rid of warning:

```
RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
  from django.core.urlresolvers import reverse as _reverse
```

@dannyroberts 