### PR TITLE
preserve user group ids and group names in ES on user save

### DIFF
--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -232,6 +232,7 @@ class UserChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
         return user
 
     @classmethod
+    @mock.patch('corehq.apps.groups.models.Group.by_user', mock.Mock(return_value=[]))
     def setUpClass(cls):
         super(UserChoiceProviderTest, cls).setUpClass()
         report = ReportConfiguration(domain=cls.domain)
@@ -283,6 +284,7 @@ class GroupChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
         return group
 
     @classmethod
+    @mock.patch('corehq.apps.groups.models.Group.by_user', mock.Mock(return_value=[]))
     def setUpClass(cls):
         super(GroupChoiceProviderTest, cls).setUpClass()
         report = ReportConfiguration(domain=cls.domain)

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -2,6 +2,7 @@ import copy
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
 from corehq.apps.change_feed.document_types import COMMCARE_USER, WEB_USER, FORM
 from corehq.apps.change_feed.topics import FORM_SQL
+from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.elastic import (
@@ -47,6 +48,9 @@ def transform_user_for_elasticsearch(doc_dict):
         doc['base_username'] = doc['username'].split("@")[0]
     else:
         doc['base_username'] = doc['username']
+    groups = Group.by_user(doc['_id'], wrap=False, include_names=True)
+    doc['__group_ids'] = [group['group_id'] for group in groups]
+    doc['__group_names'] = [group['name'] for group in groups]
     return doc
 
 


### PR DESCRIPTION
previously saving the user would wipe its group membership by excluding __group_ids and __group_names

Fixes https://manage.dimagi.com/default.asp?251023.

I should test this on staging to make sure it works the way I think it does, but what do you think of the approach? The other option is to pull these from what's currently in elasticsearch, but pulling from source of truth seems better to me, even if it's somewhat redundant.