### PR TITLE
Run reminder rules periodically

### DIFF
--- a/corehq/apps/hqcase/esaccessors.py
+++ b/corehq/apps/hqcase/esaccessors.py
@@ -1,0 +1,29 @@
+from corehq.apps.es.cases import CaseES
+
+
+def scroll_case_ids_by_domain_and_case_type(domain, case_type, chunk_size=100):
+    """
+    Retrieves the case ids in chunks, yielding a list of case ids each time
+    until there are none left.
+
+    Only filters on domain and case type, and includes both open and closed cases.
+    """
+    query = (CaseES()
+             .domain(domain)
+             .case_type(case_type)
+             .exclude_source()
+             .size(chunk_size))
+
+    result = []
+
+    for case_id in query.scroll():
+        if not isinstance(case_id, basestring):
+            raise ValueError("Something is wrong with the query, expected ids only")
+
+        result.append(case_id)
+        if len(result) >= chunk_size:
+            yield result
+            result = []
+
+    if result:
+        yield result

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -503,6 +503,9 @@ class BaseScheduleCaseReminderForm(forms.Form):
 
         super(BaseScheduleCaseReminderForm, self).__init__(data, *args, **kwargs)
 
+        if is_edit:
+            self.fields['case_type'].disabled = True
+
         self.domain = domain
         self.is_edit = is_edit
         self.is_previewer = is_previewer

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1515,10 +1515,10 @@ class CaseReminderHandler(Document):
         self.get_handler_ids.clear(CaseReminderHandler, self.domain, reminder_type_filter=None)
         reminder_type = self.reminder_type or REMINDER_TYPE_DEFAULT
         self.get_handler_ids.clear(CaseReminderHandler, self.domain, reminder_type_filter=reminder_type)
+        self.get_handler_ids_for_case_post_save.clear(CaseReminderHandler, self.domain, self.case_type)
 
     def save(self, **params):
         from corehq.apps.reminders.tasks import process_reminder_rule
-        self.clear_caches()
         self.check_state()
         schedule_changed = params.pop("schedule_changed", False)
         prev_definition = params.pop("prev_definition", None)
@@ -1530,6 +1530,7 @@ class CaseReminderHandler(Document):
         else:
             self.locked = True
         super(CaseReminderHandler, self).save(**params)
+        self.clear_caches()
         delay = self.start_condition_type == CASE_CRITERIA
         if not unlock:
             if delay:
@@ -1625,6 +1626,24 @@ class CaseReminderHandler(Document):
         ).all()
         count = reduced[0]['value'] if reduced else 0
         return count > 0
+
+    @classmethod
+    @quickcache(['domain', 'case_type'], timeout=4 * 60 * 60)
+    def get_handler_ids_for_case_post_save(cls, domain, case_type):
+        result = cls.view('reminders/handlers_by_reminder_type',
+            startkey=[domain],
+            endkey=[domain, {}],
+            include_docs=True,
+            reduce=False,
+        )
+
+        def filter_fcn(handler):
+            return (
+                handler.case_type == case_type and
+                (handler.reminder_type is None or handler.reminder_type == REMINDER_TYPE_DEFAULT)
+            )
+
+        return [handler._id for handler in result if filter_fcn(handler)]
 
     @classmethod
     @quickcache(['domain', 'reminder_type_filter'], timeout=60 * 60)

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1408,6 +1408,10 @@ class CaseReminderHandler(Document):
             if getattr(obj, name) in [None, ""]:
                 raise IllegalModelStateException("%s is required" % name)
 
+        if self.active and self.uses_parent_case_property:
+            raise IllegalModelStateException("Parent case property references will only be "
+                "available in the new reminders framework")
+
         if self.start_condition_type == CASE_CRITERIA:
             check_attr("case_type")
             check_attr("start_property")

--- a/corehq/apps/reminders/signals.py
+++ b/corehq/apps/reminders/signals.py
@@ -1,6 +1,7 @@
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.signals import case_post_save
-from corehq.apps.reminders.tasks import case_changed
+from corehq.apps.reminders.models import CaseReminderHandler
+from corehq.apps.reminders.tasks import process_handlers_for_case_changed
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.form_processor.signals import sql_case_post_save
 from dimagi.utils.logging import notify_exception
