### PR TITLE
do not save blob_db to the class

### DIFF
--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -281,7 +281,6 @@ class BlobDownload(DownloadBase):
         )
         self.identifier = identifier
         self.bucket = bucket
-        self.blobdb = get_blob_db()
 
     def get_filename(self):
         return self.identifier
@@ -290,7 +289,7 @@ class BlobDownload(DownloadBase):
         raise NotImplementedError
 
     def toHttpResponse(self):
-        file_obj = self.blobdb.get(self.identifier, self.bucket)
+        file_obj = get_blob_db().get(self.identifier, self.bucket)
 
         response = StreamingHttpResponse(
             FileWrapper(file_obj, CHUNK_SIZE),


### PR DESCRIPTION
@proteusvacuum @dannyroberts `DownloadBase` saves the object to redis and it cannot pickle the blob db. it's unclear to me still why this didn't fail locally. https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/soil/__init__.py#L82