### PR TITLE
rebuild once per hour instead of every 3 min

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -24,7 +24,7 @@ from pillowtop.processors import PillowProcessor
 from pillowtop.utils import ensure_matched_revisions, ensure_document_exists
 
 
-REBUILD_CHECK_INTERVAL = 10 * 60  # in seconds
+REBUILD_CHECK_INTERVAL = 60 * 60  # in seconds
 UCR_CHECKPOINT_ID = 'pillow-checkpoint-ucr-main'
 UCR_STATIC_CHECKPOINT_ID = 'pillow-checkpoint-ucr-static'
 


### PR DESCRIPTION
Check if a table needs to be rebuild once per hour instead of every 10 min.

On prod one of the partitioned pillows takes 3 min to rebuild. which means we're losing 1/3 of of our processing time on this. I'm not convinced we need it at all, but want to do some more digging to make sure that's correct. 

It rebuilds no matter what when the pillow starts, so that fixes static pillows. 
Report builder reports are rebuilt on save.
This should only affect edits to custom reports that don't hit the rebuild table

@gcapalbo 