### PR TITLE
Remove app dashboard from v2

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -27,7 +27,7 @@ from corehq import toggles, privileges
 from toggle.shortcuts import set_toggle
 from corehq.apps.app_manager.forms import CopyApplicationForm
 from corehq.apps.app_manager import id_strings
-from corehq.apps.dashboard.views import NewUserDashboardView
+from corehq.apps.dashboard.views import DomainDashboardView
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.tour import tours
@@ -95,7 +95,7 @@ def delete_app(request, domain, app_id):
     clear_app_cache(request, domain)
 
     if toggles.APP_MANAGER_V2.enabled(domain):
-        return HttpResponseRedirect(reverse(NewUserDashboardView.urlname, args=[domain]))
+        return HttpResponseRedirect(reverse(DomainDashboardView.urlname, args=[domain]))
     return back_to_main(request, domain)
 
 

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -168,10 +168,9 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
             'is_app_settings_page': not release_manager,
         })
     else:
-        from corehq.apps.dashboard.views import NewUserDashboardView
+        from corehq.apps.dashboard.views import DomainDashboardView, NewUserDashboardView
         if toggles.APP_MANAGER_V2.enabled(domain):
-            context.update(NewUserDashboardView.get_page_context(domain))
-            template = NewUserDashboardView.template_name
+            template = DomainDashboardView.template_name
         else:
             return HttpResponseRedirect(reverse(NewUserDashboardView.urlname, args=[domain]))
 

--- a/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
+++ b/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
@@ -12,83 +12,33 @@
 {% block dashboard-content %}
 {% initial_page_data 'templates' templates %}
 <div class="page-header">
-    {% if request|toggle_enabled:"APP_MANAGER_V2" %}
-        <h1>{% trans 'Would you like to work on an existing app or create a new one?' %}</h1>
-    {% else %}
-        <h1>{% trans 'What type of app would you like to build?' %}</h1>
-    {% endif %}
+    <h1>{% trans 'What type of app would you like to build?' %}</h1>
 </div>
 <div class="row">
-    {% if request|toggle_enabled:"APP_MANAGER_V2" %}
-        <div class="col-md-6">
-            <div class="panel panel-dashboard panel-dashboard-large">
-                <div class="panel-heading">
-                    <a class="dashboard-link"
-                        data-index="0"
-                        href="#">
-                        {% trans 'Existing Applications' %}
-                    </a>
-                </div>
-                <div class="panel-body">
-                    <i class="fcc fcc-applications dashboard-icon dashboard-icon-large dashboard-icon-bg"></i>
-                    <div class="list-group">
-                        {% for app in apps %}
-                            <div class="list-group-item">
-                                <a href='{% url "view_app" domain app.id %}'>{{ app.name }}</a>
-                            </div>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-6">
+    {% for template in templates %}
+        <div class="col-md-4">
             <div class="panel panel-dashboard">
                 <div class="panel-heading">
                     <a class="dashboard-link"
-                        data-index="1"
-                        href="{% url 'default_new_app' domain %}">
-                        {% trans 'Blank Application' %}
+                        data-index="{{ forloop.counter0 }}"
+                        href="{{ template.url }}">
+                        {{ template.heading }}
                     </a>
                 </div>
                 <div class="panel-body">
                     <p class="text-center">
                         <a class="dashboard-link"
-                            data-index="1"
-                            href="{% url 'default_new_app' domain %}">
-                        <i class="fcc fcc-blankapp dashboard-icon dashboard-icon-large"></i>
+                            data-index="{{ forloop.counter0 }}"
+                            href="{{ template.url }}">
+                        <i class="fcc {{ template.icon }} dashboard-icon dashboard-icon-large"></i>
                         <span class="lead">
-                            {% trans 'Start from scratch' %}
+                            {{ template.lead }}
                         </span>
                     </a></p>
                 </div>
             </div>
         </div>
-    {% else %}
-        {% for template in templates %}
-            <div class="col-md-4">
-                <div class="panel panel-dashboard">
-                    <div class="panel-heading">
-                        <a class="dashboard-link"
-                            data-index="{{ forloop.counter0 }}"
-                            href="{{ template.url }}">
-                            {{ template.heading }}
-                        </a>
-                    </div>
-                    <div class="panel-body">
-                        <p class="text-center">
-                            <a class="dashboard-link"
-                                data-index="{{ forloop.counter0 }}"
-                                href="{{ template.url }}">
-                            <i class="fcc {{ template.icon }} dashboard-icon dashboard-icon-large"></i>
-                            <span class="lead">
-                                {{ template.lead }}
-                            </span>
-                        </a></p>
-                    </div>
-                </div>
-            </div>
-        {% endfor %}
-    {% endif %}
+    {% endfor %}
 </div>
 
 {% endblock dashboard-content %}


### PR DESCRIPTION
v2 doesn't use template apps, doesn't need the apps dashboard. The places that redirect to the app dashboard in v1 (e.g., after you delete an app) will instead redirect to the main domain dashboard.

@biyeun / @NoahCarnahan 