### PR TITLE
eNikshay custom reports: Display location restricted users' locations in location filter

### DIFF
--- a/custom/enikshay/reports/filters.py
+++ b/custom/enikshay/reports/filters.py
@@ -33,7 +33,8 @@ class EnikshayLocationFilter(BaseMultipleOptionFilter):
         """
         location_ids = self.request.GET.getlist(self.slug)
 
-        if len(location_ids) == 0 and not self.request.couch_user.has_permission(self.request.domain, 'access_all_locations'):
+        if len(location_ids) == 0 \
+                and not self.request.couch_user.has_permission(self.request.domain, 'access_all_locations'):
             # Display the user's location in the filter if none is selected
             location_ids = self.request.couch_user.get_location_ids(self.request.domain)
 

--- a/custom/enikshay/reports/filters.py
+++ b/custom/enikshay/reports/filters.py
@@ -32,6 +32,11 @@ class EnikshayLocationFilter(BaseMultipleOptionFilter):
         :return: Selected locations without their descendants
         """
         location_ids = self.request.GET.getlist(self.slug)
+
+        if len(location_ids) == 0 and not self.request.couch_user.has_permission(self.request.domain, 'access_all_locations'):
+            # Display the user's location in the filter if none is selected
+            location_ids = self.request.couch_user.get_location_ids(self.request.domain)
+
         choice_provider = LocationChoiceProvider(StubReport(domain=self.domain), None)
         # We don't include descendants here because they will show up in select box
         choice_provider.configure({'include_descendants': False})


### PR DESCRIPTION
When a user loads a custom eNikshay report with a location filter, if that user is location restricted, their location will be displayed as a selected value in that report. (The report is already filtered by the users location, but previously there had been no visible indication of this).
@esoergel 
buddy @gcapalbo 