### PR TITLE
Cache restore payload paths in redis

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -223,6 +223,7 @@ def get_restore_params(request):
         'has_data_cleanup_privelege': has_privilege(request, privileges.DATA_CLEANUP),
         'overwrite_cache': request.GET.get('overwrite_cache') == 'true',
         'openrosa_version': openrosa_version,
+        'device_id': request.GET.get('device_id'),
     }
 
 
@@ -230,7 +231,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,
                          force_restore_mode=None,
-                         as_user=None,
+                         as_user=None, device_id=None,
                          has_data_cleanup_privelege=False,
                          openrosa_version=OPENROSA_DEFAULT_VERSION):
     # not a view just a view util
@@ -266,6 +267,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
             state_hash=state,
             include_item_count=items,
             app=app,
+            device_id=device_id,
         ),
         cache_settings=RestoreCacheSettings(
             force_cache=force_cache or async_restore_enabled,

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -328,31 +328,19 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
         """
         raise NotImplementedError()
 
-    def set_cached_payload(self, payload_path, version):
-        self.cache_payload_paths[self._cache_key(version)] = payload_path
-
-    def get_cached_payload(self, version, stream=False):
-        if self._cache_key(version) in self.cache_payload_paths:
-            return self.response_class.get_payload(self.cache_payload_paths[self._cache_key(version)])
-        return None
-
-    def get_cached_payload_path(self, version):
-        if self._cache_key(version) in self.cache_payload_paths:
-            return self.cache_payload_paths[self._cache_key(version)]
-        return None
-
     def _cache_key(self, version):
-        return u'{}-{}'.format(self.response_class.__name__, version)
-
-    def invalidate_cached_payloads(self):
         from casexml.apps.phone.restore import restore_cache_key
-        keys = [restore_cache_key(
+
+        return restore_cache_key(
             self.domain,
             RESTORE_CACHE_KEY_PREFIX,
             self.user_id,
             version=version,
             sync_log_id=self._id,
-        ) for version in [V1, V2]]
+        )
+
+    def invalidate_cached_payloads(self):
+        keys = [self._cache_key(version) for version in [V1, V2]]
 
         for key in keys:
             get_redis_default_cache().delete(key)

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -11,12 +11,15 @@ from corehq.util.soft_assert import soft_assert
 from corehq.toggles import ENABLE_LOADTEST_USERS
 from corehq.apps.domain.models import Domain
 from dimagi.ext.couchdbkit import *
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from django.db import models
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.mixins import UnicodeMixIn
 from dimagi.utils.couch import LooselyEqualDocumentSchema
 from dimagi.utils.couch.database import get_db
 from casexml.apps.case import const
+from casexml.apps.case.xml import V1, V2
+from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.case.sharedmodels import CommCareCaseIndex, IndexHoldingMixIn
 from casexml.apps.phone.checksum import Checksum, CaseStateHash
 from casexml.apps.phone.utils import get_restore_response_class
@@ -342,8 +345,17 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
         return u'{}-{}'.format(self.response_class.__name__, version)
 
     def invalidate_cached_payloads(self):
-        self.cache_payload_paths = {}
-        self.save()
+        from casexml.apps.phone.restore import restore_cache_key
+        keys = [restore_cache_key(
+            self.domain,
+            RESTORE_CACHE_KEY_PREFIX,
+            self.user_id,
+            version=version,
+            sync_log_id=self._id,
+        ) for version in [V1, V2]]
+
+        for key in keys:
+            get_redis_default_cache().delete(key)
 
     @classmethod
     def from_other_format(cls, other_sync_log):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -66,14 +66,15 @@ from xml.etree import ElementTree
 logger = logging.getLogger(__name__)
 
 
-def restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None):
+def restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None, device_id=None):
     response_class = get_restore_response_class(domain)
-    hashable_key = '{response_class}-{prefix}-{user}-{version}-{sync_log_id}'.format(
+    hashable_key = '{response_class}-{prefix}-{user}-{version}-{sync_log_id}-{device_id}'.format(
         response_class=response_class.__name__,
         prefix=prefix,
         user=user_id,
         version=version or '',
         sync_log_id=sync_log_id or '',
+        device_id=device_id or '',
     )
     return hashlib.md5(hashable_key).hexdigest()
 
@@ -406,14 +407,22 @@ class RestoreParams(object):
     :param version:             The version of the restore format
     :param state_hash:          The case state hash string to use to verify the state of the phone
     :param include_item_count:  Set to `True` to include the item count in the response
+    :param device_id:           The Device id of the device restoring
     """
 
-    def __init__(self, sync_log_id='', version=V1, state_hash='', include_item_count=False, app=None):
+    def __init__(self,
+            sync_log_id='',
+            version=V1,
+            state_hash='',
+            include_item_count=False,
+            device_id=None,
+            app=None):
         self.sync_log_id = sync_log_id
         self.version = version
         self.state_hash = state_hash
         self.include_item_count = include_item_count
         self.app = app
+        self.device_id = device_id
 
     @property
     def app_id(self):
@@ -654,6 +663,7 @@ class RestoreConfig(object):
             self.restore_user.user_id,
             version=self.version,
             sync_log_id=self.sync_log._id if self.sync_log else '',
+            device_id=self.params.device_id,
         )
 
     def validate(self):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -677,7 +677,7 @@ class RestoreConfig(object):
         return restore_cache_key(ASYNC_RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id)
 
     @property
