### PR TITLE
Add no_result_task

### DIFF
--- a/corehq/apps/reminders/tasks.py
+++ b/corehq/apps/reminders/tasks.py
@@ -6,6 +6,7 @@ from corehq.apps.reminders.models import (CaseReminderHandler, CaseReminder,
     CASE_CRITERIA, REMINDER_TYPE_DEFAULT)
 from corehq.form_processor.abstract_models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.celery_utils import no_result_task
 from corehq.util.decorators import serial_task
 from django.conf import settings
 from dimagi.utils.logging import notify_exception
@@ -35,9 +36,8 @@ if not settings.REMINDERS_QUEUE_ENABLED:
         CaseReminderHandler.fire_reminders()
 
 
-@task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, ignore_result=True, acks_late=True,
-      default_retry_delay=CASE_CHANGED_RETRY_INTERVAL * 60, max_retries=CASE_CHANGED_RETRY_MAX,
-      bind=True)
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True, bind=True,
+                default_retry_delay=CASE_CHANGED_RETRY_INTERVAL * 60, max_retries=CASE_CHANGED_RETRY_MAX)
 def case_changed(self, domain, case_id):
     try:
         handler_ids = CaseReminderHandler.get_handler_ids(
@@ -50,9 +50,8 @@ def case_changed(self, domain, case_id):
         self.retry(exc=e)
 
 
-@task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, ignore_result=True, acks_late=True,
-      default_retry_delay=CASE_CHANGED_RETRY_INTERVAL * 60, max_retries=CASE_CHANGED_RETRY_MAX,
-      bind=True)
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True, bind=True,
+                default_retry_delay=CASE_CHANGED_RETRY_INTERVAL * 60, max_retries=CASE_CHANGED_RETRY_MAX)
 def process_handlers_for_case_changed(self, domain, case_id, handler_ids):
     try:
         _case_changed(domain, case_id, handler_ids)
@@ -77,7 +76,7 @@ def _case_changed(domain, case_id, handler_ids):
             handler.case_changed(case, **kwargs)
 
 
-@task(queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True, acks_late=True)
+@no_result_task(queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True)
 def process_reminder_rule(handler, schedule_changed, prev_definition,
     send_immediately):
     try:
@@ -88,7 +87,7 @@ def process_reminder_rule(handler, schedule_changed, prev_definition,
     handler.save(unlock=True)
 
 
-@task(queue=CELERY_REMINDERS_QUEUE, ignore_result=True, acks_late=True)
+@no_result_task(queue=CELERY_REMINDERS_QUEUE, acks_late=True)
 def fire_reminder(reminder_id, domain):
     try:
         if reminder_rate_limiter.can_perform_action(domain):
@@ -126,7 +125,7 @@ def _fire_reminder(reminder_id):
                 reminder.save()
 
 
-@task(queue='background_queue', ignore_result=True, acks_late=True)
+@no_result_task(queue='background_queue', acks_late=True)
 def delete_reminders_for_cases(domain, case_ids):
     handler_ids = CaseReminderHandler.get_handler_ids(
         domain, reminder_type_filter=REMINDER_TYPE_DEFAULT)

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -19,6 +19,7 @@ from corehq.apps.sms.change_publishers import publish_sms_saved
 from corehq.apps.sms.util import is_contact_active
 from corehq.apps.users.models import CouchUser, CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.celery_utils import no_result_task
 from corehq.util.timezones.conversions import ServerTime
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from dimagi.utils.couch import release_lock, CriticalSection
@@ -176,7 +177,7 @@ def handle_incoming(msg):
         handle_unsuccessful_processing_attempt(msg)
 
 
-@task(queue="sms_queue", ignore_result=True, acks_late=True)
+@no_result_task(queue="sms_queue", acks_late=True)
 def process_sms(queued_sms_pk):
     """
     queued_sms_pk - pk of a QueuedSMS entry
@@ -247,7 +248,7 @@ def process_sms(queued_sms_pk):
             process_sms.delay(queued_sms_pk)
 
 
-@task(ignore_result=True, default_retry_delay=10 * 60, max_retries=10, bind=True)
+@no_result_task(default_retry_delay=10 * 60, max_retries=10, bind=True)
 def store_billable(self, msg):
     if not isinstance(msg, SMS):
         raise Exception("Expected msg to be an SMS")
@@ -274,7 +275,7 @@ def store_billable(self, msg):
             raise
 
 
-@task(queue='background_queue', ignore_result=True, acks_late=True)
+@no_result_task(queue='background_queue', acks_late=True)
 def delete_phone_numbers_for_owners(owner_ids):
     for p in PhoneNumber.objects.filter(owner_id__in=owner_ids):
         # Clear cache and delete
@@ -286,8 +287,8 @@ def clear_case_caches(case):
     is_case_contact_active.clear(case.domain, case.case_id)
 
 
-@task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, ignore_result=True, acks_late=True,
-      default_retry_delay=5 * 60, max_retries=10, bind=True)
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
+                default_retry_delay=5 * 60, max_retries=10, bind=True)
 def sync_case_phone_number(self, case):
     try:
         clear_case_caches(case)
@@ -351,8 +352,8 @@ def _sync_case_phone_number(contact_case):
         phone_number.save()
 
 
-@task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, ignore_result=True, acks_late=True,
-      default_retry_delay=5 * 60, max_retries=10, bind=True)
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
+                default_retry_delay=5 * 60, max_retries=10, bind=True)
 def sync_user_phone_numbers(self, couch_user_id):
     try:
         _sync_user_phone_numbers(couch_user_id)
@@ -393,8 +394,8 @@ def _sync_user_phone_numbers(couch_user_id):
                     pass
 
 
-@task(queue='background_queue', ignore_result=True, acks_late=True,
-      default_retry_delay=5 * 60, max_retries=10, bind=True)
+@no_result_task(queue='background_queue', acks_late=True,
+                default_retry_delay=5 * 60, max_retries=10, bind=True)
 def publish_sms_change(self, sms):
     try:
         publish_sms_saved(sms)
@@ -402,7 +403,7 @@ def publish_sms_change(self, sms):
         self.retry(exc=e)
 
 
-@task(queue='background_queue')
+@no_result_task(queue='background_queue')
 def sync_phone_numbers_for_domain(domain):
     for user_id in CouchUser.ids_by_domain(domain, is_active=True):
         _sync_user_phone_numbers(user_id)

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -1,17 +1,12 @@
 from __future__ import print_function
 import kombu.five
 from celery import Celery
+from celery import current_app
 from celery.backends.base import DisabledBackend
 from celery.task import task
 from django.conf import settings
 from datetime import datetime
 from time import sleep, time
-
-
-def get_disabled_backend():
-    app = Celery()
-    app.config_from_object(settings)
-    return DisabledBackend(app)
 
 
 def no_result_task(*args, **kwargs):
@@ -29,7 +24,7 @@ def no_result_task(*args, **kwargs):
     result info.
     """
     kwargs['ignore_result'] = True
-    kwargs['backend'] = get_disabled_backend()
+    kwargs['backend'] = DisabledBackend(current_app)
 
     def wrapper(fcn):
         return task(*args, **kwargs)(fcn)


### PR DESCRIPTION
Adds a decorator to define a task which won't create any records in celery_taskmeta, by specifying that the DisabledBackend results backend be used for that task.

@dimagi/scale-team 
buddy @NoahCarnahan 