### PR TITLE
prevent dictionary lookup by passing in tuples

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -42,7 +42,7 @@
 {% if get %}
 <table>
     <tbody>
-        {% for key, value in get.items %}
+        {% for key, value in get %}
         <tr>
             <td><pre>{{ key }}</pre></td>
             <td><pre>{{ value }}</pre></td>

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -115,7 +115,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
             })
 
             context.update({
-                'get': request.GET,
+                'get': request.GET.items(),
                 'post': SafeExceptionReporterFilter().get_post_parameters(request),
                 'method': request.method,
                 'username': request.user.username if getattr(request, 'user', None) else "",


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/239319451/

Figured this one out - Django does dictionary lookups in templates so `get.items` was returning the value of the `items` key in the dict and not the list of tuples.

https://docs.djangoproject.com/en/1.10/ref/templates/api/#variables-and-lookups