### PR TITLE
bump refresh_interval

### DIFF
--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -17,7 +17,7 @@ INDEX_REINDEX_SETTINGS = {
 
 INDEX_STANDARD_SETTINGS = {
     "index": {
-        "refresh_interval": "1s",
+        "refresh_interval": "5s",
         "merge.policy.merge_factor": 10,
         "store.throttle.max_bytes_per_sec": "5mb",
         "store.throttle.type": "node",


### PR DESCRIPTION
@emord @snopoke Updated here, this I believe won't get run unless we do a reindex (https://github.com/dimagi/commcare-hq/blob/br/refresh-interval/corehq/apps/hqcase/management/commands/ptop_preindex.py#L95). However, I've already updated the refresh_interval using the command line. I opted to not change the max_bytes_per_sec in order to isolate changes. We should really be doing some sort of performance benchmarking, but we aren't that close to having that setup. Instead I'm just going to rely on our monitoring and see what effect these changes have. I still think this isn't a bad setting to have for all indices. I don't think we care that much about a slightly longer delay in things showing up in ES, but feel free to push back

cc: @millerdev 