### PR TITLE
Override getHash and stop FireFox double request bug

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -453,3 +453,35 @@ FormplayerFrontend.on('navigateHome', function() {
         FormplayerFrontend.navigate("/apps", { trigger: true });
     }
 });
+
+/**
+ * This is a hack to ensure that routing works properly on FireFox. Normally,
+ * location.href is supposed to return a url decoded string. However, FireFox's
+ * location.href returns a url encoded string. For example:
+ *
+ * Chrome:
+ * > location.hash
+ * > "#{"appId"%3A"db732ce1735229da84b451cbd7cfa7ac"}"
+ *
+ * FireFox:
+ * > location.hash
+ * > "#{%22appId%22%3A%22db732ce1735229da84b451cbd7cfa7ac%22}"
+ *
+ * This is important because BackBone caches the non url encoded fragment when you call `navigate`.
+ * Then on the 'onhashchange' event, Backbone compares the cached value with the `getHash`
+ * function. If they do not match it will trigger a call to loadUrl which triggers BackBone's router.
+ * On FireFox, it registers as a URL change since it compares the url encoded
+ * version to the url decoded version which will always mismatch. Therefore, in
+ * addition to running the route through the mouseclick, the route gets run again
+ * when the hash changes.
+ *
+ * Additional explanation here: http://stackoverflow.com/a/25849032/835696
+ *
+ * https://manage.dimagi.com/default.asp?250644
+ */
+_.extend(Backbone.History.prototype, {
+    getHash: function(window) {
+        var match = (window || this).location.href.match(/#(.*)$/);
+        return match ? decodeURI(match[1]) : '';
+    },
+});


### PR DESCRIPTION
this was a fun one! https://manage.dimagi.com/default.asp?250644

the stack exchange answer i linked to is a little misleading. it surmises that this error happens when you don't url encode your routes. however i don't think this is the case here. the error is coming from the fact that Chrome and FireFox return different values