### PR TITLE
Fix export sorting

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -147,6 +147,19 @@ class ExportItem(DocumentSchema):
     inferred = BooleanProperty(default=False)
     inferred_from = SetProperty(default=set)
 
+    def __key(self):
+        return'{}:{}:{}'.format(
+            _path_nodes_to_string(self.path),
+            self.doc_type,
+            self.transform,
+        )
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return self.__key() == other.__key()
+
     @classmethod
     def wrap(cls, data):
         if cls is ExportItem:
@@ -1396,7 +1409,7 @@ class ExportDataSchema(Document):
         orders = {}
         for group_schema in ordered_schema.group_schemas:
             for idx, item in enumerate(group_schema.items):
-                orders[tuple(item.path)] = idx
+                orders[item] = idx
 
         # Next iterate through current schema and order the ones that have an order
         # and put the rest at the bottom. The ones not ordered are deleted items
@@ -1404,8 +1417,8 @@ class ExportDataSchema(Document):
             ordered_items = [None] * len(group_schema.items)
             unordered_items = []
             for idx, item in enumerate(group_schema.items):
-                if tuple(item.path) in orders:
-                    ordered_items.insert(orders[tuple(item.path)], item)
+                if item in orders:
+                    ordered_items.insert(orders[item], item)
                 else:
                     unordered_items.append(item)
             group_schema.items = filter(None, ordered_items) + unordered_items
@@ -1425,11 +1438,7 @@ class ExportDataSchema(Document):
         def resolvefn(group_schema1, group_schema2):
 
             def keyfn(export_item):
-                return'{}:{}:{}'.format(
-                    _path_nodes_to_string(export_item.path),
-                    export_item.doc_type,
-                    export_item.transform,
-                )
+                return export_item
 
             group_schema1.last_occurrences = _merge_dicts(
                 group_schema1.last_occurrences,

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -29,6 +29,8 @@ from corehq.apps.export.models import (
     CaseInferredSchema,
     ExportGroupSchema,
     ExportItem,
+    GeopointItem,
+    ScalarItem,
     LabelItem,
     PARENT_CASE_TABLE,
 )
@@ -1156,7 +1158,7 @@ class TestOrderingOfSchemas(SimpleTestCase):
             if not items:
                 break
 
-            self.assertEqual(item.path, items.pop(0).path)
+            self.assertEqual(item, items.pop(0))
 
     def test_basic_ordering(self):
         schema = self._create_schema([
@@ -1237,5 +1239,35 @@ class TestOrderingOfSchemas(SimpleTestCase):
                 ExportItem(path=[PathNode(name='one')]),
                 ExportItem(path=[PathNode(name='two')]),
                 ExportItem(path=[PathNode(name='three')]),
+            ],
+        )
+
+    def test_different_doc_types_ordering(self):
+        schema = self._create_schema([
+            GeopointItem(path=[PathNode(name='one')]),
+            ScalarItem(path=[PathNode(name='two')]),
+            ScalarItem(path=[PathNode(name='three')]),
+            ScalarItem(path=[PathNode(name='one')]),
+        ])
+
+        ordered_schema = self._create_schema([
+            ScalarItem(path=[PathNode(name='two')]),
+            ScalarItem(path=[PathNode(name='one')]),
+            ScalarItem(path=[PathNode(name='three')]),
+            GeopointItem(path=[PathNode(name='one')]),
+        ])
+
+        schema = CaseExportDataSchema._reorder_schema_from_schema(
+            schema,
+            ordered_schema,
+        )
+        self._assert_item_order(
+            schema,
+            [],
+            [
+                ScalarItem(path=[PathNode(name='two')]),
+                ScalarItem(path=[PathNode(name='one')]),
+                ScalarItem(path=[PathNode(name='three')]),
+                GeopointItem(path=[PathNode(name='one')]),
             ],
         )


### PR DESCRIPTION
Still puzzling over why the export sorting isn't quite working for a few domains. This is definitely more correct. My theory is that people have been changing the question types and it thus creates a false order since the ordering only checks the path not the doc_type

https://manage.dimagi.com/default.asp?250350