### PR TITLE
App manager v2: more intelligently pick case type for new module

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -994,14 +994,11 @@ def new_module(request, domain, app_id):
                 followup.actions.update_case = UpdateCaseAction(condition=FormActionCondition(type='always'))
 
                 # make case type unique across app
-                app_case_types = set(
-                    [module.case_type for module in app.modules if
-                     module.case_type])
-                module.case_type = 'case'
-                suffix = 0
-                while module.case_type in app_case_types:
-                    suffix = suffix + 1
-                    module.case_type = 'case-{}'.format(suffix)
+                app_case_types = [module.case_type for module in app.modules if module.case_type]
+                if len(app_case_types):
+                    module.case_type = app_case_types[0]
+                else:
+                    module.case_type = 'case'
             else:
                 app.new_form(module_id, "Survey", lang)
             form_id = 0

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -994,7 +994,7 @@ def new_module(request, domain, app_id):
                 followup.actions.update_case = UpdateCaseAction(condition=FormActionCondition(type='always'))
 
                 # make case type unique across app
-                app_case_types = [module.case_type for module in app.modules if module.case_type]
+                app_case_types = [m.case_type for m in app.modules if m.case_type]
                 if len(app_case_types):
                     module.case_type = app_case_types[0]
                 else:


### PR DESCRIPTION
The old logic assigned a new case type for each module: `case` for the first, `case-1` for the second, etc. Thought about this and decided it doesn't really make sense...people are reasonably likely to want a second module with the same case type as an existing module, but they're never going to want a second module called `case-1`, so we might as well default to an existing case type. People will still often need to change it, but at least they won't *always* need to change it.

@biyeun / @esoergel 