### PR TITLE
exclude root node from metrics

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -66,7 +66,7 @@ def restore(request, domain, app_id=None):
     ]
     datadog_counter('commcare.restores.count', tags=tags)
     if timing_context is not None:
-        for timer in timing_context.to_list():
+        for timer in timing_context.to_list(exclude_root=True):
             # Only record leaf nodes so we can sum to get the total
             if timer.is_leaf_node:
                 datadog_gauge(

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -50,9 +50,9 @@ class NestableTimer(object):
             'subs': [sub.to_dict() for sub in self.subs]
         }
 
-    def to_list(self):
-        timers = [self] + list(itertools.chain(*[sub.to_list() for sub in self.subs]))
-        return timers
+    def to_list(self, exclude_root=False):
+        root = [] if exclude_root else [self]
+        return root + list(itertools.chain(*[sub.to_list() for sub in self.subs]))
 
     @property
     def is_leaf_node(self):
@@ -130,6 +130,6 @@ class TimingContext(object):
     def duration(self):
         return self.to_dict()['duration']
 
-    def to_list(self):
+    def to_list(self, exclude_root=False):
         """Get the list of ``NestableTimer`` objects in hierarchy order"""
-        return self.root.to_list()
+        return self.root.to_list(exclude_root)


### PR DESCRIPTION
not sure why this is necessary since root node should never be a leaf
but perhaps in cases where there are errors or timeouts none of the
nested timers get executed