### PR TITLE
Use custom expressions to avoid expensive eNikshay UCR calculations

### DIFF
--- a/custom/enikshay/expressions.py
+++ b/custom/enikshay/expressions.py
@@ -28,7 +28,7 @@ class FirstCaseFormWithXmlns(JsonObject):
     def _get_forms(self, case_id, context):
         domain = context.root_doc['domain']
 
-        cache_key = (self.__class__.__name__, case_id)
+        cache_key = (self.__class__.__name__, case_id, self.xmlns, self.reverse)
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 
@@ -70,12 +70,12 @@ class CountCaseFormsWithXmlns(JsonObject):
             return None
 
         assert context.root_doc['domain']
-        return self._get_forms(case_id, context)
+        return self._count_forms(case_id, context)
 
-    def _get_forms(self, case_id, context):
+    def _count_forms(self, case_id, context):
         domain = context.root_doc['domain']
 
-        cache_key = (self.__class__.__name__, case_id)
+        cache_key = (self.__class__.__name__, case_id, self.xmlns)
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 

--- a/custom/enikshay/expressions.py
+++ b/custom/enikshay/expressions.py
@@ -1,8 +1,96 @@
+from jsonobject import DefaultProperty, BooleanProperty
 from jsonobject.properties import ListProperty, StringProperty
 
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.specs import TypeProperty
+from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from dimagi.ext.jsonobject import JsonObject
+
+
+class FirstCaseFormWithXmlns(JsonObject):
+    type = TypeProperty('first_case_form_with_xmlns')
+    xmlns = StringProperty(required=True)
+    case_id_expression = DefaultProperty(required=True)
+    reverse = BooleanProperty(default=False)
+
+    def configure(self, case_id_expression):
+        self._case_id_expression = case_id_expression
+
+    def __call__(self, item, context=None):
+        case_id = self._case_id_expression(item, context)
+
+        if not case_id:
+            return None
+
+        assert context.root_doc['domain']
+        return self._get_forms(case_id, context)
+
+    def _get_forms(self, case_id, context):
+        domain = context.root_doc['domain']
+
+        cache_key = (self.__class__.__name__, case_id)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        xforms = FormProcessorInterface(domain).get_case_forms(case_id)
+        xforms = sorted(
+            [form for form in xforms if form.xmlns == self.xmlns and form.domain == domain],
+            key=lambda x: x.received_on
+        )
+        if not xforms:
+            form = None
+        else:
+            index = -1 if self.reverse else 0
+            form = xforms[index].to_json()
+
+        context.set_cache_value(cache_key, form)
+        return form
+
+
+def first_case_form_with_xmlns_expression(spec, context):
+    wrapped = FirstCaseFormWithXmlns.wrap(spec)
+    wrapped.configure(
+        ExpressionFactory.from_spec(wrapped.case_id_expression)
+    )
+    return wrapped
+
+
+class CountCaseFormsWithXmlns(JsonObject):
+    type = TypeProperty('count_case_forms_with_xmlns')
+    xmlns = StringProperty(required=True)
+    case_id_expression = DefaultProperty(required=True)
+
+    def configure(self, case_id_expression):
+        self._case_id_expression = case_id_expression
+
+    def __call__(self, item, context=None):
+        case_id = self._case_id_expression(item, context)
+
+        if not case_id:
+            return None
+
+        assert context.root_doc['domain']
+        return self._get_forms(case_id, context)
+
+    def _get_forms(self, case_id, context):
+        domain = context.root_doc['domain']
+
+        cache_key = (self.__class__.__name__, case_id)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        xforms = FormProcessorInterface(domain).get_case_forms(case_id)
+        count = len([form for form in xforms if form.xmlns == self.xmlns and form.domain == domain])
+        context.set_cache_value(cache_key, count)
+        return count
+
+
+def count_case_forms_with_xmlns_expression(spec, context):
+    wrapped = CountCaseFormsWithXmlns.wrap(spec)
+    wrapped.configure(
+        ExpressionFactory.from_spec(wrapped.case_id_expression)
+    )
+    return wrapped
 
 
 class ConcatenateStrings(JsonObject):

