### PR TITLE
Highlight feature flags for debugging help in App Manager

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
@@ -333,6 +333,7 @@
                         <form class="form form-horizontal" method="post" action="{% url "copy_app" domain %}">
                             {% crispy copy_app_form %}
                         </form>
+                        {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
                         {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
                             <h3>Export compressed application</h3>
                             <form action="{% url "gzip_app" domain app.id %}" method="POST">

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -433,6 +433,7 @@
                         {% block usercase_management_content %}
                             {%  if form.uses_usercase and not allow_usercase %}
                                 <div class="container-fluid col-sm-6">
+                              {{ request|toggle_tag_info:"USER_PROPERTY_EASY_REFS" }}
                               {% if request|toggle_enabled:"USER_PROPERTY_EASY_REFS" %}
                                 <p>{% blocktrans %}
                                     The User Properties feature is no longer available because of the change in your

--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view.html
@@ -21,13 +21,13 @@
     <script src="{% static 'app_manager/js/shadow-module-settings.js' %}"></script>
 
     {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
-        {% for detail in details %}
-            {% if detail.type == 'case' %}
-                {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
-            {% else %}
-                {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
-            {% endif %}
-        {% endfor %}
+      {% for detail in details %}
+          {% if detail.type == 'case' %}
+              {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+          {% else %}
+              {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+          {% endif %}
+      {% endfor %}
     {% endif %}
 
     {% if case_list_form_options %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view_advanced.html
@@ -17,6 +17,10 @@
                 {% trans "Visit Scheduler" %}
             </a>
         </li>
+    {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
+      <li>
+          {{ request|toggle_tag_info:"VISIT_SCHEDULER" }}
+      </li>
     {% endif %}
 {% endblock %}
 
@@ -25,7 +29,8 @@
         {% initial_page_data 'schedule_phases' schedule_phases %}
         {% registerurl 'edit_schedule_phases' app.domain app.id module.id %}
         <div class="tab-pane" id="visit-scheduler-module-config-tab">
-            {% include "app_manager/v1/partials/enable_schedule.html" %}
+          {{ request|toggle_tag_info:"VISIT_SCHEDULER" }}
+          {% include "app_manager/v1/partials/enable_schedule.html" %}
         </div>
     {% endif %}
 {% endblock %} 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/add_property_button.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/add_property_button.html
@@ -6,19 +6,18 @@
         {% trans "Add Property" %}
     </button>
     {% if request|toggle_enabled:'GRAPH_CREATION' %}
-    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-        <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu">
-        <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
-        {% if request|toggle_enabled:'GRAPH_CREATION' %}
-        <!-- ko if: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
-        <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>
-        <!-- /ko -->
-        <!-- ko ifnot: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
-        <li class="disabled"><a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a></li>
-        <!-- /ko -->
-        {% endif %}
-    </ul>
+      <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+          <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+          <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
+          <!-- ko if: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
+          <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>
+          <!-- /ko -->
+          <!-- ko ifnot: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
+          <li class="disabled"><a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a></li>
+          <!-- /ko -->
+      </ul>
     {% endif %}
 </div>
+{{ request|toggle_tag_info:"GRAPH_CREATION" }}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/app-settings.html
@@ -263,6 +263,7 @@
                 </div>
             </fieldset>
         </div>
+        {{ request|toggle_tag_info:"CUSTOM_PROPERTIES" }}
         {% if request|toggle_enabled:"CUSTOM_PROPERTIES" %}
         <fieldset>
             <legend>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_detail.html
@@ -28,6 +28,7 @@
       data-content="{% blocktrans %}Do you have a lot of case properties? Try splitting them into tabs, which will appear as separate screens that mobile users can swipe through. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Tabs+on+Case+Detail+Screen' target='_blank'>Help Site</a>.{% endblocktrans %}"
 </span>
 
+{{ request|toggle_tag_info:"DETAIL_LIST_TAB_NODESETS" }}
 {% if request|toggle_enabled:"DETAIL_LIST_TAB_NODESETS" %}
     <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(true); }">
         <i class="fa fa-plus"></i>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -24,6 +24,7 @@
 </legend>
 
 <div data-bind="with: shortScreen">
+    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
     {% if request|toggle_enabled:'CASE_LIST_TILE' %}
     <div class="row">
         <div class="col-sm-6">
@@ -35,6 +36,7 @@
     </div>
     {% endif %}
 
+    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
     {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
     <div data-bind="visible: useCaseTiles() == 'no'">
         <div class="checkbox">
@@ -42,6 +44,8 @@
                 <input type="checkbox" data-bind="checked: persistCaseContext">
                 {% trans "Show some information about the case at the top of the screen when filling out forms" %}
             </label>
+
+            {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
         </div>
         <div class="form-inline" data-bind="visible: persistCaseContext">
             <label>
@@ -104,7 +108,9 @@
                     </th>
                     <th>{% trans "Direction" %}</th>
                     {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-                        <th>{% trans "Sort Calculation" %}</th>
+                        <th>{% trans "Sort Calculation" %}{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
+                    {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
+                        <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
                     {% endif %}
                     <th>{% trans "Format" %}</th>
                     <th>
@@ -153,9 +159,11 @@
                     </td>
 
                     {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-                    <td>
-                        <input class="form-control" type='text' data-bind='value: sortCalculation'/>
-                    </td>
+                      <td>
+                          <input class="form-control" type='text' data-bind='value: sortCalculation'/>
+                      </td>
+                    {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
+                      <td></td>
                     {% endif %}
 
                     <td>
@@ -175,6 +183,7 @@
                             <option value="distance">
                                 {% trans "Distance from current location" %}
                             </option>
+                            {{ request|toggle_tag_info:"CACHE_AND_INDEX" }}
                             {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
                                 <option value="index">
                                     {% trans "Cache and Index" %}
@@ -237,12 +246,15 @@
 </div>
 {% endif %}
 
+{{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
 {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
     {% include "app_manager/v1/partials/case_list_lookup.html" %}
     <div class="spacer"></div>
 {% endif %}
 
+{{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
 {% if detail.fixture_select and request|toggle_enabled:"FIXTURE_CASE_SELECTION" %}
+    {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
     {% include "app_manager/v1/partials/fixture_case_selection.html" %}
 {% endif %}
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -254,7 +254,6 @@
 
 {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
 {% if detail.fixture_select and request|toggle_enabled:"FIXTURE_CASE_SELECTION" %}
-    {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
     {% include "app_manager/v1/partials/fixture_case_selection.html" %}
 {% endif %}
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/form_tab_settings.html
@@ -64,10 +64,12 @@
 
             </div>
 
+            {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
             {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
                 {% include "app_manager/v1/partials/custom_instances.html" %}
             {% endif %}
 
+            {{ request|toggle_tag_info:"NO_VELLUM" }}
             {% if request|toggle_enabled:'NO_VELLUM' %}
             <div class="form-group">
                 <label class="control-label col-sm-2">

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/releases.html
@@ -112,6 +112,8 @@
             <th>{% trans "Comments" %}</th>
             {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <th>Errors</th>
+            {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
+                <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
             {% endif %}
             <th>
                 {% trans "Released" %}
@@ -212,6 +214,8 @@
                     <a data-bind="text: num_errors,
                                   attr: {href: $root.url('application_errors', version())}" />
                 </td>
+                {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
+                <td>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</td>
                 {% endif %}
                 <td class="build-is-released">
                     <div data-bind="starred: is_released, click: $root.toggleRelease"></div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
@@ -278,6 +278,7 @@
                     </div>
                     </div>
                 {% endif %}
+                {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
                 {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
                     <legend>Export compressed application</legend>
                     <form action="{% url "gzip_app" domain app.id %}" method="POST">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_detail.html
@@ -32,6 +32,7 @@
       data-content="{% blocktrans %}Do you have a lot of case properties? Try splitting them into tabs, which will appear as separate screens that mobile users can swipe through. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Tabs+on+Case+Detail+Screen' target='_blank'>Help Site</a>.{% endblocktrans %}"
 </span>
 
+{{ request|toggle_tag_info:"DETAIL_LIST_TAB_NODESETS" }}
 {% if request|toggle_enabled:"DETAIL_LIST_TAB_NODESETS" %}
     <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(true); }">
         <i class="fa fa-plus"></i>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -47,6 +47,7 @@
   </div>
   <div class="panel-body">
     <div data-bind="with: shortScreen">
+        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
         {% if request|toggle_enabled:'CASE_LIST_TILE' %}
         <div class="row">
             <div class="col-sm-6">
@@ -57,6 +58,7 @@
             </div>
         </div>
         {% endif %}
+        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
         {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
         <div data-bind="visible: useCaseTiles() == 'no'">
             <div class="checkbox">
@@ -130,6 +132,8 @@
                             <th>{% trans "Direction" %}</th>
                             {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
                             <th>{% trans "Sort Calculation" %}</th>
+                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+                              <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
                             {% endif %}
                             <th>{% trans "Format" %}</th>
                             <th>
@@ -180,6 +184,8 @@
                             <td>
                                 <input class="form-control" type='text' data-bind='value: sortCalculation'/>
                             </td>
+                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+                              <td></td>
                             {% endif %}
 
 
@@ -200,6 +206,7 @@
                                     <option value="distance">
                                         {% trans "Distance from current location" %}
                                     </option>
+                                    {{ request|toggle_tag_info:"CACHE_AND_INDEX" }}
                                     {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
                                         <option value="index">
                                             {% trans "Cache and Index" %}
@@ -233,10 +240,12 @@
 </div>
 {% endif %}
 
+{{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
 {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
     {% include "app_manager/v2/partials/case_list_lookup.html" %}
 {% endif %}
 
+{{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
 {% if detail.fixture_select and request|toggle_enabled:"FIXTURE_CASE_SELECTION" %}
     {% include "app_manager/v2/partials/fixture_case_selection.html" %}
 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -132,7 +132,7 @@
                             <th>{% trans "Direction" %}</th>
                             {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
                             <th>{% trans "Sort Calculation" %}</th>
-                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
                               <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
                             {% endif %}
                             <th>{% trans "Format" %}</th>
@@ -184,7 +184,7 @@
                             <td>
                                 <input class="form-control" type='text' data-bind='value: sortCalculation'/>
                             </td>
-                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
                               <td></td>
                             {% endif %}
 

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/commcare_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/commcare_settings.html
@@ -61,7 +61,8 @@
       </div>
     </div>
   </div>
-  {% if False and request|toggle_enabled:"CUSTOM_PROPERTIES" %}
+  {{ request|toggle_tag_info:"CUSTOM_PROPERTIES" }}
+  {% if request|toggle_enabled:"CUSTOM_PROPERTIES" %}
     <fieldset>
       <legend>
         <a

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_tab_settings.html
@@ -85,6 +85,7 @@
 
                     </div>
 
+                    {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
                     {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
                         {% include "app_manager/v2/partials/custom_instances.html" %}
                     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
@@ -140,6 +140,8 @@
             <th>{% trans "Comments" %}</th>
             {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <th>Errors</th>
+            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+              <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
             {% endif %}
             <th>
                 {% trans "Released" %}
@@ -240,6 +242,8 @@
                     <a data-bind="text: num_errors,
                                   attr: {href: $root.url('application_errors', version())}" />
                 </td>
+                {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+                  <td></td>
                 {% endif %}
                 <td class="build-is-released">
                     <div data-bind="starred: is_released, click: $root.toggleRelease"></div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases.html
@@ -140,7 +140,7 @@
             <th>{% trans "Comments" %}</th>
             {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <th>Errors</th>
-            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
               <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
             {% endif %}
             <th>
@@ -242,7 +242,7 @@
                     <a data-bind="text: num_errors,
                                   attr: {href: $root.url('application_errors', version())}" />
                 </td>
-                {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
+                {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
                   <td></td>
                 {% endif %}
                 <td class="build-is-released">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/add_property_button.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/add_property_button.html.diff.txt
@@ -1,23 +1,22 @@
 --- 
 +++ 
-@@ -5,20 +5,4 @@
+@@ -5,19 +5,4 @@
          <i class="fa fa-plus"></i>
          {% trans "Add Property" %}
      </button>
 -    {% if request|toggle_enabled:'GRAPH_CREATION' %}
--    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
--        <span class="caret"></span>
--    </button>
--    <ul class="dropdown-menu">
--        <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
--        {% if request|toggle_enabled:'GRAPH_CREATION' %}
--        <!-- ko if: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
--        <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>
--        <!-- /ko -->
--        <!-- ko ifnot: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
--        <li class="disabled"><a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a></li>
--        <!-- /ko -->
--        {% endif %}
--    </ul>
+-      <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+-          <span class="caret"></span>
+-      </button>
+-      <ul class="dropdown-menu">
+-          <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
+-          <!-- ko if: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
+-          <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>
+-          <!-- /ko -->
+-          <!-- ko ifnot: hqImport('app_manager/js/app_manager.js').checkCommcareVersion("2.17") -->
+-          <li class="disabled"><a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a></li>
+-          <!-- /ko -->
+-      </ul>
 -    {% endif %}
  </div>
+-{{ request|toggle_tag_info:"GRAPH_CREATION" }}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
@@ -125,7 +125,7 @@
          <input type="number" class="col-sm-3 form-control" data-bind="
              value: visibleValue,
              valueUpdate: 'textchange',
-@@ -137,165 +138,175 @@
+@@ -137,166 +138,176 @@
  </script>
  
  <script type="text/html" id="CommcareSettings.widgets.textarea">
@@ -359,6 +359,7 @@
 +                    </div>
 +                    </div>
 +                {% endif %}
++                {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
 +                {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
 +                    <legend>Export compressed application</legend>
 +                    <form action="{% url "gzip_app" domain app.id %}" method="POST">
@@ -399,6 +400,7 @@
 -                </div>
 -            </fieldset>
 -        </div>
+-        {{ request|toggle_tag_info:"CUSTOM_PROPERTIES" }}
 -        {% if request|toggle_enabled:"CUSTOM_PROPERTIES" %}
 -        <fieldset>
 -            <legend>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,251 +1,246 @@
+@@ -1,263 +1,255 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  
@@ -53,6 +53,7 @@
 +  </div>
 +  <div class="panel-body">
 +    <div data-bind="with: shortScreen">
++        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 +        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
          <div class="row">
              <div class="col-sm-6">
@@ -74,6 +75,7 @@
 -</legend>
 -
 -<div data-bind="with: shortScreen">
+-    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 -    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
 -    <div class="row">
 -        <div class="col-sm-6">
@@ -82,6 +84,7 @@
 -                <option value="yes">{% trans "Use Case Tiles" %}</option>
 -            </select>
 +        {% endif %}
++        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
 +        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
 +        <div data-bind="visible: useCaseTiles() == 'no'">
 +            <div class="checkbox">
@@ -100,6 +103,7 @@
 -    </div>
 -    {% endif %}
 -
+-    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
 -    {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
 -    <div data-bind="visible: useCaseTiles() == 'no'">
 -        <div class="checkbox">
@@ -107,6 +111,8 @@
 -                <input type="checkbox" data-bind="checked: persistCaseContext">
 -                {% trans "Show some information about the case at the top of the screen when filling out forms" %}
 -            </label>
+-
+-            {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 +        {% endif %}
 +        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
 +            <div class="checkbox">
@@ -188,7 +194,9 @@
 -                    </th>
 -                    <th>{% trans "Direction" %}</th>
 -                    {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
--                        <th>{% trans "Sort Calculation" %}</th>
+-                        <th>{% trans "Sort Calculation" %}{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
+-                    {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
+-                        <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
 -                    {% endif %}
 -                    <th>{% trans "Format" %}</th>
 -                    <th>
@@ -237,9 +245,11 @@
 -                    </td>
 -
 -                    {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
--                    <td>
--                        <input class="form-control" type='text' data-bind='value: sortCalculation'/>
--                    </td>
+-                      <td>
+-                          <input class="form-control" type='text' data-bind='value: sortCalculation'/>
+-                      </td>
+-                    {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
+-                      <td></td>
 -                    {% endif %}
 -
 -                    <td>
@@ -259,6 +269,7 @@
 -                            <option value="distance">
 -                                {% trans "Distance from current location" %}
 -                            </option>
+-                            {{ request|toggle_tag_info:"CACHE_AND_INDEX" }}
 -                            {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
 -                                <option value="index">
 -                                    {% trans "Cache and Index" %}
@@ -299,6 +310,8 @@
 +                            <th>{% trans "Direction" %}</th>
 +                            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
 +                            <th>{% trans "Sort Calculation" %}</th>
++                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++                              <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
                              {% endif %}
 -                        </select>
 -                    </td>
@@ -403,6 +416,8 @@
 +                            <td>
 +                                <input class="form-control" type='text' data-bind='value: sortCalculation'/>
 +                            </td>
++                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++                              <td></td>
 +                            {% endif %}
 +
 +
@@ -423,6 +438,7 @@
 +                                    <option value="distance">
 +                                        {% trans "Distance from current location" %}
 +                                    </option>
++                                    {{ request|toggle_tag_info:"CACHE_AND_INDEX" }}
 +                                    {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
 +                                        <option value="index">
 +                                            {% trans "Cache and Index" %}
@@ -456,13 +472,16 @@
  </div>
  {% endif %}
  
+ {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
 -    {% include "app_manager/v1/partials/case_list_lookup.html" %}
 -    <div class="spacer"></div>
 +    {% include "app_manager/v2/partials/case_list_lookup.html" %}
  {% endif %}
  
+ {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
  {% if detail.fixture_select and request|toggle_enabled:"FIXTURE_CASE_SELECTION" %}
+-    {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
 -    {% include "app_manager/v1/partials/fixture_case_selection.html" %}
 +    {% include "app_manager/v2/partials/fixture_case_selection.html" %}
  {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,263 +1,255 @@
+@@ -1,262 +1,255 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  
@@ -481,7 +481,6 @@
  
  {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
  {% if detail.fixture_select and request|toggle_enabled:"FIXTURE_CASE_SELECTION" %}
--    {{ request|toggle_tag_info:"FIXTURE_CASE_SELECTION" }}
 -    {% include "app_manager/v1/partials/fixture_case_selection.html" %}
 +    {% include "app_manager/v2/partials/fixture_case_selection.html" %}
  {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -310,7 +310,7 @@
 +                            <th>{% trans "Direction" %}</th>
 +                            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
 +                            <th>{% trans "Sort Calculation" %}</th>
-+                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
 +                              <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
                              {% endif %}
 -                        </select>
@@ -416,7 +416,7 @@
 +                            <td>
 +                                <input class="form-control" type='text' data-bind='value: sortCalculation'/>
 +                            </td>
-+                            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
 +                              <td></td>
 +                            {% endif %}
 +

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_tab_settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_tab_settings.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,90 +1,115 @@
+@@ -1,92 +1,116 @@
  {% load i18n %}
  {% load xforms_extras %}
  {% load hq_shared_tags %}
@@ -87,6 +87,7 @@
 +                </div>
              </div>
  
+-            {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
 -            {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
 -                {% include "app_manager/v1/partials/custom_instances.html" %}
 -            {% endif %}
@@ -107,6 +108,7 @@
 +                        visible: visible,
 +                        css: {error: hasError()}">
  
+-            {{ request|toggle_tag_info:"NO_VELLUM" }}
 -            {% if request|toggle_enabled:'NO_VELLUM' %}
 -            <div class="form-group">
 -                <label class="control-label col-sm-2">
@@ -162,6 +164,7 @@
 +
 +                    </div>
 +
++                    {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
 +                    {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
 +                        {% include "app_manager/v2/partials/custom_instances.html" %}
 +                    {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases.html.diff.txt
@@ -76,7 +76,7 @@
                  <th>Errors</th>
 -            {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
 -                <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
-+            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
 +              <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
              {% endif %}
              <th>
@@ -104,7 +104,7 @@
                  </td>
 -                {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
 -                <td>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</td>
-+                {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++                {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
 +                  <td></td>
                  {% endif %}
                  <td class="build-is-released">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases.html.diff.txt
@@ -70,7 +70,18 @@
          <tr>
              <th colspan="2">{% trans "Version" %}</th>
              <th colspan="2">{% trans "Date &amp; Time" %}</th>
-@@ -197,7 +225,7 @@
+@@ -112,8 +140,8 @@
+             <th>{% trans "Comments" %}</th>
+             {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
+                 <th>Errors</th>
+-            {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
+-                <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
++            {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++              <th>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</th>
+             {% endif %}
+             <th>
+                 {% trans "Released" %}
+@@ -199,7 +227,7 @@
                  </td>
                  <td>
                      <b data-bind="text: comment_user_name"></b>
@@ -79,7 +90,7 @@
                          value: build_comment,
                          rows: 1,
                          placeholder: '{% trans "(Click here to add a comment)"|escapejs %}',
-@@ -205,7 +233,7 @@
+@@ -207,15 +235,15 @@
                          saveParams: {'build_id': id},
                          saveValueName: 'comment',
                          errorMessage:'{% trans "Error updating comment.  Please try again."|escapejs %}',
@@ -88,7 +99,17 @@
                  </td>
                  {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                  <td>
-@@ -290,17 +318,18 @@
+                     <a data-bind="text: num_errors,
+                                   attr: {href: $root.url('application_errors', version())}" />
+                 </td>
+-                {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
+-                <td>{{ request|toggle_tag_info:"APPLICATION_ERROR_REPORT" }}</td>
++                {% elif request|toggle_enabmed:'SHOW_DEV_TOGGLE_INFO' %}
++                  <td></td>
+                 {% endif %}
+                 <td class="build-is-released">
+                     <div data-bind="starred: is_released, click: $root.toggleRelease"></div>
+@@ -294,17 +322,18 @@
          </div>
      </script>
      <script type="text/html" id="deploy-build-modal-template">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,397 +1,114 @@
+@@ -1,398 +1,114 @@
 -{% extends "app_manager/v1/managed_app.html" %}
 +{% extends "app_manager/v2/managed_app.html" %}
  {% load xforms_extras %}
@@ -427,6 +427,7 @@
 -                        <form class="form form-horizontal" method="post" action="{% url "copy_app" domain %}">
 -                            {% crispy copy_app_form %}
 -                        </form>
+-                        {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
 -                        {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
 -                            <h3>Export compressed application</h3>
 -                            <form action="{% url "gzip_app" domain app.id %}" method="POST">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view_base.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view_base.html.diff.txt
@@ -260,7 +260,15 @@
              <div class="tab-pane" id="usercase-configuration">
                  {% if form_errors or xform_validation_errored %}
                      <p class="alert alert-warning">
-@@ -477,7 +455,7 @@
+@@ -433,7 +411,6 @@
+                         {% block usercase_management_content %}
+                             {%  if form.uses_usercase and not allow_usercase %}
+                                 <div class="container-fluid col-sm-6">
+-                              {{ request|toggle_tag_info:"USER_PROPERTY_EASY_REFS" }}
+                               {% if request|toggle_enabled:"USER_PROPERTY_EASY_REFS" %}
+                                 <p>{% blocktrans %}
+                                     The User Properties feature is no longer available because of the change in your
+@@ -478,7 +455,7 @@
                                  </p>
                                  </div>
                              {% endif %}
@@ -269,7 +277,7 @@
                          {% endblock %}
                      </div>
                  {% else %}
-@@ -490,23 +468,25 @@
+@@ -491,23 +468,25 @@
                      </p>
                  {% endif %}
              </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
@@ -24,15 +24,20 @@
      <script src="{% static 'app_manager/js/shadow-module-settings.js' %}"></script>
  
      {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
-         {% for detail in details %}
-             {% if detail.type == 'case' %}
--                {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+-      {% for detail in details %}
+-          {% if detail.type == 'case' %}
+-              {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+-          {% else %}
+-              {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+-          {% endif %}
+-      {% endfor %}
++        {% for detail in details %}
++            {% if detail.type == 'case' %}
 +                {% include "app_manager/v2/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
-             {% else %}
--                {% include "app_manager/v1/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
++            {% else %}
 +                {% include "app_manager/v2/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
-             {% endif %}
-         {% endfor %}
++            {% endif %}
++        {% endfor %}
      {% endif %}
  
      {% if case_list_form_options %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_advanced.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_advanced.html.diff.txt
@@ -6,11 +6,23 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load i18n %}
-@@ -25,10 +25,10 @@
+@@ -17,10 +17,6 @@
+                 {% trans "Visit Scheduler" %}
+             </a>
+         </li>
+-    {% elif request|toggle_enabled:"SHOW_DEV_TOGGLE_INFO" %}
+-      <li>
+-          {{ request|toggle_tag_info:"VISIT_SCHEDULER" }}
+-      </li>
+     {% endif %}
+ {% endblock %}
+ 
+@@ -29,11 +25,10 @@
          {% initial_page_data 'schedule_phases' schedule_phases %}
          {% registerurl 'edit_schedule_phases' app.domain app.id module.id %}
          <div class="tab-pane" id="visit-scheduler-module-config-tab">
--            {% include "app_manager/v1/partials/enable_schedule.html" %}
+-          {{ request|toggle_tag_info:"VISIT_SCHEDULER" }}
+-          {% include "app_manager/v1/partials/enable_schedule.html" %}
 +            {% include "app_manager/v2/partials/enable_schedule.html" %}
          </div>
      {% endif %}

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -25,6 +25,7 @@ from corehq.util.soft_assert import soft_assert
 from dimagi.utils.web import json_handler
 from corehq.apps.hqwebapp.models import MaintenanceAlert
 from corehq.apps.hqwebapp.exceptions import AlreadyRenderedException
+from corehq import toggles
 
 
 register = template.Library()
@@ -206,11 +207,16 @@ def pretty_doc_info(doc_info):
     })
 
 
-def _toggle_enabled(module, request, toggle_or_toggle_name):
+def _get_toggle(module, toggle_or_toggle_name):
     if isinstance(toggle_or_toggle_name, basestring):
         toggle = getattr(module, toggle_or_toggle_name)
     else:
         toggle = toggle_or_toggle_name
+    return toggle
+
+
+def _toggle_enabled(module, request, toggle_or_toggle_name):
+    toggle = _get_toggle(module, toggle_or_toggle_name)
     return toggle.enabled_for_request(request)
 
 
@@ -218,6 +224,26 @@ def _toggle_enabled(module, request, toggle_or_toggle_name):
 def toggle_enabled(request, toggle_or_toggle_name):
     import corehq.toggles
     return _toggle_enabled(corehq.toggles, request, toggle_or_toggle_name)
+
+@register.filter
+def toggle_tag_info(request, toggle_or_toggle_name):
+    """Show Tag Information for feature flags / Toggles,
+    and if not enabled, show where the UI would be.
+    Useful for trying to find out if you have all the flags enabled in a
+    particular location or whether a feature on prod is part of a particular
+    flag. """
+    if not toggles.SHOW_DEV_TOGGLE_INFO.enabled_for_request(request):
+        return ""
+    flag = _get_toggle(toggles, toggle_or_toggle_name)
+    tag = flag.tag
+    is_enabled = flag.enabled_for_request(request)
+    return mark_safe("""<div class="label label-{css_class} label-flag{css_disabled}">{tag_name}: {description}{status}</div>""".format(
+        css_class=tag.css_class,
+        tag_name=tag.name,
+        description=flag.label,
+        status=" <strong>[DISABLED]</strong>" if not is_enabled else "",
+        css_disabled=" label-flag-disabled" if not is_enabled else "",
+    ))
 
 
 @register.filter

--- a/corehq/apps/style/static/style/less/_hq/label.less
+++ b/corehq/apps/style/static/style/less/_hq/label.less
@@ -35,3 +35,19 @@
 .label-plan-community {
   background-color: @cc-dark-cool-accent-mid;
 }
+
+.label-flag {
+  display: block;
+  line-height: 1.4rem;
+  font-size: 1rem;
+  margin: 15px 0 5px;
+  padding: 10px;
+  white-space: normal;
+}
+.label-flag-disabled {
+  margin: 25px 0;
+
+}
+table .label-flag {
+  max-width: 100px;
+}

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1049,3 +1049,11 @@ COUCH_SQL_MIGRATION_BLACKLIST = StaticToggle(
         'ews-ghana', 'ils-gateway', 'ils-gateway-train'
     }
 )
+
+SHOW_DEV_TOGGLE_INFO = StaticToggle(
+    'highlight_feature_flags',
+    'Highlight / Mark Feature Flags in the UI',
+    TAG_DEV_TOOLS,
+    [NAMESPACE_USER]
+)
+

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -40,7 +40,12 @@ TAG_PREVIEW = Tag(
     css_class='default',
     description="",  # I'm not sure...
 )
-ALL_TAGS = [TAG_ONE_OFF, TAG_EXPERIMENTAL, TAG_PRODUCT_PATH, TAG_PRODUCT_CORE, TAG_PREVIEW]
+TAG_DEV_TOOLS = Tag(
+    name='Dev Tools',
+    css_class='default',
+    description="These features are UI enhancements intended for use by developers only.",
+)
+ALL_TAGS = [TAG_ONE_OFF, TAG_EXPERIMENTAL, TAG_PRODUCT_PATH, TAG_PRODUCT_CORE, TAG_PREVIEW, TAG_DEV_TOOLS]
 
 
 class StaticToggle(object):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -40,12 +40,7 @@ TAG_PREVIEW = Tag(
     css_class='default',
     description="",  # I'm not sure...
 )
-TAG_DEV_TOOLS = Tag(
-    name='Dev Tools',
-    css_class='default',
-    description="These features are UI enhancements intended for use by developers only.",
-)
-ALL_TAGS = [TAG_ONE_OFF, TAG_EXPERIMENTAL, TAG_PRODUCT_PATH, TAG_PRODUCT_CORE, TAG_PREVIEW, TAG_DEV_TOOLS]
+ALL_TAGS = [TAG_ONE_OFF, TAG_EXPERIMENTAL, TAG_PRODUCT_PATH, TAG_PRODUCT_CORE, TAG_PREVIEW]
 
 
 class StaticToggle(object):
@@ -1053,7 +1048,7 @@ COUCH_SQL_MIGRATION_BLACKLIST = StaticToggle(
 SHOW_DEV_TOGGLE_INFO = StaticToggle(
     'highlight_feature_flags',
     'Highlight / Mark Feature Flags in the UI',
-    TAG_DEV_TOOLS,
+    TAG_ONE_OFF,
     [NAMESPACE_USER]
 )
 


### PR DESCRIPTION
- tags are only visible if the flag `Highlight / Mark Feature Flags in UI` is enabled
- not meant to look pretty, just for debugging between v2 and v1

<img width="879" alt="screen shot 2017-03-10 at 3 32 41 pm" src="https://cloud.githubusercontent.com/assets/716573/23812094/0470ff8c-05a7-11e7-9c0b-82e2a6d5969e.png">

@orangejenny 
cc @benrudolph 