### PR TITLE
Handle empty locations

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -252,7 +252,7 @@ class ExportColumn(DocumentSchema):
             if '#text' in value:
                 value = value.get('#text')
             else:
-                return MISSING_VALUE
+                return EMPTY_VALUE
 
         if transform_dates:
             value = couch_to_excel_datetime(value, doc)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -248,8 +248,11 @@ class ExportColumn(DocumentSchema):
         # <element>value</element>  -> 'value'
         #
         # This line ensures that we grab the actual value instead of the dictionary
-        if isinstance(value, dict) and '#text' in value:
-            value = value.get('#text')
+        if isinstance(value, dict):
+            if '#text' in value:
+                value = value.get('#text')
+            else:
+                return MISSING_VALUE
 
         if transform_dates:
             value = couch_to_excel_datetime(value, doc)

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -581,6 +581,54 @@ class WriterTest(SimpleTestCase):
                 }
             )
 
+    def test_empty_location(self):
+        export_instance = FormExportInstance(
+            export_format=Format.JSON,
+            tables=[
+                TableConfiguration(
+                    label="My table",
+                    selected=True,
+                    columns=[
+                        ExportColumn(
+                            label="location",
+                            item=ScalarItem(
+                                path=[PathNode(name='form'), PathNode(name='meta'), PathNode(name='location')],
+                            ),
+                            selected=True
+                        ),
+                    ]
+                )
+            ]
+        )
+
+        docs = [
+            {
+                'domain': 'my-domain',
+                '_id': '1234',
+                'form': {
+                    'meta': {
+                        'location': {'xmlns': 'abc'},
+                    }
+                }
+            }
+        ]
+
+        writer = _get_writer([export_instance])
+        with writer.open([export_instance]):
+            _write_export_instance(writer, export_instance, docs)
+
+        with ExportFile(writer.path, writer.format) as export:
+            self.assertEqual(
+                json.loads(export.read()),
+                {
+                    u'My table': {
+                        u'headers': [u'location'],
+                        u'rows': [[MISSING_VALUE]],
+
+                    }
+                }
+            )
+
     def test_empty_table_label(self):
         export_instance = FormExportInstance(
             export_format=Format.JSON,

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -623,7 +623,7 @@ class WriterTest(SimpleTestCase):
                 {
                     u'My table': {
                         u'headers': [u'location'],
-                        u'rows': [[MISSING_VALUE]],
+                        u'rows': [[EMPTY_VALUE]],
 
                     }
                 }


### PR DESCRIPTION
@NoahCarnahan when people would export empty locations it'd return a dict like {'xmlns': 'blah'} when converted from xml to json. this ensures we just say the value is empty instead of returning a dict (unless of course there is a `#text` node
https://manage.dimagi.com/default.asp?249948
cc: @dannyroberts @proteusvacuum 