### PR TITLE
DRY up BaseSelect2Handler

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/accounting.software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/accounting.software_plan_version_handler.js
@@ -67,13 +67,13 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
         self.createNew = function () {
             self.utils.sendToAsyncHandler('create', {
                 name: self.select2.value(),
-                rate_type: self.rateType()
+                rate_type: self.rateType(),
             }, self.addRate);
         };
     
         self.apply = function () {
             self.utils.sendToAsyncHandler('apply', {
-                rate_id: self.select2.value()
+                rate_id: self.select2.value(),
             }, self.addRate);
         };
     
@@ -104,11 +104,11 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
                     statusCode: {
                         500: function () {
                             self.error("Server encountered a problem. Please notify a dev.");
-                        }
-                    }
+                        },
+                    },
                 });
-            }
-        }
+            },
+        };
     };
     
     var PermissionsManager = function (options) {
@@ -118,10 +118,10 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
         self.existingRoles = ko.observableArray();
         self.roleType = ko.observable(options.roleType);
         self.isRoleTypeNew = ko.computed(function () {
-            return self.roleType() == 'new';
+            return self.roleType() === 'new';
         });
         self.isRoleTypeExisting = ko.computed(function () {
-            return self.roleType() == 'existing';
+            return self.roleType() === 'existing';
         });
     
         self.new = new NewRoleManager(self.existingRoles, options.newPrivileges);
@@ -148,12 +148,12 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
                 }
             });
             $('#id_role_slug').select2();
-            $('#roles form').submit(function (e) {
+            $('#roles form').submit(function () {
                 if (self.new.hasMatchingRole() && self.isRoleTypeNew()) {
                     self.existing.roleSlug(self.new.matchingRole().slug());
                     $('#id_role_slug').select2('val', self.new.matchingRole().slug());
                 }
-            })
+            });
         };
     };
     
@@ -215,7 +215,7 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
             return [];
         });
         self.hasNoPrivileges = ko.computed(function () {
-            return _.isEmpty(self.selectedPrivileges())
+            return _.isEmpty(self.selectedPrivileges());
         });
     };
     
@@ -234,10 +234,10 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
             return 'select2_rate';
         };
     
-        self.getExtraData = function (term) {
+        self.getExtraData = function () {
             return {
-                existing: self.currentValue()
-            }
+                existing: self.currentValue(),
+            };
         };
     
         self.createNewChoice = function (term, selectedData) {
@@ -247,7 +247,11 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
                 return item.text;
             });
             if (matching.indexOf(term) === -1 && term) {
-                return {id: term, text: term, isNew: true}
+                return {
+                    id: term,
+                    text: term,
+                    isNew: true,
+                };
             }
         };
     
@@ -268,8 +272,8 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
             return {id: element.val(), text: element.val()};
         };
     
