### PR TITLE
Ability to disable sorting and log scroll times

### DIFF
--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -5,6 +5,7 @@ from corehq.apps.es import FormES
 from corehq.apps.es.sms import SMSES
 from corehq.apps.es.aggregations import AggregationTerm, NestedTermAggregationsHelper
 from corehq.elastic import get_es_new
+from corehq.toggles import EXPORT_NO_SORT
 
 
 def get_form_export_base_query(domain, app_id, xmlns, include_errors):
@@ -12,8 +13,11 @@ def get_form_export_base_query(domain, app_id, xmlns, include_errors):
             .domain(domain)
             .app(app_id)
             .xmlns(xmlns)
-            .sort("received_on")
             .remove_default_filter('has_user'))
+
+    if not EXPORT_NO_SORT.enabled(domain):
+        query = query.sort("received_on")
+
     if include_errors:
         query = query.remove_default_filter("is_xform_instance")
         query = query.doc_type(["xforminstance", "xformarchived", "xformdeprecated", "xformduplicate"])
@@ -21,10 +25,14 @@ def get_form_export_base_query(domain, app_id, xmlns, include_errors):
 
 
 def get_case_export_base_query(domain, case_type):
-    return (CaseES()
+    query = (CaseES()
             .domain(domain)
-            .case_type(case_type)
-            .sort("opened_on"))
+            .case_type(case_type))
+
+    if not EXPORT_NO_SORT.enabled(domain):
+        query = query.sort("opened_on")
+
+    return query
 
 
 def get_sms_export_base_query(domain):

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 from collections import Counter
 
-import time
 import datetime
 
 from couchdbkit import ResourceConflict
@@ -14,7 +13,6 @@ from couchexport.export import FormattedRow, get_writer
 from couchexport.models import Format
 from corehq.toggles import PAGINATED_EXPORTS
 from corehq.util.files import safe_filename
-from corehq.util.datadog.gauges import datadog_gauge
 from corehq.apps.export.esaccessors import (
     get_form_export_base_query,
     get_case_export_base_query,
@@ -356,10 +354,7 @@ def _write_export_instance(writer, export_instance, documents, progress_tracker=
     if progress_tracker:
         DownloadBase.set_progress(progress_tracker, 0, documents.count)
 
-    domain = export_instance.domain
-
     for row_number, doc in enumerate(documents):
-        start = int(time.time() * 1000)
         for table in export_instance.selected_tables:
             rows = table.get_rows(
                 doc,
@@ -373,11 +368,6 @@ def _write_export_instance(writer, export_instance, documents, progress_tracker=
                 writer.write(table, row)
         if progress_tracker:
             DownloadBase.set_progress(progress_tracker, row_number + 1, documents.count)
-
-        datadog_gauge('commcare.export_iteration', (time.time() * 1000) - start, tags=[
-            u'iteration:{}'.format(row_number / 500),
-            u'domain:{}'.format(domain),
-        ])
 
 
 def _get_base_query(export_instance):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -376,6 +376,13 @@ USER_CONFIGURABLE_REPORTS = StaticToggle(
     help_link='https://confluence.dimagi.com/display/RD/User+Configurable+Reporting', 
 )
 
+EXPORT_NO_SORT = StaticToggle(
+    'export_no_sort',
+    'Do not sort exports',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN],
+)
+
 LOCATIONS_IN_UCR = StaticToggle(
     'locations_in_ucr',
     'Add Locations as one of the Source Types for User Configurable Reports',


### PR DESCRIPTION
Edit: completely changed this PR

This adds the ability to disable sorting and also logs time it takes for a scroll query in datadog. The docs specifically say that `scan` should disable sorting, but I'm a little skeptical. This PR will help be figure out if scroll queries are taking longer and longer time as well. hoping this will help figure out if sorting affects it at all

cc: @calellowitz 