### PR TITLE
use endswith instead of in

### DIFF
--- a/corehq/util/supervisord/api.py
+++ b/corehq/util/supervisord/api.py
@@ -153,7 +153,7 @@ class PillowtopSupervisorApi(HQSupervisorApi):
     def get_pillow_process_info(self, pillow_name):
         process_info = [
             info for info in self.get_all_process_info()
-            if pillow_name in info.name
+            if info.name.endswith(pillow_name)
         ]
         try:
             return process_info[0]


### PR DESCRIPTION
kafka-ucr-main shows as running because it's a subset of kafka-ucr-main-08

@gcapalbo 