### PR TITLE
fix domain delete mgmt command

### DIFF
--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'domain',
+            '--domain',
             dest='domain_name',
         )
         parser.add_argument(

--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -10,8 +10,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--domain',
-            dest='domain_name',
+            'domain_name',
         )
         parser.add_argument(
             '--noinput',


### PR DESCRIPTION
can't mix optional and position-based arguments and specify a dest for the position arg. throws `ValueError('dest supplied twice for positional argument')` otherwise

@calellowitz // @sravfeyn 