### PR TITLE
re-apply "get_casedb_schema: don't load cases unless needed"

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -296,6 +296,7 @@ class SchemaTest(SimpleTestCase):
             pregnancy = self.add_form("pregnancy")
             self.factory.form_opens_case(pregnancy, case_type='referral', is_subcase=True)
             referral_2 = self.add_form_app_2('referral')
+            referral_2.requires = "case"
             schema = util.get_casedb_schema(referral_2)
             subsets = {s["id"]: s for s in schema["subsets"]}
             self.assertTrue(re.match(r'^parent \((pregnancy|child) or (pregnancy|child)\)$',

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -295,8 +295,14 @@ class SchemaTest(SimpleTestCase):
             self.factory.form_opens_case(child, case_type='referral', is_subcase=True)
             pregnancy = self.add_form("pregnancy")
             self.factory.form_opens_case(pregnancy, case_type='referral', is_subcase=True)
+            schema = util.get_casedb_schema(pregnancy)
+            subsets = {s["id"]: s for s in schema["subsets"]}
+            self.assertEqual(subsets, {})
+
             referral_2 = self.add_form_app_2('referral')
-            referral_2.requires = "case"
+            self.factory.form_requires_case(referral_2, case_type='referral', update={
+                'foo': '/data/question1',
+            })
             schema = util.get_casedb_schema(referral_2)
             subsets = {s["id"]: s for s in schema["subsets"]}
             self.assertTrue(re.match(r'^parent \((pregnancy|child) or (pregnancy|child)\)$',

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -409,7 +409,7 @@ def get_casedb_schema(form):
     This lists all case types and their properties for the given app.
     """
     app = form.get_app()
-    base_case_type = form.get_module().case_type
+    base_case_type = form.get_module().case_type if form.requires_case() else None
     case_types = app.get_case_types() | get_shared_case_types(app)
     per_type_defaults = get_per_type_defaults(app.domain, case_types)
     builder = ParentCasePropertyBuilder(app, ['case_name'], per_type_defaults)


### PR DESCRIPTION
See https://github.com/dimagi/commcare-hq/pull/15901

@dannyroberts / @millerdev 

@millerdev I agree that there's likely a bug in `_form_uses_case` but didn't want to think through the implications of updating that function at this moment. I suspect it'll come up again when user properties in the form builder qa happens.