### PR TITLE
fix usage of render_to_string

### DIFF
--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from functools import partial
 
-from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.core.urlresolvers import reverse
 from django import template
@@ -211,7 +210,7 @@ def render_form(form, domain, options):
         "show_edit_options": show_edit_options,
         "show_edit_submission": show_edit_submission,
         "show_resave": show_resave,
-    }, RequestContext(request))
+    }, request=request)
 
 
 def _top_level_tags(form):


### PR DESCRIPTION
Fixes error ```ERROR: AttributeError: 'RequestContext' object has no attribute 'path'``` seen on staging due to changes in the django api in 1.10

@dannyroberts 