### PR TITLE
Updates to Live Preview Tablet Style

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -102,6 +102,9 @@ hqDefine('app_manager/js/preview_app.js', function() {
         } else {
             _private.phoneView(true);
         }
+        setTimeout(function () {
+            $(window).trigger(module.EVENTS.RESIZE);
+        }, 1001);
     };
 
     _private.toggleLocalStorageDatum = function(datum) {

--- a/corehq/apps/style/static/app_manager/less/preview_app-main.less
+++ b/corehq/apps/style/static/app_manager/less/preview_app-main.less
@@ -10,7 +10,7 @@ preview_app/less */
 
 @preview-phone-wrapper-width: 310px;
 @preview-phone-width: 250px;
-@preview-tablet-wrapper-width: 500px;
+@preview-tablet-wrapper-width: 515px;
 @preview-tablet-width: 450px;
 @preview-tablet-height: 644px;
 @preview-phone-height: 444px;


### PR DESCRIPTION
@benrudolph 

Some updates to Live Preview's tablet style. Jen mentioned this in her feedback.

- make sure resize event is triggered after switching to phone or tablet view, so that height is recalculated and nav bar doesn't overlap the UI
- make the tablet container a little wider so that the border doesn't overlap the close button and the tablet looks centered