### PR TITLE
Fix broken custom location safe reports (eNikshay)

### DIFF
--- a/custom/enikshay/reports/filters.py
+++ b/custom/enikshay/reports/filters.py
@@ -47,6 +47,8 @@ class EnikshayLocationFilter(BaseMultipleOptionFilter):
     @classmethod
     def get_value(cls, request, domain):
         selected = super(EnikshayLocationFilter, cls).get_value(request, domain)
+        if not request.couch_user.has_permission(domain, 'access_all_locations'):
+            selected += request.couch_user.get_location_ids(domain)
         choice_provider = LocationChoiceProvider(StubReport(domain=domain), None)
         choice_provider.configure({'include_descendants': True})
         return [

--- a/custom/enikshay/reports/filters.py
+++ b/custom/enikshay/reports/filters.py
@@ -47,14 +47,18 @@ class EnikshayLocationFilter(BaseMultipleOptionFilter):
     @classmethod
     def get_value(cls, request, domain):
         selected = super(EnikshayLocationFilter, cls).get_value(request, domain)
-        if not request.couch_user.has_permission(domain, 'access_all_locations'):
-            selected += request.couch_user.get_location_ids(domain)
         choice_provider = LocationChoiceProvider(StubReport(domain=domain), None)
         choice_provider.configure({'include_descendants': True})
-        return [
+        selected_locations = [
             choice.value
             for choice in choice_provider.get_choices_for_known_values(selected, request.couch_user)
         ]
+        if len(selected_locations) == 0 and not request.couch_user.has_permission(domain, 'access_all_locations'):
+            # Force the user to select their assigned locations, otherwise selecting no locations will result in
+            # all results being returned.
+            return request.couch_user.get_location_ids(domain)
+        return selected_locations
+
 
     @property
     def pagination_source(self):


### PR DESCRIPTION
The custom enikshay reports weren't fully location safe. They restricted users from selecting locations outside of their hierarchy, but they didn't filter the data at all if no location was selected to filter by. This change should ensure that if a user is location restricted, the user's locations will be added to the filter.
@esoergel cc @millerdev 