### PR TITLE
Add print template for case detail to multimedia suite

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -566,6 +566,13 @@ class HQMediaMixin(Document):
                                 for icon in icons
                                 if icon]
                             )
+                # Print template
+                if display and details.display == 'long' and details.print_template:
+                    media.append(ApplicationMediaReference(
+                        details.print_template['path'],
+                        media_class=CommCareMultimedia,
+                        **media_kwargs)
+                    )
 
             if module.case_list_form.form_id:
                 _add_menu_media(module.case_list_form, **media_kwargs)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/15539#issuecomment-290354030

Verified that the template now has a reference in `media_suite.xml` and that the html file appears in `commcare/text`.

@dannyroberts 

fyi @amstone326 