### PR TITLE
Add custom expressions to avoid expensive eNikshay UCR calculations

### DIFF
--- a/custom/enikshay/expressions.py
+++ b/custom/enikshay/expressions.py
@@ -50,7 +50,7 @@ class FirstCaseFormWithXmlns(JsonObject):
 def first_case_form_with_xmlns_expression(spec, context):
     wrapped = FirstCaseFormWithXmlns.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.case_id_expression)
+        ExpressionFactory.from_spec(wrapped.case_id_expression, context)
     )
     return wrapped
 
@@ -88,7 +88,7 @@ class CountCaseFormsWithXmlns(JsonObject):
 def count_case_forms_with_xmlns_expression(spec, context):
     wrapped = CountCaseFormsWithXmlns.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.case_id_expression)
+        ExpressionFactory.from_spec(wrapped.case_id_expression, context)
     )
     return wrapped
 

--- a/custom/enikshay/expressions.py
+++ b/custom/enikshay/expressions.py
@@ -1,8 +1,96 @@
+from jsonobject import DefaultProperty, BooleanProperty
 from jsonobject.properties import ListProperty, StringProperty
 
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.specs import TypeProperty
+from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from dimagi.ext.jsonobject import JsonObject
+
+
+class FirstCaseFormWithXmlns(JsonObject):
+    type = TypeProperty('first_case_form_with_xmlns')
+    xmlns = StringProperty(required=True)
+    case_id_expression = DefaultProperty(required=True)
+    reverse = BooleanProperty(default=False)
+
+    def configure(self, case_id_expression):
+        self._case_id_expression = case_id_expression
+
+    def __call__(self, item, context=None):
+        case_id = self._case_id_expression(item, context)
+
+        if not case_id:
+            return None
+
+        assert context.root_doc['domain']
+        return self._get_forms(case_id, context)
+
+    def _get_forms(self, case_id, context):
+        domain = context.root_doc['domain']
+
+        cache_key = (self.__class__.__name__, case_id, self.xmlns, self.reverse)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        xforms = FormProcessorInterface(domain).get_case_forms(case_id)
+        xforms = sorted(
+            [form for form in xforms if form.xmlns == self.xmlns and form.domain == domain],
+            key=lambda x: x.received_on
+        )
+        if not xforms:
+            form = None
+        else:
+            index = -1 if self.reverse else 0
+            form = xforms[index].to_json()
+
+        context.set_cache_value(cache_key, form)
+        return form
+
+
+def first_case_form_with_xmlns_expression(spec, context):
+    wrapped = FirstCaseFormWithXmlns.wrap(spec)
+    wrapped.configure(
+        ExpressionFactory.from_spec(wrapped.case_id_expression)
+    )
+    return wrapped
+
+
+class CountCaseFormsWithXmlns(JsonObject):
+    type = TypeProperty('count_case_forms_with_xmlns')
+    xmlns = StringProperty(required=True)
+    case_id_expression = DefaultProperty(required=True)
+
+    def configure(self, case_id_expression):
+        self._case_id_expression = case_id_expression
+
+    def __call__(self, item, context=None):
+        case_id = self._case_id_expression(item, context)
+
+        if not case_id:
+            return None
+
+        assert context.root_doc['domain']
+        return self._count_forms(case_id, context)
+
+    def _count_forms(self, case_id, context):
+        domain = context.root_doc['domain']
+
+        cache_key = (self.__class__.__name__, case_id, self.xmlns)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        xforms = FormProcessorInterface(domain).get_case_forms(case_id)
+        count = len([form for form in xforms if form.xmlns == self.xmlns and form.domain == domain])
+        context.set_cache_value(cache_key, count)
+        return count
+
+
+def count_case_forms_with_xmlns_expression(spec, context):
+    wrapped = CountCaseFormsWithXmlns.wrap(spec)
+    wrapped.configure(
+        ExpressionFactory.from_spec(wrapped.case_id_expression)
+    )
+    return wrapped
 
 
 class ConcatenateStrings(JsonObject):

