### PR TITLE
Drop vellum_beta toggle

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
@@ -17,9 +17,6 @@
 {% block js %}{{ block.super }}
     <script src="{% static 'moment/moment.js' %}"></script>
     <script src="{% static 'requirejs/require.js' %}"></script>
-    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
-        <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
-    {% endif %}
     <script src="{% static 'app_manager/js/app-notifications.js' %}"></script>
     <script src="{% static 'js/ws4redis.js' %}"></script>
 {% endblock %}
@@ -197,46 +194,3 @@
 {% endblock %}
 
 {% block column_style %}hq-flush-content{% endblock %}
-
-{% block modals %}
-    {{ block.super }}
-    {% with slug="vellum_beta" name="New Form Builder" %}
-    {% registerurl "enable_vellum_beta" %}
-    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
-        <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
-        <div class="modal rollout-modal" data-slug="{{ slug }}">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    {% blocktrans %}
-                    <div class="modal-header">
-                        <h4 class="modal-title">{{ name }} Available!</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            We're about to release changes to make form builder easier to use.
-                            <a href="http://www.dimagi.com/blog/new-commcare-form-builder-improvements-released/">Check them out here.</a>
-                        </p>
-                        <p>
-                            These changes will be rolled out permanently on <strong>March 24th</strong>, but if
-                            you'd like, you can turn them on now.
-                        </p>
-                        <div class="row">
-                            <div class="col-sm-6 text-center">
-                                <button class="btn btn-lg btn-primary btn-full-width flag-enable">
-                                    Yes, turn on {{ name }}!
-                                </button>
-                            </div>
-                            <div class="col-sm-6 text-center">
-                                <button class="btn btn-lg btn-default btn-full-width flag-snooze">
-                                    No, remind me later
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                    {% endblocktrans %}
-                </div>
-            </div>
-        </div>
-    {% endif %}
-    {% endwith %}
-{% endblock modals %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
@@ -26,9 +26,6 @@
 {% block js %}{{ block.super }}
     <script src="{% static 'moment/moment.js' %}"></script>
     <script src="{% static 'requirejs/require.js' %}"></script>
-    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
-        <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
-    {% endif %}
     <script src="{% static 'app_manager/js/app-notifications.js' %}"></script>
     <script src="{% static 'js/ws4redis.js' %}"></script>
 {% endblock %}
@@ -305,46 +302,3 @@
 {% block column_style %}hq-flush-content{% endblock %}
 
 {% block footer %}{% endblock %}
-
-{% block modals %}
-    {{ block.super }}
-    {% with slug="vellum_beta" name="New Form Builder" %}
-    {% registerurl "enable_vellum_beta" %}
-    {% if False and not request|toggle_enabled:'VELLUM_BETA' %}
-        <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
-        <div class="modal rollout-modal" data-slug="{{ slug }}">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    {% blocktrans %}
-                    <div class="modal-header">
-                        <h4 class="modal-title">{{ name }} Available!</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            We're about to release changes to make form builder easier to use.
-                            <a href="http://www.dimagi.com/blog/new-commcare-form-builder-improvements-released/">Check them out here.</a>
-                        </p>
-                        <p>
-                            These changes will be rolled out permanently on <strong>March 24th</strong>, but if
-                            you'd like, you can turn them on now.
-                        </p>
-                        <div class="row">
-                            <div class="col-sm-6 text-center">
-                                <button class="btn btn-lg btn-primary btn-full-width flag-enable">
-                                    Yes, turn on {{ name }}!
-                                </button>
-                            </div>
-                            <div class="col-sm-6 text-center">
-                                <button class="btn btn-lg btn-default btn-full-width flag-snooze">
-                                    No, remind me later
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                    {% endblocktrans %}
-                </div>
-            </div>
-        </div>
-    {% endif %}
-    {% endwith %}
-{% endblock modals %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_designer.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_designer.html.diff.txt
@@ -6,12 +6,10 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load i18n %}
-@@ -12,6 +12,15 @@
-     {% elif vellum_debug == "dev-min" %}
-         <link href="{% static 'formdesigner/_build/style.css' %}" type="text/css" rel="stylesheet"/>
+@@ -14,6 +14,15 @@
      {% endif %}
-+{% endblock %}
-+
+ {% endblock %}
+ 
 +{% block stylesheets %}{{ block.super }}
 +  <style type="text/css">
 +    .hq-container {
@@ -19,10 +17,12 @@
 +      margin-bottom: 0;
 +    }
 +  </style>
- {% endblock %}
- 
++{% endblock %}
++
  {% block js %}{{ block.super }}
-@@ -31,6 +40,16 @@
+     <script src="{% static 'moment/moment.js' %}"></script>
+     <script src="{% static 'requirejs/require.js' %}"></script>
+@@ -28,6 +37,16 @@
              plugins: {{ plugins|JSON }},
              features: {{ features|JSON }},
              core: {
@@ -39,7 +39,7 @@
                  dataSourcesEndpoint: '{% url "get_form_data_schema" domain=domain form_unique_id=form.get_unique_id %}',
                  dataSources: [
                      {% comment %} DEPRECATED. Use dataSourcesEndpoint {% endcomment %}
-@@ -42,6 +61,16 @@
+@@ -39,6 +58,16 @@
                  ],
                  form: {{ form.source|JSON }},
                  formId: '{{ form.get_unique_id }}',
@@ -56,7 +56,7 @@
                  formName: "{{ form.name|trans:app.langs|escapejs }}",
                  saveType: 'patch',
                  saveUrl: '{% url "edit_form_attr" domain app.id form.get_unique_id "xform" %}',
-@@ -59,6 +88,7 @@
+@@ -56,6 +85,7 @@
                  onFormSave: function (data) {
                      var app_manager = hqImport('app_manager/js/app_manager.js')
                      app_manager.updateDOM(data.update);
@@ -64,7 +64,7 @@
                      {% if request.couch_user.days_since_created == 0 %}
                          analytics.workflow('Saved the Form Builder within first 24 hours');
                      {% endif %}
-@@ -165,11 +195,10 @@
+@@ -162,11 +192,10 @@
                  'jquery.vellum': 'main'
              }
          });
