### PR TITLE
remove unused *args from handle()

### DIFF
--- a/corehq/apps/analytics/management/commands/initialize_kissmetrics_plan_editions.py
+++ b/corehq/apps/analytics/management/commands/initialize_kissmetrics_plan_editions.py
@@ -6,6 +6,6 @@ from corehq.apps.domain.models import Domain
 class Command(BaseCommand):
     help = ("Send KISSmetrics data on subscriptions for all domains")
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for domain in Domain.get_all():
             subscription_upgrade_or_downgrade.send_robust(None, domain=domain)

--- a/corehq/apps/app_manager/management/commands/audit_app_profile_properties.py
+++ b/corehq/apps/app_manager/management/commands/audit_app_profile_properties.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         Determine how many apps have changed their profile properties from the default values.
     '''
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         domains = [row['key'] for row in Domain.get_all(include_docs=False)]
         settings = {s['id']: s['default'] for s in get_custom_commcare_settings() if 'default' in s}
         deviant_counts = {id: 0 for id in settings.keys()}

--- a/corehq/apps/app_manager/management/commands/build_app_manager_v2_diffs.py
+++ b/corehq/apps/app_manager/management/commands/build_app_manager_v2_diffs.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
     Computes diffs of
     '''
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         self.base_dir = os.path.dirname(os.path.realpath(__file__))
         self._make_diffs(
             RELATIVE_YAML_V1,

--- a/corehq/apps/app_manager/management/commands/find_intents.py
+++ b/corehq/apps/app_manager/management/commands/find_intents.py
@@ -6,7 +6,7 @@ import sys
 
 class Command(BaseCommand):
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         csvWriter = csv.writer(sys.stdout)
         for domain in Domain.get_all():
             for app in domain.full_applications(include_builds=False):

--- a/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         Migrate any non-migrated apps
     '''
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         app_query = AppES().is_build(False).term('vellum_case_management', False) \
                            .term('doc_type', 'Application').size(500).source(['domain', '_id'])
 

--- a/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         parser.add_argument('--force', action='store_true',
             help='Migrate even if app.vellum_case_management is already true.')
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         domains = []
         app_ids = []
         self.force = options["force"]

--- a/corehq/apps/change_feed/management/commands/create_kafka_topics.py
+++ b/corehq/apps/change_feed/management/commands/create_kafka_topics.py
@@ -6,7 +6,7 @@ from corehq.apps.change_feed.connection import get_kafka_client
 
 class Command(BaseCommand):
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         create_kafka_topics()
 
 

--- a/corehq/apps/change_feed/management/commands/run_form_websocket_feed.py
+++ b/corehq/apps/change_feed/management/commands/run_form_websocket_feed.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             help="Use 'compact' mode - don't include additional domain metadata (faster)",
         )
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         since = options['from']
         sleep = float(options['sleep'] or '.01')
         last_domain = None

--- a/corehq/apps/commtrack/management/commands/check_product_migration.py
+++ b/corehq/apps/commtrack/management/commands/check_product_migration.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     # context: https://github.com/dimagi/commcare-hq/pull/4043/files#diff-649db0a832878e7671cee114fa1e66b0R50
     help = 'Checks the state of products prior to migrating them to sql'
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
 
         self.stdout.write("Processing products...\n")
         products = set()

--- a/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
+++ b/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
     help = ("Make sure all supply point cases have their owner_id set "
             "to the location_id")
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         all_domains = Domain.get_all_names()
         total = len(all_domains)
         finished = 0

--- a/corehq/apps/data_dictionary/management/commands/generate_data_dictionary.py
+++ b/corehq/apps/data_dictionary/management/commands/generate_data_dictionary.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     """
     help = 'Generates data dictionary for all domains'
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         print('Generating data dictionary for domains')
         failed_domains = []
         for domain_dict in with_progress_bar(Domain.get_all(include_docs=False)):

--- a/corehq/apps/domain/management/commands/fill_last_modified_date.py
+++ b/corehq/apps/domain/management/commands/fill_last_modified_date.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         ])
         return filter(lambda x: 'last_modified' not in x or not x['last_modified'], docs)
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for domain_doc in self._get_domains_without_last_modified_date():
             print("Updating domain {}".format(domain_doc['name']))
             domain = Domain.wrap(domain_doc)

--- a/corehq/apps/domain/management/commands/find_secure_submission_image_domains.py
+++ b/corehq/apps/domain/management/commands/find_secure_submission_image_domains.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
                                 ])
                                 return
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         with open('domain_results.csv', 'wb+') as csvfile:
             csv_writer = csv.writer(
                 csvfile,

--- a/corehq/apps/domain/management/commands/mark_snapshot_head.py
+++ b/corehq/apps/domain/management/commands/mark_snapshot_head.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
     help = "Marks most recent snapshot of a domain"
     args = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         print("Migrating snapshot documents to have a marked head")
 
         for domain in Domain.get_all(include_docs=False):

--- a/corehq/apps/domain/management/commands/migrate_can_use_data.py
+++ b/corehq/apps/domain/management/commands/migrate_can_use_data.py
@@ -7,10 +7,8 @@ from corehq.apps.domain.models import Domain
 
 class Command(BaseCommand):
     help = "Migrates the 'can_use_data' field to not be the opposite of what it sounds like."
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         opted_out_domains = []
         failed = []
         for domain in Domain.get_all():

--- a/corehq/apps/domain/management/commands/migrate_domain_countries.py
+++ b/corehq/apps/domain/management/commands/migrate_domain_countries.py
@@ -6,10 +6,8 @@ from corehq.apps.domain.models import Domain
 
 class Command(BaseCommand):
     help = "Migrates old django domain countries from string to list. Sept 2014."
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         print("Migrating Domain countries")
 
         country_lookup = {v.lower(): k for k, v in COUNTRIES.iteritems()}

--- a/corehq/apps/domain/management/commands/migrate_impact_annotations.py
+++ b/corehq/apps/domain/management/commands/migrate_impact_annotations.py
@@ -5,9 +5,8 @@ from corehq.apps.domain.models import Domain
 
 class Command(BaseCommand):
     help = "Migrates wam and pam eligibility from apps to domains"
-    args = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         print("Migrating impact annotations")
 
         for domain in Domain.get_all():

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -5,7 +5,7 @@ from corehq.apps.domain.models import Domain
 class Command(BaseCommand):
     help = "Detects and removes duplicate domains"
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         domains = Domain.get_all()
         seen = set([])
         dups = set([])

--- a/corehq/apps/export/management/commands/migrate_export_toggle.py
+++ b/corehq/apps/export/management/commands/migrate_export_toggle.py
@@ -11,7 +11,7 @@ from corehq import toggles
 class Command(BaseCommand):
     help = "Migrates old exports to new ones"
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for doc in Domain.get_all(include_docs=False):
             domain = doc['key']
             if not use_new_exports(domain):

--- a/corehq/apps/hqadmin/management/commands/check_case_index_ids.py
+++ b/corehq/apps/hqadmin/management/commands/check_case_index_ids.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         parser.add_argument('--debug', action='store_true', dest='debug', default=False)
         parser.add_argument('--cleanup', action='store_true', dest='cleanup', default=False)
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         domain = options['domain']
         debug = options['debug']
         cleanup = options['cleanup']

--- a/corehq/apps/hqadmin/management/commands/delete_related_cases.py
+++ b/corehq/apps/hqadmin/management/commands/delete_related_cases.py
@@ -15,9 +15,7 @@ class Command(BaseCommand):
         parser.add_argument('case_id', type=unicode)
         parser.add_argument('--filename', dest='filename', default='case-delete-info.csv')
 
-    def handle(self, *args, **options):
-        domain = options['domain']
-        case_id = options['case_id']
+    def handle(self, domain, case_id, **options):
         case_accessor = CaseAccessors(domain=domain)
         case = case_accessor.get_case(case_id)
         if not case.is_deleted and raw_input('\n'.join([

--- a/corehq/apps/hqadmin/management/commands/deploy_in_progress.py
+++ b/corehq/apps/hqadmin/management/commands/deploy_in_progress.py
@@ -9,6 +9,6 @@ class Command(BaseCommand):
     Sets a deploy_in_progress flag when we purposefully shut down services during deploy
     """
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         cache = get_redis_default_cache()
         cache.set(DEPLOY_IN_PROGRESS_FLAG, True, timeout=5 * 60)

--- a/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
+++ b/corehq/apps/hqadmin/management/commands/kill_stale_celery_workers.py
@@ -17,7 +17,7 @@ _soft_assert = soft_assert(
 class Command(BaseCommand):
     help = "Kills stale celery workers"
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         _kill_stale_workers()
 
 

--- a/corehq/apps/hqadmin/management/commands/update_django_locales.py
+++ b/corehq/apps/hqadmin/management/commands/update_django_locales.py
@@ -8,9 +8,8 @@ import django
 
 class Command(BaseCommand):
     help = "Update django locales for three-digit codes"
-    args = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         # if we were feeling ambitious we could get this from something more
         # formal/standard, but this seems totally workable for our needs
         HQ_TO_DJANGO_MAP = {

--- a/corehq/apps/hqmedia/management/commands/update_media_file_domains.py
+++ b/corehq/apps/hqmedia/management/commands/update_media_file_domains.py
@@ -5,7 +5,7 @@ from corehq.apps.domain.models import Domain
 class Command(BaseCommand):
     help = 'Make sure valid_domains is a superset of owners for all media'
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         def settify(entity):
             entity = [entity] if not isinstance(entity, list) else entity
             return set(filter(None, entity))

--- a/corehq/apps/reports/management/commands/test_reports.py
+++ b/corehq/apps/reports/management/commands/test_reports.py
@@ -4,10 +4,8 @@ from corehq.apps.reports.tasks import daily_reports, weekly_reports
 
 class Command(BaseCommand):
     help = "Tests sending reports. Equvalent to firing the celery tasks right NOW."
-    args = ""
-    label = ""
     
-    def handle(self, *args, **options):
+    def handle(self, **options):
         daily_reports()
         weekly_reports()
         

--- a/corehq/apps/smsbillables/management/commands/add_moz_zero_charge.py
+++ b/corehq/apps/smsbillables/management/commands/add_moz_zero_charge.py
@@ -41,8 +41,6 @@ def add_moz_zero_charge(apps):
 
 class Command(BaseCommand):
     help = "bootstrap MOZ global SMS backend gateway default fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         add_moz_zero_charge(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_apposit_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_apposit_gateway.py
@@ -35,8 +35,6 @@ def bootstrap_apposit_gateway(apps=None):
 
 class Command(BaseCommand):
     help = "bootstrap Apposit backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_apposit_gateway()

--- a/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway.py
@@ -45,8 +45,6 @@ def bootstrap_grapevine_gateway(apps):
 
 class Command(BaseCommand):
     help = "bootstrap Grapevine gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_grapevine_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway_update.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway_update.py
@@ -69,8 +69,6 @@ def bootstrap_grapevine_gateway_update(apps):
 
 class Command(BaseCommand):
     help = "update Grapevine gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_grapevine_gateway_update(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_icds_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_icds_gateway.py
@@ -35,8 +35,6 @@ def bootstrap_icds_gateway(apps=None):
 
 class Command(BaseCommand):
     help = "bootstrap ICDS backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_icds_gateway()

--- a/corehq/apps/smsbillables/management/commands/bootstrap_mach_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_mach_gateway.py
@@ -69,8 +69,6 @@ def bootstrap_mach_gateway(apps):
 
 class Command(BaseCommand):
     help = "bootstrap MACH/Syniverse gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_mach_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_moz_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_moz_gateway.py
@@ -121,8 +121,6 @@ def bootstrap_moz_gateway(apps):
 
 class Command(BaseCommand):
     help = "bootstrap MOZ global SMS backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_moz_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_smsgh_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_smsgh_gateway.py
@@ -38,8 +38,6 @@ def bootstrap_smsgh_gateway(apps=None):
 
 class Command(BaseCommand):
     help = "bootstrap SMSGH backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_smsgh_gateway()

--- a/corehq/apps/smsbillables/management/commands/bootstrap_telerivet_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_telerivet_gateway.py
@@ -38,8 +38,6 @@ def bootstrap_telerivet_gateway(apps):
 
 class Command(BaseCommand):
     help = "bootstrap Telerivet SMS backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_telerivet_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_test_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_test_gateway.py
@@ -40,8 +40,6 @@ bootstrap_test_gateway.__test__ = False
 
 class Command(BaseCommand):
     help = "bootstrap Test SMS backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_test_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_tropo_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_tropo_gateway.py
@@ -51,8 +51,6 @@ def bootstrap_tropo_gateway(apps):
 
 class Command(BaseCommand):
     help = "bootstrap Tropo gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_tropo_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway.py
@@ -121,8 +121,6 @@ def bootstrap_twilio_gateway(apps, twilio_rates_filename):
 
 class Command(BaseCommand):
     help = "bootstrap Twilio gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_twilio_gateway(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway_incoming.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway_incoming.py
@@ -28,8 +28,6 @@ def bootstrap_twilio_gateway_incoming(apps):
 
 class Command(BaseCommand):
     help = "bootstrap incoming Twilio gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_twilio_gateway_incoming(None)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_usage_fees.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_usage_fees.py
@@ -14,8 +14,6 @@ def bootstrap_usage_fees(apps):
 
 class Command(BaseCommand):
     help = "bootstrap usage fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_usage_fees(apps)

--- a/corehq/apps/smsbillables/management/commands/bootstrap_yo_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_yo_gateway.py
@@ -37,8 +37,6 @@ def bootstrap_yo_gateway(apps):
 
 class Command(BaseCommand):
     help = "bootstrap Yo global SMS backend gateway fees"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         bootstrap_yo_gateway(None)

--- a/corehq/apps/smsforms/management/commands/close_deleted_sms_sessions.py
+++ b/corehq/apps/smsforms/management/commands/close_deleted_sms_sessions.py
@@ -9,10 +9,8 @@ from touchforms.formplayer.api import (
 
 
 class Command(BaseCommand):
-    args = ""
-    help = ""
     
-    def handle(self, *args, **options):
+    def handle(self, **options):
         sessions = SQLXFormsSession.objects.filter(
             Q(session_type__isnull=True) | Q(session_type=XFORMS_SESSION_SMS),
             end_time__isnull=True,

--- a/corehq/apps/style/management/commands/fix_less_imports_collectstatic.py
+++ b/corehq/apps/style/management/commands/fix_less_imports_collectstatic.py
@@ -14,9 +14,8 @@ class Command(BaseCommand):
             " and replace the variable with the appropriate static file"
             " path once collectstatic is run on production"
             "the variable is necessary for less.js debug mode.")
-    args = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         # all the less files collected during collectstatic
         collectedless = [os.path.join(root, file)
                          for root, dir, files in os.walk(settings.STATIC_ROOT)

--- a/corehq/apps/style/management/commands/purge_compressed_files.py
+++ b/corehq/apps/style/management/commands/purge_compressed_files.py
@@ -13,7 +13,7 @@ MANIFEST_FILE = os.path.join(CACHE_DIR, settings.COMPRESS_OFFLINE_MANIFEST)
 class Command(BaseCommand):
     help = "Purges all static files that aren't in the manifest.json file"
 
-    def handle(self, *args, **kwargs):
+    def handle(self, **kwargs):
         with open(MANIFEST_FILE, 'r+') as f:
             manifest = json.loads(f.read())
 

--- a/corehq/apps/styleguide/management/commands/styleguide_update.py
+++ b/corehq/apps/styleguide/management/commands/styleguide_update.py
@@ -22,11 +22,10 @@ DJ_TEMPLATES_TO_PYCCO = [
 
 class Command(BaseCommand):
     help = "Prints the paths of all the static files"
-    args = "save or soft"
 
     root_dir = settings.FILEPATH
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         examples_dir = os.path.join(self.root_dir, EXAMPLES_PATH)
         template_dir = os.path.join(self.root_dir, TEMPLATE_PATH)
         docs_dir = os.path.join(self.root_dir, DOCS_TEMPLATE_PATH)

--- a/corehq/apps/users/management/commands/add_location_permission.py
+++ b/corehq/apps/users/management/commands/add_location_permission.py
@@ -8,7 +8,6 @@ from corehq.util.log import with_progress_bar
 
 
 class Command(BaseCommand):
-    args = ""
     help = "Migrate UserRoles, using whatever edit_commcare_users is set to for edit_locations"
 
     def add_arguments(self, parser):
@@ -18,7 +17,7 @@ class Command(BaseCommand):
             default=False,
         )
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         if not options['noinput']:
             num_roles = len(get_all_role_ids())
             confirm = raw_input("Found {} roles, update? (Y/n)\n".format(num_roles))

--- a/corehq/apps/users/management/commands/add_multi_location_property.py
+++ b/corehq/apps/users/management/commands/add_multi_location_property.py
@@ -8,10 +8,9 @@ from corehq.util.log import with_progress_bar
 
 
 class Command(BaseCommand):
-    args = ""
     help = ("(Migration) Autofill the new field assigned_location_ids to existing users")
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         self.options = options
         user_ids = with_progress_bar(self.get_user_ids())
         iter_update(CouchUser.get_db(), self.migrate_user, user_ids, verbose=True)

--- a/corehq/apps/users/management/commands/clear_bad_user_data.py
+++ b/corehq/apps/users/management/commands/clear_bad_user_data.py
@@ -6,11 +6,10 @@ from corehq.util.log import with_progress_bar
 
 
 class Command(BaseCommand):
-    args = ""
     help = ("Clears commcare_location_id and commtrack-supply-point on any "
             "users without location_id set")
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         clean_users()
 
 

--- a/corehq/apps/users/management/commands/create_billing_admin_role.py
+++ b/corehq/apps/users/management/commands/create_billing_admin_role.py
@@ -4,10 +4,9 @@ from corehq.apps.users.models import UserRole, UserRolePresets
 
 
 class Command(BaseCommand):
-    args = ""
     help = ("Adds the billing admin preset role to all existing domains")
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for domain in Domain.get_all():
             UserRole.get_or_create_with_permissions(
                 domain.name,

--- a/corehq/apps/users/management/commands/restore_domain_membership.py
+++ b/corehq/apps/users/management/commands/restore_domain_membership.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
                             help='Find the offset to start from')
 
     @change_log_level('kafka', 'ERROR')
-    def handle(self, *args, **options):
+    def handle(self, **options):
         if options['print_kafka_offsets']:
             start, end = self.get_min_max_offsets()
             print("\n\nKakfa topic offset range: {} - {}".format(start, end))

--- a/corehq/preindex/management/commands/sync_couch_views.py
+++ b/corehq/preindex/management/commands/sync_couch_views.py
@@ -6,7 +6,7 @@ from corehq.preindex import get_preindex_plugins
 class Command(BaseCommand):
     help = 'Copy temporary design docs over existing ones'
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for preindex_plugin in get_preindex_plugins():
             plugin_class_name = preindex_plugin.__class__.__name__
             if plugin_class_name == 'DefaultPreindexPlugin':

--- a/corehq/preindex/management/commands/sync_finish_couchdb_hq.py
+++ b/corehq/preindex/management/commands/sync_finish_couchdb_hq.py
@@ -6,7 +6,7 @@ from corehq.preindex import get_preindex_plugins
 class Command(BaseCommand):
     help = 'Copy temporary design docs over existing ones'
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for plugin in get_preindex_plugins():
             print("Copying design docs for plugin {}".format(plugin.app_label))
             plugin.copy_designs(temp='tmp')

--- a/custom/_legacy/mvp/management/commands/mvp_make_couch_indicators.py
+++ b/custom/_legacy/mvp/management/commands/mvp_make_couch_indicators.py
@@ -63,10 +63,8 @@ SUM_LAST_UNIQUE_INICATORS = [
 
 class Command(BaseCommand):
     help = "Create the indicator definitions necessary to compute MVP Indicators."
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         all_indicators = DynamicIndicatorDefinition.view("indicators/dynamic_indicator_definitions",
             reduce=False,
             include_docs=True,

--- a/custom/_legacy/mvp/management/commands/mvp_make_indicators.py
+++ b/custom/_legacy/mvp/management/commands/mvp_make_indicators.py
@@ -11,10 +11,8 @@ from mvp.static_definitions.question_id_mapping import (CHILD_CLOSE_FORM_QUESTIO
 
 class Command(BaseCommand):
     help = "Create the indicator definitions necessary to compute MVP Indicators."
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for domain in MVP.DOMAINS:
             shared_args=(
                 MVP.NAMESPACE,

--- a/custom/_legacy/mvp/management/commands/mvp_reset_class_path.py
+++ b/custom/_legacy/mvp/management/commands/mvp_reset_class_path.py
@@ -11,9 +11,8 @@ from mvp.models import (
 
 class Command(BaseCommand):
     help = "Resets the class path for the MVP indicator type specified"
-    args = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         indicator_types = [
             MVPDaysSinceLastTransmission,
             MVPActiveCasesIndicatorDefinition,

--- a/custom/bihar/management/commands/bihar_cleanup_case.py
+++ b/custom/bihar/management/commands/bihar_cleanup_case.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
     One time command for cleaning up care-bihar data
     """
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         with open('bihar_case_cleanup.csv', 'wb') as f:
             csv_file = csv.writer(f)
             csv_file.writerow(CaseRow.headers)

--- a/custom/ilsgateway/management/commands/find_duplicated_group_summaries.py
+++ b/custom/ilsgateway/management/commands/find_duplicated_group_summaries.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             cursor.execute(query)
             return cursor.fetchall()
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for location_id, title, date, ids in self.get_duplicated_rows():
             ids = ids.split(',')
             sql_location = SQLLocation.objects.get(location_id=location_id)

--- a/hqscripts/generic_queue.py
+++ b/hqscripts/generic_queue.py
@@ -41,13 +41,11 @@ class GenericEnqueuingOperation(BaseCommand):
     """
     Implements a generic enqueuing operation.
     """
-    args = ""
-    help = ""
 
     def get_fetching_interval(self):
         return 15
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         if self.use_queue():
             self.validate_args(**options)
             self.keep_fetching_items()

--- a/hqscripts/management/commands/list_couchdbs.py
+++ b/hqscripts/management/commands/list_couchdbs.py
@@ -5,9 +5,7 @@ from corehq.util.couchdb_management import couch_config
 
 class Command(BaseCommand):
     help = "List names of active couchdb dbs"
-    args = ""
-    label = ""
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         for name in couch_config.all_dbs_by_db_name.keys():
             print(name)


### PR DESCRIPTION
Cleaning up because args not added in ```add_arguments()``` won't be recognized by django 1.10.  Will follow up by updating management commands where ```*args``` is used without ```add_arguments()```

@emord cc: @mkangia 