### PR TITLE
PNLPPGI - Fix issue when first dates of new year include to the last week of prev year

### DIFF
--- a/custom/pnlppgi/expressions.py
+++ b/custom/pnlppgi/expressions.py
@@ -24,7 +24,7 @@ class YearExpressionSpec(JsonObject):
             date = force_to_datetime(item[self.property])
         except ValueError:
             return -1
-        return date.year
+        return date.isocalendar()[0]
 
 
 def week_expression(spec, context):


### PR DESCRIPTION
@snopoke 
When we have a date for example 2017-01-01 then this day should depend to the week 52/2016. 