@@ -77,7 +77,7 @@
  
                  $('#formdesigner').vellum(VELLUM_OPTIONS);
  
-@@ -186,17 +215,96 @@
+@@ -183,14 +212,93 @@
              });
          });
          analytics.workflow('Entered the Form Builder');
@@ -174,6 +174,3 @@
  {% block column_style %}hq-flush-content{% endblock %}
 +
 +{% block footer %}{% endblock %}
- 
- {% block modals %}
-     {{ block.super }}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/rollout_modal.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/rollout_modal.js
@@ -1,4 +1,7 @@
 /* globals alert_user */
+/*
+    To use, include this file on a page that also includes hqwebapp/rollout_modal.html
+*/
 hqDefine("hqwebapp/js/rollout_modal.js", function() {
     $(function() {
         var $modal = $(".rollout-modal"),

--- a/corehq/apps/hqwebapp/templates/hqwebapp/rollout_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/rollout_modal.html
@@ -1,0 +1,40 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% with slug="vellum_beta" name="New Form Builder" %}
+{% registerurl "enable_vellum_beta" %}
+    <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
+    <div class="modal rollout-modal" data-slug="{{ slug }}">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                {% blocktrans %}
+                <div class="modal-header">
+                    <h4 class="modal-title">{{ name }} Available!</h4>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        We're about to release changes to make form builder easier to use.
+                        <a href="http://www.dimagi.com/blog/new-commcare-form-builder-improvements-released/">Check them out here.</a>
+                    </p>
+                    <p>
+                        These changes will be rolled out permanently on <strong>March 24th</strong>, but if
+                        you'd like, you can turn them on now.
+                    </p>
+                    <div class="row">
+                        <div class="col-sm-6 text-center">
+                            <button class="btn btn-lg btn-primary btn-full-width flag-enable">
+                                Yes, turn on {{ name }}!
+                            </button>
+                        </div>
+                        <div class="col-sm-6 text-center">
+                            <button class="btn btn-lg btn-default btn-full-width flag-snooze">
+                                No, remind me later
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                {% endblocktrans %}
+            </div>
+        </div>
+    </div>
+{% endwith %}

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -940,14 +940,6 @@ CLOUDCARE_LATEST_BUILD = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
-VELLUM_BETA = StaticToggle(
-    'vellum_beta',
-    'Use Vellum beta version. This flag has been deactivated and will be removed soon; all users are on the beta\
-    unless they also have the vellum alpha flag set.',
-    TAG_PRODUCT_PATH,
-    [NAMESPACE_USER]
-)
-
 VELLUM_ALPHA = StaticToggle(
     'vellum_alpha',
     'Use alpha (pre-beta) Vellum',


### PR DESCRIPTION
@millerdev 

I separated out the modal as its own partial and removed it from the form designer template. There's still a bit of work you'll need to do to use this elsewhere: namely, update the copy in the modal and also the [view that enabled the toggle](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/toggle_ui/views.py#L181).

There's also still a bit of work for me to do to completely roll out the new vellum changes (merge the `onboarding-redux` branch into master, get rid of the `vellum_beta` directory, and drop the `VELLUM_ALPHA` toggle), but I'm going to hold off on that for a bit longer, until UATBC hits their next release, juuuuust in case.

cc @esoergel 