### PR TITLE
Externalize JavaScript: download export

### DIFF
--- a/corehq/apps/export/static/export/js/download_export.js
+++ b/corehq/apps/export/static/export/js/download_export.js
@@ -1,0 +1,24 @@
+hqDefine('export/js/download_export.js', function() {
+   'use strict';
+
+    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
+    var downloadExportsApp = window.angular.module('downloadExportsApp', ['hq.download_export']);
+    downloadExportsApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
+        djangoRMIProvider.configure(initial_page_data('djng_current_rmi'));
+    }]);
+    downloadExportsApp.constant('exportList', initial_page_data('export_list'));
+    downloadExportsApp.constant('maxColumnSize', initial_page_data('max_column_size'));
+    downloadExportsApp.constant('defaultDateRange', initial_page_data('default_date_range'));
+    downloadExportsApp.constant('checkForMultimedia', initial_page_data('check_for_multimedia'));
+    downloadExportsApp.constant('formElement', {
+        progress: function () {
+            return $('#download-progress-bar');
+        },
+        group: function () {
+            return $('#id_group');
+        },
+        user_type: function () {
+            return $('#id_user_types');
+        }
+    });
+});

--- a/corehq/apps/export/static/export/js/download_export.js
+++ b/corehq/apps/export/static/export/js/download_export.js
@@ -1,5 +1,5 @@
 hqDefine('export/js/download_export.js', function() {
-   'use strict';
+    'use strict';
 
     var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
     var downloadExportsApp = window.angular.module('downloadExportsApp', ['hq.download_export']);
@@ -19,6 +19,6 @@ hqDefine('export/js/download_export.js', function() {
         },
         user_type: function () {
             return $('#id_user_types');
-        }
+        },
     });
 });

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -44,14 +44,16 @@
 <script>
 (function (angular, undefined) {
    'use strict';
+
+    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
     var downloadExportsApp = angular.module('downloadExportsApp', ['hq.download_export']);
     downloadExportsApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
-        djangoRMIProvider.configure({% djng_current_rmi %});
+        djangoRMIProvider.configure(initial_page_data('djng_current_rmi'));
     }]);
-    downloadExportsApp.constant('exportList', {{ export_list|JSON }});
-    downloadExportsApp.constant('maxColumnSize', {{ max_column_size|JSON }});
-    downloadExportsApp.constant('defaultDateRange', '{{ default_date_range }}');
-    downloadExportsApp.constant('checkForMultimedia', {{ check_for_multimedia|BOOL }});
+    downloadExportsApp.constant('exportList', initial_page_data('export_list'));
+    downloadExportsApp.constant('maxColumnSize', initial_page_data('max_column_size'));
+    downloadExportsApp.constant('defaultDateRange', initial_page_data('default_date_range'));
+    downloadExportsApp.constant('checkForMultimedia', initial_page_data('check_for_multimedia'));
     downloadExportsApp.constant('formElement', {
         progress: function () {
             return $('#download-progress-bar');
@@ -68,6 +70,11 @@
 {% endblock %}
 
 {% block page_content %}
+    {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
+    {% initial_page_data 'export_list' export_list %}
+    {% initial_page_data 'max_column_size' max_column_size %}
+    {% initial_page_data 'default_date_range' default_date_range %}
+    {% initial_page_data 'check_for_multimedia' check_for_multimedia %}
     <div ng-app="downloadExportsApp">
         <div ng-controller="DownloadExportFormController"
              ng-cloak>

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -38,35 +38,7 @@
 {% block js %}
 <script src="{% static 'reports/js/reports.util.js' %}"></script>
 <script src="{% static 'export/js/download_export.ng.js' %}"></script>
-{% endblock %}
-
-{% block js-inline %}
-<script>
-(function (angular, undefined) {
-   'use strict';
-
-    var initial_page_data = hqImport('hqwebapp/js/initial_page_data.js').get;
-    var downloadExportsApp = angular.module('downloadExportsApp', ['hq.download_export']);
-    downloadExportsApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
-        djangoRMIProvider.configure(initial_page_data('djng_current_rmi'));
-    }]);
-    downloadExportsApp.constant('exportList', initial_page_data('export_list'));
-    downloadExportsApp.constant('maxColumnSize', initial_page_data('max_column_size'));
-    downloadExportsApp.constant('defaultDateRange', initial_page_data('default_date_range'));
-    downloadExportsApp.constant('checkForMultimedia', initial_page_data('check_for_multimedia'));
-    downloadExportsApp.constant('formElement', {
-        progress: function () {
-            return $('#download-progress-bar');
-        },
-        group: function () {
-            return $('#id_group');
-        },
-        user_type: function () {
-            return $('#id_user_types');
-        }
-    });
-}(window.angular));
-</script>
+<script src="{% static 'export/js/download_export.js' %}"></script>
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -570,6 +570,15 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
 
         return context
 
+    # Add the output of djng_current_rmi to view context, which requires having
+    # the rest of the context, specifically context['view'], available.
+    # See https://github.com/jrief/django-angular/blob/master/djng/templatetags/djng_tags.py
+    def get_context_data(self, **kwargs):
+        context = super(BaseDownloadExportView, self).get_context_data(**kwargs)
+        from djangular.templatetags.djangular_tags import djng_current_rmi
+        context['djng_current_rmi'] = json.loads(djng_current_rmi(context))
+        return context
+
     @property
     def export_list_url(self):
         """Should return a the URL for the export list view"""


### PR DESCRIPTION
Just one page in this PR; it took a while to figure out how to get `djng_current_rmi` added to the view context. Will probably move the `get_context_data` override into a mixin that can be used by other angular views, but decided it was premature to do that now.

@esoergel / @biyeun 