### PR TITLE
Use parser to add command line arg

### DIFF
--- a/corehq/apps/accounting/management/commands/make_domain_enterprise_level.py
+++ b/corehq/apps/accounting/management/commands/make_domain_enterprise_level.py
@@ -9,7 +9,8 @@ class Command(BaseCommand):
     help = ('Create a billing account and an enterprise level subscription '
             'for the given domain')
 
-    args = ['domain']
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
 
     @require_debug_true()
     def handle(self, domain, **kwargs):


### PR DESCRIPTION
Resolves this:
```
$ ./manage.py make_domain_enterprise_level nhproject
usage: manage.py make_domain_enterprise_level [-h] [--version] [-v {0,1,2,3}]
                                              [--settings SETTINGS]
                                              [--pythonpath PYTHONPATH]
                                              [--traceback] [--no-color]
```

@dannyroberts 
buddy @biyeun 
