### PR TITLE
Cache get_last_synclog_for_user

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
@@ -1,9 +1,7 @@
 from casexml.apps.phone.models import SyncLog
 from dimagi.utils.couch.database import get_db
-from corehq.util.quickcache import quickcache
 
 
-@quickcache(['user_id'], timeout=60 * 60)
 def get_last_synclog_for_user(user_id):
     results = synclog_view(
         "phone/sync_logs_by_user",

--- a/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
@@ -1,7 +1,9 @@
 from casexml.apps.phone.models import SyncLog
 from dimagi.utils.couch.database import get_db
+from corehq.util.quickcache import quickcache
 
 
+@quickcache(['user_id'], timeout=60 * 60)
 def get_last_synclog_for_user(user_id):
     results = synclog_view(
         "phone/sync_logs_by_user",


### PR DESCRIPTION
@dimagi/scale-team Realized one of the ways couch is getting hammered is via this call. It's only used in one place, the Application Status report. Essentially we loop through every user and get the latest sync log for that user. And when that's 100k users... that's a lot of hits. This does two things, 1) cache that call, and 2) limit the number users on the App Status to 5000

<img width="1474" alt="screen shot 2017-04-22 at 7 33 01 pm" src="https://cloud.githubusercontent.com/assets/918514/25306781/8ec32390-2794-11e7-9aa0-44d238f046da.png">

buddy: @calellowitz 