### PR TITLE
Fix pagination of enikshay locations filter

### DIFF
--- a/custom/enikshay/reports/views.py
+++ b/custom/enikshay/reports/views.py
@@ -32,6 +32,6 @@ class LocationsView(View):
                     {'id': location.value, 'text': location.display}
                     for location in location_choice_provider.query(query_context)
                 ],
-                'total': location_choice_provider.query_count(query_context, user)
+                'total': location_choice_provider.query_count(query_context.query, user)
             }
         )


### PR DESCRIPTION
The enikshay locations report filter never shows multiple pages of results. That is because `query_count()` is expecting a string as its first argument, not a `ChoiceQueryContext`. This PR fixes it.
cc @millerdev 
fyi enikshay people: @mkangia @nickpell @proteusvacuum 
