### PR TITLE
Migration of all blobs to new Riak cluster

### DIFF
--- a/corehq/blobs/fsdb.py
+++ b/corehq/blobs/fsdb.py
@@ -75,7 +75,16 @@ class FilesystemBlobDB(AbstractBlobDB):
         return success
 
     def copy_blob(self, content, info, bucket):
-        raise NotImplementedError
+        path = self.get_path(info.identifier, bucket)
+        dirpath = dirname(path)
+        if not isdir(dirpath):
+            os.makedirs(dirpath)
+        with openfile(path, "xb") as fh:
+            while True:
+                chunk = content.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                fh.write(chunk)
 
     def get_path(self, identifier=None, bucket=DEFAULT_BUCKET):
         bucket_path = safejoin(self.rootdir, bucket)

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -71,16 +71,19 @@ import os
 import traceback
 from abc import abstractmethod
 from base64 import b64encode
+from functools import partial
+from itertools import groupby
 from tempfile import mkdtemp
 
 from django.conf import settings
 
+from corehq.apps.dump_reload.sql.dump import allow_form_processing_queries
 from corehq.apps.export import models as exports
 from corehq.apps.ota.models import DemoUserRestore
 from corehq.blobs import get_blob_db, DEFAULT_BUCKET, BlobInfo
 from corehq.blobs.exceptions import NotFound
 from corehq.blobs.migratingdb import MigratingBlobDB
-from corehq.blobs.mixin import BlobHelper
+from corehq.blobs.mixin import BlobHelper, BlobMeta
 from corehq.blobs.models import BlobMigrationState
 from corehq.blobs.zipdb import get_export_filename
 from corehq.dbaccessors.couchapps.all_docs import get_doc_count_by_type
@@ -88,17 +91,21 @@ from corehq.util.doc_processor.couch import (
     CouchDocumentProvider, doc_type_tuples_to_dict, CouchViewDocumentProvider
 )
 from corehq.util.doc_processor.couch import CouchProcessorProgressLogger
+from corehq.util.doc_processor.sql import SqlDocumentProvider
 from corehq.util.doc_processor.interface import (
     BaseDocProcessor, DOCS_SKIPPED_WARNING,
     DocumentProcessorController
 )
 from couchdbkit import ResourceConflict
+from corehq.form_processor.backends.sql.dbaccessors import ReindexAccessor
 
 # models to be migrated
 import corehq.apps.hqmedia.models as hqmedia
 import couchforms.models as xform
 import casexml.apps.case.models as cases
-from corehq.apps.app_manager.models import Application, RemoteApp
+import corehq.apps.app_manager.models as apps
+from corehq.apps.case_importer.tracking.filestorage import BUCKET as CASE_UPLOAD_BUCKET
+from corehq.apps.case_importer.tracking.models import CaseUploadFileMeta
 from couchexport.models import SavedBasicExport
 import corehq.form_processor.models as sql_xform
 
@@ -147,12 +154,13 @@ class BaseDocMigrator(BaseDocProcessor):
     # If true, load attachment content before migrating.
     load_attachments = False
 
-    def __init__(self, slug, couchdb, filename=None):
+    def __init__(self, slug, couchdb, filename=None, blob_helper=BlobHelper):
         super(BaseDocMigrator, self).__init__()
         self.slug = slug
         self.couchdb = couchdb
         self.dirpath = None
         self.filename = filename
+        self.blob_helper = blob_helper
         if filename is None:
             self.dirpath = mkdtemp()
             self.filename = os.path.join(self.dirpath, "export.txt")
@@ -169,7 +177,7 @@ class BaseDocMigrator(BaseDocProcessor):
 
     def _prepare_doc(self, doc):
         if self.load_attachments:
