### PR TITLE
Smartly order export columns

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1344,7 +1344,11 @@ class ExportDataSchema(Document):
         if inferred_schema:
             current_schema = cls._merge_schemas(current_schema, inferred_schema)
 
-        current_schema = cls._reorder_schema_from_app(current_schema, app_id, identifier)
+        try:
+            current_schema = cls._reorder_schema_from_app(current_schema, app_id, identifier)
+        except Exception as e:
+            _soft_assert = soft_assert('{}@{}'.format('brudolph', 'dimagi.com'))
+            _soft_assert(False, 'Failed to process app during reorder {}. {}'.format(app._id, e))
 
         current_schema.domain = domain
         current_schema.app_id = app_id


### PR DESCRIPTION
@NoahCarnahan this was kind of annoying ticket that i've been sitting on https://manage.dimagi.com/default.asp?248514. essentially the user has changed their form so much that the columns appear out of order when they create an export (by default we order by however the schema is ordered). this makes it so we re order the schema to match whatever the current form looks like

cc: @biyeun 