### PR TITLE
App manager v2: fit in care plan modules

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/managed_app.html
@@ -125,7 +125,7 @@
         {% if show_care_plan %}
           <div class="pull-left">
             <button type="button" class="popover-additem-option new-module" data-toggle="modal" href="#careplan-module-modal">
-              <i class="fa fa-bars"></i> {% trans "Care Plan Menu" %}
+              <i class="fa fa-clipboard"></i> {% trans "Care Plan" %}
               <p>{% blocktrans %}Tasks and goals.{% endblocktrans %}</p>
             </button>
           </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
@@ -350,7 +350,7 @@
 +        {% if show_care_plan %}
 +          <div class="pull-left">
 +            <button type="button" class="popover-additem-option new-module" data-toggle="modal" href="#careplan-module-modal">
-+              <i class="fa fa-bars"></i> {% trans "Care Plan Menu" %}
++              <i class="fa fa-clipboard"></i> {% trans "Care Plan" %}
 +              <p>{% blocktrans %}Tasks and goals.{% endblocktrans %}</p>
 +            </button>
 +          </div>

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/popover.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/popover.less
@@ -1,6 +1,6 @@
 .popover-additem {
   background-color: @cc-light-cool-accent-low;
-  max-width: 610px;
+  max-width: 730px;
   height: 215px;
   .border-top-radius(0);
   .border-bottom-radius(0);


### PR DESCRIPTION
Forgot to test these while doing https://github.com/dimagi/commcare-hq/pull/15687 and it turns out they didn't quite fit in the popover.

@biyeun / @esoergel 

<img width="136" alt="screen shot 2017-04-08 at 10 52 40 am" src="https://cloud.githubusercontent.com/assets/1486591/24829933/ccb5c316-1c49-11e7-8f9a-27a5a6fbb43b.png">
