### PR TITLE
Allow retries for failing 99dots records

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -34,11 +34,6 @@ class Base99DOTSRepeater(CaseRepeater):
     def available_for_domain(cls, domain):
         return NINETYNINE_DOTS.enabled(domain)
 
-    def allow_retries(self, response):
-        if response is not None and response.status_code == 500:
-            return True
-        return False
-
     def allow_immediate_retries(self, response):
         return False
 


### PR DESCRIPTION
We've been running into issues where their server is 400'ing for no reason. For now, retry these records later to try again later until we figure out why it is happening.