### PR TITLE
Add meta settings to prod

### DIFF
--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.test import SimpleTestCase
+from django.test.utils import override_settings
 from corehq.pillows.utils import get_all_expected_es_indices
 
 
@@ -15,12 +16,11 @@ class ProdIndexManagementTest(SimpleTestCase):
     def tearDownClass(cls):
         settings.PILLOWTOPS = cls._PILLOWTOPS
 
+    @override_settings(SERVER_ENVIRONMENT='production')
     def test_prod_config(self):
         found_prod_indices = [info.to_json() for info in get_all_expected_es_indices()]
         for info in found_prod_indices:
             # for now don't test these two properties, just ensure they exist
-            self.assertTrue(info['meta'])
-            del info['meta']
             self.assertTrue(info['mapping'])
             del info['mapping']
         found_prod_indices = sorted(found_prod_indices, key=lambda info: info['index'])
@@ -31,56 +31,275 @@ EXPECTED_PROD_INDICES = [
     {
         "alias": "case_search",
         "index": "test_case_search_2016-03-15",
-        "type": "case"
+        "type": "case",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "hqapps",
         "index": "test_hqapps_2016-10-20_1835",
-        "type": "app"
+        "type": "app",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "type": "custom",
+                            "tokenizer": "whitespace",
+                            "filter": ["lowercase"]
+                        },
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "hqcases",
         "index": "test_hqcases_2016-03-04",
-        "type": "case"
+        "type": "case",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "hqdomains",
         "index": "test_hqdomains_2016-08-08",
-        "type": "hqdomain"
+        "type": "hqdomain",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "type": "custom",
+                            "tokenizer": "whitespace",
+                            "filter": ["lowercase"]
+                        },
+                        "comma": {
+                            "type": "pattern",
+                            "pattern": "\s*,\s*"
+                        },
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "hqgroups",
         "index": "test_hqgroups_20150403_1501",
-        "type": "group"
+        "type": "group",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "hqusers",
         "index": "test_hqusers_2017-02-03",
-        "type": "user"
+        "type": "user",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "type": "custom",
+                            "tokenizer": "whitespace",
+                            "filter": ["lowercase"]
+                        },
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "ledgers",
         "index": "test_ledgers_2016-03-15",
-        "type": "ledger"
+        "type": "ledger",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "report_cases",
         "index": "test_report_cases_czei39du507m9mmpqk3y01x72a3ux4p0",
-        "type": "report_case"
+        "type": "report_case",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "report_xforms",
         "index": "test_report_xforms_20160824_1708",
-        "type": "report_xform"
+        "type": "report_xform",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "smslogs",
         "index": "test_smslogs_2017-02-09",
-        "type": "sms"
+        "type": "sms",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "alias": "xforms",
         "index": "test_xforms_2016-07-07",
-        "type": "xform"
+        "type": "xform",
+        "meta": {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "whitespace"
+                        },
+                        "sortable_exact": {
+                            "filter": [
+                                "lowercase"
+                            ],
+                            "type": "custom",
+                            "tokenizer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
     }
 ]


### PR DESCRIPTION
@emord made this separately so on my other shard PR it's very obvious that we aren't accidentally changing any of the index settings that we don't want. realize this only tests the prod settings, but i think that's ok tradeoff given how annoying this test usually ends up being (would rather not write out the indexes for all the envs)

cc: @millerdev 