### PR TITLE
Cache fixture items by datatype

### DIFF
--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -27,7 +27,7 @@ def get_fixture_data_types_in_domain(domain):
     ))
 
 
-@quickcache(['domain', 'data_type_id'], timeout=60, skip_arg='bypass_cache')
+@quickcache(['domain', 'data_type_id'], timeout=5 * 60, skip_arg='bypass_cache')
 def get_fixture_items_by_data_type(domain, data_type_id, bypass_cache=False):
     from corehq.apps.fixtures.models import FixtureDataItem
     return list(FixtureDataItem.view(

--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -27,6 +27,18 @@ def get_fixture_data_types_in_domain(domain):
     ))
 
 
+@quickcache(['domain', 'data_type_id'], timeout=60, skip_arg='bypass_cache')
+def get_fixture_items_by_data_type(domain, data_type_id, bypass_cache=False):
+    from corehq.apps.fixtures.models import FixtureDataItem
+    return list(FixtureDataItem.view(
+        'fixtures/data_items_by_domain_type',
+        key=[domain, data_type_id],
+        reduce=False,
+        include_docs=True,
+        descending=True
+    ))
+
+
 def get_owner_ids_by_type(domain, owner_type, data_item_id):
     from corehq.apps.fixtures.models import FixtureOwnership
     assert owner_type in FixtureOwnership.owner_type.choices, \

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -51,6 +51,7 @@ class ItemListsProvider(object):
     def __call__(self, restore_user, version, last_sync=None, app=None):
         assert isinstance(restore_user, OTARestoreUser)
 
+        # cached for 30 min
         all_types = dict([(t._id, t) for t in FixtureDataType.by_domain(restore_user.domain)])
         global_types = dict([(id, t) for id, t in all_types.items() if t.is_global])
 
@@ -62,10 +63,11 @@ class ItemListsProvider(object):
             item._data_type = data_type
 
         for global_fixture in global_types.values():
-            items = list(FixtureDataItem.by_data_type(restore_user.domain, global_fixture))
+            items = FixtureDataItem.by_data_type(restore_user.domain, global_fixture)
             _ = [_set_cached_type(item, global_fixture) for item in items]
             items_by_type[global_fixture._id] = items
 
+        # uses FixtureDataItem.by_user. several couch calls. no cache
         other_items = restore_user.get_fixture_data_items()
         data_types = {}
 

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -51,7 +51,6 @@ class ItemListsProvider(object):
     def __call__(self, restore_user, version, last_sync=None, app=None):
         assert isinstance(restore_user, OTARestoreUser)
 
-        # cached for 30 min
         all_types = dict([(t._id, t) for t in FixtureDataType.by_domain(restore_user.domain)])
         global_types = dict([(id, t) for id, t in all_types.items() if t.is_global])
 
@@ -67,7 +66,6 @@ class ItemListsProvider(object):
             _ = [_set_cached_type(item, global_fixture) for item in items]
             items_by_type[global_fixture._id] = items
 
-        # uses FixtureDataItem.by_user. several couch calls. no cache
         other_items = restore_user.get_fixture_data_items()
         data_types = {}
 

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -205,7 +205,7 @@ def update_items(fields_patches, domain, data_type_id, transaction):
                 )
         setattr(item, "fields", updated_fields)
         transaction.save(item)
-    data_items = FixtureDataItem.by_data_type(domain, data_type_id)
+    data_items = FixtureDataItem.by_data_type(domain, data_type_id, bypass_cache=True)
 
 
 def create_types(fields_patches, domain, data_tag, is_global, transaction):


### PR DESCRIPTION
@dimagi/scale-team 

This caches the data items. I think this is sufficient as none of the fixtures use fixture ownership