### PR TITLE
adding retry

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -12,7 +12,7 @@ def create_user_cases(domain_name):
         sync_usercase(user)
 
 
-@serial_task('{app._id}', max_retries=0, timeout=60*60)
+@serial_task('{app._id}', max_retries=30, default_retry_delay=120, timeout=60*60)
 def make_async_build(app):
     latest_build = app.get_latest_app(released_only=False)
     if latest_build.version == app.version:

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -12,7 +12,7 @@ def create_user_cases(domain_name):
         sync_usercase(user)
 
 
-@serial_task('{app._id}', max_retries=30, default_retry_delay=120, timeout=60*60)
+@serial_task('{app._id}-{app.version}', max_retries=0, timeout=60*60)
 def make_async_build(app):
     latest_build = app.get_latest_app(released_only=False)
     if latest_build.version == app.version:


### PR DESCRIPTION
@biyeun
This makes async builds (those triggered by updating the phone to the latest saved version of an app), retry if an older build is ongoing. I picked some relatively arbitrary numbers for retries and delay, but wanted to make sure the total time spent retrying was as long as the timeout for the lock.

cc: @amstone326 FYI