### PR TITLE
Add caching for UCR lookups in SMS indicators

### DIFF
--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -46,7 +46,7 @@ REPORT_IDS = [
 
 @quickcache(['domain'], timeout=4 * 60 * 60, memoize_timeout=4 * 60 * 60)
 def get_report_configs(domain):
-    app = get_app(domain, SUPERVISOR_APP_ID)
+    app = get_app(domain, SUPERVISOR_APP_ID, latest=True)
     return {
         report_config.report_id: report_config
         for module in app.modules if isinstance(module, ReportModule)

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -319,18 +319,22 @@ class LSAggregatePerformanceIndicator(LSIndicator):
         )
 
     @property
+    @memoized
     def visits_fixture(self):
         return self.get_report_fixture(HOME_VISIT_REPORT_ID)
 
     @property
+    @memoized
     def thr_fixture(self):
         return self.get_report_fixture(THR_REPORT_ID)
 
     @property
+    @memoized
     def weighed_fixture(self):
         return self.get_report_fixture(CHILDREN_WEIGHED_REPORT_ID)
 
     @property
+    @memoized
     def days_open_fixture(self):
         return self.get_report_fixture(DAYS_AWC_OPEN_REPORT_ID)
 

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -165,11 +165,6 @@ class LSIndicator(SMSIndicator):
 class AWWAggregatePerformanceIndicator(AWWIndicator):
     template = 'aww_aggregate_performance.txt'
 
-    @property
-    @memoized
-    def ls_agg_perf(self):
-        return LSAggregatePerformanceIndicator(self.domain, self.supervisor)
-
     def get_value_from_fixture(self, fixture, attribute):
         xpath = './rows/row[@is_total_row="False"]'
         rows = fixture.findall(xpath)
@@ -187,7 +182,7 @@ class AWWAggregatePerformanceIndicator(AWWIndicator):
         raise IndicatorError("AWC {} not found in the restore".format(location_name))
 
     def get_messages(self, language_code=None):
-        agg_perf = self.ls_agg_perf
+        agg_perf = LSAggregatePerformanceIndicator(self.domain, self.supervisor)
 
         visits = self.get_value_from_fixture(agg_perf.visits_fixture, 'count')
         thr_gte_21 = self.get_value_from_fixture(agg_perf.thr_fixture, 'open_ccs_thr_gte_21')

--- a/custom/icds/tests/test_ls_aggregate_performance.py
+++ b/custom/icds/tests/test_ls_aggregate_performance.py
@@ -37,7 +37,6 @@ class TestLSAggregatePerformanceIndicator(SimpleTestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = LSAggregatePerformanceIndicator('domain', 'user')
-        self.addCleanup(indicator.clear_caches)
         message = indicator.get_messages()[0]
         self.assertIn('Timely Home Visits - 22 / 269', message)
         self.assertIn('Received adequate THR / Due for THR - 19 / 34', message)
@@ -92,7 +91,6 @@ class TestAWWAggregatePerformanceIndicator(TestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = AWWAggregatePerformanceIndicator(self.domain, self.aww)
-        self.addCleanup(indicator.ls_agg_perf.clear_caches)
         message = indicator.get_messages()[0]
         self.assertIn('Home Visits - 6 / 65', message)
         self.assertIn('Received adequate THR / Due for THR - 1 / 2', message)
@@ -111,7 +109,6 @@ class TestAWWAggregatePerformanceIndicator(TestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = AWWAggregatePerformanceIndicator(self.domain, aww3)
-        self.addCleanup(indicator.ls_agg_perf.clear_caches)
         with self.assertRaises(Exception) as e:
             indicator.get_messages()
         self.assertIn('AWC AWC3 not found in the restore', e.exception.message)
@@ -126,7 +123,6 @@ class TestAWWAggregatePerformanceIndicator(TestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = AWWAggregatePerformanceIndicator(self.domain, self.aww)
-        self.addCleanup(indicator.ls_agg_perf.clear_caches)
         with self.assertRaises(Exception) as e:
             indicator.get_messages()
         self.assertIn('Attribute awc_opened_count not found in restore for AWC AWC1', e.exception.message)

--- a/custom/icds/tests/test_ls_aggregate_performance.py
+++ b/custom/icds/tests/test_ls_aggregate_performance.py
@@ -37,6 +37,7 @@ class TestLSAggregatePerformanceIndicator(SimpleTestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = LSAggregatePerformanceIndicator('domain', 'user')
+        self.addCleanup(indicator.clear_caches)
         message = indicator.get_messages()[0]
         self.assertIn('Timely Home Visits - 22 / 269', message)
         self.assertIn('Received adequate THR / Due for THR - 19 / 34', message)
@@ -91,6 +92,7 @@ class TestAWWAggregatePerformanceIndicator(TestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = AWWAggregatePerformanceIndicator(self.domain, self.aww)
+        self.addCleanup(indicator.ls_agg_perf.clear_caches)
         message = indicator.get_messages()[0]
         self.assertIn('Home Visits - 6 / 65', message)
         self.assertIn('Received adequate THR / Due for THR - 1 / 2', message)
@@ -109,6 +111,7 @@ class TestAWWAggregatePerformanceIndicator(TestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = AWWAggregatePerformanceIndicator(self.domain, aww3)
+        self.addCleanup(indicator.ls_agg_perf.clear_caches)
         with self.assertRaises(Exception) as e:
             indicator.get_messages()
         self.assertIn('AWC AWC3 not found in the restore', e.exception.message)
@@ -123,6 +126,7 @@ class TestAWWAggregatePerformanceIndicator(TestCase, TestXmlMixin):
         thr.return_value = ET.fromstring(self.get_xml('thr_fixture'))
         visits.return_value = ET.fromstring(self.get_xml('visit_fixture'))
         indicator = AWWAggregatePerformanceIndicator(self.domain, self.aww)
+        self.addCleanup(indicator.ls_agg_perf.clear_caches)
         with self.assertRaises(Exception) as e:
             indicator.get_messages()
         self.assertIn('Attribute awc_opened_count not found in restore for AWC AWC1', e.exception.message)


### PR DESCRIPTION
Makes it so that we only load the UCRs once per supervisor instead of once per user.
@emord @snopoke 