### PR TITLE
correct check on user admin permit

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -515,7 +515,7 @@ class NewLocationView(BaseLocationView):
         clean_location.send(
             self.__class__.__name__,
             domain=self.domain,
-            request_user=self.request.user,
+            request_user=self.request.couch_user,
             location=self.location,
             forms={self.location_form.__class__.__name__: self.location_form},
         )


### PR DESCRIPTION
Introduced here: https://github.com/dimagi/commcare-hq/pull/15502/files

Causing `AttributeError: 'User' object has no attribute 'is_domain_admin'`
```
  File "/home/cchq/www/softlayer/releases/2017-04-03_21.14/custom/enikshay/user_setup.py", line 113, in clean_location_callback
    if not toggles.ENIKSHAY.enabled(domain) or request_user.is_domain_admin(domain):
```

@esoergel should this be changed everywhere?