### PR TITLE
[App V2] User Testing Feedback pt1

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -290,7 +290,8 @@ hqDefine('app_manager/js/app_manager.js', function () {
 
         if (COMMCAREHQ.toggleEnabled('APP_MANAGER_V2')) {
             $('.appnav-responsive').on('click', function () {
-                $('#js-appmanager-body').addClass('hide')
+                // TODO doesn't handle vellum with saved changes.
+                $('#js-appmanager-body.appmanager-settings-content').addClass('hide');
             });
         }
 

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -38,22 +38,24 @@ hqDefine('app_manager/js/preview_app.js', function() {
     _private.showAppPreview = function(triggerAnalytics) {
         $(module.SELECTORS.PREVIEW_ACTION_TEXT_SHOW).addClass('hide');
         $(module.SELECTORS.PREVIEW_ACTION_TEXT_HIDE).removeClass('hide');
-        if (_private.isFormdesigner) {
-            $(module.SELECTORS.FORMDESIGNER).addClass('offset-for-preview');
-        }
 
         if (triggerAnalytics) {
             window.analytics.workflow("[app-preview] Clicked Show App Preview");
             window.analytics.usage("[app-preview] Clicked Show App Preview");
         }
 
+        var $offsetContainer = (_private.isFormdesigner) ? $(module.SELECTORS.FORMDESIGNER) : $(module.SELECTORS.APP_MANAGER_BODY);
+        $offsetContainer.addClass('offset-for-preview');
+        if (localStorage.getItem(module.DATA.TABLET)) $offsetContainer.addClass('offset-for-tablet');
     };
+
     _private.hideAppPreview = function(triggerAnalytics) {
         $(module.SELECTORS.PREVIEW_ACTION_TEXT_SHOW).removeClass('hide');
         $(module.SELECTORS.PREVIEW_ACTION_TEXT_HIDE).addClass('hide');
-        if (_private.isFormdesigner) {
-            $(module.SELECTORS.FORMDESIGNER).removeClass('offset-for-preview');
-        }
+
+        var $offsetContainer = (_private.isFormdesigner) ? $(module.SELECTORS.FORMDESIGNER) : $(module.SELECTORS.APP_MANAGER_BODY);
+        $offsetContainer.removeClass('offset-for-preview');
+        if (localStorage.getItem(module.DATA.TABLET)) $offsetContainer.removeClass('offset-for-tablet');
 
         if (triggerAnalytics) {
             window.analytics.workflow("[app-preview] Clicked Hide App Preview");
@@ -103,8 +105,8 @@ hqDefine('app_manager/js/preview_app.js', function() {
             _private.phoneView(true);
         }
         setTimeout(function () {
-            $(window).trigger(module.EVENTS.RESIZE);
-        }, 1001);
+            $(window).trigger('resize');
+        }, 501);
     };
 
     _private.toggleLocalStorageDatum = function(datum) {
@@ -124,6 +126,11 @@ hqDefine('app_manager/js/preview_app.js', function() {
         } else {
             _private.hideAppPreview(true);
         }
+
+        setTimeout(function () {
+            $(window).trigger('resize');
+        }, 501);
+
     };
 
     module.forceShowPreview = function () {
@@ -156,6 +163,7 @@ hqDefine('app_manager/js/preview_app.js', function() {
             var $nav = $(layoutController.selector.navigation),
                 $alerts = $('.alert-maintenance');
             var maxHeight = $appPreview.find('.preview-phone-container').outerHeight() + $nav.outerHeight() + 80;
+            var $offsetContainer = (_private.isFormdesigner) ? $(module.SELECTORS.FORMDESIGNER) : $appBody;
 
             if ($alerts.length > 0) {
                 maxHeight = maxHeight + $alerts.outerHeight();
@@ -165,11 +173,13 @@ hqDefine('app_manager/js/preview_app.js', function() {
 
             if (localStorage.getItem(module.DATA.OPEN)) {
                 $appPreview.addClass('open');
-                if (!_private.isFormdesigner) $appBody.addClass('offset-for-preview');
+                $offsetContainer.addClass('offset-for-preview');
+                if (localStorage.getItem(module.DATA.TABLET)) $offsetContainer.addClass('offset-for-tablet');
                 $messages.addClass('offset-for-preview');
             } else {
                 $appPreview.removeClass('open');
-                if (!_private.isFormdesigner) $appBody.removeClass('offset-for-preview');
+                $offsetContainer.removeClass('offset-for-preview');
+                if (localStorage.getItem(module.DATA.TABLET)) $offsetContainer.removeClass('offset-for-tablet');
                 $messages.removeClass('offset-for-preview');
             }
 

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/build_errors.html
@@ -12,9 +12,9 @@
                     <span>
                         {% case error.type "blank form" %}
                             {% if not error.message %}
-                                <i class="fa fa-plus"></i> <strong>Add Question</strong> to the
+                                <strong>Add a Question</strong> to the
                             {% endif %}
-                            {% include "app_manager/v2/partials/form_error_message.html" %}.
+                            {% include "app_manager/v2/partials/form_error_message.html" %}
                         {% case "invalid xml" %}
                             {% if not error.message %}
                                 If you don't know why this happened, please report an issue.
@@ -230,7 +230,7 @@
                             {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
                             {% if not not_actual_build %}in form {% include "app_manager/v2/partials/form_error_message.html" %}{% endif %}
                         {% case "case_name required" %}
-                            Every case must have a name. Please specify a value for the name property under
+                            <strong>Every case must have a name.</strong> Please specify a value for the name property under
                             "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
                             {% if not not_actual_build %}in form {% include "app_manager/v2/partials/form_error_message.html" %}{% endif %}
                         {% case "path error" %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_shared.html
@@ -165,7 +165,7 @@
                     <td class="col-sm-5">
                         <div data-bind="template: {
                             name: 'case-config:case-properties:property',
-                            data: {property: $data, suggestedProperties: case_transaction.suggestedSaveProperties}
+                            data: {property: $data, suggestedProperties: case_transaction.suggestedSaveProperties},
                             afterRender: $root.makePopover
                         }"></div>
                         <p class="help-block" data-bind="html: validate, visible: validate"></p>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_error_message.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_error_message.html
@@ -1,6 +1,8 @@
 {% load xforms_extras %}
+{% load i18n %}
 {% if not not_actual_build %}
 "<a href="{% url "form_source" domain app.id error.module.id error.form.id %}">{{ error.form.name|trans:langs }}</a>"
   Form
-in the "{{ error.module.name|trans:langs }}" Menu
+in the "{{ error.module.name|trans:langs }}" Menu.<br />
+  <a class="btn btn-primary btn-xs" href="{% url "form_source" domain app.id error.module.id error.form.id %}">{% trans 'Fix' %} {{ error.form.name|trans:langs }} {% trans 'Form' %}</a>
 {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/build_errors.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/build_errors.html.diff.txt
@@ -25,9 +25,9 @@
 -                                Try adding questions to the form
 -                            {% endif %}
 -                            {% include "app_manager/v1/partials/form_error_message.html" %}
-+                                <i class="fa fa-plus"></i> <strong>Add Question</strong> to the
++                                <strong>Add a Question</strong> to the
 +                            {% endif %}
-+                            {% include "app_manager/v2/partials/form_error_message.html" %}.
++                            {% include "app_manager/v2/partials/form_error_message.html" %}
                          {% case "invalid xml" %}
                              {% if not error.message %}
                                  If you don't know why this happened, please report an issue.
@@ -299,7 +299,8 @@
 -                            {% if not not_actual_build %}in form {% include "app_manager/v1/partials/form_error_message.html" %}{% endif %}
 +                            {% if not not_actual_build %}in form {% include "app_manager/v2/partials/form_error_message.html" %}{% endif %}
                          {% case "case_name required" %}
-                             Every case must have a name. Please specify a value for the name property under
+-                            Every case must have a name. Please specify a value for the name property under
++                            <strong>Every case must have a name.</strong> Please specify a value for the name property under
                              "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
 -                            {% if not not_actual_build %}in form {% include "app_manager/v1/partials/form_error_message.html" %}{% endif %}
 +                            {% if not not_actual_build %}in form {% include "app_manager/v2/partials/form_error_message.html" %}{% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_shared.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_shared.html.diff.txt
@@ -166,7 +166,7 @@
 +                    <td class="col-sm-5">
 +                        <div data-bind="template: {
 +                            name: 'case-config:case-properties:property',
-+                            data: {property: $data, suggestedProperties: case_transaction.suggestedSaveProperties}
++                            data: {property: $data, suggestedProperties: case_transaction.suggestedSaveProperties},
 +                            afterRender: $root.makePopover
 +                        }"></div>
 +                        <p class="help-block" data-bind="html: validate, visible: validate"></p>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_error_message.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_error_message.html.diff.txt
@@ -1,11 +1,13 @@
 --- 
 +++ 
-@@ -1,5 +1,6 @@
+@@ -1,5 +1,8 @@
  {% load xforms_extras %}
++{% load i18n %}
  {% if not not_actual_build %}
 -<a href="{% url "form_source" domain app.id error.module.id error.form.id %}">{{ error.form.name|trans:langs }}</a>
 -in module "{{ error.module.name|trans:langs }}"
 +"<a href="{% url "form_source" domain app.id error.module.id error.form.id %}">{{ error.form.name|trans:langs }}</a>"
 +  Form
-+in the "{{ error.module.name|trans:langs }}" Menu
++in the "{{ error.module.name|trans:langs }}" Menu.<br />
++  <a class="btn btn-primary btn-xs" href="{% url "form_source" domain app.id error.module.id error.form.id %}">{% trans 'Fix' %} {{ error.form.name|trans:langs }} {% trans 'Form' %}</a>
  {% endif %}

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
@@ -21,6 +21,13 @@
   &.formdesigner-content-wrapper {
     padding: 0;
   }
+  #formdesigner {
+    background-color: @cc-brand-low !important;
+    .fd-content-right .fd-head,
+    .fd-content-right .fd-form-actions {
+      margin-right: -2px;
+    }
+  }
 }
 
 .appmanager-content {

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
@@ -25,6 +25,9 @@
     background-color: @cc-brand-low !important;
     .fd-content-right .fd-head,
     .fd-content-right .fd-form-actions {
+      // There is a 2px white line between the right edge of form player and the
+      // right edge of the screen. This gets rid of it. If I make the container
+      // 2px bigger, all of formplayer bumps down to the next line --B
       margin-right: -2px;
     }
   }

--- a/corehq/apps/style/static/app_manager/less/preview_app-main.less
+++ b/corehq/apps/style/static/app_manager/less/preview_app-main.less
@@ -35,7 +35,7 @@ preview_app/less */
   padding-left: @preview-phone-case-offset-x;
 
   .box-shadow(0 0px 10px 3px rgba(0,0,0,.45));
-  .transition(all 1s);
+  .transition(all @transition-speed);
 }
 
 #js-appmanager-body.offset-for-preview,
@@ -56,7 +56,7 @@ preview_app/less */
 }
 
 #hq-messages-container > div > div > .alert {
-  .transition(margin-right 1s);
+  .transition(margin-right @transition-speed);
 }
 
 #hq-messages-container.offset-for-preview > div > div > .alert {
@@ -71,7 +71,7 @@ preview_app/less */
   z-index: @zindex-app-preview;
   width: 0;
   background-color: @cc-light-cool-accent-hi;
-  .transition(width 1s);
+  .transition(width @transition-speed);
   overflow: hidden;
   border-left: 0px;
 
@@ -97,7 +97,7 @@ preview_app/less */
 .preview-phone-window {
    height: @preview-phone-height;
    width: @preview-phone-width;
-   transition: all 1s;
+   transition: all @transition-speed;
    background-color: white;
 }
 
@@ -151,7 +151,7 @@ preview_app/less */
 }
 
 .appmanager-content-transition-all {
-  .transition(all 1s);
+  .transition(all @transition-speed);
 }
 
 .btn-preview-toggle {
@@ -203,9 +203,9 @@ preview_app/less */
   background-color: red;
   border-radius: 10px;
 
-  -webkit-animation: pulsate 1s ease-out;
+  -webkit-animation: pulsate @transition-speed ease-out;
   -webkit-animation-iteration-count: infinite;
-  animation: pulsate 1s ease-out;
+  animation: pulsate @transition-speed ease-out;
   animation-iteration-count: infinite;
 }
 
@@ -221,7 +221,7 @@ preview_app/less */
     display: inline-block;
     background-color: transparent;
     color: darken(white, 20);
-    .transition(1s color);
+    .transition(@transition-speed color);
     font-size: 1.8rem;
     width: 25%;
     &:focus {

--- a/corehq/apps/style/static/app_manager/less/preview_app-main.less
+++ b/corehq/apps/style/static/app_manager/less/preview_app-main.less
@@ -17,7 +17,7 @@ preview_app/less */
 @preview-phone-case-offset-y: 40px;
 @preview-phone-case-offset-x: 15px;
 
-
+@transition-speed: .5s;
 
 .preview-phone-container {
   box-sizing: border-box;
@@ -38,11 +38,21 @@ preview_app/less */
   .transition(all 1s);
 }
 
-#js-appmanager-body.offset-for-preview {
+#js-appmanager-body.offset-for-preview,
+#formdesigner.offset-for-preview {
   margin-right: @preview-phone-wrapper-width;
   width: -webkit-calc(~"100% - " @preview-phone-wrapper-width);
   width: -moz-calc(~"100% - " @preview-phone-wrapper-width);
   width: calc(~"100% - " @preview-phone-wrapper-width);
+}
+
+#js-appmanager-body.offset-for-tablet,
+#formdesigner.offset-for-tablet {
+  margin-right: @preview-tablet-wrapper-width;
+  width: -webkit-calc(~"100% - " @preview-tablet-wrapper-width);
+  width: -moz-calc(~"100% - " @preview-tablet-wrapper-width);
+  width: calc(~"100% - " @preview-tablet-wrapper-width);
+  .transition(all @transition-speed);
 }
 
 #hq-messages-container > div > div > .alert {

--- a/corehq/apps/style/static/preview_app/less/preview_app-main.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app-main.less
@@ -5,6 +5,8 @@
 
 @import "../../cloudcare/less/cloudcare/mixins";
 
+@transition-speed: .5s;
+
 @import "preview_app/base";
 @import "preview_app/variables";
 @import "preview_app/notifications";

--- a/corehq/apps/style/static/preview_app/less/preview_app/appicon.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/appicon.less
@@ -6,7 +6,7 @@
   margin-bottom: 10px;
 
   .appicon-title {
-    .transition(height 1s);
+    .transition(height @transition-speed);
     height: 30px;
     bottom: 7px;
     h3 {

--- a/corehq/apps/style/static/preview_app/less/preview_app/formnav.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/formnav.less
@@ -1,10 +1,10 @@
 .btn-formnav-submit {
-  transition: width 1s;
+  transition: width @transition-speed;
   width: @preview-phone-width - 46px;
   text-transform: uppercase;
   padding: 8px 10px;
   border: none;
-  .transition(all 1s);
+  .transition(all @transition-speed);
 
   .border-top-radius(0);
   .border-bottom-radius(0);

--- a/corehq/apps/style/static/preview_app/less/preview_app/navigation.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/navigation.less
@@ -22,7 +22,7 @@
     color: white;
     line-height: @preview-navbar-height;
     padding-right: 19px;
-    .transition(background 1s);
+    .transition(background @transition-speed);
 
     &:link, &:focus, &:visited, &:hover {
       color: white;

--- a/corehq/apps/style/static/preview_app/less/preview_app/notifications.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/notifications.less
@@ -14,6 +14,9 @@
 
 .alert-build {
   #build-errors > li {
-    margin-bottom: 3px;
+    font-size: 11px;
+    margin-bottom: 5px;
+    padding-bottom: 3px;
+    border-bottom: 1px solid fade(@cc-dark-warm-accent-low, 20);
   }
 }

--- a/corehq/apps/style/static/preview_app/less/preview_app/scrollable.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/scrollable.less
@@ -1,5 +1,5 @@
 .scrollable-container {
-  transition: width 1s;
+  transition: width @transition-speed;
   overflow-x: hidden;
   overflow-y: scroll;
   // 15px is the approximate width of the scrollbar in OSX.


### PR DESCRIPTION
@orangejenny 
cc @benrudolph 

fixes:
- tablet overlap of buttons
- overlap of app preview in formbuilder
- syntax error on form settings page
- terrible error where the whole page automatically gets hidden on formbuilders's `onunload` event capture, rendering it useless.

adds:
- friendly fix me buttons to build errors directing users to what to do next
- reduce time between transitions
- cleans up some styling here and there