### PR TITLE
Final step in case attachments migration

### DIFF
--- a/corehq/blobs/migrations/0004_auto_20170321_1956.py
+++ b/corehq/blobs/migrations/0004_auto_20170321_1956.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.blobs.migrate import assert_migration_complete
+from corehq.sql_db.operations import HqRunPython
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blobs', '0003_auto_20161012_1358'),
+    ]
+
+    operations = [
+        HqRunPython(*assert_migration_complete("cases")),
+    ]

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -159,7 +159,6 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
     representation of the case - the result of playing all
     the actions in sequence.
     """
-    _migrating_blobs_from_couch = True
 
     domain = StringProperty()
     export_tag = StringListProperty()


### PR DESCRIPTION
Original migration PR: #14624

See steps 5-7 of [corehq/blobs/migrate.py](https://github.com/dimagi/commcare-hq/blob/58995b7cc70a7fb44cfb160c30e1c4f4256e5797/corehq/blobs/migrate.py#L43-L64)

@benrudolph @snopoke @dannyroberts