### PR TITLE
Save case search config if there are only default properties

### DIFF
--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -1,0 +1,40 @@
+<partial>
+  <remote-request>
+    <post url="https://www.example.com/a/test_domain/phone/claim-case/"
+          relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">
+      <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+    </post>
+    <command id="search_command.m0">
+      <display>
+        <text>
+          <locale id="case_search.m0"/>
+        </text>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
+    <instance id="locations" src="jr://fixture/locations"/>
+    <instance id="reports" src="jr://fixture/commcare:reports"/>
+    <session>
+      <query url="https://www.example.com/a/test_domain/phone/search/"
+             storage-instance="results"
+             template="case">
+        <data key="case_type" ref="'case'"/>
+        <data key="include_closed" ref="'False'"/>
+        <data key="&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;"/>
+        <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
+      </query>
+      <datum id="case_id"
+             nodeset="instance('results')/results/case[@case_type='case']"
+             value="./@case_id"
+             detail-confirm="m0_case_long"
+             detail-select="m0_case_short"/>
+    </session>
+    <stack>
+      <push>
+        <rewind value="instance('commcaresession')/session/data/case_id"/>
+      </push>
+    </stack>
+  </remote-request>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -91,3 +91,24 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual(condition, suite.xpath('./detail[1]/action/@relevant')[0])
+
+    def test_only_default_properties(self):
+        self.module.search_config = CaseSearch(
+            default_properties=[
+                DefaultCaseSearchProperty(
+                    property=u'ɨŧsȺŧɍȺᵽ',
+                    defaultValue=(
+                        u"instance('casedb')/case"
+                        u"[@case_id='instance('commcaresession')/session/data/case_id']"
+                        u"/ɨŧsȺŧɍȺᵽ")
+                ),
+                DefaultCaseSearchProperty(
+                    property='name',
+                    defaultValue="instance('locations')/locations/location[@id=123]/@type",
+                ),
+            ],
+        )
+        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
+            get_url_base_patch.return_value = 'https://www.example.com'
+            suite = self.app.create_suite()
+        self.assertXmlPartialEqual(self.get_xml('search_config_default_only'), suite, "./remote-request[1]")

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -739,7 +739,8 @@ def module_offers_search(module):
     return (
         isinstance(module, (Module, AdvancedModule, ShadowModule)) and
         module.search_config and
-        module.search_config.properties
+        module.search_config.properties or
+        module.search_config.default_properties
     )
 
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -739,8 +739,8 @@ def module_offers_search(module):
     return (
         isinstance(module, (Module, AdvancedModule, ShadowModule)) and
         module.search_config and
-        module.search_config.properties or
-        module.search_config.default_properties
+        (module.search_config.properties or
+         module.search_config.default_properties)
     )
 
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -858,7 +858,10 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     if fixture_select is not None:
         module.fixture_select = FixtureSelect.wrap(fixture_select)
     if search_properties is not None:
-        if search_properties.get('properties') is not None:
+        if (
+                search_properties.get('properties') is not None
+                or search_properties.get('default_properties') is not None
+        ):
             module.search_config = CaseSearch(
                 properties=[
                     CaseSearchProperty.wrap(p)


### PR DESCRIPTION
@benrudolph @dannyroberts 
We are going to have the mobile skip the search screen if there is only default properties at some point. This allows HQ to generate the required XML for this. 