### PR TITLE
Upgrade kafka client

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,7 +25,7 @@ feedparser==5.1.3
 ghdiff==0.4
 gunicorn==19.4
 lxml==3.4.4
-kafka-python==0.9.4
+kafka-python==0.9.5
 mock==0.8.0
 openpyxl==2.2.5
 Pillow==2.7.0


### PR DESCRIPTION
The logs are littered with https://github.com/dpkp/kafka-python/pull/432/files which were changed to debug in 0.9.5.

@gcapalbo 