### PR TITLE
NewLocationImporter needs location types

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -346,6 +346,8 @@ class LocationExcelValidator(object):
                 extra=", ".join(actual - expected),
             ))
 
+        type_stubs = self._get_types(type_sheet_reader)
+
         # all locations sheets should have correct headers
         location_stubs = []
         optional_headers = [LOCATION_SHEET_HEADERS['custom_data'], LOCATION_SHEET_HEADERS['uncategorized_data']]


### PR DESCRIPTION
[FB 252774](http://manage.dimagi.com/default.asp?252774)

`type_stubs` was accidentally deleted last week, but we need it. It's referred to in line 368, and is used to instantiate `NewLocationImporter`.

This could also use a test. I'll follow that up separately.

@dannyroberts cc @sravfeyn buddy @biyeun 
