### PR TITLE
fix unicode for ddog

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1036,8 +1036,8 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
                 }
             except BillingRecord.DoesNotExist:
                 log_accounting_error(
-                    "An invoice was generated for %(invoice_id)d "
-                    "(domain: %(domain)s), but no billing record!" % {
+                    u"An invoice was generated for %(invoice_id)d "
+                    u"(domain: %(domain)s), but no billing record!" % {
                         'invoice_id': invoice.id,
                         'domain': self.domain,
                     }

--- a/corehq/apps/domainsync/management/commands/copy_domain.py
+++ b/corehq/apps/domainsync/management/commands/copy_domain.py
@@ -215,7 +215,7 @@ class Command(BaseCommand):
                                                                 endkey=endkey, reduce=False)]
         total = len(doc_ids)
         count = 0
-        msg = "Found %s matching documents in domain: %s" % (total, domain)
+        msg = u"Found %s matching documents in domain: %s" % (total, domain)
         msg += " of type: %s" % (doc_type) if doc_type else ""
         msg += " since: %s" % (since) if since else ""
         print(msg)

--- a/corehq/apps/dump_reload/couch/load.py
+++ b/corehq/apps/dump_reload/couch/load.py
@@ -107,7 +107,7 @@ class DomainLoader(DataLoader):
         else:
             if existing_domain:
                 if force:
-                    self.stderr.write('Loading data for existing domain: {}'.format(domain_name))
+                    self.stderr.write(u'Loading data for existing domain: {}'.format(domain_name))
                 else:
                     raise DataExistsException("Domain: {}".format(domain_name))
 

--- a/corehq/apps/indicators/models.py
+++ b/corehq/apps/indicators/models.py
@@ -48,8 +48,8 @@ class IndicatorDefinition(Document, AdminCRUDDocumentMixin):
         self.class_path = self._class_path
 
     def __str__(self):
-        return "\n\n%(class_name)s - Modified %(last_modified)s\n %(slug)s, domain: %(domain)s," \
-            " version: %(version)s, namespace: %(namespace)s. ID: %(indicator_id)s." % {
+        return u"\n\n%(class_name)s - Modified %(last_modified)s\n %(slug)s, domain: %(domain)s," \
+            u" version: %(version)s, namespace: %(namespace)s. ID: %(indicator_id)s." % {
                 'class_name': self.__class__.__name__,
                 'slug': self.slug,
                 'domain': self.domain,

--- a/corehq/apps/locations/management/commands/migrate_new_location_fixture.py
+++ b/corehq/apps/locations/management/commands/migrate_new_location_fixture.py
@@ -49,13 +49,13 @@ class Command(BaseCommand):
         # and update their location configuration to use hierarchical fixture for now
         for domain in domains_to_stay_on_hierarchical_fixture:
             if not dry_run:
-                print("Setting HIERARCHICAL_LOCATION_FIXTURE toggle for domain: %s" % domain)
+                print(u"Setting HIERARCHICAL_LOCATION_FIXTURE toggle for domain: %s" % domain)
                 HIERARCHICAL_LOCATION_FIXTURE.set(domain, True, NAMESPACE_DOMAIN)
             else:
-                print("HIERARCHICAL_LOCATION_FIXTURE toggle would be set for domain: %s" % domain)
+                print(u"HIERARCHICAL_LOCATION_FIXTURE toggle would be set for domain: %s" % domain)
 
             if not dry_run:
-                print("Enabling legacy fixture for domain: %s" % domain)
+                print(u"Enabling legacy fixture for domain: %s" % domain)
                 location_configuration = LocationFixtureConfiguration.for_domain(domain)
                 print("Current Configuration, Persisted: %s, Use Flat fixture: %s, Use Hierarchical fixture %s" % (
                     not location_configuration._state.adding, location_configuration.sync_hierarchical_fixture,
@@ -63,7 +63,7 @@ class Command(BaseCommand):
 
                 enable_legacy_fixture_for_domain(domain)
             else:
-                print("Legacy fixture to be enabled for domain: %s" % domain)
+                print(u"Legacy fixture to be enabled for domain: %s" % domain)
                 location_configuration = LocationFixtureConfiguration.for_domain(domain)
                 print("Current Configuration, Persisted: %s, Use Flat fixture: %s, Use Hierarchical fixture %s" % (
                     not location_configuration._state.adding, location_configuration.sync_hierarchical_fixture,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -95,7 +95,7 @@ def search(request, domain):
             to="{}@{}.com".format('frener', 'dimagi'),
             notify_admins=False, send_to_ops=False
         )
-        _soft_assert(False, "Someone in domain: {} tried accessing case search without a config".format(domain), e)
+        _soft_assert(False, u"Someone in domain: {} tried accessing case search without a config".format(domain), e)
         config = CaseSearchConfig(domain=domain)
 
     query_addition_id = criteria.pop(SEARCH_QUERY_ADDITION_KEY, None)

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -189,11 +189,11 @@ class PillowBase(object):
     def __record_change_metric_in_datadog(self, metric, change, timer=None):
         if change.metadata is not None:
             tags = [
-                'datasource:{}'.format(change.metadata.data_source_name),
-                'document_type:{}'.format(change.metadata.document_type),
-                'domain:{}'.format(change.metadata.domain),
-                'is_deletion:{}'.format(change.metadata.is_deletion),
-                'pillow_name:{}'.format(self.get_name())
+                u'datasource:{}'.format(change.metadata.data_source_name),
+                u'document_type:{}'.format(change.metadata.document_type),
+                u'domain:{}'.format(change.metadata.domain),
+                u'is_deletion:{}'.format(change.metadata.is_deletion),
+                u'pillow_name:{}'.format(self.get_name())
             ]
             datadog_counter(metric, tags=tags)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/cchq/www/production/current/manage.py", line 118, in <module>
    execute_from_command_line(sys.argv)
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py", line 80, in handle
    start_pillow(pillow)
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/run_pillowtop.py", line 40, in start_pillow
    pillow_instance.run()
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 85, in run
    self.process_changes(since=self.get_last_checkpoint_sequence(), forever=True)
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 108, in process_changes
    self._record_change_success_in_datadog(change)
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 184, in _record_change_success_in_datadog
    self.__record_change_metric_in_datadog('commcare.change_feed.changes.success', change)
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 194, in __record_change_metric_in_datadog
    'domain:{}'.format(change.metadata.domain),
UnicodeEncodeError: 'ascii' codec can't encode character u'\xda' in position 12: ordinal not in range(128)
```

@snopoke @dannyroberts @gcapalbo 