### PR TITLE
Switch app manager v2 flag from domain to user

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -961,7 +961,7 @@ APP_MANAGER_V2 = StaticToggle(
     'app_manager_v2',
     'Prototype for case management onboarding (App Manager V2)',
     TAG_PRODUCT_PATH,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_USER]
 )
 
 USER_TESTING_SIMPLIFY = StaticToggle(


### PR DESCRIPTION
To simplify the eventual migration.

The only people with this turned on in prod are me, Biyeun, and Jeremy.

@esoergel / @biyeun 