### PR TITLE
Put existing reg from case list logic back

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -4,40 +4,7 @@
 
 {% if not module.is_surveys and app.advanced_app_builder %}
 
-  <script>
-      // show extra fields if user wants reg form in both case list and menu
-      $(function() {
-          var $form = $("#case-list-form"),
-              $config = $("#case_list_form-label, #case_list_media");
-          $config.addClass("hide");
-          $form.on("change", "input[type='checkbox']", function() {
-              if ($form.find(":checked").length === 2) {
-                  $config.removeClass("hide");
-              } else {
-                  $config.addClass("hide");
-              }
-          });
-      });
-  </script>
-
   <div id="case-list-form">
-      <div class="form-group">
-          <label class="col-sm-2 control-label">
-              Registration Form Accessible in Menu
-              <span class="hq-help-template"
-                    data-title="{% trans "Registration Form Accessible from Case List" %}"
-                    data-content="{% blocktrans %}Minimize duplicate case registrations by requiring mobile workers
-                    to search the case list before they can enter a form that registers new cases.{% endblocktrans %}"
-              ></span>
-          </label>
-          <div class="col-sm-4">
-              <div class="checkbox">
-                  <label>
-                      <input type="checkbox" />
-                  </label>
-              </div>
-          </div>
-      </div>
       <div class="form-group">
           <label class="col-sm-2 control-label">
               {% trans "Registration Form Accessible from Case List" %}
@@ -47,10 +14,45 @@
               ></span>
           </label>
           <div class="col-sm-4">
-              <div class="checkbox">
-                  <label>
-                      <input type="checkbox" checked />
-                  </label>
+              <div data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
+                  <select class="form-control" data-bind="
+                      optstr: caseListFormOptstr,
+                      value: caseListFormProxy
+                      "></select>
+                  <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
+                  <div data-bind="visible: formMissing()" class="help-block">
+                      {% trans "Error! The selected form does not exist." %}
+                  </div>
+              </div>
+              <div class="btn-group" data-bind="visible: !allowed && !caseListForm()">
+                  <button class="btn btn-default disabled" disabled="disabled">
+                      <span>{% trans "Not available" %}</span>
+                  </button>
+                  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                      <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu">
+                      <li>
+                          <a href="#" data-bind="click: toggleMessage">
+                              {% trans "Why can't I select a registration form?" %}
+                          </a>
+                      </li>
+                  </ul>
+              </div>
+              <div class="help-block" data-bind="visible: messageVisible">
+                  <div>
+                      {% blocktrans %}
+                      Registration forms are only available from the case list when<br/>
+                      (1) The registration form is in a different module<br/>
+                      (2) Every form in the module updates or closes the case<br/>
+                      (3) The case list does not have parent case selection configured.<br/>
+                      (4) The module's "Menu Mode" is configured as "Display module and then forms".<br/>
+                      To learn more, see our <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates" target="_blank">Help Site</a>
+                      {% endblocktrans %}
+                  </div>
+                  <a href="#" class="btn btn-default btn-xs" data-bind="click: toggleMessage">
+                      {% trans "OK, close this" %}
+                  </a>
               </div>
           </div>
       </div>
@@ -60,6 +62,14 @@
           </label>
           <div class="col-sm-4">
               {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
+              <div data-bind="visible: !allowed" class="help-block">
+                  {%  trans "Error! Registration form will be ignored since this module is not allowed to have one for the following reason:" %}<br/>
+                  <ul><li data-bind="text: now_allowed_reason"></li></ul>
+                  {% blocktrans %}
+                      To learn more, see our
+                      <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates#MinimizeDuplicates-Limitations" target="_blank">Help Site</a>
+                  {% endblocktrans %}
+              </div>
           </div>
       </div>
   </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_form_setting.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_form_setting.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,76 +1,70 @@
+@@ -1,76 +1,80 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load i18n %}
@@ -80,40 +80,7 @@
 +
 +{% if not module.is_surveys and app.advanced_app_builder %}
 +
