### PR TITLE
double the throughput on laboratory UCRs

### DIFF
--- a/corehq/apps/userreports/adapter.py
+++ b/corehq/apps/userreports/adapter.py
@@ -53,6 +53,15 @@ class IndicatorAdapter(object):
         """
         Saves the document. Should bubble up known errors.
         """
+        indicator_rows = self.get_all_values(doc)
+        self.save_rows(indicator_rows, doc)
+
+    def get_all_values(self, doc):
+        "Gets all the values from a document to save"
+        return self.config.get_all_values(doc)
+
+    def save_rows(self, rows, doc):
+        "Saves rows to a data source"
         raise NotImplementedError
 
     def delete(self, doc):

--- a/corehq/apps/userreports/adapter.py
+++ b/corehq/apps/userreports/adapter.py
@@ -36,6 +36,17 @@ class IndicatorAdapter(object):
         For certain known, expected errors this will do no additional logging.
         For unexpected errors it will log them.
         """
+        try:
+            indicator_rows = self.get_all_values(doc)
+        except Exception as e:
+            self.handle_exception(doc, e)
+        else:
+            self.best_effort_save_rows(indicator_rows, doc)
+
+    def best_effort_save_rows(self, rows, doc):
+        """
+        Like save_rows, but catches errors
+        """
         raise NotImplementedError
 
     def handle_exception(self, doc, exception):

--- a/corehq/apps/userreports/adapter.py
+++ b/corehq/apps/userreports/adapter.py
@@ -41,11 +41,11 @@ class IndicatorAdapter(object):
         except Exception as e:
             self.handle_exception(doc, e)
         else:
-            self.best_effort_save_rows(indicator_rows, doc)
+            self._best_effort_save_rows(indicator_rows, doc)
 
-    def best_effort_save_rows(self, rows, doc):
+    def _best_effort_save_rows(self, rows, doc):
         """
-        Like save_rows, but catches errors
+        Like save rows, but should catch errors and log them
         """
         raise NotImplementedError
 
@@ -65,13 +65,13 @@ class IndicatorAdapter(object):
         Saves the document. Should bubble up known errors.
         """
         indicator_rows = self.get_all_values(doc)
-        self.save_rows(indicator_rows, doc)
+        self._save_rows(indicator_rows, doc)
 
     def get_all_values(self, doc):
         "Gets all the values from a document to save"
         return self.config.get_all_values(doc)
 
-    def save_rows(self, rows, doc):
+    def _save_rows(self, rows, doc):
         "Saves rows to a data source"
         raise NotImplementedError
 

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -198,16 +198,21 @@ class IndicatorESAdapter(IndicatorAdapter):
         """
         Saves the document. Should bubble up known errors.
         """
-        indicator_rows = self.config.get_all_values(doc)
-        if indicator_rows:
-            es = get_es_new()
-            for indicator_row in indicator_rows:
-                primary_key_values = [str(i.value) for i in indicator_row if i.column.is_primary_key]
-                all_values = {i.column.database_column_name: i.value for i in indicator_row}
-                es.index(
-                    index=self.table_name, body=all_values,
-                    id=normalize_id(primary_key_values), doc_type="indicator"
-                )
+        indicator_rows = self.get_all_values(doc)
+        self.save_rows(indicator_rows, doc)
+
+    def save_rows(self, rows, doc):
+        if not rows:
+            return
+
+        es = get_es_new()
+        for row in rows:
+            primary_key_values = [str(i.value) for i in row if i.column.is_primary_key]
+            all_values = {i.column.database_column_name: i.value for i in row}
+            es.index(
+                index=self.table_name, body=all_values,
+                id=normalize_id(primary_key_values), doc_type="indicator"
+            )
 
 
 def build_es_mapping(data_source_config):

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -188,18 +188,11 @@ class IndicatorESAdapter(IndicatorAdapter):
 
         return distinct_values, too_many_values
 
-    def best_effort_save(self, doc):
+    def best_effort_save_rows(self, rows, doc):
         try:
-            self.save(doc)
+            self.save_rows(rows, doc)
         except Exception as e:
             self.handle_exception(doc, e)
-
-    def save(self, doc):
-        """
-        Saves the document. Should bubble up known errors.
-        """
-        indicator_rows = self.get_all_values(doc)
-        self.save_rows(indicator_rows, doc)
 
     def save_rows(self, rows, doc):
         if not rows:

--- a/corehq/apps/userreports/es/adapter.py
+++ b/corehq/apps/userreports/es/adapter.py
@@ -188,13 +188,13 @@ class IndicatorESAdapter(IndicatorAdapter):
 
         return distinct_values, too_many_values
 
-    def best_effort_save_rows(self, rows, doc):
+    def _best_effort_save_rows(self, rows, doc):
         try:
-            self.save_rows(rows, doc)
+            self._save_rows(rows, doc)
         except Exception as e:
             self.handle_exception(doc, e)
 
-    def save_rows(self, rows, doc):
+    def _save_rows(self, rows, doc):
         if not rows:
             return
 

