### PR TITLE
Show HTML5 validation alert for select2 in report builder config

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1297,7 +1297,7 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
                     _("Rows"),
                     _('Choose which property this report will group its results by. Each value of this property will be a row in the table. For example, if you choose a yes or no question, the report will show a row for "yes" and a row for "no."'),
                 ),
-                'group_by',
+                crispy.Field('group_by', required=True),
             ),
             self.user_filter_fieldset,
             self.default_filter_fieldset

--- a/corehq/apps/userreports/templates/userreports/base_report_builder.html
+++ b/corehq/apps/userreports/templates/userreports/base_report_builder.html
@@ -3,6 +3,19 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
+{% block js-inline %}{{ block.super }}
+  <script type="text/javascript">
+    $(function () {
+      _.each($('.select2'), function (elem) {
+        if ($(elem).prop('required')) {
+          $(elem).prev().find('.select2-focusser').prop('required', true);
+          $(elem).removeProp('required');
+        }
+      });
+    })
+  </script>
+{% endblock %}
+
 {% block page_content %}
     {% crispy form %}
 {% endblock %}


### PR DESCRIPTION
Ideally, a more robust js validation should be happening, but I'll have to dig deeper. This should be good for now.

fixes https://manage.dimagi.com/default.asp?252317#1319919

@dannyroberts cc @NoahCarnahan 

<img width="776" alt="screen shot 2017-04-24 at 11 54 01 am" src="https://cloud.githubusercontent.com/assets/716573/25346431/88aa5148-28e5-11e7-89a7-884e1faa4bf2.png">
