### PR TITLE
add migration metadata

### DIFF
--- a/custom/enikshay/nikshay_datamigration/factory.py
+++ b/custom/enikshay/nikshay_datamigration/factory.py
@@ -149,6 +149,7 @@ class EnikshayCaseFactory(object):
                     'sex': self.patient_detail.sex,
 
                     'migration_created_case': 'true',
+                    'migration_created_from_record': self.patient_detail.PregId,
                 },
             },
         }
@@ -209,7 +210,9 @@ class EnikshayCaseFactory(object):
                     'name': 'Occurrence #1',
                     'occurrence_episode_count': 1,
                     'occurrence_id': get_human_friendly_id(),
+
                     'migration_created_case': 'true',
+                    'migration_created_from_record': self.patient_detail.PregId,
                 },
             },
             'indices': [CaseIndex(
@@ -278,6 +281,7 @@ class EnikshayCaseFactory(object):
                     'treatment_supporter_mobile_number': validate_phone_number(self.patient_detail.dotmob),
 
                     'migration_created_case': 'true',
+                    'migration_created_from_record': self.patient_detail.PregId,
                 },
             },
             'indices': [CaseIndex(
@@ -315,6 +319,7 @@ class EnikshayCaseFactory(object):
                     'name': self.patient_detail.pname,
 
                     'migration_created_case': 'true',
+                    'migration_created_from_record': self.patient_detail.PregId,
                 }
             },
             'indices': [CaseIndex(

--- a/custom/enikshay/nikshay_datamigration/factory.py
+++ b/custom/enikshay/nikshay_datamigration/factory.py
@@ -313,6 +313,8 @@ class EnikshayCaseFactory(object):
                 'owner_id': self.drtb_hiv.location_id,
                 'update': {
                     'name': self.patient_detail.pname,
+
+                    'migration_created_case': 'true',
                 }
             },
             'indices': [CaseIndex(

--- a/custom/enikshay/nikshay_datamigration/models.py
+++ b/custom/enikshay/nikshay_datamigration/models.py
@@ -339,16 +339,3 @@ class Outcome(models.Model):
                 except ValueError:
                     date_string = self.OutcomeDate[:-2] + '20' + self.OutcomeDate[-2:]
                     return datetime.strptime(date_string, format).date()
-
-
-# class Household(models.Model):
-#     PatientID = models.ForeignKey(APatientDetail)  # have to move to end of excel CSV
-#     Name = models.CharField(max_length=255, null=True)
-#     Dosage = models.CharField(max_length=255, null=True)
-#     Weight = models.CharField(max_length=255, null=True)
-#     M1 = models.CharField(max_length=255, null=True)
-#     M2 = models.CharField(max_length=255, null=True)
-#     M3 = models.CharField(max_length=255, null=True)
-#     M4 = models.CharField(max_length=255, null=True)
-#     M5 = models.CharField(max_length=255, null=True)
-#     M6 = models.CharField(max_length=255, null=True)

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -51,16 +51,11 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
             PatientId=self.patient_detail,
             Outcome='NULL',
             HIVStatus='Neg',
-            # loginDate=datetime(2016, 1, 2),
         )
-        # Household.objects.create(
-        #     PatientID=patient_detail,
-        # )
         self.case_accessor = CaseAccessors(self.domain)
 
     def tearDown(self):
         Outcome.objects.all().delete()
-        # Household.objects.all().delete()
         PatientDetail.objects.all().delete()
 
         super(TestCreateEnikshayCases, self).tearDown()

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -200,6 +200,12 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         drtb_hiv_referral_case = self.case_accessor.get_case(drtb_hiv_referral_case_ids[0])
         self.assertEqual('A B C', drtb_hiv_referral_case.name)
         self.assertEqual(self.drtb_hiv.location_id, drtb_hiv_referral_case.owner_id)
+        self.assertEqual(
+            OrderedDict([
+                ('migration_created_case', 'true'),
+            ]),
+            drtb_hiv_referral_case.dynamic_case_properties()
+        )
 
     def test_case_update(self):
         self.outcome.HIVStatus = None

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -54,12 +54,6 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         )
         self.case_accessor = CaseAccessors(self.domain)
 
-    def tearDown(self):
-        Outcome.objects.all().delete()
-        PatientDetail.objects.all().delete()
-
-        super(TestCreateEnikshayCases, self).tearDown()
-
     @patch('custom.enikshay.nikshay_datamigration.factory.datetime')
     def test_case_creation(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2016, 9, 8, 1, 2, 3, 4123)

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -85,6 +85,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
                 ('is_active', 'yes'),
                 ('last_name', 'C'),
                 ('migration_created_case', 'true'),
+                ('migration_created_from_record', 'MH-ABD-05-16-0001'),
                 ('person_id', 'NIK-MH-ABD-05-16-0001'),
                 ('phi', 'PHI'),
                 ('phi_assigned_to', self.phi.location_id),
@@ -112,6 +113,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
                 ('ihv_date', '2016-12-25'),
                 ('initial_home_visit_status', 'completed'),
                 ('migration_created_case', 'true'),
+                ('migration_created_from_record', 'MH-ABD-05-16-0001'),
                 ('occurrence_episode_count', '1'),
                 ('occurrence_id', '20160908010203004'),
             ]),
@@ -148,6 +150,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
                 ('episode_pending_registration', 'no'),
                 ('episode_type', 'confirmed_tb'),
                 ('migration_created_case', 'true'),
+                ('migration_created_from_record', 'MH-ABD-05-16-0001'),
                 ('nikshay_id', 'MH-ABD-05-16-0001'),
                 ('occupation', 'physical_mathematical_and_engineering'),
                 ('patient_type_choice', 'treatment_after_lfu'),
@@ -203,6 +206,7 @@ class TestCreateEnikshayCases(ENikshayLocationStructureMixin, TestCase):
         self.assertEqual(
             OrderedDict([
                 ('migration_created_case', 'true'),
+                ('migration_created_from_record', 'MH-ABD-05-16-0001'),
             ]),
             drtb_hiv_referral_case.dynamic_case_properties()
         )


### PR DESCRIPTION
Adds ```migration_created_case: 'true'``` to drtb-hiv-referral, and records the nikshay ID of the migrated record in ```migration_created_from_record```.  This way it is easily to tell for each case if 1) it was created in a migration and 2) which nikshay record it came from.

I was able to figure out this stuff when deleting records for GU-MSN, but it would have been easier to just have this data stored in the case.

Recommend 🐡 

@mkangia 