### PR TITLE
add @method_decorator to toggle decorator in class-based views

### DIFF
--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -158,7 +158,7 @@ class DataDictionaryView(BaseProjectDataView):
 
     @method_decorator(login_and_domain_required)
     @use_jquery_ui
-    @toggles.DATA_DICTIONARY.required_decorator()
+    @method_decorator(toggles.DATA_DICTIONARY.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         return super(DataDictionaryView, self).dispatch(request, *args, **kwargs)
 
@@ -189,7 +189,7 @@ class UploadDataDictionaryView(BaseProjectDataView):
 
     @method_decorator(login_and_domain_required)
     @use_jquery_ui
-    @toggles.DATA_DICTIONARY.required_decorator()
+    @method_decorator(toggles.DATA_DICTIONARY.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         return super(UploadDataDictionaryView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2162,7 +2162,7 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
     template_name = 'domain/admin/case_search.html'
 
     @method_decorator(domain_admin_required)
-    @toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
+    @method_decorator(toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         return super(CaseSearchConfigView, self).dispatch(request, *args, **kwargs)
 
@@ -2219,7 +2219,7 @@ class CalendarFixtureConfigView(BaseAdminProjectSettingsView):
     template_name = 'domain/admin/calendar_fixture.html'
 
     @method_decorator(domain_admin_required)
-    @toggles.CUSTOM_CALENDAR_FIXTURE.required_decorator()
+    @method_decorator(toggles.CUSTOM_CALENDAR_FIXTURE.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         return super(CalendarFixtureConfigView, self).dispatch(request, *args, **kwargs)
 
@@ -2245,7 +2245,7 @@ class LocationFixtureConfigView(BaseAdminProjectSettingsView):
     template_name = 'domain/admin/location_fixture.html'
 
     @method_decorator(domain_admin_required)
-    @toggles.HIERARCHICAL_LOCATION_FIXTURE.required_decorator()
+    @method_decorator(toggles.HIERARCHICAL_LOCATION_FIXTURE.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         return super(LocationFixtureConfigView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -262,7 +262,7 @@ class PrimeRestoreCacheView(BaseSectionPageView, DomainViewMixin):
     template_name = "ota/prime_restore_cache.html"
 
     @method_decorator(domain_admin_required)
-    @toggles.PRIME_RESTORE.required_decorator()
+    @method_decorator(toggles.PRIME_RESTORE.required_decorator())
     def dispatch(self, *args, **kwargs):
         return super(PrimeRestoreCacheView, self).dispatch(*args, **kwargs)
 


### PR DESCRIPTION
this works totally by chance if the toggle is enabled, which is why we
haven't noticed this until now.

Basically in the decorator inner function the first param is called
`request`, but what's passed (without method_decorator) is the
class-based view object, which also happens to respond to `.domain`.
So everything's fine through `toggle.enabled(request.domain)`, but if
that returns `False`, then it fails later on `request.user`, since the
CBV object doesn't respond to `.user`.