--- a/corehq/apps/userreports/laboratory/adapter.py
+++ b/corehq/apps/userreports/laboratory/adapter.py
@@ -1,4 +1,3 @@
-from sqlalchemy.exc import IntegrityError
 from corehq.apps.userreports.adapter import IndicatorAdapter
 from corehq.apps.userreports.es.adapter import IndicatorESAdapter
 from corehq.apps.userreports.sql.adapter import IndicatorSqlAdapter

--- a/corehq/apps/userreports/laboratory/adapter.py
+++ b/corehq/apps/userreports/laboratory/adapter.py
@@ -46,19 +46,13 @@ class IndicatorLaboratoryAdapter(IndicatorAdapter):
         raise NotImplementedError
 
     def best_effort_save(self, doc):
-        indicator_rows = self.get_all_values(doc)
-
         try:
-            self.es_adapter.save_rows(indicator_rows, doc)
+            indicator_rows = self.get_all_values(doc)
         except Exception as e:
-            self.es_adapter.handle_exception(doc, e)
-
-        try:
-            self.sql_adapter.save_rows(indicator_rows, doc)
-        except IntegrityError:
-            pass  # can be due to users messing up their tables/data so don't bother logging
-        except Exception as e:
-            self.sql_adapter.handle_exception(doc, e)
+            self.handle_exception(doc, e)
+        else:
+            self.es_adapter.best_effort_save_rows(indicator_rows, doc)
+            self.sql_adapter.best_effort_save_rows(indicator_rows, doc)
 
     def save_rows(self, rows, doc):
         self.es_adapter.save_rows(rows, doc)

--- a/corehq/apps/userreports/laboratory/adapter.py
+++ b/corehq/apps/userreports/laboratory/adapter.py
@@ -51,9 +51,9 @@ class IndicatorLaboratoryAdapter(IndicatorAdapter):
         except Exception as e:
             self.handle_exception(doc, e)
         else:
-            self.es_adapter.best_effort_save_rows(indicator_rows, doc)
-            self.sql_adapter.best_effort_save_rows(indicator_rows, doc)
+            self.es_adapter._best_effort_save_rows(indicator_rows, doc)
+            self.sql_adapter._best_effort_save_rows(indicator_rows, doc)
 
-    def save_rows(self, rows, doc):
-        self.es_adapter.save_rows(rows, doc)
-        self.sql_adapter.save_rows(rows, doc)
+    def _save_rows(self, rows, doc):
+        self.es_adapter._save_rows(rows, doc)
+        self.sql_adapter._save_rows(rows, doc)

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -95,15 +95,15 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
         return distinct_values, too_many_values
 
-    def best_effort_save_rows(self, rows, doc):
+    def _best_effort_save_rows(self, rows, doc):
         try:
-            self.save_rows(rows, doc)
+            self._save_rows(rows, doc)
         except IntegrityError:
             pass  # can be due to users messing up their tables/data so don't bother logging
         except Exception as e:
             self.handle_exception(doc, e)
 
-    def save_rows(self, rows, doc):
+    def _save_rows(self, rows, doc):
         if not rows:
             return
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -95,9 +95,9 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
         return distinct_values, too_many_values
 
-    def best_effort_save(self, doc):
+    def best_effort_save_rows(self, rows, doc):
         try:
-            self.save(doc)
+            self.save_rows(rows, doc)
         except IntegrityError:
             pass  # can be due to users messing up their tables/data so don't bother logging
         except Exception as e:

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -103,21 +103,19 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         except Exception as e:
             self.handle_exception(doc, e)
 
-    def save(self, doc):
-        """
-        Saves the document. Should bubble up known errors.
-        """
-        indicator_rows = self.config.get_all_values(doc)
-        if indicator_rows:
-            table = self.get_table()
-            with self.engine.begin() as connection:
-                # delete all existing rows for this doc to ensure we aren't left with stale data
-                delete = table.delete(table.c.doc_id == doc['_id'])
-                connection.execute(delete)
-                for indicator_row in indicator_rows:
-                    all_values = {i.column.database_column_name: i.value for i in indicator_row}
-                    insert = table.insert().values(**all_values)
-                    connection.execute(insert)
+    def save_rows(self, rows, doc):
+        if not rows:
+            return
+
+        table = self.get_table()
+        with self.engine.begin() as connection:
+            # delete all existing rows for this doc to ensure we aren't left with stale data
+            delete = table.delete(table.c.doc_id == doc['_id'])
+            connection.execute(delete)
+            for row in rows:
+                all_values = {i.column.database_column_name: i.value for i in row}
+                insert = table.insert().values(**all_values)
+                connection.execute(insert)
 
     def delete(self, doc):
         table = self.get_table()


### PR DESCRIPTION
Calls `self.config.get_all_values(doc)` once instead of twice for the UCRs. That is where all the db hits happen  to generate the rows.

This should be a huge boon to icds since all the UCRs in laboratory now. w=1 may be helpful for some of the review

familiar with UCR @NoahCarnahan @nickpell 

buddy @sravfeyn FYI @sheelio 