### PR TITLE
Redo "Externalize JavaScript: export list"

### DIFF
--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -1,5 +1,5 @@
 hqDefine("export/js/export_list.js", function() {
-   'use strict';
+    'use strict';
     var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get,
         listExportsApp = window.angular.module('listExportsApp', ['hq.list_exports', 'hq.app_data_drilldown']);
     listExportsApp.config(["$httpProvider", function($httpProvider) {
@@ -23,7 +23,7 @@ hqDefine("export/js/export_list.js", function() {
         },
         emwf_case_filter: function () {
             return $('#id_emwf_case_filter');
-        }
+        },
     });
     listExportsApp.constant('filterFormModalElement', function () {
         return $('#setFeedFiltersModal');

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -1,0 +1,31 @@
+hqDefine("export/js/export_list.js", function() {
+   'use strict';
+    var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get,
+        listExportsApp = window.angular.module('listExportsApp', ['hq.list_exports', 'hq.app_data_drilldown']);
+    listExportsApp.config(["$httpProvider", function($httpProvider) {
+        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+    }]);
+    listExportsApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
+        djangoRMIProvider.configure(initial_page_data("djng_current_rmi"));
+    }]);
+    listExportsApp.constant('formModalSelector', '#createExportOptionsModal');
+    listExportsApp.constant('processApplicationDataFormSuccessCallback', function (data) {
+        window.location = data.url;
+    });
+    listExportsApp.constant('bulk_download_url', initial_page_data("bulk_download_url"));
+    listExportsApp.constant('legacy_bulk_download_url', initial_page_data("legacy_bulk_download_url"));
+    listExportsApp.constant('modelType', initial_page_data("model_type"));
+    listExportsApp.constant('staticModelType', initial_page_data("static_model_type"));
+    listExportsApp.constant('filterFormElements', {
+        emwf_form_filter: function () {
+            return $('#id_emwf_form_filter');
+        },
+        emwf_case_filter: function () {
+            return $('#id_emwf_case_filter');
+        }
+    });
+    listExportsApp.constant('filterFormModalElement', function () {
+        return $('#setFeedFiltersModal');
+    });
+});

--- a/corehq/apps/export/templates/export/daily_saved_export_list.html
+++ b/corehq/apps/export/templates/export/daily_saved_export_list.html
@@ -10,6 +10,8 @@
 {% endblock js%}
 
 {% block page_content %}
+    {% include 'export/partial/export_list_initial_page_data.html' %}
+
     <div ng-app="listExportsApp">
         {% include 'export/partial/daily_saved_export_list_controller.html' %}
         {% include 'export/partial/export_list_create_export_modal.html' %}

--- a/corehq/apps/export/templates/export/dashboard_feed_list.html
+++ b/corehq/apps/export/templates/export/dashboard_feed_list.html
@@ -6,6 +6,7 @@
 {% load djangular_tags %}
 
 {% block page_content %}
+    {% include 'export/partial/export_list_initial_page_data.html' %}
     <div ng-app="listExportsApp">
         {% include 'export/partial/dashboard_list_controller.html' %}
         {% include 'export/partial/export_list_create_export_modal.html' %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -25,22 +25,23 @@
 <script>
 (function (angular, undefined) {
    'use strict';
-    var listExportsApp = angular.module('listExportsApp', ['hq.list_exports', 'hq.app_data_drilldown']);
+    var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get,
+        listExportsApp = angular.module('listExportsApp', ['hq.list_exports', 'hq.app_data_drilldown']);
     listExportsApp.config(["$httpProvider", function($httpProvider) {
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';
         $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
     }]);
     listExportsApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
-        djangoRMIProvider.configure({% djng_current_rmi %});
+        djangoRMIProvider.configure(initial_page_data("djng_current_rmi"));
     }]);
     listExportsApp.constant('formModalSelector', '#createExportOptionsModal');
     listExportsApp.constant('processApplicationDataFormSuccessCallback', function (data) {
         window.location = data.url;
     });
-    listExportsApp.constant('bulk_download_url', "{{ bulk_download_url }}");
-    listExportsApp.constant('legacy_bulk_download_url', "{{ legacy_bulk_download_url }}");
-    listExportsApp.constant('modelType', {{ model_type|JSON }});
-    listExportsApp.constant('staticModelType', {{ static_model_type|JSON }});
+    listExportsApp.constant('bulk_download_url', initial_page_data("bulk_download_url"));
+    listExportsApp.constant('legacy_bulk_download_url', initial_page_data("legacy_bulk_download_url"));
+    listExportsApp.constant('modelType', initial_page_data("model_type"));
+    listExportsApp.constant('staticModelType', initial_page_data("static_model_type"));
     listExportsApp.constant('filterFormElements', {
         emwf_form_filter: function () {
             return $('#id_emwf_form_filter');
@@ -57,6 +58,12 @@
 {% endblock %}
 
 {% block page_content %}
+    {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
+    {% initial_page_data 'bulk_download_url' bulk_download_url %}
+    {% initial_page_data 'legacy_bulk_download_url' legacy_bulk_download_url %}
+    {% initial_page_data 'model_type' model_type %}
+    {% initial_page_data 'static_model_type' static_model_type %}
+
     <div ng-app="listExportsApp">
         {% include 'export/partial/export_list_controller.html' %}
         {% include 'export/partial/export_list_create_export_modal.html' %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -23,11 +23,7 @@
 {% endblock %}
 
 {% block page_content %}
-    {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
-    {% initial_page_data 'bulk_download_url' bulk_download_url %}
-    {% initial_page_data 'legacy_bulk_download_url' legacy_bulk_download_url %}
-    {% initial_page_data 'model_type' model_type %}
-    {% initial_page_data 'static_model_type' static_model_type %}
+    {% include 'export/partial/export_list_initial_page_data.html' %}
 
     <div ng-app="listExportsApp">
         {% include 'export/partial/export_list_controller.html' %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -19,42 +19,7 @@
 {% block js %}
 <script src="{% static 'export/js/list_exports.ng.js' %}"></script>
 <script src="{% static 'app_manager/js/hq.app_data_drilldown.ng.js' %}"></script>
-{% endblock %}
-
-{% block js-inline %}
-<script>
-(function (angular, undefined) {
-   'use strict';
-    var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get,
-        listExportsApp = angular.module('listExportsApp', ['hq.list_exports', 'hq.app_data_drilldown']);
-    listExportsApp.config(["$httpProvider", function($httpProvider) {
-        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
-        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
-    }]);
-    listExportsApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
-        djangoRMIProvider.configure(initial_page_data("djng_current_rmi"));
-    }]);
-    listExportsApp.constant('formModalSelector', '#createExportOptionsModal');
-    listExportsApp.constant('processApplicationDataFormSuccessCallback', function (data) {
-        window.location = data.url;
-    });
-    listExportsApp.constant('bulk_download_url', initial_page_data("bulk_download_url"));
-    listExportsApp.constant('legacy_bulk_download_url', initial_page_data("legacy_bulk_download_url"));
-    listExportsApp.constant('modelType', initial_page_data("model_type"));
-    listExportsApp.constant('staticModelType', initial_page_data("static_model_type"));
-    listExportsApp.constant('filterFormElements', {
-        emwf_form_filter: function () {
-            return $('#id_emwf_form_filter');
-        },
-        emwf_case_filter: function () {
-            return $('#id_emwf_case_filter');
-        }
-    });
-    listExportsApp.constant('filterFormModalElement', function () {
-        return $('#setFeedFiltersModal');
-    });
-}(window.angular));
-</script>
+<script src="{% static 'export/js/export_list.js' %}"></script>
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/export/templates/export/partial/export_list_initial_page_data.html
+++ b/corehq/apps/export/templates/export/partial/export_list_initial_page_data.html
@@ -1,0 +1,7 @@
+{% load hq_shared_tags %}
+
+{% initial_page_data 'djng_current_rmi' djng_current_rmi %}
+{% initial_page_data 'bulk_download_url' bulk_download_url %}
+{% initial_page_data 'legacy_bulk_download_url' legacy_bulk_download_url %}
+{% initial_page_data 'model_type' model_type %}
+{% initial_page_data 'static_model_type' static_model_type %}

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -29,7 +29,7 @@ import re
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 
-from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
+from djangular.views.mixins import allow_remote_invocation
 import pytz
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -965,7 +965,7 @@ class DownloadCaseExportView(BaseDownloadExportView):
         return filter_form
 
 
-class BaseExportListView(ExportsPermissionsMixin, JSONResponseMixin, BaseProjectDataView):
+class BaseExportListView(ExportsPermissionsMixin, HQJSONResponseMixin, BaseProjectDataView):
     template_name = 'export/export_list.html'
     allow_bulk_export = True
     is_deid = False


### PR DESCRIPTION
Redo https://github.com/dimagi/commcare-hq/pull/15694

https://github.com/dimagi/commcare-hq/commit/7f03039b4ce9346aabfed4e400faa751503d75c0 is the only new commit. Descendant templates overwrite `page_content`, so they didn't get the initial page data from `export_list.html`.

@esoergel / @millerdev 