### PR TITLE
remove generator.instantiate_accounting() from more tests

### DIFF
--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -36,7 +36,6 @@ from corehq.apps.accounting.models import (
     Subscription,
     SubscriptionAdjustment
 )
-from corehq.apps.accounting.tests import generator
 from corehq.apps.api.es import ElasticAPIQuerySet
 from corehq.apps.api.fields import ToManyDocumentsField, ToOneDocumentField, UseIfRequested, ToManyDictField
 from corehq.apps.api.resources import v0_4, v0_5
@@ -119,7 +118,6 @@ class APIResourceTest(TestCase):
         super(APIResourceTest, cls).setUpClass()
 
         Role.get_cache().clear()
-        generator.instantiate_accounting()
         cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
         cls.list_endpoint = cls._get_list_endpoint()
         cls.username = 'rudolph@qwerty.commcarehq.org'
@@ -1501,7 +1499,6 @@ class TestBulkUserAPI(APIResourceTest):
     @classmethod
     def setUpClass(cls):
         Role.get_cache().clear()
-        generator.instantiate_accounting()
         cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
         cls.username = 'rudolph@qwerty.commcarehq.org'
         cls.password = '***'

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -18,7 +18,6 @@ from corehq.apps.accounting.models import (
     Subscription,
     SubscriptionManager,
 )
-from corehq.apps.accounting.tests import generator
 from corehq.apps.domain.models import Domain
 from corehq.apps.ivr.models import Call
 from corehq.apps.locations.models import Location, LocationType, SQLLocation
@@ -97,7 +96,6 @@ class TestDeleteDomain(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestDeleteDomain, cls).setUpClass()
-        generator.instantiate_accounting()
 
     def setUp(self):
         super(TestDeleteDomain, self).setUp()

--- a/corehq/apps/sms/tests/test_registration.py
+++ b/corehq/apps/sms/tests/test_registration.py
@@ -2,7 +2,6 @@ import base64
 import json
 from corehq.apps.accounting.models import (BillingAccount, DefaultProductPlan,
     SoftwarePlanEdition, SubscriptionAdjustment, Subscription)
-from corehq.apps.accounting.tests import generator
 from corehq.apps.domain.calculations import num_mobile_users
 from corehq.apps.domain.models import Domain
 from corehq.apps.sms.api import incoming
@@ -383,7 +382,6 @@ class RegistrationAPITestCase(TestCase):
     def setUpClass(cls):
         super(RegistrationAPITestCase, cls).setUpClass()
         Role.get_cache().clear()
-        generator.instantiate_accounting()
 
         cls.domain1, cls.account1, cls.subscription1 = cls.setup_domain('reg-api-test-1')
         cls.domain2, cls.account2, cls.subscription2 = cls.setup_domain('reg-api-test-2')

--- a/corehq/apps/zapier/tests.py
+++ b/corehq/apps/zapier/tests.py
@@ -20,7 +20,6 @@ from corehq.apps.zapier.views import SubscribeView, UnsubscribeView, ZapierCreat
 from corehq.apps.zapier.api.v0_5 import ZapierCustomFieldCaseResource
 from corehq.apps.zapier.models import ZapierSubscription
 
-from corehq.apps.accounting.tests import generator
 from corehq.apps.zapier.util import remove_advanced_fields
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
@@ -93,7 +92,6 @@ class TestZapierIntegration(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestZapierIntegration, cls).setUpClass()
-        generator.instantiate_accounting()
 
         cls.domain_object = Domain.get_or_create_with_name(TEST_DOMAIN, is_active=True)
         cls.domain = cls.domain_object.name
@@ -405,7 +403,6 @@ class TestZapierCreateCaseAction(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestZapierCreateCaseAction, cls).setUpClass()
-        generator.instantiate_accounting()
         cls.domain_object = Domain.get_or_create_with_name('fruit', is_active=True)
         cls.domain = cls.domain_object.name
         account = BillingAccount.get_or_create_account_by_domain(cls.domain, created_by="automated-test")[0]

--- a/custom/ewsghana/utils.py
+++ b/custom/ewsghana/utils.py
@@ -11,7 +11,6 @@ from django.db.models.query_utils import Q
 from django.utils import html
 
 from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, SoftwarePlanEdition, Subscription
-from corehq.apps.accounting.tests import generator
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import SQLLocation, LocationType, Location
@@ -143,7 +142,6 @@ def prepare_domain(domain_name):
     _make_loc_type(name="Polyclinic", parent_type=district)
     _make_loc_type(name="facility", parent_type=district)
 
-    generator.instantiate_accounting()
     account = BillingAccount.get_or_create_account_by_domain(
         domain.name,
         created_by="automated-test",

--- a/custom/ilsgateway/tests/handlers/utils.py
+++ b/custom/ilsgateway/tests/handlers/utils.py
@@ -1,5 +1,4 @@
 from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, SoftwarePlanEdition, Subscription
-from corehq.apps.accounting.tests import generator
 from corehq.apps.commtrack.models import CommtrackActionConfig
 from corehq.apps.custom_data_fields import CustomDataFieldsDefinition
 from corehq.apps.custom_data_fields.models import CustomDataField
@@ -159,7 +158,6 @@ def prepare_domain(domain_name):
             administrative=administrative,
         )
 
-    generator.instantiate_accounting()
     account = BillingAccount.get_or_create_account_by_domain(
         domain.name,
         created_by="automated-test",


### PR DESCRIPTION
removes all uses outside of accounting tests, where this is needed for creating the "test" plans which have lower user/SMS thresholds.