-    def _initial_cache_key(self):
+    def _restore_cache_key(self):
         return restore_cache_key(RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id, self.version)
 
     def validate(self):
@@ -727,7 +727,7 @@ class RestoreConfig(object):
         if self.sync_log:
             cache_payload_path = self.sync_log.get_cached_payload_path(self.version)
         else:
-            cache_payload_path = self.cache.get(self._initial_cache_key)
+            cache_payload_path = self.cache.get(self._restore_cache_key)
 
         payload = CachedPayload(
             self.domain,
@@ -834,8 +834,8 @@ class RestoreConfig(object):
             pass
 
     def _set_cache_in_redis(self, cache_payload_path):
-        self.cache.set(self._initial_cache_key, cache_payload_path, self.cache_timeout)
+        self.cache.set(self._restore_cache_key, cache_payload_path, self.cache_timeout)
 
     def delete_cached_payload_if_necessary(self):
-        if self.overwrite_cache and self.cache.get(self._initial_cache_key):
-            self.cache.delete(self._initial_cache_key)
+        if self.overwrite_cache and self.cache.get(self._restore_cache_key):
+            self.cache.delete(self._restore_cache_key)

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -66,18 +66,14 @@ from xml.etree import ElementTree
 logger = logging.getLogger(__name__)
 
 
-def restore_cache_key(prefix, user_id, version=None):
-    if version is not None:
-        hashable_key = '{prefix}-{user}-{version}'.format(
-            prefix=prefix,
-            user=user_id,
-            version=version,
-        )
-    else:
-        hashable_key = '{prefix}-{user}'.format(
-            prefix=prefix,
-            user=user_id,
-        )
+def restore_cache_key(domain, prefix, user_id, version=None):
+    response_class = get_restore_response_class(domain)
+    hashable_key = '{response_class}-{prefix}-{user}-{version}'.format(
+        response_class=response_class.__name__,
+        prefix=prefix,
+        user=user_id,
+        version=version or '',
+    )
     return hashlib.md5(hashable_key).hexdigest()
 
 
@@ -674,11 +670,11 @@ class RestoreConfig(object):
 
     @property
     def async_cache_key(self):
-        return restore_cache_key(ASYNC_RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id)
+        return restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id)
 
     @property
     def _restore_cache_key(self):
-        return restore_cache_key(RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id, self.version)
+        return restore_cache_key(self.domain, RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id, self.version)
 
     def validate(self):
         try:

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -653,7 +653,7 @@ class RestoreConfig(object):
             RESTORE_CACHE_KEY_PREFIX,
             self.restore_user.user_id,
             version=self.version,
-            sync_log_id=self.sync_log._id,
+            sync_log_id=self.sync_log._id if self.sync_log else '',
         )
 
     def validate(self):
@@ -697,7 +697,7 @@ class RestoreConfig(object):
         return response
 
     def get_cached_response(self):
-        if self.overwrite_cache or self.sync_log:
+        if self.overwrite_cache:
             return None
 
         cache_payload_path = self.cache.get(self._restore_cache_key)
