### PR TITLE
a better pillowtop status page for system info

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/system_info.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/system_info.js
@@ -147,28 +147,34 @@ hqDefine('hqadmin/js/system_info.js', function () {
             self.pillow_model.perform_operation(operation);
         }
     }
-    
+
     function PillowProgress(name, db_offset, seq) {
         var self = this;
         self.name = name;
         self.db_offset = db_offset;
         self.seq = seq;
-    
+
+        self.changes_behind = function () {
+            return self.db_offset - self.seq;
+        };
+
         self.width = function() {
             return (self.seq * 100) / self.db_offset;
         };
     
         self.status = function() {
-            if (self.width() > 98) {
+            if (self.changes_behind() < 500) {
                 return 'progress-bar-success';
-            } else if (self.width() < 50) {
-                return 'progress-bar-danger';
-            } else if (self.width() < 75) {
+            } else if (self.changes_behind() < 1000) {
+                return ''; // will be a blue, but not quite info
+            } else if (self.changes_behind() < 5000) {
                 return 'progress-bar-warning';
+            } else {
+                return 'progress-bar-danger';
             }
         };
     }
-    
+
     function PillowModel(pillow) {
         var self = this;
         self.name = ko.observable();

--- a/corehq/apps/hqadmin/templates/hqadmin/system_info.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/system_info.html
@@ -160,6 +160,7 @@
                               <div class="col-sm-4">
                                   <span data-bind="text: seq"></span>
                                         / <span data-bind="text: db_offset"></span>
+                                      (<span data-bind="text: changes_behind()"></span>)
                               </div>
                               <div class="col-sm-4" data-bind="text: name">
                               </div>


### PR DESCRIPTION
We're at a point where having colors based on the percentage of changes gone through means nothing. 2% of the commcarehq feed would be 3.5 million changes behind which is pretty absurd. 

Would like to get rid of the progress bar, but not sure of a better way to have a quick look at the page to check if anything is up

Also adding the # changes behind on a feed after the raw numbers

@gcapalbo @dannyroberts 