### PR TITLE
Partial Location Uplaod

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -346,18 +346,6 @@ class LocationExcelValidator(object):
                 extra=", ".join(actual - expected),
             ))
 
-        # all listed types should have a corresponding locations sheet
-        type_stubs = self._get_types(type_sheet_reader)
-        expected_sheet_names = [lt.code for lt in type_stubs] + ['types']
-        actual_sheet_names = sheets_by_title.keys()
-        missing_sheet_names = set(expected_sheet_names) - set(actual_sheet_names)
-        if missing_sheet_names:
-            raise LocationExcelSheetError(
-                _(u"Location sheets do not exist for the location types '{}' - "
-                  "All types listed in 'types' sheet should have a location sheet")
-                .format(", ".join(missing_sheet_names))
-            )
-
         # all locations sheets should have correct headers
         location_stubs = []
         optional_headers = [LOCATION_SHEET_HEADERS['custom_data'], LOCATION_SHEET_HEADERS['uncategorized_data']]

--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -706,8 +706,8 @@ class LocationTreeValidator(object):
                     # check old_collection if it's not listed in current excel
                     parent = self.old_collection.locations_by_site_code.get(location.parent_code)
                     if not parent:
-                        return _(u"Location '{}' does not have a parent set or its parent is being deleted").format(
-                            location.site_code)
+                        return _(u"Location '{}' does not have a parent set or its parent "
+                                 "is being deleted").format(location.site_code)
                     else:
                         actual_parent_type = parent.location_type.code
                 else:

--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -557,10 +557,10 @@ class LocationTreeValidator(object):
 
     @memoized
     def _check_required_locations_missing(self):
-        if not self.old_collection:
+        if not self.locations_to_be_deleted or not self.old_collection:
+            # skip this check if no old locations or no location to be deleted
             return []
 
-        # Todo: performance issue for large orgs
         old_locs_by_parent = self.old_collection.locations_by_parent_code
 
         missing_locs = []

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -230,6 +230,7 @@ def make_collection(types, locations):
         domain_name='location-bulk-management',
     )
 
+
 class TestTreeValidator(SimpleTestCase):
 
     def test_good_location_set(self):
@@ -327,7 +328,7 @@ class TestTreeValidator(SimpleTestCase):
         self.assertIn('galaxy', missing_type_errors[0])
 
     def test_missing_location_ids(self):
