### PR TITLE
Revert "Fixes issue with static widths on select2s in case management + live preview"

### DIFF
--- a/corehq/apps/style/static/style/less/_hq/forms.less
+++ b/corehq/apps/style/static/style/less/_hq/forms.less
@@ -112,7 +112,13 @@ legend .subtext {
 }
 
 #case-config-ko, #usercase-config-ko {
-    .case-config-select2s(100%);
+    @select2Width: 210px;
+
+    .case-config-select2s(@select2Width);
+
+    .wide-select2s {
+        .case-config-select2s(@select2Width * 1.5);
+    }
 }
 
 // hack to fix issues with placeholder not showing up fully
@@ -242,13 +248,4 @@ textarea.vertical-resize {
 
 table .ko-inline-edit .read-only:hover {
     background-color: @cc-neutral-hi;
-}
-
-table .select2-container .select2-choice {
-  white-space: normal;
-}
-
-table .select2-container .select2-choice > .select2-chosen {
-  white-space: normal;
-  margin-right: 0;
 }


### PR DESCRIPTION
Reverting dimagi/commcare-hq#14795 because it caused https://manage.dimagi.com/default.asp?249148 and stretches out the select2 in conditional case opening:

<img width="1086" alt="screen shot 2017-03-10 at 1 44 46 pm" src="https://cloud.githubusercontent.com/assets/1486591/23808416/c557c498-0597-11e7-91fb-17d4c14c7e94.png">

@biyeun / @calellowitz / @dannyroberts 