### PR TITLE
Paginate exports

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -89,8 +89,10 @@ class _Writer(object):
                         )
                     table_titles[table] = sheet_name
             self.writer.open(headers, file, table_titles=table_titles, archive_basepath=name)
-            yield
-            self.writer.close()
+            try:
+                yield
+            finally:
+                self.writer.close()
 
     def write(self, table, row):
         """
@@ -146,8 +148,10 @@ class _PaginatedWriter(object):
                 table_titles=self._get_paginated_table_titles(),
                 archive_basepath=self.name
             )
-            yield
-            self.writer.close()
+            try:
+                yield
+            finally:
+                self.writer.close()
 
     def _get_name(self, export_instances):
         if len(export_instances) == 1:

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -5,12 +5,14 @@ import tempfile
 import datetime
 
 from couchdbkit import ResourceConflict
+from collections import Counter
 
 from soil import DownloadBase
 
 from couchexport.export import FormattedRow, get_writer
 from couchexport.files import Temp
 from couchexport.models import Format
+from corehq.toggles import PAGINATED_EXPORTS
 from corehq.util.files import safe_filename
 from corehq.apps.export.esaccessors import (
     get_form_export_base_query,
@@ -22,6 +24,7 @@ from corehq.apps.export.models.new import (
     FormExportInstance,
     SMSExportInstance,
 )
+from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
 
 
 class ExportFile(object):
@@ -109,6 +112,164 @@ class _Writer(object):
         return self._path
 
 
+class _PaginatedWriter(object):
+
+    def __init__(self, writer, page_length=None):
+        self.format = writer.format
+        self._path = None
+        self.page_length = page_length or MAX_EXPORTABLE_ROWS
+        self.pages = Counter()
+        self.rows_written = Counter()
+        # An instance of a couchexport.ExportWriter
+        self.writer = writer
+        self.file_handle = None
+
+    @contextlib.contextmanager
+    def open(self, export_instances):
+        """
+        Open the _PaginatedWriter for writing. This must be called before using _PaginatedWriter.write().
+        A _PaginatedWriter can only be opened once.
+        """
+
+        assert self._path is None
+
+        self.name = self._get_name(export_instances)
+        self.headers = self._get_headers(export_instances)
+        self.table_names = self._get_table_names(export_instances)
+
+        # Create and open a temp file
+        fd, self._path = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as file_handle:
+            self.writer.open(
+                self._get_paginated_headers().iteritems(),
+                file_handle,
+                table_titles=self._get_paginated_table_titles(),
+                archive_basepath=self.name
+            )
+            yield
+            self.writer.close()
+
+    def _get_name(self, export_instances):
+        if len(export_instances) == 1:
+            name = export_instances[0].name or 'Export'
+        else:
+            name = 'BulkExport'
+        return safe_filename(name)
+
+    def _get_headers(self, export_instances):
+        '''
+        Returns a dictionary that maps all TableConfigurations in the list of ExportInstances to an
+        array of headers
+        {
+            TableConfiguration(): ['Column1', 'Column2']
+            ...
+        }
+
+        :export_instances: - A list of ExportInstances
+        '''
+        headers = {}
+        for instance_index, instance in enumerate(export_instances):
+            for table in instance.selected_tables:
+                headers[table] = table.get_headers(
+                    split_columns=instance.split_multiselects
+                )
+
+        return headers
+
+    def _get_table_names(self, export_instances):
+        '''
+        Returns a dictionary that maps all TableConfigurations in the list of ExportInstances to a
+        table name. If the table name is a duplicate from another ExportInstance, it will automatically
+        prefix the table name with the export name to prevent duplicate table names.
+
+        {
+            TableConfiguration(): 'Table Name'
+        }
+        '''
+        table_names = {}
+        for instance_index, instance in enumerate(export_instances):
+            for table_index, table in enumerate(instance.selected_tables):
+                table_name = table.label or "Sheet{}".format(table_index + 1)
+                if len(export_instances) > 1:
+                    table_name = u"{}-{}".format(
+                        instance.name or "Export{}".format(instance_index + 1),
+                        table_name
+                    )
+                table_names[table] = table_name
+        return table_names
+
+    def _paged_table_index(self, table):
+        '''
+        Returns an index of the paged table. Relies on the internal state of self.pages
+        ((PathNode(), PathNode()), 3)
+        '''
+        return (tuple(table.path), self.pages[table])
+
+    def _get_paginated_headers(self):
+        '''
+        Maps the headers in self.headers to
+        1) Match the data structure that couchexport.writers.ExportWriter expects
+        2) Map the key in the headers dictionary to the paged table index
+
+        {
+            TableConfiguration(): ['Column1', 'Column2']
+        }
+
+        Becomes
+
+        {
+            (<table.path>, <page>): (['Column1', 'Column2'],)
+        }
+        '''
+        return {self._paged_table_index(table): (headers,) for table, headers in self.headers.iteritems()}
+
+    def _get_paginated_table_titles(self):
+        '''
+        Maps the table titles to tables titles with their page count
+
+        {
+            TableConfiguration(): 'Table Name'
+        }
+
+        Becomes
+        {
+            (<table.path>, <page>: 'Table Name_<page>'
+        }
+        '''
+        paginated_table_titles = {}
+        for table, table_name in self.table_names.iteritems():
+            paginated_table_titles[self._paged_table_index(table)] = '{}_{}'.format(
+                table_name, format(self.pages[table], '03')
+            )
+        return paginated_table_titles
+
+    def write(self, table, row):
+        """
+        Write the given row to the given table of the export.
+        Will automatically open a new table and write to that if it
+        has exceeded the number of rows written in the first table.
+        :param table: A TableConfiguration
+        :param row: An ExportRow
+        """
+        if self.rows_written[table] >= self.page_length * (self.pages[table] + 1):
+            self.pages[table] += 1
+            self.writer.add_table(
+                self._paged_table_index(table),
+                self._get_paginated_headers()[self._paged_table_index(table)][0],
+                table_title=self._get_paginated_table_titles()[self._paged_table_index(table)],
+            )
+
+        self.writer.write([(self._paged_table_index(table), [FormattedRow(data=row.data)])])
+        self.rows_written[table] += 1
+
+    @property
+    def path(self):
+        """
+        The path to the file that this object writes to.
+        """
+        return self._path
+
+
 def _get_writer(export_instances):
     """
     Return a new _Writer
