### PR TITLE
Increase shards

### DIFF
--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -7,7 +7,7 @@ from pillowtop.logger import pillow_logging
 
 INDEX_REINDEX_SETTINGS = {
     "index": {
-        "refresh_interval": "900s",
+        "refresh_interval": "1800s",
         "merge.policy.merge_factor": 20,
         "store.throttle.max_bytes_per_sec": "1mb",
         "store.throttle.type": "merge",

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -40,6 +40,9 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
     def meta(self):
         meta_settings = deepcopy(settings.ES_META['default'])
         meta_settings.update(
+            settings.ES_META.get(self.alias, {})
+        )
+        meta_settings.update(
             settings.ES_META.get(settings.SERVER_ENVIRONMENT, {}).get(self.alias, {})
         )
         return meta_settings
@@ -68,7 +71,6 @@ def set_index_normal_settings(es, index):
 
 
 def create_index_and_set_settings_normal(es, index, metadata=None):
-    print index_info.meta
     metadata = metadata or {}
     es.indices.create(index=index, body=metadata)
     set_index_normal_settings(es, index)

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -44,6 +44,10 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
         )
         return meta_settings
 
+    def to_json(self):
+        json = super(ElasticsearchIndexInfo, self).to_json()
+        json['meta'] = self.meta
+        return json
 
 def update_settings(es, index, settings_dict):
     return es.indices.put_settings(settings_dict, index=index)
@@ -64,6 +68,7 @@ def set_index_normal_settings(es, index):
 
 
 def create_index_and_set_settings_normal(es, index, metadata=None):
+    print index_info.meta
     metadata = metadata or {}
     es.indices.create(index=index, body=metadata)
     set_index_normal_settings(es, index)

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -1,5 +1,6 @@
 from dimagi.ext import jsonobject
-from copy import copy
+from django.conf import settings
+from copy import copy, deepcopy
 from datetime import datetime
 from elasticsearch import TransportError
 from pillowtop import get_all_pillow_classes
@@ -30,11 +31,18 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
     index = jsonobject.StringProperty(required=True)
     alias = jsonobject.StringProperty()
     type = jsonobject.StringProperty()
-    meta = jsonobject.DictProperty()
     mapping = jsonobject.DictProperty()
 
     def __unicode__(self):
         return u'{} ({})'.format(self.alias, self.index)
+
+    @property
+    def meta(self):
+        meta_settings = deepcopy(settings.ES_META['default'])
+        meta_settings.update(
+            settings.ES_META.get(settings.SERVER_ENVIRONMENT, {}).get(self.alias, {})
+        )
+        return meta_settings
 
 
 def update_settings(es, index, settings_dict):

--- a/corehq/ex-submodules/pillowtop/tests/utils.py
+++ b/corehq/ex-submodules/pillowtop/tests/utils.py
@@ -5,19 +5,6 @@ from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.es_utils import ElasticsearchIndexInfo
 from pillowtop.pillow.interface import ConstructedPillow
 
-TEST_ES_META = {
-    "settings": {
-        "analysis": {
-            "analyzer": {
-                "default": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": ["lowercase"]
-                },
-            }
-        }
-    }
-}
 
 TEST_ES_MAPPING = {
     '_meta': {
@@ -38,7 +25,6 @@ TEST_INDEX_INFO = ElasticsearchIndexInfo(
     index=TEST_ES_INDEX,
     alias=TEST_ES_ALIAS,
     type=TEST_ES_TYPE,
-    meta=TEST_ES_META,
     mapping=TEST_ES_MAPPING
 )
 

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -1,22 +1,4 @@
 VALUE_TAG = '#value'
-DEFAULT_META = {
-    "settings": {
-        "analysis": {
-            "analyzer": {
-                "default": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": ["lowercase"]
-                },
-                "sortable_exact": {
-                    "type": "custom",
-                    "tokenizer": "keyword",
-                    "filter": ["lowercase"]
-                }
-            }
-        }
-    }
-}
 
 
 def map_types(item, mapping, override_root_keys=None):

--- a/corehq/pillows/mappings/app_mapping.py
+++ b/corehq/pillows/mappings/app_mapping.py
@@ -324,23 +324,10 @@ APP_MAPPING={'_meta': {'created': None},
 
 APP_ES_ALIAS = "hqapps"
 APP_ES_TYPE = "app"
-APP_ES_META = {
-    "settings": {
-        "analysis": {
-            "analyzer": {
-                "default": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": ["lowercase"]
-                },
-            }
-        }
-    }
-}
+# TODO has changed
 APP_INDEX_INFO = ElasticsearchIndexInfo(
     index=APP_INDEX,
     alias=APP_ES_ALIAS,
     type=APP_ES_TYPE,
-    meta=APP_ES_META,
     mapping=APP_MAPPING
 )

--- a/corehq/pillows/mappings/app_mapping.py
+++ b/corehq/pillows/mappings/app_mapping.py
@@ -324,7 +324,6 @@ APP_MAPPING={'_meta': {'created': None},
 
 APP_ES_ALIAS = "hqapps"
 APP_ES_TYPE = "app"
-# TODO has changed
 APP_INDEX_INFO = ElasticsearchIndexInfo(
     index=APP_INDEX,
     alias=APP_ES_ALIAS,

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -1,10 +1,11 @@
+from copy import deepcopy
 from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
-CASE_INDEX = es_index("hqcases_2016-03-04")
+CASE_INDEX = es_index("hqcases_2017-03-28")
 CASE_ES_TYPE = 'case'
 
 CASE_MAPPING = {
@@ -104,10 +105,17 @@ CASE_MAPPING = {
 
 CASE_ES_ALIAS = "hqcases"
 
+CASE_INDEX_META = deepcopy(DEFAULT_META)
+CASE_INDEX_META.update({
+    'settings': {
+        'number_of_shards': 10,
+    },
+})
+
 CASE_INDEX_INFO = ElasticsearchIndexInfo(
     index=CASE_INDEX,
     alias=CASE_ES_ALIAS,
     type=CASE_ES_TYPE,
-    meta=DEFAULT_META,
+    meta=CASE_INDEX_META,
     mapping=CASE_MAPPING
 )

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from django.conf import settings
-from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
@@ -106,19 +105,9 @@ CASE_MAPPING = {
 
 CASE_ES_ALIAS = "hqcases"
 
-CASE_INDEX_META = deepcopy(DEFAULT_META)
-
-if settings.SERVER_ENVIRONMENT == 'production':
-    CASE_INDEX_META.update({
-        'settings': {
-            'number_of_shards': 10,
-        },
-    })
-
 CASE_INDEX_INFO = ElasticsearchIndexInfo(
     index=CASE_INDEX,
     alias=CASE_ES_ALIAS,
     type=CASE_ES_TYPE,
-    meta=CASE_INDEX_META,
     mapping=CASE_MAPPING
 )

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-from django.conf import settings
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -3,7 +3,7 @@ from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
-CASE_INDEX = es_index("hqcases_2017-03-28")
+CASE_INDEX = es_index("hqcases_2016-03-04")
 CASE_ES_TYPE = 'case'
 
 CASE_MAPPING = {

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from django.conf import settings
 from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
 from corehq.pillows.mappings import NULL_VALUE
@@ -106,11 +107,13 @@ CASE_MAPPING = {
 CASE_ES_ALIAS = "hqcases"
 
 CASE_INDEX_META = deepcopy(DEFAULT_META)
-CASE_INDEX_META.update({
-    'settings': {
-        'number_of_shards': 10,
-    },
-})
+
+if settings.SERVER_ENVIRONMENT == 'production':
+    CASE_INDEX_META.update({
+        'settings': {
+            'number_of_shards': 10,
+        },
+    })
 
 CASE_INDEX_INFO = ElasticsearchIndexInfo(
     index=CASE_INDEX,

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -1,5 +1,3 @@
-from corehq.pillows.base import DEFAULT_META
-
 from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.utils import mapping_from_json
 from corehq.util.elastic import es_index
@@ -16,6 +14,5 @@ CASE_SEARCH_INDEX_INFO = ElasticsearchIndexInfo(
     index=CASE_SEARCH_INDEX,
     alias=CASE_SEARCH_ALIAS,
     type=CASE_ES_TYPE,
-    meta=DEFAULT_META,
     mapping=CASE_SEARCH_MAPPING,
 )

--- a/corehq/pillows/mappings/domain_mapping.py
+++ b/corehq/pillows/mappings/domain_mapping.py
@@ -258,29 +258,9 @@ DOMAIN_MAPPING = {'_meta': {'comment': '',
                 'yt_id': {'type': 'string'}}}
 
 
-DOMAIN_META = {
-    "settings": {
-        "analysis": {
-            "analyzer": {
-                "default": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": ["lowercase"]
-                },
-                "comma": {
-                    "type": "pattern",
-                    "pattern": "\s*,\s*"
-                },
-            }
-        }
-    }
-}
-
-
 DOMAIN_INDEX_INFO = ElasticsearchIndexInfo(
     index=DOMAIN_INDEX,
     alias='hqdomains',
     type='hqdomain',
-    meta=DOMAIN_META,
     mapping=DOMAIN_MAPPING,
 )

--- a/corehq/pillows/mappings/group_mapping.py
+++ b/corehq/pillows/mappings/group_mapping.py
@@ -1,4 +1,3 @@
-from corehq.pillows.base import DEFAULT_META
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
@@ -68,6 +67,5 @@ GROUP_INDEX_INFO = ElasticsearchIndexInfo(
     index=GROUP_INDEX,
     alias='hqgroups',
     type='group',
-    meta=DEFAULT_META,
     mapping=GROUP_MAPPING,
 )

--- a/corehq/pillows/mappings/ledger_mapping.py
+++ b/corehq/pillows/mappings/ledger_mapping.py
@@ -1,5 +1,3 @@
-from corehq.pillows.base import DEFAULT_META
-
 from corehq.pillows.mappings.utils import mapping_from_json
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
@@ -15,6 +13,5 @@ LEDGER_INDEX_INFO = ElasticsearchIndexInfo(
     index=LEDGER_INDEX,
     alias=LEDGER_ALIAS,
     type=LEDGER_TYPE,
-    meta=DEFAULT_META,
     mapping=LEDGER_MAPPING,
 )

--- a/corehq/pillows/mappings/reportcase_mapping.py
+++ b/corehq/pillows/mappings/reportcase_mapping.py
@@ -1,4 +1,3 @@
-from corehq.pillows.base import DEFAULT_META
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
@@ -134,6 +133,5 @@ REPORT_CASE_INDEX_INFO = ElasticsearchIndexInfo(
     index=REPORT_CASE_INDEX,
     alias=REPORT_CASE_ES_ALIAS,
     type=REPORT_CASE_ES_TYPE,
-    meta=DEFAULT_META,
     mapping=REPORT_CASE_MAPPING,
 )

--- a/corehq/pillows/mappings/reportxform_mapping.py
+++ b/corehq/pillows/mappings/reportxform_mapping.py
@@ -1,4 +1,3 @@
-from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
@@ -163,6 +162,5 @@ REPORT_XFORM_INDEX_INFO = ElasticsearchIndexInfo(
     index=REPORT_XFORM_INDEX,
     alias=REPORT_XFORM_ALIAS,
     type=REPORT_XFORM_TYPE,
-    meta=DEFAULT_META,
     mapping=REPORT_XFORM_MAPPING,
 )

--- a/corehq/pillows/mappings/sms_mapping.py
+++ b/corehq/pillows/mappings/sms_mapping.py
@@ -1,4 +1,3 @@
-from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
@@ -47,6 +46,5 @@ SMS_INDEX_INFO = ElasticsearchIndexInfo(
     index=SMS_INDEX,
     alias="smslogs",
     type=SMS_TYPE,
-    meta=DEFAULT_META,
     mapping=SMS_MAPPING,
 )

--- a/corehq/pillows/mappings/user_mapping.py
+++ b/corehq/pillows/mappings/user_mapping.py
@@ -106,25 +106,9 @@ USER_MAPPING = {'_all': {'analyzer': 'standard'},
                                                                 'type': 'string'}},
                                   'type': 'multi_field'}}}
 
-USER_META = {
-    "settings": {
-        "analysis": {
-            "analyzer": {
-                "default": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": ["lowercase"]
-                },
-            }
-        }
-    }
-}
-
-
 USER_INDEX_INFO = ElasticsearchIndexInfo(
     index=USER_INDEX,
     alias='hqusers',
     type='user',
-    meta=USER_META,
     mapping=USER_MAPPING,
 )

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -1,10 +1,11 @@
+from copy import deepcopy
 from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
-XFORM_INDEX = es_index("xforms_2016-07-07")
+XFORM_INDEX = es_index("xforms_2017-03-28")
 
 XFORM_MAPPING = {
     "date_detection": False,
@@ -120,11 +121,17 @@ XFORM_MAPPING = {
 
 XFORM_ES_TYPE = 'xform'
 XFORM_ALIAS = "xforms"
+XFORM_INDEX_META = deepcopy(DEFAULT_META)
+XFORM_INDEX_META.update({
+    'settings': {
+        'number_of_shards': 10,
+    },
+})
 
 XFORM_INDEX_INFO = ElasticsearchIndexInfo(
     index=XFORM_INDEX,
     alias=XFORM_ALIAS,
     type=XFORM_ES_TYPE,
-    meta=DEFAULT_META,
+    meta=XFORM_INDEX_META,
     mapping=XFORM_MAPPING,
 )

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from django.conf import settings
 from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 from corehq.pillows.mappings import NULL_VALUE
@@ -122,11 +123,13 @@ XFORM_MAPPING = {
 XFORM_ES_TYPE = 'xform'
 XFORM_ALIAS = "xforms"
 XFORM_INDEX_META = deepcopy(DEFAULT_META)
-XFORM_INDEX_META.update({
-    'settings': {
-        'number_of_shards': 10,
-    },
-})
+
+if settings.SERVER_ENVIRONMENT == 'production':
+    XFORM_INDEX_META.update({
+        'settings': {
+            'number_of_shards': 10,
+        },
+    })
 
 XFORM_INDEX_INFO = ElasticsearchIndexInfo(
     index=XFORM_INDEX,

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from django.conf import settings
-from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
@@ -122,19 +121,10 @@ XFORM_MAPPING = {
 
 XFORM_ES_TYPE = 'xform'
 XFORM_ALIAS = "xforms"
-XFORM_INDEX_META = deepcopy(DEFAULT_META)
-
-if settings.SERVER_ENVIRONMENT == 'production':
-    XFORM_INDEX_META.update({
-        'settings': {
-            'number_of_shards': 10,
-        },
-    })
 
 XFORM_INDEX_INFO = ElasticsearchIndexInfo(
     index=XFORM_INDEX,
     alias=XFORM_ALIAS,
     type=XFORM_ES_TYPE,
-    meta=XFORM_INDEX_META,
     mapping=XFORM_MAPPING,
 )

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-from django.conf import settings
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index

--- a/env_settings.py
+++ b/env_settings.py
@@ -88,7 +88,6 @@ ES_META = {
         },
         'hqcases': {
             'settings': {
-                'number_of_shards': 10,
                 "analysis": {
                     "analyzer": {
                         "default": {

--- a/env_settings.py
+++ b/env_settings.py
@@ -1,0 +1,91 @@
+ES_META = {
+    # Default settings for all indexes on ElasticSearch
+    'default': {
+        "settings": {
+            "analysis": {
+                "analyzer": {
+                    "default": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    },
+                    "sortable_exact": {
+                        "type": "custom",
+                        "tokenizer": "keyword",
+                        "filter": ["lowercase"]
+                    }
+                }
+            }
+        }
+    },
+    # Default settings for aliases on all environments (overrides default settings)
+    'hqdomains': {
+        "settings": {
+            "analysis": {
+                "analyzer": {
+                    "default": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    },
+                    "comma": {
+                        "type": "pattern",
+                        "pattern": "\s*,\s*"
+                    },
+                }
+            }
+        }
+    },
+
+    'hqapps': {
+        "settings": {
+            "analysis": {
+                "analyzer": {
+                    "default": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    },
+                }
+            }
+        }
+    },
+
+    # Default settings for aliases per environment (overrides default settings for alias)
+    'production': {
+        'xforms': {
+            'settings': {
+                'number_of_shards': 10,
+                "analyzer": {
+                    "default": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    },
+                    "sortable_exact": {
+                        "type": "custom",
+                        "tokenizer": "keyword",
+                        "filter": ["lowercase"]
+                    }
+                }
+            },
+        },
+        'hqcases': {
+            'settings': {
+                'number_of_shards': 10,
+                "analyzer": {
+                    "default": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    },
+                    "sortable_exact": {
+                        "type": "custom",
+                        "tokenizer": "keyword",
+                        "filter": ["lowercase"]
+                    }
+                }
+            },
+        }
+    },
+}

--- a/env_settings.py
+++ b/env_settings.py
@@ -51,40 +51,58 @@ ES_META = {
         }
     },
 
+    'hqusers': {
+        "settings": {
+            "analysis": {
+                "analyzer": {
+                    "default": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    },
+                }
+            }
+        }
+    },
+
     # Default settings for aliases per environment (overrides default settings for alias)
     'production': {
         'xforms': {
             'settings': {
                 'number_of_shards': 10,
-                "analyzer": {
-                    "default": {
-                        "type": "custom",
-                        "tokenizer": "whitespace",
-                        "filter": ["lowercase"]
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "type": "custom",
+                            "tokenizer": "whitespace",
+                            "filter": ["lowercase"]
+                        },
+                        "sortable_exact": {
+                            "type": "custom",
+                            "tokenizer": "keyword",
+                            "filter": ["lowercase"]
+                        }
                     },
-                    "sortable_exact": {
-                        "type": "custom",
-                        "tokenizer": "keyword",
-                        "filter": ["lowercase"]
-                    }
-                }
+                },
             },
         },
         'hqcases': {
             'settings': {
                 'number_of_shards': 10,
-                "analyzer": {
-                    "default": {
-                        "type": "custom",
-                        "tokenizer": "whitespace",
-                        "filter": ["lowercase"]
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "type": "custom",
+                            "tokenizer": "whitespace",
+                            "filter": ["lowercase"]
+                        },
+                        "sortable_exact": {
+                            "type": "custom",
+                            "tokenizer": "keyword",
+                            "filter": ["lowercase"]
+                        },
                     },
-                    "sortable_exact": {
-                        "type": "custom",
-                        "tokenizer": "keyword",
-                        "filter": ["lowercase"]
-                    }
-                }
+                },
             },
         }
     },

--- a/settings.py
+++ b/settings.py
@@ -899,6 +899,8 @@ SENTRY_API_KEY = None
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = None
 
+from env_settings import *
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -20,7 +20,7 @@ class ProdIndexManagementTest(SimpleTestCase):
     def test_prod_config(self):
         found_prod_indices = [info.to_json() for info in get_all_expected_es_indices()]
         for info in found_prod_indices:
-            # for now don't test these two properties, just ensure they exist
+            # for now don't test this property, just ensure it exist
             self.assertTrue(info['mapping'])
             del info['mapping']
         found_prod_indices = sorted(found_prod_indices, key=lambda info: info['index'])

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -75,11 +75,10 @@ EXPECTED_PROD_INDICES = [
     },
     {
         "alias": "hqcases",
-        "index": "test_hqcases_2017-03-28",
+        "index": "test_hqcases_2016-03-04",
         "type": "case",
         "meta": {
             "settings": {
-                'number_of_shards': 10,
                 "analysis": {
                     "analyzer": {
                         "default": {

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -75,8 +75,8 @@ EXPECTED_PROD_INDICES = [
     },
     {
         "alias": "hqcases",
-        "index": "test_hqcases_2016-03-04",
-        "type": "case",
+        "index": "test_hqcases_2017-03-28",
+        "type": "case"
         "meta": {
             "settings": {
                 "analysis": {
@@ -277,8 +277,8 @@ EXPECTED_PROD_INDICES = [
     },
     {
         "alias": "xforms",
-        "index": "test_xforms_2016-07-07",
-        "type": "xform",
+        "index": "test_xforms_2017-03-28",
+        "type": "xform"
         "meta": {
             "settings": {
                 "analysis": {

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -79,6 +79,7 @@ EXPECTED_PROD_INDICES = [
         "type": "case",
         "meta": {
             "settings": {
+                'number_of_shards': 10,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -281,6 +282,7 @@ EXPECTED_PROD_INDICES = [
         "type": "xform",
         "meta": {
             "settings": {
+                'number_of_shards': 10,
                 "analysis": {
                     "analyzer": {
                         "default": {

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -76,7 +76,7 @@ EXPECTED_PROD_INDICES = [
     {
         "alias": "hqcases",
         "index": "test_hqcases_2017-03-28",
-        "type": "case"
+        "type": "case",
         "meta": {
             "settings": {
                 "analysis": {
@@ -278,7 +278,7 @@ EXPECTED_PROD_INDICES = [
     {
         "alias": "xforms",
         "index": "test_xforms_2017-03-28",
-        "type": "xform"
+        "type": "xform",
         "meta": {
             "settings": {
                 "analysis": {

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -44,7 +44,7 @@
     "CaseToElasticsearchPillow": {
         "advertised_name": "CaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "CaseToElasticsearchPillow-test_hqcases_2016-03-04",
+        "checkpoint_id": "CaseToElasticsearchPillow-test_hqcases_2017-03-28",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseToElasticsearchPillow"
     },
@@ -247,7 +247,7 @@
     "XFormToElasticsearchPillow": {
         "advertised_name": "XFormToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "XFormToElasticsearchPillow-test_xforms_2016-07-07",
+        "checkpoint_id": "XFormToElasticsearchPillow-test_xforms_2017-03-28",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "XFormToElasticsearchPillow"
     },

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -44,7 +44,7 @@
     "CaseToElasticsearchPillow": {
         "advertised_name": "CaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "CaseToElasticsearchPillow-test_hqcases_2017-03-28",
+        "checkpoint_id": "CaseToElasticsearchPillow-test_hqcases_2016-03-04",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseToElasticsearchPillow"
     },


### PR DESCRIPTION
We may want to combine this with @calellowitz [PR](https://github.com/dimagi/commcare-hq/pull/15514), but I never love combining changes, so would rather not if we think it's doable to just run the AppSubmissionTracker pillow reindex on its own. I looked at our disk usage and I think we'll actually be fine not reallocating another node. Our most full disk still has around 120 GB of free space. hqcases is 61gb and xforms is 110gb. That will roughly add 60GB - 70GB to each node conservatively. 

1. `fab <softlayer|production> setup_release:keep_days=10 --set code_branch=br/more-shards`
1.5. disable shard reallocation
2. `./manage.py ptop_preindex --reset` (in a screen)
3. Merge this PR
4. Deploy
5. Run `./manage.py prune_elastic_indices` once we feel good that everything is settled

es head should then look something like this except distributed amongst 3 nodes
<img width="190" alt="screen shot 2017-03-28 at 1 20 44 pm" src="https://cloud.githubusercontent.com/assets/918514/24420767/919b8f74-13b9-11e7-9809-8674d3b9ab27.png">