-            obj = BlobHelper(doc, self.couchdb)
+            obj = self.blob_helper(doc, self.couchdb)
             doc["_attachments"] = {
                 name: {
                     "content_type": meta["content_type"],
@@ -226,7 +234,7 @@ class CouchAttachmentMigrator(BaseDocMigrator):
     def _do_migration(self, doc):
         attachments = doc.pop("_attachments")
         external_blobs = doc.setdefault("external_blobs", {})
-        obj = BlobHelper(doc, self.couchdb)
+        obj = self.blob_helper(doc, self.couchdb)
         try:
             with obj.atomic_blobs():
                 for name, data in list(attachments.iteritems()):
@@ -246,9 +254,14 @@ class CouchAttachmentMigrator(BaseDocMigrator):
 
 
 class BlobDbBackendMigrator(BaseDocMigrator):
+    """Migrate blobs from one blob db to another
 
-    def __init__(self, slug, couchdb, filename=None):
-        super(BlobDbBackendMigrator, self).__init__(slug, couchdb, filename)
+    The backup log for this migrator will contain one JSON object
+    for each blob that was not found in the old blob db.
+    """
+
+    def __init__(self, *args, **kw):
+        super(BlobDbBackendMigrator, self).__init__(*args, **kw)
         self.db = get_blob_db()
         self.total_blobs = 0
         self.not_found = 0
@@ -256,8 +269,11 @@ class BlobDbBackendMigrator(BaseDocMigrator):
             raise MigrationError(
                 "Expected to find migrating blob db backend (got %r)" % self.db)
 
+    def _backup_doc(self, doc):
+        pass
+
     def _do_migration(self, doc):
-        obj = BlobHelper(doc, self.couchdb)
+        obj = self.blob_helper(doc, self.couchdb)
         bucket = obj._blobdb_bucket()
         assert obj.external_blobs and obj.external_blobs == obj.blobs, doc
         for name, meta in obj.blobs.iteritems():
@@ -265,6 +281,12 @@ class BlobDbBackendMigrator(BaseDocMigrator):
             try:
                 content = self.db.old_db.get(meta.id, bucket)
             except NotFound:
+                super(BlobDbBackendMigrator, self)._backup_doc({
+                    "doc_type": obj.doc_type,
+                    "doc_id": obj._id,
+                    "blob_identifier": meta.id,
+                    "blob_bucket": bucket,
+                })
                 self.not_found += 1
             else:
                 with content:
@@ -275,9 +297,12 @@ class BlobDbBackendMigrator(BaseDocMigrator):
         super(BlobDbBackendMigrator, self).processing_complete(skipped)
         if self.not_found:
             print(PROCESSING_COMPLETE_MESSAGE.format(self.not_found, self.total_blobs))
+            if self.dirpath is None:
+                print("Missing blob ids have been written in the log file:")
+                print(self.filename)
 
     def should_process(self, doc):
-        return doc.get("external_blobs")
+        return self.blob_helper.get_external_blobs(doc)
 
 
 class BlobDbBackendExporter(BaseDocProcessor):
@@ -295,7 +320,7 @@ class BlobDbBackendExporter(BaseDocProcessor):
         self.db.close()
 
     def process_doc(self, doc):
-        obj = BlobHelper(doc, self.couchdb)
+        obj = self.blob_helper(doc, self.couchdb)
         bucket = obj._blobdb_bucket()
         assert obj.external_blobs and obj.external_blobs == obj.blobs, doc
         from_db = get_blob_db()
@@ -315,7 +340,7 @@ class BlobDbBackendExporter(BaseDocProcessor):
             print(PROCESSING_COMPLETE_MESSAGE.format(self.not_found, self.total_blobs))
 
     def should_process(self, doc):
-        return doc.get("external_blobs")
+        return self.blob_helper.get_external_blobs(doc)
 
 
 class SqlObjectExporter(object):
@@ -378,6 +403,91 @@ class DemoUserRestoreExporter(SqlObjectExporter):
                 self.db.copy_blob(content, info, DEFAULT_BUCKET)
 
 
+class SqlBlobHelper(object):
+    """Adapt a SQL model object to look like a BlobHelper
+
+    This is currently built on the assumtion that the SQL model only
+    references a single blob, and the blob name is not used.
+    """
+
+    def __init__(self, obj, blob_id, bucket):
+        self.obj = obj
+        self.blobs = {"name-ignored": BlobMeta(id=blob_id)}
+        self.external_blobs = self.blobs
+        self._blobdb_bucket = lambda:bucket
+
+    @property
+    def _id(self):
+        return self.obj.id
+
+    @property
+    def doc_type(self):
+        return type(self.obj).__name__
+
+
+def sql_blob_helper(id_attr, bucket):
+    get_bucket = bucket if hasattr(bucket, "__call__") else (lambda obj: bucket)
+
+    def blob_helper(doc, couchdb_ignored=None):
+        """This has the same signature as BlobHelper
+
+        :returns: Object having parts of BlobHelper interface needed
+        for blob migrations (currently only used by BlobDbBackendMigrator).
+        """
+        obj = doc["_obj_not_json"]
+        blob_id = getattr(obj, id_attr)
+        bucket = get_bucket(obj)
+        return SqlBlobHelper(obj, blob_id, bucket)
+
+    blob_helper.id_attr = id_attr
+
+    # HACK this is only ever used to determine if there are blobs
+    # to migrate. For SQL objects there always will be.
+    blob_helper.get_external_blobs = lambda doc: True
+
+    return staticmethod(blob_helper)
+
+
+class PkReindexAccessor(ReindexAccessor):
+    startkey_min_value = -1
+    startkey_attribute_name = 'id'
+
+    def get_doc(self, *args, **kw):
+        # only used for retries; BlobDbBackendMigrator doesn't retry
+        raise NotImplementedError
+
+    def doc_to_json(self, obj):
+        return {"_id": obj.id, "_obj_not_json": obj}
+
+    def get_docs(self, from_db, startkey, last_doc_pk=None, limit=500):
+        params = {self.startkey_attribute_name + "__gt":
+            startkey or self.startkey_min_value}
+        return (self.model_class.objects
+            .using(from_db)
+            .filter(**params)
+            .order_by(self.startkey_attribute_name)[:limit])
+
+
+class CaseUploadFileMetaReindexAccessor(PkReindexAccessor):
+    model_class = CaseUploadFileMeta
+    blob_helper = sql_blob_helper("identifier", CASE_UPLOAD_BUCKET)
+
+
+class CaseAttachmentSQLReindexAccessor(PkReindexAccessor):
+    model_class = sql_xform.CaseAttachmentSQL
+    blob_helper = sql_blob_helper("blob_id", lambda obj: obj.blobdb_bucket())
+
+
+class XFormAttachmentSQLReindexAccessor(PkReindexAccessor):
+    model_class = sql_xform.XFormAttachmentSQL
+    blob_helper = sql_blob_helper("blob_id", lambda obj: obj.blobdb_bucket())
+
+
+class DemoUserRestoreReindexAccessor(PkReindexAccessor):
+    model_class = DemoUserRestore
+    blob_helper = sql_blob_helper("restore_blob_id", DEFAULT_BUCKET)
+
+
 class Migrator(object):
 
     def __init__(self, slug, doc_types, doc_migrator_class):
@@ -385,7 +495,8 @@ class Migrator(object):
         self.doc_migrator_class = doc_migrator_class
         self.doc_types = doc_types
         first_type = doc_types[0]
-        self.couchdb = (first_type[0] if isinstance(first_type, tuple) else first_type).get_db()
+        first_type = (first_type[0] if isinstance(first_type, tuple) else first_type)
+        self.couchdb = first_type.get_db() if hasattr(first_type, "get_db") else None
 
         sorted_types = sorted(doc_type_tuples_to_dict(self.doc_types))
         self.iteration_key = "{}-blob-migration/{}".format(self.slug, " ".join(sorted_types))
@@ -409,6 +520,50 @@ class Migrator(object):
 
     def _get_progress_logger(self):
         return CouchProcessorProgressLogger(self.doc_types)
+
+
+class SqlMigrator(Migrator):
+
+    def __init__(self, slug, reindexer, doc_migrator_class):
+        types = [reindexer.model_class]
+        assert not hasattr(types[0], "get_db"), types[0] # not a couch model
+        doc_migrator = partial(doc_migrator_class, blob_helper=reindexer.blob_helper)
+        super(SqlMigrator, self).__init__(slug, types, doc_migrator)
+        self.reindexer = reindexer
+
+    def migrate(self, *args, **kw):
+        with allow_form_processing_queries():
+            return super(SqlMigrator, self).migrate(*args, **kw)
+
+    def _get_document_provider(self):
+        return SqlDocumentProvider(self.iteration_key, self.reindexer)
+
+
+class MultiDbMigrator(object):
+
+    def __init__(self, slug, couch_types, sql_reindexers, doc_migrator_class):
+        self.slug = slug
+        self.migrators = migrators = []
+        def db_key(doc_type):
+            if isinstance(doc_type, tuple):
+                doc_type = doc_type[1]
+            return doc_type.get_db().dbname
+        for key, types in groupby(sorted(couch_types, key=db_key), key=db_key):
+            migrators.append(Migrator(slug, list(types), doc_migrator_class))
+        for rex in sql_reindexers:
+            migrators.append(SqlMigrator(slug, rex(), doc_migrator_class))
+
+    def migrate(self, filename, *args, **kw):
+        def filen(n):
+            return None if filename is None else "{}.{}".format(filename, n)
+        migrated = 0
+        skipped = 0
+        for n, item in enumerate(self.migrators):
+            one_migrated, one_skipped = item.migrate(filen(n), *args, **kw)
+            migrated += one_migrated
+            skipped += one_skipped
+            print("\n")
+        return migrated, skipped
 
 
 class ExportByDomain(Migrator):
@@ -452,7 +607,6 @@ class SqlModelMigrator(Migrator):
 
     def migrate(self, filename=None, reset=False, max_retry=2, chunk_size=100):
         from corehq.apps.dump_reload.sql.dump import get_all_model_querysets_for_domain
-        from corehq.apps.dump_reload.sql.dump import allow_form_processing_queries
 
         if not self.domain:
             raise MigrationError("Must specify domain")
@@ -478,12 +632,11 @@ class SqlModelMigrator(Migrator):
 
 MIGRATIONS = {m.slug: m for m in [
     Migrator("saved_exports", [SavedBasicExport], CouchAttachmentMigrator),
-    Migrator("migrate_backend", [SavedBasicExport], BlobDbBackendMigrator),
     Migrator("applications", [
-        Application,
-        RemoteApp,
-        ("Application-Deleted", Application),
-        ("RemoteApp-Deleted", RemoteApp),
+        apps.Application,
+        apps.RemoteApp,
+        ("Application-Deleted", apps.Application),
+        ("RemoteApp-Deleted", apps.RemoteApp),
     ], CouchAttachmentMigrator),
     Migrator("multimedia", [
         hqmedia.CommCareAudio,
@@ -507,14 +660,50 @@ MIGRATIONS = {m.slug: m for m in [
         ('CommCareCase-Deleted', cases.CommCareCase),
         ('CommCareCase-Deleted-Deleted', cases.CommCareCase),
     ], CouchAttachmentMigrator),
+    MultiDbMigrator("migrate_backend",
+        couch_types=[
+            apps.Application,
+            apps.LinkedApplication,
+            apps.RemoteApp,
+            #SavedAppBuild, # do we need to migrate these? (none in couch on prod)
+            ("Application-Deleted", apps.Application),
+            ("RemoteApp-Deleted", apps.RemoteApp),
+            SavedBasicExport,
+            hqmedia.CommCareAudio,
+            hqmedia.CommCareImage,
+            hqmedia.CommCareVideo,
+            hqmedia.CommCareMultimedia,
+            xform.XFormInstance,
+            ("XFormInstance-Deleted", xform.XFormInstance),
+            xform.XFormArchived,
+            xform.XFormDeprecated,
+            xform.XFormDuplicate,
+            xform.XFormError,
+            xform.SubmissionErrorLog,
+            ("HQSubmission", xform.XFormInstance),
+            cases.CommCareCase,
+            ('CommCareCase-deleted', cases.CommCareCase),
+            ('CommCareCase-Deleted', cases.CommCareCase),
+            ('CommCareCase-Deleted-Deleted', cases.CommCareCase),
+            exports.CaseExportInstance,
+            exports.FormExportInstance,
+        ],
+        sql_reindexers=[
+            CaseUploadFileMetaReindexAccessor,
+            CaseAttachmentSQLReindexAccessor,
+            XFormAttachmentSQLReindexAccessor,
+            DemoUserRestoreReindexAccessor,
+        ],
+        doc_migrator_class=BlobDbBackendMigrator,
+    ),
 ]}
 
 EXPORTERS = {m.slug: m for m in [
     ExportByDomain("applications", [
-        Application,
-        RemoteApp,
-        ("Application-Deleted", Application),
-        ("RemoteApp-Deleted", RemoteApp),
+        apps.Application,
+        apps.RemoteApp,
+        ("Application-Deleted", apps.Application),
+        ("RemoteApp-Deleted", apps.RemoteApp),
     ], BlobDbBackendExporter),
     ExportMultimediaByDomain("multimedia", [
         hqmedia.CommCareMultimedia,

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -414,7 +414,7 @@ class SqlBlobHelper(object):
         self.obj = obj
         self.blobs = {"name-ignored": BlobMeta(id=blob_id)}
         self.external_blobs = self.blobs
-        self._blobdb_bucket = lambda:bucket
+        self._blobdb_bucket = lambda: bucket
 
     @property
     def _id(self):
@@ -526,7 +526,7 @@ class SqlMigrator(Migrator):
 
     def __init__(self, slug, reindexer, doc_migrator_class):
         types = [reindexer.model_class]
-        assert not hasattr(types[0], "get_db"), types[0] # not a couch model
+        assert not hasattr(types[0], "get_db"), types[0]  # not a couch model
         doc_migrator = partial(doc_migrator_class, blob_helper=reindexer.blob_helper)
         super(SqlMigrator, self).__init__(slug, types, doc_migrator)
         self.reindexer = reindexer
@@ -544,12 +544,15 @@ class MultiDbMigrator(object):
     def __init__(self, slug, couch_types, sql_reindexers, doc_migrator_class):
         self.slug = slug
         self.migrators = migrators = []
+
         def db_key(doc_type):
             if isinstance(doc_type, tuple):
                 doc_type = doc_type[1]
             return doc_type.get_db().dbname
+
         for key, types in groupby(sorted(couch_types, key=db_key), key=db_key):
             migrators.append(Migrator(slug, list(types), doc_migrator_class))
+
         for rex in sql_reindexers:
             migrators.append(SqlMigrator(slug, rex(), doc_migrator_class))
 

--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -258,16 +258,21 @@ class BlobHelper(object):
             raise TypeError("BlobHelper requires a real _id")
         self._id = doc["_id"]
         self.doc = doc
+        self.doc_type = doc["doc_type"]
         self.database = database
         self.couch_only = "external_blobs" not in doc
         self._migrating_blobs_from_couch = bool(doc.get("_attachments")) \
             and not self.couch_only
         self._attachments = doc.get("_attachments")
-        blobs = doc.get("external_blobs", {})
+        blobs = self.get_external_blobs(doc, {})
         self.external_blobs = {n: BlobMeta.wrap(m.copy())
                                for n, m in blobs.iteritems()}
 
     _atomic_blobs = None
+
+    @staticmethod
+    def get_external_blobs(doc, default=None):
+        return doc.get("external_blobs", default)
 
     @property
     def blobs(self):

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import print_function
 import json
+import uuid
+from cStringIO import StringIO
 from os.path import join
 
 import corehq.blobs.migrate as mod
@@ -8,8 +10,10 @@ from corehq.blobs import get_blob_db
 from corehq.blobs.mixin import BlobMixin
 from corehq.blobs.s3db import maybe_not_found
 from corehq.blobs.tests.util import (
+    install_blob_db,
     TemporaryFilesystemBlobDB, TemporaryMigratingBlobDB, TemporaryS3BlobDB
 )
+from corehq.blobs.util import random_url_id
 from corehq.util.doc_processor.couch import CouchDocumentProvider, doc_type_tuples_to_dict
 from corehq.util.test_utils import trap_extra_setup
 
@@ -49,10 +53,12 @@ class BaseMigrationTest(TestCase):
     @staticmethod
     def discard_migration_state(slug):
         migrator = mod.MIGRATIONS[slug]
-        iterator = CouchDocumentProvider(
-            migrator.iteration_key, migrator.doc_types
-        ).get_document_iterator(1)
-        iterator.discard_state()
+        if hasattr(migrator, "migrators"):
+            providers = [m._get_document_provider() for m in migrator.migrators]
+        else:
+            providers = [migrator._get_document_provider()]
+        for provider in providers:
+            provider.get_document_iterator(1).discard_state()
         mod.BlobMigrationState.objects.filter(slug=slug).delete()
 
     # abstract property, must be overridden in base class
@@ -434,31 +440,147 @@ class TestCommCareCaseMigrations(BaseMigrationTest):
 class TestMigrateBackend(TestCase):
 
     slug = "migrate_backend"
-    test_size = 5
+    couch_doc_types = {
+        "Application": mod.apps.Application,
+        "LinkedApplication": mod.apps.LinkedApplication,
+        "RemoteApp": mod.apps.RemoteApp,
+        "Application-Deleted": mod.apps.Application,
+        "RemoteApp-Deleted": mod.apps.RemoteApp,
+        "SavedBasicExport": mod.SavedBasicExport,
+        "CommCareAudio": mod.hqmedia.CommCareAudio,
+        "CommCareImage": mod.hqmedia.CommCareImage,
+        "CommCareVideo": mod.hqmedia.CommCareVideo,
+        "CommCareMultimedia": mod.hqmedia.CommCareMultimedia,
+        "XFormInstance": mod.xform.XFormInstance,
+        "XFormInstance-Deleted": mod.xform.XFormInstance,
+        "XFormArchived": mod.xform.XFormArchived,
+        "XFormDeprecated": mod.xform.XFormDeprecated,
+        "XFormDuplicate": mod.xform.XFormDuplicate,
+        "XFormError": mod.xform.XFormError,
+        "SubmissionErrorLog": mod.xform.SubmissionErrorLog,
+        "HQSubmission": mod.xform.XFormInstance,
+        "CommCareCase": mod.cases.CommCareCase,
+        'CommCareCase-deleted': mod.cases.CommCareCase,
+        'CommCareCase-Deleted': mod.cases.CommCareCase,
+        'CommCareCase-Deleted-Deleted': mod.cases.CommCareCase,
+        "CaseExportInstance": mod.exports.CaseExportInstance,
+        "FormExportInstance": mod.exports.FormExportInstance,
+    }
+    sql_reindex_accessors = [
+        mod.CaseUploadFileMetaReindexAccessor,
+        mod.CaseAttachmentSQLReindexAccessor,
+        mod.XFormAttachmentSQLReindexAccessor,
+        mod.DemoUserRestoreReindexAccessor,
+    ]
+
+    def _sql_save(self, obj, rex):
+        if rex.is_sharded():
+            # HACK why does it have to be so hard to use form_processor
+            # even just for testing...
+            from corehq.form_processor.models import DisabledDbMixin
+            super(DisabledDbMixin, obj).save_base()
+        else:
+            obj.save()
+
+    def CaseAttachmentSQL_save(self, obj, rex):
+        obj.attachment_id = uuid.uuid4()
+        obj.case_id = "not-there"
+        obj.name = "name"
+        obj.identifier = "what is this?"
+        obj.md5 = "blah"
+        self._sql_save(obj, rex)
+
+    def XFormAttachmentSQL_save(self, obj, rex):
+        obj.attachment_id = uuid.uuid4()
+        obj.form_id = "not-there"
+        obj.name = "name"
+        obj.identifier = "what is this?"
+        obj.md5 = "blah"
+        self._sql_save(obj, rex)
+
+    def DemoUserRestore_save(self, obj, rex):
+        obj.attachment_id = uuid.uuid4()
+        obj.demo_user_id = "not-there"
+        self._sql_save(obj, rex)
 
     def setUp(self):
         with trap_extra_setup(AttributeError, msg="S3_BLOB_DB_SETTINGS not configured"):
             config = settings.S3_BLOB_DB_SETTINGS
 
-        fsdb = TemporaryFilesystemBlobDB()
-        assert get_blob_db() is fsdb, (get_blob_db(), fsdb)
-        self.migrate_docs = docs = []
-        for i in range(self.test_size):
-            doc = SavedBasicExport(configuration=_mk_config("config-%s" % i))
-            doc.save()
-            doc.set_payload(("content %s" % i).encode('utf-8'))
-            docs.append(doc)
+        lost_db = TemporaryFilesystemBlobDB() # must be created before S3 dbs
+        db1 = TemporaryS3BlobDB(config)
+        assert get_blob_db() is db1, (get_blob_db(), db1)
+        missing = "found.not"
+        name = "blob.bin"
+        data = b'binary data not valid utf-8 \xe4\x94'
 
-        s3db = TemporaryS3BlobDB(config)
-        self.db = TemporaryMigratingBlobDB(s3db, fsdb)
+        self.not_founds = set()
+        self.couch_docs = []
+        with lost_db:
+            for doc_type, model_class in self.couch_doc_types.items():
+                item = model_class()
+                item.doc_type = doc_type
+                item.save()
+                item.put_attachment(data, name)
+                with install_blob_db(lost_db):
+                    item.put_attachment(data, missing)
+                    self.not_founds.add((
+                        doc_type,
+                        item._id,
+                        item.external_blobs[missing].id,
+                        item._blobdb_bucket(),
+                    ))
+                item.save()
+                self.couch_docs.append(item)
+
+        def create_obj(rex):
+            ident = random_url_id(8)
+            args = {rex.blob_helper.id_attr: ident}
+            fields = {getattr(f, "attname", "")
+                for f in rex.model_class._meta.get_fields()}
+            if "content_length" in fields:
+                args["content_length"] = len(data)
+            elif "length" in fields:
+                args["length"] = len(data)
+            item = rex.model_class(**args)
+            save_attr = rex.model_class.__name__ + "_save"
+            if hasattr(self, save_attr):
+                getattr(self, save_attr)(item, rex)
+            else:
+                item.save()
+            return item, ident
+        self.sql_docs = []
+        with mod.allow_form_processing_queries():
+            for rex in self.sql_reindex_accessors:
+                item, ident = create_obj(rex)
+                helper = rex.blob_helper({"_obj_not_json": item})
+                db1.put(StringIO(data), ident, helper._blobdb_bucket())
+                self.sql_docs.append(item)
+                lost, lost_blob_id = create_obj(rex)
+                self.not_founds.add((
+                    rex.model_class.__name__,
+                    lost.id,
+                    lost_blob_id,
+                    rex.blob_helper({"_obj_not_json": lost})._blobdb_bucket(),
+                ))
+
+        self.test_size = len(self.couch_docs) + len(self.sql_docs)
+        db2 = TemporaryS3BlobDB(config)
+        self.db = TemporaryMigratingBlobDB(db2, db1)
         assert get_blob_db() is self.db, (get_blob_db(), self.db)
         BaseMigrationTest.discard_migration_state(self.slug)
 
     def tearDown(self):
+        from corehq.form_processor.models import DisabledDbMixin
         self.db.close()
         BaseMigrationTest.discard_migration_state(self.slug)
-        for doc in self.migrate_docs:
+        for doc in self.couch_docs:
             doc.get_db().delete_doc(doc._id)
+        for doc in self.sql_docs:
+            if isinstance(doc, DisabledDbMixin):
+                super(DisabledDbMixin, doc).delete()
+            else:
+                doc.delete()
 
     def test_migrate_backend(self):
         # verify: attachment is in couch and migration not complete
@@ -476,22 +598,32 @@ class TestMigrateBackend(TestCase):
             # verify: migration state recorded
             mod.BlobMigrationState.objects.get(slug=self.slug)
 
-            # verify: migrated data was written to the file
-            with open(filename) as fh:
-                lines = list(fh)
-            ids = {d._id for d in self.migrate_docs}
-            migrated = {d["_id"] for d in (json.loads(x) for x in lines)}
-            self.assertEqual(len(ids.intersection(migrated)), self.test_size)
+            # verify: missing blobs written to log files
+            missing_log = set()
+            fields = ["doc_type", "doc_id", "blob_identifier", "blob_bucket"]
+            for n, ignore in enumerate(mod.MIGRATIONS[self.slug].migrators):
+                with open("{}.{}".format(filename, n)) as fh:
+                    for line in fh:
+                        doc = json.loads(line)
+                        missing_log.add(tuple(doc[x] for x in fields))
+            self.assertEqual(
+                len(self.not_founds.intersection(missing_log)),
+                len(self.not_founds)
+            )
 
-        # verify: attachment was copied to new blob db
-        for doc in self.migrate_docs:
-            exp = SavedBasicExport.get(doc._id)
+        # verify: couch attachments were copied to new blob db
+        for doc in self.couch_docs:
+            exp = type(doc).get(doc._id)
             self.assertEqual(exp._rev, doc._rev)  # rev should not change
             self.assertTrue(doc.blobs)
             bucket = doc._blobdb_bucket()
-            for meta in doc.blobs.values():
+            for name, meta in doc.blobs.items():
+                if name == "found.not":
+                    continue
                 content = self.db.new_db.get(meta.id, bucket)
-                self.assertEqual(len(content.read()), meta.content_length)
+                data = content.read()
+                self.assertEqual(data, b'binary data not valid utf-8 \xe4\x94')
+                self.assertEqual(len(data), meta.content_length)
 
 
 def _mk_config(name='some export name', index='dummy_index'):

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -555,6 +555,7 @@ class TestMigrateBackend(TestCase):
                 db1.put(StringIO(data), ident, helper._blobdb_bucket())
                 self.sql_docs.append(item)
                 lost, lost_blob_id = create_obj(rex)
+                self.sql_docs.append(lost)
                 self.not_founds.add((
                     rex.model_class.__name__,
                     lost.id,

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -549,7 +549,7 @@ class TestMigrateBackend(TestCase):
             return item, ident
         self.sql_docs = []
         with mod.allow_form_processing_queries():
-            for rex in self.sql_reindex_accessors:
+            for rex in (x() for x in self.sql_reindex_accessors):
                 item, ident = create_obj(rex)
                 helper = rex.blob_helper({"_obj_not_json": item})
                 db1.put(StringIO(data), ident, helper._blobdb_bucket())

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -507,7 +507,7 @@ class TestMigrateBackend(TestCase):
         with trap_extra_setup(AttributeError, msg="S3_BLOB_DB_SETTINGS not configured"):
             config = settings.S3_BLOB_DB_SETTINGS
 
-        lost_db = TemporaryFilesystemBlobDB() # must be created before S3 dbs
+        lost_db = TemporaryFilesystemBlobDB()  # must be created before S3 dbs
         db1 = TemporaryS3BlobDB(config)
         assert get_blob_db() is db1, (get_blob_db(), db1)
         missing = "found.not"

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -575,6 +575,8 @@ class TestBlobHelper(BaseTestCase):
             doc = {}
         if "_id" not in doc:
             doc["_id"] = uuid.uuid4().hex
+        if "doc_type" not in doc:
+            doc["doc_type"] = "FakeDoc"
         if doc.get("_attachments"):
             for name, attach in doc["_attachments"].iteritems():
                 self.couch.put_attachment(doc, name=name, **attach)
@@ -616,6 +618,7 @@ class TestBlobHelper(BaseTestCase):
         couch = FakeCouchDatabase()
         couch.fetch_attachment = fetch_fail
         obj = mod.BlobHelper({
+            "doc_type": "FakeDoc",
             "_id": "fetch-fail",
             "external_blobs": {"not-found.txt": {"id": "hahaha"}},
         }, couch)
@@ -625,6 +628,7 @@ class TestBlobHelper(BaseTestCase):
 
     def test_fetch_attachment_not_found_while_migrating(self):
         obj = mod.BlobHelper({
+            "doc_type": "FakeDoc",
             "_id": "fetch-fail",
             "_attachments": {"migrating...": {}},
             "external_blobs": {"not-found.txt": {"id": "nope"}},
@@ -641,6 +645,7 @@ class TestBlobHelper(BaseTestCase):
         self.assertEqual(obj.fetch_attachment("file.txt"), content)
         self.assertFalse(self.couch.data)
         self.assertEqual(self.couch.save_log, [{
+            "doc_type": "FakeDoc",
             "_id": obj._id,
             "external_blobs": {
                 "file.txt": {
@@ -680,6 +685,7 @@ class TestBlobHelper(BaseTestCase):
         with obj.atomic_blobs():
             # save before put
             self.assertEqual(self.couch.save_log, [{
+                "doc_type": "FakeDoc",
                 "_id": obj._id,
                 "_attachments": {},
             }])
@@ -697,6 +703,7 @@ class TestBlobHelper(BaseTestCase):
             self.assertEqual(self.couch.save_log, [])
             obj.put_attachment("test", "file.txt", content_type="text/plain")
         self.assertEqual(self.couch.save_log, [{
+            "doc_type": "FakeDoc",
             "_id": obj._id,
             "_attachments": {},
             "external_blobs": {
@@ -737,6 +744,7 @@ class TestBlobHelper(BaseTestCase):
         # fetch from blob db
         self.assertEqual(obj.fetch_attachment("doc.txt"), "doc")
         self.assertEqual(self.couch.save_log, [{
+            "doc_type": "FakeDoc",
             "_id": obj._id,
             "_attachments": {},
             "external_blobs": {

--- a/corehq/blobs/tests/util.py
+++ b/corehq/blobs/tests/util.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from shutil import rmtree
 from tempfile import mkdtemp
 from uuid import uuid4
@@ -44,6 +45,18 @@ class TemporaryBlobDBMixin(object):
 
     def __exit__(self, *exc_info):
         self.close()
+
+
+@contextmanager
+def install_blob_db(db, uninstall_first=True):
+    """Temporarily install the given blob db"""
+    blobs._db.append(db)
+    assert blobs.get_blob_db() is db, 'got wrong blob db'
+    try:
+        yield db
+    finally:
+        assert blobs._db[-1] is db, blobs._db[-1]
+        blobs._db.pop()
 
 
 class TemporaryFilesystemBlobDB(TemporaryBlobDBMixin, FilesystemBlobDB):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -139,6 +139,18 @@ class ShardAccessor(object):
 
 
 class ReindexAccessor(six.with_metaclass(ABCMeta)):
+    startkey_min_value = datetime.min
+
+    @classmethod
+    def is_sharded(cls):
+        """
+        :return: True the django model is sharded, otherwise false.
+        """
+        # TODO check for subclass of PartitionedModel when PR merged:
+        # https://github.com/dimagi/commcare-hq/pull/14852
+        from corehq.form_processor.models import RestrictedManager
+        return isinstance(cls.model_class.objects, RestrictedManager)
+
     @abstractproperty
     def model_class(self):
         """

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -141,15 +141,14 @@ class ShardAccessor(object):
 class ReindexAccessor(six.with_metaclass(ABCMeta)):
     startkey_min_value = datetime.min
 
-    @classmethod
-    def is_sharded(cls):
+    def is_sharded(self):
         """
         :return: True the django model is sharded, otherwise false.
         """
         # TODO check for subclass of PartitionedModel when PR merged:
         # https://github.com/dimagi/commcare-hq/pull/14852
         from corehq.form_processor.models import RestrictedManager
-        return isinstance(cls.model_class.objects, RestrictedManager)
+        return isinstance(self.model_class.objects, RestrictedManager)
 
     @abstractproperty
     def model_class(self):

--- a/corehq/util/doc_processor/couch.py
+++ b/corehq/util/doc_processor/couch.py
@@ -89,7 +89,7 @@ class CouchProcessorProgressLogger(ProcessorProgressLogger):
         print("Processing {} documents{}: {}...".format(
             total,
             " (~{} already processed)".format(previously_visited) if previously_visited else "",
-            ", ".join(sorted(self.doc_types))
+            ", ".join(self.doc_types)
         ))
 
 
@@ -119,7 +119,8 @@ class CouchDocumentProvider(DocumentProvider):
             raise ValueError("Invalid (duplicate?) doc types")
 
         self.couchdb = next(iter(self.doc_type_map.values())).get_db()
-        assert all(m.get_db() is self.couchdb for m in self.doc_type_map.values()), \
+        dbname = self.couchdb.dbname
+        assert all(m.get_db().dbname == dbname for m in self.doc_type_map.values()), \
             "documents must live in same couch db: %s" % repr(self.doc_type_map)
 
         if domain:
@@ -172,4 +173,4 @@ def doc_type_tuples_to_dict(doc_types):
 
 
 def doc_type_tuples_to_list(doc_types):
-    return list(doc_type_tuples_to_dict(doc_types))
+    return sorted(doc_type_tuples_to_dict(doc_types))

--- a/corehq/util/doc_processor/couch.py
+++ b/corehq/util/doc_processor/couch.py
@@ -119,8 +119,9 @@ class CouchDocumentProvider(DocumentProvider):
             raise ValueError("Invalid (duplicate?) doc types")
 
         self.couchdb = next(iter(self.doc_type_map.values())).get_db()
-        dbname = self.couchdb.dbname
-        assert all(m.get_db().dbname == dbname for m in self.doc_type_map.values()), \
+        couchid = lambda db: getattr(db, "dbname", id(db))
+        dbid = couchid(self.couchdb)
+        assert all(couchid(m.get_db()) == dbid for m in self.doc_type_map.values()), \
             "documents must live in same couch db: %s" % repr(self.doc_type_map)
 
         if domain:

--- a/corehq/util/doc_processor/interface.py
+++ b/corehq/util/doc_processor/interface.py
@@ -223,8 +223,11 @@ class DocumentProcessorController(object):
 
     def _update_progress(self):
         self.visited += 1
+        if self.visited + self.previously_visited > self.total:
+            self.total = self.visited + self.previously_visited
         if self.visited % self.chunk_size == 0:
-            self.document_iterator.set_iterator_detail('progress', {"visited": self.visited, "total": self.total})
+            self.document_iterator.set_iterator_detail('progress',
+                {"visited": self.visited, "total": self.total})
 
         now = datetime.now()
         attempted = self.attempted
@@ -240,7 +243,8 @@ class DocumentProcessorController(object):
 
     def _processing_complete(self):
         if self.session_visited:
-            self.document_iterator.set_iterator_detail('progress', {"visited": self.visited, "total": self.total})
+            self.document_iterator.set_iterator_detail('progress',
+                {"visited": self.visited, "total": self.total})
         self.doc_processor.processing_complete(self.skipped)
         self.progress_logger.progress_complete(
             self.processed,

--- a/testsettings.py
+++ b/testsettings.py
@@ -82,10 +82,11 @@ def _set_logging_levels(levels):
 _set_logging_levels({
     # Quiet down a few really noisy ones.
     # (removing these can be handy to debug couchdb access for failing tests)
-    'boto3': 'INFO',
+    'boto3': 'WARNING',
     'botocore': 'INFO',
     'couchdbkit.request': 'INFO',
     'restkit.client': 'INFO',
+    's3transfer': 'INFO',
 })
 
 # use empty LOGGING dict with --debug=nose,nose.plugins to debug test discovery

--- a/testsettings.py
+++ b/testsettings.py
@@ -82,6 +82,8 @@ def _set_logging_levels(levels):
 _set_logging_levels({
     # Quiet down a few really noisy ones.
     # (removing these can be handy to debug couchdb access for failing tests)
+    'boto3': 'INFO',
+    'botocore': 'INFO',
     'couchdbkit.request': 'INFO',
     'restkit.client': 'INFO',
 })


### PR DESCRIPTION
I continued with the existing pattern of blob db migrations. We'll need to add two new localsettings:

```py
BLOB_DB_MIGRATING_FROM_S3_TO_S3 = True
OLD_S3_BLOB_DB_SETTINGS = {...}
```

The test is slow and ended up with way too much boilerplate for setup 😞 

@snopoke @javierwilson 