### PR TITLE
set auto width for data tables with no columns

### DIFF
--- a/corehq/apps/reports/datatables/__init__.py
+++ b/corehq/apps/reports/datatables/__init__.py
@@ -120,6 +120,7 @@ class DataTablesHeader(object):
     no_sort = False
     complex = True
     span = 0
+    auto_width = False
     custom_sort = None
 
     def __init__(self, *args):


### PR DESCRIPTION
@biyeun cc: @snopoke 
http://manage.dimagi.com/default.asp?250642#1310870
lookup tables with no columns were broken. this makes sure the `auto_width` property is set even if no columns are added.