### PR TITLE
Don't override celery queue

### DIFF
--- a/corehq/apps/reports/scheduled.py
+++ b/corehq/apps/reports/scheduled.py
@@ -7,7 +7,7 @@ from corehq.util.soft_assert import soft_assert
 _soft_assert = soft_assert(exponential_backoff=True)
 
 
-def get_scheduled_reports(period, as_of=None):
+def get_scheduled_report_ids(period, as_of=None):
     as_of = as_of or datetime.utcnow()
     assert period in ('daily', 'weekly', 'monthly'), period
 
@@ -50,13 +50,13 @@ def get_scheduled_reports(period, as_of=None):
         raise StopIteration
 
     for key in keys:
-        for report in ReportNotification.view(
+        for result in ReportNotification.view(
             "reportconfig/all_notifications",
             reduce=False,
-            include_docs=True,
+            include_docs=False,
             **key
         ).all():
-            yield report
+            yield result['id']
 
 
 def guess_reporting_minute(now=None):

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -59,18 +59,18 @@ from .models import (
     ReportNotification,
     UnsupportedScheduledReportError,
 )
-from .scheduled import get_scheduled_reports
+from .scheduled import get_scheduled_report_ids
 
 
 logging = get_task_logger(__name__)
 EXPIRE_TIME = 60 * 60 * 24
 
 
-def send_delayed_report(report):
+def send_delayed_report(report_id):
     """
     Sends a scheduled report, via  celery background task.
     """
-    send_report.delay(report._id)
+    send_report.delay(report_id)
 
 
 @task(queue='background_queue', ignore_result=True)
@@ -105,8 +105,8 @@ def create_metadata_export(download_id, domain, format, filename, datespan=None,
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
 def daily_reports():
-    for rep in get_scheduled_reports('daily'):
-        send_delayed_report(rep)
+    for report_id in get_scheduled_report_ids('daily'):
+        send_delayed_report(report_id)
 
 
 @periodic_task(
@@ -114,8 +114,8 @@ def daily_reports():
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
 def weekly_reports():
-    for rep in get_scheduled_reports('weekly'):
-        send_delayed_report(rep)
+    for report_id in get_scheduled_report_ids('weekly'):
+        send_delayed_report(report_id)
 
 
 @periodic_task(
@@ -123,8 +123,8 @@ def weekly_reports():
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
 def monthly_reports():
-    for rep in get_scheduled_reports('monthly'):
-        send_delayed_report(rep)
+    for report_id in get_scheduled_report_ids('monthly'):
+        send_delayed_report(report_id)
 
 
 @periodic_task(run_every=crontab(hour="23", minute="59", day_of_week="*"), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE','celery'))

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -70,17 +70,7 @@ def send_delayed_report(report):
     """
     Sends a scheduled report, via  celery background task.
     """
-    send_report.apply_async(args=[report._id], queue=get_report_queue(report))
-
-
-def get_report_queue(report):
-    # This is a super-duper hacky, hard coded way to deal with the fact that MVP reports
-    # consistently crush the celery queue for everyone else.
-    # Just send them to their own longrunning background queue
-    if report.domain in get_mvp_domains():
-        return 'background_queue'
-    else:
-        return 'celery'
+    send_report.delay(report._id)
 
 
 @task(queue='background_queue', ignore_result=True)

--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -167,25 +167,26 @@ class ScheduledReportSendingTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.domain_obj = create_domain(cls.domain)
+        cls.user = WebUser.create(
+            domain=cls.domain,
+            username='dummy@example.com',
+            password='secret',
+        )
 
     @classmethod
     def tearDownClass(cls):
         cls.domain_obj.delete()
+        cls.user.delete()
 
     def test_get_scheduled_report_response(self):
         domain = self.domain
-        user = WebUser.create(
-            domain=domain,
-            username='dummy@example.com',
-            password='secret',
-        )
         report_config = ReportConfig.wrap({
             "date_range": "last30",
             "days": 30,
             "domain": domain,
             "report_slug": "worker_activity",
             "report_type": "project_report",
-            "owner_id": user._id,
+            "owner_id": self.user._id,
         })
         report_config.save()
         report = ReportNotification(
@@ -193,6 +194,6 @@ class ScheduledReportSendingTest(TestCase):
         )
         report.save()
         response = get_scheduled_report_response(
-            couch_user=user, domain=domain, scheduled_report_id=report._id
+            couch_user=self.user, domain=domain, scheduled_report_id=report._id
         )[0]
-        self.assertTrue(user.username in response)
+        self.assertTrue(self.user.username in response)

--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -3,7 +3,6 @@ from django.test import SimpleTestCase, TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports.models import ReportNotification, ReportConfig
 from corehq.apps.reports.scheduled import guess_reporting_minute, get_scheduled_reports
-from corehq.apps.reports.tasks import get_report_queue
 from corehq.apps.reports.views import get_scheduled_report_response
 from corehq.apps.users.models import WebUser
 
@@ -197,12 +196,3 @@ class ScheduledReportSendingTest(TestCase):
             couch_user=user, domain=domain, scheduled_report_id=report._id
         )[0]
         self.assertTrue(user.username in response)
-
-
-class TestMVPCeleryQueueHack(SimpleTestCase):
-
-    def test_queue_selection_mvp(self):
-        self.assertEqual('background_queue', get_report_queue(ReportNotification(domain='mvp-tiby')))
-
-    def test_queue_selection_normal(self):
-        self.assertEqual('celery', get_report_queue(ReportNotification(domain='not-mvp')))

--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from django.test import SimpleTestCase, TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports.models import ReportNotification, ReportConfig
-from corehq.apps.reports.scheduled import guess_reporting_minute, get_scheduled_reports
+from corehq.apps.reports.scheduled import guess_reporting_minute, get_scheduled_report_ids
 from corehq.apps.reports.views import get_scheduled_report_response
 from corehq.apps.users.models import WebUser
 
@@ -49,7 +49,7 @@ class ScheduledReportTest(TestCase):
             report.delete()
 
     def _check(self, period, as_of, count):
-        self.assertEqual(count, len(list(get_scheduled_reports(period, as_of))))
+        self.assertEqual(count, len(list(get_scheduled_report_ids(period, as_of))))
 
     def testDefaultValue(self):
         now = datetime.utcnow()
@@ -60,7 +60,7 @@ class ScheduledReportTest(TestCase):
         else:
             self.assertRaises(
                 ValueError,
-                lambda: list(get_scheduled_reports('daily', None))
+                lambda: list(get_scheduled_report_ids('daily', None))
             )
 
     def testDailyReportEmptyMinute(self):
@@ -79,7 +79,7 @@ class ScheduledReportTest(TestCase):
         # but not too lenient
         self.assertRaises(
             ValueError,
-            lambda: list(get_scheduled_reports('daily', datetime(2014, 10, 31, 12, 6)))
+            lambda: list(get_scheduled_report_ids('daily', datetime(2014, 10, 31, 12, 6)))
         )
 
     def testDailyReportWithMinuteHalfHour(self):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1111,11 +1111,10 @@ def send_test_scheduled_report(request, domain, scheduled_report_id):
 
     user_id = request.couch_user._id
 
-    notification = ReportNotification.get(scheduled_report_id)
     user = CouchUser.get_by_user_id(user_id, domain)
 
     try:
-        send_delayed_report(notification)
+        send_delayed_report(scheduled_report_id)
     except Exception as e:
         import logging
         logging.exception(e)


### PR DESCRIPTION
@gcapalbo this prevents us from overriding the queue name in the task decorator

cc: @biyeun 