### PR TITLE
don't call "add inferred case props" unless we need to

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -97,10 +97,10 @@ class _UserCaseHelper(object):
 
     def _user_case_changed(self, fields):
         field_names = fields.keys()
-        if _domain_has_new_fields(self.domain, field_names):
+        if _domain_has_new_fields(self.domain.name, field_names):
             add_inferred_export_properties.delay(
                 'UserSave',
-                self.domain,
+                self.domain.name,
                 USERCASE_TYPE,
                 field_names,
             )

--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -69,6 +69,7 @@ class _UserCaseHelper(object):
             update=fields
         )
         self._submit_case_block(caseblock)
+        self._user_case_changed(fields)
 
     def update_user_case(self, case, case_type, fields):
         caseblock = CaseBlock(
@@ -81,6 +82,7 @@ class _UserCaseHelper(object):
             update=fields
         )
         self._submit_case_block(caseblock)
+        self._user_case_changed(fields)
 
     def close_user_case(self, case, case_type):
         caseblock = CaseBlock(
@@ -91,6 +93,14 @@ class _UserCaseHelper(object):
             close=True,
         )
         self._submit_case_block(caseblock)
+
+    def _user_case_changed(self, fields):
+        add_inferred_export_properties.delay(
+            'UserSave',
+            self.domain,
+            USERCASE_TYPE,
+            fields.keys(),
+        )
 
 
 class CallCenterCase(namedtuple('CallCenterCase', 'case_id hq_user_id')):
@@ -156,12 +166,6 @@ def _get_user_case_fields(commcare_user):
         'phone_number': commcare_user.phone_number or ''
     })
 
-    add_inferred_export_properties.delay(
-        'UserSave',
-        commcare_user.domain,
-        USERCASE_TYPE,
-        fields.keys(),
-    )
     return fields
 
 


### PR DESCRIPTION
This should relieve some stress on celery for large user imports