### PR TITLE
throttle riak down errors on form submission

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,8 +1,10 @@
 import logging
+from botocore.vendored.requests.packages.urllib3.exceptions import ProtocolError
 from couchdbkit import ResourceNotFound
 from django.http import (
     HttpResponseBadRequest,
     HttpResponseForbidden,
+    HttpResponseServerError,
 )
 from casexml.apps.case.xform import get_case_updates, is_device_report
 from corehq.apps.domain.decorators import (
@@ -27,6 +29,7 @@ from corehq.form_processor.utils import convert_xform_to_json, should_use_sql_ba
 from corehq.util.datadog.gauges import datadog_gauge, datadog_counter
 from corehq.util.datadog.metrics import MULTIMEDIA_SUBMISSION_ERROR_COUNT
 from corehq.util.datadog.utils import log_counter
+from corehq.util.service_down import notify_riak_down
 from corehq.util.timer import TimingContext
 import couchforms
 from django.views.decorators.http import require_POST
@@ -89,8 +92,12 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         last_sync_token=couchforms.get_last_sync_token(request),
         openrosa_headers=couchforms.get_openrosa_headers(request),
     )
-    with TimingContext() as timer:
-        result = submission_post.run()
+    try:
+        with TimingContext() as timer:
+            result = submission_post.run()
+    except ProtocolError:
+        notify_riak_down()
+        return HttpResponseServerError()
 
     response = result.response
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -5,6 +5,7 @@ import contextlib
 import datetime
 import logging
 from collections import namedtuple
+from botocore.vendored.requests.packages.urllib3.exceptions import ProtocolError
 
 from django.http import (
     HttpRequest,
@@ -162,6 +163,9 @@ class SubmissionPost(object):
                 if instance.xmlns == DEVICE_LOG_XMLNS:
                     try:
                         process_device_log(self.domain, instance)
+                    except ProtocolError:
+                        # if riak is down/struggling, the caller will catch and notify
+                        raise
                     except Exception:
                         notify_exception(None, "Error processing device log", details={
                             'xml': self.instance,

--- a/corehq/util/service_down.py
+++ b/corehq/util/service_down.py
@@ -1,0 +1,19 @@
+from corehq.util.cache_utils import ExponentialBackoff
+from corehq.util.global_request import get_request
+from dimagi.utils.logging import notify_exception
+
+
+def notify_service_down(message, exponential_backoff_key):
+
+    count = ExponentialBackoff.increment(exponential_backoff_key)
+    if not ExponentialBackoff.should_backoff(exponential_backoff_key):
+        notify_exception(get_request(), message, details={
+            'count': count,
+        })
+
+
+def notify_riak_down():
+    notify_service_down(
+        message="Riak is struggling or down",
+        exponential_backoff_key='riak_down',
+    )


### PR DESCRIPTION
I haven't tested this locally, but it uses the same `ExponentialBackoff` utility that soft_assert uses and it's fairly straightforward. Also, if something in the logging doesn't work, it'll basically just throw a different exception where we're currently throwing an exception, so the downside/risk is pretty small.

The goal here is to reduce the unnecessary burden on sentry (which costs 💰) when a service (in this case Riak) goes down or struggles, while still making sure we get notified. The exception will also contain total count of occurances since counter was reset (will be a power of 2). The counter counter is reset every N seconds where N is our default redis timeout. (I believe it's 5 minutes.)