### PR TITLE
unicode report builder choices

### DIFF
--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -76,10 +76,10 @@ def _build_choice_list_indicator(spec, context):
     base_display_name = wrapped_spec.display_name
 
     def _construct_display(choice):
-        return '{base} ({choice})'.format(base=base_display_name, choice=choice)
+        return u'{base} ({choice})'.format(base=base_display_name, choice=choice)
 
     def _construct_column(choice):
-        return '{col}_{choice}'.format(col=spec['column_id'], choice=choice)
+        return u'{col}_{choice}'.format(col=spec['column_id'], choice=choice)
 
     choice_indicators = [
         BooleanIndicator(


### PR DESCRIPTION
@NoahCarnahan @millerdev 
to address the first traceback in http://manage.dimagi.com/default.asp?249347#1304078
There was a non ascii character that was failing to be encoded. I have not been able to reproduce this bug however, so its possible my understanding is off. Does this seem safe @millerdev 