### PR TITLE
Call get_short_odk_url to reset app_code

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -161,6 +161,7 @@ hqDefine('app_manager/js/releases.js', function () {
             ga_track_event('App Manager', 'Deploy Button', self.id());
             analytics.workflow('Clicked Deploy');
             $.post(releasesMain.options.urls.hubspot_click_deploy);
+            self.get_short_odk_url();
         };
 
         self.clickScan = function() {

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -93,7 +93,10 @@ hqDefine('app_manager/js/releases.js', function () {
             if (!(ko.utils.unwrapObservable(self[url_type])) || self.build_profile()) {
                 return self.generate_short_url(url_type);
             } else {
-                return ko.utils.unwrapObservable(self[url_type]);
+                var data = ko.utils.unwrapObservable(self[url_type]);
+                var bitly_code = self.parse_bitly_url(data);
+                self.app_code(bitly_code);
+                return data;
             }
         };
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/releases_deploy_modal.html
@@ -27,8 +27,10 @@
                             href="#panel-android"
                             aria-expanded="true"
                             aria-controls="panel-android"
-                            data-bind="attr: {'data-parent': '#deploy-accordion_' + id()}"
-                            >
+                            data-bind="
+                                click: get_short_odk_url,
+                                attr: {'data-parent': '#deploy-accordion_' + id()}
+                            ">
                             {% trans "Download to Android" %}
                         </a>
                     </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/releases_deploy_modal.html
@@ -28,8 +28,10 @@
                                 href="#panel-android"
                                 aria-expanded="true"
                                 aria-controls="panel-android"
-                                data-bind="attr: {'data-parent': '#deploy-accordion_' + id()}"
-                                >
+                                data-bind="
+                                    click: get_short_odk_url,
+                                    attr: {'data-parent': '#deploy-accordion_' + id()}
+                                ">
                                 {% trans "Download to Android" %}
                             </a>
                         </h4>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
@@ -13,8 +13,8 @@
 -                            aria-expanded="true"
 -                            aria-controls="panel-android"
 -                            data-bind="
--                               click: get_short_odk_url,
--                               attr: {'data-parent': '#deploy-accordion_' + id()}
+-                                click: get_short_odk_url,
+-                                attr: {'data-parent': '#deploy-accordion_' + id()}
 -                            ">
 -                            {% trans "Download to Android" %}
 -                        </a>
@@ -63,7 +63,7 @@
                                              <p>
                                                  {% trans "Download" %}
                                                  <a href="https://play.google.com/store/apps/details?id=org.commcare.dalvik">
-@@ -106,7 +113,7 @@
+@@ -108,7 +115,7 @@
                                                      </span>
                                                  </p>
                                              </div>
@@ -72,7 +72,7 @@
                                              <div data-bind="ifnot: hqImport('app_manager/js/app_manager.js').versionGE(build_spec.version(), '2.13.0')">
                                                  Upgrade to CommCare 2.13 to use this feature
                                              </div>
-@@ -164,20 +171,22 @@
+@@ -166,20 +173,22 @@
                          </div>
                      </div>
                  </div>
@@ -108,7 +108,7 @@
                      </div>
                      <div class="panel-collapse collapse" data-bind="attr: {id: id() + '_download_java'}">
                          <div class="panel-body">
-@@ -207,8 +216,9 @@
+@@ -209,8 +218,9 @@
                      </div>
                  </div>
                  {% if can_send_sms %}
@@ -119,7 +119,7 @@
                              <a data-toggle="collapse"
                                 data-bind="
                                     click: onSMSPanelClick,
-@@ -219,8 +229,9 @@
+@@ -221,8 +231,9 @@
                                     }
                                  "
                                 aria-expanded="true" aria-controls="panel-sms">
@@ -131,7 +131,7 @@
                      </div>
                      <div class="panel-collapse collapse" data-bind="attr: {id: id() + '_sms'}">
                          <div class="panel-body">
-@@ -277,20 +288,22 @@
+@@ -279,20 +290,22 @@
                  </div>
                  {% endif %}
                  {% if multimedia_state.has_media %}
@@ -167,7 +167,7 @@
                          </div>
                          <div class="panel-collapse collapse" data-bind="attr: {id: id() + '_multimedia'}">
                              <div class="panel-body">
-@@ -300,11 +313,13 @@
+@@ -302,11 +315,13 @@
                      </div>
                  {% endif %}
                  {% if request.user.is_superuser %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/releases_deploy_modal.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -20,32 +20,39 @@
+@@ -20,34 +20,41 @@
              </div>
          {% else %}
              <div class="panel-group" data-bind="attr: {id: 'deploy-accordion_' + id()}">
@@ -12,8 +12,10 @@
 -                            href="#panel-android"
 -                            aria-expanded="true"
 -                            aria-controls="panel-android"
--                            data-bind="attr: {'data-parent': '#deploy-accordion_' + id()}"
--                            >
+-                            data-bind="
+-                               click: get_short_odk_url,
+-                               attr: {'data-parent': '#deploy-accordion_' + id()}
+-                            ">
 -                            {% trans "Download to Android" %}
 -                        </a>
 +                        <h4 class="panel-title">
@@ -22,8 +24,10 @@
 +                                href="#panel-android"
 +                                aria-expanded="true"
 +                                aria-controls="panel-android"
-+                                data-bind="attr: {'data-parent': '#deploy-accordion_' + id()}"
-+                                >
++                                data-bind="
++                                    click: get_short_odk_url,
++                                    attr: {'data-parent': '#deploy-accordion_' + id()}
++                                ">
 +                                {% trans "Download to Android" %}
 +                            </a>
 +                        </h4>


### PR DESCRIPTION
[FB 251649](http://manage.dimagi.com/default.asp?251649)

The `app_code` observable was getting set with the Java short code, but wasn't getting reset back to the Android short code.
