### PR TITLE
standard_hq_report.js

### DIFF
--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -3,7 +3,7 @@ $(function () {
     var data = hqImport('hqwebapp/js/initial_page_data.js').get;
     if (data('renderReportTables')) {
         var reportTables = new HQReportDataTables(data('dataTablesOptions')),
-            standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
         if (typeof standardHQReport !== 'undefined') {
             standardHQReport.handleTabularReportCookies(reportTables);
         }

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
+    <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
     <script src="{% static 'fixtures/js/view-table.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/reports/static/reports/js/saved_reports.js
+++ b/corehq/apps/reports/static/reports/js/saved_reports.js
@@ -36,7 +36,7 @@ var ReportConfig = function (data) {
 
     self.unwrap = function () {
         var data = ko.mapping.toJS(self);
-        var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+        var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
         if (null !== standardHQReport.slug) {
             data['report_slug'] = standardHQReport.slug;
         }

--- a/corehq/apps/reports/static/reports/js/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/standard_hq_report.js
@@ -1,3 +1,4 @@
+/* globals COMMCAREHQ_MODULES, standardHQReport */
 /*
     Ugly half-measure, because reports and UCR traditionally depend on a global standardHQReport
     variable that's defined in several different places. The UCR version of standardHQReport now

--- a/corehq/apps/reports/static/reports/js/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/standard_hq_report.js
@@ -1,0 +1,23 @@
+/*
+    Ugly half-measure, because reports and UCR traditionally depend on a global standardHQReport
+    variable that's defined in several different places. The UCR version of standardHQReport now
+    lives in userreports/js/configurable_report.js, whereas the other standardHQReport vars are
+    still defined globally. This module's sole purpose is to fetch the correct standardHQReport,
+    if it exists at all.
+*/
+hqDefine("reports/js/standard_hq_report.js", function() {
+    var get = function() {
+        if (typeof standardHQReport !== 'undefined') {
+            return standardHQReport;
+        }
+        var ucr = "userreports/js/configurable_report.js";
+        if (typeof COMMCAREHQ_MODULES[ucr] !== 'undefined') {
+            return hqImport(ucr).getStandardHQReport();
+        }
+        return undefined;
+    };
+
+    return {
+        getStandardHQReport: get,
+    };
+});

--- a/corehq/apps/reports/templates/reports/async/tabular.html
+++ b/corehq/apps/reports/templates/reports/async/tabular.html
@@ -154,7 +154,7 @@
                     fixColsWidth: {{ report_table.left_col.fixed.width }},
                 {% endif %}
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }

--- a/corehq/apps/reports/templates/reports/filters/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/datespan.html
@@ -35,7 +35,7 @@
         $(function () {
             var separator = '{{ separator }}';
             var report_labels = JSON.parse('{{ report_labels|safe }}');
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
 
             $('#filter_range').createDateRangePicker(
                 report_labels, separator,

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -18,6 +18,7 @@
     <script src="{% static 'reports/js/reports.config.js' %}"></script>
     <script src="{% static 'reports/js/reports.util.js' %}"></script>
     <script src="{% static 'reports/js/reports.async.js' %}"></script>
+    <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
 
     {% endcompress %}
     {% endblock %}

--- a/corehq/apps/reports/templates/reports/standard/partials/report_loader.html
+++ b/corehq/apps/reports/templates/reports/standard/partials/report_loader.html
@@ -2,6 +2,7 @@
 {% load hq_shared_tags %}
 {% load hqstyle_tags %}
 {% load i18n %}
+<script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
 <script>
     var standardHQReport = new HQReport({
         domain: '{{ domain }}',

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -5,6 +5,7 @@
 {% block js %}{{ block.super }}
     <script src="{% static 'reports/js/reports.util.js' %}"></script>
     <script src="{% static 'reports/js/reports.config.js' %}"></script>
+    <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
     <script src="{% static 'reports/js/saved_reports.js' %}"></script>
     <script src="{% static 'userreports/js/configurable_report.js' %}"></script>
 {% endblock %}

--- a/custom/apps/gsid/templates/relative_date.html
+++ b/custom/apps/gsid/templates/relative_date.html
@@ -31,7 +31,7 @@
 {% ifequal slug 'datespan'  %}
 <script type="text/javascript">
     $(function () {
-        var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+        var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
         $('#{{ css_id }}_relativedate').change(function() { 
             var diff = parseInt($(this).val());
             if (!diff || diff<=0) 

--- a/custom/care_pathways/templates/care_pathways/adoption_disaggregated_report.html
+++ b/custom/care_pathways/templates/care_pathways/adoption_disaggregated_report.html
@@ -38,7 +38,7 @@
                 showAllRowsOption: {{ report_table.show_all_rows|JSON }},
                 defaultSort: false,
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }

--- a/custom/care_pathways/templates/care_pathways/partials/report_table.html
+++ b/custom/care_pathways/templates/care_pathways/partials/report_table.html
@@ -72,7 +72,7 @@
             fixColsNumLeft: 2,
             fixColsWidth: 200
         });
-        var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+        var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
         if (typeof standardHQReport !== 'undefined') {
             standardHQReport.handleTabularReportCookies(reportTables);
         }

--- a/custom/ewsghana/templates/ewsghana/partials/report_table.html
+++ b/custom/ewsghana/templates/ewsghana/partials/report_table.html
@@ -92,7 +92,7 @@
                     fixColsWidth: 130,
                 {% endif %}
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }

--- a/custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html
+++ b/custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html
@@ -117,7 +117,7 @@
                 {% if report_table.headers.custom_sort %}customSort: {{ report_table.headers.custom_sort|JSON }},{% endif %}
                 loadingTemplateSelector: '#js-template-loading-report'
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }

--- a/custom/intrahealth/templates/intrahealth/partials/report_table.html
+++ b/custom/intrahealth/templates/intrahealth/partials/report_table.html
@@ -88,7 +88,7 @@
             fixColsNumLeft: 1,
             fixColsWidth: 130
         });
-        var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+        var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
         if (typeof standardHQReport !== 'undefined') {
             standardHQReport.handleTabularReportCookies(reportTables);
         }

--- a/custom/m4change/templates/m4change/fields/daterange.html
+++ b/custom/m4change/templates/m4change/fields/daterange.html
@@ -34,7 +34,7 @@
         $.getScript("{% static 'm4change/javascripts/daterangepicker.js' %}", function () {
             var separator = '{{ separator }}';
             var report_labels = JSON.parse('{{ report_labels|safe }}');
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
 
             $('#filter_range').createDateRangePicker(report_labels, separator);
             $('#filter_range').on('apply', function(ev, picker) {

--- a/custom/pnlppgi/templates/pnlppgi/pnlppgi_base.html
+++ b/custom/pnlppgi/templates/pnlppgi/pnlppgi_base.html
@@ -158,7 +158,7 @@
                     fixColsWidth: {{ report_table.left_col.fixed.width }},
                 {% endif %}
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }

--- a/custom/succeed/templates/succeed/ucla_table.html
+++ b/custom/succeed/templates/succeed/ucla_table.html
@@ -37,7 +37,7 @@
                 includeFilter: true,
                 aaSorting: [[5, 'asc']],
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }

--- a/custom/up_nrhm/templates/up_nrhm/datespan.html
+++ b/custom/up_nrhm/templates/up_nrhm/datespan.html
@@ -7,7 +7,7 @@
         $(function () {
             var separator = '{{ separator }}';
             var report_labels = JSON.parse('{{ report_labels|safe }}');
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
 
             $('#filter_range').createDateRangePicker(
                 report_labels,

--- a/custom/world_vision/templates/world_vision/datespan.html
+++ b/custom/world_vision/templates/world_vision/datespan.html
@@ -51,7 +51,7 @@
 {% ifequal slug 'datespan'  %}
 <script type="text/javascript">
     $(function () {
-        var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+        var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
         $(standardHQReport.filterAccordion).trigger('hqreport.filter.datespan.startdate', '');
         $(standardHQReport.filterAccordion).trigger('hqreport.filter.datespan.enddate', '');
 

--- a/custom/world_vision/templates/world_vision/multi_report.html
+++ b/custom/world_vision/templates/world_vision/multi_report.html
@@ -89,7 +89,7 @@
                     fixColsWidth: {{ report_table.left_col.fixed.width }},
                 {% endif %}
             });
-            var standardHQReport = hqImport("userreports/js/configurable_report.js").getStandardHQReport();
+            var standardHQReport = hqImport("reports/js/standard_hq_report.js").getStandardHQReport();
             if (typeof standardHQReport !== 'undefined') {
                 standardHQReport.handleTabularReportCookies(reportTables);
             }


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?252807

@dannyroberts 

I did implement a module just to keep track of `standardHQReport`, but only use it to get, not to set. Tested locally with UCRs, standard reports (the WAR), and fixtures.