### PR TITLE
do not validate when app is a build

### DIFF
--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -93,7 +93,11 @@ def direct_ccz(request, domain):
     except (ResourceNotFound, DocTypeError):
         return error("Application not found", code=404)
 
-    errors = app.validate_app()
+    if not app.copy_of:
+        errors = app.validate_app()
+    else:
+        errors = None
+
     if errors:
         lang, langs = get_langs(request, app)
         template = get_app_manager_template(
@@ -125,7 +129,7 @@ def direct_ccz(request, domain):
         filename='{}.ccz'.format(slugify(app.name)),
     )
 
-    if errors['errors']:
+    if errors is not None and errors['errors']:
         return json_response(
             errors,
             status_code=400,


### PR DESCRIPTION
@snopoke @wpride was able to reproduce easily by faking a static ucr. couldn't reproduce with a dynamic one. offending line: https://github.com/dimagi/commcare-hq/blob/br/dont-validate-app/corehq/apps/userreports/models.py#L730

cc: @biyeun 