--- a/custom/enikshay/ucr/data_sources/expression_test.json
+++ b/custom/enikshay/ucr/data_sources/expression_test.json
@@ -1,0 +1,3274 @@
+{
+    "domains": [
+        "enikshay",
+        "enikshay-test"
+    ],
+    "config": {
+        "referenced_doc_type": "CommCareCase",
+        "engine_id": "ucr",
+        "description": "",
+        "base_item_expression": {
+        },
+        "table_id": "exp_test",
+        "display_name": "exp_test",
+        "configured_filter": {
+            "type": "and",
+            "filters": [
+                {
+                    "operator": "eq",
+                    "expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "type"
+                    },
+                    "type": "boolean_expression",
+                    "property_value": "episode"
+                }
+            ]
+        },
+        "configured_indicators": [
+            {
+                "display_name": "diagnostic_test_lab_serial_number",
+                "column_id": "diagnostic_test_lab_serial_number",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "first_case_form_with_xmlns",
+                        "case_id_expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "latest_diagnostic_test_case"
+                            },
+                            "value_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
+                        },
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                        "reverse": true
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "_id"
+                        ]
+                    }
+                }
+            },
+            {
+                "display_name": "diagnostic_test_lab_serial_number_ORIGINAL",
+                "column_id": "diagnostic_test_lab_serial_number_ORIGINAL",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_case_forms",
+                                    "case_id_expression": {
+                                        "type": "nested",
+                                        "argument_expression": {
+                                            "type": "named",
+                                            "name": "latest_diagnostic_test_case"
+                                        },
+                                        "value_expression": {
+                                            "type": "property_name",
+                                            "property_name": "_id"
+                                        }
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "xmlns"
+                                    },
+                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "received_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "_id"
+                        ]
+                    }
+                }
+            },
+            {
+                "display_name": "diagnostic_test_location_name",
+                "column_id": "diagnostic_test_location_name",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "first_case_form_with_xmlns",
+                        "case_id_expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "latest_diagnostic_test_case"
+                            },
+                            "value_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
+                        },
+                        "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                        "reverse": true
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "_id"
+                        ]
+                    }
+                }
+            },
+            {
+                "display_name": "diagnostic_test_location_name_ORIGINAL",
+                "column_id": "diagnostic_test_location_name_ORIGINAL",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_case_forms",
+                                    "case_id_expression": {
+                                        "type": "nested",
+                                        "argument_expression": {
+                                            "type": "named",
+                                            "name": "latest_diagnostic_test_case"
+                                        },
+                                        "value_expression": {
+                                            "type": "property_name",
+                                            "property_name": "_id"
+                                        }
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "xmlns"
+                                    },
+                                    "property_value": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "received_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "_id"
+                        ]
+                    }
+                }
+            },
+
+            {
+                "display_name": "microbiological_test_lab_serial_number",
+                "column_id": "microbiological_test_lab_serial_number",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "first_case_form_with_xmlns",
+                        "reverse": true,
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                        "case_id_expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "latest_microbiological_test_case"
+                            },
+                            "value_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
+                        }
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "form",
+                            "microscopy",
+                            "ql_microscopy",
+                            "lab_serial_number"
+                        ]
+                    }
+                }
+            },
+            {
+                "display_name": "microbiological_test_location_name",
+                "column_id": "microbiological_test_location_name",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "value_expression":{
+                        "type":"property_name",
+                        "property_name":"name"
+                    },
+                    "type":"related_doc",
+                    "related_doc_type":"Location",
+                    "doc_id_expression":{
+                        "type": "nested",
+                        "argument_expression": {
+                            "type": "first_case_form_with_xmlns",
+                            "reverse": true,
+                            "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                            "case_id_expression": {
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "named",
+                                    "name": "latest_microbiological_test_case"
+                                },
+                                "value_expression": {
+                                    "type": "property_name",
+                                    "property_name": "_id"
+                                }
+                            }
+                        },
+                        "value_expression": {
+                            "type": "property_path",
+                            "property_path": [
+                                "form",
+                                "user_location_id"
+                            ]
+                        }
+                    }
+
+                }
+            },
+
+            {
+                "display_name": "lab_results",
+                "type": "expression",
+                "datatype": "integer",
+                "column_id": "lab_results",
+                "expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "map_items",
+                        "items_expression": {
+                            "type": "filter_items",
+                            "items_expression": {
+                                "type": "get_subcases",
+                                "case_id_expression": {
+                                    "value_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "referenced_id"
+                                    },
+                                    "type": "nested",
+                                    "argument_expression": {
+                                        "type": "array_index",
+                                        "array_expression": {
+                                            "datatype": null,
+                                            "type": "property_name",
+                                            "property_name": "indices"
+                                        },
+                                        "index_expression": {
+                                            "type": "constant",
+                                            "constant": 0
+                                        }
+                                    }
+                                }
+                            },
+                            "filter_expression": {
+                                "type": "boolean_expression",
+                                "operator": "eq",
+                                "expression": {
+                                    "type": "property_name",
+                                    "property_name": "type"
+                                },
+                                "property_value": "test"
+                            }
+
+                        },
+                        "map_expression": {
+                            "type": "count_case_forms_with_xmlns",
+                            "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                            "case_id_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
+                        }
+                    },
+                    "aggregation_fn": "sum"
+                }
+            },
+            {
+                "display_name": "lab_results_ORIGINAL",
+                "column_id": "lab_results_ORIGINAL",
+                "type": "expression",
+                "datatype": "integer",
+                "expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "map_items",
+                        "items_expression": {
+                            "type": "filter_items",
+                            "items_expression": {
+                                "type": "get_subcases",
+                                "case_id_expression": {
+                                    "value_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "referenced_id"
+                                    },
+                                    "type": "nested",
+                                    "argument_expression": {
+                                        "type": "array_index",
+                                        "array_expression": {
+                                            "datatype": null,
+                                            "type": "property_name",
+                                            "property_name": "indices"
+                                        },
+                                        "index_expression": {
+                                            "type": "constant",
+                                            "constant": 0
+                                        }
+                                    }
+                                }
+                            },
+                            "filter_expression": {
+                                "type": "boolean_expression",
+                                "operator": "eq",
+                                "expression": {
+                                    "type": "property_name",
+                                    "property_name": "type"
+                                },
+                                "property_value": "test"
+                            }
+
+                        },
+                        "map_expression": {
+                            "type": "reduce_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_case_forms",
+                                    "case_id_expression": {
+                                        "type": "property_name",
+                                        "property_name": "_id"
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "xmlns"
+                                    },
+                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
+                                }
+                            },
+                            "aggregation_fn": "count"
+                        }
+                    },
+                    "aggregation_fn": "sum"
+                }
+            },
+
+            {
+                "display_name": "diagnostic_test_lab_serial_number_not_reverse",
+                "column_id": "diagnostic_test_lab_serial_number_not_reverse",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "first_case_form_with_xmlns",
+                        "case_id_expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "latest_diagnostic_test_case"
+                            },
+                            "value_expression": {
+                                "type": "property_name",
+                                "property_name": "_id"
+                            }
+                        },
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "_id"
+                        ]
+                    }
+                }
+            },
+            {
+                "display_name": "diagnostic_test_lab_serial_number_not_reverse_ORIGINAL",
+                "column_id": "diagnostic_test_lab_serial_number_not_reverse_ORIGINAL",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_case_forms",
+                                    "case_id_expression": {
+                                        "type": "nested",
+                                        "argument_expression": {
+                                            "type": "named",
+                                            "name": "latest_diagnostic_test_case"
+                                        },
+                                        "value_expression": {
+                                            "type": "property_name",
+                                            "property_name": "_id"
+                                        }
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "xmlns"
+                                    },
+                                    "property_value": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "received_on"
+                            }
+                        },
+                        "aggregation_fn": "first_item"
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "_id"
+                        ]
+                    }
+                }
+            }
+        ],
+        "named_filters": {
+            "cat2": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "previous_tb_treatment"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "property_value": "yes"
+            },
+            "cat1": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "previous_tb_treatment"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "property_value": "no"
+            },
+            "cpt_months_delivered_zero": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "cpt_months_delivered"
+                },
+                "property_value": "0"
+            },
+            "cpt_initiated": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "cpt_initiated"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "property_value": "yes"
+            },
+            "initiated_on_art": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "art_initiated"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "property_value": "yes"
+            },
+            "episode_type_patient": {
+                "type": "boolean_expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "episode_type"
+                },
+                "operator": "eq",
+                "property_value": "Patient"
+            },
+            "under_15": {
+                "operator": "lt",
+                "type": "boolean_expression",
+                "expression": {
+                    "datatype": "integer",
+                    "type": "named",
+                    "name": "age_in_days"
+                },
+                "property_value": 5475
+            },
+            "over_15": {
+                "operator": "gte",
+                "type": "boolean_expression",
+                "expression": {
+                    "datatype": "integer",
+                    "type": "named",
+                    "name": "age_in_days"
+                },
+                "property_value": 5475
+            },
+            "age_under_4": {
+                "operator": "lte",
+                "type": "boolean_expression",
+                "expression": {
+                    "datatype": "integer",
+                    "type": "named",
+                    "name": "age"
+                },
+                "property_value": 4
+            },
+            "age_5_14": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "gte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 5
+                    },
+                    {
+                        "operator": "lte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 14
+                    }
+                ]
+            },
+            "age_15_24": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "gte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 15
+                    },
+                    {
+                        "operator": "lte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 24
+                    }
+                ]
+            },
+            "age_25_34": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "gte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 25
+                    },
+                    {
+                        "operator": "lte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 34
+                    }
+                ]
+            },
+            "age_35_44": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "gte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 35
+                    },
+                    {
+                        "operator": "lte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 44
+                    }
+                ]
+            },
+            "age_45_54": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "gte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 45
+                    },
+                    {
+                        "operator": "lte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 54
+                    }
+                ]
+            },
+            "age_55_64": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "gte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 55
+                    },
+                    {
+                        "operator": "lte",
+                        "type": "boolean_expression",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "named",
+                            "name": "age"
+                        },
+                        "property_value": 64
+                    }
+                ]
+            },
+            "age_over_65": {
+                "operator": "gte",
+                "type": "boolean_expression",
+                "expression": {
+                    "datatype": "integer",
+                    "type": "named",
+                    "name": "age"
+                },
+                "property_value": 65
+            },
+            "new_patient": {
+                "operator": "eq",
+                "expression": {
+                    "datatype": "string",
+                    "type": "property_name",
+                    "property_name": "patient_type_choice"
+                },
+                "type": "boolean_expression",
+                "property_value": "new"
+            },
+            "retreatment": {
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "not",
+                        "filter": {
+                            "operator": "in",
+                            "expression": {
+                                "datatype": "string",
+                                "type": "property_name",
+                                "property_name": "patient_type_choice"
+                            },
+                            "type": "boolean_expression",
+                            "property_value": ["", null]
+                        }
+                    },
+                    {
+                        "type": "not",
+                        "filter": {
+                            "operator": "eq",
+                            "expression": {
+                                "datatype": "string",
+                                "type": "property_name",
+                                "property_name": "patient_type_choice"
+                            },
+                            "type": "boolean_expression",
+                            "property_value": "new"
+                        }
+                    }
+                ]
+
+            },
+            "others_patient": {
+                "operator": "eq",
+                "expression": {
+                    "datatype": "string",
+                    "type": "property_name",
+                    "property_name": "patient_type_choice"
+                },
+                "type": "boolean_expression",
+                "property_value": "others"
+            },
+            "female": {
+                "operator": "eq",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "sex"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "female"
+            },
+            "pulmonary": {
+                "operator": "eq",
+                "expression": {
+                    "datatype": "string",
+                    "type": "property_name",
+                    "property_name": "disease_classification"
+                },
+                "type": "boolean_expression",
+                "property_value": "pulmonary"
+            },
+            "transgender": {
+                "operator": "eq",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "sex"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "transgender"
+            },
+            "male": {
+                "operator": "eq",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "sex"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "male"
+            },
+            "hiv_positive": {
+                "operator": "eq",
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "hiv_status"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "reactive"
+            },
+            "microscopy_test": {
+                "type": "boolean_expression",
+                "operator": "in",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "named",
+                        "name": "test_request_form"
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "form",
+                            "rpt_referral_details",
+                            "test_type_value"
+                        ]
+                    }
+                },
+                "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+            },
+            "diagnostic": {
+                "operator": "eq",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "named",
+                        "name": "test_request_form"
+                    },
+                    "value_expression": {
+                        "type": "property_path",
+                        "property_path": [
+                            "form",
+                            "ql_request_details",
+                            "purpose_of_testing"
+                        ],
+                        "datatype": "string"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "diagnostic"
+            },
+            "positive_slide": {
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "operator": "in",
+                        "expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "test_result_form"
+                            },
+                            "value_expression": {
+                                "type": "property_path",
+                                "property_path": [
+                                    "form",
+                                    "microscopy",
+                                    "ql_sample_a",
+                                    "sample_a_result_value"
+                                ]
+                            }
+                        },
+                        "property_value": ["0", "1", "2", "3"]
+                    },
+                    {
+                        "type": "boolean_expression",
+                        "operator": "in",
+                        "expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "test_result_form"
+                            },
+                            "value_expression": {
+                                "type": "property_path",
+                                "property_path": [
+                                    "form",
+                                    "microscopy",
+                                    "ql_sample_b",
+                                    "sample_b_result_value"
+                                ]
+                            }
+                        },
+                        "property_value": ["0", "1", "2", "3"]
+                    }
+                ]
+            },
+            "negative_slide": {
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "test_result_form"
+                            },
+                            "value_expression": {
+                                "type": "property_path",
+                                "property_path": [
+                                    "form",
+                                    "microscopy",
+                                    "ql_sample_a",
+                                    "sample_a_result_value"
+                                ]
+                            }
+                        },
+                        "property_value": "-1"
+                    },
+                    {
+                        "type": "boolean_expression",
+                        "operator": "in",
+                        "expression": {
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "named",
+                                "name": "test_result_form"
+                            },
+                            "value_expression": {
+                                "type": "property_path",
+                                "property_path": [
+                                    "form",
+                                    "microscopy",
+                                    "ql_sample_b",
+                                    "sample_b_result_value"
+                                ]
+                            }
+                        },
+                        "property_value": "-1"
+                    }
+                ]
+            },
+
+            "sputum_positive": {
+                "type": "boolean_expression",
+                "operator": "eq",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_subcases",
+                                    "case_id_expression": {
+                                        "type": "named",
+                                        "name": "occurrence_id"
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": "microscopy-zn"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "opened_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "result"
+                    }
+                },
+                "property_value": "tb_detected"
+            },
+            "sputum_negative": {
+                "type": "boolean_expression",
+                "operator": "eq",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_subcases",
+                                    "case_id_expression": {
+                                        "type": "named",
+                                        "name": "occurrence_id"
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": "microscopy-zn"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "opened_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "result"
+                    }
+                },
+                "property_value": "tb_not_detected"
+            },
+            "sputum_na": {
+                "type": "boolean_expression",
+                "operator": "in",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_subcases",
+                                    "case_id_expression": {
+                                        "type": "named",
+                                        "name": "occurrence_id"
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": "microscopy-zn"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "opened_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "result"
+                    }
+                },
+                "property_value": ["", null]
+            },
+            "test_purpose_diagnostic": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_subcases",
+                                    "case_id_expression": {
+                                        "type": "named",
+                                        "name": "occurrence_id"
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": "microscopy-zn"
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "opened_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "purpose_of_testing"
+                    }
+                },
+                "property_value": "diagnostic"
+            },
+            "test_purpose_end_of_ip": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "reduce_items",
+                        "items_expression": {
+                            "type": "sort_items",
+                            "items_expression": {
+                                "type": "filter_items",
+                                "items_expression": {
+                                    "type": "get_subcases",
+                                    "case_id_expression": {
+                                        "type": "named",
+                                        "name": "occurrence_id"
+                                    }
+                                },
+                                "filter_expression": {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                }
+                            },
+                            "sort_expression": {
+                                "type": "property_name",
+                                "property_name": "opened_on"
+                            }
+                        },
+                        "aggregation_fn": "last_item"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "purpose_of_testing"
+                    }
+                },
+                "property_value": "end_of_ip"
+            },
+            "has_patient_type": {
+                "type": "not",
+                "filter": {
+                    "operator": "in",
+                    "expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "patient_type"
+                    },
+                    "type": "boolean_expression",
+                    "property_value": [
+                        "",
+                        null
+                    ]
+                }
+            },
+            "2months_length_of_ip": {
+                "type": "and",
+                "filters": [
+                    {
+                        "operator": "lt",
+                        "expression": {
+                            "datatype": "integer",
+                            "type": "property_name",
+                            "property_name": "length_of_ip"
+                        },
+                        "type": "boolean_expression",
+                        "property_value": 90
+                    },
+                    {
+                        "type": "not",
+                        "filter": {
+                            "operator": "in",
+                            "expression": {
+                                "datatype": "string",
+                                "type": "property_name",
+                                "property_name": "length_of_ip"
+                            },
+                            "type": "boolean_expression",
+                            "property_value": [
+                                "",
+                                null
+                            ]
+                        }
+                    }
+                ]
+            },
+            "3months_length_of_ip": {
+                "operator": "gte",
+                "expression": {
+                    "datatype": "integer",
+                    "type": "property_name",
+                    "property_name": "length_of_ip"
+                },
+                "type": "boolean_expression",
+                "property_value": 90
+            },
+            "current_episode_type_suspect": {
+                "operator": "eq",
+                "expression": {
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "type": "named",
+                        "name": "occurrence_id"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "current_episode_type"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "presumptive_tb"
+            },
+            "current_episode_type_patient": {
+                "operator": "eq",
+                "expression": {
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "type": "named",
+                        "name": "occurrence_id"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "current_episode_type"
+                    }
+                },
+                "type": "boolean_expression",
+                "property_value": "confirmed_tb"
+            },
+            "dots_commcareuser" : {
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "datatype": "string",
+                            "type": "property_name",
+                            "property_name": "adherence_type_choice"
+                        },
+                        "property_value": "dots"
+                    },
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "datatype": "string",
+                            "type": "property_name",
+                            "property_name": "treatment_supporter_designation"
+                        },
+                        "property_value": "tbhv_to"
+                    }
+                ]
+            }
+        },
+        "named_expressions": {
+            "test_result": {
+                "type": "conditional",
+                "test": {
+                    "operator": "eq",
+                    "expression": {
+                        "type": "property_name",
+                        "property_name": "test_type_value"
+                    },
+                    "type": "boolean_expression",
+                    "property_value": "cbnaat"
+                },
+                "expression_if_true": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "first_case_form_with_xmlns",
+                        "reverse": true,
+                        "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                        "case_id_expression": {
+                            "type": "property_name",
+                            "property_name": "_id"
+                        }
+                    },
+                    "value_expression": {
+                        "type":"concatenate_strings",
+                        "expressions": [
+                            {
+                                "type": "property_path",
+                                "property_path": [
+                                    "form",
+                                    "cbnaat",
+                                    "mtb_result"
+                                ]
+                            },
+                            {
+                                "type": "property_path",
+                                "property_path": [
+                                    "form",
+                                    "cbnaat",
+                                    "rif_resistance_result"
+                                ]
+                            }
+                        ],
+                        "separator": " "
+                    }
+                },
+                "expression_if_false": {
+                    "type": "property_name",
+                    "property_name": "result_grade"
+                }
+            },
+            "age": {
+                "value_expression": {
+                    "datatype": "integer",
+                    "type": "property_name",
+                    "property_name": "age"
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                    "value_expression": {
+                        "type": "nested",
+                        "value_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "referenced_id"
+                        },
+                        "argument_expression": {
+                            "type": "array_index",
+                            "array_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "indices"
+                            },
+                            "index_expression": {
+                                "type": "constant",
+                                "constant": 0
+                            }
+                        }
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "value_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "referenced_id"
+                        },
+                        "type": "nested",
+                        "argument_expression": {
+                            "type": "array_index",
+                            "array_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "indices"
+                            },
+                            "index_expression": {
+                                "type": "constant",
+                                "constant": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "occurrence_id": {
+                "value_expression": {
+                    "datatype": null,
+                    "type": "property_name",
+                    "property_name": "referenced_id"
+                },
+                "type": "nested",
+                "argument_expression": {
+                    "type": "array_index",
+                    "array_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "indices"
+                    },
+                    "index_expression": {
+                        "type": "constant",
+                        "constant": 0
+                    }
+                }
+            },
+            "person_id": {
+                "value_expression": {
+                    "type": "nested",
+                    "value_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "referenced_id"
+                    },
+                    "argument_expression": {
+                        "type": "array_index",
+                        "array_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "indices"
+                        },
+                        "index_expression": {
+                            "type": "constant",
+                            "constant": 0
+                        }
+                    }
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                    "value_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "referenced_id"
+                    },
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "array_index",
+                        "array_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "indices"
+                        },
+                        "index_expression": {
+                            "type": "constant",
+                            "constant": 0
+                        }
+                    }
+                }
+            },
+            "test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "boolean_expression",
+                            "operator": "eq",
+                            "expression": {
+                                "type": "property_name",
+                                "property_name": "type"
+                            },
+                            "property_value": "test"
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "referral_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "type": "nested",
+                                    "value_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "referenced_id"
+                                    },
+                                    "argument_expression": {
+                                        "type": "array_index",
+                                        "array_expression": {
+                                            "datatype": null,
+                                            "type": "property_name",
+                                            "property_name": "indices"
+                                        },
+                                        "index_expression": {
+                                            "type": "constant",
+                                            "constant": 0
+                                        }
+                                    }
+                                },
+                                "type": "related_doc",
+                                "related_doc_type": "CommCareCase",
+                                "doc_id_expression": {
+                                    "value_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "referenced_id"
+                                    },
+                                    "type": "nested",
+                                    "argument_expression": {
+                                        "type": "array_index",
+                                        "array_expression": {
+                                            "datatype": null,
+                                            "type": "property_name",
+                                            "property_name": "indices"
+                                        },
+                                        "index_expression": {
+                                            "type": "constant",
+                                            "constant": 0
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "boolean_expression",
+                            "operator": "eq",
+                            "expression": {
+                                "type": "property_name",
+                                "property_name": "type"
+                            },
+                            "property_value": "referral"
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_diagnostic_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "diagnostic"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_microbiological_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent", "cbnaat"]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_not_microbiological_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "not",
+                                    "filter": {
+                                        "type": "boolean_expression",
+                                        "operator": "in",
+                                        "expression": {
+                                            "type": "property_name",
+                                            "property_name": "test_type_value"
+                                        },
+                                        "property_value": ["microscopy-zn", "microscopy-fluorescent", "cbnaat"]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_diagnostic_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "diagnostic"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_suspect_diagnostic_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "diagnostic"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "episode_type_at_request"
+                                    },
+                                    "property_value": "presumptive_tb"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_follow_up_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_suspect_follow_up_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "episode_type_at_request"
+                                    },
+                                    "property_value": "presumptive_tb"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_suspect_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "episode_type_at_request"
+                                    },
+                                    "property_value": "presumptive_tb"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_microscopy_test_request_form": {
+                "type": "first_case_form_with_xmlns",
+                "reverse": true,
+                "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                "case_id_expression": {
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "named",
+                        "name": "latest_microscopy_test_case"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
+                }
+            },
+            "latest_diagnostic_mbr_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "diagnostic"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["cbnaat", "culture", "line_probe_assay"]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_endofip_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "end_of_ip"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_endofip_microscopy_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "end_of_ip"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": ["microscopy-zn", "microscopy-fluorescent"]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_endofcp_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "end_of_cp"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_post_treatment_6_month_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "posttreatment_6month"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_post_treatment_12_month_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "posttreatment_12month"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_post_treatment_18_month_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "posttreatment_18month"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "latest_post_treatment_24_month_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "purpose_of_testing"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "follow_up"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "follow_up_test_reason"
+                                    },
+                                    "operator": "eq",
+                                    "property_value": "posttreatment_24month"
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "last_item"
+            },
+            "test_request_form": {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "sort_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "sort_expression": {
+                            "type": "property_name",
+                            "property_name": "opened_on"
+                        }
+                    },
+                    "aggregation_fn": "last_item"
+                },
+                "value_expression": {
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/826B0458-C4ED-4A58-8AFD-F8E437C3646F",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
+                }
+            },
+            "test_result_form": {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "sort_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "sort_expression": {
+                            "type": "property_name",
+                            "property_name": "opened_on"
+                        }
+                    },
+                    "aggregation_fn": "last_item"
+                },
+                "value_expression": {
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/0598A2DE-3E33-48BF-96AC-226C25C70CB3",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
+                }
+            },
+            "sample_receipt_form": {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "sort_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "sort_expression": {
+                            "type": "property_name",
+                            "property_name": "opened_on"
+                        }
+                    },
+                    "aggregation_fn": "last_item"
+                },
+                "value_expression": {
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/B139DDFB-13C5-4E89-8BE6-E74ACB9FCBBE",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
+                }
+            },
+            "suspect_registration": {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "sort_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "sort_expression": {
+                            "type": "property_name",
+                            "property_name": "opened_on"
+                        }
+                    },
+                    "aggregation_fn": "last_item"
+                },
+                "value_expression": {
+                    "type": "first_case_form_with_xmlns",
+                    "reverse": true,
+                    "xmlns": "http://openrosa.org/formdesigner/1953B000-3BB5-4A6C-B5BB-D60BD17028D0",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
+                }
+            },
+            "patient_registration": {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "reduce_items",
+                    "items_expression": {
+                        "type": "sort_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "sort_expression": {
+                            "type": "property_name",
+                            "property_name": "opened_on"
+                        }
+                    },
+                    "aggregation_fn": "last_item"
+                },
+                "value_expression": {
+                    "type": "first_case_form_with_xmlns",
+                    "xmlns": "http://openrosa.org/formdesigner/60B0DB43-CC15-43A0-BFE7-885310AFD6E4",
+                    "case_id_expression": {
+                        "type": "property_name",
+                        "property_name": "_id"
+                    }
+                }
+            },
+            "complete_treatment_form": {
+                "type": "first_case_form_with_xmlns",
+                "reverse": true,
+                "xmlns": "http://openrosa.org/formdesigner/60B0DB43-CC15-43A0-BFE7-885310AFD6E4",
+                "case_id_expression": {
+                    "type": "property_name",
+                    "property_name": "_id"
+                }
+            },
+            "hiv_status": {
+                "value_expression": {
+                    "datatype": "string",
+                    "type": "property_name",
+                    "property_name": "hiv_status"
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                    "type": "named",
+                    "name": "person_id"
+                }
+            },
+            "key_populations": {
+                "value_expression": {
+                    "datatype": "string",
+                    "type": "property_name",
+                    "property_name": "key_populations"
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                    "value_expression": {
+                        "type": "nested",
+                        "value_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "referenced_id"
+                        },
+                        "argument_expression": {
+                            "type": "array_index",
+                            "array_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "indices"
+                            },
+                            "index_expression": {
+                                "type": "constant",
+                                "constant": 0
+                            }
+                        }
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "value_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "referenced_id"
+                        },
+                        "type": "nested",
+                        "argument_expression": {
+                            "type": "array_index",
+                            "array_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "indices"
+                            },
+                            "index_expression": {
+                                "type": "constant",
+                                "constant": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "treatment_outcome": {
+                "datatype": "string",
+                "type": "property_name",
+                "property_name": "treatment_outcome"
+            },
+            "age_in_days": {
+                "type": "diff_days",
+                "from_date_expression": {
+                    "value_expression": {
+                        "datatype": "date",
+                        "type": "property_name",
+                        "property_name": "dob"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "value_expression": {
+                            "type": "nested",
+                            "value_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "referenced_id"
+                            },
+                            "argument_expression": {
+                                "type": "array_index",
+                                "array_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "indices"
+                                },
+                                "index_expression": {
+                                    "type": "constant",
+                                    "constant": 0
+                                }
+                            }
+                        },
+                        "type": "related_doc",
+                        "related_doc_type": "CommCareCase",
+                        "doc_id_expression": {
+                            "value_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "referenced_id"
+                            },
+                            "type": "nested",
+                            "argument_expression": {
+                                "type": "array_index",
+                                "array_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "indices"
+                                },
+                                "index_expression": {
+                                    "type": "constant",
+                                    "constant": 0
+                                }
+                            }
+                        }
+                    }
+                },
+                "to_date_expression": {
+                    "datatype": "date",
+                    "type": "property_name",
+                    "property_name": "opened_on"
+                }
+            },
+            "bacteriological_examination_test_case": {
+                "type": "reduce_items",
+                "items_expression": {
+                    "type": "sort_items",
+                    "items_expression": {
+                        "type": "filter_items",
+                        "items_expression": {
+                            "type": "get_subcases",
+                            "case_id_expression": {
+                                "value_expression": {
+                                    "datatype": null,
+                                    "type": "property_name",
+                                    "property_name": "referenced_id"
+                                },
+                                "type": "nested",
+                                "argument_expression": {
+                                    "type": "array_index",
+                                    "array_expression": {
+                                        "datatype": null,
+                                        "type": "property_name",
+                                        "property_name": "indices"
+                                    },
+                                    "index_expression": {
+                                        "type": "constant",
+                                        "constant": 0
+                                    }
+                                }
+                            }
+                        },
+                        "filter_expression": {
+                            "type": "and",
+                            "filters": [
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "eq",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "type"
+                                    },
+                                    "property_value": "test"
+                                },
+                                {
+                                    "type": "boolean_expression",
+                                    "operator": "in",
+                                    "expression": {
+                                        "type": "property_name",
+                                        "property_name": "test_type_value"
+                                    },
+                                    "property_value": [
+                                        "microscopy-zn",
+                                        "microscopy-fluorescent",
+                                        "cbnaat",
+                                        "culture",
+                                        "dst",
+                                        "line_probe_assay"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "sort_expression": {
+                        "type": "property_name",
+                        "property_name": "opened_on"
+                    }
+                },
+                "aggregation_fn": "first_item"
+            }
+        }
+    }
+}

