### PR TITLE
Mk nikshay repeaters update

### DIFF
--- a/custom/enikshay/integrations/nikshay/repeater_generator.py
+++ b/custom/enikshay/integrations/nikshay/repeater_generator.py
@@ -142,8 +142,12 @@ class NikshayTreatmentOutcomePayload(BaseNikshayPayloadGenerator):
         person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
         episode_case_properties = episode_case.dynamic_case_properties()
         base_properties = self._base_properties(repeat_record, person_case)
+        nikshay_id = (
+            episode_case_properties.get("nikshay_id", None) or
+            person_case.dynamic_case_properties().get('nikshay_id')
+        )
         base_properties.update({
-            "PatientID": episode_case_properties.get("nikshay_id"),
+            "PatientID": nikshay_id,
             "OutcomeDate": episode_case_properties.get(TREATMENT_OUTCOME_DATE),
             "Outcome": treatment_outcome.get(episode_case_properties.get(TREATMENT_OUTCOME)),
             "MO": u"{} {}".format(
@@ -178,8 +182,12 @@ class NikshayHIVTestPayloadGenerator(BasePayloadGenerator):
         episode_case = get_open_episode_case_from_person(person_case.domain, person_case.get_id)
         episode_case_properties = episode_case.dynamic_case_properties()
         person_case_properties = person_case.dynamic_case_properties()
+        nikshay_id = (
+            episode_case_properties.get("nikshay_id", None) or
+            person_case.dynamic_case_properties().get('nikshay_id')
+        )
         properties_dict = {
-            "PatientID": episode_case_properties.get('nikshay_id'),
+            "PatientID": nikshay_id,
             "HIVStatus": hiv_status.get(person_case_properties.get('hiv_status')),
             "HIVTestDate": datetime.datetime.strptime(
                 person_case_properties.get('hiv_test_date', NIKSHAY_NULL_DATE), '%Y-%m-%d'

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -84,7 +84,7 @@ class NikshayHIVTestRepeater(CaseRepeater):
                 return False
 
             return (
-                (person_migrated_from_nikshay(person_case) or person_registered_via_api(episode_case)) and
+                (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
                 not test_submission(person_case) and
                 (
                     related_dates_changed(person_case) or
@@ -116,7 +116,7 @@ class NikshayTreatmentOutcomeRepeater(CaseRepeater):
         if allowed_case_types_and_users:
             person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
             return (
-                (person_migrated_from_nikshay(person_case) or person_registered_via_api(episode_case)) and
+                (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
                 case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
                 episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
             )
@@ -181,12 +181,10 @@ def person_registered_via_api(episode_case):
     )
 
 
-def person_migrated_from_nikshay(person_case):
+def person_nikshay_id_present(person_case):
     person_case_properties = person_case.dynamic_case_properties()
-    return (
-        person_case_properties.get('migration_created_case', None) == 'true' and
-        person_case_properties.get('nikshay_id')
-    )
+    return bool(person_case_properties.get('nikshay_id'))
+
 
 case_post_save.connect(create_case_repeat_records, CommCareCaseSQL)
 case_post_save.connect(create_hiv_test_repeat_records, CommCareCaseSQL)

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -82,11 +82,9 @@ class NikshayHIVTestRepeater(CaseRepeater):
                 episode_case = get_open_episode_case_from_person(person_case.domain, person_case.get_id)
             except ENikshayCaseNotFound:
                 return False
-            episode_case_properties = episode_case.dynamic_case_properties()
 
             return (
-                episode_case_properties.get('nikshay_registered', 'false') == 'true' and
-                episode_case_properties.get('nikshay_id') and
+                (person_migrated_from_nikshay(person_case) or person_registered_via_api(episode_case)) and
                 not test_submission(person_case) and
                 (
                     related_dates_changed(person_case) or
@@ -115,12 +113,15 @@ class NikshayTreatmentOutcomeRepeater(CaseRepeater):
     def allowed_to_forward(self, episode_case):
         allowed_case_types_and_users = self._allowed_case_type(episode_case) and self._allowed_user(episode_case)
         episode_case_properties = episode_case.dynamic_case_properties()
-        return allowed_case_types_and_users and (
-            episode_case_properties.get('nikshay_registered', 'false') == 'true' and
-            episode_case_properties.get('nikshay_id', False) and
-            case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
-            episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
-        )
+        if allowed_case_types_and_users:
+            person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
+            return (
+                (person_migrated_from_nikshay(person_case) or person_registered_via_api(episode_case)) and
+                case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
+                episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
+            )
+        else:
+            return False
 
 
 def test_submission(person_case):
@@ -170,6 +171,22 @@ def create_case_repeat_records(sender, case, **kwargs):
 
 def create_hiv_test_repeat_records(sender, case, **kwargs):
     create_repeat_records(NikshayHIVTestRepeater, case)
+
+
+def person_registered_via_api(episode_case):
+    episode_case_properties = episode_case.dynamic_case_properties()
+    return (
+        episode_case_properties.get('nikshay_registered', 'false') == 'true' and
+        episode_case_properties.get('nikshay_id')
+    )
+
+
+def person_migrated_from_nikshay(person_case):
+    person_case_properties = person_case.dynamic_case_properties()
+    return (
+        person_case_properties.get('migration_created_case', None) == 'true' and
+        person_case_properties.get('nikshay_id')
+    )
 
 case_post_save.connect(create_case_repeat_records, CommCareCaseSQL)
 case_post_save.connect(create_hiv_test_repeat_records, CommCareCaseSQL)

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -84,7 +84,7 @@ class NikshayHIVTestRepeater(CaseRepeater):
                 return False
 
             return (
-                (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
+                person_nikshay_id_present(person_case) and
                 not test_submission(person_case) and
                 (
                     related_dates_changed(person_case) or
@@ -116,7 +116,7 @@ class NikshayTreatmentOutcomeRepeater(CaseRepeater):
         if allowed_case_types_and_users:
             person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
             return (
-                (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
+                person_nikshay_id_present(person_case) and
                 case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
                 episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
             )
@@ -171,14 +171,6 @@ def create_case_repeat_records(sender, case, **kwargs):
 
 def create_hiv_test_repeat_records(sender, case, **kwargs):
     create_repeat_records(NikshayHIVTestRepeater, case)
-
-
-def person_registered_via_api(episode_case):
-    episode_case_properties = episode_case.dynamic_case_properties()
-    return (
-        episode_case_properties.get('nikshay_registered', 'false') == 'true' and
-        episode_case_properties.get('nikshay_id')
-    )
 
 
 def person_nikshay_id_present(person_case):

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -116,8 +116,8 @@ class NikshayTreatmentOutcomeRepeater(CaseRepeater):
         allowed_case_types_and_users = self._allowed_case_type(episode_case) and self._allowed_user(episode_case)
         episode_case_properties = episode_case.dynamic_case_properties()
         return allowed_case_types_and_users and (
-            not episode_case_properties.get('nikshay_registered', 'false') == 'true' and
-            not episode_case_properties.get('nikshay_id', False) and
+            episode_case_properties.get('nikshay_registered', 'false') == 'true' and
+            episode_case_properties.get('nikshay_id', False) and
             case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
             episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
         )

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -117,6 +117,7 @@ class NikshayTreatmentOutcomeRepeater(CaseRepeater):
             person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
             return (
                 (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
+                not test_submission(person_case) and
                 case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
                 episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
             )

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -84,7 +84,7 @@ class NikshayHIVTestRepeater(CaseRepeater):
                 return False
 
             return (
-                person_nikshay_id_present(person_case) and
+                (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
                 not test_submission(person_case) and
                 (
                     related_dates_changed(person_case) or
@@ -116,7 +116,7 @@ class NikshayTreatmentOutcomeRepeater(CaseRepeater):
         if allowed_case_types_and_users:
             person_case = get_person_case_from_episode(episode_case.domain, episode_case.get_id)
             return (
-                person_nikshay_id_present(person_case) and
+                (person_nikshay_id_present(person_case) or person_registered_via_api(episode_case)) and
                 case_properties_changed(episode_case, [TREATMENT_OUTCOME]) and
                 episode_case_properties.get(TREATMENT_OUTCOME) in treatment_outcome.keys()
             )
@@ -171,6 +171,14 @@ def create_case_repeat_records(sender, case, **kwargs):
 
 def create_hiv_test_repeat_records(sender, case, **kwargs):
     create_repeat_records(NikshayHIVTestRepeater, case)
+
+
+def person_registered_via_api(episode_case):
+    episode_case_properties = episode_case.dynamic_case_properties()
+    return (
+        episode_case_properties.get('nikshay_registered', 'false') == 'true' and
+        episode_case_properties.get('nikshay_id')
+    )
 
 
 def person_nikshay_id_present(person_case):

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -386,6 +386,22 @@ class TestNikshayHIVTestRepeater(ENikshayLocationStructureMixin, NikshayRepeater
         )
         self.assertEqual(1, len(self.repeat_records().all()))
 
+    def test_trigger_with_test_submission(self):
+        self.assertEqual(0, len(self.repeat_records().all()))
+        self.phi.metadata['is_test'] = 'yes'
+        self.phi.save()
+        self.factory.create_or_update_cases([self.episode])
+        update_case(
+            self.domain,
+            self.person_id,
+            {
+                "owner_id": self.phi.location_id,
+                "nikshay_id": DUMMY_NIKSHAY_ID,
+                "hiv_status": "unknown",
+            }
+        )
+        self.assertEqual(0, len(self.repeat_records().all()))
+
 
 class TestNikshayHIVTestPayloadGenerator(ENikshayLocationStructureMixin, NikshayRepeaterTestBase):
     def setUp(self):

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -501,6 +501,7 @@ class TestNikshayTreatmentOutcomeRepeater(ENikshayLocationStructureMixin, Niksha
     def test_trigger(self):
         # nikshay not enabled
         self.create_case(self.episode)
+        self.assign_person_to_location(self.phi.location_id)
         update_case(
             self.domain,
             self.episode_id,
@@ -543,6 +544,7 @@ class TestNikshayTreatmentOutcomeRepeater(ENikshayLocationStructureMixin, Niksha
 
     def test_trigger_with_person_nikshay_id(self):
         self.create_case(self.episode)
+        self.assign_person_to_location(self.phi.location_id)
         update_case(self.domain, self.person_id, {"nikshay_id": DUMMY_NIKSHAY_ID})
         self.assertEqual(0, len(self.repeat_records().all()))
 
@@ -555,6 +557,24 @@ class TestNikshayTreatmentOutcomeRepeater(ENikshayLocationStructureMixin, Niksha
             }
         )
         self.assertEqual(1, len(self.repeat_records().all()))
+
+    def test_trigger_with_test_submission(self):
+        self.create_case(self.episode)
+        self.phi.metadata['is_test'] = 'yes'
+        self.phi.save()
+        self.assign_person_to_location(self.phi.location_id)
+        update_case(self.domain, self.person_id, {"nikshay_id": DUMMY_NIKSHAY_ID})
+        self.assertEqual(0, len(self.repeat_records().all()))
+
+        # change triggered
+        update_case(
+            self.domain,
+            self.episode_id,
+            {
+                TREATMENT_OUTCOME: "cured",
+            }
+        )
+        self.assertEqual(0, len(self.repeat_records().all()))
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -483,6 +483,14 @@ class TestNikshayTreatmentOutcomeRepeater(ENikshayLocationStructureMixin, Niksha
         # nikshay not enabled
         self.create_case(self.episode)
         self._create_nikshay_enabled_case()
+        update_case(
+            self.domain,
+            self.episode_id,
+            {
+                "nikshay_registered": 'true',
+                "nikshay_id": DUMMY_NIKSHAY_ID,
+            },
+        )
         self.assertEqual(0, len(self.repeat_records().all()))
 
         # change triggered


### PR DESCRIPTION
Turns out we should be sending updates for 
1. Migrated patients
2. patients registered via API
3. patients that provide nikshay_id during registration

So, update to send HIV Test update and Treatment Outcome for patients that have nikshay_id available 