### PR TITLE
Fix styling for 'View Source Files' in deploy modal

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
@@ -313,11 +313,13 @@
                     </div>
                 {% endif %}
                 {% if request.user.is_superuser %}
-                    <div class="panel panel-default">
+                    <div class="panel panel-appmanager">
                         <div class="panel-heading">
-                            <a data-bind="attr: {href: $root.url('source', id)}">
-                                {% trans 'View Source Files' %}
-                            </a>
+                            <h4 class="panel-title">
+                                <a data-bind="attr: {href: $root.url('source', id)}">
+                                    {% trans 'View Source Files' %}
+                                </a>
+                            </h4>
                         </div>
                     </div>
                 {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
@@ -163,3 +163,21 @@
                          </div>
                          <div class="panel-collapse collapse" data-bind="attr: {id: id() + '_multimedia'}">
                              <div class="panel-body">
+@@ -300,11 +313,13 @@
+                     </div>
+                 {% endif %}
+                 {% if request.user.is_superuser %}
+-                    <div class="panel panel-default">
++                    <div class="panel panel-appmanager">
+                         <div class="panel-heading">
+-                            <a data-bind="attr: {href: $root.url('source', id)}">
+-                                {% trans 'View Source Files' %}
+-                            </a>
++                            <h4 class="panel-title">
++                                <a data-bind="attr: {href: $root.url('source', id)}">
++                                    {% trans 'View Source Files' %}
++                                </a>
++                            </h4>
+                         </div>
+                     </div>
+                 {% endif %}


### PR DESCRIPTION
Before
<img width="631" alt="screen shot 2017-04-06 at 1 43 28 pm" src="https://cloud.githubusercontent.com/assets/1486591/24768944/89ab686e-1ad2-11e7-8a8c-89e33dcda010.png">

After
<img width="625" alt="screen shot 2017-04-06 at 2 07 52 pm" src="https://cloud.githubusercontent.com/assets/1486591/24768949/8e9d542c-1ad2-11e7-92c1-51013da98962.png">

@esoergel / @biyeun 