### PR TITLE
App manager v2: Use .nav-pills for deploy modal

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
@@ -38,7 +38,7 @@
                         <div class="panel-body">
                             <div data-bind="bootstrapTabs: true">
                                 <div class="tabbable">
-                                    <ul class="nav nav-tabs" role="tablist">
+                                    <ul class="nav nav-pills" role="tablist">
                                       <li class="active">
                                         <a href="#online-install-tab" data-toggle="tab">
                                           {% trans "Online Install" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
@@ -39,7 +39,7 @@
 -                                        <li>
 -                                            <a>{% trans "Offline Install" %}</a>
 -                                        </li>
-+                                    <ul class="nav nav-tabs" role="tablist">
++                                    <ul class="nav nav-pills" role="tablist">
 +                                      <li class="active">
 +                                        <a href="#online-install-tab" data-toggle="tab">
 +                                          {% trans "Online Install" %}


### PR DESCRIPTION
Minor. This looks not great:
<img width="558" alt="screen shot 2017-04-20 at 2 38 45 pm" src="https://cloud.githubusercontent.com/assets/1486591/25247953/761262e0-25da-11e7-80ab-701ac28fab9b.png">

This is better:
<img width="513" alt="screen shot 2017-04-20 at 3 00 12 pm" src="https://cloud.githubusercontent.com/assets/1486591/25247963/806f782c-25da-11e7-8bc6-da0b3e9788d2.png">

@dannyroberts / @biyeun 