--- a/settings.py
+++ b/settings.py
@@ -1846,7 +1846,9 @@ CUSTOM_UCR_EXPRESSIONS = [
     ('cqi_action_item', 'custom.eqa.expressions.cqi_action_item'),
     ('year_expression', 'custom.pnlppgi.expressions.year_expression'),
     ('week_expression', 'custom.pnlppgi.expressions.week_expression'),
-    ('concatenate_strings', 'custom.enikshay.expressions.concatenate_strings_expression')
+    ('concatenate_strings', 'custom.enikshay.expressions.concatenate_strings_expression'),
+    ('first_case_form_with_xmlns', 'custom.enikshay.expressions.first_case_form_with_xmlns_expression'),
+    ('count_case_forms_with_xmlns', 'custom.enikshay.expressions.count_case_forms_with_xmlns_expression'),
 ]
 
 CUSTOM_UCR_EXPRESSION_LISTS = [

--- a/settings.py
+++ b/settings.py
@@ -1783,6 +1783,7 @@ STATIC_DATA_SOURCES = [
 
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'test.json'),
+    os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'expression_test.json'),
 
     os.path.join('custom', 'pnlppgi', 'resources', 'site_reporting_rates.json'),
     os.path.join('custom', 'pnlppgi', 'resources', 'malaria.json')


### PR DESCRIPTION
This is one half of this PR: https://github.com/dimagi/commcare-hq/pull/15373

http://manage.dimagi.com/default.asp?249246
I wrote these custom expressions to avoid [this line](https://github.com/dimagi/commcare-hq/blob/73ee772b70df3b31295923dd55a4b09af0e2583a/corehq/apps/userreports/expressions/specs.py#L302), which is very time consuming if the number of forms is large.

Other optimizations could be done, such as caching the value of `FormProcessorInterface(domain).get_case_forms(case_id)`, but at least right now that call is insignificant compared to all the calls to `form.to_json()`, which require a trip to riak.

@calellowitz @emord