### PR TITLE
Vellum alpha flag

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -136,7 +136,7 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
 
     vellum_base = 'corehq/apps/app_manager/static/app_manager/js/'
     vellum_dir = 'vellum'
-    if isdir(join(vellum_base, 'vellum_beta')):
+    if isdir(join(vellum_base, 'vellum_beta')) and not toggles.VELLUM_ALPHA.enabled(request.user.username):
         vellum_dir = 'vellum_beta'
 
     context = get_apps_base_context(request, domain, app)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -942,7 +942,15 @@ CLOUDCARE_LATEST_BUILD = StaticToggle(
 
 VELLUM_BETA = StaticToggle(
     'vellum_beta',
-    'Use Vellum beta version',
+    'Use Vellum beta version. This flag has been deactivated and will be removed soon; all users are on the beta\
+    unless they also have the vellum alpha flag set.',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_USER]
+)
+
+VELLUM_ALPHA = StaticToggle(
+    'vellum_alpha',
+    'Use alpha (pre-beta) Vellum',
     TAG_PRODUCT_PATH,
     [NAMESPACE_USER]
 )


### PR DESCRIPTION
Since https://github.com/dimagi/commcare-hq/pull/15512 there hasn't been a way to turn off the new vellum, which I'd like to be able to do for debugging purposes.

A little bit confusing, but the plan is for this flag (along with vellum_beta) to be short-lived, just for the next week or two, until old vellum is fully removed from the codebase.

@NoahCarnahan / @millerdev 