### PR TITLE
Make new user number easy to disable

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -79,7 +79,7 @@ class NewUserNumberAbTestMixin__Disabled(object):
         pass
 
 
-NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__Enabled
+NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__Disabled
 
 
 class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View):

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -48,7 +48,7 @@ def registration_default(request):
     return redirect(UserRegistrationView.urlname)
 
 
-class NewUserNumberAbTestMixin(object):
+class NewUserNumberAbTestMixin__Enabled(object):
     @property
     @memoized
     def _ab(self):
@@ -64,6 +64,22 @@ class NewUserNumberAbTestMixin(object):
 
     def ab_update_response(self, response):
         self._ab.update_response(response)
+
+
+class NewUserNumberAbTestMixin__Disabled(object):
+    @property
+    def ab_show_number(self):
+        return False
+
+    @property
+    def ab_context(self):
+        return None
+
+    def ab_update_response(self, response):
+        pass
+
+
+NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__Enabled
 
 
 class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View):

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -48,7 +48,25 @@ def registration_default(request):
     return redirect(UserRegistrationView.urlname)
 
 
-class ProcessRegistrationView(JSONResponseMixin, View):
+class NewUserNumberAbTestMixin(object):
+    @property
+    @memoized
+    def _ab(self):
+        return ab_tests.ABTest(ab_tests.NEW_USER_NUMBER, self.request)
+
+    @property
+    def ab_show_number(self):
+        return self._ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM
+
+    @property
+    def ab_context(self):
+        return self._ab.context
+
+    def ab_update_response(self, response):
+        self._ab.update_response(response)
+
+
+class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View):
     urlname = 'process_registration'
 
     def get(self, request, *args, **kwargs):
@@ -67,16 +85,11 @@ class ProcessRegistrationView(JSONResponseMixin, View):
         track_workflow(new_user.email, "Requested new account")
         login(self.request, new_user)
 
-    @property
-    @memoized
-    def ab(self):
-        return ab_tests.ABTest(ab_tests.NEW_USER_NUMBER, self.request)
-
     @allow_remote_invocation
     def register_new_user(self, data):
         reg_form = RegisterWebUserForm(
             data['data'],
-            show_number=(self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM)
+            show_number=self.ab_show_number
         )
         if reg_form.is_valid():
             self._create_new_account(reg_form)
@@ -115,7 +128,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
         }
 
 
-class UserRegistrationView(BasePageView):
+class UserRegistrationView(NewUserNumberAbTestMixin, BasePageView):
     urlname = 'register_user'
     template_name = 'registration/register_new_user.html'
 
@@ -132,7 +145,7 @@ class UserRegistrationView(BasePageView):
             else:
                 return redirect("homepage")
         response = super(UserRegistrationView, self).dispatch(request, *args, **kwargs)
-        self.ab.update_response(response)
+        self.ab_update_response(response)
         return response
 
     def post(self, request, *args, **kwargs):
@@ -150,11 +163,6 @@ class UserRegistrationView(BasePageView):
         return self.request.GET.get('internal', False)
 
     @property
-    @memoized
-    def ab(self):
-        return ab_tests.ABTest(ab_tests.NEW_USER_NUMBER, self.request)
-
-    @property
     def page_context(self):
         prefills = {
             'email': self.prefilled_email,
@@ -163,12 +171,12 @@ class UserRegistrationView(BasePageView):
         return {
             'reg_form': RegisterWebUserForm(
                 initial=prefills,
-                show_number=(self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM),
+                show_number=self.ab_show_number,
             ),
             'reg_form_defaults': prefills,
             'hide_password_feedback': settings.ENABLE_DRACONIAN_SECURITY_FEATURES,
-            'show_number': (self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM),
-            'ab_test': self.ab.context,
+            'show_number': self.ab_show_number,
+            'ab_test': self.ab_context,
         }
 
     @property


### PR DESCRIPTION
and disable it

quick response to https://manage.dimagi.com/default.asp?252377

in the future to enable just change

```
NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__Disabled
```

back to

```
NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__Enabled
```

For context I'm doing this because it's already been added, reverted, and then re-added (see https://github.com/dimagi/commcare-hq/pull/14557). The chance that there's some more back and forth on this reasonable, and this is a tiny little gift to whoever eventually enables it again.