### PR TITLE
switch to using SimpleProducer

### DIFF
--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -4,7 +4,7 @@ import time
 from django.conf import settings
 
 from corehq.util.soft_assert import soft_assert
-from kafka import KeyedProducer
+from kafka import SimpleProducer
 from kafka.common import LeaderNotAvailableError, FailedPayloadsError, KafkaUnavailableError
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
 
@@ -13,7 +13,6 @@ def send_to_kafka(producer, topic, change_meta):
     def _send_to_kafka():
         producer.send_messages(
             bytes(topic),
-            bytes(change_meta.domain.encode('utf-8') if change_meta.domain is not None else None),
             bytes(json.dumps(change_meta.to_json())),
         )
 
@@ -63,7 +62,7 @@ class ChangeProducer(object):
     def producer(self):
         if self._producer is None and not self._has_error:
             if self.kafka is not None:
-                self._producer = KeyedProducer(self._kafka)
+                self._producer = SimpleProducer(self._kafka)
             else:
                 # if self.kafka is None then we should be in an error state
                 assert self._has_error

--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -1,6 +1,6 @@
 import uuid
 from django.test import SimpleTestCase, TestCase
-from kafka import KeyedProducer
+from kafka import SimpleProducer
 from kafka.common import KafkaUnavailableError
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
@@ -107,7 +107,7 @@ class KafkaCheckpointTest(TestCase):
 
 @memoized
 def _get_producer():
-    return KeyedProducer(get_kafka_client_or_none())
+    return SimpleProducer(get_kafka_client_or_none())
 
 
 def publish_stub_change(topic):


### PR DESCRIPTION
We don't want to shard the changes between the topic partitions. `SimpleProducer` does round robin allocation.

buddy @mkangia 