### PR TITLE
Build error missing reports

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4124,6 +4124,11 @@ class ReportModule(ModuleBase):
                 'type': 'report config ref invalid',
                 'module': self.get_module_info()
             })
+        if not self.reports:
+            errors.append({
+                'type': 'no reports',
+                'module': self.get_module_info(),
+            })
         return errors
 
 

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -409,6 +409,12 @@ hqDefine('app_manager/js/report-module.js', function () {
             self.reports.push(report);
         }
     }
+
+    $(function () {
+        var setupValidation = hqImport('app_manager/js/app_manager.js').setupValidation;
+        setupValidation(hqImport('hqwebapp/js/urllib.js').reverse('validate_module_for_build'));
+    });
+
     return {
         ReportModule: ReportModule,
         StaticFilterData: StaticFilterData,

--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
@@ -13,13 +13,7 @@
     {% include "app_manager/v1/partials/report_configs_js.html" %}
 {% endblock %}
 {% block form-view %}
-    {% if warnings %}
-        <div class="alert alert-danger" data-bind="visible: !contextVariables.requires_case_details()">
-        {% for warning in warnings %}
-            {{ warning }}
-        {% endfor %}
-        </div>
-    {% endif %}
+    {% registerurl "validate_module_for_build" domain app.id module.id %}
     {% include 'app_manager/v1/partials/module_view_heading.html' %}
     {% include 'app_manager/v1/partials/mobile_report_configs.html' %}
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/build_errors.html
@@ -74,6 +74,10 @@
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             has no forms or case list.
+                        {% case "no reports" %}
+                            Report module
+                            <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
+                            has no reports.
                         {% case "circular case hierarchy" %}
                             {% url "view_module" domain app.id error.module.id as module_url %}
                             {% blocktrans with module_name=error.module.name|trans:langs %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
@@ -13,13 +13,7 @@
     {% include "app_manager/v2/partials/report_configs_js.html" %}
 {% endblock %}
 {% block form-view %}
-    {% if warnings %}
-        <div class="alert alert-danger" data-bind="visible: !contextVariables.requires_case_details()">
-        {% for warning in warnings %}
-            {{ warning }}
-        {% endfor %}
-        </div>
-    {% endif %}
+    {% registerurl "validate_module_for_build" domain app.id module.id %}
     {% include 'app_manager/v2/partials/module_view_heading.html' %}
     {% include 'app_manager/v2/partials/mobile_report_configs.html' %}
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/build_errors.html
@@ -70,6 +70,9 @@
                         {% case "no forms or case list" %}
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             has no forms or case list.
+                        {% case "no reports" %}
+                            <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
+                            has no reports.
                         {% case "circular case hierarchy" %}
                             {% url "view_module" domain app.id error.module.id as module_url %}
                             {% blocktrans with module_name=error.module.name|trans:langs %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/build_errors.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/build_errors.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,86 +1,81 @@
+@@ -1,90 +1,84 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  {% load xforms_extras %}{% if build_errors %}
@@ -96,6 +96,10 @@
 -                            Module
                              <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                              has no forms or case list.
+                         {% case "no reports" %}
+-                            Report module
+                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
+                             has no reports.
                          {% case "circular case hierarchy" %}
                              {% url "view_module" domain app.id error.module.id as module_url %}
                              {% blocktrans with module_name=error.module.name|trans:langs %}
@@ -107,7 +111,7 @@
                              <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                              uses cases but doesn't have a
                              case type defined.
-@@ -89,29 +84,28 @@
+@@ -93,29 +87,28 @@
                              {% url "view_form" domain app.id error.module.id error.form.id as form_url %}
                              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
                              You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
@@ -144,7 +148,7 @@
                              {% endblocktrans %}
                          {% case "form filter has xpath error" %}
                              {% url "view_module" domain app.id error.module.id as module_url %}
-@@ -119,72 +113,72 @@
+@@ -123,72 +116,72 @@
                              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
                              Display Condition has syntax errors
                              in the <a href="{{ form_url }}">{{ form_name }}</a> form
@@ -242,7 +246,7 @@
                              <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                              has an invalid case tile configuration. Reason: {{ error.reason }}
                          {% case "no source module id" %}
-@@ -192,49 +186,49 @@
+@@ -196,49 +189,49 @@
                              <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                              doesn't have a source module specified.
                          {% case "no parent select id" %}
@@ -306,7 +310,7 @@
                                  references a question that no longer exists: "{{ error.path }}". It is likely that
                                  this question has been renamed or deleted. Please update or delete this question
                                  reference before you make a new version.
-@@ -249,40 +243,40 @@
+@@ -253,40 +246,40 @@
                              One of your languages is empty. Check your <a href="{% url "view_app" domain app.id %}">app settings</a>.
                          {% case "missing parent tag" %}
                              A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
@@ -359,7 +363,7 @@
                                  {% endblocktrans %}
                              {% endif %}
                          {% case "invalid user property xpath reference" %}
-@@ -331,14 +325,14 @@
+@@ -335,14 +328,14 @@
                  </li>
              {% endfor %}
          </ul>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
@@ -6,7 +6,7 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load reports_core_tags %}
-@@ -7,10 +7,10 @@
+@@ -7,22 +7,22 @@
  {% block js %}{{ block.super }}
      <script src="{% static 'app_manager/js/report-module.js' %}"></script>
      <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>
@@ -18,11 +18,7 @@
 +    {% include "app_manager/v2/partials/report_configs_js.html" %}
  {% endblock %}
  {% block form-view %}
-     {% if warnings %}
-@@ -20,15 +20,15 @@
-         {% endfor %}
-         </div>
-     {% endif %}
+     {% registerurl "validate_module_for_build" domain app.id module.id %}
 -    {% include 'app_manager/v1/partials/module_view_heading.html' %}
 -    {% include 'app_manager/v1/partials/mobile_report_configs.html' %}
 +    {% include 'app_manager/v2/partials/module_view_heading.html' %}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -255,17 +255,12 @@ def _get_report_module_context(app, module):
 
     all_reports = ReportConfiguration.by_domain(app.domain) + \
                   StaticReportConfiguration.by_domain(app.domain)
-    warnings = []
     validity = module.check_report_validity()
 
     # We're now proactively deleting these references, so after that's been
     # out for a while, this can be removed (say June 2016 or later)
     if not validity.is_valid:
         module.report_configs = validity.valid_report_configs
-        warnings.append(
-            gettext_lazy('Your app contains references to reports that are '
-                         'deleted. These will be removed on save.')
-        )
 
     filter_choices = [
         {'slug': f.doc_type, 'description': f.short_description} for f in get_all_mobile_filter_configs()
@@ -277,7 +272,6 @@ def _get_report_module_context(app, module):
     return {
         'all_reports': [_report_to_config(r) for r in all_reports],
         'current_reports': [r.to_json() for r in module.report_configs],
-        'warnings': warnings,
         'filter_choices': filter_choices,
         'auto_filter_choices': auto_filter_choices,
         'daterange_choices': [choice._asdict() for choice in get_simple_dateranges()],


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?249054

@dannyroberts / @nickpell 

Also added build validation on the module view page for report modules, and incorporated the existing validation, so where you used to see this for modules with an invalid configuration:
![screen shot 2017-03-07 at 2 57 36 pm](https://cloud.githubusercontent.com/assets/1486591/23675531/a6f0dc76-0347-11e7-9443-ea0a5652cd5f.png)

you now see the more standard
![screen shot 2017-03-07 at 2 59 31 pm](https://cloud.githubusercontent.com/assets/1486591/23675543/af0e371e-0347-11e7-9d86-3987217e4f8c.png)

This does mean that `check_report_validity` is now called twice on module view (once during build validation, and once [to remove any invalid reports](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/views/modules.py#L264).