### PR TITLE
Don't thwack 99DOTS server if they return an error

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -39,6 +39,9 @@ class Base99DOTSRepeater(CaseRepeater):
             return True
         return False
 
+    def allow_immediate_retries(self, response):
+        return False
+
 
 class NinetyNineDotsRegisterPatientRepeater(Base99DOTSRepeater):
     """Register a patient in 99DOTS


### PR DESCRIPTION
I don't know why repeaters do this, but if they encounter an error, they just pummel that server with 3 more of the same request. This is mean, so I'm turning it off for 99DOTS.
@NoahCarnahan 

CC: @sravfeyn 

