### PR TITLE
Add response content to failure message

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -564,7 +564,10 @@ class RepeatRecord(Document):
     def handle_failure(self, response, post_info, tries):
         """Do something with the response if the repeater fails
         """
-        self._fail(u'{}: {}'.format(response.status_code, response.reason), response)
+        self._fail(
+            u'{}: {}. {}'.format(response.status_code, response.reason, getattr(response, 'content', None)),
+            response
+        )
         self.repeater.handle_failure(response, self)
 
     def handle_exception(self, exception):


### PR DESCRIPTION
@NoahCarnahan @mkangia 
The content used to show up in our error reports because it was getting set from the cache [here](https://github.com/dimagi/commcare-hq/pull/15870/files#diff-7a94e70a3056d09745068e953a4847f6L68).


cc: @sravfeyn 