@@ -780,7 +780,7 @@ class RestoreConfig(object):
         # on initial sync, only cache if the duration was longer than the threshold
         is_long_restore = duration > timedelta(seconds=INITIAL_SYNC_CACHE_THRESHOLD)
 
-        if self.force_cache or is_long_restore:
+        if self.force_cache or is_long_restore or self.sync_log:
             self._set_cache_in_redis(cache_payload_path)
 
     def _set_cache_in_redis(self, cache_payload_path):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -360,7 +360,7 @@ class AsyncRestoreResponse(object):
         return response
 
 
-class CachedPayload(object):
+class CachedResponse(object):
 
     def __init__(self, domain, payload_path):
         self.payload_path = payload_path
@@ -381,18 +381,6 @@ class CachedPayload(object):
 
     def as_file(self):
         return self.payload
-
-
-class CachedResponse(object):
-
-    def __init__(self, payload):
-        self.payload = payload
-
-    def __nonzero__(self):
-        return bool(self.payload)
-
-    def as_string(self):
-        return self.payload.as_string()
 
     def get_http_response(self):
         headers = {}
@@ -710,16 +698,11 @@ class RestoreConfig(object):
 
     def get_cached_response(self):
         if self.overwrite_cache or self.sync_log:
-            return CachedResponse(None)
+            return None
 
         cache_payload_path = self.cache.get(self._restore_cache_key)
 
-        payload = CachedPayload(
-            self.domain,
-            cache_payload_path,
-        )
-
-        return CachedResponse(payload)
+        return CachedResponse(self.domain, cache_payload_path)
 
     def _get_asynchronous_payload(self):
         new_task = False

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -20,7 +20,6 @@ from casexml.apps.phone.restore import (
     AsyncRestoreResponse,
     FileRestoreResponse,
     restore_cache_key,
-    CachedPayload
 )
 from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX, RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
@@ -100,7 +99,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
 
     def test_subsequent_syncs_when_job_complete(self):
         # First sync, return a timout. Ensure that the async_task_id gets set
