### PR TITLE
Dirty hack to temporarily fix UCR pillow table rebuilding bug

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -194,16 +194,17 @@ class ConfigurableReportTableManagerMixin(object):
             adapter.rebuild_table_if_necessary()
 
     def rebuild_table(self, adapter):
-        # https://manage.dimagi.com/default.asp?252832
-        if adapter.config.get_id not in ("static-enikshay-episode", "static-np-migration-3-episode"):
-            config = adapter.config
-            if not config.is_static:
-                latest_rev = config.get_db().get_rev(config._id)
-                if config._rev != latest_rev:
-                    raise StaleRebuildError('Tried to rebuild a stale table ({})! Ignoring...'.format(config))
-            adapter.rebuild_table()
-            if self.auto_repopulate_tables:
-                rebuild_indicators.delay(adapter.config.get_id)
+        if adapter.config.get_id in ("static-enikshay-episode", "static-np-migration-3-episode"):
+            # https://manage.dimagi.com/default.asp?252832
+            return
+        config = adapter.config
+        if not config.is_static:
+            latest_rev = config.get_db().get_rev(config._id)
+            if config._rev != latest_rev:
+                raise StaleRebuildError('Tried to rebuild a stale table ({})! Ignoring...'.format(config))
+        adapter.rebuild_table()
+        if self.auto_repopulate_tables:
+            rebuild_indicators.delay(adapter.config.get_id)
 
 
 class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, PillowProcessor):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -194,14 +194,16 @@ class ConfigurableReportTableManagerMixin(object):
             adapter.rebuild_table_if_necessary()
 
     def rebuild_table(self, adapter):
-        config = adapter.config
-        if not config.is_static:
-            latest_rev = config.get_db().get_rev(config._id)
-            if config._rev != latest_rev:
-                raise StaleRebuildError('Tried to rebuild a stale table ({})! Ignoring...'.format(config))
-        adapter.rebuild_table()
-        if self.auto_repopulate_tables:
-            rebuild_indicators.delay(adapter.config.get_id)
+        # https://manage.dimagi.com/default.asp?252832
+        if not adapter.config.get_id == "static-enikshay-episode":
+            config = adapter.config
+            if not config.is_static:
+                latest_rev = config.get_db().get_rev(config._id)
+                if config._rev != latest_rev:
+                    raise StaleRebuildError('Tried to rebuild a stale table ({})! Ignoring...'.format(config))
+            adapter.rebuild_table()
+            if self.auto_repopulate_tables:
+                rebuild_indicators.delay(adapter.config.get_id)
 
 
 class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, PillowProcessor):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -195,7 +195,7 @@ class ConfigurableReportTableManagerMixin(object):
 
     def rebuild_table(self, adapter):
         # https://manage.dimagi.com/default.asp?252832
-        if not adapter.config.get_id == "static-enikshay-episode":
+        if adapter.config.get_id not in ("static-enikshay-episode", "static-np-migration-3-episode"):
             config = adapter.config
             if not config.is_static:
                 latest_rev = config.get_db().get_rev(config._id)


### PR DESCRIPTION
A demo to important stakeholders tomorrow requires that the reports be functional. Due to this UCR pillow bug, the data sources keep getting emptied: https://manage.dimagi.com/default.asp?252832

This needs to be deployed today
@emord 
buddy @gcapalbo 