### PR TITLE
Remove border on legend

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -4,7 +4,8 @@
 <script type="text/html" id="sub-group-fullform-ko-template">
       <div class="gr" data-bind="
         css: {
-          'gr-no-children': $data.children().length === 0
+          'gr-no-children': $data.children().length === 0,
+          'gr-has-no-questions': _.all($data.children(), function(d) { return d.type !== 'question' })
         }">
         <fieldset class="gr-header">
             <legend>

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -56,7 +56,7 @@
 <script type="text/template" id="menu-view-grid-item-template">
     <div class="col-xs-6 col-sm-4 col-lg-3">
         <% if (imageUrl) { %>
-          <div class="gridicon" style="background-image: url('<%- imageUrl %>'); background-size: cover;"></div>
+          <div class="gridicon" style="background-image: url('<%- imageUrl %>');"></div>
         <% } else { %>
           <div class="gridicon gridicon-circle">
             <% if (navState === "JUMP") { %>

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/appicon.less
@@ -89,6 +89,21 @@
   }
 }
 
+.gridicon {
+  background-color: transparent;
+  background-size: contain;
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  // For icons with their own image, don't make assumptions about the shadowing
+  .box-shadow(0 0 0 0 rgba(0, 0, 0, 0));
+}
+
+.gridicon.gridicon-circle {
+  background-color: @cc-neutral-mid;
+  .box-shadow(0 0 5px 0 rgba(0, 0, 0, 0.45));
+}
+
 .make-appicon-size(170px, 115px, 35px, 16px);
 .make-gridicon-size(70px);
 

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/appicon.less
@@ -90,7 +90,6 @@
 }
 
 .gridicon {
-  background-color: transparent;
   background-size: contain;
   background-color: transparent;
   background-repeat: no-repeat;

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -14,3 +14,7 @@
   text-align: center;
   line-height: 20px;
 }
+
+legend {
+  border: none;
+}

--- a/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-common/form.less
@@ -18,3 +18,7 @@
 legend {
   border: none;
 }
+
+.gr-has-no-questions legend {
+  margin-bottom: 0px;
+}


### PR DESCRIPTION
@dimagi/ux we need to remove the border on empty groups: https://manage.dimagi.com/default.asp?249226. however instead of having a bunch of logic to determine when or when not to show the borders, i've decided to just remove it completely (nested empty groups could get annoying). i think it looks clean without. curious if you think this is OK. screen shots below are very contrived

Before
<img width="1210" alt="screen shot 2017-03-13 at 12 31 13 pm" src="https://cloud.githubusercontent.com/assets/918514/23850727/59321332-07e9-11e7-9e6f-16bada0c421f.png">

After
<img width="1219" alt="screen shot 2017-03-13 at 12 27 28 pm" src="https://cloud.githubusercontent.com/assets/918514/23850726/58c7d08a-07e9-11e7-95d8-2cc80b8d9f58.png">

