### PR TITLE
App Manager v2: Style panel for EXPORT_ZIPPED_APPS flag

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/app-settings.html
@@ -280,15 +280,18 @@
                 {% endif %}
                 {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
                 {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
-                    <legend>Export compressed application</legend>
-                    <form action="{% url "gzip_app" domain app.id %}" method="POST">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-primary">
-                            <i class="fa fa-arrow-down"></i>
-                            {% trans "Download" %}
-                        </button>
-                    </form>
-                    <br>
+                    <div class="panel panel-appmanager panel-appmanager-form panel-appmanager-form-danger">
+                        <form action="{% url "gzip_app" domain app.id %}" method="POST">
+                            {% csrf_token %}
+                            <legend>Export compressed application</legend>
+                            <div class="panel-body">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fa fa-arrow-down"></i>
+                                    {% trans "Download" %}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
                 {% endif %}
             {% endif %}
             <div class="panel panel-appmanager panel-appmanager-form panel-appmanager-form-danger">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
@@ -125,7 +125,7 @@
          <input type="number" class="col-sm-3 form-control" data-bind="
              value: visibleValue,
              valueUpdate: 'textchange',
-@@ -137,166 +138,174 @@
+@@ -137,166 +138,177 @@
  </script>
  
  <script type="text/html" id="CommcareSettings.widgets.textarea">
@@ -352,8 +352,6 @@
 -                                    <i class="fa" data-bind="css: {'fa-arrow-left': !optionOK(), 'fa-check': optionOK}"></i>
 -                                    <span data-bind="text: disabledMessage()"></span>
 -                                </span>
--                            </div>
--                        </div>
 +                        <div data-bind="saveButton: saveButton"></div>
 +                        <table class="table">
 +                            <thead>
@@ -370,7 +368,23 @@
 +                            </tr>
 +                            </tbody>
 +                        </table>
-                     </div>
++                    </div>
++                    </div>
++                {% endif %}
++                {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
++                {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
++                    <div class="panel panel-appmanager panel-appmanager-form panel-appmanager-form-danger">
++                        <form action="{% url "gzip_app" domain app.id %}" method="POST">
++                            {% csrf_token %}
++                            <legend>Export compressed application</legend>
++                            <div class="panel-body">
++                                <button type="submit" class="btn btn-primary">
++                                    <i class="fa fa-arrow-down"></i>
++                                    {% trans "Download" %}
++                                </button>
+                             </div>
+-                        </div>
+-                    </div>
 -                </div>
 -            </fieldset>
 -        </div>
@@ -398,25 +412,15 @@
 -                            name: 'CommcareSettings.widgets.customProperty'
 -                        }
 -                        ">
-                     </div>
+-                    </div>
 -
 -                </div>
 -                <button class="btn btn-default" data-bind="click: onAddCustomProperty">
 -                    <i class="fa fa-plus"></i>
 -                    {% trans "Add Custom Property" %}
 -                </button>
-+                {% endif %}
-+                {{ request|toggle_tag_info:"EXPORT_ZIPPED_APPS" }}
-+                {% if request|toggle_enabled:"EXPORT_ZIPPED_APPS" %}
-+                    <legend>Export compressed application</legend>
-+                    <form action="{% url "gzip_app" domain app.id %}" method="POST">
-+                        {% csrf_token %}
-+                        <button type="submit" class="btn btn-primary">
-+                            <i class="fa fa-arrow-down"></i>
-+                            {% trans "Download" %}
-+                        </button>
-+                    </form>
-+                    <br>
++                        </form>
++                    </div>
 +                {% endif %}
 +            {% endif %}
 +            <div class="panel panel-appmanager panel-appmanager-form panel-appmanager-form-danger">


### PR DESCRIPTION
Before
<img width="986" alt="screen shot 2017-04-06 at 2 18 37 pm" src="https://cloud.githubusercontent.com/assets/1486591/24769293/ff044242-1ad3-11e7-97b1-6cedb9738977.png">

After
<img width="985" alt="screen shot 2017-04-06 at 2 17 59 pm" src="https://cloud.githubusercontent.com/assets/1486591/24769301/0612cc2a-1ad4-11e7-911b-03e2bdb0e136.png">

@esoergel / @biyeun 