### PR TITLE
App manager v2: show advanced features used in simple apps

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config.html
@@ -107,7 +107,7 @@
                     <span class="help-block" data-bind="visible: !case_type()">{% trans "Required" %}</span>
                     {% if show_custom_ref %}
                         <label>{% trans "Override reference id: " %}</label>
-                        <input type="text" data-bind="value: reference_id"/>
+                        <input type="text" class="form-control" data-bind="value: reference_id"/>
                     {% endif %}
                 </span>
                 <a href="#" data-bind="openModal: 'remove-subcase-modal-template'" class="pull-right">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config.html
@@ -24,10 +24,12 @@
 </script>
 
 <script type="text/html" id="case-config:case-transaction">
+    {% if app.advanced_app_builder or form.actions.open_case.condition.type == 'if' %}
     <div data-bind="template: {
         name: 'case-config:condition',
         data: {condition: condition, config: $data}
     }, visible: allow.condition()"></div>
+    {% endif %}
     <div data-bind="if: allow.case_preload()">
         <div class="panel panel-appmanager case-properties wide-select2s"
              data-bind="template: 'case-config:case-transaction:case-properties'"></div>
@@ -37,19 +39,19 @@
              data-bind="template: 'case-config:case-transaction:case-properties'"></div>
     </div>
     {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}
-    {% if app.advanced_app_builder or form.get_action_type != 'open' %}
         <div class="panel panel-appmanager">
             <label class="panel-body">
                 <input type="checkbox" data-bind="checked: close_case"/>
                 {% trans "Close this case when the form is complete" %}
             </label>
+            {% if app.advanced_app_builder or form.actions.close_case.condition.type == 'if' %}
             <div data-bind="template: {
                 name: 'case-config:condition',
                 data: {condition: $data.close_condition, config: $data},
                 if: $data.close_condition
             }"></div>
+            {% endif %}
         </div>
-    {% endif %}
     {% endif %}
 </script>
 

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config.html
@@ -75,7 +75,7 @@
     <div data-bind="template: 'case-config:refresh-form-questions'"></div>
 
     <div data-bind="with: caseConfigViewModel">
-        {% if app.advanced_app_builder %}
+        {% if app.advanced_app_builder or form.actions.subcases %}
             <div class="form-inline container-fluid">
                 {% trans "This form " %}
                 {% trans "Does not use cases" as no_cases %}
@@ -103,7 +103,7 @@
                      data-bind="template: {name: 'case-config:case-transaction', data: case_transaction}">
                 </div>
             </div>
-                {% if app.advanced_app_builder %}
+                {% if app.advanced_app_builder or form.actions.subcases %}
                 <!--ko if: actionType() !== 'none'-->
                 <header class="clearfix" data-bind="visible: actionType() !== 'open-other'">
                     <h5 class="pull-left">{% trans "Child Cases" %}</h5>
@@ -127,7 +127,7 @@
                             <span class="help-block" data-bind="visible: !case_type()">{% trans "Required" %}</span>
                             {% if show_custom_ref %}
                                 <label>{% trans "Override reference id: " %}</label>
-                                <input type="text" data-bind="value: reference_id"/>
+                                <input type="text" class="form-control" data-bind="value: reference_id"/>
                             {% endif %}
                         </span>
                         <a href="#" data-bind="openModal: 'remove-subcase-modal-template'" class="pull-right">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_shared.html
@@ -4,11 +4,9 @@
     <!--ko with: condition -->
     <span data-bind="text: $parent.actionType"></span>
 
-    {% if app.advanced_app_builder or form.get_action_type != 'open' %}
-      <div data-bind="visible: type() === 'always'">
-          <a href="#" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
-      </div>
-    {% endif %}
+    <div data-bind="visible: type() === 'always'">
+        <a href="#" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
+    </div>
 
     <div class="form-inline" data-bind="visible: type() === 'if'">
         <a href="#" data-bind="click: function () {type('always')}">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% if not module.is_surveys and app.advanced_app_builder %}
+{% if app.advanced_app_builder or module.case_list_form.form_id %}
 
   <div id="case-list-form">
       <div class="form-group">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_setting.html
