### PR TITLE
Cancel repeat record

### DIFF
--- a/corehq/apps/repeaters/tests/test_dbaccessors.py
+++ b/corehq/apps/repeaters/tests/test_dbaccessors.py
@@ -27,25 +27,25 @@ class TestRepeatRecordDBAccessors(TestCase):
             domain=cls.domain,
             failure_reason='Some python error',
             repeater_id=cls.repeater_id,
-            next_event=before,
+            next_check=before,
         )
         success = RepeatRecord(
             domain=cls.domain,
             succeeded=True,
             repeater_id=cls.repeater_id,
-            next_event=before,
+            next_check=before,
         )
         pending = RepeatRecord(
             domain=cls.domain,
             succeeded=False,
             repeater_id=cls.repeater_id,
-            next_event=before,
+            next_check=before,
         )
         other_id = RepeatRecord(
             domain=cls.domain,
             succeeded=False,
             repeater_id=cls.other_id,
-            next_event=before,
+            next_check=before,
         )
 
         cls.records = [

--- a/corehq/couchapps/receiverwrapper/views/repeat_records_by_next_check/map.js
+++ b/corehq/couchapps/receiverwrapper/views/repeat_records_by_next_check/map.js
@@ -1,6 +1,6 @@
 function (doc) {
     if (doc.doc_type === 'RepeatRecord') {
-        if (!doc.succeeded && !doc.cancelled) {
+        if (!doc.succeeded && doc.next_check && !doc.cancelled) {
             emit([doc.domain, doc.next_check], null);
             emit([null, doc.next_check], null);
         }

--- a/corehq/couchapps/receiverwrapper/views/repeat_records_by_next_check/map.js
+++ b/corehq/couchapps/receiverwrapper/views/repeat_records_by_next_check/map.js
@@ -1,6 +1,6 @@
 function (doc) {
     if (doc.doc_type === 'RepeatRecord') {
-        if (!doc.succeeded) {
+        if (!doc.succeeded && !doc.cancelled) {
             emit([doc.domain, doc.next_check], null);
             emit([null, doc.next_check], null);
         }


### PR DESCRIPTION
Repeat records get fired in a few steps

- non-succeeded records end up in the `receiverwrapper/repeat_records_by_next_check` view
- that view gets polled every 5 minutes by the `check_repeaters` task
- that task queues a `process_repeat_record` task for each record

Towards the end of January, a feature was introduced to cancel repeat records. This was done by setting a (new) `cancelled` property on the record to true and nulling the `next_check`. `receiverwrapper/repeat_records_by_next_check` however did not check this new property, nor did it actually check to filter out records with null `next_check`s, so these cancelled records still made it into the records-to-be-queued view, and thus into the queue. It appears there are currently 250k records with `succeeded` set to false, but with a null `next_check`. Every time `check_repeaters` is called, it has to make its way through these 250k records before queuing any actual records. My hypothesis is that these records remain in the queue indefinitely and thus as the number grows these records have been taking more and more time to get through, to the point that eventually we can barely queue any real records in the 5 minute time slot.

This PR fixes this by removing them from the records-to-be-queued view, `receiverwrapper/repeat_records_by_next_check`.

EDIT: At the time I wrote this PR message, I was conflating two things, namely the existance of the `cancelled` property and the existence of the "Cancel" button. In fact, the `cancelled` property has been around a long time, and is the mechanism for stopping retries after trying on 3 different occasions. So, while this was the fix, I have no reason to believe it was caused by the introduction of the "Cancel" button.

EDIT 2: Actually it seems like my last edit was incorrect and the recent commit https://github.com/dimagi/commcare-hq/pull/14706 did in fact introduce `cancelled` and `cancel()`—but since it didn't actually have the effect of getting them out of the to-be-queued queue, it resulted in the buildup we saw.