### PR TITLE
Fix app copying in app manager v2

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/app_view.html
@@ -197,7 +197,7 @@
         });
     </script>
     <script>
-        $("#copy form button").click(function() {
+        $("#copy-app-form form button").click(function() {
             var $submit = $(this),
                 $form = $submit.closest("form"),
                 domain = $form.find("#id_domain").val(),
@@ -319,7 +319,7 @@
             </div>
 
         {% endif %}
-        <div class="tab-pane{% if copy_app_form.is_bound %} active{% endif %}" id="copy">
+        <div class="tab-pane{% if copy_app_form.is_bound %} active{% endif %}" id="copy-app-form">
             {% if linked_apps_enabled %}
             <div class="tabbable">
                 <ul class="nav nav-tabs">

--- a/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
@@ -244,7 +244,7 @@
     <li class="text-hq-nav-header">{% trans "Actions" %}</li>
     {% if app.get_doc_type != "LinkedApplication" %}
     <li class="app-name-div{% if copy_app_form and copy_app_form.is_bound %} active{% endif %}">
-        <a href="{% url "view_app" domain app.id %}copy/#copy" {% if is_app_view %}data-toggle="tab"{% endif %} data-pagetitle="{% trans "Copy" %}: {{ app.name }}">
+        <a href="{% url "view_app" domain app.id %}copy/#copy-app-form" {% if is_app_view %}data-toggle="tab"{% endif %} data-pagetitle="{% trans "Copy" %}: {{ app.name }}">
             <i class="fa fa-copy"></i>
             {% trans "Copy Application" %}
         </a>

--- a/corehq/apps/app_manager/templates/app_manager/v2/app_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/app_view_settings.html
@@ -127,7 +127,7 @@
     });
   </script>
   <script>
-    $("#copy form button").click(function() {
+    $("#copy-app-form form button").click(function() {
       var $submit = $(this),
         $form = $submit.closest("form"),
         domain = $form.find("#id_domain").val(),

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
@@ -240,7 +240,7 @@
         <div class="tab-pane" id="actions">
             {% if app.get_doc_type != 'LinkedApplication' %}
                 {% if copy_app_form %}
-                    <div class="panel panel-appmanager panel-appmanager-form">
+                    <div class="panel panel-appmanager panel-appmanager-form" id="copy-app-form">
                         <form class="form form-horizontal" method="post" action="{% url "copy_app" domain %}">
                             {% crispy copy_app_form %}
                         </form>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
@@ -307,7 +307,7 @@
 +        <div class="tab-pane" id="actions">
 +            {% if app.get_doc_type != 'LinkedApplication' %}
 +                {% if copy_app_form %}
-+                    <div class="panel panel-appmanager panel-appmanager-form">
++                    <div class="panel panel-appmanager panel-appmanager-form" id="copy-app-form">
 +                        <form class="form form-horizontal" method="post" action="{% url "copy_app" domain %}">
 +                            {% crispy copy_app_form %}
 +                        </form>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
@@ -201,7 +201,7 @@
 -        });
 -    </script>
 -    <script>
--        $("#copy form button").click(function() {
+-        $("#copy-app-form form button").click(function() {
 -            var $submit = $(this),
 -                $form = $submit.closest("form"),
 -                domain = $form.find("#id_domain").val(),
@@ -413,7 +413,7 @@
 -            </div>
 -
 -        {% endif %}
--        <div class="tab-pane{% if copy_app_form.is_bound %} active{% endif %}" id="copy">
+-        <div class="tab-pane{% if copy_app_form.is_bound %} active{% endif %}" id="copy-app-form">
 -            {% if linked_apps_enabled %}
 -            <div class="tabbable">
 -                <ul class="nav nav-tabs">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
@@ -272,7 +272,7 @@
 -    <li class="text-hq-nav-header">{% trans "Actions" %}</li>
 -    {% if app.get_doc_type != "LinkedApplication" %}
 -    <li class="app-name-div{% if copy_app_form and copy_app_form.is_bound %} active{% endif %}">
--        <a href="{% url "view_app" domain app.id %}copy/#copy" {% if is_app_view %}data-toggle="tab"{% endif %} data-pagetitle="{% trans "Copy" %}: {{ app.name }}">
+-        <a href="{% url "view_app" domain app.id %}copy/#copy-app-form" {% if is_app_view %}data-toggle="tab"{% endif %} data-pagetitle="{% trans "Copy" %}: {{ app.name }}">
 -            <i class="fa fa-copy"></i>
 -            {% trans "Copy Application" %}
 -        </a>


### PR DESCRIPTION
The actual bug is that v2's `app-settings.html` didn't have a `copy` id in it, probably got lost while redesigning app_view, so the copy button's click handler wasn't running. The other changes are just renaming `#copy`, which seemed like a dangerously generic id.

@dannyroberts / @biyeun 