### PR TITLE
bump lock timeout on forms

### DIFF
--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -85,7 +85,7 @@ class FormProcessorInterface(object):
             return LedgerDBCouch()
 
     def acquire_lock_for_xform(self, xform_id):
-        lock = self.xform_model.get_obj_lock_by_id(xform_id, timeout_seconds=2 * 60)
+        lock = self.xform_model.get_obj_lock_by_id(xform_id, timeout_seconds=5 * 60)
         try:
             lock.acquire()
         except RedisError:

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -78,7 +78,7 @@ def process_xform_xml(domain, instance, attachments=None):
     except (MissingXMLNSError, XMLSyntaxError) as e:
         return _get_submission_error(domain, instance, e)
     except DuplicateError as e:
-        return _handle_id_conflict(instance, e.xform, domain)
+        return _handle_id_conflict(e.xform, domain)
 
 
 def _create_new_xform(domain, instance_xml, attachments=None):
@@ -138,7 +138,7 @@ def _get_submission_error(domain, instance, error):
     return FormProcessingResult(xform)
 
 
-def _handle_id_conflict(instance, xform, domain):
+def _handle_id_conflict(xform, domain):
     """
     For id conflicts, we check if the files contain exactly the same content,
     If they do, we just log this as a dupe. If they don't, we deprecate the
@@ -151,7 +151,7 @@ def _handle_id_conflict(instance, xform, domain):
     interface = FormProcessorInterface(domain)
     if interface.is_duplicate(conflict_id, domain):
         # It looks like a duplicate/edit in the same domain so pursue that workflow.
-        return _handle_duplicate(xform, instance)
+        return _handle_duplicate(xform)
     else:
         # the same form was submitted to two domains, or a form was submitted with
         # an ID that belonged to a different doc type. these are likely developers
@@ -160,7 +160,7 @@ def _handle_id_conflict(instance, xform, domain):
         return FormProcessingResult(xform)
 
 
-def _handle_duplicate(new_doc, instance):
+def _handle_duplicate(new_doc):
     """
     Handle duplicate xforms and xform editing ('deprecation')
 


### PR DESCRIPTION
Getting some errors like this https://sentry.io/dimagi/commcarehq/issues/250116028/ where the phone times out and re-submits a form. I think this should hopefully stop it.

(sneaking in the first commit as a tiny cleanup)