### PR TITLE
Don't error on UCR transform

### DIFF
--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -4,7 +4,10 @@ from dimagi.utils.dates import force_to_datetime
 
 
 def get_month_display(month_index):
-    return calendar.month_name[int(month_index)]
+    try:
+        return calendar.month_name[int(month_index)]
+    except Exception as e:
+        return ""
 
 
 def days_elapsed_from_date(date):


### PR DESCRIPTION
If the value is `""`, this will error. Not certain if `""` is the best return value, or returning the value is better.
@nickpell cc @millerdev 