### PR TITLE
Release vellum onboarding changes

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
@@ -17,7 +17,7 @@
 {% block js %}{{ block.super }}
     <script src="{% static 'moment/moment.js' %}"></script>
     <script src="{% static 'requirejs/require.js' %}"></script>
-    {% if not request|toggle_enabled:'VELLUM_BETA' %}
+    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
         <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
     {% endif %}
     <script src="{% static 'app_manager/js/app-notifications.js' %}"></script>
@@ -202,7 +202,7 @@
     {{ block.super }}
     {% with slug="vellum_beta" name="New Form Builder" %}
     {% registerurl "enable_vellum_beta" %}
-    {% if not request|toggle_enabled:'VELLUM_BETA' %}
+    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
         <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
         <div class="modal rollout-modal" data-slug="{{ slug }}">
             <div class="modal-dialog">

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
@@ -26,7 +26,7 @@
 {% block js %}{{ block.super }}
     <script src="{% static 'moment/moment.js' %}"></script>
     <script src="{% static 'requirejs/require.js' %}"></script>
-    {% if not request|toggle_enabled:'VELLUM_BETA' %}
+    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
         <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
     {% endif %}
     <script src="{% static 'app_manager/js/app-notifications.js' %}"></script>
@@ -310,7 +310,7 @@
     {{ block.super }}
     {% with slug="vellum_beta" name="New Form Builder" %}
     {% registerurl "enable_vellum_beta" %}
-    {% if not request|toggle_enabled:'VELLUM_BETA' %}
+    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
         <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
         <div class="modal rollout-modal" data-slug="{{ slug }}">
             <div class="modal-dialog">

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -136,13 +136,13 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
 
     vellum_base = 'corehq/apps/app_manager/static/app_manager/js/'
     vellum_dir = 'vellum'
-    if toggles.VELLUM_BETA.enabled(request.user.username) and isdir(join(vellum_base, 'vellum_beta')):
+    if isdir(join(vellum_base, 'vellum_beta')):
         vellum_dir = 'vellum_beta'
 
     context = get_apps_base_context(request, domain, app)
     context.update(locals())
     context.update({
-        'vellum_debug': settings.VELLUM_DEBUG and not toggles.VELLUM_BETA.enabled(request.user.username),
+        'vellum_debug': settings.VELLUM_DEBUG,
         'nav_form': form,
         'vellum_style_path': 'app_manager/js/{}/style.css'.format(vellum_dir),
         'vellum_ckeditor_path': 'app_manager/js/{}/lib/ckeditor/'.format(vellum_dir),


### PR DESCRIPTION
Deliberately doing this in a brain-dead way just to get the release out; will remove the feature flag, the `vellum_beta` branch, etc. once this has been in production for a week or two.

@millerdev / @NoahCarnahan 