### PR TITLE
cache blob content on attachment during write

### DIFF
--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -34,7 +34,7 @@ class FormProcessorSQL(object):
                 attachment_id=uuid.uuid4(),
                 content_type=attachment.content_type,
             )
-            xform_attachment.write_content(attachment.content_as_file())
+            xform_attachment.write_content(attachment.content)
             if xform_attachment.is_image:
                 try:
                     img_size = Image.open(attachment.content_as_file()).size


### PR DESCRIPTION
@dimagi/scale-team this should reduce our riak reads by a lot. At the moment we read the form out of riak during form processing instead of keeping it in memory (dumb).

buddy @nickpell 