--- a/custom/enikshay/ucr/data_sources/episode.json
+++ b/custom/enikshay/ucr/data_sources/episode.json
@@ -784,41 +784,20 @@
                 "expression": {
                     "type": "nested",
                     "argument_expression": {
-                        "type": "reduce_items",
-                        "items_expression": {
-                            "type": "sort_items",
-                            "items_expression": {
-                                "type": "filter_items",
-                                "items_expression": {
-                                    "type": "get_case_forms",
-                                    "case_id_expression": {
-                                        "type": "nested",
-                                        "argument_expression": {
-                                            "type": "named",
-                                            "name": "latest_diagnostic_test_case"
-                                        },
-                                        "value_expression": {
-                                            "type": "property_name",
-                                            "property_name": "_id"
-                                        }
-                                    }
-                                },
-                                "filter_expression": {
-                                    "type": "boolean_expression",
-                                    "operator": "eq",
-                                    "expression": {
-                                        "type": "property_name",
-                                        "property_name": "xmlns"
-                                    },
-                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
-                                }
+                        "type": "first_case_form_with_xmlns",
+                        "case_id_expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "latest_diagnostic_test_case"
                             },
-                            "sort_expression": {
+                            "value_expression": {
                                 "type": "property_name",
-                                "property_name": "received_on"
+                                "property_name": "_id"
                             }
                         },
-                        "aggregation_fn": "last_item"
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                        "reverse": true
                     },
                     "value_expression": {
                         "type": "property_path",
@@ -880,41 +859,20 @@
                     "doc_id_expression":{
                         "type": "nested",
                         "argument_expression": {
-                            "type": "reduce_items",
-                            "items_expression": {
-                                "type": "sort_items",
-                                "items_expression": {
-                                    "type": "filter_items",
-                                    "items_expression": {
-                                        "type": "get_case_forms",
-                                        "case_id_expression": {
-                                            "type": "nested",
-                                            "argument_expression": {
-                                                "type": "named",
-                                                "name": "latest_diagnostic_test_case"
-                                            },
-                                            "value_expression": {
-                                                "type": "property_name",
-                                                "property_name": "_id"
-                                            }
-                                        }
-                                    },
-                                    "filter_expression": {
-                                        "type": "boolean_expression",
-                                        "operator": "eq",
-                                        "expression": {
-                                            "type": "property_name",
-                                            "property_name": "xmlns"
-                                        },
-                                        "property_value": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F"
-                                    }
+                            "type": "first_case_form_with_xmlns",
+                            "case_id_expression": {
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "named",
+                                    "name": "latest_diagnostic_test_case"
                                 },
-                                "sort_expression": {
+                                "value_expression": {
                                     "type": "property_name",
-                                    "property_name": "received_on"
+                                    "property_name": "_id"
                                 }
                             },
-                            "aggregation_fn": "last_item"
+                            "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                            "reverse": true
                         },
                         "value_expression": {
                             "type": "property_path",
@@ -969,41 +927,20 @@
                 "expression": {
                     "type": "nested",
                     "argument_expression": {
-                        "type": "reduce_items",
-                        "items_expression": {
-                            "type": "sort_items",
-                            "items_expression": {
-                                "type": "filter_items",
-                                "items_expression": {
-                                    "type": "get_case_forms",
-                                    "case_id_expression": {
-                                        "type": "nested",
-                                        "argument_expression": {
-                                            "type": "named",
-                                            "name": "latest_microbiological_test_case"
-                                        },
-                                        "value_expression": {
-                                            "type": "property_name",
-                                            "property_name": "_id"
-                                        }
-                                    }
-                                },
-                                "filter_expression": {
-                                    "type": "boolean_expression",
-                                    "operator": "eq",
-                                    "expression": {
-                                        "type": "property_name",
-                                        "property_name": "xmlns"
-                                    },
-                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
-                                }
+                        "type": "first_case_form_with_xmlns",
+                        "reverse": true,
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                        "case_id_expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "latest_microbiological_test_case"
                             },
-                            "sort_expression": {
+                            "value_expression": {
                                 "type": "property_name",
-                                "property_name": "received_on"
+                                "property_name": "_id"
                             }
-                        },
-                        "aggregation_fn": "last_item"
+                        }
                     },
                     "value_expression": {
                         "type": "property_path",
@@ -1200,41 +1137,20 @@
                     "doc_id_expression":{
                         "type": "nested",
                         "argument_expression": {
-                            "type": "reduce_items",
-                            "items_expression": {
-                                "type": "sort_items",
-                                "items_expression": {
-                                    "type": "filter_items",
-                                    "items_expression": {
-                                        "type": "get_case_forms",
-                                        "case_id_expression": {
-                                            "type": "nested",
-                                            "argument_expression": {
-                                                "type": "named",
-                                                "name": "latest_microbiological_test_case"
-                                            },
-                                            "value_expression": {
-                                                "type": "property_name",
-                                                "property_name": "_id"
-                                            }
-                                        }
-                                    },
-                                    "filter_expression": {
-                                        "type": "boolean_expression",
-                                        "operator": "eq",
-                                        "expression": {
-                                            "type": "property_name",
-                                            "property_name": "xmlns"
-                                        },
-                                        "property_value": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F"
-                                    }
+                            "type": "first_case_form_with_xmlns",
+                            "reverse": true,
+                            "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                            "case_id_expression": {
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "named",
+                                    "name": "latest_microbiological_test_case"
                                 },
-                                "sort_expression": {
+                                "value_expression": {
                                     "type": "property_name",
-                                    "property_name": "received_on"
+                                    "property_name": "_id"
                                 }
-                            },
-                            "aggregation_fn": "last_item"
+                            }
                         },
                         "value_expression": {
                             "type": "property_path",
@@ -4174,27 +4090,12 @@
 
                         },
                         "map_expression": {
-                            "type": "reduce_items",
-                            "items_expression": {
-                                "type": "filter_items",
-                                "items_expression": {
-                                    "type": "get_case_forms",
-                                    "case_id_expression": {
-                                        "type": "property_name",
-                                        "property_name": "_id"
-                                    }
-                                },
-                                "filter_expression": {
-                                    "type": "boolean_expression",
-                                    "operator": "eq",
-                                    "expression": {
-                                        "type": "property_name",
-                                        "property_name": "xmlns"
-                                    },
-                                    "property_value": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F"
-                                }
-                            },
-                            "aggregation_fn": "count"
+                            "type": "count_case_forms_with_xmlns",
+                            "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                            "case_id_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
                         }
                     },
                     "aggregation_fn": "sum"
@@ -4245,27 +4146,12 @@
 
                         },
                         "map_expression": {
-                            "type": "reduce_items",
-                            "items_expression": {
-                                "type": "filter_items",
-                                "items_expression": {
-                                    "type": "get_case_forms",
-                                    "case_id_expression": {
-                                        "type": "property_name",
-                                        "property_name": "_id"
-                                    }
-                                },
-                                "filter_expression": {
-                                    "type": "boolean_expression",
-                                    "operator": "eq",
-                                    "expression": {
-                                        "type": "property_name",
-                                        "property_name": "xmlns"
-                                    },
-                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
-                                }
-                            },
-                            "aggregation_fn": "count"
+                            "type": "count_case_forms_with_xmlns",
+                            "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                            "case_id_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
                         }
                     },
                     "aggregation_fn": "sum"
@@ -6110,34 +5996,13 @@
                 "expression_if_true": {
                     "type": "nested",
                     "argument_expression": {
-                        "type": "reduce_items",
-                        "items_expression": {
-                            "type": "sort_items",
-                            "items_expression": {
-                                "type": "filter_items",
-                                "items_expression": {
-                                    "type": "get_case_forms",
-                                    "case_id_expression": {
-                                        "type": "property_name",
-                                        "property_name": "_id"
-                                    }
-                                },
-                                "filter_expression": {
-                                    "type": "boolean_expression",
-                                    "operator": "eq",
-                                    "expression": {
-                                        "type": "property_name",
-                                        "property_name": "xmlns"
-                                    },
-                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
-                                }
-                            },
-                            "sort_expression": {
-                                "type": "property_name",
-                                "property_name": "received_on"
-                            }
-                        },
-                        "aggregation_fn": "last_item"
+                        "type": "first_case_form_with_xmlns",
+                        "reverse": true,
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                        "case_id_expression": {
+                            "type": "property_name",
+                            "property_name": "_id"
+                        }
                     },
                     "value_expression": {
                         "type":"concatenate_strings",
@@ -7007,41 +6872,20 @@
                 "aggregation_fn": "last_item"
             },
             "latest_microscopy_test_request_form": {
-                "type": "reduce_items",
-                "items_expression": {
-                    "type": "sort_items",
-                    "items_expression": {
-                        "type": "filter_items",
-                        "items_expression": {
-                            "type": "get_case_forms",
-                            "case_id_expression": {
-                                "type": "nested",
-                                "argument_expression": {
-                                    "type": "named",
-                                    "name": "latest_microscopy_test_case"
-                                },
-                                "value_expression": {
-                                    "type": "property_name",
-                                    "property_name": "_id"
-                                }
-                            }
-                        },
-                        "filter_expression": {
-                            "type": "boolean_expression",
-                            "operator": "eq",
-                            "expression": {
-                                "type": "property_name",
-                                "property_name": "xmlns"
-                            },
-                            "property_value": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F"
-                        }
+                "type": "first_case_form_with_xmlns",
+                "reverse": true,
+                "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                "case_id_expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "named",
+                        "name": "latest_microscopy_test_case"
                     },
-                    "sort_expression": {
+                    "value_expression": {
                         "type": "property_name",
-                        "property_name": "received_on"
+                        "property_name": "_id"
                     }
-                },
-                "aggregation_fn": "last_item"
+                }
             },
             "latest_diagnostic_mbr_test_case": {
                 "type": "reduce_items",
@@ -7641,34 +7485,13 @@
                     "aggregation_fn": "last_item"
                 },
                 "value_expression": {
-                    "type": "reduce_items",
-                    "items_expression": {
-                        "type": "sort_items",
-                        "items_expression": {
-                            "type": "filter_items",
-                            "items_expression": {
-                                "type": "get_case_forms",
-                                "case_id_expression": {
-                                    "type": "property_name",
-                                    "property_name": "_id"
-                                }
-                            },
-                            "filter_expression": {
-                                "type": "boolean_expression",
-                                "operator": "eq",
-                                "expression": {
-                                    "type": "property_name",
-                                    "property_name": "xmlns"
-                                },
-                                "property_value": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F"
-                            }
-                        },
-                        "sort_expression": {
-                            "type": "property_name",
-                            "property_name": "received_on"
-                        }
-                    },
-                    "aggregation_fn": "last_item"
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
                 }
             },
             "test_result_form": {
@@ -7708,34 +7531,13 @@
                     "aggregation_fn": "last_item"
                 },
                 "value_expression": {
-                    "type": "reduce_items",
-                    "items_expression": {
-                        "type": "sort_items",
-                        "items_expression": {
-                            "type": "filter_items",
-                            "items_expression": {
-                                "type": "get_case_forms",
-                                "case_id_expression": {
-                                    "type": "property_name",
-                                    "property_name": "_id"
-                                }
-                            },
-                            "filter_expression": {
-                                "type": "boolean_expression",
-                                "operator": "eq",
-                                "expression": {
-                                    "type": "property_name",
-                                    "property_name": "xmlns"
-                                },
-                                "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
-                            }
-                        },
-                        "sort_expression": {
-                            "type": "property_name",
-                            "property_name": "received_on"
-                        }
-                    },
-                    "aggregation_fn": "last_item"
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
                 }
             },
             "sample_receipt_form": {
@@ -7775,34 +7577,13 @@
                     "aggregation_fn": "last_item"
                 },
                 "value_expression": {
-                    "type": "reduce_items",
-                    "items_expression": {
-                        "type": "sort_items",
-                        "items_expression": {
-                            "type": "filter_items",
-                            "items_expression": {
-                                "type": "get_case_forms",
-                                "case_id_expression": {
-                                    "type": "property_name",
-                                    "property_name": "_id"
-                                }
-                            },
-                            "filter_expression": {
-                                "type": "boolean_expression",
-                                "operator": "eq",
-                                "expression": {
-                                    "type": "property_name",
-                                    "property_name": "xmlns"
-                                },
-                                "property_value": "http://openrosa.org/formdesigner/B139DDFB-13C5-4E89-8BE6-E74ACB9FCBBE"
-                            }
-                        },
-                        "sort_expression": {
-                            "type": "property_name",
-                            "property_name": "received_on"
-                        }
-                    },
-                    "aggregation_fn": "last_item"
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/B139DDFB-13C5-4E89-8BE6-E74ACB9FCBBE",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
                 }
             },
             "suspect_registration": {
@@ -7842,34 +7623,13 @@
                     "aggregation_fn": "last_item"
                 },
                 "value_expression": {
-                    "type": "reduce_items",
-                    "items_expression": {
-                        "type": "sort_items",
-                        "items_expression": {
-                            "type": "filter_items",
-                            "items_expression": {
-                                "type": "get_case_forms",
-                                "case_id_expression": {
-                                    "type": "property_name",
-                                    "property_name": "_id"
-                                }
-                            },
-                            "filter_expression": {
-                                "type": "boolean_expression",
-                                "operator": "eq",
-                                "expression": {
-                                    "type": "property_name",
-                                    "property_name": "xmlns"
-                                },
-                                "property_value": "http://openrosa.org/formdesigner/1953B000-3BB5-4A6C-B5BB-D60BD17028D0"
-                            }
-                        },
-                        "sort_expression": {
-                            "type": "property_name",
-                            "property_name": "received_on"
-                        }
-                    },
-                    "aggregation_fn": "last_item"
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/1953B000-3BB5-4A6C-B5BB-D60BD17028D0",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
                 }
             },
             "patient_registration": {
@@ -7909,66 +7669,22 @@
                     "aggregation_fn": "last_item"
                 },
                 "value_expression": {
-                    "type": "reduce_items",
-                    "items_expression": {
-                        "type": "sort_items",
-                        "items_expression": {
-                            "type": "filter_items",
-                            "items_expression": {
-                                "type": "get_case_forms",
-                                "case_id_expression": {
-                                    "type": "property_name",
-                                    "property_name": "_id"
-                                }
-                            },
-                            "filter_expression": {
-                                "type": "boolean_expression",
-                                "operator": "eq",
-                                "expression": {
-                                    "type": "property_name",
-                                    "property_name": "xmlns"
-                                },
-                                "property_value": "http://openrosa.org/formdesigner/60B0DB43-CC15-43A0-BFE7-885310AFD6E4"
-                            }
-                        },
-                        "sort_expression": {
-                            "type": "property_name",
-                            "property_name": "received_on"
-                        }
-                    },
-                    "aggregation_fn": "first_item"
+                    "type": "first_case_form_with_xmlns",
+                    "xmlns": "http://openrosa.org/formdesigner/60B0DB43-CC15-43A0-BFE7-885310AFD6E4",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
                 }
             },
             "complete_treatment_form": {
-                "type": "reduce_items",
-                "items_expression": {
-                    "type": "sort_items",
-                    "items_expression": {
-                        "type": "filter_items",
-                        "items_expression": {
-                            "type": "get_case_forms",
-                            "case_id_expression": {
-                                "type": "property_name",
-                                "property_name": "_id"
-                            }
-                        },
-                        "filter_expression": {
-                            "type": "boolean_expression",
-                            "operator": "eq",
-                            "expression": {
-                                "type": "property_name",
-                                "property_name": "xmlns"
-                            },
-                            "property_value": "http://openrosa.org/formdesigner/60B0DB43-CC15-43A0-BFE7-885310AFD6E4"
-                        }
-                    },
-                    "sort_expression": {
-                        "type": "property_name",
-                        "property_name": "received_on"
-                    }
-                },
-                "aggregation_fn": "last_item"
-
+                "type": "first_case_form_with_xmlns",
+                "reverse": true,
+                "xmlns": "http://openrosa.org/formdesigner/60B0DB43-CC15-43A0-BFE7-885310AFD6E4",
+                "case_id_expression": {
+                    "type": "property_name",
+                    "property_name": "_id"
+                }
             },
             "hiv_status": {
                 "value_expression": {

--- a/settings.py
+++ b/settings.py
@@ -1847,8 +1847,8 @@ CUSTOM_UCR_EXPRESSIONS = [
     ('year_expression', 'custom.pnlppgi.expressions.year_expression'),
     ('week_expression', 'custom.pnlppgi.expressions.week_expression'),
     ('concatenate_strings', 'custom.enikshay.expressions.concatenate_strings_expression'),
-    ('first_case_form_with_xmlns', 'custom.enikshay.expressions.first_case_form_with_xmlns'),
-    ('count_case_forms_with_xmlns', 'custom.enikshay.expressions.count_case_forms_with_xmlns'),
+    ('first_case_form_with_xmlns', 'custom.enikshay.expressions.first_case_form_with_xmlns_expression'),
+    ('count_case_forms_with_xmlns', 'custom.enikshay.expressions.count_case_forms_with_xmlns_expression'),
 ]
 
 CUSTOM_UCR_EXPRESSION_LISTS = [

--- a/settings.py
+++ b/settings.py
@@ -1846,7 +1846,9 @@ CUSTOM_UCR_EXPRESSIONS = [
     ('cqi_action_item', 'custom.eqa.expressions.cqi_action_item'),
     ('year_expression', 'custom.pnlppgi.expressions.year_expression'),
     ('week_expression', 'custom.pnlppgi.expressions.week_expression'),
-    ('concatenate_strings', 'custom.enikshay.expressions.concatenate_strings_expression')
+    ('concatenate_strings', 'custom.enikshay.expressions.concatenate_strings_expression'),
+    ('first_case_form_with_xmlns', 'custom.enikshay.expressions.first_case_form_with_xmlns'),
+    ('count_case_forms_with_xmlns', 'custom.enikshay.expressions.count_case_forms_with_xmlns'),
 ]
 
 CUSTOM_UCR_EXPRESSION_LISTS = [


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?249246
I wrote these custom expressions to avoid [this line](https://github.com/dimagi/commcare-hq/blob/73ee772b70df3b31295923dd55a4b09af0e2583a/corehq/apps/userreports/expressions/specs.py#L302), which is very time consuming if the number of forms is large.

Other optimizations could be done, such as caching the value of `FormProcessorInterface(domain).get_case_forms(case_id)`, but at least right now that call is insignificant compared to all the calls to `form.to_json()`, which require a trip to riak.

Hold off on merge until I have tested this.
@calellowitz @emord 