### PR TITLE
update pillowtop loggin

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1122,7 +1122,7 @@ LOGGING = {
         },
         'pillowtop': {
             'handlers': ['pillowtop'],
-            'level': 'ERROR',
+            'level': 'INFO',
             'propagate': False,
         },
         'smsbillables': {


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/15484#discussion_r107597848

@sravfeyn @snopoke 

Not convinced this is necessary, but should be consistent.

I think https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/pillowtop/logger.py#L5 overrides that setting (possible we can get rid of that todo, but i haven't debugged that yet)

and I'm certain that https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/pillowtop/checkpoints/manager.py#L62-L64 is logged and it's info