### PR TITLE
Optimize Forms by Submission

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -684,12 +684,12 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
 
     @property
     @memoized
-    def selected_user_ids(self):
+    def selected_simplified_users(self):
         mobile_user_and_group_slugs = self.request.GET.getlist(EMWF.slug)
-        return EMWF.user_es_query(
+        return util.get_simplified_users(EMWF.user_es_query(
             self.domain,
             mobile_user_and_group_slugs,
-        ).values_list('_id', flat=True)
+        ))
 
     @quickcache(['self.domain', 'mobile_user_and_group_slugs'], timeout=10)
     def is_query_too_big(self, mobile_user_and_group_slugs):
@@ -708,17 +708,16 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
 
         rows = []
         totals = [0] * (len(self.all_relevant_forms) + 1)
-        for user_doc in iter_docs(CommCareUser.get_db(), self.selected_user_ids):
-            user = CommCareUser.wrap(user_doc)
+        for simplified_user in self.selected_simplified_users:
             row = []
             if self.all_relevant_forms:
                 for form in self.all_relevant_forms.values():
                     row.append(self._form_counts[
-                        (user.user_id, form['app_id'], form['xmlns'].lower())
+                        (simplified_user.user_id, form['app_id'], form['xmlns'].lower())
                     ])
                 row_sum = sum(row)
                 row = (
-                    [self.get_user_link(user)] +
+                    [self.get_user_link(simplified_user)] +
                     [self.table_cell(row_data, zerostyle=True) for row_data in row] +
                     [self.table_cell(row_sum, "<strong>%s</strong>" % row_sum)]
                 )
@@ -726,7 +725,7 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
                           for i, col in enumerate(row[1:])]
                 rows.append(row)
             else:
-                rows.append([self.get_user_link(user), '--'])
+                rows.append([self.get_user_link(simplified_user), '--'])
         if self.all_relevant_forms:
             self.total_row = [_("All Users")] + totals
         return rows
@@ -738,7 +737,7 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
         if EMWF.show_all_mobile_workers(mobile_user_and_group_slugs):
             user_ids = []
         else:
-            user_ids = self.selected_user_ids
+            user_ids = [simplified_user.user_id for simplified_user in self.selected_simplified_users]
         return get_form_counts_by_user_xmlns(
             domain=self.domain,
             startdate=self.datespan.startdate_utc.replace(tzinfo=pytz.UTC),

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -7,8 +7,6 @@ from pygooglechart import ScatterChart
 from corehq.util.quickcache import quickcache
 import pytz
 
-from dimagi.utils.couch.database import iter_docs
-
 from corehq import toggles
 from corehq.apps.es import filters
 from corehq.apps.es import cases as case_es


### PR DESCRIPTION
This should help out the forms by submission report quite a bit for ICDS. Just removing `pull_users_and_groups` is always a big win. This still does do some pretty expensive queries for each user though (getting the form counts for each user). Hard to paginate because we need to sort by the forms submitted.

@proteusvacuum @dannyroberts 