### PR TITLE
Better handle errors

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -433,7 +433,12 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
     resp = $.ajax(options);
     resp.fail(function () {
         tfLoadingComplete(true);
-    }).done(function() {
+    }).done(function(response) {
+        if (response.hasOwnProperty('exception')) {
+            tfLoadingComplete(true);
+            return;
+        }
+
         tfLoadingComplete();
         $("#cloudcare-notifications").empty();
         FormplayerFrontend.trigger('navigateHome');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -6,6 +6,10 @@ FormplayerFrontend.Constants = {
     // These should match corehq/apps/cloudcare/const.py
     WEB_APPS_ENVIRONMENT: 'web-apps',
     PREVIEW_APP_ENVIRONMENT: 'preview-app',
+    GENERIC_ERROR: gettext(
+        'Formplayer encountered an error. ' +
+        'Please report an issue if you continue to see this message.'
+    ),
 
     LayoutStyles: {
         GRID: 'grid',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -22,10 +22,10 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                         FormplayerFrontend.trigger('retry', response, function() {
                             menus.fetch($.extend(true, {}, options));
                         }, gettext('Waiting for server progress'));
-                    } else if (response.exception){
+                    } else if (response.hasOwnProperty('exception')){
                         FormplayerFrontend.trigger(
                             'showError',
-                            response.exception,
+                            response.exception || FormplayerFrontend.Constants.GENERIC_ERROR,
                             response.type === 'html'
                         );
                         FormplayerFrontend.trigger('navigation:back');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
@@ -22,10 +22,10 @@ FormplayerFrontend.module("Sessions", function (Sessions, FormplayerFrontend, Ba
                 }),
                 url: formplayerUrl + '/get_sessions',
                 success: function (parsed, response) {
-                    if (response.exception){
+                    if (response.hasOwnProperty('exception')){
                         FormplayerFrontend.trigger(
                             'showError',
-                            response.exception,
+                            response.exception || FormplayerFrontend.Constants.GENERIC_ERROR,
                             response.type === 'html'
                         );
                         FormplayerFrontend.trigger('navigation:back');


### PR DESCRIPTION
@wpride noticed that we don't handle errors very well when we fail sometimes. there are cases where the exception message is null, usually a NPE. this ensures that we at least show an error message if that happens

cc: @dannyroberts @proteusvacuum 