-        # all locations in the domain should be listed in given excel
+        # not all locations need to be specified in the upload
         old_locations = (
             BASIC_LOCATION_TREE +
             [('extra_state', 'ex_code', 'state', '', 'ex_id', False) + extra_stub_args]
@@ -335,9 +336,8 @@ class TestTreeValidator(SimpleTestCase):
         old_collection = make_collection(FLAT_LOCATION_TYPES, old_locations)
         validator = get_validator(FLAT_LOCATION_TYPES, BASIC_LOCATION_TREE, old_collection)
         missing_locations = validator._check_unlisted_location_ids()
-        self.assertEqual(len(missing_locations), 1)
+        self.assertEqual(len(missing_locations), 0)
         self.assertEqual(len(validator.errors), 1)
-        self.assertIn('extra_state', missing_locations[0])
 
     def test_unknown_location_ids(self):
         # all locations in the domain should be listed in given excel
@@ -944,6 +944,7 @@ class TestBulkManagement(TestCase):
         self.assertCouchSync()
 
     def test_case_sensitivity(self):
+        # site-codes are automatically converted to lower-case
         upper_case = [
             ('State 1', 'S1', 'state', '', '', False) + extra_stub_args,
             ('State 2', 'S2', 'state', '', '', False) + extra_stub_args,
@@ -966,4 +967,174 @@ class TestBulkManagement(TestCase):
         self.assertEqual(result.errors, [])
         self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
         self.assertLocationsMatch(self.as_pairs(lower_case))
+        self.assertCouchSync()
+
+    def test_partial_addition(self):
+        # new locations can be added without having to specify all of old ones
+        self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            self.basic_tree
+        )
+
+        addition = [
+            ('State 3', 's3', 'state', '', '', False) + extra_stub_args,
+            ('County 21', 'county3', 'county', 's3', '', False) + extra_stub_args,
+        ]
+
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            addition
+        )
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch(self.as_pairs(self.basic_tree).union({
+            ('s3', None), ('count3', 's3')
+        }))
+        self.assertCouchSync()
+
+    def test_partial_attribute_edits_by_location_id(self):
+        # a subset of locations can be edited and can be referenced by location_id
+        lt_by_code = self.create_location_types(FLAT_LOCATION_TYPES)
+        locations_by_code = self.create_locations(self.basic_tree, lt_by_code)
+
+        _loc_id = lambda x: locations_by_code[x].location_id
+        change_names = [
+            ('My State 1', '', 'state', '', _loc_id('s1'), False) + extra_stub_args,
+            ('My County 11', '', 'county', 's1', _loc_id('county11'), False) + extra_stub_args,
+        ]
+
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            change_names
+        )
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch({
+            ('My State 1', ''), ('State2', ''), ('My County 11', 's1'),
+            ('County21', 's2'), ('City111', 'county11'), ('City112', 'county11'),
+            ('City211', 'county21'),
+        }, check_attr='name')
+        self.assertCouchSync()
+
+    def test_partial_attribute_edits_by_site_code(self):
+        # a subset of locations can be edited and can be referenced by site_code
+        lt_by_code = self.create_location_types(FLAT_LOCATION_TYPES)
+        self.create_locations(self.basic_tree, lt_by_code)
+
+        change_names = [
+            ('My State 1', '', 'state', '', 's1', False) + extra_stub_args,
+            ('My County 11', '', 'county', 's1', 'county11', False) + extra_stub_args,
+        ]
+
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            change_names
+        )
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch({
+            ('My State 1', ''), ('State2', ''), ('My County 11', 's1'),
+            ('County21', 's2'), ('City111', 'county11'), ('City112', 'county11'),
+            ('City211', 'county21'),
+        }, check_attr='name')
+        self.assertCouchSync()
+
+    def test_partial_parent_edits(self):
+        self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            self.basic_tree
+        )
+        change_parents = [
+            ('County 21', 'c2', 'county', 's1', '', False) + extra_stub_args,
+        ]
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            change_parents
+        )
+
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch({
+            ('s1', ''), ('s2', ''), ('county11', 's1'),
+            ('county21', 's1'), ('city111', 'county11'), ('city112', 'county11'),
+            ('city211', 'county21'),
+        })
+        self.assertCouchSync()
+
+    def test_partial_parent_edits_invalid(self):
+        # can't set invalid type location for a parent location
+        self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            self.basic_tree
+        )
+        change_parents = [
+            # city type can't have parent of state type
+            ('City211', 'city211', 'city', 's1', '', False) + extra_stub_args,
+        ]
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            change_parents
+        )
+
+        self.assertNotEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch(self.as_pairs(self.basic_tree))
+        self.assertCouchSync()
+
+    def test_partial_delete_children(self):
+        self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            self.basic_tree
+        )
+
+        # deleting location that has children, if listing all of its children is valid
+        delete = [
+            ('County 21', 'county21', 'city', 's2', '', True) + extra_stub_args,
+            ('City211', 'city211', 'city', 'county11', '', True) + extra_stub_args,
+        ]
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            delete
+        )
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch(self.as_pairs(self.basic_tree) - {
+            ('city211', 'county21'), ('county21', 's2')
+        })
+        self.assertCouchSync()
+
+        # deleting location if it doesn't have children should work
+        delete = [
+            ('City111', 'city111', 'city', 'county11', '', True) + extra_stub_args,
+        ]
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            delete
+        )
+
+        self.assertEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch(self.as_pairs(self.basic_tree) - {
+            ('city211', 'county21'), ('county21', 's2'), ('city111', 'county11')
+        })
+        self.assertCouchSync()
+
+    def test_partial_delete_children_invalid(self):
+        self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            self.basic_tree
+        )
+
+        # deleting location that has children, without listing all of its children is invalid
+        delete = [
+            ('County 21', 'county21', 'city', 's2', '', True) + extra_stub_args,
+            # city211 is missing
+        ]
+        result = self.bulk_update_locations(
+            FLAT_LOCATION_TYPES,
+            delete
+        )
+        self.assertNotEqual(result.errors, [])
+        self.assertLocationTypesMatch(FLAT_LOCATION_TYPES)
+        self.assertLocationsMatch(self.as_pairs(self.basic_tree))
         self.assertCouchSync()


### PR DESCRIPTION
This implements partial location upload for admin users, needed for ICDS. This doesn't add support for location-safe upload yet. 
1. Full types sheet should be present in partial upload as well (can remove this constraint latter)
2. Subset of locations can be added/edited/deleted without affecting unlisted locations

@esoergel 
@sheelio might want to double-check the test cases