-+  <script>
-+      // show extra fields if user wants reg form in both case list and menu
-+      $(function() {
-+          var $form = $("#case-list-form"),
-+              $config = $("#case_list_form-label, #case_list_media");
-+          $config.addClass("hide");
-+          $form.on("change", "input[type='checkbox']", function() {
-+              if ($form.find(":checked").length === 2) {
-+                  $config.removeClass("hide");
-+              } else {
-+                  $config.addClass("hide");
-+              }
-+          });
-+      });
-+  </script>
-+
 +  <div id="case-list-form">
-+      <div class="form-group">
-+          <label class="col-sm-2 control-label">
-+              Registration Form Accessible in Menu
-+              <span class="hq-help-template"
-+                    data-title="{% trans "Registration Form Accessible from Case List" %}"
-+                    data-content="{% blocktrans %}Minimize duplicate case registrations by requiring mobile workers
-+                    to search the case list before they can enter a form that registers new cases.{% endblocktrans %}"
-+              ></span>
-+          </label>
-+          <div class="col-sm-4">
-+              <div class="checkbox">
-+                  <label>
-+                      <input type="checkbox" />
-+                  </label>
-+              </div>
-+          </div>
-+      </div>
 +      <div class="form-group">
 +          <label class="col-sm-2 control-label">
 +              {% trans "Registration Form Accessible from Case List" %}
@@ -123,10 +90,45 @@
 +              ></span>
 +          </label>
 +          <div class="col-sm-4">
-+              <div class="checkbox">
-+                  <label>
-+                      <input type="checkbox" checked />
-+                  </label>
++              <div data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
++                  <select class="form-control" data-bind="
++                      optstr: caseListFormOptstr,
++                      value: caseListFormProxy
++                      "></select>
++                  <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
++                  <div data-bind="visible: formMissing()" class="help-block">
++                      {% trans "Error! The selected form does not exist." %}
++                  </div>
++              </div>
++              <div class="btn-group" data-bind="visible: !allowed && !caseListForm()">
++                  <button class="btn btn-default disabled" disabled="disabled">
++                      <span>{% trans "Not available" %}</span>
++                  </button>
++                  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
++                      <span class="caret"></span>
++                  </button>
++                  <ul class="dropdown-menu">
++                      <li>
++                          <a href="#" data-bind="click: toggleMessage">
++                              {% trans "Why can't I select a registration form?" %}
++                          </a>
++                      </li>
++                  </ul>
++              </div>
++              <div class="help-block" data-bind="visible: messageVisible">
++                  <div>
++                      {% blocktrans %}
++                      Registration forms are only available from the case list when<br/>
++                      (1) The registration form is in a different module<br/>
++                      (2) Every form in the module updates or closes the case<br/>
++                      (3) The case list does not have parent case selection configured.<br/>
++                      (4) The module's "Menu Mode" is configured as "Display module and then forms".<br/>
++                      To learn more, see our <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates" target="_blank">Help Site</a>
++                      {% endblocktrans %}
++                  </div>
++                  <a href="#" class="btn btn-default btn-xs" data-bind="click: toggleMessage">
++                      {% trans "OK, close this" %}
++                  </a>
 +              </div>
 +          </div>
 +      </div>
@@ -136,6 +138,14 @@
 +          </label>
 +          <div class="col-sm-4">
 +              {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
++              <div data-bind="visible: !allowed" class="help-block">
++                  {%  trans "Error! Registration form will be ignored since this module is not allowed to have one for the following reason:" %}<br/>
++                  <ul><li data-bind="text: now_allowed_reason"></li></ul>
++                  {% blocktrans %}
++                      To learn more, see our
++                      <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates#MinimizeDuplicates-Limitations" target="_blank">Help Site</a>
++                  {% endblocktrans %}
++              </div>
 +          </div>
 +      </div>
 +  </div>


### PR DESCRIPTION
The original v2 design includes making registration from the case list the default setup for new apps. Onboarding team discussed and decided to punt on this for now - it's a better experience, but it isn't enough of an issue to block the v2 release.

@biyeun / @esoergel 