### PR TITLE
ICDS: Add all indicators to monthly tables

### DIFF
--- a/custom/icds_reports/migrations/0012_extend_monthly_case_tables.py
+++ b/custom/icds_reports/migrations/0012_extend_monthly_case_tables.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from corehq.sql_db.operations import RawSQLMigration
+
+migrator = RawSQLMigration(('custom', 'icds_reports', 'migrations', 'sql_templates'))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icds_reports', '0011_add_trained_indicators'),
+    ]
+
+    operations = [
+        migrator.get_migration('create_functions.sql'),
+        migrator.get_migration('update_tables7.sql'),
+    ]

--- a/custom/icds_reports/migrations/sql_templates/create_functions.sql
+++ b/custom/icds_reports/migrations/sql_templates/create_functions.sql
@@ -123,7 +123,10 @@ BEGIN
 		'counsel_skin_to_skin, ' ||
 		'counsel_immediate_breastfeeding, ' ||
 		'weight_recorded_in_month, ' ||
-		'height_recorded_in_month FROM ' || quote_ident(_ucr_child_monthly_table) || ' WHERE month = ' || quote_literal(_start_date) || ')';
+		'height_recorded_in_month, ' ||
+		'has_aadhar_id, ' ||
+		'thr_eligible, ' ||
+		'pnc_eligible FROM ' || quote_ident(_ucr_child_monthly_table) || ' WHERE month = ' || quote_literal(_start_date) || ')';
 
     EXECUTE 'CREATE INDEX ' || quote_ident(_tablename || '_indx1') || ' ON ' || quote_ident(_tablename) || '(awc_id, case_id)';
 
@@ -186,7 +189,9 @@ BEGIN
 		'bp2_complete, ' ||
 		'bp3_complete, ' ||
 		'pnc_complete, ' ||
-		'postnatal FROM ' || quote_ident(_ucr_ccs_record_table) || ' WHERE month = ' || quote_literal(_start_date) || ')';
+		'postnatal, ' ||
+		'has_aadhar_id, ' ||
+		'counsel_fp_methods FROM ' || quote_ident(_ucr_ccs_record_table) || ' WHERE month = ' || quote_literal(_start_date) || ')';
 
 		EXECUTE 'CREATE INDEX ' || quote_ident(_tablename || '_indx1') || ' ON ' || quote_ident(_tablename) || '(awc_id, case_id)';
         -- There may be better indexes to put here. Should investigate what tableau queries

--- a/custom/icds_reports/migrations/sql_templates/update_tables7.sql
+++ b/custom/icds_reports/migrations/sql_templates/update_tables7.sql
@@ -1,0 +1,5 @@
+ALTER TABLE child_health_monthly ADD COLUMN has_aadhar_id integer;
+ALTER TABLE child_health_monthly ADD COLUMN thr_eligible integer;
+ALTER TABLE child_health_monthly ADD COLUMN pnc_eligible integer;
+ALTER TABLE ccs_record_monthly ADD COLUMN has_aadhar_id integer;
+ALTER TABLE ccs_record_monthly ADD COLUMN counsel_fp_methods integer;


### PR DESCRIPTION
@emord 

This PR makes sure we're saving all of our monthly indicators to the monthly Tableau tables.  This will allow us to download data if we need to share with the government.  