### PR TITLE
Show the correct levels for expand-to if this is a forked hierarchy

### DIFF
--- a/corehq/apps/locations/static/locations/js/location_types.js
+++ b/corehq/apps/locations/static/locations/js/location_types.js
@@ -278,20 +278,26 @@ hqDefine('locations/js/location_types.js', function(){
 
         self.expand_to_options = function(){
             // display all locations with the same index as being on the same level
-            var children = self.children(),
-                children_same_levels = self.view.types_by_index(children),
-                children_to_return = [];
-            for (var level in children_same_levels){
+            var locs_to_return = [],
+                locs = self.children();
+            if (self.expand_from() && self.expand_from() !== ROOT_LOCATION_ID){
+                locs = self.view.loc_types_by_id()[self.expand_from()].children();
+            }
+            if (self.expand_from() && self.expand_from() === ROOT_LOCATION_ID){
+                locs = self.view.loc_types();
+            }
+            var locs_same_levels = self.view.types_by_index(locs);
+            for (var level in locs_same_levels){
                 // Only display a single child at each level
-                var child_to_add = children_same_levels[level][0];
-                children_to_return.push(new LocationTypeModel({
+                var child_to_add = locs_same_levels[level][0];
+                locs_to_return.push(new LocationTypeModel({
                     name: child_to_add.compiled_name(),
                     pk: child_to_add.pk,
                 }, false, self.view));
             }
             return {
-                children: children_to_return.slice(0, children_to_return.length - 1),
-                leaf: children_to_return[children_to_return.length - 1],
+                children: locs_to_return.slice(0, locs_to_return.length - 1),
+                leaf: locs_to_return[locs_to_return.length - 1],
             };
         };
 

--- a/corehq/apps/locations/static/locations/spec/types_spec.js
+++ b/corehq/apps/locations/static/locations/spec/types_spec.js
@@ -130,7 +130,30 @@ describe('Location Types', function() {
                 assert.equal(this.state_model.level(), 0);
                 assert.equal(this.city_model.level(), 2);
             });
+
+            it('shows correct levels when expand_from is above current fork', function(){
+                this.city_model.expand_from(this.state_model.pk);
+                var returned_loc_types = this.city_model.expand_to_options(),
+                    desired_children_returned = ["state", "county | region"],
+                    desired_leaf_returned = "city | town";
+                assert.sameMembers(desired_children_returned, _.map(
+                    returned_loc_types.children, extract_name
+                ));
+                assert.equal(desired_leaf_returned, returned_loc_types.leaf.name());
+            });
+
+            it('shows all levels when expand_from is root', function(){
+                this.city_model.expand_from(-1);
+                var returned_loc_types = this.city_model.expand_to_options(),
+                    desired_children_returned = ['state', 'county | region'],
+                    desired_leaf_returned = "city | town";
+                assert.sameMembers(desired_children_returned, _.map(
+                    returned_loc_types.children, extract_name
+                ));
+                assert.equal(desired_leaf_returned, returned_loc_types.leaf.name());
+            });
         });
+
         describe('include_without_expanding_options', function(){
             it('Provides all levels', function(){
                 var returned_loc_types = _.map(


### PR DESCRIPTION
@esoergel 
@sravfeyn 
Noticed that when you select an `expand_from` level above the current level in a forked hierarchy, you are given the wrong options. This gives you all options visible below the location set as "expand_from".
(The backend was already doing this).