### PR TITLE
[eNikshay] Store device ID

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -56,6 +56,11 @@ def restore(request, domain, app_id=None):
     """
     couch_user = CouchUser.from_django_user_include_anonymous(domain, request.user)
     assert couch_user is not None, 'No couch user to use for restore'
+    device_id = request.GET.get('device_id')
+    if device_id and isinstance(couch_user, CommCareUser):
+        if not couch_user.is_demo_user:
+            couch_user.update_device_id_last_used(device_id)
+            couch_user.save()
     response, _ = get_restore_response(domain, couch_user, app_id, **get_restore_params(request))
     return response
 

--- a/custom/enikshay/tests/test_user_setup.py
+++ b/custom/enikshay/tests/test_user_setup.py
@@ -1,4 +1,5 @@
 import mock
+from datetime import datetime
 from django.test import TestCase, override_settings
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.custom_data_fields import CustomDataFieldsDefinition, CustomDataEditor
@@ -243,3 +244,16 @@ class TestUserSetupUtils(TestCase):
         # the next id should be 1 more than this ID
         arys = self.make_user('aoakheart@kingsguard.gov', 'DTO')
         self.assertTrue(areo_number + 1 == arys.user_data['id_issuer_number'])
+
+    def test_device_id(self):
+        user = self.make_user('redviper@martell.biz', 'DTO')
+        user.update_device_id_last_used('rotary', datetime(1984, 1, 1))
+        user.update_device_id_last_used('palm-pilot', datetime(1997, 1, 1))
+        user.update_device_id_last_used('blackberry', datetime(2008, 1, 1))
+        user.save()
+        self.assertEqual(user.user_data['id_device_number'], 3)
+
+        # Oberyn uses the palm-pilot again, which was device #2
+        user.update_device_id_last_used('palm-pilot', datetime(2017, 1, 1))
+        user.save()
+        self.assertEqual(user.user_data['id_device_number'], 2)


### PR DESCRIPTION
eNikshay wants some information about the current device available to the app as part of `user.user_data`.  The method `update_device_id_last_used` provides the necessary information for that to get updated, however, that's only called in `fetch_key_records` at the moment.

https://github.com/dimagi/commcare-hq/commit/71e699ec90594adb6199780f58c0368d166bf361 has changes to `corehq/apps/ota/views.py` that I'm unsure of.
@kaapstorm do you know why that is?  Is it correct to also update `user.devices` when users restore?
@snopoke pinging for suggestions on where this logic belongs, or a place to inject something custom if it doesn't.

@nickpell code buddy