@@ -11,7 +12,9 @@ def case_changed_receiver(sender, case, **kwargs):
     Spawns a task to update reminder instances tied to the given case.
     """
     try:
-        case_changed.delay(case.domain, case.case_id)
+        handler_ids = CaseReminderHandler.get_handler_ids_for_case_post_save(case.domain, case.type)
+        if handler_ids:
+            process_handlers_for_case_changed.delay(case.domain, case.case_id, handler_ids)
     except Exception:
         notify_exception(
             None,

--- a/corehq/apps/reminders/tasks.py
+++ b/corehq/apps/reminders/tasks.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta
+from celery.schedules import crontab
 from celery.task import periodic_task, task
+from corehq.apps.hqcase.esaccessors import scroll_case_ids_by_domain_and_case_type
 from corehq.apps.reminders.models import (CaseReminderHandler, CaseReminder,
     CASE_CRITERIA, REMINDER_TYPE_DEFAULT)
 from corehq.form_processor.abstract_models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.decorators import serial_task
 from django.conf import settings
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.chunked import chunked
@@ -135,3 +138,39 @@ def delete_reminders_for_cases(domain, case_ids):
             include_docs=True
         )
         soft_delete_docs([row['doc'] for row in results], CaseReminder)
+
+
+@periodic_task(run_every=crontab(minute=0), queue=settings.CELERY_PERIODIC_QUEUE)
+def run_periodic_rules():
+    for domain in settings.ICDS_SMS_INDICATOR_DOMAINS:
+        run_handlers_in_domain.delay(domain)
+
+
+def organize_handlers_by_case_type(handlers):
+    result = {}
+    for handler in handlers:
+        if handler.start_condition_type == CASE_CRITERIA and handler.case_type:
+            if handler.case_type not in result:
+                result[handler.case_type] = [handler]
+            else:
+                result[handler.case_type].append(handler)
+    return result
+
+
+@serial_task(
+    '{domain}',
+    timeout=4 * 60 * 60,
+    max_retries=0,
+    queue=settings.CELERY_MAIN_QUEUE,
+)
+def run_handlers_in_domain(domain):
+    handlers = CaseReminderHandler.get_handlers(domain, reminder_type_filter=REMINDER_TYPE_DEFAULT)
+    handlers_by_case_type = organize_handlers_by_case_type(handlers)
+
+    for case_type, handlers in handlers_by_case_type.items():
+        for case_ids in scroll_case_ids_by_domain_and_case_type(domain, case_type):
+            for case in CaseAccessors(domain).iter_cases(case_ids):
+                for handler in handlers:
+                    if handler.domain != case.domain:
+                        raise ValueError("Unexpected domain mismatch: %s, %s" % (handler.domain, case.domain))
+                    handler.case_changed(case)

--- a/corehq/apps/reminders/tasks.py
+++ b/corehq/apps/reminders/tasks.py
@@ -70,10 +70,6 @@ def _case_changed(domain, case_id, handler_ids):
                     'prev_definition': handler,
                 }
             handler.case_changed(case, **kwargs)
-            if handler.uses_parent_case_property:
-                subcases = case.get_subcases(index_identifier=DEFAULT_PARENT_IDENTIFIER)
-                for subcase in subcases:
-                    handler.case_changed(subcase, **kwargs)
 
 
 @task(queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True, acks_late=True)

--- a/corehq/apps/reminders/tests/test_lookup.py
+++ b/corehq/apps/reminders/tests/test_lookup.py
@@ -1,0 +1,59 @@
+from datetime import time
+from django.test import TestCase
+from corehq.apps.reminders.models import CaseReminderHandler, MATCH_EXACT, REPEAT_SCHEDULE_INDEFINITELY
+
+
+class ReminderLookupsTest(TestCase):
+
+    domain_1 = 'reminder-lookup-test-1'
+    domain_2 = 'reminder-lookup-test-2'
+    case_type_1 = 'case-type-1'
+    case_type_2 = 'case-type-2'
+
+    def _create_reminder(self, domain, case_type):
+        reminder = (CaseReminderHandler
+            .create(domain, 'test')
+            .set_case_criteria_start_condition(case_type, 'status', MATCH_EXACT, 'green')
+            .set_case_criteria_start_date()
+            .set_case_recipient()
+            .set_sms_content_type('en')
+            .set_daily_schedule(fire_time=time(12, 0),
+                message={'en': 'Hello {case.name}, your test result was normal.'})
+            .set_stop_condition(max_iteration_count=REPEAT_SCHEDULE_INDEFINITELY)
+            .set_advanced_options())
+        reminder.save()
+        return reminder
+
+    def test_get_handler_ids_for_case_post_save(self):
+        reminder1 = self._create_reminder(self.domain_1, self.case_type_1)
+        reminder2 = self._create_reminder(self.domain_1, self.case_type_2)
+        reminder3 = self._create_reminder(self.domain_2, self.case_type_1)
+        self.addCleanup(reminder1.delete)
+        self.addCleanup(reminder2.delete)
+        self.addCleanup(reminder3.delete)
+
+        self.assertEqual(
+            CaseReminderHandler.get_handler_ids_for_case_post_save(self.domain_1, self.case_type_1),
+            [reminder1._id]
+        )
+
+        self.assertEqual(
+            CaseReminderHandler.get_handler_ids_for_case_post_save(self.domain_1, self.case_type_2),
+            [reminder2._id]
+        )
+
+        self.assertEqual(
+            CaseReminderHandler.get_handler_ids_for_case_post_save(self.domain_2, self.case_type_1),
+            [reminder3._id]
+        )
+
+        # Test cache clear
+        reminder4 = self._create_reminder(self.domain_1, self.case_type_1)
+        self.addCleanup(reminder4.delete)
+
+        result = CaseReminderHandler.get_handler_ids_for_case_post_save(self.domain_1, self.case_type_1)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(
+            set(result),
+            set([reminder1._id, reminder4._id])
+        )

--- a/corehq/apps/reminders/tests/test_responsiveness.py
+++ b/corehq/apps/reminders/tests/test_responsiveness.py
@@ -1,5 +1,6 @@
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from corehq.apps.hqcase.utils import update_case
+from corehq.apps.reminders.tasks import process_handlers_for_case_changed
 from corehq.apps.users.models import CommCareUser
 from corehq.util.test_utils import set_parent_case
 from corehq.apps.reminders.models import (CaseReminderHandler, CaseReminder, MATCH_EXACT,
@@ -406,6 +407,7 @@ class ReminderResponsivenessTest(TestCase):
                 message={'en': 'Hello {case.name}, your test result was normal.'})
             .set_stop_condition(max_iteration_count=REPEAT_SCHEDULE_INDEFINITELY)
             .set_advanced_options())
+        reminder.active = False
         reminder.save()
 
         self.assertEqual(self.get_reminders(), [])
@@ -413,9 +415,11 @@ class ReminderResponsivenessTest(TestCase):
         with create_test_case(self.domain, 'participant', 'bob', drop_signals=False) as child_case, \
                 create_test_case(self.domain, 'parent-case', 'jim', drop_signals=False) as parent_case, \
                 patch('corehq.apps.reminders.models.CaseReminderHandler.get_now') as now_mock:
+            process_handlers_for_case_changed(self.domain, child_case.case_id, [reminder._id])
             self.assertEqual(self.get_reminders(), [])
 
             set_parent_case(self.domain, child_case, parent_case)
+            process_handlers_for_case_changed(self.domain, child_case.case_id, [reminder._id])
             self.assertEqual(self.get_reminders(), [])
 
             now_mock.return_value = datetime(2016, 1, 1, 10, 0)
@@ -426,10 +430,11 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(self.get_reminders(), [])
 
             update_case(self.domain, parent_case.case_id, case_properties={'status': 'green'})
+            process_handlers_for_case_changed(self.domain, child_case.case_id, [reminder._id])
             reminder_instance = self.assertOneReminder()
             self.assertEqual(reminder_instance.domain, self.domain)
             self.assertEqual(reminder_instance.handler_id, reminder.get_id)
-            self.assertTrue(reminder_instance.active)
+            self.assertFalse(reminder_instance.active)
             self.assertEqual(reminder_instance.start_date, date(2016, 1, 1))
             self.assertIsNone(reminder_instance.start_condition_datetime)
             self.assertEqual(reminder_instance.next_fire, datetime(2016, 1, 1, 12, 0))
@@ -439,6 +444,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
             update_case(self.domain, parent_case.case_id, case_properties={'status': 'red'})
+            process_handlers_for_case_changed(self.domain, child_case.case_id, [reminder._id])
             self.assertEqual(self.get_reminders(), [])
 
     @run_with_all_backends

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -466,6 +466,8 @@ class EditScheduledReminderView(CreateScheduledReminderView):
         return reverse(self.urlname, args=[self.domain, self.handler_id])
 
     def process_schedule_form(self):
+        if self.schedule_form.cleaned_data['case_type'] != self.reminder_handler.case_type:
+            raise ValueError("Reminder case type is expected to be read only on edit")
         self.schedule_form.save(self.reminder_handler)
 
     def rule_in_progress(self):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?251705

The only reminders currently in ICDS are using the old framework and send emails in response to cases created or updated from the issue tracker, so the volume of these cases is low.

There's currently a big backlog of case updates to process (which I'm working on working down), so this is a workaround which will process the issue tracker reminders periodically every hour so that the emails will go out and won't be affected by the backlog.

@mkangia 