-        cache_id = restore_cache_key(ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
+        cache_id = restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
         with mock.patch('casexml.apps.phone.restore.get_async_restore_payload') as task:
             delay = mock.MagicMock()
             delay.id = 'random_task_id'
@@ -130,7 +129,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
                 get_result.assert_called_with(timeout=1)
 
     def test_completed_task_deletes_cache(self):
-        cache_id = restore_cache_key(ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
+        cache_id = restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
         restore_config = self._restore_config(async=True)
         restore_config.cache.set(cache_id, 'im going to be deleted by the next command')
         get_async_restore_payload.delay(restore_config)
@@ -156,11 +155,10 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         """
         submit_form_locally(form, self.domain)
 
-    @mock.patch.object(CachedPayload, 'finalize')  # fake that a cached payload exists
     @mock.patch.object(RestoreConfig, 'cache')
     @mock.patch.object(FileRestoreResponse, 'get_payload')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
-    def test_clears_cache(self, task, response, cache, _):
+    def test_clears_cache(self, task, response, cache):
         delay = mock.MagicMock()
         delay.id = 'random_task_id'
         task.delay.return_value = delay
@@ -180,8 +178,13 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
     def test_restore_in_progress_form_submitted_kills_old_jobs(self):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
-        task_cache_id = restore_cache_key(ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
-        initial_sync_cache_id = restore_cache_key(RESTORE_CACHE_KEY_PREFIX, self.user.user_id, version='2.0')
+        task_cache_id = restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
+        initial_sync_cache_id = restore_cache_key(
+            self.domain,
+            RESTORE_CACHE_KEY_PREFIX,
+            self.user.user_id,
+            version='2.0'
+        )
         fake_cached_thing = 'fake-cached-thing'
         restore_config = self._restore_config(async=True)
         # pretend we have a task running
@@ -220,11 +223,10 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         """
         submit_form_locally(form, self.domain)
 
-    @mock.patch.object(CachedPayload, 'finalize')  # fake that a cached payload exists
     @mock.patch.object(RestoreConfig, 'cache')
     @mock.patch.object(FileRestoreResponse, 'get_payload')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
-    def test_clears_cache(self, task, response, cache, _):
+    def test_clears_cache(self, task, response, cache):
         delay = mock.MagicMock()
         delay.id = 'random_task_id'
         task.delay.return_value = delay

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -92,7 +92,7 @@ class BaseOtaRestoreTest(TestCase, TestFileMixin):
         delete_all_cases()
         delete_all_sync_logs()
         restore_config = RestoreConfig(project=self.project, restore_user=self.restore_user)
-        restore_config.cache.delete(restore_config._initial_cache_key)
+        restore_config.cache.delete(restore_config._restore_cache_key)
         super(BaseOtaRestoreTest, self).tearDown()
 
 
@@ -130,11 +130,6 @@ class OtaRestoreTest(BaseOtaRestoreTest):
         self.assertNotIsInstance(restore_config.get_payload(), CachedResponse)
         self.assertIsInstance(restore_config_cached.get_payload(), CachedResponse)
         self.assertNotIsInstance(restore_config_overwrite.get_payload(), CachedResponse)
-
-        # even cached responses change the sync log id so they are not the same
-        restore_payload = restore_config.get_payload().as_string()
-        self.assertNotEqual(restore_payload, restore_config_cached.get_payload().as_string())
-        self.assertNotEqual(restore_payload, restore_config_overwrite.get_payload().as_string())
 
     def testUserRestoreWithCase(self):
         xml_data = self.get_xml('create_short')

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -131,6 +131,11 @@ class OtaRestoreTest(BaseOtaRestoreTest):
         self.assertIsInstance(restore_config_cached.get_payload(), CachedResponse)
         self.assertNotIsInstance(restore_config_overwrite.get_payload(), CachedResponse)
 
+        # even cached responses change the sync log id so they are not the same
+        restore_payload = restore_config.get_payload().as_string()
+        self.assertNotEqual(restore_payload, restore_config_cached.get_payload().as_string())
+        self.assertNotEqual(restore_payload, restore_config_overwrite.get_payload().as_string())
+
     def testUserRestoreWithCase(self):
         xml_data = self.get_xml('create_short')
         xml_data = xml_data.format(user_id=self.restore_user.user_id)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -92,7 +92,7 @@ class BaseOtaRestoreTest(TestCase, TestFileMixin):
         delete_all_cases()
         delete_all_sync_logs()
         restore_config = RestoreConfig(project=self.project, restore_user=self.restore_user)
-        restore_config.cache.delete(restore_config._restore_cache_key)
+        restore_config.cache.clear()
         super(BaseOtaRestoreTest, self).tearDown()
 
 
@@ -131,10 +131,19 @@ class OtaRestoreTest(BaseOtaRestoreTest):
         self.assertIsInstance(restore_config_cached.get_payload(), CachedResponse)
         self.assertNotIsInstance(restore_config_overwrite.get_payload(), CachedResponse)
 
-        # even cached responses change the sync log id so they are not the same
-        restore_payload = restore_config.get_payload().as_string()
-        self.assertNotEqual(restore_payload, restore_config_cached.get_payload().as_string())
-        self.assertNotEqual(restore_payload, restore_config_overwrite.get_payload().as_string())
+    def testDifferentDeviceCache(self):
+        '''
+        Ensure that if restore is coming from different device, do not return cached response
+        '''
+        restore_config = get_restore_config(
+            self.project, self.restore_user, items=True, force_cache=True, device_id='123',
+        )
+        restore_config_other_device = get_restore_config(
+            self.project, self.restore_user, items=True, device_id='456'
+        )
+
+        self.assertNotIsInstance(restore_config.get_payload(), CachedResponse)
+        self.assertNotIsInstance(restore_config_other_device.get_payload(), CachedResponse)
 
     def testUserRestoreWithCase(self):
         xml_data = self.get_xml('create_short')

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -84,7 +84,7 @@ class SyncBaseTest(TestCase):
 
     def tearDown(self):
         restore_config = RestoreConfig(project=self.project, restore_user=self.user)
-        restore_config.cache.delete(restore_config._initial_cache_key)
+        restore_config.cache.delete(restore_config._restore_cache_key)
         super(SyncBaseTest, self).tearDown()
 
     @classmethod

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -77,7 +77,7 @@ def generate_restore_payload(project, user, restore_id="", version=V1, state_has
 
 
 def get_restore_config(project, user, restore_id="", version=V1, state_hash="",
-                       items=False, overwrite_cache=False, force_cache=False):
+                       items=False, overwrite_cache=False, force_cache=False, device_id=None):
     return RestoreConfig(
         project=project,
         restore_user=user,
@@ -85,7 +85,8 @@ def get_restore_config(project, user, restore_id="", version=V1, state_hash="",
             sync_log_id=restore_id,
             version=version,
             state_hash=state_hash,
-            include_item_count=items
+            include_item_count=items,
+            device_id=device_id,
         ),
         cache_settings=RestoreCacheSettings(
             overwrite_cache=overwrite_cache,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -1,4 +1,5 @@
 from xml.etree import ElementTree
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.models import (
     get_properly_wrapped_sync_log,
@@ -6,9 +7,10 @@ from casexml.apps.phone.models import (
     OTARestoreWebUser,
     OTARestoreCommCareUser,
 )
-from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings, restore_cache_key
 from casexml.apps.phone.tests.dbaccessors import get_all_sync_logs_docs
 from casexml.apps.phone.xml import SYNC_XMLNS
+from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX
 
 from corehq.apps.users.models import CommCareUser, WebUser
 
@@ -106,5 +108,21 @@ def generate_restore_response(project, user, restore_id="", version=V1, state_ha
     return config.get_response()
 
 
-def has_cached_payload(sync_log, version):
-    return bool(sync_log.get_cached_payload(version))
+def has_cached_payload(sync_log, version, prefix=RESTORE_CACHE_KEY_PREFIX):
+    return bool(get_redis_default_cache().get(restore_cache_key(
+        sync_log.domain,
+        prefix,
+        sync_log.user_id,
+        version=version,
+        sync_log_id=sync_log._id,
+    )))
+
+
+def get_cached_payload(sync_log, version, prefix=RESTORE_CACHE_KEY_PREFIX):
+    return get_redis_default_cache().get(restore_cache_key(
+        sync_log.domain,
+        prefix,
+        sync_log.user_id,
+        version=version,
+        sync_log_id=sync_log._id,
+    ))

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -116,13 +116,3 @@ def has_cached_payload(sync_log, version, prefix=RESTORE_CACHE_KEY_PREFIX):
         version=version,
         sync_log_id=sync_log._id,
     )))
-
-
-def get_cached_payload(sync_log, version, prefix=RESTORE_CACHE_KEY_PREFIX):
-    return get_redis_default_cache().get(restore_cache_key(
-        sync_log.domain,
-        prefix,
-        sync_log.user_id,
-        version=version,
-        sync_log_id=sync_log._id,
-    ))

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -207,14 +207,19 @@ class SubmissionPost(object):
 
     def _invalidate_caches(self, user_id):
         """invalidate cached initial restores"""
-        initial_restore_cache_key = self._restore_cache_key(RESTORE_CACHE_KEY_PREFIX, user_id, version=V2)
+        initial_restore_cache_key = self._restore_cache_key(
+            self.domain,
+            RESTORE_CACHE_KEY_PREFIX,
+            user_id,
+            version=V2
+        )
         self._cache.delete(initial_restore_cache_key)
 
         if ASYNC_RESTORE.enabled(self.domain):
             self._invalidate_async_caches(user_id)
 
     def _invalidate_async_caches(self, user_id):
-        cache_key = self._restore_cache_key(ASYNC_RESTORE_CACHE_KEY_PREFIX, user_id)
+        cache_key = self._restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, user_id)
         task_id = self._cache.get(cache_key)
 
         if task_id is not None:

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -302,7 +302,7 @@ class FundamentalCaseTests(TestCase):
 
     def test_restore_caches_cleared(self):
         cache = get_redis_default_cache()
-        cache_key = restore_cache_key(RESTORE_CACHE_KEY_PREFIX, 'user_id', version="2.0")
+        cache_key = restore_cache_key(DOMAIN, RESTORE_CACHE_KEY_PREFIX, 'user_id', version="2.0")
         cache.set(cache_key, 'test-thing')
         self.assertEqual(cache.get(cache_key), 'test-thing')
         form = """


### PR DESCRIPTION
@snopoke this refactors restores to cache restore payload paths in redis. best read 🐟 

_Previous world_
On initial sync we would cache the payload path in redis if it took a long time. When the user was in steady state sync, we would store the cache path on the sync log token

_New world_
All syncs store the path to the cached restore in redis

cc: @calellowitz 