### PR TITLE
Remove None column headers in excel import

### DIFF
--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -108,7 +108,8 @@ class WorksheetWrapper(object):
 
     def get_header_columns(self):
         if self.max_row > 0:
-            return self.iter_rows().next()
+            # remove None columns the library sometimes returns
+            return filter(None, self.iter_rows().next())
         else:
             return []
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?247333#1299572

When the excel file in that ticket is parsed by the python library it returns 1024 headers ([case_id, name,... None, None, None....]) which is returned to the page which tries to add 1024 rows to the excel import

@gcapalbo 