### PR TITLE
drop unneeded cast

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -111,7 +111,7 @@ def get_module_view_context(app, module, lang=None):
         'lang': lang,
         'langs': app.langs,
         'module_type': module.module_type,
-        'requires_case_details': bool(module.requires_case_details()),
+        'requires_case_details': module.requires_case_details(),
     }
     case_property_builder = _setup_case_property_builder(app)
     if isinstance(module, CareplanModule):


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/15820#pullrequestreview-34333549

Agree this isn't needed. I didn't dig deeply into the commit history, beyond noticing that the bug was reported before https://github.com/dimagi/commcare-hq/pull/13540 which I'd think would have included me testing the warning on case list and case detail...decided to leave the origin of this bug a mystery.

@dannyroberts 