### PR TITLE
reduce usages of generator.instantiate_accounting()

### DIFF
--- a/corehq/apps/accounting/bootstrap/config/enterprise.py
+++ b/corehq/apps/accounting/bootstrap/config/enterprise.py
@@ -1,0 +1,18 @@
+from decimal import Decimal
+
+from corehq.apps.accounting.models import (
+    FeatureType,
+    SoftwarePlanEdition,
+    UNLIMITED_FEATURE_USAGE,
+)
+
+BOOTSTRAP_CONFIG = {
+    (SoftwarePlanEdition.ENTERPRISE, False, False): {
+        'role': 'enterprise_plan_v0',
+        'product_rate': dict(monthly_fee=Decimal('0.00')),
+        'feature_rates': {
+            FeatureType.USER: dict(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
+            FeatureType.SMS: dict(monthly_limit=UNLIMITED_FEATURE_USAGE),
+        }
+    },
+}

--- a/corehq/apps/accounting/migrations/0001_squashed_0052_ensure_report_builder_plans.py
+++ b/corehq/apps/accounting/migrations/0001_squashed_0052_ensure_report_builder_plans.py
@@ -9,6 +9,7 @@ import django.db.models.deletion
 
 import jsonfield.fields
 
+from corehq.apps.accounting.bootstrap.config.enterprise import BOOTSTRAP_CONFIG as enterprise_config
 from corehq.apps.accounting.bootstrap.config.report_builder_v0 import BOOTSTRAP_CONFIG as report_builder_config
 from corehq.apps.accounting.bootstrap.config.resellers_and_managed_hosting import BOOTSTRAP_CONFIG as resellers_config
 from corehq.apps.accounting.bootstrap.config.user_buckets_jan_2017 import BOOTSTRAP_CONFIG as self_service_config
@@ -20,6 +21,7 @@ import corehq.util.mixin
 
 def _cchq_software_plan_bootstrap(apps, schema_editor):
     pricing_config = self_service_config
+    pricing_config.update(enterprise_config)
     pricing_config.update(report_builder_config)
     pricing_config.update(resellers_config)
     ensure_plans(pricing_config, verbose=True, apps=apps)

--- a/corehq/apps/accounting/tests/base_tests.py
+++ b/corehq/apps/accounting/tests/base_tests.py
@@ -11,4 +11,3 @@ class BaseAccountingTest(TestCase):
     def setUpClass(cls):
         super(BaseAccountingTest, cls).setUpClass()
         Role.get_cache().clear()
-        generator.instantiate_accounting()

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -15,6 +15,11 @@ from corehq.util.dates import get_previous_month_date_range
 
 class TestDomainInvoiceFactory(BaseAccountingTest):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestDomainInvoiceFactory, cls).setUpClass()
+        generator.instantiate_accounting()
+
     def setUp(self):
         super(TestDomainInvoiceFactory, self).setUp()
         self.invoice_start, self.invoice_end = get_previous_month_date_range()

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -41,6 +41,7 @@ class BaseInvoiceTestCase(BaseAccountingTest):
     @classmethod
     def setUpClass(cls):
         super(BaseInvoiceTestCase, cls).setUpClass()
+        generator.instantiate_accounting()  # TODO - only call for subclasses that actually need the test plans
         cls.billing_contact = generator.create_arbitrary_web_user_name()
         cls.dimagi_user = generator.create_arbitrary_web_user_name(is_dimagi=True)
         cls.currency = generator.init_default_currency()

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -5,7 +5,6 @@ from datetime import date, timedelta
 
 from django.test import TestCase
 
-from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.models import (
     BillingAccount,
     DefaultProductPlan,
@@ -28,11 +27,6 @@ class TestExplicitCommunitySubscriptions(TestCase):
         cls.domain = Domain(name=str(uuid.uuid4()))
         cls.domain.save()
         cls.from_date = date.today()
-
-    def setUp(self):
-        super(TestExplicitCommunitySubscriptions, self).setUp()
-        generator.instantiate_accounting()
-        assert Subscription.objects.count() == 0
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/apps/analytics/tests/test_subscription_properties.py
+++ b/corehq/apps/analytics/tests/test_subscription_properties.py
@@ -11,7 +11,6 @@ from corehq.apps.accounting.models import (
     ProBonoStatus,
     SubscriptionType
 )
-from corehq.apps.accounting.tests import generator
 from corehq.apps.analytics.signals import get_subscription_properties_by_user
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser
@@ -22,7 +21,6 @@ class TestSubscriptionProperties(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestSubscriptionProperties, cls).setUpClass()
-        generator.instantiate_accounting()
 
         cls.base_domain = Domain(name="base", is_active=True)
         cls.base_domain.save()


### PR DESCRIPTION
Don't call ```generator.instantiate_accounting()``` if a test can just use the default plans provided by the accounting setup migration.