### PR TITLE
show stack trace when downgrading logos errors

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -194,8 +194,8 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
             return True
         except Exception:
             log_accounting_error(
-                "Failed to remove all commcare logos for domain %s."
-                % domain.name
+                "Failed to remove all commcare logos for domain %s." % domain.name,
+                show_stack_trace=True,
             )
             return False
 


### PR DESCRIPTION
this has been an issue a few times, and has been difficult to track down without a stack trace

@mkangia 