### PR TITLE
Make is_previewer result json-serializable

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1103,7 +1103,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
     def is_previewer(self):
         from django.conf import settings
         return (self.is_superuser or
-                re.compile(settings.PREVIEWER_RE).match(self.username))
+                bool(re.compile(settings.PREVIEWER_RE).match(self.username)))
 
     def sync_from_django_user(self, django_user):
         if not django_user:


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?252842

Nick found this while doing app manager v2 qa, but it's a prod bug introduced in https://github.com/dimagi/commcare-hq/pull/15872 - I was assuming that `is_previewer` returned a boolean, but it sometimes returns a regex object instead, which breaks when `app_view_options` gets json serialized by `initial_page_data`.

@dannyroberts 