### PR TITLE
Add need_processing metric

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -6,6 +6,7 @@ from corehq.util.soft_assert import soft_assert
 from corehq.util.datadog.gauges import datadog_counter, datadog_gauge
 from dimagi.utils.logging import notify_exception
 from pillowtop.const import CHECKPOINT_MIN_WAIT
+from pillowtop.utils import force_seq_int
 from pillowtop.exceptions import PillowtopCheckpointReset
 from pillowtop.logger import pillow_logging
 
@@ -144,7 +145,7 @@ class PillowBase(object):
             else:
                 return {}
 
-            sequence = {topic: int(sequence)}
+            sequence = {topic: force_seq_int(sequence)}
         return sequence
 
     def _record_checkpoint_in_datadog(self):


### PR DESCRIPTION
@snopoke @dannyroberts this ends up being annoying to calculate and graph properly in datadog, so just creating another metric. also i realize i might be confusing datadog with this. do you think i need to add the topic name in the metric name? for example, if sms is 10 behind and form is 20 behind, it will record 10, and 20 for the same metric. i'm wondering if that would mess with numbers. i think as long as we disaggregate the number it should be ok

cc: @biyeun 