### PR TITLE
replace django.core.urlresolvers with django.urls

### DIFF
--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -3,7 +3,7 @@ import calendar
 import datetime
 from dateutil.relativedelta import relativedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop as _
 
 from dimagi.utils.dates import DateSpan

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import MinLengthValidator, validate_slug
 from django.db import transaction
 from django.forms.utils import ErrorList

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -3,7 +3,7 @@ import datetime
 import json
 
 from couchdbkit import ResourceConflict
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, ungettext
 

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop, ugettext_lazy as _, ugettext
 from corehq.apps.accounting.models import (

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 from django.forms.forms import NON_FIELD_ERRORS
 from django.forms.utils import ErrorList
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -17,7 +17,7 @@ import KISSmetrics
 import logging
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from email_validator import validate_email, EmailNotValidError
 from corehq.toggles import deterministic_random
 from corehq.util.decorators import analytics_task

--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import urllib
 from wsgiref.util import FileWrapper
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, Http404, StreamingHttpResponse, HttpResponseForbidden
 from django.utils.decorators import method_decorator
 from django.views.generic import View

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -1,6 +1,6 @@
 import json
 
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import NoReverseMatch
 from django.http import HttpResponse
 from tastypie import http
 from tastypie.resources import Resource

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseForbidden, HttpResponse, HttpResponseBadRequest
 from tastypie import fields
 from tastypie.authentication import Authentication

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -12,7 +12,7 @@ from tastypie.utils import dict_strip_unicode_keys
 from collections import namedtuple
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from tastypie import fields
 from tastypie.bundle import Bundle

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from datetime import datetime
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import QueryDict
 from django.test import TestCase
 from django.utils.http import urlencode

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.http import HttpResponseRedirect, HttpResponse
 from couchdbkit.exceptions import ResourceConflict
 from django.views.decorators.http import require_POST
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.app_manager.exceptions import CaseError
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import AppEditingError

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -1,5 +1,5 @@
 import logging
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 import collections
 import itertools

--- a/corehq/apps/app_manager/management/commands/import_app.py
+++ b/corehq/apps/app_manager/management/commands/import_app.py
@@ -1,6 +1,6 @@
 from getpass import getpass
 from django.core.management.base import BaseCommand, CommandError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import requests
 from requests.auth import HTTPDigestAuth
 from corehq.apps.app_manager.models import import_app

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -58,7 +58,7 @@ from corehq.util.timezones.utils import get_timezone_for_domain
 from dimagi.ext.couchdbkit import *
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from restkit.errors import ResourceError
 from couchdbkit.resource import ResourceNotFound

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,6 +1,6 @@
 import urllib
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.app_manager.exceptions import MediaResourceError
 from corehq.apps.app_manager.suite_xml.post_process.menu import GridMenuHelper

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import patch
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -6,7 +6,7 @@ import json
 import os
 import uuid
 import yaml
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
     get_apps_in_domain, get_case_sharing_apps_in_domain

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -2,7 +2,7 @@ from copy import copy
 from StringIO import StringIO
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.utils.translation import ugettext_noop, ugettext_lazy as _
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -13,7 +13,7 @@ from django.utils.http import urlencode as django_urlencode
 from couchdbkit.exceptions import ResourceConflict
 from django.http import HttpResponse, Http404, HttpResponseBadRequest
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
 from django.contrib import messages

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -5,7 +5,7 @@ from StringIO import StringIO
 
 from couchdbkit import ResourceConflict, ResourceNotFound
 from django.contrib import messages
-from django.core.urlresolvers import RegexURLResolver, Resolver404
+from django.urls import RegexURLResolver, Resolver404
 from django.http import HttpResponse, Http404, JsonResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -13,7 +13,7 @@ from lxml import etree
 from diff_match_patch import diff_match_patch
 from django.utils.translation import ugettext as _
 from django.http import HttpResponse, Http404, HttpResponseBadRequest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 from django.conf import settings

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -7,7 +7,7 @@ from lxml import etree
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _, gettext_lazy
 from django.http import HttpResponse, Http404, HttpResponseBadRequest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.decorators.http import require_GET
 from django.contrib import messages
 from corehq.apps.app_manager.views.media_utils import process_media_attribute, \

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -2,7 +2,7 @@ from StringIO import StringIO
 
 from django.contrib import messages
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from urllib import urlencode
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.template.loader import render_to_string
 

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -1,6 +1,6 @@
 from django.http import Http404
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 from corehq.apps.app_manager.const import APP_V1
 

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -6,7 +6,7 @@ from urllib import urlencode
 from couchdbkit import ResourceNotFound
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponse
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from cStringIO import StringIO
 from couchdbkit import ResourceNotFound, BadValueError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseBadRequest, HttpResponse, Http404
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.csrf import csrf_exempt

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -3,7 +3,7 @@ import json
 import urllib
 
 from django.contrib.humanize.templatetags.humanize import naturaltime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from couchdbkit.exceptions import ResourceNotFound

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from mock import patch

--- a/corehq/apps/cloudcare/touchforms_api.py
+++ b/corehq/apps/cloudcare/touchforms_api.py
@@ -3,7 +3,7 @@ from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from touchforms.formplayer.api import post_data
 import json
 from corehq.apps.cloudcare import CLOUDCARE_DEVICE_ID
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.users.models import CouchUser
 from corehq import toggles
 from django.conf import settings

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from django.conf import settings
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadRequest, Http404
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt

--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -9,7 +9,7 @@ from corehq.apps.hqwebapp.forms import FormListForm
 from corehq.apps.products.models import Product
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_product, get_default_monthly_consumption
 from corehq.toggles import LOCATION_TYPE_STOCK_RATES
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class CommTrackSettingsForm(forms.Form):

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -2,7 +2,7 @@ import json
 import copy
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404, HttpResponseBadRequest
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_noop

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django import forms
 

--- a/corehq/apps/dashboard/models.py
+++ b/corehq/apps/dashboard/models.py
@@ -4,7 +4,7 @@ import requests
 
 import settings
 from corehq.apps.export.views import ExportsPermissionsMixin
-from django.core.urlresolvers import reverse, resolve, Resolver404
+from django.urls import reverse, resolve, Resolver404
 from corehq.tabs.uitab import url_is_location_safe
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
 from corehq.apps.reports.models import ReportConfig, FormExportSchema, CaseExportSchema

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_noop, ugettext as _
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -1,6 +1,6 @@
 import uuid
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import Client, TestCase
 
 from corehq.apps.data_dictionary.models import CaseType, CaseProperty

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -2,7 +2,7 @@ import json
 
 import itertools
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models.query import Prefetch
 from django.http import HttpResponse
 from django.http import JsonResponse

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -1,5 +1,5 @@
 from django.contrib.humanize.templatetags.humanize import naturaltime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_noop
 

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -46,7 +46,7 @@ from corehq.const import SERVER_DATETIME_FORMAT
 from .dispatcher import require_form_management_privilege
 from .interfaces import FormManagementMode, BulkFormManagementInterface
 from django.db import transaction
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404, HttpResponseServerError
 from django.shortcuts import render
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -7,7 +7,7 @@ from base64 import b64decode
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (
     HttpResponse, HttpResponseRedirect, Http404, HttpResponseForbidden, JsonResponse,
 )

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -21,7 +21,7 @@ from django.contrib.auth.forms import SetPasswordForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models import F
 from django.forms.fields import (ChoiceField, CharField, BooleanField,

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -23,7 +23,7 @@ from dimagi.ext.couchdbkit import (
     DocumentSchema, SchemaProperty, DictProperty,
     StringListProperty, SchemaListProperty, TimeProperty, DecimalProperty
 )
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from corehq.apps.appstore.models import SnapshotMixin

--- a/corehq/apps/domain/tasks.py
+++ b/corehq/apps/domain/tasks.py
@@ -2,7 +2,7 @@ from celery.schedules import crontab
 from celery.task import periodic_task
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 
 from corehq.apps.domain.views import EditInternalDomainInfoView

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -2,7 +2,7 @@ from __future__ import print_function, unicode_literals
 from datetime import datetime
 
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import Client
 

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, unicode_literals
 
 from bs4 import BeautifulSoup
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.client import Client

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -24,7 +24,7 @@ from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.http import urlsafe_base64_decode
 from django.utils.safestring import mark_safe
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import redirect, render, render_to_response
 from django.contrib import messages

--- a/corehq/apps/dropbox/utils.py
+++ b/corehq/apps/dropbox/utils.py
@@ -1,7 +1,7 @@
 from dropbox.client import DropboxOAuth2Flow
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from dimagi.utils.web import get_url_base
 

--- a/corehq/apps/dropbox/views.py
+++ b/corehq/apps/dropbox/views.py
@@ -1,6 +1,6 @@
 from dropbox.client import DropboxOAuth2Flow
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse
 from django.views.generic import View
 

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import dateutil
 from django import forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _, ugettext_lazy
 from unidecode import unidecode
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -8,7 +8,7 @@ from collections import defaultdict, OrderedDict, namedtuple
 from couchdbkit import ResourceConflict
 from couchdbkit.ext.django.schema import IntegerProperty
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.http import Http404
 

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -2,7 +2,7 @@
 import json
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 
 from corehq.apps.export.models import CaseExportInstance

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.exceptions import SuspiciousOperation
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, Http404
 from django.template.defaultfilters import filesizeformat
 from django.views.decorators.csrf import csrf_exempt

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -5,7 +5,7 @@ from couchdbkit import ResourceNotFound
 from collections import OrderedDict
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, Http404
 from django.http.response import HttpResponseServerError
 from django.shortcuts import render

--- a/corehq/apps/groups/views.py
+++ b/corehq/apps/groups/views.py
@@ -1,7 +1,7 @@
 import json
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.views.decorators.http import require_POST
 from django.utils.translation import ugettext as _

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -1081,7 +1081,7 @@ class GlobalAdminReports(AdminDomainStatsReport):
     def template_context(self):
         context = super(GlobalAdminReports, self).template_context
         indicator_data = copy.deepcopy(INDICATOR_DATA)
-        from django.core.urlresolvers import reverse
+        from django.urls import reverse
         for key in self.indicators:
             indicator_data[key]["ajax_url"] = reverse(
                 indicator_data[key]["ajax_view"]

--- a/corehq/apps/hqadmin/tests/test_authenticate_as.py
+++ b/corehq/apps/hqadmin/tests/test_authenticate_as.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, CommCareUser

--- a/corehq/apps/hqmedia/controller.py
+++ b/corehq/apps/hqmedia/controller.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop
 
 

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -12,7 +12,7 @@ from dimagi.ext.couchdbkit import *
 from dimagi.utils.couch.database import get_safe_read_kwargs, iter_docs
 from dimagi.utils.couch.resource_conflict import retry_resource
 from dimagi.utils.decorators.memoized import memoized
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from PIL import Image
 

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 import json
 import itertools
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View, TemplateView

--- a/corehq/apps/hqpillow_retry/tasks.py
+++ b/corehq/apps/hqpillow_retry/tasks.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from celery.schedules import crontab
 from celery.task.base import periodic_task
 from django.core.mail import mail_admins
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models.aggregates import Count
 from django.template.loader import render_to_string
 from dimagi.utils.web import get_url_base

--- a/corehq/apps/hqpillow_retry/views.py
+++ b/corehq/apps/hqpillow_retry/views.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import re
 from django.contrib import messages
 from django.core.mail.message import EmailMessage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models.aggregates import Count
 from django.http.response import Http404

--- a/corehq/apps/hqwebapp/doc_info.py
+++ b/corehq/apps/hqwebapp/doc_info.py
@@ -1,7 +1,7 @@
 from couchdbkit import ResourceNotFound
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.couch.undo import DELETED_SUFFIX
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from dimagi.ext.jsonobject import *
 from corehq.apps.users.util import raw_username

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -11,7 +11,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from django.http import QueryDict
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/apps/hqwebapp/templatetags/mainreport_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/mainreport_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from datetime import datetime, timedelta
 from corehq.const import SERVER_DATETIME_FORMAT_NO_SEC
 

--- a/corehq/apps/hqwebapp/tests/test_csrf_middleware.py
+++ b/corehq/apps/hqwebapp/tests/test_csrf_middleware.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, Client
 
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, Client
 from corehq.apps.app_manager.models import Application
 from corehq.apps.cloudcare.views import FormplayerMain

--- a/corehq/apps/hqwebapp/tests/test_views.py
+++ b/corehq/apps/hqwebapp/tests/test_views.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.domain.tests.test_views import BaseAutocompleteTest
 from corehq.apps.domain.shortcuts import create_domain

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext
 from twilio.rest import TwilioRestClient
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.messaging.smsbackends.twilio.models import SQLTwilioBackend
 

--- a/corehq/apps/indicators/admin/__init__.py
+++ b/corehq/apps/indicators/admin/__init__.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.crud.interface import BaseCRUDAdminInterface
 from corehq.apps.indicators.dispatcher import IndicatorAdminInterfaceDispatcher
 from corehq.apps.indicators.utils import get_namespaces

--- a/corehq/apps/indicators/views.py
+++ b/corehq/apps/indicators/views.py
@@ -1,6 +1,6 @@
 import json
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -5,7 +5,7 @@ import string
 from StringIO import StringIO
 import mock
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 
 from corehq.apps.es.fake.users_fake import UserESFake

--- a/corehq/apps/notifications/forms.py
+++ b/corehq/apps/notifications/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy, ugettext as _
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator

--- a/corehq/apps/ota/tests/test_digest_restore.py
+++ b/corehq/apps/ota/tests/test_digest_restore.py
@@ -2,7 +2,7 @@ import time
 from python_digest import build_authorization_request, calculate_nonce
 from django.test import TestCase, Client
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.domain.tests.test_utils import delete_all_domains
 from corehq.apps.domain.shortcuts import create_domain

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -1,7 +1,7 @@
 import re
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, Client
 from mock import patch
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -1,5 +1,5 @@
 from distutils.version import LooseVersion
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_noop

--- a/corehq/apps/performance_sms/views.py
+++ b/corehq/apps/performance_sms/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -7,7 +7,7 @@ from couchexport.models import Format
 from couchdbkit import ResourceNotFound
 from corehq.apps.commtrack.util import get_or_create_default_program
 from django.views.decorators.http import require_POST
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.utils.translation import ugettext as _, ugettext_noop

--- a/corehq/apps/programs/views.py
+++ b/corehq/apps/programs/views.py
@@ -6,7 +6,7 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.web import json_response
 from django.views.decorators.http import require_POST
 from django.utils.translation import ugettext as _, ugettext_noop
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.commtrack.views import BaseCommTrackManageView
 from corehq.apps.products.models import SQLProduct

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -1,5 +1,5 @@
 import uuid
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from urllib import urlencode
 
 from corehq.apps.users.models import CommCareUser

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -8,7 +8,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.util.test_utils import TestFileMixin
 from django.test.client import Client
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import os
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from corehq.apps.users.models import WebUser
 from corehq.apps.domain.shortcuts import create_domain
 from django.test.client import Client
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import os
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -15,7 +15,7 @@ from dimagi.utils.couch import CriticalSection
 from dimagi.utils.name_to_url import name_to_url
 from dimagi.utils.web import get_ip, get_url_base, get_site_domain
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, CouchUser, UserRole
 from corehq.apps.hqwebapp.tasks import send_html_email_async

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -4,7 +4,7 @@ import logging
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import redirect, render

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -6,7 +6,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
 from crispy_forms import bootstrap as twbscrispy
 from corehq.apps.style import crispy as hqcrispy
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from datetime import timedelta, datetime, time, date
 from django.conf import settings

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.db import transaction
 from django.utils.decorators import method_decorator
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.style.decorators import use_datatables, use_jquery_ui, \

--- a/corehq/apps/repeaters/views.py
+++ b/corehq/apps/repeaters/views.py
@@ -1,6 +1,6 @@
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import View
 
 from dimagi.utils.web import json_response

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponseBadRequest
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from corehq.apps.reports.filters.base import (
     BaseReportFilter, BaseSingleOptionFilter, BaseTagsFilter, BaseMultipleOptionFilter

--- a/corehq/apps/reports/filters/fixtures.py
+++ b/corehq/apps/reports/filters/fixtures.py
@@ -1,5 +1,5 @@
 import json
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop
 from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem
 from corehq.apps.locations.util import load_locs_json, location_hierarchy_config

--- a/corehq/apps/reports/filters/location.py
+++ b/corehq/apps/reports/filters/location.py
@@ -2,7 +2,7 @@ from dimagi.utils.decorators.memoized import memoized
 from corehq.apps.locations.models import SQLLocation
 from .users import ExpandedMobileWorkerFilter
 from .api import EmwfOptionsView
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy
 
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from django.utils.translation import ugettext as _
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import dateutil
 import warnings
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.groups.models import Group
 from corehq.apps.reports import util

--- a/corehq/apps/reports/standard/cases/careplan.py
+++ b/corehq/apps/reports/standard/cases/careplan.py
@@ -6,7 +6,7 @@ from corehq.apps.reports.standard import ProjectReportParametersMixin, ProjectRe
 from corehq.apps.reports.standard.cases.basic import CaseListReport
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
 from corehq.apps.style.decorators import use_timeago
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import NoReverseMatch
 from django.utils import html
 from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -1,7 +1,7 @@
 import datetime
 import dateutil
 from django.core import cache
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import NoReverseMatch
 from django.template.defaultfilters import yesno
 from django.utils import html
 from django.utils.translation import ugettext as _

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -2,7 +2,7 @@
 from datetime import date, datetime, timedelta
 
 from django.contrib.humanize.templatetags.humanize import naturaltime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext as _
 
 from casexml.apps.phone.analytics import get_sync_logs_for_user

--- a/corehq/apps/reports/standard/forms/reports.py
+++ b/corehq/apps/reports/standard/forms/reports.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from corehq.apps.reports.standard.deployments import DeploymentsReport
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.standard.forms.filters import SubmissionTypeFilter, SubmissionErrorType

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import cgi
 from django.db.models import Q, Count
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.utils.translation import ugettext_noop
 from django.utils.translation import ugettext as _

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from functools import partial
 
 from django.template.loader import render_to_string
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django import template
 from django.utils.html import format_html
 from couchdbkit.exceptions import ResourceNotFound

--- a/corehq/apps/reports/tests/test_export_api.py
+++ b/corehq/apps/reports/tests/test_export_api.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import time
 import uuid
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 from django.test import SimpleTestCase
 

--- a/corehq/apps/reports/tests/test_form_export.py
+++ b/corehq/apps/reports/tests/test_form_export.py
@@ -4,7 +4,7 @@ import json
 import datetime
 
 import mock
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, SimpleTestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.export.models import FormExportInstance, TableConfiguration, ExportColumn, ScalarItem, PathNode

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -12,7 +12,7 @@ from dimagi.utils.dates import DateSpan
 from dimagi.utils.decorators.memoized import memoized
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import six
 from six.moves import range
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -26,7 +26,7 @@ from django.utils.translation import (ugettext as _, ugettext_noop, ugettext_laz
     activate, LANGUAGE_SESSION_KEY)
 from corehq.apps.domain.decorators import (login_and_domain_required, require_superuser,
                                            login_required)
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -4,7 +4,7 @@ from crispy_forms.bootstrap import InlineField, StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div
 from django import forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms.forms import Form
 from django.forms.fields import *
 from crispy_forms import layout as crispy

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -4,7 +4,7 @@ import base64
 from datetime import datetime, timedelta, time
 import re
 import json
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponseBadRequest, Http404
 from django.shortcuts import render

--- a/corehq/apps/styleguide/examples/controls_demo/views.py
+++ b/corehq/apps/styleguide/examples/controls_demo/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_noop, ugettext as _

--- a/corehq/apps/styleguide/examples/simple_crispy_form/views.py
+++ b/corehq/apps/styleguide/examples/simple_crispy_form/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_noop, ugettext as _

--- a/corehq/apps/styleguide/tabs.py
+++ b/corehq/apps/styleguide/tabs.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext as _
 from corehq.tabs.uitab import UITab
 from corehq.tabs.utils import dropdown_dict

--- a/corehq/apps/styleguide/views/__init__.py
+++ b/corehq/apps/styleguide/views/__init__.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.generic import *

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -1,7 +1,7 @@
 import json
 from collections import Counter
 from couchdbkit.exceptions import ResourceNotFound
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http.response import Http404, HttpResponse
 from django.utils.decorators import method_decorator
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster, \

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -4,7 +4,7 @@ import json
 from urllib import urlencode
 import uuid
 from django import forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms import Widget
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -1,7 +1,7 @@
 import datetime
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sqlagg.filters import (
     BasicFilter,

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -28,7 +28,7 @@ from dimagi.utils.dates import DateSpan
 from dimagi.utils.modules import to_function
 from django.conf import settings
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.translation import ugettext as _, ugettext_noop
 from braces.views import JSONResponseMixin

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -9,7 +9,7 @@ from dimagi.utils.django.fields import TrimmedCharField
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator, validate_email
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms.widgets import PasswordInput
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_noop, string_concat

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext as _
 from corehq import toggles
 

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -1,6 +1,6 @@
 import json
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.views.mobile.users import MobileWorkerListView

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -1,6 +1,6 @@
 from couchdbkit.exceptions import ResourceNotFound
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_noop

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.humanize.templatetags.humanize import naturaltime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse,\
     HttpResponseForbidden, HttpResponseBadRequest, Http404
 from django.http.response import HttpResponseServerError

--- a/corehq/apps/zapier/tests.py
+++ b/corehq/apps/zapier/tests.py
@@ -1,7 +1,7 @@
 import json
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.testcases import TestCase, SimpleTestCase
 from django.test.client import Client
 

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -13,7 +13,6 @@ import logging
 
 from django.core.cache import cache
 from django.conf import settings
-from django.urls import reverse
 from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceNotFound
 

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -13,7 +13,7 @@ import logging
 
 from django.core.cache import cache
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceNotFound
 

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -7,7 +7,7 @@ import json
 import types
 
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -8,7 +8,7 @@ from wsgiref.util import FileWrapper
 
 from django.conf import settings
 from django.core import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import IntegrityError
 from django.http import HttpResponse, StreamingHttpResponse
 

--- a/corehq/ex-submodules/soil/views.py
+++ b/corehq/ex-submodules/soil/views.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404, HttpResponse, HttpResponseServerError
 from django.shortcuts import render_to_response, render
 from django.template.context import RequestContext

--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -291,7 +291,7 @@ class AbstractCommCareCase(CaseToXMLMixin):
         """
         if identifier in self.case_attachments:
             from dimagi.utils import web
-            from django.core.urlresolvers import reverse
+            from django.urls import reverse
             return "%s%s" % (web.get_url_base(),
                  reverse("api_case_attachment", kwargs={
                      "domain": self.domain,

--- a/corehq/messaging/ivrbackends/kookoo/models.py
+++ b/corehq/messaging/ivrbackends/kookoo/models.py
@@ -5,7 +5,7 @@ from corehq.apps.sms.util import strip_plus
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import get_url_base
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from urllib import urlencode
 from urllib2 import urlopen
 from xml.etree.ElementTree import XML

--- a/corehq/messaging/smsbackends/telerivet/views.py
+++ b/corehq/messaging/smsbackends/telerivet/views.py
@@ -10,7 +10,7 @@ from corehq.messaging.smsbackends.telerivet.models import IncomingRequest, SQLTe
 from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from django.db import transaction
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -6,7 +6,7 @@ import datetime
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth.views import logout as django_logout
 
 from corehq.apps.domain.models import Domain

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -1,5 +1,5 @@
 import datetime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq import privileges
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_class
 from corehq.apps.domain.models import Domain

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1,6 +1,6 @@
 from urllib import urlencode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.http import Http404
 from django.utils.html import strip_tags

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -1,5 +1,5 @@
 from django.core.cache import cache
-from django.core.urlresolvers import reverse, resolve, Resolver404
+from django.urls import reverse, resolve, Resolver404
 from django.utils.translation import get_language
 from corehq.tabs.exceptions import UrlPrefixFormatError, UrlPrefixFormatsSuggestion
 from corehq.tabs.utils import sidebar_to_dropdown

--- a/corehq/tabs/utils.py
+++ b/corehq/tabs/utils.py
@@ -1,7 +1,7 @@
 import urlparse
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import resolve, reverse
+from django.urls import resolve, reverse
 from django.http import Http404
 from ws4redis.context_processors import default
 from corehq.apps.accounting.utils import domain_has_privilege

--- a/custom/_legacy/mvp/indicator_admin/custom.py
+++ b/custom/_legacy/mvp/indicator_admin/custom.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.indicators.admin.couch_indicators import CouchIndicatorAdminInterface
 from corehq.apps.indicators.admin.dynamic_indicators import BaseDynamicIndicatorAdminInterface
 from corehq.apps.reports.datatables import DataTablesColumn

--- a/custom/_legacy/pact/reports/chw.py
+++ b/custom/_legacy/pact/reports/chw.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from django.http import Http404
 from corehq.apps.api.es import ReportCaseES, ReportXFormES
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn

--- a/custom/_legacy/pact/reports/chw_list.py
+++ b/custom/_legacy/pact/reports/chw_list.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import  NoReverseMatch
+from django.urls import  NoReverseMatch
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin

--- a/custom/_legacy/pact/reports/chw_list.py
+++ b/custom/_legacy/pact/reports/chw_list.py
@@ -1,4 +1,4 @@
-from django.urls import  NoReverseMatch
+from django.urls import NoReverseMatch
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin

--- a/custom/_legacy/pact/reports/patient.py
+++ b/custom/_legacy/pact/reports/patient.py
@@ -1,5 +1,5 @@
 import logging
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 import json
 from corehq.apps.api.es import ReportXFormES

--- a/custom/_legacy/pact/reports/patient_list.py
+++ b/custom/_legacy/pact/reports/patient_list.py
@@ -1,4 +1,4 @@
-from django.urls import  NoReverseMatch
+from django.urls import NoReverseMatch
 from django.utils import html
 
 from corehq.apps.api.es import ReportCaseES, ReportXFormES

--- a/custom/_legacy/pact/reports/patient_list.py
+++ b/custom/_legacy/pact/reports/patient_list.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import  NoReverseMatch
+from django.urls import  NoReverseMatch
 from django.utils import html
 
 from corehq.apps.api.es import ReportCaseES, ReportXFormES

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -3,7 +3,7 @@ import datetime
 from django.utils.translation import ugettext_noop
 from django.utils import html
 from casexml.apps.case.models import CommCareCase
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from django.utils.translation import ugettext as _
 from corehq.apps.reports.standard.cases.basic import CaseListReport
 

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.repeaters.models import CaseRepeater
 from corehq.form_processor.models import CommCareCaseSQL

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -1,5 +1,5 @@
 from corehq.toggles import NINETYNINE_DOTS
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from corehq.form_processor.models import CommCareCaseSQL

--- a/custom/enikshay/reports/filters.py
+++ b/custom/enikshay/reports/filters.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.reports.filters.base import BaseMultipleOptionFilter, BaseReportFilter, BaseSingleOptionFilter
 from corehq.apps.reports.filters.dates import DatespanFilter

--- a/custom/ewsghana/forms.py
+++ b/custom/ewsghana/forms.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.reminders.forms import BroadcastForm
 from corehq.apps.reminders.models import (RECIPIENT_USER_GROUP, RECIPIENT_LOCATION)
 from corehq.apps.users.forms import SupplyPointSelectWidget

--- a/custom/ewsghana/reports/__init__.py
+++ b/custom/ewsghana/reports/__init__.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string

--- a/custom/ewsghana/reports/stock_levels_report.py
+++ b/custom/ewsghana/reports/stock_levels_report.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from datetime import timedelta
 from itertools import chain
 import datetime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.utils.timesince import timesince
 from math import ceil

--- a/custom/ewsghana/tests/test_input_stock_view.py
+++ b/custom/ewsghana/tests/test_input_stock_view.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from casexml.apps.stock.models import StockTransaction, StockReport
 from corehq.apps.accounting.models import SoftwarePlanEdition

--- a/custom/fri/reports/reports.py
+++ b/custom/fri/reports/reports.py
@@ -24,7 +24,7 @@ from custom.fri.api import get_message_bank, add_metadata, get_date
 from corehq.apps.sms.models import INCOMING, OUTGOING, SMS
 from corehq.apps.users.models import UserCache
 from custom.fri.api import get_interactive_participants, get_valid_date_range
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from corehq.apps.reports.dispatcher import CustomProjectReportDispatcher
 from dateutil.parser import parse
 

--- a/custom/fri/views.py
+++ b/custom/fri/views.py
@@ -5,7 +5,7 @@ from custom.fri.models import FRIMessageBankMessage
 from corehq.apps.reports.dispatcher import CustomProjectReportDispatcher
 from corehq.apps.domain.decorators import require_previewer, login_and_domain_required
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib import messages
 from django.utils.translation import ugettext as _
 

--- a/custom/icds/views.py
+++ b/custom/icds/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils.decorators import method_decorator

--- a/custom/icds_reports/reports/reports.py
+++ b/custom/icds_reports/reports/reports.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.filters.fixtures import AsyncLocationFilter

--- a/custom/ilsgateway/filters.py
+++ b/custom/ilsgateway/filters.py
@@ -1,7 +1,7 @@
 import calendar
 from datetime import datetime
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.programs.models import Program

--- a/custom/ilsgateway/slab/views.py
+++ b/custom/ilsgateway/slab/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http.response import HttpResponseRedirect, HttpResponseBadRequest
 from django.utils.decorators import method_decorator
 

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -2,7 +2,7 @@ import base64
 import StringIO
 from datetime import datetime
 import json
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.db.models import Count
 from django.http.response import HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404

--- a/custom/intrahealth/filters.py
+++ b/custom/intrahealth/filters.py
@@ -1,6 +1,6 @@
 import calendar
 import json
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_noop
 from corehq.apps.locations.util import location_hierarchy_config, load_locs_json
 from corehq.apps.reports.filters.fixtures import AsyncLocationFilter

--- a/custom/m4change/reports/mcct_project_review.py
+++ b/custom/m4change/reports/mcct_project_review.py
@@ -1,5 +1,5 @@
 from datetime import date
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 

--- a/custom/opm/beneficiary.py
+++ b/custom/opm/beneficiary.py
@@ -6,7 +6,7 @@ These are used in the Beneficiary Payment Report and Conditions Met Report
 import re
 import datetime
 from decimal import Decimal
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.defaultfilters import yesno
 from corehq.apps.reports.datatables import DTSortType
 from custom.opm.constants import InvalidRow, BIRTH_PREP_XMLNS, CHILDREN_FORMS, CFU1_XMLNS, DOMAIN, CFU2_XMLNS, \

--- a/custom/succeed/reports/patient_submissions.py
+++ b/custom/succeed/reports/patient_submissions.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from sqlagg.columns import SimpleColumn
 from sqlagg.filters import EQ
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn

--- a/custom/succeed/reports/patient_task_list.py
+++ b/custom/succeed/reports/patient_task_list.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import html
 from django.utils.translation import ugettext as _, ugettext_noop
 from sqlagg.base import AliasColumn

--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -1,6 +1,6 @@
 from lxml import etree
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 
 from corehq.apps.app_manager.dbaccessors import get_app

--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -13,5 +13,5 @@ def post_fork(server, worker):
     mimetypes.init()
     # hacky way to address gunicorn gevent requests hitting django too early before urls are loaded
     # see: https://github.com/benoitc/gunicorn/issues/527#issuecomment-19601046
-    from django.core.urlresolvers import resolve
+    from django.urls import resolve
     resolve('/')


### PR DESCRIPTION
remove deprecation warnings like:

RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
  from django.core.urlresolvers import reverse