@@ -118,7 +279,10 @@ def _get_writer(export_instances):
         format = export_instances[0].export_format
 
     legacy_writer = get_writer(format)
-    writer = _Writer(legacy_writer)
+    if PAGINATED_EXPORTS.enabled(export_instances[0].domain):
+        writer = _PaginatedWriter(legacy_writer)
+    else:
+        writer = _Writer(legacy_writer)
     return writer
 
 

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -46,7 +46,7 @@ from corehq.apps.export.tests.util import (
 from corehq.elastic import send_to_elasticsearch, get_es_new
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
-from corehq.util.test_utils import trap_extra_setup
+from corehq.util.test_utils import trap_extra_setup, flag_enabled
 from couchexport.export import get_writer
 from couchexport.models import Format
 from couchexport.transforms import couch_to_excel_datetime
@@ -127,6 +127,53 @@ class WriterTest(SimpleTestCase):
                         u'headers': [u'Q3', u'Q1'],
                         u'rows': [[u'baz', u'foo'], [u'bop', u'bip']],
 
+                    }
+                }
+            )
+
+    @patch('corehq.apps.export.export.MAX_EXPORTABLE_ROWS', 2)
+    @flag_enabled('PAGINATED_EXPORTS')
+    def test_paginated_table(self):
+        export_instance = FormExportInstance(
+            export_format=Format.JSON,
+            tables=[
+                TableConfiguration(
+                    label="My table",
+                    selected=True,
+                    columns=[
+                        ExportColumn(
+                            label="Q3",
+                            item=ScalarItem(
+                                path=[PathNode(name='form'), PathNode(name='q3')],
+                            ),
+                            selected=True
+                        ),
+                        ExportColumn(
+                            label="Q1",
+                            item=ScalarItem(
+                                path=[PathNode(name='form'), PathNode(name='q1')],
+                            ),
+                            selected=True
+                        ),
+                    ]
+                )
+            ]
+        )
+        writer = _get_writer([export_instance])
+        with writer.open([export_instance]):
+            _write_export_instance(writer, export_instance, self.docs + self.docs)
+
+        with ExportFile(writer.path, writer.format) as export:
+            self.assertEqual(
+                json.loads(export.read()),
+                {
+                    u'My table_000': {
+                        u'headers': [u'Q3', u'Q1'],
+                        u'rows': [[u'baz', u'foo'], [u'bop', u'bip']],
+                    },
+                    u'My table_001': {
+                        u'headers': [u'Q3', u'Q1'],
+                        u'rows': [[u'baz', u'foo'], [u'bop', u'bip']],
                     }
                 }
             )

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -10,7 +10,7 @@ from django.template.defaultfilters import filesizeformat
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
-from corehq.toggles import MESSAGE_LOG_METADATA
+from corehq.toggles import MESSAGE_LOG_METADATA, PAGINATED_EXPORTS
 from corehq.apps.export.export import get_export_download, get_export_size
 from corehq.apps.export.models.new import DatePeriod, DailySavedExportNotification
 from corehq.apps.locations.models import SQLLocation
@@ -2200,7 +2200,7 @@ class GenericDownloadNewExportMixin(object):
         count = 0
         for instance in export_instances:
             count += get_export_size(instance, filters)
-        if count > MAX_EXPORTABLE_ROWS:
+        if count > MAX_EXPORTABLE_ROWS and not PAGINATED_EXPORTS.enabled(self.domain):
             raise ExportAsyncException(
                 _("This export contains %(row_count)s rows. Please change the "
                   "filters to be less than %(max_rows)s rows.") % {

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1037,6 +1037,13 @@ COUCH_SQL_MIGRATION_BLACKLIST = StaticToggle(
     }
 )
 
+PAGINATED_EXPORTS = StaticToggle(
+    'paginated_exports',
+    'Allows for pagination of exports for very large exports',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_DOMAIN]
+)
+
 SHOW_DEV_TOGGLE_INFO = StaticToggle(
     'highlight_feature_flags',
     'Highlight / Mark Feature Flags in the UI',


### PR DESCRIPTION
@NoahCarnahan this is the beginnings of paginating exports. This currently just creates a drop in replacement for `_Writer` that automatically pages export files. There are some other tasks that need to be tackled but will be done in different PRs to keep things small.

This is what it ends up looking like, it keeps the current row number too:
<img width="585" alt="screen shot 2017-03-24 at 9 10 20 pm" src="https://cloud.githubusercontent.com/assets/918514/24316908/094407d8-10c0-11e7-8cc2-93918c4db579.png">

cc: @millerdev 