@@ -21,7 +21,7 @@
     </div>
     <div class="form-group" id="{{ SLUG }}-label">
         <label class="col-sm-2 control-label">
-            Label for Case List Menu Item
+            {% trans "Label for Case List Menu Item" %}
         </label>
         <div class="col-sm-4">
             {% input_trans case_list.label langs %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_setting.html
@@ -1,60 +1,65 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 {% load i18n %}
-<div class="form-group">
-    <label class="col-sm-2 control-label">
-        {% trans LABEL %}
-        <span class="hq-help-template"
-              data-title="{% trans LABEL %}"
-              data-content="{% trans DESC %}"
-        ></span>
-    </label>
-    <div class="col-sm-4">
-        <select class="form-control" type="text" name="{{ SLUG }}-show">
-            <option value="false" {% if not case_list.show %}selected{% endif %}>Don't Show</option>
-            <option value="true" {% if case_list.show %}selected{% endif %}>Show</option>
-        </select>
-    </div>
-</div>
-<div class="form-group" id="{{ SLUG }}-label">
-    <label class="col-sm-2 control-label">
-        Label for Case List Menu Item
-    </label>
-    <div class="col-sm-4">
-        {% input_trans case_list.label langs %}
-    </div>
-    <div class="col-sm-2">
-        <span class="label label-danger" id="case_list_label_error" style="display: none;">
-            {% trans "Case list menu item requires a label" %}
-        </span>
-    </div>
-</div>
 
-<script>
-    $(function () {
-        function updateCaseListLabelError() {
-            var label_text = $('#{{ SLUG }}-label input').val();
-            var show = $('[name="{{ SLUG }}-show"]').val();
-            if (!label_text.length && show === 'true') {
-                $("#{{ SLUG }}-label").closest('.form-group').addClass('has-error');
-                $('#case_list_label_error').css('display', 'inline');
-            } else {
-                $("#{{ SLUG }}-label").closest('.form-group').removeClass('has-error');
-                $('#case_list_label_error').css('display', 'none');
+{% if app.advanced_app_builder or case_list.show %}
+
+    <div class="form-group">
+        <label class="col-sm-2 control-label">
+            {% trans LABEL %}
+            <span class="hq-help-template"
+                  data-title="{% trans LABEL %}"
+                  data-content="{% trans DESC %}"
+            ></span>
+        </label>
+        <div class="col-sm-4">
+            <select class="form-control" type="text" name="{{ SLUG }}-show">
+                <option value="false" {% if not case_list.show %}selected{% endif %}>Don't Show</option>
+                <option value="true" {% if case_list.show %}selected{% endif %}>Show</option>
+            </select>
+        </div>
+    </div>
+    <div class="form-group" id="{{ SLUG }}-label">
+        <label class="col-sm-2 control-label">
+            Label for Case List Menu Item
+        </label>
+        <div class="col-sm-4">
+            {% input_trans case_list.label langs %}
+        </div>
+        <div class="col-sm-2">
+            <span class="label label-danger" id="case_list_label_error" style="display: none;">
+                {% trans "Case list menu item requires a label" %}
+            </span>
+        </div>
+    </div>
+
+    <script>
+        $(function () {
+            function updateCaseListLabelError() {
+                var label_text = $('#{{ SLUG }}-label input').val();
+                var show = $('[name="{{ SLUG }}-show"]').val();
+                if (!label_text.length && show === 'true') {
+                    $("#{{ SLUG }}-label").closest('.form-group').addClass('has-error');
+                    $('#case_list_label_error').css('display', 'inline');
+                } else {
+                    $("#{{ SLUG }}-label").closest('.form-group').removeClass('has-error');
+                    $('#case_list_label_error').css('display', 'none');
+                }
             }
-        }
-        function updateCaseListLabel() {
-            $('#{{ SLUG }}-label')[$(this).val() === 'true' ? 'show' : 'hide']();
-            $('#{{ SLUG }}-media')[$(this).val() === 'true' ? 'show' : 'hide']();
-            updateCaseListLabelError.call(this);
-        }
-        $('#{{ SLUG }}-label input').attr('name', '{{ SLUG }}-label');
-        $('[name="{{ SLUG }}-show"]').change(updateCaseListLabel).each(updateCaseListLabel);
+            function updateCaseListLabel() {
+                $('#{{ SLUG }}-label')[$(this).val() === 'true' ? 'show' : 'hide']();
+                $('#{{ SLUG }}-media')[$(this).val() === 'true' ? 'show' : 'hide']();
+                updateCaseListLabelError.call(this);
+            }
+            $('#{{ SLUG }}-label input').attr('name', '{{ SLUG }}-label');
+            $('[name="{{ SLUG }}-show"]').change(updateCaseListLabel).each(updateCaseListLabel);
 
-        $('#{{ SLUG }}-label input').on('textchange', updateCaseListLabelError);
-    });
-</script>
+            $('#{{ SLUG }}-label input').on('textchange', updateCaseListLabelError);
+        });
+    </script>
 
-<div id="{{ SLUG }}-media">
-    {% include "app_manager/v1/partials/nav_menu_media.html" with ICON_LABEL="Icon for Case List Menu Item" AUDIO_LABEL="Audio for Case List Menu Item" qualifier="case_list-menu_item_" %}
-</div>
+    <div id="{{ SLUG }}-media">
+        {% include "app_manager/v2/partials/nav_menu_media.html" with ICON_LABEL="Icon for Case List Menu Item" AUDIO_LABEL="Audio for Case List Menu Item" qualifier="case_list-menu_item_" %}
+    </div>
+
+{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_settings.html
@@ -119,17 +119,19 @@
             </div>
           </div>
 
-           {% if app.advanced_app_builder %}
-           <div class="panel panel-appmanager">
-            <div class="panel-heading">
-              <h4 class="panel-title panel-title-nolink">{% trans "Advanced Settings" %}</h4>
-            </div>
-            <div class="panel-body">
-              {% include 'app_manager/v2/partials/case_list_form_setting.html' %}
+           {% if not module.is_surveys %}
+             {% if app.advanced_app_builder or module.case_list_form.form_id or module.case_list.show %}
+             <div class="panel panel-appmanager">
+              <div class="panel-heading">
+                <h4 class="panel-title panel-title-nolink">{% trans "Advanced Settings" %}</h4>
+              </div>
+              <div class="panel-body">
+                {% include 'app_manager/v2/partials/case_list_form_setting.html' %}
 
-              {% include 'app_manager/v2/partials/case_list_setting.html' with LABEL="Case List Menu Item" DESC="An item in the module's menu that lets you browse the case list without moving on to fill out a form." SLUG="case_list" case_list=module.case_list %}
+                {% include 'app_manager/v2/partials/case_list_setting.html' with LABEL="Case List Menu Item" DESC="An item in the module's menu that lets you browse the case list without moving on to fill out a form." SLUG="case_list" case_list=module.case_list %}
+              </div>
             </div>
-          </div>
+            {% endif %}
           {% endif %}
 
         {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_settings.html
@@ -72,7 +72,7 @@
               </div>
               {% endif %}
 
-              {% if app.advanced_app_builder or module.is_surveys %}
+              {% if app.advanced_app_builder or module.put_in_root %}
                   <div class="form-group">
                       <label class="col-sm-2 control-label">
                           {% trans "Menu Mode" %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_settings.html
@@ -120,7 +120,7 @@
           </div>
 
            {% if not module.is_surveys %}
-             {% if app.advanced_app_builder or module.case_list_form.form_id or module.case_list.show %}
+             {% if app.advanced_app_builder or module.case_list_form.form_id or module.case_list.show or module.task_list.show %}
              <div class="panel panel-appmanager">
               <div class="panel-heading">
                 <h4 class="panel-title panel-title-nolink">{% trans "Advanced Settings" %}</h4>
@@ -129,6 +129,10 @@
                 {% include 'app_manager/v2/partials/case_list_form_setting.html' %}
 
                 {% include 'app_manager/v2/partials/case_list_setting.html' with LABEL="Case List Menu Item" DESC="An item in the module's menu that lets you browse the case list without moving on to fill out a form." SLUG="case_list" case_list=module.case_list %}
+
+                {% if module.module_type == 'basic' and request.project.survey_management_enabled or module.task_list.show %}
+                    {% include 'app_manager/v1/partials/case_list_setting.html' with LABEL="Task List" DESC="Whether to have an item in the module's menu that lets you see all of your delegated tasks. Only makes sense if you're using a delegation workflow." SLUG="task_list" case_list=module.task_list %}
+                {% endif %}
               </div>
             </div>
             {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config.html.diff.txt
@@ -9,7 +9,12 @@
  
  <script type="text/html" id="remove-subcase-modal-template">
      <div class="modal-dialog">
-@@ -28,101 +28,121 @@
+@@ -24,105 +24,127 @@
+ </script>
+ 
+ <script type="text/html" id="case-config:case-transaction">
++    {% if app.advanced_app_builder or form.actions.open_case.condition.type == 'if' %}
+     <div data-bind="template: {
          name: 'case-config:condition',
          data: {condition: condition, config: $data}
      }, visible: allow.condition()"></div>
@@ -17,6 +22,7 @@
 -        <div class='col-sm-9 wide-select2s'>
 -            <div class="panel panel-default case-properties"
 -                 data-bind="template: 'case-config:case-transaction:case-properties'"></div>
++    {% endif %}
 +    <div data-bind="if: allow.case_preload()">
 +        <div class="panel panel-appmanager case-properties wide-select2s"
 +             data-bind="template: 'case-config:case-transaction:case-properties'"></div>
@@ -26,17 +32,18 @@
 +             data-bind="template: 'case-config:case-transaction:case-properties'"></div>
 +    </div>
 +    {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}
-+    {% if app.advanced_app_builder or form.get_action_type != 'open' %}
 +        <div class="panel panel-appmanager">
 +            <label class="panel-body">
 +                <input type="checkbox" data-bind="checked: close_case"/>
 +                {% trans "Close this case when the form is complete" %}
 +            </label>
++            {% if app.advanced_app_builder or form.actions.close_case.condition.type == 'if' %}
 +            <div data-bind="template: {
 +                name: 'case-config:condition',
 +                data: {condition: $data.close_condition, config: $data},
 +                if: $data.close_condition
 +            }"></div>
++            {% endif %}
          </div>
 -    </div>
 -    <div data-bind="if: !allow.case_preload()" class="row">
@@ -56,7 +63,6 @@
 -            if: $data.close_condition
 -        }"></div>
 -    </div>
-+    {% endif %}
 +    {% endif %}
  </script>
  
@@ -100,7 +106,7 @@
 -        <div data-bind="if: actionType() === 'update'">
 -            <div class="container-fluid"
 -                 data-bind="template: {name: 'case-config:case-transaction', data: case_transaction}">
-+        {% if app.advanced_app_builder %}
++        {% if app.advanced_app_builder or form.actions.subcases %}
 +            <div class="form-inline container-fluid">
 +                {% trans "This form " %}
 +                {% trans "Does not use cases" as no_cases %}
@@ -141,7 +147,7 @@
 +                     data-bind="template: {name: 'case-config:case-transaction', data: case_transaction}">
 +                </div>
 +            </div>
-+                {% if app.advanced_app_builder %}
++                {% if app.advanced_app_builder or form.actions.subcases %}
 +                <!--ko if: actionType() !== 'none'-->
 +                <header class="clearfix" data-bind="visible: actionType() !== 'open-other'">
 +                    <h5 class="pull-left">{% trans "Child Cases" %}</h5>
@@ -165,7 +171,7 @@
 -                    <span class="help-block" data-bind="visible: !case_type()">{% trans "Required" %}</span>
 -                    {% if show_custom_ref %}
 -                        <label>{% trans "Override reference id: " %}</label>
--                        <input type="text" data-bind="value: reference_id"/>
+-                        <input type="text" class="form-control" data-bind="value: reference_id"/>
 -                    {% endif %}
 -                </span>
 -                <a href="#" data-bind="openModal: 'remove-subcase-modal-template'" class="pull-right">
@@ -196,7 +202,7 @@
 +                            <span class="help-block" data-bind="visible: !case_type()">{% trans "Required" %}</span>
 +                            {% if show_custom_ref %}
 +                                <label>{% trans "Override reference id: " %}</label>
-+                                <input type="text" data-bind="value: reference_id"/>
++                                <input type="text" class="form-control" data-bind="value: reference_id"/>
 +                            {% endif %}
 +                        </span>
 +                        <a href="#" data-bind="openModal: 'remove-subcase-modal-template'" class="pull-right">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_shared.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_shared.html.diff.txt
@@ -1,18 +1,13 @@
 --- 
 +++ 
-@@ -3,15 +3,19 @@
+@@ -3,15 +3,17 @@
  <script type="text/html" id="case-config:condition">
      <!--ko with: condition -->
      <span data-bind="text: $parent.actionType"></span>
--    <div data-bind="visible: type() === 'always'">
--        <a href="#" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
--    </div>
 +
-+    {% if app.advanced_app_builder or form.get_action_type != 'open' %}
-+      <div data-bind="visible: type() === 'always'">
-+          <a href="#" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
-+      </div>
-+    {% endif %}
+     <div data-bind="visible: type() === 'always'">
+         <a href="#" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
+     </div>
 +
      <div class="form-inline" data-bind="visible: type() === 'if'">
          <a href="#" data-bind="click: function () {type('always')}">
@@ -24,7 +19,7 @@
              This would normally use .form-control, but it's going to become a select2,
              which adds wonky height & borders on Firefox when it uses .form-control
          -->
-@@ -40,7 +44,7 @@
+@@ -40,7 +42,7 @@
  </script>
  
  <script type="text/html" id="case-config:case-properties:question">
@@ -33,7 +28,7 @@
          This would normally use .form-control, but it's going to become a select2,
          which adds wonky height & borders on Firefox when it uses .form-control
      -->
-@@ -64,7 +68,7 @@
+@@ -64,7 +66,7 @@
          <input type="text" class="form-control" data-bind="
              valueDefault: property.key,
              default: property.defaultKey,
@@ -42,7 +37,7 @@
          "/>
      </span>
      <span data-bind="visible: property.required()">
-@@ -73,12 +77,16 @@
+@@ -73,12 +75,16 @@
  </script>
  
  <script type="text/html" id="case-config:case-transaction:case-preload">
@@ -61,7 +56,7 @@
                  <th></th>
                  <th>{% trans "Question" %}</th>
              </tr>
-@@ -112,9 +120,9 @@
+@@ -112,9 +118,9 @@
      </table>
      <div class="panel-body">
          <div class="alert alert-block alert-info" data-bind="visible: !case_preload().length">
@@ -73,7 +68,7 @@
              <i class="fa fa-plus"></i>
              {% trans "Load properties" %}
          </a>
-@@ -122,65 +130,68 @@
+@@ -122,65 +128,68 @@
  </script>
  
  <script type="text/html" id="case-config:case-transaction:case-properties">
@@ -198,7 +193,7 @@
              <i class="fa fa-plus"></i>
              {% trans "Save properties" %}
          </a>
-@@ -188,12 +199,14 @@
+@@ -188,12 +197,14 @@
  </script>
  
  <script type="text/html" id="case-config:refresh-form-questions">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_form_setting.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_form_setting.html.diff.txt
@@ -78,7 +78,7 @@
 -    {% include "app_manager/v1/partials/nav_menu_media.html" with item=multimedia.case_list_form qualifier='case_list_form_' ICON_LABEL="Registration Form Icon" AUDIO_LABEL="Registration Form Audio" %}
 -</div>
 +
-+{% if not module.is_surveys and app.advanced_app_builder %}
++{% if app.advanced_app_builder or module.case_list_form.form_id %}
 +
 +  <div id="case-list-form">
 +      <div class="form-group">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_setting.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_setting.html.diff.txt
@@ -1,0 +1,121 @@
+--- 
++++ 
+@@ -1,60 +1,65 @@
+ {% load xforms_extras %}
+ {% load hq_shared_tags %}
+ {% load i18n %}
+-<div class="form-group">
+-    <label class="col-sm-2 control-label">
+-        {% trans LABEL %}
+-        <span class="hq-help-template"
+-              data-title="{% trans LABEL %}"
+-              data-content="{% trans DESC %}"
+-        ></span>
+-    </label>
+-    <div class="col-sm-4">
+-        <select class="form-control" type="text" name="{{ SLUG }}-show">
+-            <option value="false" {% if not case_list.show %}selected{% endif %}>Don't Show</option>
+-            <option value="true" {% if case_list.show %}selected{% endif %}>Show</option>
+-        </select>
++
++{% if app.advanced_app_builder or case_list.show %}
++
++    <div class="form-group">
++        <label class="col-sm-2 control-label">
++            {% trans LABEL %}
++            <span class="hq-help-template"
++                  data-title="{% trans LABEL %}"
++                  data-content="{% trans DESC %}"
++            ></span>
++        </label>
++        <div class="col-sm-4">
++            <select class="form-control" type="text" name="{{ SLUG }}-show">
++                <option value="false" {% if not case_list.show %}selected{% endif %}>Don't Show</option>
++                <option value="true" {% if case_list.show %}selected{% endif %}>Show</option>
++            </select>
++        </div>
+     </div>
+-</div>
+-<div class="form-group" id="{{ SLUG }}-label">
+-    <label class="col-sm-2 control-label">
+-        Label for Case List Menu Item
+-    </label>
+-    <div class="col-sm-4">
+-        {% input_trans case_list.label langs %}
++    <div class="form-group" id="{{ SLUG }}-label">
++        <label class="col-sm-2 control-label">
++            Label for Case List Menu Item
++        </label>
++        <div class="col-sm-4">
++            {% input_trans case_list.label langs %}
++        </div>
++        <div class="col-sm-2">
++            <span class="label label-danger" id="case_list_label_error" style="display: none;">
++                {% trans "Case list menu item requires a label" %}
++            </span>
++        </div>
+     </div>
+-    <div class="col-sm-2">
+-        <span class="label label-danger" id="case_list_label_error" style="display: none;">
+-            {% trans "Case list menu item requires a label" %}
+-        </span>
++
++    <script>
++        $(function () {
++            function updateCaseListLabelError() {
++                var label_text = $('#{{ SLUG }}-label input').val();
++                var show = $('[name="{{ SLUG }}-show"]').val();
++                if (!label_text.length && show === 'true') {
++                    $("#{{ SLUG }}-label").closest('.form-group').addClass('has-error');
++                    $('#case_list_label_error').css('display', 'inline');
++                } else {
++                    $("#{{ SLUG }}-label").closest('.form-group').removeClass('has-error');
++                    $('#case_list_label_error').css('display', 'none');
++                }
++            }
++            function updateCaseListLabel() {
++                $('#{{ SLUG }}-label')[$(this).val() === 'true' ? 'show' : 'hide']();
++                $('#{{ SLUG }}-media')[$(this).val() === 'true' ? 'show' : 'hide']();
++                updateCaseListLabelError.call(this);
++            }
++            $('#{{ SLUG }}-label input').attr('name', '{{ SLUG }}-label');
++            $('[name="{{ SLUG }}-show"]').change(updateCaseListLabel).each(updateCaseListLabel);
++
++            $('#{{ SLUG }}-label input').on('textchange', updateCaseListLabelError);
++        });
++    </script>
++
++    <div id="{{ SLUG }}-media">
++        {% include "app_manager/v2/partials/nav_menu_media.html" with ICON_LABEL="Icon for Case List Menu Item" AUDIO_LABEL="Audio for Case List Menu Item" qualifier="case_list-menu_item_" %}
+     </div>
+-</div>
+ 
+-<script>
+-    $(function () {
+-        function updateCaseListLabelError() {
+-            var label_text = $('#{{ SLUG }}-label input').val();
+-            var show = $('[name="{{ SLUG }}-show"]').val();
+-            if (!label_text.length && show === 'true') {
+-                $("#{{ SLUG }}-label").closest('.form-group').addClass('has-error');
+-                $('#case_list_label_error').css('display', 'inline');
+-            } else {
+-                $("#{{ SLUG }}-label").closest('.form-group').removeClass('has-error');
+-                $('#case_list_label_error').css('display', 'none');
+-            }
+-        }
+-        function updateCaseListLabel() {
+-            $('#{{ SLUG }}-label')[$(this).val() === 'true' ? 'show' : 'hide']();
+-            $('#{{ SLUG }}-media')[$(this).val() === 'true' ? 'show' : 'hide']();
+-            updateCaseListLabelError.call(this);
+-        }
+-        $('#{{ SLUG }}-label input').attr('name', '{{ SLUG }}-label');
+-        $('[name="{{ SLUG }}-show"]').change(updateCaseListLabel).each(updateCaseListLabel);
+-
+-        $('#{{ SLUG }}-label input').on('textchange', updateCaseListLabelError);
+-    });
+-</script>
+-
+-<div id="{{ SLUG }}-media">
+-    {% include "app_manager/v1/partials/nav_menu_media.html" with ICON_LABEL="Icon for Case List Menu Item" AUDIO_LABEL="Audio for Case List Menu Item" qualifier="case_list-menu_item_" %}
+-</div>
++{% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_setting.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_setting.html.diff.txt
@@ -44,7 +44,7 @@
 -        {% input_trans case_list.label langs %}
 +    <div class="form-group" id="{{ SLUG }}-label">
 +        <label class="col-sm-2 control-label">
-+            Label for Case List Menu Item
++            {% trans "Label for Case List Menu Item" %}
 +        </label>
 +        <div class="col-sm-4">
 +            {% input_trans case_list.label langs %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/module_view_settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/module_view_settings.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -8,89 +8,130 @@
+@@ -8,89 +8,136 @@
      <div class="save-button-holder clearfix"></div>
      <fieldset>
          {% block settings_fields %}
@@ -80,7 +80,7 @@
 +              </div>
 +              {% endif %}
 +
-+              {% if app.advanced_app_builder or module.is_surveys %}
++              {% if app.advanced_app_builder or module.put_in_root %}
 +                  <div class="form-group">
 +                      <label class="col-sm-2 control-label">
 +                          {% trans "Menu Mode" %}
@@ -171,10 +171,21 @@
 -                        {% trans "Grid" %}
 -                    </option>
 -                </select>
-+           {% if app.advanced_app_builder %}
-+           <div class="panel panel-appmanager">
-+            <div class="panel-heading">
-+              <h4 class="panel-title panel-title-nolink">{% trans "Advanced Settings" %}</h4>
++           {% if not module.is_surveys %}
++             {% if app.advanced_app_builder or module.case_list_form.form_id or module.case_list.show or module.task_list.show %}
++             <div class="panel panel-appmanager">
++              <div class="panel-heading">
++                <h4 class="panel-title panel-title-nolink">{% trans "Advanced Settings" %}</h4>
++              </div>
++              <div class="panel-body">
++                {% include 'app_manager/v2/partials/case_list_form_setting.html' %}
++
++                {% include 'app_manager/v2/partials/case_list_setting.html' with LABEL="Case List Menu Item" DESC="An item in the module's menu that lets you browse the case list without moving on to fill out a form." SLUG="case_list" case_list=module.case_list %}
++
++                {% if module.module_type == 'basic' and request.project.survey_management_enabled or module.task_list.show %}
++                    {% include 'app_manager/v1/partials/case_list_setting.html' with LABEL="Task List" DESC="Whether to have an item in the module's menu that lets you see all of your delegated tasks. Only makes sense if you're using a delegation workflow." SLUG="task_list" case_list=module.task_list %}
++                {% endif %}
++              </div>
              </div>
 -        </div>
 -        {% endif %}
@@ -194,14 +205,10 @@
 -                        </option>
 -                    {% endfor %}
 -                </select>
-+            <div class="panel-body">
-+              {% include 'app_manager/v2/partials/case_list_form_setting.html' %}
-+
-+              {% include 'app_manager/v2/partials/case_list_setting.html' with LABEL="Case List Menu Item" DESC="An item in the module's menu that lets you browse the case list without moving on to fill out a form." SLUG="case_list" case_list=module.case_list %}
-             </div>
+-            </div>
 -        </div>
 -        {% endif %}
-+          </div>
++            {% endif %}
 +          {% endif %}
 +
          {% endblock %}


### PR DESCRIPTION
To simplify migration (make it easier to flip toggle on/off and also reduce problems if one user in a domain is on v1 and another is on v2), make the various "advanced" features display if they're in use, even if this isn't an advanced app.

Easiest to review by commit.

@esoergel / @biyeun 