### PR TITLE
Export download to use blobdb

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -32,6 +32,7 @@ class ExportFile(object):
     # This is essentially coppied from couchexport.files.ExportFiles
 
     def __init__(self, path, format):
+        self.path = path
         self.file = Temp(path)
         self.format = format
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -8,8 +8,10 @@ from corehq.apps.export.system_properties import MAIN_CASE_TABLE_PROPERTIES
 from corehq.util.decorators import serial_task
 from corehq.util.files import safe_filename_header
 from corehq.util.quickcache import quickcache
+from corehq.blobs import get_blob_db
+from corehq.toggles import BLOBDB_EXPORTS
 from couchexport.models import Format
-from soil.util import expose_cached_download
+from soil.util import expose_cached_download, expose_blob_download
 
 logger = logging.getLogger('export_migration')
 
@@ -26,16 +28,32 @@ def populate_export_download_task(export_instances, filters, download_id, filena
 
     file_format = Format.from_format(export_file.format)
     filename = filename or export_instances[0].name
-    payload = export_file.file.payload
-    expose_cached_download(
-        payload,
-        expiry,
-        ".{}".format(file_format.extension),
-        mimetype=file_format.mimetype,
-        content_disposition=safe_filename_header(filename, file_format.extension),
-        download_id=download_id,
-    )
-    export_file.file.delete()
+    domain = export_instances[0].domain
+
+    try:
+        if BLOBDB_EXPORTS.enabled(domain):
+            db = get_blob_db()
+            db.put(open(export_file.path, 'r'), download_id, timeout=expiry)
+
+            expose_blob_download(
+                download_id,
+                mimetype=file_format.mimetype,
+                content_disposition=safe_filename_header(filename, file_format.extension),
+                download_id=download_id,
+            )
+        else:
+            payload = export_file.file.payload
+
+            expose_cached_download(
+                payload,
+                expiry,
+                ".{}".format(file_format.extension),
+                mimetype=file_format.mimetype,
+                content_disposition=safe_filename_header(filename, file_format.extension),
+                download_id=download_id,
+            )
+    finally:
+        export_file.file.delete()
 
 
 @task(queue='background_queue', ignore_result=True)

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -287,13 +287,7 @@ class BlobDownload(DownloadBase):
         return self.identifier
 
     def get_content(self):
-        file_obj = None
-        try:
-            file_obj = self.blobdb.get(self.identifier, self.bucket).read()
-            return file_obj.read()
-        finally:
-            if file_obj is not None:
-                file_obj.close()
+        raise NotImplementedError
 
     def toHttpResponse(self):
         file_obj = self.blobdb.get(self.identifier, self.bucket)

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -303,9 +303,9 @@ class BlobDownload(DownloadBase):
         return response
 
     @classmethod
-    def create(cls, path, **kwargs):
+    def create(cls, identifier, **kwargs):
         """
         Create a BlobDownload object from a payload, plus any
         additional arguments to pass through to the constructor.
         """
-        return cls(identifier=path, **kwargs)
+        return cls(identifier=identifier, **kwargs)

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -14,6 +14,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 
 from django_transfer import TransferHttpResponse
 from soil.progress import get_task_progress, get_multiple_task_progress
+from corehq.blobs import DEFAULT_BUCKET, get_blob_db
 
 
 GLOBAL_RW = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
@@ -257,3 +258,60 @@ class FileDownload(DownloadBase):
         additional arguments to pass through to the constructor.
         """
         return cls(filename=path, **kwargs)
+
+
+class BlobDownload(DownloadBase):
+    """
+    Download that lives in the blobdb
+    """
+    has_file = True
+
+    def __init__(self, identifier, mimetype="text/plain",
+                 content_disposition='attachment; filename="download.txt"',
+                 transfer_encoding=None, extras=None, download_id=None, cache_backend=SOIL_DEFAULT_CACHE,
+                 content_type=None, bucket=DEFAULT_BUCKET):
+
+        super(BlobDownload, self).__init__(
+            mimetype=content_type if content_type else mimetype,
+            content_disposition=content_disposition,
+            transfer_encoding=transfer_encoding,
+            extras=extras,
+            download_id=download_id,
+            cache_backend=cache_backend
+        )
+        self.identifier = identifier
+        self.bucket = bucket
+        self.blobdb = get_blob_db()
+
+    def get_filename(self):
+        return self.identifier
+
+    def get_content(self):
+        file_obj = None
+        try:
+            file_obj = self.blobdb.get(self.identifier, self.bucket).read()
+            return file_obj.read()
+        finally:
+            if file_obj is not None:
+                file_obj.close()
+
+    def toHttpResponse(self):
+        file_obj = self.blobdb.get(self.identifier, self.bucket)
+
+        response = StreamingHttpResponse(
+            FileWrapper(file_obj, CHUNK_SIZE),
+            content_type=self.content_type
+        )
+
+        response['Content-Disposition'] = self.content_disposition
+        for k, v in self.extras.items():
+            response[k] = v
+        return response
+
+    @classmethod
+    def create(cls, path, **kwargs):
+        """
+        Create a BlobDownload object from a payload, plus any
+        additional arguments to pass through to the constructor.
+        """
+        return cls(identifier=path, **kwargs)

--- a/corehq/ex-submodules/soil/tests/test_download_base.py
+++ b/corehq/ex-submodules/soil/tests/test_download_base.py
@@ -1,0 +1,38 @@
+from io import StringIO
+from django.test import SimpleTestCase
+
+from soil import BlobDownload
+from soil.util import expose_blob_download
+
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+
+
+class TestBlobDownload(SimpleTestCase):
+    identifier = 'identifier'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db = TemporaryFilesystemBlobDB()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+
+    def test_expose_blob_download(self):
+        content_disposition = 'text/xml'
+        download_id = 'abc123'
+
+        self.db.put(StringIO(u'content'), self.identifier)
+
+        expose_blob_download(
+            self.identifier,
+            content_disposition=content_disposition,
+            download_id=download_id
+        )
+
+        download = BlobDownload.get(download_id)
+
+        self.assertIsNotNone(download)
+
+        response = download.toHttpResponse()
+        self.assertEqual(response.streaming_content.next(), u'content')

--- a/corehq/ex-submodules/soil/util.py
+++ b/corehq/ex-submodules/soil/util.py
@@ -33,7 +33,7 @@ def expose_blob_download(
         content_disposition=None,
         download_id=None):
     """
-    Expose a file download object that potentially uses the external drive
+    Expose a blob object for download
     """
     ref = BlobDownload.create(
         identifier,

--- a/corehq/ex-submodules/soil/util.py
+++ b/corehq/ex-submodules/soil/util.py
@@ -1,4 +1,4 @@
-from soil import DownloadBase, CachedDownload, FileDownload, MultipleTaskDownload
+from soil import DownloadBase, CachedDownload, FileDownload, MultipleTaskDownload, BlobDownload
 from soil.exceptions import TaskFailedError
 from soil.heartbeat import is_alive, heartbeat_enabled
 from soil.progress import get_task_status
@@ -23,6 +23,24 @@ def expose_file_download(path, **kwargs):
     Expose a file download object that potentially uses the external drive
     """
     ref = FileDownload.create(path, **kwargs)
+    ref.save()
+    return ref
+
+
+def expose_blob_download(
+        identifier,
+        mimetype='text/plain',
+        content_disposition=None,
+        download_id=None):
+    """
+    Expose a file download object that potentially uses the external drive
+    """
+    ref = BlobDownload.create(
+        identifier,
+        mimetype=mimetype,
+        content_disposition=content_disposition,
+        download_id=download_id,
+    )
     ref.save()
     return ref
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1062,6 +1062,14 @@ COUCH_SQL_MIGRATION_BLACKLIST = StaticToggle(
     }
 )
 
+BLOBDB_EXPORTS = PredictablyRandomToggle(
+    'blobdb_exports',
+    'Use the blobdb to do exports',
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN],
+    randomness=0,
+)
+
 PAGINATED_EXPORTS = StaticToggle(
     'paginated_exports',
     'Allows for pagination of exports for very large exports',


### PR DESCRIPTION
@millerdev @NoahCarnahan this converts the export code to use the blobdb instead of redis. this has the huge added benefit of not having to load the entire file into memory. Decided to put this behind a flag before rollout just in case there are some quirks with production riak that I didn't foresee

buddies @dannyroberts @proteusvacuum 