### PR TITLE
Add indexes to awc_id

### DIFF
--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -37,6 +37,7 @@ def _build_raw_indicator(spec, context):
         datatype=wrapped.datatype,
         is_nullable=wrapped.is_nullable,
         is_primary_key=wrapped.is_primary_key,
+        create_index=wrapped.create_index,
     )
     return RawIndicator(
         wrapped.display_name,
@@ -52,6 +53,7 @@ def _build_expression_indicator(spec, context):
         datatype=wrapped.datatype,
         is_nullable=wrapped.is_nullable,
         is_primary_key=wrapped.is_primary_key,
+        create_index=wrapped.create_index,
     )
     return RawIndicator(
         wrapped.display_name,

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -75,6 +75,7 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
+        "create_index": true,
         "expression": {
           "location_id_expression": {
             "expression": {

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -64,6 +64,7 @@
         "is_nullable": false,
         "is_primary_key": false,
         "column_id": "awc_id",
+        "create_index": true,
         "type": "expression"
       },
       {

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
@@ -236,7 +236,8 @@
         "transform": {},
         "is_nullable": false,
         "type": "expression",
-        "column_id": "awc_id"
+        "column_id": "awc_id",
+        "create_index": true
       },
       {
         "display_name": null,

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
@@ -50,7 +50,8 @@
         "transform": {},
         "is_nullable": false,
         "type": "expression",
-        "column_id": "month"
+        "column_id": "month",
+        "create_index": true
       },
       {
         "display_name": null,
@@ -257,7 +258,8 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id"
+        "column_id": "supervisor_id",
+        "create_index": true
       },
       {
         "display_name": null,

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau.json
@@ -196,6 +196,7 @@
       },
       {
         "column_id": "awc_id",
+        "create_index": true,
         "datatype": "string",
         "display_name": null,
         "expression": {

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
@@ -50,7 +50,8 @@
           "type": "named",
           "name": "display_month"
         },
-        "column_id": "month"
+        "column_id": "month",
+        "create_index": true
       },
       {
         "display_name": null,
@@ -196,7 +197,8 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id"
+        "column_id": "supervisor_id",
+        "create_index": true
       },
       {
         "display_name": null,

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
@@ -175,7 +175,8 @@
             "property_name": "owner_id"
           }
         },
-        "column_id": "awc_id"
+        "column_id": "awc_id",
+        "create_index": true
       },
       {
         "display_name": null,

--- a/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
@@ -71,6 +71,7 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
+        "create_index": true,
         "expression": {
           "location_id_expression": {
             "value_expression": {

--- a/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
@@ -37,6 +37,7 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "awc_id",
+        "create_index": true,
         "expression": {
           "value_expression": {
             "datatype": null,

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -157,7 +157,8 @@
         "transform": {},
         "is_nullable": false,
         "type": "expression",
-        "column_id": "awc_id"
+        "column_id": "awc_id",
+        "create_index": true
       },
       {
         "display_name": null,

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -178,7 +178,8 @@
           },
           "type": "location_parent_id"
         },
-        "column_id": "supervisor_id"
+        "column_id": "supervisor_id",
+        "create_index": true
       },
       {
         "display_name": null,

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
@@ -193,6 +193,7 @@
       },
       {
         "column_id": "awc_id",
+        "create_index": true,
         "datatype": "string",
         "display_name": null,
         "expression": {

--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -89,6 +89,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "supervisor_id",
+        "create_index": true,
         "type": "expression"
       },
       {

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -90,7 +90,8 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id"
+        "column_id": "supervisor_id",
+        "create_index": true
       },
       {
         "display_name": "Block ID",

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -53,7 +53,8 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "awc_id"
+        "column_id": "awc_id",
+        "create_index": true
       },
       {
         "display_name": "Supervisor ID",

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -68,6 +68,7 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
+        "create_index": true,
         "type": "expression"
       },
       {

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -40,6 +40,7 @@
         "is_nullable": false,
         "is_primary_key": false,
         "column_id": "awc_id",
+        "create_index": true,
         "expression": {
           "type": "root_doc",
           "expression": {

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -53,6 +53,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "awc_id",
+        "create_index": true,
         "type": "expression"
       },
       {

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -90,6 +90,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "supervisor_id",
+        "create_index": true,
         "type": "expression"
       },
       {

--- a/custom/icds_reports/ucr/data_sources/person_cases.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases.json
@@ -58,6 +58,7 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
+        "create_index": true,
         "expression": {
           "location_id_expression": {
             "expression": {
@@ -155,6 +156,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "opened_on",
+        "create_index": true,
         "type": "raw",
         "property_name": "opened_on"
       },

--- a/custom/icds_reports/ucr/data_sources/person_cases.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases.json
@@ -47,6 +47,7 @@
         "is_nullable": false,
         "is_primary_key": false,
         "column_id": "awc_id",
+        "create_index": true,
         "type": "expression"
       },
       {
@@ -183,6 +184,7 @@
         "datatype": "integer",
         "is_primary_key": false,
         "column_id": "age_at_reg",
+        "create_index": true,
         "is_nullable": true,
         "type": "raw",
         "property_name": "age_at_reg"
@@ -1331,6 +1333,7 @@
         "datatype": "date",
         "is_primary_key": false,
         "column_id": "last_referral_date",
+        "create_index": true,
         "is_nullable": true,
         "type": "raw",
         "property_name": "last_referral_date"

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -68,6 +68,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "supervisor_id",
+        "create_index": true,
         "type": "expression"
       },
       {

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -40,6 +40,7 @@
         "is_primary_key": false,
         "is_nullable": false,
         "column_id": "awc_id",
+        "create_index": true,
         "expression": {
           "type": "root_doc",
           "expression": {

--- a/custom/icds_reports/ucr/data_sources/vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/vhnd_form.json
@@ -32,6 +32,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "awc_id",
+        "create_index": true,
         "expression": {
           "value_expression": {
             "datatype": null,

--- a/custom/icds_reports/ucr/data_sources/vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/vhnd_form.json
@@ -66,6 +66,7 @@
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "supervisor_id",
+        "create_index": true,
         "expression": {
           "location_id_expression": {
             "value_expression": {

--- a/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
+++ b/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
@@ -92,7 +92,8 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id"
+        "column_id": "supervisor_id",
+        "create_index": true
       },
       {
         "display_name": "Block ID",

--- a/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
+++ b/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
@@ -55,7 +55,8 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "awc_id"
+        "column_id": "awc_id",
+        "create_index": true
       },
       {
         "display_name": "Supervisor ID",


### PR DESCRIPTION
https://docs.google.com/document/d/1dp_QXUvE6V9UKsgDrpBNXvVnDxQJDltCUJcPvlqE1SA/edit

@snopoke @benrudolph you guys had an [UNCLEAR] before one of the indexes so I didn't add it here. I think this was just based on the mobile ucrs? it's probable that adding indexes all of the ids (block_id, district_id, supervisor_id etc) would help the web based ones

@sheelio 