### PR TITLE
Noop this translation

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -366,7 +366,7 @@ class RoleForm(forms.Form):
 class SetUserPasswordForm(SetPasswordForm):
 
     new_password1 = forms.CharField(
-        label=ugettext_lazy("New password"),
+        label=ugettext_noop("New password"),
         widget=forms.PasswordInput(),
     )
 


### PR DESCRIPTION
The other properties in this file use `ugettext_noop`.  This one isn't being translated.
@millerdev