### PR TITLE
UCR improvements for icds

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -84,11 +84,12 @@ class NamedExpressionSpec(JsonObject):
 
     def __call__(self, item, context=None):
         key = self._context_cache_key()
-        if context.exists_in_cache(key):
+        if context and context.exists_in_cache(key):
             return context.get_cache_value(key)
 
         result = self._context.named_expressions[self.name](item, context)
-        context.set_iteration_cache_value(key, result)
+        if context:
+            context.set_iteration_cache_value(key, result)
         return result
 
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -79,8 +79,17 @@ class NamedExpressionSpec(JsonObject):
             raise BadSpecError(u'Name {} not found in list of named expressions!'.format(self.name))
         self._context = context
 
+    def _context_cache_key(self):
+        return 'named_expression-{}'.format(self.name)
+
     def __call__(self, item, context=None):
-        return self._context.named_expressions[self.name](item, context)
+        key = self._context_cache_key()
+        if context.exists_in_cache(key):
+            return context.get_cache_value(key)
+
+        result = self._context.named_expressions[self.name](item, context)
+        context.set_iteration_cache_value(key, result)
+        return result
 
 
 class ConditionalExpressionSpec(JsonObject):

--- a/corehq/apps/userreports/specs.py
+++ b/corehq/apps/userreports/specs.py
@@ -31,15 +31,30 @@ class EvaluationContext(object):
         self.iteration = iteration
         self.inserted_timestamp = datetime.utcnow()
         self.cache = {}
+        self.iteration_cache = {}
+
+    def exists_in_cache(self, key):
+        return key in self.cache or key in self.iteration_cache
 
     def get_cache_value(self, key):
-        return self.cache.get(key, None)
+        if key in self.cache:
+            return self.cache[key]
+
+        if key in self.iteration_cache:
+            return self.iteration_cache[key]
+
+        return None
 
     def set_cache_value(self, key, value):
         self.cache[key] = value
 
+    def set_iteration_cache_value(self, key, value):
+        self.iteration_cache[key] = value
+
     def increment_iteration(self):
+        self.iteration_cache = {}
         self.iteration += 1
 
     def reset_iteration(self):
+        self.iteration_cache = {}
         self.iteration = 0

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from jsonobject.base_properties import DefaultProperty
 from casexml.apps.case.xform import extract_case_blocks
 from corehq.apps.es.forms import FormES
@@ -149,8 +150,9 @@ class FormsInDateExpressionSpec(JsonObject):
 
     def _get_forms(self, case_id, from_date, to_date, context):
         domain = context.root_doc['domain']
+        xmlns_tuple = tuple(self.xmlns)
         cache_key = (self.__class__.__name__, case_id, self.count, from_date,
-                     to_date, tuple(self.xmlns))
+                     to_date, xmlns_tuple)
 
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
@@ -158,28 +160,50 @@ class FormsInDateExpressionSpec(JsonObject):
         xform_ids = self._get_case_form_ids(case_id, context)
         # TODO(Emord) this will eventually break down when cases have a lot of
         # forms associated with them. perhaps change to intersecting two sets
-        query = (
-            FormES()
-            .domain(domain)
-            .doc_id(xform_ids)
-        )
-        if from_date:
-            query = query.completed(gte=from_date)
-        if to_date:
-            query = query.completed(lte=to_date)
+        xforms = self._get_filtered_forms_from_es(case_id, xform_ids, context)
         if self.xmlns:
-            query = query.xmlns(list(self.xmlns))
+            xforms = [x for x in xforms if x['xmlns'] in xmlns_tuple]
+        if from_date:
+            xforms = [x for x in xforms if x['timeEnd'] >= from_date]
+        if to_date:
+            xforms = [x for x in xforms if x['timeEnd'] <= to_date]
         if self.count:
-            count = query.count()
+            count = len(xforms)
             context.set_cache_value(cache_key, count)
             return count
 
-        form_ids = query.get_ids()
+        form_ids = [x['_id'] for x in xforms]
         xforms = FormAccessors(domain).get_forms(form_ids)
         xforms = [self._get_form_json(f, context) for f in xforms if f.domain == domain]
 
         context.set_cache_value(cache_key, xforms)
         return xforms
+
+    def _get_filtered_forms_from_es(self, case_id, xform_ids, context):
+        cache_key = (self.__class__.__name__, 'es_helper', case_id, tuple(xform_ids))
+        if context.get_cache_value(cache_key) is not None:
+            return context.get_cache_value(cache_key)
+
+        def _transform_time_end(xform):
+            if not xform.get('xmlns', None):
+                return None
+            try:
+                time = xform['form']['meta']['timeEnd']
+            except KeyError:
+                return None
+
+            xform['timeEnd'] = datetime.strptime(time, '%Y-%m-%dT%H:%M:%S.%fZ').date()
+            return xform
+
+        forms = (
+            FormES()
+            .domain(context.root_doc['domain'])
+            .doc_id(xform_ids)
+            .source(['form.meta.timeEnd', 'xmlns', '_id'])
+        ).run().hits
+        forms = filter(None, map(_transform_time_end, forms))
+        context.set_cache_value(cache_key, forms)
+        return forms
 
     def _get_case_form_ids(self, case_id, context):
         cache_key = (self.__class__.__name__, 'helper', case_id)


### PR DESCRIPTION
Chipping away at some UCR stuff

Now caches named expressions (only for the current iteration). Also changes the ES query in ICDS to not depend on the date or xmlns arguments. Results in 8 or so less queries

@NoahCarnahan @sheelio @sravfeyn 