### PR TITLE
do not refetch couch user

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -56,10 +56,8 @@ def restore(request, domain, app_id=None):
     We override restore because we have to supply our own
     user model (and have the domain in the url)
     """
-    couch_user = CouchUser.from_django_user_include_anonymous(domain, request.user)
-    assert couch_user is not None, 'No couch user to use for restore'
-    update_device_id(couch_user, request.GET.get('device_id'))
-    response, timing_context = get_restore_response(domain, couch_user, app_id, **get_restore_params(request))
+    update_device_id(request.couch_user, request.GET.get('device_id'))
+    response, timing_context = get_restore_response(domain, request.couch_user, app_id, **get_restore_params(request))
     tags = [
         u'domain:{}'.format(domain),
         u'status_code:{}'.format(response.status_code),
@@ -178,9 +176,8 @@ def claim(request, domain):
     """
     Allows a user to claim a case that they don't own.
     """
-    couch_user = CouchUser.from_django_user(request.user)
     as_user = request.POST.get('commcare_login_as', None)
-    restore_user = get_restore_user(domain, couch_user, as_user)
+    restore_user = get_restore_user(domain, request.couch_user, as_user)
 
     case_id = request.POST.get('case_id', None)
     if case_id is None:


### PR DESCRIPTION
@dannyroberts I'm mostly guessing that this is just legacy, but is there any reason the restore code re-fetches the couch user even though we have it set during middleware? found this being set a long time ago: https://github.com/dimagi/commcare-hq/commit/a6689bacfb749078562ed1f758f1cd0882e5639a

fyi: @dimagi/scale-team 