### PR TITLE
stop checking main DB for synclogs

### DIFF
--- a/corehq/apps/dump_reload/couch/id_providers.py
+++ b/corehq/apps/dump_reload/couch/id_providers.py
@@ -77,7 +77,6 @@ class SyncLogIDProvider(BaseIDProvider):
         from corehq.apps.users.dbaccessors.all_commcare_users import get_all_user_ids_by_domain
         from casexml.apps.phone.models import SyncLog
         for user_id in get_all_user_ids_by_domain(domain):
-            # this excludes sync logs in old DB (prior to migration to synclog DB). See ``synclog_view``.
             rows = SyncLog.view(
                 "phone/sync_logs_by_user",
                 startkey=[user_id],

--- a/corehq/ex-submodules/casexml/apps/phone/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/phone/__init__.py
@@ -1,4 +1,0 @@
-from corehq.preindex import ExtraPreindexPlugin
-from django.conf import settings
-
-ExtraPreindexPlugin.register('phone', __file__, (None, settings.SYNCLOGS_DB))

--- a/corehq/ex-submodules/casexml/apps/phone/analytics.py
+++ b/corehq/ex-submodules/casexml/apps/phone/analytics.py
@@ -1,14 +1,13 @@
-from casexml.apps.phone.dbaccessors.sync_logs_by_user import synclog_view
-from casexml.apps.phone.models import properly_wrap_sync_log
+from casexml.apps.phone.models import properly_wrap_sync_log, SyncLog
 from corehq.util.couch import stale_ok
 
 
 def update_analytics_indexes():
-    synclog_view("phone/sync_logs_by_user", limit=1, reduce=False)
+    SyncLog.view("phone/sync_logs_by_user", limit=1, reduce=False)
 
 
 def get_sync_logs_for_user(user_id, limit):
-    rows = synclog_view(
+    rows = SyncLog.view(
         "phone/sync_logs_by_user",
         startkey=[user_id, {}],
         endkey=[user_id],
@@ -16,7 +15,8 @@ def get_sync_logs_for_user(user_id, limit):
         reduce=False,
         limit=limit,
         include_docs=True,
-        stale=stale_ok()
+        stale=stale_ok(),
+        wrap_doc=False
     )
     sync_log_jsons = (row['doc'] for row in rows)
     return [properly_wrap_sync_log(sync_log_json) for sync_log_json in sync_log_jsons]

--- a/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
@@ -1,9 +1,9 @@
-from casexml.apps.phone.models import SyncLog
+from casexml.apps.phone.models import SyncLog, properly_wrap_sync_log
 from dimagi.utils.couch.database import get_db
 
 
 def get_last_synclog_for_user(user_id):
-    results = synclog_view(
+    result = SyncLog.view(
         "phone/sync_logs_by_user",
         startkey=[user_id, {}],
         endkey=[user_id],
@@ -11,31 +11,8 @@ def get_last_synclog_for_user(user_id):
         limit=1,
         reduce=False,
         include_docs=True,
+        wrap_doc=False
     )
-    if results:
-        row, = results
-        return SyncLog.wrap(row['doc'])
-    else:
-        return None
-
-
-def synclog_view(view_name, **params):
-    return combine_views([SyncLog.get_db(), get_db(None)], view_name, **params)
-
-
-def combine_views(dbs, view_name, **params):
-    assert params.get('reduce') is False, 'You must call combine_views with reduce=False'
-    assert not params.get('skip'), 'You cannot call combine_views with skip'
-    rows = []
-    for db in dbs:
-        rows.extend(db.view(view_name, **params))
-
-    if params.get('descending'):
-        rows.sort(key=lambda row: row['key'], reverse=True)
-    else:
-        rows.sort(key=lambda row: row['key'])
-
-    if 'limit' in params:
-        return rows[:params['limit']]
-    else:
-        return rows
+    if result:
+        row, = result
+        return properly_wrap_sync_log(row['doc'])

--- a/corehq/ex-submodules/casexml/apps/phone/management/commands/invalidate_sync_heads.py
+++ b/corehq/ex-submodules/casexml/apps/phone/management/commands/invalidate_sync_heads.py
@@ -1,7 +1,6 @@
-from django.core.management import BaseCommand, CommandError
+from django.core.management import BaseCommand
 
 from casexml.apps.phone.models import SimplifiedSyncLog
-from casexml.apps.phone.dbaccessors.sync_logs_by_user import synclog_view
 
 
 class Command(BaseCommand):
@@ -15,7 +14,7 @@ class Command(BaseCommand):
         parser.add_argument('date')
 
     def handle(self, user_id, date, **options):
-        results = synclog_view(
+        results = SimplifiedSyncLog.view(
             "phone/sync_logs_by_user",
             startkey=[user_id, {}],
             endkey=[user_id, date],
@@ -25,8 +24,7 @@ class Command(BaseCommand):
         )
 
         logs = []
-        for res in results:
-            log = SimplifiedSyncLog.wrap(res['doc'])
+        for log in results:
             log.case_ids_on_phone = {'broken to force 412'}
             logs.append(log)
         SimplifiedSyncLog.bulk_save(logs)

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -275,11 +275,6 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
 
     strict = True  # for asserts
 
-    @classmethod
-    def get(cls, doc_id):
-        doc = get_sync_log_doc(doc_id)
-        return cls.wrap(doc)
-
     def _assert(self, conditional, msg="", case_id=None):
         if not conditional:
             _get_logger().warn("assertion failed: %s" % msg)
@@ -1197,21 +1192,12 @@ def _domain_has_legacy_toggle_set():
     return LEGACY_SYNC_SUPPORT.enabled(domain) if domain else False
 
 
-def get_sync_log_doc(doc_id):
-    try:
-        return SyncLog.get_db().get(doc_id)
-    except ResourceNotFound:
-        legacy_doc = get_db(None).get(doc_id, attachments=True)
-        del legacy_doc['_rev']  # remove the rev so we can save this to the new DB
-        return legacy_doc
-
-
 def get_properly_wrapped_sync_log(doc_id):
     """
     Looks up and wraps a sync log, using the class based on the 'log_format' attribute.
     Defaults to the existing legacy SyncLog class.
     """
-    return properly_wrap_sync_log(get_sync_log_doc(doc_id))
+    return properly_wrap_sync_log(SyncLog.get_db().get(doc_id))
 
 
 def properly_wrap_sync_log(doc):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_dbaccessors.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_dbaccessors.py
@@ -1,9 +1,10 @@
 import datetime
-from casexml.apps.phone.analytics import get_sync_logs_for_user, update_analytics_indexes
-from dimagi.utils.couch.database import get_db
+
 from django.test import TestCase
+
+from casexml.apps.phone.analytics import get_sync_logs_for_user, update_analytics_indexes
 from casexml.apps.phone.dbaccessors.sync_logs_by_user import get_last_synclog_for_user
-from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog, get_properly_wrapped_sync_log
+from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog
 from corehq.util.test_utils import DocTestMixin
 
 
@@ -22,43 +23,15 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         cls.docs = cls.sync_logs + sync_logs_other
         for doc in cls.docs:
             doc.save()
-        cls.legacy_sync_logs = [
-            SyncLog(user_id=cls.user_id, date=datetime.datetime(2014, 12, 31, 0, 0))
-        ]
-        for doc in cls.legacy_sync_logs:
-            get_db(None).save_doc(doc)
         update_analytics_indexes()
 
     @classmethod
     def tearDownClass(cls):
         for doc in cls.docs:
             doc.delete()
-        get_db(None).delete_docs(cls.legacy_sync_logs)
 
     def test_get_sync_logs_for_user(self):
-        self.assert_doc_sets_equal(
-            get_sync_logs_for_user(self.user_id, 4),
-            self.sync_logs + self.legacy_sync_logs)
+        self.assert_doc_sets_equal(get_sync_logs_for_user(self.user_id, 4), self.sync_logs)
 
     def test_get_last_synclog_for_user(self):
-        self.assert_docs_equal(
-            get_last_synclog_for_user(self.user_id), self.sync_logs[0])
-
-    def test_get_and_save_legacy_synclog_with_attachm(self):
-        legacy_sync_log = self.legacy_sync_logs[0]
-        attachment_name = 'test_attach'
-        get_db(None).put_attachment(legacy_sync_log._doc, 'test', attachment_name, 'text/plain')
-
-        sync_log = get_properly_wrapped_sync_log(legacy_sync_log._id)
-        self.assertIn(attachment_name, sync_log._attachments)
-
-        # this used to fail for docs with attachments
-        sync_log.save()
-
-        # cleanup
-        def del_attachment():
-            get_db(None).delete_attachment(legacy_sync_log._doc, attachment_name)
-            del legacy_sync_log._attachments
-
-        self.addCleanup(del_attachment)
-        self.addCleanup(sync_log.delete)
+        self.assert_docs_equal(get_last_synclog_for_user(self.user_id), self.sync_logs[0])


### PR DESCRIPTION
buddy @nickpell 
@dimagi/scale-team 

I think it's been log enough that there won't be any active synclogs in the main DB. 

related to: https://trello.com/c/acH1iJxe/21-start-saving-synclogs-to-a-new-db-but-continue-checking-the-old-one