### PR TITLE
ignore forms that are errors

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -58,7 +58,7 @@ def tag_forms_as_deleted_rebuild_associated_cases(user_id, domain, form_id_list,
     cases_to_rebuild = set()
 
     for form in FormAccessors(domain).iter_forms(form_id_list):
-        if form.domain != domain or form.is_error:
+        if form.domain != domain or not form.is_normal:
             continue
 
         # rebuild all cases anyways since we don't know if this has run or not if the task was killed

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -58,7 +58,7 @@ def tag_forms_as_deleted_rebuild_associated_cases(user_id, domain, form_id_list,
     cases_to_rebuild = set()
 
     for form in FormAccessors(domain).iter_forms(form_id_list):
-        if form.domain != domain:
+        if form.domain != domain or form.is_error:
             continue
 
         # rebuild all cases anyways since we don't know if this has run or not if the task was killed


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?249103#1299502

Form was an errored form that caused it to not have an attachment associated with it (https://github.com/dimagi/commcare-hq/blob/master/corehq/form_processor/models.py#L262)

An errored form shouldn't ever have an effect on cases so we should just skip them

@gcapalbo 