### PR TITLE
shortcircuit DB lookup

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -814,10 +814,13 @@ def get_report_configs(config_ids, domain):
         if config.domain != domain:
             raise ReportConfigurationNotFoundError
 
-    dynamic_report_configs = [
-        ReportConfiguration.wrap(doc) for doc in
-        get_docs(ReportConfiguration.get_db(), dynamic_report_config_ids)
-    ]
+    dynamic_report_configs = []
+    if dynamic_report_config_ids:
+        dynamic_report_configs = [
+            ReportConfiguration.wrap(doc) for doc in
+            get_docs(ReportConfiguration.get_db(), dynamic_report_config_ids)
+        ]
+
     if len(dynamic_report_configs) != len(dynamic_report_config_ids):
         raise ReportConfigurationNotFoundError
     for config in dynamic_report_configs:

--- a/settings.py
+++ b/settings.py
@@ -1277,6 +1277,8 @@ APPS_DB = NEW_APPS_DB
 
 SYNCLOGS_DB = 'synclogs'
 
+META_DB = 'meta'
+
 
 COUCHDB_APPS = [
     'api',
@@ -1340,10 +1342,10 @@ COUCHDB_APPS = [
     'ilsgateway',
     'ewsghana',
     ('auditcare', 'auditcare'),
-    ('performance_sms', 'meta'),
+    ('performance_sms', META_DB),
     ('repeaters', 'receiverwrapper'),
-    ('userreports', 'meta'),
-    ('custom_data_fields', 'meta'),
+    ('userreports', META_DB),
+    ('custom_data_fields', META_DB),
     # needed to make couchdbkit happy
     ('fluff', 'fluff-bihar'),
     ('bihar', 'fluff-bihar'),
@@ -1351,8 +1353,8 @@ COUCHDB_APPS = [
     ('fluff', 'fluff-opm'),
     ('mc', 'fluff-mc'),
     ('m4change', 'm4change'),
-    ('export', 'meta'),
-    ('callcenter', 'meta'),
+    ('export', META_DB),
+    ('callcenter', META_DB),
 
     # users and groups
     ('groups', USERS_GROUPS_DB),


### PR DESCRIPTION
@dimagi/scale-team 

This will only help if all the app reports are static. There is no caching here so this get's called at least once per restore request.