### PR TITLE
icds lab

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -75,7 +75,7 @@ class ConfigurableReportTableManagerMixin(object):
             adapter
             for adapter_list in self.table_adapters_by_domain.values()
             for adapter in adapter_list
-            if get_backend_id(adapter.config) in engine_ids
+            if get_backend_id(adapter.config, can_handle_laboratory=True) in engine_ids
         ]
 
     def rebuild_tables_if_necessary(self):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -113,6 +113,7 @@ class ConfigurableReportTableManagerMixin(object):
                     self.rebuild_table(sql_adapter)
 
     def _rebuild_es_tables(self, adapters):
+        # note unlike sql rebuilds this doesn't rebuild the indicators
         for adapter in adapters:
             adapter.rebuild_table_if_necessary()
 

--- a/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
+++ b/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
@@ -404,6 +404,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -1746,6 +1746,7 @@
         "property_value": "st"
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
@@ -3115,6 +3115,7 @@
         "type": "not"
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau.json
@@ -2020,6 +2020,7 @@
         }
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
@@ -4093,6 +4093,7 @@
         ]
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
@@ -898,6 +898,7 @@
         ]
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -1491,6 +1491,7 @@
         "property_value": true
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
@@ -2950,6 +2950,7 @@
         ]
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -986,6 +986,7 @@
         ]
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -630,6 +630,7 @@
         "property_value": "F"
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/home_visit_forms.json
+++ b/custom/icds_reports/ucr/data_sources/home_visit_forms.json
@@ -173,6 +173,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -172,6 +172,7 @@
         "property_value": false
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -1361,6 +1361,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
+++ b/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
@@ -135,6 +135,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/person_cases.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases.json
@@ -2542,6 +2542,7 @@
         "property_value": null
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -330,6 +330,7 @@
         "property_value": "pregnancy"
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
@@ -412,6 +412,7 @@
         "property_value": "ls"
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms.json
@@ -117,6 +117,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/usage_forms.json
+++ b/custom/icds_reports/ucr/data_sources/usage_forms.json
@@ -915,6 +915,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/vhnd_form.json
@@ -705,6 +705,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
+++ b/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
@@ -322,6 +322,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "backend_id": "LABORATORY"
   }
 }

--- a/custom/icds_reports/ucr/tests/test_ccs_record_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_ccs_record_monthly.py
@@ -5,6 +5,7 @@ from django.test import override_settings
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseStructure, CaseIndex
+from corehq.apps.userreports.const import UCR_SQL_BACKEND
 from custom.icds_reports.ucr.tests.base_test import BaseICDSDatasourceTest, add_element
 
 XMNLS_BP_FORM = 'http://openrosa.org/formdesigner/2864010F-B1B1-4711-8C59-D5B2B81D65DB'
@@ -14,6 +15,7 @@ XMLNS_EBF_FORM = 'http://openrosa.org/formdesigner/89097FB1-6C08-48BA-95B2-67BCF
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+@override_settings(OVERRIDE_UCR_BACKEND=UCR_SQL_BACKEND)
 class TestCCSRecordDataSource(BaseICDSDatasourceTest):
     datasource_filename = 'ccs_record_cases_monthly_tableau'
 

--- a/custom/icds_reports/ucr/tests/test_child_health_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_child_health_monthly.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseStructure, CaseIndex
+from corehq.apps.userreports.const import UCR_SQL_BACKEND
 from custom.icds_reports.ucr.tests.base_test import BaseICDSDatasourceTest, add_element
 
 XMNLS_BP_FORM = 'http://openrosa.org/formdesigner/2864010F-B1B1-4711-8C59-D5B2B81D65DB'
@@ -25,6 +26,7 @@ NUTRITION_STATUS_SEVERE = "red"
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+@override_settings(OVERRIDE_UCR_BACKEND=UCR_SQL_BACKEND)
 class TestChildHealthDataSource(BaseICDSDatasourceTest):
     datasource_filename = 'child_health_cases_monthly_tableau'
 


### PR DESCRIPTION
Due to a "feature" (some may say :bug:), this will only create the ES indexes.

Once this is deployed we will need to manually "rebuild table in place" on the icds reports. Not fixing that bug right now because I think this may be the preferable behavior at the moment.

I left out the locations ucr since that should be small and I didn't htink we'd gain much from converting to ES.

I also wanted to change the tests to support the ES backend, but there's a blocker on that (noted in a comment)

@snopoke @sheelio @gcapalbo 