### PR TITLE
Add filtering by timeEnd and xmlns to get_case_forms

### DIFF
--- a/corehq/apps/es/fake/forms_fake.py
+++ b/corehq/apps/es/fake/forms_fake.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+from dateutil import parser
+from corehq.pillows.xform import transform_xform_for_elasticsearch
+from corehq.apps.es.fake.es_query_fake import HQESQueryFake
+
+
+class FormESFake(HQESQueryFake):
+    _all_docs = []
+
+    def domain(self, domain):
+        return self._filtered(
+            lambda doc: (doc.get('domain') == domain
+                         or domain in doc.get('domains', [])))
+
+    def xmlns(self, xmlns):
+        return self.term('xmlns.exact', xmlns)
+
+    def completed(self, gt=None, gte=None, lt=None, lte=None):
+        return self.date_range('form.meta.timeEnd', gt, gte, lt, lte)
+
+    @staticmethod
+    def transform_doc(doc):
+        doc = deepcopy(doc)
+        doc['xmlns.exact'] = doc.get('xmlns', '')
+        doc['form.meta.timeEnd'] = parser.parse(doc['form']['meta']['timeEnd'])
+        return transform_xform_for_elasticsearch(doc)
+
+    def count(self):
+        return len(self._result_docs)

--- a/corehq/apps/userreports/examples/examples.md
+++ b/corehq/apps/userreports/examples/examples.md
@@ -523,6 +523,22 @@ This will return the difference in seconds between two times (i.e. start and end
 }
 ```
 
+## Getting forms submitted from specific forms for a case
+
+```json
+{
+    "type": "get_case_forms",
+    "case_id_expression": {
+        "type": "property_name",
+        "property_name": "case_id"
+    },
+    "xmlns": [
+        "http://openrosa.org/formdesigner/D8EED5E3-88CD-430E-984F-45F14E76A551",
+        "http://openrosa.org/formdesigner/F1B73934-8B70-4CEE-B462-3E4C81F80E4A"
+    ]
+}
+```
+
 ## Filter, Map, Reduce, Flatten and Sort expressions
 
 ### Getting number of forms of a particular type

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
+import datetime
 import functools
 import json
-import datetime
+
 from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
+import six
+
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.specs import (
     PropertyNameGetterSpec, PropertyPathGetterSpec,
@@ -12,7 +15,6 @@ from corehq.apps.userreports.expressions.specs import (
     NestedExpressionSpec, DictExpressionSpec, NamedExpressionSpec, EvalExpressionSpec, FormsExpressionSpec,
     IterationNumberExpressionSpec, SubcasesExpressionSpec, SplitStringExpressionSpec,
     CaseSharingGroupsExpressionSpec, ReportingGroupsExpressionSpec, CoalesceExpressionSpec,
-    FormsInDateExpressionSpec
 )
 from corehq.apps.userreports.expressions.date_specs import AddDaysExpressionSpec, AddMonthsExpressionSpec, \
     MonthStartDateExpressionSpec, MonthEndDateExpressionSpec, DiffDaysExpressionSpec
@@ -20,7 +22,6 @@ from corehq.apps.userreports.expressions.list_specs import FilterItemsExpression
     MapItemsExpressionSpec, ReduceItemsExpressionSpec, FlattenExpressionSpec, SortItemsExpressionSpec
 from dimagi.utils.parsing import json_format_datetime, json_format_date
 from dimagi.utils.web import json_handler
-import six
 
 
 def _make_filter(spec, context):
@@ -186,16 +187,6 @@ def _get_forms_expression(spec, context):
     return wrapped
 
 
-def _get_forms_in_date_expression(spec, context):
-    wrapped = FormsInDateExpressionSpec.wrap(spec)
-    wrapped.configure(
-        case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, context),
-        from_date_expression=ExpressionFactory.from_spec(wrapped.from_date_expression, context),
-        to_date_expression=ExpressionFactory.from_spec(wrapped.to_date_expression, context)
-    )
-    return wrapped
-
-
 def _get_subcases_expression(spec, context):
     wrapped = SubcasesExpressionSpec.wrap(spec)
     wrapped.configure(
@@ -304,7 +295,6 @@ class ExpressionFactory(object):
         'diff_days': _diff_days_expression,
         'evaluator': _evaluator_expression,
         'get_case_forms': _get_forms_expression,
-        'get_case_forms_in_date': _get_forms_in_date_expression,
         'get_subcases': _get_subcases_expression,
         'get_case_sharing_groups': _get_case_sharing_groups_expression,
         'get_reporting_groups': _get_reporting_groups_expression,

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -5,12 +5,15 @@ import datetime
 from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
-from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, PropertyPathGetterSpec, \
-    ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec, \
-    IdentityExpressionSpec, IteratorExpressionSpec, SwitchExpressionSpec, ArrayIndexExpressionSpec, \
-    NestedExpressionSpec, DictExpressionSpec, NamedExpressionSpec, EvalExpressionSpec, FormsExpressionSpec, \
-    IterationNumberExpressionSpec, SubcasesExpressionSpec, SplitStringExpressionSpec, \
-    CaseSharingGroupsExpressionSpec, ReportingGroupsExpressionSpec, CoalesceExpressionSpec
+from corehq.apps.userreports.expressions.specs import (
+    PropertyNameGetterSpec, PropertyPathGetterSpec,
+    ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec,
+    IdentityExpressionSpec, IteratorExpressionSpec, SwitchExpressionSpec, ArrayIndexExpressionSpec,
+    NestedExpressionSpec, DictExpressionSpec, NamedExpressionSpec, EvalExpressionSpec, FormsExpressionSpec,
+    IterationNumberExpressionSpec, SubcasesExpressionSpec, SplitStringExpressionSpec,
+    CaseSharingGroupsExpressionSpec, ReportingGroupsExpressionSpec, CoalesceExpressionSpec,
+    FormsInDateExpressionSpec
+)
 from corehq.apps.userreports.expressions.date_specs import AddDaysExpressionSpec, AddMonthsExpressionSpec, \
     MonthStartDateExpressionSpec, MonthEndDateExpressionSpec, DiffDaysExpressionSpec
 from corehq.apps.userreports.expressions.list_specs import FilterItemsExpressionSpec, \
@@ -183,6 +186,16 @@ def _get_forms_expression(spec, context):
     return wrapped
 
 
+def _get_forms_in_date_expression(spec, context):
+    wrapped = FormsInDateExpressionSpec.wrap(spec)
+    wrapped.configure(
+        case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, context),
+        from_date_expression=ExpressionFactory.from_spec(wrapped.from_date_expression, context),
+        to_date_expression=ExpressionFactory.from_spec(wrapped.to_date_expression, context)
+    )
+    return wrapped
+
+
 def _get_subcases_expression(spec, context):
     wrapped = SubcasesExpressionSpec.wrap(spec)
     wrapped.configure(
@@ -291,6 +304,7 @@ class ExpressionFactory(object):
         'diff_days': _diff_days_expression,
         'evaluator': _evaluator_expression,
         'get_case_forms': _get_forms_expression,
+        'get_case_forms_in_date': _get_forms_in_date_expression,
         'get_subcases': _get_subcases_expression,
         'get_case_sharing_groups': _get_case_sharing_groups_expression,
         'get_reporting_groups': _get_reporting_groups_expression,

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -304,14 +304,33 @@ class FormsExpressionSpec(JsonObject):
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 
-        xforms = FormProcessorInterface(domain).get_case_forms(case_id)
+        xforms = self._get_case_forms(case_id, context)
         if self.xmlns:
             xforms = [f for f in xforms if f.xmlns in self.xmlns]
 
-        xforms = [f.to_json() for f in xforms if f.domain == domain]
+        xforms = [self._get_form_json(f, context) for f in xforms if f.domain == domain]
 
         context.set_cache_value(cache_key, xforms)
         return xforms
+
+    def _get_case_forms(self, case_id, context):
+        cache_key = (self.__class__.__name__, 'helper', case_id)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        domain = context.root_doc['domain']
+        xforms = FormProcessorInterface(domain).get_case_forms(case_id)
+        context.set_cache_value(cache_key, xforms)
+        return xforms
+
+    def _get_form_json(self, form, context):
+        cache_key = (self.__class__.__name__, 'xform', form.id)
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        form_json = form.to_json()
+        context.set_cache_value(cache_key, form_json)
+        return form_json
 
 
 class SubcasesExpressionSpec(JsonObject):

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -324,7 +324,7 @@ class FormsExpressionSpec(JsonObject):
         return xforms
 
     def _get_form_json(self, form, context):
-        cache_key = (self.__class__.__name__, 'xform', form.id)
+        cache_key = (self.__class__.__name__, 'xform', form.get_id)
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 import hashlib
 from simpleeval import InvalidExpression
-from corehq.apps.es.forms import FormES
 from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 from corehq.apps.userreports.document_stores import get_document_store
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.couch import get_db_by_doc_type
 from dimagi.ext.jsonobject import JsonObject, StringProperty, ListProperty, DictProperty
 from jsonobject.base_properties import DefaultProperty
@@ -309,60 +308,6 @@ class FormsExpressionSpec(JsonObject):
         if self.xmlns:
             xforms = [f for f in xforms if f.xmlns in self.xmlns]
 
-        xforms = [f.to_json() for f in xforms if f.domain == domain]
-
-        context.set_cache_value(cache_key, xforms)
-        return xforms
-
-
-class FormsInDateExpressionSpec(JsonObject):
-    type = TypeProperty('get_case_forms_in_date')
-    case_id_expression = DefaultProperty(required=True)
-    xmlns = ListProperty(required=False)
-    from_date_expression = DictProperty(required=True)
-    to_date_expression = DictProperty(required=True)
-
-    def configure(self, case_id_expression, from_date_expression, to_date_expression):
-        self._case_id_expression = case_id_expression
-        self._from_date_expression = from_date_expression
-        self._to_date_expression = to_date_expression
-
-    def __call__(self, item, context=None):
-        case_id = self._case_id_expression(item, context)
-        from_date = self._from_date_expression(item, context)
-        to_date = self._to_date_expression(item, context)
-
-        if not case_id:
-            return []
-
-        assert context.root_doc['domain']
-        return self._get_forms(case_id, from_date, to_date, context)
-
-    def _get_forms(self, case_id, from_date, to_date, context):
-        domain = context.root_doc['domain']
-        cache_hash = "{},{}".format(from_date.toordinal(), to_date.toordinal())
-        if self.xmlns:
-            cache_hash += ''.join(self.xmlns)
-
-        cache_hash = hashlib.md5(cache_hash).hexdigest()[:4]
-
-        cache_key = (self.__class__.__name__, case_id, cache_hash)
-        if context.get_cache_value(cache_key) is not None:
-            return context.get_cache_value(cache_key)
-
-        xform_ids = CaseAccessors(domain).get_case_xform_ids(case_id)
-        # TODO(Emord) this will eventually break down when cases have a lot of
-        # forms associated with them. perhaps change to intersecting two sets
-        query = (
-            FormES()
-            .domain(domain)
-            .completed(gte=from_date, lte=to_date)
-            .doc_id(xform_ids)
-        )
-        if self.xmlns:
-            query = query.xmlns(self.xmlns)
-        form_ids = query.get_ids()
-        xforms = FormAccessors(domain).get_forms(form_ids)
         xforms = [f.to_json() for f in xforms if f.domain == domain]
 
         context.set_cache_value(cache_key, xforms)

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import hashlib
 from simpleeval import InvalidExpression
 from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 from corehq.apps.userreports.document_stores import get_document_store
@@ -295,12 +294,8 @@ class FormsExpressionSpec(JsonObject):
 
     def _get_forms(self, case_id, context):
         domain = context.root_doc['domain']
-        if self.xmlns:
-            xmlns_hash = hashlib.md5(''.join(self.xmlns)).hexdigest()[:4]
-        else:
-            xmlns_hash = ''
 
-        cache_key = (self.__class__.__name__, case_id, xmlns_hash)
+        cache_key = (self.__class__.__name__, case_id, tuple(self.xmlns))
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -6,10 +6,12 @@ from decimal import Decimal
 from django.test import SimpleTestCase, TestCase, override_settings
 from fakecouch import FakeCouchDb
 from simpleeval import InvalidExpression
+import mock
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseStructure, CaseFactory, CaseIndex
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
+from corehq.apps.es.fake.forms_fake import FormESFake
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.expressions.specs import (
@@ -1051,6 +1053,116 @@ class TestFormsExpressionSpec(TestCase):
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class TestFormsExpressionSpecSQL(TestCase):
+    pass
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
+@mock.patch('corehq.apps.userreports.expressions.specs.FormES', FormESFake)
+class TestFormsExpressionSpecWithFilter(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestFormsExpressionSpecWithFilter, cls).setUpClass()
+        cls.domain = uuid.uuid4().hex
+        factory = CaseFactory(domain=cls.domain)
+        [cls.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
+        cls.forms = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case.xform_ids)]
+        for form in cls.forms:
+            FormESFake.save_doc(form)
+        #  redundant case to create extra forms that shouldn't be in the results for cls.case
+        [cls.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
+        cls.forms_b = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case_b.xform_ids)]
+        for form in cls.forms_b:
+            FormESFake.save_doc(form)
+
+    @classmethod
+    def tearDownClass(cls):
+        FormESFake.reset_docs()
+        delete_all_xforms()
+        delete_all_cases()
+        super(TestFormsExpressionSpecWithFilter, cls).tearDownClass()
+
+    def _make_expression(self, from_statement, to_statement, xmlns=None):
+        spec = {
+            "type": "get_case_forms_in_date",
+            "case_id_expression": {
+                "type": "property_name",
+                "property_name": "_id"
+            },
+            "from_date_expression": {
+                "type": "add_months",
+                "datatype": "datetime",
+                "date_expression": {
+                    "type": "property_name",
+                    "property_name": "server_modified_on"
+                },
+                "months_expression": {
+                    "type": "evaluator",
+                    "statement": from_statement,
+                    "context_variables": {
+                        "iteration": {
+                            "type": "base_iteration_number"
+                        }
+                    }
+                },
+            },
+            "to_date_expression": {
+                "type": "add_months",
+                "datatype": "datetime",
+                "date_expression": {
+                    "type": "property_name",
+                    "property_name": "server_modified_on"
+                },
+                "months_expression": {
+                    "type": "evaluator",
+                    "statement": to_statement,
+                    "context_variables": {
+                        "iteration": {
+                            "type": "base_iteration_number"
+                        }
+                    }
+                },
+            },
+        }
+
+        if xmlns:
+            spec['xmlns'] = [xmlns]
+
+        return ExpressionFactory.from_spec(spec)
+
+    def test_from_inside_date_range(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+    def test_from_outside_date_range(self):
+        expression = self._make_expression('iteration - 2', 'iteration - 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(forms, [])
+
+    def test_from_correct_xmlns(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1', 'http://commcarehq.org/case')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+    def test_from_incorrect_xmlns(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1', 'silly-xmlns')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(forms, [])
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+class TestFormsExpressionSpecWithFilterSQL(TestFormsExpressionSpecWithFilter):
     pass
 
 

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -3,7 +3,7 @@ import copy
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 from fakecouch import FakeCouchDb
 from simpleeval import InvalidExpression
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
@@ -990,43 +990,68 @@ class TestEvaluatorTypes(SimpleTestCase):
         self.assertEqual(type(ExpressionFactory.from_spec(spec)({})), int)
 
 
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
 class TestFormsExpressionSpec(TestCase):
 
-    def setUp(self):
-        super(TestFormsExpressionSpec, self).setUp()
-        self.domain = uuid.uuid4().hex
-        factory = CaseFactory(domain=self.domain)
-        [self.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
-        self.forms = [f.to_json() for f in FormAccessors(self.domain).get_forms(self.case.xform_ids)]
-        #  redundant case to create extra forms that shouldn't be in the results for self.case
-        [self.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
+    @classmethod
+    def setUpClass(cls):
+        super(TestFormsExpressionSpec, cls).setUpClass()
+        cls.domain = uuid.uuid4().hex
+        factory = CaseFactory(domain=cls.domain)
+        [cls.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
+        cls.forms = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case.xform_ids)]
+        #  redundant case to create extra forms that shouldn't be in the results for cls.case
+        [cls.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
 
-        self.expression = ExpressionFactory.from_spec({
+    @classmethod
+    def tearDownClass(cls):
+        delete_all_xforms()
+        delete_all_cases()
+        super(TestFormsExpressionSpec, cls).tearDownClass()
+
+    def _make_expression(self, xmlns=None):
+        spec = {
             "type": "get_case_forms",
             "case_id_expression": {
                 "type": "property_name",
                 "property_name": "_id"
             },
-        })
+        }
+        if xmlns:
+            spec['xmlns'] = [xmlns]
+        return ExpressionFactory.from_spec(spec)
 
-    def tearDown(self):
-        delete_all_xforms()
-        delete_all_cases()
-        super(TestFormsExpressionSpec, self).tearDown()
-
-    @run_with_all_backends
     def test_evaluation(self):
+        expression = self._make_expression()
         context = EvaluationContext({"domain": self.domain}, 0)
-        forms = self.expression(self.case.to_json(), context)
+        forms = expression(self.case.to_json(), context)
 
         self.assertEqual(len(forms), 1)
         self.assertEqual(forms, self.forms)
 
-    @run_with_all_backends
     def test_wrong_domain(self):
+        expression = self._make_expression()
         context = EvaluationContext({"domain": "wrong-domain"}, 0)
-        forms = self.expression(self.case.to_json(), context)
+        forms = expression(self.case.to_json(), context)
         self.assertEqual(forms, [])
+
+    def test_correct_xmlns(self):
+        expression = self._make_expression('http://commcarehq.org/case')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+    def test_incorrect_xmlns(self):
+        expression = self._make_expression('silly-xmlns')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+        self.assertEqual(forms, [])
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+class TestFormsExpressionSpecSQL(TestCase):
+    pass
 
 
 class TestGetSubcasesExpression(TestCase):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -6,12 +6,10 @@ from decimal import Decimal
 from django.test import SimpleTestCase, TestCase, override_settings
 from fakecouch import FakeCouchDb
 from simpleeval import InvalidExpression
-import mock
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseStructure, CaseFactory, CaseIndex
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
-from corehq.apps.es.fake.forms_fake import FormESFake
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.expressions.specs import (
@@ -1053,116 +1051,6 @@ class TestFormsExpressionSpec(TestCase):
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class TestFormsExpressionSpecSQL(TestCase):
-    pass
-
-
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
-@mock.patch('corehq.apps.userreports.expressions.specs.FormES', FormESFake)
-class TestFormsExpressionSpecWithFilter(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestFormsExpressionSpecWithFilter, cls).setUpClass()
-        cls.domain = uuid.uuid4().hex
-        factory = CaseFactory(domain=cls.domain)
-        [cls.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
-        cls.forms = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case.xform_ids)]
-        for form in cls.forms:
-            FormESFake.save_doc(form)
-        #  redundant case to create extra forms that shouldn't be in the results for cls.case
-        [cls.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
-        cls.forms_b = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case_b.xform_ids)]
-        for form in cls.forms_b:
-            FormESFake.save_doc(form)
-
-    @classmethod
-    def tearDownClass(cls):
-        FormESFake.reset_docs()
-        delete_all_xforms()
-        delete_all_cases()
-        super(TestFormsExpressionSpecWithFilter, cls).tearDownClass()
-
-    def _make_expression(self, from_statement, to_statement, xmlns=None):
-        spec = {
-            "type": "get_case_forms_in_date",
-            "case_id_expression": {
-                "type": "property_name",
-                "property_name": "_id"
-            },
-            "from_date_expression": {
-                "type": "add_months",
-                "datatype": "datetime",
-                "date_expression": {
-                    "type": "property_name",
-                    "property_name": "server_modified_on"
-                },
-                "months_expression": {
-                    "type": "evaluator",
-                    "statement": from_statement,
-                    "context_variables": {
-                        "iteration": {
-                            "type": "base_iteration_number"
-                        }
-                    }
-                },
-            },
-            "to_date_expression": {
-                "type": "add_months",
-                "datatype": "datetime",
-                "date_expression": {
-                    "type": "property_name",
-                    "property_name": "server_modified_on"
-                },
-                "months_expression": {
-                    "type": "evaluator",
-                    "statement": to_statement,
-                    "context_variables": {
-                        "iteration": {
-                            "type": "base_iteration_number"
-                        }
-                    }
-                },
-            },
-        }
-
-        if xmlns:
-            spec['xmlns'] = [xmlns]
-
-        return ExpressionFactory.from_spec(spec)
-
-    def test_from_inside_date_range(self):
-        expression = self._make_expression('iteration - 1', 'iteration + 1')
-        context = EvaluationContext({"domain": self.domain}, 0)
-        forms = expression(self.case.to_json(), context)
-
-        self.assertEqual(len(forms), 1)
-        self.assertEqual(forms, self.forms)
-
-    def test_from_outside_date_range(self):
-        expression = self._make_expression('iteration - 2', 'iteration - 1')
-        context = EvaluationContext({"domain": self.domain}, 0)
-        forms = expression(self.case.to_json(), context)
-
-        self.assertEqual(forms, [])
-
-    def test_from_correct_xmlns(self):
-        expression = self._make_expression('iteration - 1', 'iteration + 1', 'http://commcarehq.org/case')
-        context = EvaluationContext({"domain": self.domain}, 0)
-        forms = expression(self.case.to_json(), context)
-
-        self.assertEqual(len(forms), 1)
-        self.assertEqual(forms, self.forms)
-
-    def test_from_incorrect_xmlns(self):
-        expression = self._make_expression('iteration - 1', 'iteration + 1', 'silly-xmlns')
-        context = EvaluationContext({"domain": self.domain}, 0)
-        forms = expression(self.case.to_json(), context)
-
-        self.assertEqual(forms, [])
-
-
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
-class TestFormsExpressionSpecWithFilterSQL(TestFormsExpressionSpecWithFilter):
     pass
 
 

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -1,4 +1,3 @@
-import hashlib
 from jsonobject.base_properties import DefaultProperty
 from casexml.apps.case.xform import extract_case_blocks
 from corehq.apps.es.forms import FormES
@@ -139,17 +138,9 @@ class FormsInDateExpressionSpec(JsonObject):
 
     def _get_forms(self, case_id, from_date, to_date, context):
         domain = context.root_doc['domain']
-        cache_hash = "{}".format(self.count)
-        if from_date:
-            cache_hash += "{}".format(from_date.toordinal())
-        if to_date:
-            cache_hash += "{}".format(to_date.toordinal())
-        if self.xmlns:
-            cache_hash += ''.join(self.xmlns)
+        cache_key = (self.__class__.__name__, case_id, self.count, from_date,
+                     to_date, tuple(self.xmlns))
 
-        cache_hash = hashlib.md5(cache_hash).hexdigest()[:4]
-
-        cache_key = (self.__class__.__name__, case_id, cache_hash)
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -988,6 +988,11 @@ def get_case_history_by_date(spec, context):
     else:
         case_id_expression = spec['case_id_expression']
 
+    case_history_spec = {
+        "type": "icds_get_case_history",
+        "case_id_expression": case_id_expression
+    }
+
     filters = []
     if spec['start_date'] is not None:
         start_date_filter = {
@@ -1026,18 +1031,14 @@ def get_case_history_by_date(spec, context):
     if spec['filter'] is not None:
         filters.append(spec['filter'])
 
-    spec = {
-        "type": "icds_get_case_history",
-        "case_id_expression": case_id_expression
-    }
     if len(filters) > 0:
-        spec = {
+        case_history_spec = {
             "filter_expression": {
                 "type": "and",
                 "filters": filters
             },
             "type": "filter_items",
-            "items_expression": spec
+            "items_expression": case_history_spec
         }
     spec = {
         'type': 'sort_items',
@@ -1046,7 +1047,7 @@ def get_case_history_by_date(spec, context):
             'type': 'property_name',
             'property_name': '@date_modified',
         },
-        "items_expression": spec
+        "items_expression": case_history_spec
     }
     return ExpressionFactory.from_spec(spec, context)
 

--- a/custom/icds_reports/ucr/tests/test_ccs_record_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_ccs_record_monthly.py
@@ -2,9 +2,10 @@ import uuid
 from datetime import datetime, date
 from xml.etree import ElementTree
 from django.test import override_settings
-from corehq.apps.receiverwrapper.util import submit_form_locally
+import mock
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseStructure, CaseIndex
+from corehq.apps.es.fake.forms_fake import FormESFake
 from corehq.apps.userreports.const import UCR_SQL_BACKEND
 from custom.icds_reports.ucr.tests.base_test import BaseICDSDatasourceTest, add_element
 
@@ -16,6 +17,7 @@ XMLNS_EBF_FORM = 'http://openrosa.org/formdesigner/89097FB1-6C08-48BA-95B2-67BCF
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 @override_settings(OVERRIDE_UCR_BACKEND=UCR_SQL_BACKEND)
+@mock.patch('custom.icds_reports.ucr.expressions.FormES', FormESFake)
 class TestCCSRecordDataSource(BaseICDSDatasourceTest):
     datasource_filename = 'ccs_record_cases_monthly_tableau'
 
@@ -137,7 +139,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
         add_element(fp_group, 'counsel_accessible_ppfp', counsel_accessible_postpartum_fp)
         form.append(fp_group)
 
-        submit_form_locally(ElementTree.tostring(form), self.domain, **{})
+        self._submit_form(form)
 
     def _submit_thr_rations_form(
             self, form_date, case_id, thr_given_mother='0', rations_distributed=0):
@@ -163,7 +165,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
             add_element(mother_thr, 'days_ration_given_mother', rations_distributed)
             form.append(mother_thr)
 
-        submit_form_locally(ElementTree.tostring(form), self.domain, **{})
+        self._submit_form(form)
 
     def _submit_pnc_form(self, form_date, case_id, counsel_methods='no'):
 
@@ -183,7 +185,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
 
         add_element(form, 'counsel_methods', counsel_methods)
 
-        submit_form_locally(ElementTree.tostring(form), self.domain, **{})
+        self._submit_form(form)
 
     def _submit_ebf_form(self, form_date, case_id, counsel_methods='no'):
 
@@ -203,7 +205,7 @@ class TestCCSRecordDataSource(BaseICDSDatasourceTest):
 
         add_element(form, 'counsel_methods', counsel_methods)
 
-        submit_form_locally(ElementTree.tostring(form), self.domain, **{})
+        self._submit_form(form)
 
     def test_open_in_month(self):
         case_id = uuid.uuid4().hex

--- a/custom/icds_reports/ucr/tests/test_child_health_monthly.py
+++ b/custom/icds_reports/ucr/tests/test_child_health_monthly.py
@@ -6,10 +6,9 @@ from dateutil.relativedelta import relativedelta
 from django.test import override_settings
 import mock
 
-from corehq.apps.es.fake.forms_fake import FormESFake
-from corehq.apps.receiverwrapper.util import submit_form_locally
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseStructure, CaseIndex
+from corehq.apps.es.fake.forms_fake import FormESFake
 from corehq.apps.userreports.const import UCR_SQL_BACKEND
 from custom.icds_reports.ucr.tests.base_test import BaseICDSDatasourceTest, add_element
 
@@ -34,10 +33,6 @@ NUTRITION_STATUS_SEVERE = "red"
 @mock.patch('custom.icds_reports.ucr.expressions.FormES', FormESFake)
 class TestChildHealthDataSource(BaseICDSDatasourceTest):
     datasource_filename = 'child_health_cases_monthly_tableau'
-
-    def tearDown(self):
-        FormESFake.reset_docs()
-        super(BaseICDSDatasourceTest, self).tearDown()
 
     def _create_case(
             self, case_id, dob,
@@ -158,10 +153,6 @@ class TestChildHealthDataSource(BaseICDSDatasourceTest):
         )
 
         self.casefactory.create_or_update_cases([child_task_case])
-
-    def _submit_form(self, form):
-        blah = submit_form_locally(ElementTree.tostring(form), self.domain, **{})
-        FormESFake.save_doc(blah.xform.to_json())
 
     def _submit_gmp_form(
             self, form_date, case_id, nutrition_status=None):

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -1,0 +1,114 @@
+import uuid
+from django.test import TestCase, override_settings
+import mock
+from casexml.apps.case.mock import CaseStructure, CaseFactory
+from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
+from corehq.apps.es.fake.forms_fake import FormESFake
+from corehq.apps.userreports.expressions.factory import ExpressionFactory
+from corehq.apps.userreports.specs import EvaluationContext
+from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+@mock.patch('custom.icds_reports.ucr.expressions.FormES', FormESFake)
+class TestFormsExpressionSpecWithFilter(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestFormsExpressionSpecWithFilter, cls).setUpClass()
+        cls.domain = uuid.uuid4().hex
+        factory = CaseFactory(domain=cls.domain)
+        [cls.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
+        cls.forms = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case.xform_ids)]
+        for form in cls.forms:
+            FormESFake.save_doc(form)
+        #  redundant case to create extra forms that shouldn't be in the results for cls.case
+        [cls.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
+        cls.forms_b = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case_b.xform_ids)]
+        for form in cls.forms_b:
+            FormESFake.save_doc(form)
+
+    @classmethod
+    def tearDownClass(cls):
+        FormESFake.reset_docs()
+        delete_all_xforms()
+        delete_all_cases()
+        super(TestFormsExpressionSpecWithFilter, cls).tearDownClass()
+
+    def _make_expression(self, from_statement, to_statement, xmlns=None):
+        spec = {
+            "type": "icds_get_case_forms_in_date",
+            "case_id_expression": {
+                "type": "property_name",
+                "property_name": "_id"
+            },
+            "from_date_expression": {
+                "type": "add_months",
+                "datatype": "datetime",
+                "date_expression": {
+                    "type": "property_name",
+                    "property_name": "server_modified_on"
+                },
+                "months_expression": {
+                    "type": "evaluator",
+                    "statement": from_statement,
+                    "context_variables": {
+                        "iteration": {
+                            "type": "base_iteration_number"
+                        }
+                    }
+                },
+            },
+            "to_date_expression": {
+                "type": "add_months",
+                "datatype": "datetime",
+                "date_expression": {
+                    "type": "property_name",
+                    "property_name": "server_modified_on"
+                },
+                "months_expression": {
+                    "type": "evaluator",
+                    "statement": to_statement,
+                    "context_variables": {
+                        "iteration": {
+                            "type": "base_iteration_number"
+                        }
+                    }
+                },
+            },
+        }
+
+        if xmlns:
+            spec['xmlns'] = [xmlns]
+
+        return ExpressionFactory.from_spec(spec)
+
+    def test_from_inside_date_range(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+    def test_from_outside_date_range(self):
+        expression = self._make_expression('iteration - 2', 'iteration - 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(forms, [])
+
+    def test_from_correct_xmlns(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1', 'http://commcarehq.org/case')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+    def test_from_incorrect_xmlns(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1', 'silly-xmlns')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(forms, [])

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -35,7 +35,7 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         delete_all_cases()
         super(TestFormsExpressionSpecWithFilter, cls).tearDownClass()
 
-    def _make_expression(self, from_statement, to_statement, xmlns=None):
+    def _make_expression(self, from_statement, to_statement, xmlns=None, count=False):
         spec = {
             "type": "icds_get_case_forms_in_date",
             "case_id_expression": {
@@ -81,6 +81,8 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         if xmlns:
             spec['xmlns'] = [xmlns]
 
+        spec['count'] = count
+
         return ExpressionFactory.from_spec(spec)
 
     def test_from_inside_date_range(self):
@@ -112,3 +114,17 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         forms = expression(self.case.to_json(), context)
 
         self.assertEqual(forms, [])
+
+    def test_count_correct_xmlns(self):
+        expression = self._make_expression(
+            'iteration - 1', 'iteration + 1', 'http://commcarehq.org/case', count=True
+        )
+        context = EvaluationContext({"domain": self.domain}, 0)
+        count = expression(self.case.to_json(), context)
+        self.assertEqual(count, 1)
+
+    def test_count_incorrect_xmlns(self):
+        expression = self._make_expression('iteration - 1', 'iteration + 1', 'silly-xmlns', count=True)
+        context = EvaluationContext({"domain": self.domain}, 0)
+        count = expression(self.case.to_json(), context)
+        self.assertEqual(count, 0)

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -35,14 +35,17 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         delete_all_cases()
         super(TestFormsExpressionSpecWithFilter, cls).tearDownClass()
 
-    def _make_expression(self, from_statement, to_statement, xmlns=None, count=False):
+    def _make_expression(self, from_statement=None, to_statement=None, xmlns=None, count=False):
         spec = {
             "type": "icds_get_case_forms_in_date",
             "case_id_expression": {
                 "type": "property_name",
                 "property_name": "_id"
             },
-            "from_date_expression": {
+        }
+
+        if from_statement:
+            spec["from_date_expression"] = {
                 "type": "add_months",
                 "datatype": "datetime",
                 "date_expression": {
@@ -58,8 +61,10 @@ class TestFormsExpressionSpecWithFilter(TestCase):
                         }
                     }
                 },
-            },
-            "to_date_expression": {
+            }
+
+        if to_statement:
+            spec["to_date_expression"] = {
                 "type": "add_months",
                 "datatype": "datetime",
                 "date_expression": {
@@ -75,8 +80,7 @@ class TestFormsExpressionSpecWithFilter(TestCase):
                         }
                     }
                 },
-            },
-        }
+            }
 
         if xmlns:
             spec['xmlns'] = [xmlns]
@@ -128,3 +132,33 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         context = EvaluationContext({"domain": self.domain}, 0)
         count = expression(self.case.to_json(), context)
         self.assertEqual(count, 0)
+
+    def test_no_from_statement(self):
+        expression = self._make_expression(to_statement='iteration + 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+        expression = self._make_expression(to_statement='iteration - 3')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 0)
+        self.assertEqual(forms, [])
+
+    def test_no_to_statement(self):
+        expression = self._make_expression(from_statement='iteration - 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms, self.forms)
+
+        expression = self._make_expression(from_statement='iteration + 3')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression(self.case.to_json(), context)
+
+        self.assertEqual(len(forms), 0)
+        self.assertEqual(forms, [])


### PR DESCRIPTION
@NoahCarnahan @sheelio 

You can check out how I structured this in the test in this commit https://github.com/dimagi/commcare-hq/commit/00e58ee02d9e94960c6ce76348951a0eedf71520

@sheelio I think it's important to note that ES isn't our primary DB, which means it is usually up to date, but likely shouldn't be trusted to be 100%. In practice I think this will sometimes give you an off-by-one on your forms where the latest form for the case is not yet in ES. I"m not sure if that's acceptable for your UCRs though

:blowfish: 

buddy @sravfeyn 