### PR TITLE
Change test output to be copypastable test name

### DIFF
--- a/corehq/tests/noseplugins/uniformresult.py
+++ b/corehq/tests/noseplugins/uniformresult.py
@@ -27,7 +27,7 @@ def uniform_description(test):
         return "%s:%s" % (test.__module__, test.__name__)
     if isinstance(test, FunctionTestCase):
         descriptor = test.descriptor or test.test
-        return "%s:%s args %s" % (
+        return "%s:%s %s" % (
             descriptor.__module__,
             descriptor.__name__,
             test.arg,

--- a/corehq/tests/noseplugins/uniformresult.py
+++ b/corehq/tests/noseplugins/uniformresult.py
@@ -26,7 +26,12 @@ def uniform_description(test):
     if isinstance(test, type):
         return "%s:%s" % (test.__module__, test.__name__)
     if isinstance(test, FunctionTestCase):
-        return str(test)
+        descriptor = test.descriptor or test.test
+        return "%s:%s args %s" % (
+            descriptor.__module__,
+            descriptor.__name__,
+            test.arg,
+        )
     name = "%s:%s.%s" % (
         test.__module__,
         type(test).__name__,

--- a/corehq/tests/noseplugins/uniformresult.py
+++ b/corehq/tests/noseplugins/uniformresult.py
@@ -6,7 +6,7 @@ Usage:
     COLLECT_ONLY=1 ./manage.py test -v2 --settings=settings 2> tests-django.txt
 
     # collect nose tests
-    ./manage.py test -v2 --collect-only --with-uniform-results 2> tests-nose.txt
+    ./manage.py test -v2 --collect-only 2> tests-nose.txt
 
     # clean up django test output: s/skipped\ \'.*\'$/ok/
     # sort each output file
@@ -41,6 +41,10 @@ class UniformTestResultPlugin(Plugin):
     """
 
     name = "uniform-results"
+    enabled = True
+
+    def configure(self, options, conf):
+        """Do not call super (always enabled)"""
 
     def describeTest(self, test):
         return uniform_description(test.test)

--- a/testsettings.py
+++ b/testsettings.py
@@ -22,11 +22,11 @@ NOSE_PLUGINS = [
     'corehq.tests.noseplugins.dividedwerun.DividedWeRunPlugin',
     'corehq.tests.noseplugins.djangomigrations.DjangoMigrationsPlugin',
     'corehq.tests.noseplugins.cmdline_params.CmdLineParametersPlugin',
+    'corehq.tests.noseplugins.uniformresult.UniformTestResultPlugin',
 
     # The following are not enabled by default
     'corehq.tests.noseplugins.logfile.LogFilePlugin',
     'corehq.tests.noseplugins.timing.TimingPlugin',
-    'corehq.tests.noseplugins.uniformresult.UniformTestResultPlugin',
 
     # Uncomment to debug tests. Plugins have nice hooks for inspecting state
     # before/after each test or context setup/teardown, etc.


### PR DESCRIPTION
@millerdev
This builds off your "uniformresult" plugin, which already does copypastable names for everything except function tests.  This adds it in for function tests too, and defaults that plugin to enabled.  Does that sound reasonable?

Regarding the names for function tests, `test_compression` is a generator test, and `test_no_overlap` is a regular function test.  What do you think of this format?
```
custom.enikshay.tests.test_id_compression:test_compression args (11, 'T', 0)
custom.enikshay.tests.test_id_compression:test_compression args (12, 'LA', 0)
custom.enikshay.tests.test_id_compression:test_compression args (119, 'VT', 0)
custom.enikshay.tests.test_id_compression:test_no_overlap args ()
```
I'm not sure whether args are ever relevant for regular function tests.  For generator tests, I don't believe you can run just a single case, but you do want the info on the args in order to know which case failed, so I put them both in there, but separated for convenience.