### PR TITLE
Catch bad dates in HIV Test repeater

### DIFF
--- a/custom/enikshay/integrations/nikshay/repeater_generator.py
+++ b/custom/enikshay/integrations/nikshay/repeater_generator.py
@@ -181,19 +181,11 @@ class NikshayHIVTestPayloadGenerator(BasePayloadGenerator):
         properties_dict = {
             "PatientID": episode_case_properties.get('nikshay_id'),
             "HIVStatus": hiv_status.get(person_case_properties.get('hiv_status')),
-            "HIVTestDate": datetime.datetime.strptime(
-                person_case_properties.get('hiv_test_date', NIKSHAY_NULL_DATE), '%Y-%m-%d'
-            ).strftime('%d/%m/%Y'),
-            "CPTDeliverDate": datetime.datetime.strptime(
-                person_case_properties.get('cpt_initiation_date', NIKSHAY_NULL_DATE), '%Y-%m-%d'
-            ).strftime('%d/%m/%Y'),
-            "ARTCentreDate": datetime.datetime.strptime(
-                person_case_properties.get('art_initiation_date', NIKSHAY_NULL_DATE), '%Y-%m-%d'
-            ).strftime('%d/%m/%Y'),
+            "HIVTestDate": _format_date(person_case_properties, 'hiv_test_date'),
+            "CPTDeliverDate": _format_date(person_case_properties, 'cpt_initiation_date'),
+            "ARTCentreDate": _format_date(person_case_properties, 'art_initiation_date'),
             "InitiatedOnART": art_initiated.get(person_case_properties.get('art_initiated', 'no')),
-            "InitiatedDate": datetime.datetime.strptime(
-                person_case_properties.get('art_initiation_date', NIKSHAY_NULL_DATE), '%Y-%m-%d'
-            ).strftime('%d/%m/%Y'),
+            "InitiatedDate": _format_date(person_case_properties, 'art_initiation_date'),
             "Source": ENIKSHAY_ID,
             "regby": repeat_record.repeater.username,
             "password": repeat_record.repeater.password,
@@ -336,3 +328,11 @@ def _save_error_message(domain, case_id, error, reg_field="nikshay_registered", 
             error_field: error,
         },
     )
+
+
+def _format_date(case_properties, case_property):
+    date = case_properties.get(case_property) or NIKSHAY_NULL_DATE
+    try:
+        return datetime.datetime.strptime(date, '%Y-%m-%d').strftime('%d/%m/%Y')
+    except ValueError:
+        return datetime.datetime.strptime(NIKSHAY_NULL_DATE, '%Y-%m-%d').strftime('%d/%m/%Y')


### PR DESCRIPTION
@mkangia Found it.

To test this remotely all I had to do was:
`Repeater({repeater_id}).register({case})`. This returned a new RepeatRecord which I was able to then call `get_payload` on. This returned a `ValueError` because the dates are set to `''`.

This error was getting swallowed because of this: http://manage.dimagi.com/default.asp?249894

It looks like in the app, when dates aren't relevant in the Edit/Update Treatment Details form they are set to blanks, rather than not getting set (check [this form submission](https://india.commcarehq.org/a/enikshay/reports/form_data/78bf0ed6-ff79-496d-ac42-0e858cf29d22/download/), for [this case](https://india.commcarehq.org/a/enikshay/reports/case_data/88e9f05f-9644-44f9-9466-243456dc52b3/#!history?form_id=78bf0ed6-ff79-496d-ac42-0e858cf29d22)). This could pose a problem with the checks you are making in the `allowed_to_forward` method -- can you verify that this repeater won't get triggered every time one of those forms is submitted? 

FYI @NoahCarnahan 
