### PR TITLE
app manager v2: styling for custom properties

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/app_view.html
@@ -46,6 +46,9 @@
         settings: {
           sections: {{ settings_layout|JSON }},
           values: {{ settings_values|JSON }},
+          {% if request|toggle_enabled:"CUSTOM_PROPERTIES" %}
+          customProperties: {{ custom_properties|JSON }},
+          {% endif %}
           urls: {
             save: '{% url "edit_commcare_settings" domain app.id %}'
           },

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/commcare_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/commcare_settings.html
@@ -63,36 +63,40 @@
   </div>
   {{ request|toggle_tag_info:"CUSTOM_PROPERTIES" }}
   {% if request|toggle_enabled:"CUSTOM_PROPERTIES" %}
-    <fieldset>
-      <legend>
-        <a
-                data-toggle="collapse"
-                data-bind="
-                    attr: { href: '#' + customPropertyType },
-                    css: { collapsed: true }
-                    ">
-          <i class="fa fa-angle-double-down"></i>
-          <span>{% trans "Custom Properties" %}</span>
-        </a>
-      </legend>
-      <div class="collapse col-sm-6" data-bind="attr: { id: customPropertyType }">
-        <div class="custom-property-list" data-bind="
-                foreach: customProperties,
-                as: 'customProperty'
-                ">
-          <div class="form-group container-fluid" data-bind="
-                    template: {
-                        name: 'CommcareSettings.widgets.customProperty'
-                    }
-                    ">
-          </div>
-
-        </div>
-        <button class="btn btn-default" data-bind="click: onAddCustomProperty">
-          <i class="fa fa-plus"></i>
-          {% trans "Add Custom Property" %}
-        </button>
+    <div class="panel panel-appmanager">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a class="collapsed"
+             href="#custom-properties"
+             data-toggle="collapse">
+            <i class="fa fa-angle-double-down"></i>
+            {% trans 'Custom Properties' %}
+          </a>
+        </h4>
       </div>
-    </fieldset>
+      <div class="panel-collapse collapse" id="custom-properties">
+        <div class="panel-body">
+          <fieldset>
+            <div class="col-sm-6" data-bind="attr: { id: customPropertyType }">
+              <div class="custom-property-list" data-bind="
+                      foreach: customProperties,
+                      as: 'customProperty'
+                      ">
+                <div class="form-group container-fluid" data-bind="
+                          template: {
+                              name: 'CommcareSettings.widgets.customProperty'
+                          }
+                          ">
+                </div>
+              </div>
+              <button class="btn btn-default" data-bind="click: onAddCustomProperty">
+                <i class="fa fa-plus"></i>
+                {% trans "Add Custom Property" %}
+              </button>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
   {% endif %}
 </form>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,400 +1,115 @@
+@@ -1,400 +1,118 @@
 -{% extends "app_manager/v1/managed_app.html" %}
 +{% extends "app_manager/v2/managed_app.html" %}
  {% load xforms_extras %}
@@ -327,6 +327,9 @@
 +        settings: {
 +          sections: {{ settings_layout|JSON }},
 +          values: {{ settings_values|JSON }},
++          {% if request|toggle_enabled:"CUSTOM_PROPERTIES" %}
++          customProperties: {{ custom_properties|JSON }},
++          {% endif %}
 +          urls: {
 +            save: '{% url "edit_commcare_settings" domain app.id %}'
 +          },


### PR DESCRIPTION
Before
<img width="982" alt="screen shot 2017-04-07 at 2 14 57 pm" src="https://cloud.githubusercontent.com/assets/1486591/24813637/d2eae930-1b9c-11e7-89c6-1c355b7dcb1b.png">

After
<img width="988" alt="screen shot 2017-04-07 at 2 14 15 pm" src="https://cloud.githubusercontent.com/assets/1486591/24813645/d824ca10-1b9c-11e7-979d-55d9796731eb.png">

The custom properties section doesn't behave as a part of the accordion (it can stay open even if one of the other sections is also open). I think that's fine for a feature flag.

`w=1`

@esoergel / @biyeun 