-        self.onSelect2Change = function (event) {
-            if ($(this).val() == '') {
+        self.onSelect2Change = function () {
+            if (!$(this).val()) {
                 self.isNew(false);
                 self.isExisting(false);
             }

--- a/corehq/apps/accounting/static/accounting/js/accounting.software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/accounting.software_plan_version_handler.js
@@ -1,437 +1,354 @@
-$(function() {
-    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
-    var planVersionFormHandler = new SoftwarePlanVersionFormHandler(
-        initial_page_data('role'),
-        initial_page_data('feature_rates'),
-        initial_page_data('product_rates')
-    );
-    $('#roles').koApplyBindings(planVersionFormHandler);
-    planVersionFormHandler.init();
-});
-
-var SoftwarePlanVersionFormHandler = function (role, featureRates, productRates) {
-    'use strict';
-    var self = this;
-
-    self.role = new PermissionsManager(role);
-    self.featureRates = new RateAsyncManager(FeatureRate, featureRates);
-    self.productRates = new RateAsyncManager(ProductRate, productRates);
-
-    self.init = function () {
-        self.role.init();
-        self.featureRates.init();
-        self.productRates.init();
+// This file depends on hqwebapp/js/select2_handler.js
+hqDefine("accounting/js/accounting.software_plan_version_handler.js", function() {
+    $(function() {
+        var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
+        var planVersionFormHandler = new SoftwarePlanVersionFormHandler(
+            initial_page_data('role'),
+            initial_page_data('feature_rates'),
+            initial_page_data('product_rates')
+        );
+        $('#roles').koApplyBindings(planVersionFormHandler);
+        planVersionFormHandler.init();
+    });
+    
+    var SoftwarePlanVersionFormHandler = function (role, featureRates, productRates) {
+        'use strict';
+        var self = this;
+    
+        self.role = new PermissionsManager(role);
+        self.featureRates = new RateAsyncManager(FeatureRate, featureRates);
+        self.productRates = new RateAsyncManager(ProductRate, productRates);
+    
+        self.init = function () {
+            self.role.init();
+            self.featureRates.init();
+            self.productRates.init();
+        };
     };
-};
-
-var RateAsyncManager = function (objClass, options) {
-    'use strict';
-    var self = this;
-
-    self.handlerSlug = options.handlerSlug;
-
-    self.error = ko.observable();
-    self.showError = ko.computed(function () {
-        return !! self.error();
-    });
-
-    self.objClass = objClass;
-    self.rates = ko.observableArray();
-    self.ratesString = ko.computed(function () {
-        return JSON.stringify(_.map(self.rates(), function (obj){
-            return obj.asJSON();
-        }));
-    });
-
-    self.rateNames = ko.computed(function () {
-        return _.map(self.rates(), function(rate) {
-            return rate.name();
+    
+    var RateAsyncManager = function (objClass, options) {
+        'use strict';
+        var self = this;
+    
+        self.handlerSlug = options.handlerSlug;
+    
+        self.error = ko.observable();
+        self.showError = ko.computed(function () {
+            return !! self.error();
         });
-    });
-
-    self.select2 = new Select2RateHandler(options.select2Options, self.rateNames);
-
-    self.init = function () {
-        self.select2.init();
-        var currentValue = JSON.parse(options.currentValue || '[]');
-        self.rates(_.map(currentValue, function (data) {
-            return new self.objClass(data);
-        }));
-
-    };
-
-    self.rateType = ko.observable();
-
-    self.createNew = function () {
-        self.utils.sendToAsyncHandler('create', {
-            name: self.select2.value(),
-            rate_type: self.rateType()
-        }, self.addRate);
-    };
-
-    self.apply = function () {
-        self.utils.sendToAsyncHandler('apply', {
-            rate_id: self.select2.value()
-        }, self.addRate);
-    };
-
-    self.addRate = function (data) {
-        self.rates.push(new self.objClass(data));
-    };
-
-    self.removeRate = function (rate) {
-        self.rates.remove(rate);
-    };
-
-    self.utils = {
-        sendToAsyncHandler: function (action, data, handleSuccess) {
-            data['handler'] = self.handlerSlug;
-            data['action'] = action;
-            $.ajax({
-                dataType: 'json',
-                url: '',
-                type: 'post',
-                data: data,
-                success: function (response) {
-                    if (response.success && handleSuccess) {
-                        handleSuccess(response.data);
+    
+        self.objClass = objClass;
+        self.rates = ko.observableArray();
+        self.ratesString = ko.computed(function () {
+            return JSON.stringify(_.map(self.rates(), function (obj){
+                return obj.asJSON();
+            }));
+        });
+    
+        self.rateNames = ko.computed(function () {
+            return _.map(self.rates(), function(rate) {
+                return rate.name();
+            });
+        });
+    
+        self.select2 = new Select2RateHandler(options.select2Options, self.rateNames);
+    
+        self.init = function () {
+            self.select2.init();
+            var currentValue = JSON.parse(options.currentValue || '[]');
+            self.rates(_.map(currentValue, function (data) {
+                return new self.objClass(data);
+            }));
+    
+        };
+    
+        self.rateType = ko.observable();
+    
+        self.createNew = function () {
+            self.utils.sendToAsyncHandler('create', {
+                name: self.select2.value(),
+                rate_type: self.rateType()
+            }, self.addRate);
+        };
+    
+        self.apply = function () {
+            self.utils.sendToAsyncHandler('apply', {
+                rate_id: self.select2.value()
+            }, self.addRate);
+        };
+    
+        self.addRate = function (data) {
+            self.rates.push(new self.objClass(data));
+        };
+    
+        self.removeRate = function (rate) {
+            self.rates.remove(rate);
+        };
+    
+        self.utils = {
+            sendToAsyncHandler: function (action, data, handleSuccess) {
+                data['handler'] = self.handlerSlug;
+                data['action'] = action;
+                $.ajax({
+                    dataType: 'json',
+                    url: '',
+                    type: 'post',
+                    data: data,
+                    success: function (response) {
+                        if (response.success && handleSuccess) {
+                            handleSuccess(response.data);
+                        }
+                        self.error(response.error);
+                        self.select2.clear();
+                    },
+                    statusCode: {
+                        500: function () {
+                            self.error("Server encountered a problem. Please notify a dev.");
+                        }
                     }
-                    self.error(response.error);
-                    self.select2.clear();
-                },
-                statusCode: {
-                    500: function () {
-                        self.error("Server encountered a problem. Please notify a dev.");
-                    }
+                });
+            }
+        }
+    };
+    
+    var PermissionsManager = function (options) {
+        'use strict';
+        var self = this;
+    
+        self.existingRoles = ko.observableArray();
+        self.roleType = ko.observable(options.roleType);
+        self.isRoleTypeNew = ko.computed(function () {
+            return self.roleType() == 'new';
+        });
+        self.isRoleTypeExisting = ko.computed(function () {
+            return self.roleType() == 'existing';
+        });
+    
+        self.new = new NewRoleManager(self.existingRoles, options.newPrivileges);
+        self.existing = new ExistingRoleManager(self.existingRoles, options.currentRoleSlug);
+    
+        self.init = function () {
+            if (options.multiSelectField) {
+                var multiselect_utils = hqImport('style/js/multiselect_utils');
+                multiselect_utils.createFullMultiselectWidget(
+                    'id_' + options.multiSelectField.slug,
+                    options.multiSelectField.titleSelect,
+                    options.multiSelectField.titleSelected,
+                    options.multiSelectField.titleSearch
+                );
+            }
+            self.existingRoles(_.map(options.existingRoles, function (data) {
+                return new Role(data);
+            }));
+            $('#id_new_role_slug').on('keyup change', function (event) {
+                var c = String.fromCharCode(event.keyCode);
+                if (c.match(/\w/)) {
+                    var orig_val = $(this).val();
+                    $(this).val(orig_val.replace(' ', '_').replace('-','_'));
                 }
             });
-        }
-    }
-};
-
-var PermissionsManager = function (options) {
-    'use strict';
-    var self = this;
-
-    self.existingRoles = ko.observableArray();
-    self.roleType = ko.observable(options.roleType);
-    self.isRoleTypeNew = ko.computed(function () {
-        return self.roleType() == 'new';
-    });
-    self.isRoleTypeExisting = ko.computed(function () {
-        return self.roleType() == 'existing';
-    });
-
-    self.new = new NewRoleManager(self.existingRoles, options.newPrivileges);
-    self.existing = new ExistingRoleManager(self.existingRoles, options.currentRoleSlug);
-
-    self.init = function () {
-        if (options.multiSelectField) {
-            var multiselect_utils = hqImport('style/js/multiselect_utils');
-            multiselect_utils.createFullMultiselectWidget(
-                'id_' + options.multiSelectField.slug,
-                options.multiSelectField.titleSelect,
-                options.multiSelectField.titleSelected,
-                options.multiSelectField.titleSearch
-            );
-        }
-        self.existingRoles(_.map(options.existingRoles, function (data) {
-            return new Role(data);
+            $('#id_role_slug').select2();
+            $('#roles form').submit(function (e) {
+                if (self.new.hasMatchingRole() && self.isRoleTypeNew()) {
+                    self.existing.roleSlug(self.new.matchingRole().slug());
+                    $('#id_role_slug').select2('val', self.new.matchingRole().slug());
+                }
+            })
+        };
+    };
+    
+    var NewRoleManager = function (existingRoles, newPrivileges) {
+        'use strict';
+        var self = this;
+    
+        self.existingRoles = existingRoles;
+    
+        self.privileges = ko.observableArray(newPrivileges);
+        self.matchingRole = ko.computed(function () {
+            // If the set of current privileges match the privileges of an existing role, return that existing role.
+            var existingRole = null;
+            _.each(self.existingRoles(), function (role) {
+                var isEquivalent = _.isEmpty(role.privilegeSlugs()) && _.isEmpty(self.privileges());
+                if (isEquivalent || (!_.isEmpty(role.privilegeSlugs())
+                        && _.isEmpty(_(role.privilegeSlugs()).difference(self.privileges()))
+                        && role.privilegeSlugs().length === self.privileges().length)) {
+                    existingRole = role;
+                }
+            });
+            return existingRole;
+        });
+        self.matchingPrivileges = ko.computed(function () {
+            if (self.matchingRole()) {
+                return self.matchingRole().privileges();
+            }
+            return [];
+        });
+        self.allowCreate = ko.computed(function () {
+            return !_.isEmpty(self.privileges()) && _.isEmpty(self.matchingPrivileges());
+        });
+        self.hasMatchingRole = ko.computed(function () {
+            return !_.isNull(self.matchingRole());
+        });
+    };
+    
+    
+    var ExistingRoleManager = function (existingRoles, currentRoleSlug) {
+        'use strict';
+        var self = this;
+    
+        self.existingRoles = existingRoles;
+    
+        self.roleSlug = ko.observable(currentRoleSlug);
+        self.selectedRole = ko.computed(function () {
+            var selectedRole = null;
+            _.each(self.existingRoles(), function (role) {
+                if (role.slug() === self.roleSlug()) {
+                    selectedRole = role;
+                }
+            });
+            return selectedRole;
+        });
+        self.selectedPrivileges = ko.computed(function () {
+            if (self.selectedRole()) {
+                return self.selectedRole().privileges();
+            }
+            return [];
+        });
+        self.hasNoPrivileges = ko.computed(function () {
+            return _.isEmpty(self.selectedPrivileges())
+        });
+    };
+    
+    
+    var Select2RateHandler = function (options, currentValue) {
+        'use strict';
+        BaseSelect2Handler.call(this, options);
+    
+        var self = this;
+        self.currentValue = currentValue;
+        self.isNew = ko.observable(false);
+        self.isExisting = ko.observable(false);
+    
+        self.getHandlerSlug = function () {
+            return 'select2_rate';
+        };
+    
+        self.getExtraData = function (term) {
+            return {
+                existing: self.currentValue()
+            }
+        };
+    
+        self.createNewChoice = function (term, selectedData) {
+            // override this if you want the search to return the option of creating whatever
+            // the user entered.
+            var matching = _(selectedData).map(function (item) {
+                return item.text;
+            });
+            if (matching.indexOf(term) === -1 && term) {
+                return {id: term, text: term, isNew: true}
+            }
+        };
+    
+        self.formatResult = function (result) {
+            if (result.isNew) {
+                return '<span class="label label-success">New</span> ' + result.text;
+            }
+            return result.name + ' <span class="label">' + result.rate_type + '</span>';
+        };
+    
+        self.formatSelection = function (result) {
+            self.isNew(!!result.isNew);
+            self.isExisting(!!result.isExisting);
+            return result.text || (result.name + ' [' + result.rate_type + ']');
+        };
+    
+        self.getInitialData = function (element) {
+            return {id: element.val(), text: element.val()};
+        };
+    
+        self.onSelect2Change = function (event) {
+            if ($(this).val() == '') {
+                self.isNew(false);
+                self.isExisting(false);
+            }
+        };
+    };
+    
+    Select2RateHandler.prototype = Object.create( BaseSelect2Handler.prototype );
+    Select2RateHandler.prototype.constructor = Select2RateHandler;
+    
+    
+    var Role = function (data) {
+        'use strict';
+        var self = this;
+    
+        self.privileges = ko.observableArray(_.map(data.privileges, function (priv) {
+            return new Privilege(priv);
         }));
-        $('#id_new_role_slug').on('keyup change', function (event) {
-            var c = String.fromCharCode(event.keyCode);
-            if (c.match(/\w/)) {
-                var orig_val = $(this).val();
-                $(this).val(orig_val.replace(' ', '_').replace('-','_'));
-            }
+        self.privilegeSlugs = ko.computed(function () {
+            return _.map(self.privileges(), function (priv) {
+                return priv.slug();
+            });
         });
-        $('#id_role_slug').select2();
-        $('#roles form').submit(function (e) {
-            if (self.new.hasMatchingRole() && self.isRoleTypeNew()) {
-                self.existing.roleSlug(self.new.matchingRole().slug());
-                $('#id_role_slug').select2('val', self.new.matchingRole().slug());
-            }
-        })
+    
+        self.slug = ko.observable(data.slug);
+        self.name = ko.observable(data.name);
+        self.description = ko.observable(data.description);
     };
-};
-
-var NewRoleManager = function (existingRoles, newPrivileges) {
-    'use strict';
-    var self = this;
-
-    self.existingRoles = existingRoles;
-
-    self.privileges = ko.observableArray(newPrivileges);
-    self.matchingRole = ko.computed(function () {
-        // If the set of current privileges match the privileges of an existing role, return that existing role.
-        var existingRole = null;
-        _.each(self.existingRoles(), function (role) {
-            var isEquivalent = _.isEmpty(role.privilegeSlugs()) && _.isEmpty(self.privileges());
-            if (isEquivalent || (!_.isEmpty(role.privilegeSlugs())
-                    && _.isEmpty(_(role.privilegeSlugs()).difference(self.privileges()))
-                    && role.privilegeSlugs().length === self.privileges().length)) {
-                existingRole = role;
-            }
+    
+    
+    var Privilege = function (data) {
+        'use strict';
+        var self = this;
+        self.slug = ko.observable(data[0]);
+        self.name = ko.observable(data[1]);
+    };
+    
+    
+    var FeatureRate = function (data) {
+        'use strict';
+        var self = this;
+    
+        self.name = ko.observable(data.name);
+        self.feature_type = ko.observable(data.feature_type);
+        self.feature_id = ko.observable(data.feature_id);
+        self.rate_id = ko.observable(data.rate_id);
+        self.monthly_fee = ko.observable(data.monthly_fee);
+        self.per_excess_fee = ko.observable(data.per_excess_fee);
+        self.monthly_limit = ko.observable(data.monthly_limit);
+    
+        self.isPerExcessVisible = ko.computed(function () {
+            return self.feature_type() !== 'SMS';
         });
-        return existingRole;
-    });
-    self.matchingPrivileges = ko.computed(function () {
-        if (self.matchingRole()) {
-            return self.matchingRole().privileges();
-        }
-        return [];
-    });
-    self.allowCreate = ko.computed(function () {
-        return !_.isEmpty(self.privileges()) && _.isEmpty(self.matchingPrivileges());
-    });
-    self.hasMatchingRole = ko.computed(function () {
-        return !_.isNull(self.matchingRole());
-    });
-};
-
-
-var ExistingRoleManager = function (existingRoles, currentRoleSlug) {
-    'use strict';
-    var self = this;
-
-    self.existingRoles = existingRoles;
-
-    self.roleSlug = ko.observable(currentRoleSlug);
-    self.selectedRole = ko.computed(function () {
-        var selectedRole = null;
-        _.each(self.existingRoles(), function (role) {
-            if (role.slug() === self.roleSlug()) {
-                selectedRole = role;
-            }
-        });
-        return selectedRole;
-    });
-    self.selectedPrivileges = ko.computed(function () {
-        if (self.selectedRole()) {
-            return self.selectedRole().privileges();
-        }
-        return [];
-    });
-    self.hasNoPrivileges = ko.computed(function () {
-        return _.isEmpty(self.selectedPrivileges())
-    });
-};
-
-
-var BaseSelect2Handler = function (options, currentSelectionObj) {
-    'use strict';
-    var self = this;
-    self.currentSelection = currentSelectionObj;
-    self.fieldName = options.fieldName;
-    self.value = ko.observable();
-
-    self.clear = function () {
-        var fieldInput = self.utils.getField();
-        fieldInput.select2('val', '');
+    
+        self.asJSON = function () {
+            var result = {};
+            _.each(['name', 'feature_type', 'feature_id', 'rate_id', 'monthly_fee',
+                'per_excess_fee', 'monthly_limit'], function (field) {
+                result[field] = self[field]();
+            });
+            return result;
+        };
     };
-
-    self.getHandlerSlug = function () {
-        throw new Error('getHandlerSlug must be implemented;')
+    
+    
+    var ProductRate = function (data) {
+        'use strict';
+        var self = this;
+    
+        self.name = ko.observable(data.name);
+        self.product_type = ko.observable(data.product_type);
+        self.product_id = ko.observable(data.product_id);
+        self.rate_id = ko.observable(data.rate_id);
+        self.monthly_fee = ko.observable(data.monthly_fee);
+    
+        self.asJSON = function () {
+            var result = {};
+            _.each(['name', 'product_type', 'product_id', 'rate_id', 'monthly_fee'], function (field) {
+                result[field] = self[field]();
+            });
+            return result;
+        };
     };
-
-    self.getExtraData = function () {
-        return {}
-    };
-
-    self.processResults = function (response) {
-        // override this if you want to do something special with the response.
-        return response;
-    };
-
-    self.createNewChoice = function (term, selectedData) {
-        // override this if you want the search to return the option of creating whatever
-        // the user entered.
-    };
-
-    self.formatResult = function (result) {
-        return result.text;
-    };
-
-    self.formatSelection = function (result) {
-        return result.text;
-    };
-
-    self.getInitialData = function (element) {
-        // override this if you want to format the value that is initially stored in the field for this widget.
-    };
-
-    self.utils = {
-        getField: function () {
-            return $('[name="' + self.fieldName + '"]');
-        }
-    };
-
-    self.init = function () {
-        var fieldInput = self.utils.getField();
-        fieldInput.select2({
-            minimumInputLength: 0,
-            allowClear: true,
-            ajax: {
-                quietMillis: 150,
-                url: '',
-                dataType: 'json',
-                type: 'post',
-                data: function (term) {
-                    var data = self.getExtraData(term);
-                    data['handler'] = self.getHandlerSlug();
-                    data['action'] = self.fieldName;
-                    data['searchString'] = term;
-                    return data;
-                },
-                results: self.processResults,
-                500: function () {
-                    self.error("Server encountered a problem. Please notify a dev.");
-                }
-            },
-            createSearchChoice: self.createNewChoice,
-            formatResult: self.formatResult,
-            formatSelection: self.formatSelection,
-            initSelection : function (element, callback) {
-                if (element.val()) {
-                    var data = self.getInitialData(element);
-                    if (data) callback(data);
-                }
-            }
-        });
-        if (self.onSelect2Change) {
-            fieldInput.on("change", self.onSelect2Change);
-        }
-    };
-};
-
-var Select2RateHandler = function (options, currentValue) {
-    'use strict';
-    BaseSelect2Handler.call(this, options, currentValue);
-
-    var self = this;
-    self.currentValue = currentValue;
-    self.isNew = ko.observable(false);
-    self.isExisting = ko.observable(false);
-
-    self.getHandlerSlug = function () {
-        return 'select2_rate';
-    };
-
-    self.getExtraData = function (term) {
-        return {
-            existing: self.currentValue()
-        }
-    };
-
-    self.createNewChoice = function (term, selectedData) {
-        // override this if you want the search to return the option of creating whatever
-        // the user entered.
-        var matching = _(selectedData).map(function (item) {
-            return item.text;
-        });
-        if (matching.indexOf(term) === -1 && term) {
-            return {id: term, text: term, isNew: true}
-        }
-    };
-
-    self.formatResult = function (result) {
-        if (result.isNew) {
-            return '<span class="label label-success">New</span> ' + result.text;
-        }
-        return result.name + ' <span class="label">' + result.rate_type + '</span>';
-    };
-
-    self.formatSelection = function (result) {
-        self.isNew(!!result.isNew);
-        self.isExisting(!!result.isExisting);
-        return result.text || (result.name + ' [' + result.rate_type + ']');
-    };
-
-    self.getInitialData = function (element) {
-        return {id: element.val(), text: element.val()};
-    };
-
-    self.onSelect2Change = function (event) {
-        if ($(this).val() == '') {
-            self.isNew(false);
-            self.isExisting(false);
-        }
-    };
-};
-
-Select2RateHandler.prototype = Object.create( BaseSelect2Handler.prototype );
-Select2RateHandler.prototype.constructor = Select2RateHandler;
-
-
-var Role = function (data) {
-    'use strict';
-    var self = this;
-
-    self.privileges = ko.observableArray(_.map(data.privileges, function (priv) {
-        return new Privilege(priv);
-    }));
-    self.privilegeSlugs = ko.computed(function () {
-        return _.map(self.privileges(), function (priv) {
-            return priv.slug();
-        });
-    });
-
-    self.slug = ko.observable(data.slug);
-    self.name = ko.observable(data.name);
-    self.description = ko.observable(data.description);
-};
-
-
-var Privilege = function (data) {
-    'use strict';
-    var self = this;
-    self.slug = ko.observable(data[0]);
-    self.name = ko.observable(data[1]);
-};
-
-
-var FeatureRate = function (data) {
-    'use strict';
-    var self = this;
-
-    self.name = ko.observable(data.name);
-    self.feature_type = ko.observable(data.feature_type);
-    self.feature_id = ko.observable(data.feature_id);
-    self.rate_id = ko.observable(data.rate_id);
-    self.monthly_fee = ko.observable(data.monthly_fee);
-    self.per_excess_fee = ko.observable(data.per_excess_fee);
-    self.monthly_limit = ko.observable(data.monthly_limit);
-
-    self.isPerExcessVisible = ko.computed(function () {
-        return self.feature_type() !== 'SMS';
-    });
-
-    self.asJSON = function () {
-        var result = {};
-        _.each(['name', 'feature_type', 'feature_id', 'rate_id', 'monthly_fee',
-            'per_excess_fee', 'monthly_limit'], function (field) {
-            result[field] = self[field]();
-        });
-        return result;
-    };
-};
-
-
-var ProductRate = function (data) {
-    'use strict';
-    var self = this;
-
-    self.name = ko.observable(data.name);
-    self.product_type = ko.observable(data.product_type);
-    self.product_id = ko.observable(data.product_id);
-    self.rate_id = ko.observable(data.rate_id);
-    self.monthly_fee = ko.observable(data.monthly_fee);
-
-    self.asJSON = function () {
-        var result = {};
-        _.each(['name', 'product_type', 'product_id', 'rate_id', 'monthly_fee'], function (field) {
-            result[field] = self[field]();
-        });
-        return result;
-    };
-};
+});

--- a/corehq/apps/accounting/static/accounting/js/accounting.software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/accounting.software_plan_version_handler.js
@@ -220,6 +220,7 @@ hqDefine("accounting/js/accounting.software_plan_version_handler.js", function()
     };
     
     
+    var BaseSelect2Handler = hqImport("hqwebapp/js/select2_handler.js").BaseSelect2Handler;
     var Select2RateHandler = function (options, currentValue) {
         'use strict';
         BaseSelect2Handler.call(this, options);

--- a/corehq/apps/accounting/templates/accounting/plans.html
+++ b/corehq/apps/accounting/templates/accounting/plans.html
@@ -5,6 +5,7 @@
 
 {% block js %}{{ block.super }}
     <script src="{% static 'hqwebapp/js/stay-on-tab.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/select2_handler.js' %}"></script>
     <script src="{% static 'accounting/js/accounting.software_plan_version_handler.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
@@ -1,89 +1,95 @@
-var BaseSelect2Handler = function (options) {
-    // For use with BaseAsyncHandler
-    // todo: documentation (biyeun)
-    'use strict';
-    var self = this;
-    self.fieldName = options.fieldName;
-    self.value = ko.observable();
-
-    self.clear = function () {
-        var fieldInput = self.utils.getField();
-        fieldInput.select2('val', '');
-    };
-
-    self.getHandlerSlug = function () {
-        // This is the slug for the AsyncHandler you'll be using on the server side
-        throw new Error('getHandlerSlug must be implemented');
-    };
-
-    self.getExtraData = function () {
-        return {};
-    };
-
-    self.processResults = function (response) {
-        // override this if you want to do something special with the response.
-        return response;
-    };
-
-    self.createNewChoice = function (term, selectedData) {
-        // override this if you want the search to return the option of creating whatever
-        // the user entered.
-    };
-
-    self.formatResult = function (result) {
-        return result.text;
-    };
-
-    self.formatSelection = function (result) {
-        return result.text;
-    };
-
-    self.getInitialData = function (element) {
-        // override this if you want to format the value that is initially stored in the field for this widget.
-    };
-
-    self.utils = {
-        getField: function () {
-            return $('[name="' + self.fieldName + '"]');
-        }
-    };
-
-    self.init = function () {
-        var fieldInput = self.utils.getField();
-        fieldInput.select2({
-            minimumInputLength: 0,
-            allowClear: true,
-            ajax: {
-                quietMillis: 150,
-                url: '',
-                dataType: 'json',
-                type: 'post',
-                data: function (term) {
-                    var data = self.getExtraData(term);
-                    data['handler'] = self.getHandlerSlug();
-                    data['action'] = self.fieldName;
-                    data['searchString'] = term;
-                    return data;
-                },
-                results: self.processResults,
-                500: function () {
-                    self.error(
-                        gettext("There was an issue communicating with the server. Please try back later.")
-                    );
-                }
-            },
-            createSearchChoice: self.createNewChoice,
-            formatResult: self.formatResult,
-            formatSelection: self.formatSelection,
-            initSelection : function (element, callback) {
-                if (element.val()) {
-                    var data = self.getInitialData(element);
-                    if (data) callback(data);
-                }
+hqDefine("hqwebapp/js/select2_handler.js", function() {
+    var BaseSelect2Handler = function (options) {
+        // For use with BaseAsyncHandler
+        // todo: documentation (biyeun)
+        'use strict';
+        var self = this;
+        self.fieldName = options.fieldName;
+        self.value = ko.observable();
+    
+        self.clear = function () {
+            var fieldInput = self.utils.getField();
+            fieldInput.select2('val', '');
+        };
+    
+        self.getHandlerSlug = function () {
+            // This is the slug for the AsyncHandler you'll be using on the server side
+            throw new Error('getHandlerSlug must be implemented');
+        };
+    
+        self.getExtraData = function () {
+            return {};
+        };
+    
+        self.processResults = function (response) {
+            // override this if you want to do something special with the response.
+            return response;
+        };
+    
+        self.createNewChoice = function (term, selectedData) {
+            // override this if you want the search to return the option of creating whatever
+            // the user entered.
+        };
+    
+        self.formatResult = function (result) {
+            return result.text;
+        };
+    
+        self.formatSelection = function (result) {
+            return result.text;
+        };
+    
+        self.getInitialData = function (element) {
+            // override this if you want to format the value that is initially stored in the field for this widget.
+        };
+    
+        self.utils = {
+            getField: function () {
+                return $('[name="' + self.fieldName + '"]');
             }
-        });
-        if (self.onSelect2Change) {
-            fieldInput.on("change", self.onSelect2Change);
-        }
+        };
+    
+        self.init = function () {
+            var fieldInput = self.utils.getField();
+            fieldInput.select2({
+                minimumInputLength: 0,
+                allowClear: true,
+                ajax: {
+                    quietMillis: 150,
+                    url: '',
+                    dataType: 'json',
+                    type: 'post',
+                    data: function (term) {
+                        var data = self.getExtraData(term);
+                        data['handler'] = self.getHandlerSlug();
+                        data['action'] = self.fieldName;
+                        data['searchString'] = term;
+                        return data;
+                    },
+                    results: self.processResults,
+                    500: function () {
+                        self.error(
+                            gettext("There was an issue communicating with the server. Please try back later.")
+                        );
+                    }
+                },
+                createSearchChoice: self.createNewChoice,
+                formatResult: self.formatResult,
+                formatSelection: self.formatSelection,
+                initSelection : function (element, callback) {
+                    if (element.val()) {
+                        var data = self.getInitialData(element);
+                        if (data) callback(data);
+                    }
+                }
+            });
+            if (self.onSelect2Change) {
+                fieldInput.on("change", self.onSelect2Change);
+            }
+        };
     };
-};
+
+    return {
+        BaseSelect2Handler: BaseSelect2Handler,
+    };
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
@@ -3,7 +3,6 @@ var BaseSelect2Handler = function (options) {
     // todo: documentation (biyeun)
     'use strict';
     var self = this;
-    self.currentValue = options.currentValue;
     self.fieldName = options.fieldName;
     self.value = ko.observable();
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
@@ -46,7 +46,7 @@ hqDefine("hqwebapp/js/select2_handler.js", function() {
         self.utils = {
             getField: function () {
                 return $('[name="' + self.fieldName + '"]');
-            }
+            },
         };
     
         self.init = function () {
@@ -71,7 +71,7 @@ hqDefine("hqwebapp/js/select2_handler.js", function() {
                         self.error(
                             gettext("There was an issue communicating with the server. Please try back later.")
                         );
-                    }
+                    },
                 },
                 createSearchChoice: self.createNewChoice,
                 formatResult: self.formatResult,

--- a/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
+++ b/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
@@ -20,8 +20,8 @@ hqDefine("smsbillables/js/smsbillables.rate_calc.js", function() {
             self.select2CountryCode.getExtraData = function (term) {
                 return {
                     'gateway': self.gateway(),
-                    'direction': self.direction()
-                }
+                    'direction': self.direction(),
+                };
             };
             self.select2CountryCode.init();
         };
@@ -43,7 +43,7 @@ hqDefine("smsbillables/js/smsbillables.rate_calc.js", function() {
                         direction: self.direction(),
                         country_code: self.select2CountryCode.value(),
                         handler: 'sms_get_rate',
-                        action: 'get_rate'
+                        action: 'get_rate',
                     },
                     success: function (response) {
                         self.calculatingRate(false);
@@ -58,7 +58,7 @@ hqDefine("smsbillables/js/smsbillables.rate_calc.js", function() {
                     error: function () {
                         self.calculatingRate(false);
                         self.rate(gettext("There was an error fetching the SMS rate."));
-                    }
+                    },
                 });
             }
         };
@@ -85,28 +85,28 @@ hqDefine("smsbillables/js/smsbillables.rate_calc.js", function() {
         });
     
         var updateRate = function () {
-                self.calculatingRate(true);
-                $.ajax({
-                    url: '',
-                    dataType: 'json',
-                    type: 'POST',
-                    data: {
-                        country_code: self.country_code,
-                        handler: 'public_sms_rate_calc',
-                        action: 'public_rate'
-                    },
-                    success: function (response) {
-                        self.calculatingRate(false);
-                        self.rate_table(response.data);
-                        self.hasError(false);
-                        self.rateErrorText(false);
-                    },
-                    error: function () {
-                        self.calculatingRate(false);
-                        self.hasError(true);
-                        self.rateErrorText(gettext("There was an error fetching the SMS rate."));
-                    }
-                });
+            self.calculatingRate(true);
+            $.ajax({
+                url: '',
+                dataType: 'json',
+                type: 'POST',
+                data: {
+                    country_code: self.country_code,
+                    handler: 'public_sms_rate_calc',
+                    action: 'public_rate',
+                },
+                success: function (response) {
+                    self.calculatingRate(false);
+                    self.rate_table(response.data);
+                    self.hasError(false);
+                    self.rateErrorText(false);
+                },
+                error: function () {
+                    self.calculatingRate(false);
+                    self.hasError(true);
+                    self.rateErrorText(gettext("There was an error fetching the SMS rate."));
+                }
+            });
         };
         self.country_code.subscribe(updateRate);
     };

--- a/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
+++ b/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
@@ -1,155 +1,158 @@
-var SMSRateCalculator = function (form_data) {
-    'use strict';
-    var self = this;
-
-    self.gateway = ko.observable();
-    self.direction = ko.observable();
-    self.select2CountryCode = new Select2SmsRateHandler(form_data.country_code);
-    self.rate = ko.observable();
-    self.hasError = ko.observable(false);
-    self.noError = ko.computed(function () {
-        return ! self.hasError();
-    });
-    self.calculatingRate = ko.observable(false);
-    self.showRateInfo = ko.computed(function () {
-        return self.rate() && ! self.calculatingRate();
-    });
-
-    self.init = function () {
-        self.select2CountryCode.getExtraData = function (term) {
-            return {
-                'gateway': self.gateway(),
-                'direction': self.direction()
+hqDefine("smsbillables/js/smsbillables.rate_calc.js", function() {
+    var SMSRateCalculator = function (form_data) {
+        'use strict';
+        var self = this;
+    
+        self.gateway = ko.observable();
+        self.direction = ko.observable();
+        self.select2CountryCode = new Select2SmsRateHandler(form_data.country_code);
+        self.rate = ko.observable();
+        self.hasError = ko.observable(false);
+        self.noError = ko.computed(function () {
+            return ! self.hasError();
+        });
+        self.calculatingRate = ko.observable(false);
+        self.showRateInfo = ko.computed(function () {
+            return self.rate() && ! self.calculatingRate();
+        });
+    
+        self.init = function () {
+            self.select2CountryCode.getExtraData = function (term) {
+                return {
+                    'gateway': self.gateway(),
+                    'direction': self.direction()
+                }
+            };
+            self.select2CountryCode.init();
+        };
+    
+        self.clearSelect2 = function () {
+            self.select2CountryCode.clear();
+            self.rate('');
+        };
+    
+        self.updateRate = function () {
+            if (self.select2CountryCode.value()) {
+                self.calculatingRate(true);
+                $.ajax({
+                    url: '',
+                    dataType: 'json',
+                    type: 'POST',
+                    data: {
+                        gateway: self.gateway(),
+                        direction: self.direction(),
+                        country_code: self.select2CountryCode.value(),
+                        handler: 'sms_get_rate',
+                        action: 'get_rate'
+                    },
+                    success: function (response) {
+                        self.calculatingRate(false);
+                        if (response.success) {
+                            self.rate(response.data.rate);
+                            self.hasError(false);
+                        } else {
+                            self.rate(response.error);
+                            self.hasError(true);
+                        }
+                    },
+                    error: function () {
+                        self.calculatingRate(false);
+                        self.rate(gettext("There was an error fetching the SMS rate."));
+                    }
+                });
             }
         };
-        self.select2CountryCode.init();
     };
-
-    self.clearSelect2 = function () {
-        self.select2CountryCode.clear();
-        self.rate('');
-    };
-
-    self.updateRate = function () {
-        if (self.select2CountryCode.value()) {
-            self.calculatingRate(true);
-            $.ajax({
-                url: '',
-                dataType: 'json',
-                type: 'POST',
-                data: {
-                    gateway: self.gateway(),
-                    direction: self.direction(),
-                    country_code: self.select2CountryCode.value(),
-                    handler: 'sms_get_rate',
-                    action: 'get_rate'
-                },
-                success: function (response) {
-                    self.calculatingRate(false);
-                    if (response.success) {
-                        self.rate(response.data.rate);
+    
+    var PublicSMSRateCalculator = function (form_data) {
+        'use strict';
+        var self = this;
+    
+        var rates = [];
+        self.country_code = ko.observable();
+        self.rate_table = ko.observableArray(rates);
+        self.hasError = ko.observable(false);
+        self.rateErrorText = ko.observable();
+        self.noError = ko.computed(function () {
+            return ! self.hasError();
+        });
+        self.calculatingRate = ko.observable(false);
+        self.showTable = ko.computed(function (){
+            return !self.hasError() && !self.calculatingRate();
+        });
+        self.showRateInfo = ko.computed(function () {
+            return self.rateErrorText() && ! self.calculatingRate();
+        });
+    
+        var updateRate = function () {
+                self.calculatingRate(true);
+                $.ajax({
+                    url: '',
+                    dataType: 'json',
+                    type: 'POST',
+                    data: {
+                        country_code: self.country_code,
+                        handler: 'public_sms_rate_calc',
+                        action: 'public_rate'
+                    },
+                    success: function (response) {
+                        self.calculatingRate(false);
+                        self.rate_table(response.data);
                         self.hasError(false);
-                    } else {
-                        self.rate(response.error);
+                        self.rateErrorText(false);
+                    },
+                    error: function () {
+                        self.calculatingRate(false);
                         self.hasError(true);
+                        self.rateErrorText(gettext("There was an error fetching the SMS rate."));
                     }
+                });
+        };
+        self.country_code.subscribe(updateRate);
+    };
+    
+    var BaseSelect2Handler = hqImport("hqwebapp/js/select2_handler.js").BaseSelect2Handler;
+    var Select2SmsRateHandler = function (options) {
+        'use strict';
+        BaseSelect2Handler.call(this, options);
+        var self = this;
+    
+        self.getHandlerSlug = function () {
+            return 'sms_rate_calc';
+        };
+    
+        self.formatSelection = function (result) {
+            return result.text || (result.name + ' [' + result.rate_type + ']');
+        };
+    
+        self.getInitialData = function (element) {
+            return {id: element.val(), text: element.val()};
+        };
+    };
+    
+    Select2SmsRateHandler.prototype = Object.create( BaseSelect2Handler.prototype );
+    Select2SmsRateHandler.prototype.constructor = Select2SmsRateHandler;
+    
+    $(function() {
+        _.each($(".ko-sms-rate-calculator"), function(element) {
+            var smsRateCalculator = new SMSRateCalculator({
+                country_code: {
+                    fieldName: 'country_code',
+                    currentValue: '',
                 },
-                error: function () {
-                    self.calculatingRate(false);
-                    self.rate(gettext("There was an error fetching the SMS rate."));
-                }
             });
-        }
-    };
-};
-
-var PublicSMSRateCalculator = function (form_data) {
-    'use strict';
-    var self = this;
-
-    var rates = [];
-    self.country_code = ko.observable();
-    self.rate_table = ko.observableArray(rates);
-    self.hasError = ko.observable(false);
-    self.rateErrorText = ko.observable();
-    self.noError = ko.computed(function () {
-        return ! self.hasError();
-    });
-    self.calculatingRate = ko.observable(false);
-    self.showTable = ko.computed(function (){
-        return !self.hasError() && !self.calculatingRate();
-    });
-    self.showRateInfo = ko.computed(function () {
-        return self.rateErrorText() && ! self.calculatingRate();
-    });
-
-    var updateRate = function () {
-            self.calculatingRate(true);
-            $.ajax({
-                url: '',
-                dataType: 'json',
-                type: 'POST',
-                data: {
-                    country_code: self.country_code,
-                    handler: 'public_sms_rate_calc',
-                    action: 'public_rate'
+            $(element).koApplyBindings(smsRateCalculator);
+            smsRateCalculator.init();
+        });
+    
+        _.each($(".ko-public-sms-rate-calculator"), function(element) {
+            var smsRateCalculator = new PublicSMSRateCalculator({
+                country_code: {
+                    fieldName: 'country_code',
+                    currentValue: '',
                 },
-                success: function (response) {
-                    self.calculatingRate(false);
-                    self.rate_table(response.data);
-                    self.hasError(false);
-                    self.rateErrorText(false);
-                },
-                error: function () {
-                    self.calculatingRate(false);
-                    self.hasError(true);
-                    self.rateErrorText(gettext("There was an error fetching the SMS rate."));
-                }
             });
-    };
-    self.country_code.subscribe(updateRate);
-};
-
-var Select2SmsRateHandler = function (options) {
-    'use strict';
-    BaseSelect2Handler.call(this, options);
-    var self = this;
-
-    self.getHandlerSlug = function () {
-        return 'sms_rate_calc';
-    };
-
-    self.formatSelection = function (result) {
-        return result.text || (result.name + ' [' + result.rate_type + ']');
-    };
-
-    self.getInitialData = function (element) {
-        return {id: element.val(), text: element.val()};
-    };
-};
-
-Select2SmsRateHandler.prototype = Object.create( BaseSelect2Handler.prototype );
-Select2SmsRateHandler.prototype.constructor = Select2SmsRateHandler;
-
-$(function() {
-    _.each($(".ko-sms-rate-calculator"), function(element) {
-        var smsRateCalculator = new SMSRateCalculator({
-            country_code: {
-                fieldName: 'country_code',
-                currentValue: '',
-            },
+            $(element).koApplyBindings(smsRateCalculator);
         });
-        $(element).koApplyBindings(smsRateCalculator);
-        smsRateCalculator.init();
-    });
-
-    _.each($(".ko-public-sms-rate-calculator"), function(element) {
-        var smsRateCalculator = new PublicSMSRateCalculator({
-            country_code: {
-                fieldName: 'country_code',
-                currentValue: '',
-            },
-        });
-        $(element).koApplyBindings(smsRateCalculator);
     });
 });


### PR DESCRIPTION
Tested locally that both the select2 handler in accounting.software_plan_version_handler.js (on the plan edit page) and the other usages of select2_handler.js (domain sms rates, global sms rates) all appear to still work fine.

`w=1`

@dannyroberts / @nickpell 