### PR TITLE
App manager v2: support NO_VELLUM

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view_base.html
@@ -216,6 +216,7 @@
         $('#auto-gps-capture').koApplyBindings({
             auto_gps_capture: ko.observable({{ form.auto_gps_capture|JSON }})
         });
+
         {% if request|toggle_enabled:'NO_VELLUM' %}
         $('#no-vellum').koApplyBindings({
             no_vellum: ko.observable({{ form.no_vellum|JSON }})

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_view_base.html
@@ -210,6 +210,12 @@
             auto_gps_capture: ko.observable({{ form.auto_gps_capture|JSON }})
         });
 
+        {% if request|toggle_enabled:'NO_VELLUM' %}
+        $('#no-vellum').koApplyBindings({
+            no_vellum: ko.observable({{ form.no_vellum|JSON }})
+        });
+        {% endif %}
+
         gaTrackLink($('.breadcrumb .view-form'), 'App Builder', 'View Form', 'Breadcrumb');
 
         {% if can_preview_form and allow_cloudcare %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
@@ -5,11 +5,16 @@
 {# For APP BUILDER PROTOTYPE use only #}
 
 <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar"
+   {% if form.no_vellum %}
+   href="{% url "view_form" domain app.id module.id form.id %}"
+   data-updatevalue="{% url "view_form" domain app.id 'replacewithmoduleid' 'replacewithformid' %}"
+   {% else %}
    href="{% url "form_source" domain app.id module.id form.id %}"
+   data-updatevalue="{% url "form_source" domain app.id 'replacewithmoduleid' 'replacewithformid' %}"
+   {% endif %}
    data-moduleid="{{ module.id }}"
    data-formid="{{ form.id }}"
    data-updateprop="href"
-   data-updatevalue="{% url "form_source" domain app.id 'replacewithmoduleid' 'replacewithformid' %}"
    class="appnav-title
           {% if not form.no_vellum %}appnav-title-secondary {% endif %}
           {% if form.get_action_type == 'open' %}appnav-title-no-delete  appnav-title-registration

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_tab_settings.html
@@ -85,11 +85,6 @@
 
                     </div>
 
-                    {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
-                    {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
-                        {% include "app_manager/v2/partials/custom_instances.html" %}
-                    {% endif %}
-
                     {% if request|toggle_enabled:'NO_VELLUM' %}
                     <div class="form-group">
                         <label class="control-label col-sm-2">
@@ -106,7 +101,12 @@
                              <input type="hidden" name="no_vellum" data-bind="value: no_vellum"/>
                         </div>
                     </div>
-                  {% endif %}
+                    {% endif %}
+
+                    {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
+                    {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
+                        {% include "app_manager/v2/partials/custom_instances.html" %}
+                    {% endif %}
                   </div>
               </div>
             </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_tab_settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/form_tab_settings.html.diff.txt
@@ -164,11 +164,6 @@
 +
 +                    </div>
 +
-+                    {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
-+                    {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
-+                        {% include "app_manager/v2/partials/custom_instances.html" %}
-+                    {% endif %}
-+
 +                    {% if request|toggle_enabled:'NO_VELLUM' %}
 +                    <div class="form-group">
 +                        <label class="control-label col-sm-2">
@@ -185,7 +180,12 @@
 +                             <input type="hidden" name="no_vellum" data-bind="value: no_vellum"/>
 +                        </div>
 +                    </div>
-+                  {% endif %}
++                    {% endif %}
++
++                    {{ request|toggle_tag_info:"CUSTOM_INSTANCES" }}
++                    {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
++                        {% include "app_manager/v2/partials/custom_instances.html" %}
++                    {% endif %}
 +                  </div>
 +              </div>
 +            </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view_base.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view_base.html.diff.txt
@@ -30,7 +30,7 @@
              {% with module_name=module.name|trans:langs %}
              labels[FormWorkflow.Values.MODULE] = "{% trans "Module:" %} {{ module_name|escapejs }}";
              {% endwith %}
-@@ -203,28 +203,16 @@
+@@ -203,13 +203,6 @@
                  workflow: '{{ form.post_form_workflow }}',
              };
  
@@ -44,14 +44,7 @@
              $('#form-workflow').koApplyBindings(new FormWorkflow(options))
          {% endif %}
  
-         $('#auto-gps-capture').koApplyBindings({
-             auto_gps_capture: ko.observable({{ form.auto_gps_capture|JSON }})
-         });
--        {% if request|toggle_enabled:'NO_VELLUM' %}
--        $('#no-vellum').koApplyBindings({
--            no_vellum: ko.observable({{ form.no_vellum|JSON }})
--        });
--        {% endif %}
+@@ -225,7 +218,7 @@
  
          gaTrackLink($('.breadcrumb .view-form'), 'App Builder', 'View Form', 'Breadcrumb');
  
@@ -60,7 +53,7 @@
              // tag the 'preview in cloudcare' button with the right url
              // unfortunately, has to be done in javascript
              var getCloudCareUrl = function(urlRoot, appId, moduleId, formId, caseId) {
-@@ -290,67 +278,55 @@
+@@ -291,67 +284,55 @@
      </script>
  {% endblock %}
  
@@ -170,7 +163,7 @@
              {% if form.form_type == 'module_form' %}{% if allow_usercase or form.uses_usercase %}
              <li>
                  <a id="usercase-configuration-tab" href="#usercase-configuration" data-toggle="tab">
-@@ -362,6 +338,7 @@
+@@ -363,6 +344,7 @@
                  </a>
              </li>
              {% endif %}{% endif %}
@@ -178,7 +171,7 @@
              {% if form.form_type == 'advanced_form' and module.has_schedule %}
                   <li>
                       <a href="#visit-scheduler" data-toggle="tab">
-@@ -369,45 +346,46 @@
+@@ -370,45 +352,46 @@
                       </a>
                   </li>
              {% endif %}
@@ -260,7 +253,7 @@
              <div class="tab-pane" id="usercase-configuration">
                  {% if form_errors or xform_validation_errored %}
                      <p class="alert alert-warning">
-@@ -433,7 +411,6 @@
+@@ -434,7 +417,6 @@
                          {% block usercase_management_content %}
                              {%  if form.uses_usercase and not allow_usercase %}
                                  <div class="container-fluid col-sm-6">
@@ -268,7 +261,7 @@
                                {% if request|toggle_enabled:"USER_PROPERTY_EASY_REFS" %}
                                  <p>{% blocktrans %}
                                      The User Properties feature is no longer available because of the change in your
-@@ -478,7 +455,7 @@
+@@ -479,7 +461,7 @@
                                  </p>
                                  </div>
                              {% endif %}
@@ -277,7 +270,7 @@
                          {% endblock %}
                      </div>
                  {% else %}
-@@ -491,23 +468,25 @@
+@@ -492,23 +474,25 @@
                      </p>
                  {% endif %}
              </div>


### PR DESCRIPTION
@biyeun It looks like the intent is that the left-hand nav for forms without vellum will just link directly to the settings page (since they don't have a gear icon), so I did that.

@esoergel 