### PR TITLE
Latitude and longitude in degrees, not meters

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2098,8 +2098,8 @@ class SplitGPSExportColumn(ExportColumn):
             return super(SplitGPSExportColumn, self).get_headers()
         header = self.label
         header_templates = [
-            _(u'{}: latitude (meters)'),
-            _(u'{}: longitude (meters)'),
+            _(u'{}: latitude (degrees)'),
+            _(u'{}: longitude (degrees)'),
             _(u'{}: altitude (meters)'),
             _(u'{}: accuracy (meters)'),
         ]

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -14833,11 +14833,11 @@ msgid "Messages"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2103

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -17231,11 +17231,11 @@ msgid "Messages"
 msgstr "Mensajes"
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr "{}: latitud (metros)"
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr "{}: longitud (metros)"
 
 #: corehq/apps/export/models/new.py:2103

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -14527,11 +14527,11 @@ msgid "Messages"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2103

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -16846,11 +16846,11 @@ msgid "Messages"
 msgstr "Messages"
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr "{}: latitude (mètres)"
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr "{}: longitude (mètres)"
 
 #: corehq/apps/export/models/new.py:2103

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -14548,11 +14548,11 @@ msgid "Messages"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2103

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -14605,11 +14605,11 @@ msgid "Messages"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2103

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -14537,11 +14537,11 @@ msgid "Messages"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2101
-msgid "{}: latitude (meters)"
+msgid "{}: latitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2102
-msgid "{}: longitude (meters)"
+msgid "{}: longitude (degrees)"
 msgstr ""
 
 #: corehq/apps/export/models/new.py:2103


### PR DESCRIPTION
These measurements are in degrees, not meters