### PR TITLE
App manager v2: fix nav scrolling in vellum

### DIFF
--- a/corehq/apps/style/static/style/js/layout.js
+++ b/corehq/apps/style/static/style/js/layout.js
@@ -4,7 +4,7 @@ var hqLayout = {};
 hqLayout.selector = {
     navigation: '#hq-navigation',
     content: '#hq-content',
-    appmanager: '#js-appmanager-body.appmanager-settings-content',
+    appmanager: '#js-appmanager-body.appmanager-content',
     footer: '#hq-footer',
     sidebar: '#hq-sidebar',
     breadcrumbs: '#hq-breadcrumbs',
@@ -37,7 +37,10 @@ hqLayout.utils = {
             $breadcrumbs = $(hqLayout.selector.breadcrumbs),
             $messages = $(hqLayout.selector.messages);
 
-        var absorbedHeight = $navigation.outerHeight() + $footer.outerHeight();
+        var absorbedHeight = $navigation.outerHeight();
+        if ($footer.length) {
+            absorbedHeight += $footer.outerHeight();
+        }
         if ($breadcrumbs.length) {
             absorbedHeight += $breadcrumbs.outerHeight();
         }


### PR DESCRIPTION
Sidebar resizing hasn't been happening in v2 vellum, which lets users get into situations like this, which have thrown off some people during user testing:

![screen shot 2017-04-11 at 10 50 52 am](https://cloud.githubusercontent.com/assets/1486591/24915375/f4d91520-1ea4-11e7-9de0-9afd19efea35.png)

Sanity tested in v1, on vellum and on non-vellum app manager.

@biyeun / @esoergel 
