### PR TITLE
force all topics to bytes

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -249,6 +249,7 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
 def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
                          include_ucrs=None, exclude_ucrs=None, topics=None):
     topics = topics or KAFKA_TOPICS
+    topics = [str(t) for t in topics]
     return ConfigurableReportKafkaPillow(
         processor=ConfigurableReportPillowProcessor(
             data_source_provider=DynamicDataSourceProvider(),
@@ -265,6 +266,7 @@ def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
 def get_kafka_ucr_static_pillow(pillow_id='kafka-ucr-static', ucr_division=None,
                                 include_ucrs=None, exclude_ucrs=None, topics=None):
     topics = topics or KAFKA_TOPICS
+    topics = [str(t) for t in topics]
     return ConfigurableReportKafkaPillow(
         processor=ConfigurableReportPillowProcessor(
             data_source_provider=StaticDataSourceProvider(),


### PR DESCRIPTION
This code is already deployed to NIC (hand edited on pillow and web0/web1)

The kafka library hard errors anytime you give it unicode (even if it's only ascii characters)

https://github.com/dimagi/commcarehq-ansible/blob/cd6dcf4008e93ba37a44477538b65732d1528f6a/ansible/roles/commcarehq/templates/localsettings.py.j2#L164 json.loads always returns the dictionary elements as unicode

@snopoke @sravfeyn 