### PR TITLE
For the sake of discussion ...

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -413,11 +413,26 @@ class CachedResponse(object):
         return self.payload.as_string()
 
     def get_http_response(self):
+
+        def get_payload_content_length():
+            if isinstance(self.payload, file):
+                offset = self.payload.tell()
+                self.payload.seek(0, 2)
+                length = self.payload.tell()
+                self.payload.seek(offset)
+                return length
+            return self.payload.get_content_length()
+
+        def get_payload_as_file():
+            if isinstance(self.payload, file):
+                return self.payload
+            return self.payload.as_file()
+
         headers = {}
-        content_length = self.payload.get_content_length()
+        content_length = get_payload_content_length()
         if content_length is not None:
             headers['Content-Length'] = content_length
-        return stream_response(self.payload.as_file(), headers)
+        return stream_response(get_payload_as_file(), headers)
 
     def as_file(self):
         if self.payload:


### PR DESCRIPTION
Don't merge. This is just to help unpack [FB 252987](https://manage.dimagi.com/default.asp?252987).

I can't see why a `CachedResponse` instance has `self.payload` set to anything other than a `CachedPayload` instance. But I can imagine how it might happen. This file confuses me. It seems the words "response" and "payload" get used interchangeably. e.g. Methods called "get_payload" return Response instances and `Response.as_string()` returns a payload.

I haven't tested this code locally. It might resolve the error, but **it's not the right approach**. I need to figure out how `CachedResponse` ends up with its `payload` set to a file instead of a `Payload` instance. I'll keep digging, but all hints and feedback welcome.

@dannyroberts  cc @snopoke @proteusvacuum buddy @biyeun 
