### PR TITLE
don't migrate cases when a location is missing

### DIFF
--- a/custom/enikshay/exceptions.py
+++ b/custom/enikshay/exceptions.py
@@ -6,6 +6,10 @@ class ENikshayCaseNotFound(ENikshayException):
     pass
 
 
+class ENikshayLocationNotFound(ENikshayException):
+    pass
+
+
 class NikshayLocationNotFound(ENikshayException):
     pass
 

--- a/custom/enikshay/nikshay_datamigration/factory.py
+++ b/custom/enikshay/nikshay_datamigration/factory.py
@@ -158,21 +158,15 @@ class EnikshayCaseFactory(object):
             },
         }
 
-        if self.phi:
-            if self.phi.location_type.code == 'phi':
-                kwargs['attrs']['owner_id'] = self.phi.location_id
-                kwargs['attrs']['update']['phi'] = self.phi.name
-                kwargs['attrs']['update']['phi_assigned_to'] = self.phi.location_id
-                kwargs['attrs']['update']['tu_choice'] = self.tu.location_id
-            else:
-                kwargs['attrs']['owner_id'] = ARCHIVED_CASE_OWNER_ID
-                kwargs['attrs']['update']['archive_reason'] = 'migration_not_phi_location'
-                kwargs['attrs']['update']['migration_error'] = 'not_phi_location'
-                kwargs['attrs']['update']['migration_error_details'] = self._phi_code
+        if self.phi.location_type.code == 'phi':
+            kwargs['attrs']['owner_id'] = self.phi.location_id
+            kwargs['attrs']['update']['phi'] = self.phi.name
+            kwargs['attrs']['update']['phi_assigned_to'] = self.phi.location_id
+            kwargs['attrs']['update']['tu_choice'] = self.tu.location_id
         else:
             kwargs['attrs']['owner_id'] = ARCHIVED_CASE_OWNER_ID
-            kwargs['attrs']['update']['archive_reason'] = 'migration_location_not_found'
-            kwargs['attrs']['update']['migration_error'] = 'location_not_found'
+            kwargs['attrs']['update']['archive_reason'] = 'migration_not_phi_location'
+            kwargs['attrs']['update']['migration_error'] = 'not_phi_location'
             kwargs['attrs']['update']['migration_error_details'] = self._phi_code
 
         if self._outcome:

--- a/custom/enikshay/nikshay_datamigration/factory.py
+++ b/custom/enikshay/nikshay_datamigration/factory.py
@@ -11,7 +11,7 @@ from custom.enikshay.case_utils import (
     get_first_parent_of_case,
     get_open_drtb_hiv_case_from_episode,
 )
-from custom.enikshay.exceptions import ENikshayCaseNotFound
+from custom.enikshay.exceptions import ENikshayCaseNotFound, ENikshayLocationNotFound
 from custom.enikshay.nikshay_datamigration.models import Outcome
 
 
@@ -354,22 +354,38 @@ class EnikshayCaseFactory(object):
     def tu(self):
         if self.test_phi is not None:
             return MockLocation('FAKETU', 'fake_tu_id', MockLocationType('tu', 'tu'))
-        return self.nikshay_codes_to_location.get('-'.join(self._phi_code.split('-')[:3]))
+
+        tu_code = '-'.join(self._phi_code.split('-')[:3])
+        try:
+            return self.nikshay_codes_to_location[tu_code]
+        except KeyError:
+            raise ENikshayLocationNotFound(tu_code)
 
     @property
     def phi(self):
         if self.test_phi is not None:
             return MockLocation('FAKEPHI', self.test_phi, MockLocationType('phi', 'phi'))
-        return self.nikshay_codes_to_location.get(self._phi_code)
+
+        try:
+            return self.nikshay_codes_to_location[self._phi_code]
+        except KeyError:
+            raise ENikshayLocationNotFound(self._phi_code)
 
     @property
     def drtb_hiv(self):
         if self.test_phi is not None:
             return MockLocation('FAKEDRTBHIV', 'fake_drtb_hiv_id', MockLocationType('drtb_hiv', 'drtb_hiv'))
-        dto = self.nikshay_codes_to_location['-'.join(self._phi_code.split('-')[:2])]
+
+        dto_code = '-'.join(self._phi_code.split('-')[:2])
+        try:
+            dto = self.nikshay_codes_to_location[dto_code]
+        except KeyError:
+            raise ENikshayLocationNotFound(dto_code)
+
         for dto_child in dto.get_children():
             if dto_child.location_type.code == 'drtb-hiv':
                 return dto_child
+        raise ENikshayLocationNotFound('drtb-hiv matching DTO %s' % dto_code)
 
     @property
     def _phi_code(self):

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -210,13 +210,10 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.phi.delete()
         call_command('create_enikshay_cases', self.domain)
 
-        person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
-        self.assertEqual(1, len(person_case_ids))
-        person_case = self.case_accessor.get_case(person_case_ids[0])
-        self.assertEqual(person_case.owner_id, ARCHIVED_CASE_OWNER_ID)
-        self.assertEqual(person_case.dynamic_case_properties()['archive_reason'], 'migration_location_not_found')
-        self.assertEqual(person_case.dynamic_case_properties()['migration_error'], 'location_not_found')
-        self.assertEqual(person_case.dynamic_case_properties()['migration_error_details'], 'MH-ABD-1-2')
+        self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 0)
+        self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='occurrence')), 0)
+        self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='episode')), 0)
+        self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='drtb-hiv-referral')), 0)
 
     def test_outcome_cured(self):
         self.outcome.HIVStatus = 'Unknown'


### PR DESCRIPTION
Requirements changed to skipping cases instead of archiving them.

If I do my job right during the location resolution, we should never log these errors.  If I don't, then the migration will skip that patient and log the error.

@proteusvacuum cc: @calellowitz 