### PR TITLE
Make vellum_alpha flag domain-level

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -136,7 +136,8 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
 
     vellum_base = 'corehq/apps/app_manager/static/app_manager/js/'
     vellum_dir = 'vellum'
-    if isdir(join(vellum_base, 'vellum_beta')) and not toggles.VELLUM_ALPHA.enabled(request.user.username):
+    vellum_alpha = toggles.VELLUM_ALPHA.enabled(domain) or toggles.VELLUM_ALPHA.enabled(request.user.username)
+    if isdir(join(vellum_base, 'vellum_beta')) and not vellum_alpha:
         vellum_dir = 'vellum_beta'
 
     context = get_apps_base_context(request, domain, app)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -952,7 +952,7 @@ VELLUM_ALPHA = StaticToggle(
     'vellum_alpha',
     'Use alpha (pre-beta) Vellum',
     TAG_PRODUCT_PATH,
-    [NAMESPACE_USER]
+    [NAMESPACE_USER, NAMESPACE_DOMAIN]
 )
 
 APP_MANAGER_V2 = StaticToggle(


### PR DESCRIPTION
Would be handy to be able to be able to turn this off for entire domains, since new formbuilder is negatively affecting large forms.

@NoahCarnahan / @biyeun 