### PR TITLE
use username_to_user_id

### DIFF
--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 import django.core.exceptions
 from corehq.apps.users.models import CouchUser, InvalidUser, AnonymousCouchUser
+from corehq.apps.users.util import username_to_user_id
 from corehq.toggles import ANONYMOUS_WEB_APPS_USAGE, PUBLISH_CUSTOM_REPORTS
 
 SESSION_USER_KEY_PREFIX = "session_user_doc_%s"
@@ -38,8 +39,8 @@ class UsersMiddleware(object):
             if ANONYMOUS_WEB_APPS_USAGE.enabled(view_kwargs['domain']):
                 request.couch_user = CouchUser.get_anonymous_mobile_worker(request.domain)
         if request.user and request.user.is_authenticated:
-            request.couch_user = CouchUser.get_by_username(
-                request.user.username, strict=False)
+            user_id = username_to_user_id(request.user.username)
+            request.couch_user = CouchUser.get_by_user_id(user_id)
             if not request.couch_user.analytics_enabled:
                 request.analytics_enabled = False
             if 'domain' in view_kwargs:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -44,6 +44,7 @@ from corehq.apps.domain.models import Domain, LicenseAgreement
 from corehq.apps.users.util import (
     user_display_string,
     user_location_data,
+    username_to_user_id,
 )
 from corehq.apps.users.tasks import tag_forms_as_deleted_rebuild_associated_cases, \
     tag_cases_as_deleted_and_remove_indices, tag_system_forms_as_deleted
@@ -1193,9 +1194,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
             result = get(stale=settings.COUCH_STALE_QUERY, raise_if_none=True)
             if result['doc'] is None or result['doc']['username'] != username:
                 raise NoResultFound
-        except NoMoreData:
-            logging.exception('called get_by_username(%r) and it failed pretty bad' % username)
-            raise
         except NoResultFound:
             result = get(stale=None, raise_if_none=False)
 
@@ -1216,6 +1214,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
         self.get_by_username.clear(self.__class__, self.username)
         self.get_by_user_id.clear(self.__class__, self.user_id)
+        username_to_user_id.clear(self.username)
         domains = getattr(self, 'domains', None)
         if domains is None:
             domain = getattr(self, 'domain', None)

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.core.cache import cache
+
+from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.util import username_to_user_id
+
+
+class TestUsernameToUserID(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.user = CommCareUser.create('scale-domain', 'scale', 'dude')
+        cache.clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete()
+        cache.clear()
+
+    def test_username_to_user_id(self):
+        user_id = username_to_user_id(self.user.username)
+        self.assertEqual(user_id, self.user._id)
+
+    def test_username_to_user_id_wrong_username(self):
+        user_id = username_to_user_id('not-here')
+        self.assertIsNone(user_id)

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -6,6 +6,7 @@ from django.utils import html, safestring
 
 from couchdbkit.resource import ResourceNotFound
 from corehq import privileges
+from corehq.util.quickcache import quickcache
 
 from django.core.cache import cache
 from django_prbac.utils import has_privilege
@@ -69,6 +70,24 @@ def raw_username(username):
         return u
     else:
         return username
+
+
+@quickcache(['username'], timeout=60 * 60 * 24 * 3)
+def username_to_user_id(username):
+    '''
+    Takes a username and returns the couch user id for that user
+
+    :param username: The username name of a user
+
+    :returns: The couch user id
+    '''
+    from corehq.apps.users.models import CouchUser
+
+    user = CouchUser.get_by_username(username)
+    if not user:
+        return None
+
+    return user._id
 
 
 def user_id_to_username(user_id):


### PR DESCRIPTION
@dimagi/scale-team this uses a function that maps a username to a couch user id and then aggressively caches it. hopefully this'll provide short term relief while we work on a longer term solution. thanks @emord for the suggestion

cc: @calellowitz 