### PR TITLE
save the sync log only once

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -602,6 +602,7 @@ class RestoreState(object):
         previous_log_rev = None if self.is_initial else self.last_sync_log._rev
         last_seq = str(get_db().info()["update_seq"])
         new_synclog = SyncLog(
+            _id=uuid4().hex,
             domain=self.restore_user.domain,
             build_id=self.params.app_id,
             user_id=self.restore_user.user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -590,14 +590,14 @@ class RestoreState(object):
 
     def start_sync(self):
         self.start_time = datetime.utcnow()
-        self.current_sync_log = self.create_sync_log()
+        self.current_sync_log = self._new_sync_log()
 
     def finish_sync(self):
         self.duration = datetime.utcnow() - self.start_time
         self.current_sync_log.duration = self.duration.seconds
         self.current_sync_log.save()
 
-    def create_sync_log(self):
+    def _new_sync_log(self):
         previous_log_id = None if self.is_initial else self.last_sync_log._id
         previous_log_rev = None if self.is_initial else self.last_sync_log._rev
         last_seq = str(get_db().info()["update_seq"])
@@ -611,7 +611,6 @@ class RestoreState(object):
             previous_log_id=previous_log_id,
             previous_log_rev=previous_log_rev,
         )
-        new_synclog.save(**get_safe_write_kwargs())
         return new_synclog
 
     @property


### PR DESCRIPTION
@dimagi/scale-team how do you guys feel about only saving the sync log once per sync? this would mean that we'd only get a record of a sync log if the restore successfully finishes, which i feel like is fine. i also noticed that under load, puts put strain on the couch database. this should reduce them (there are a couple other saves):

<img width="487" alt="screen shot 2017-04-22 at 7 57 57 pm" src="https://cloud.githubusercontent.com/assets/918514/25306835/0821a724-2796-11e7-9a85-44486e9a653b.png">
 buddy: @calellowitz 