### PR TITLE
Auto-enable feature flag for new domains

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import corehq.apps.app_manager.util as util
 from corehq.apps.app_manager.models import (
     Module,
@@ -405,6 +406,8 @@ class SchemaTest(SimpleTestCase):
 @patch('corehq.apps.app_manager.models.is_usercase_in_use', MagicMock(return_value=True))
 @patch('corehq.apps.app_manager.util.is_usercase_in_use', MagicMock(return_value=True))
 @patch('corehq.apps.app_manager.util.get_per_type_defaults', MagicMock(return_value={}))
+@patch('corehq.apps.domain.models.Domain.get_by_name',
+    staticmethod(lambda name: MagicMock(spec=["date_created"], date_created=datetime(2017, 1, 1))))
 class DisabledUserPropertiesSchemaTest(SimpleTestCase):
     # TODO remove this test when removing USER_PROPERTY_EASY_REFS toggle
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -141,7 +141,11 @@ def was_domain_created_after(domain, checkpoint):
     """
     from corehq.apps.domain.models import Domain
     domain_obj = Domain.get_by_name(domain)
-    return domain_obj is not None and domain_obj.date_created > checkpoint
+    return (
+        domain_obj is not None and
+        domain_obj.date_created is not None and
+        domain_obj.date_created > checkpoint
+    )
 
 
 def deterministic_random(input_string):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -394,7 +394,7 @@ USER_CONFIGURABLE_REPORTS = StaticToggle(
     description=(
         "A feature which will allow your domain to create User Configurable Reports."
     ),
-    help_link='https://confluence.dimagi.com/display/RD/User+Configurable+Reporting', 
+    help_link='https://confluence.dimagi.com/display/RD/User+Configurable+Reporting',
 )
 
 EXPORT_NO_SORT = StaticToggle(
@@ -455,7 +455,9 @@ HIERARCHICAL_LOCATION_FIXTURE = StaticToggle(
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN],
     description=(
-        "Do not turn this feature flag.  It is only used for providing compatability for old projects.  We are actively trying to remove projects from this list."
+        "Do not turn this feature flag.  It is only used for providing "
+        "compatability for old projects.  We are actively trying to remove "
+        "projects from this list."
     ),
 )
 
@@ -894,7 +896,8 @@ TF_DOES_NOT_USE_SQLITE_BACKEND = StaticToggle(
 
 CUSTOM_APP_BASE_URL = StaticToggle(
     'custom_app_base_url',
-    'Allow specifying a custom base URL for an application. Main use case is to allow migrating ICDS to a new cluster.',
+    'Allow specifying a custom base URL for an application. Main use case is '
+    'to allow migrating ICDS to a new cluster.',
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN]
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1056,7 +1056,8 @@ USER_PROPERTY_EASY_REFS = StaticToggle(
     'user_property_easy_refs',
     'Easy-reference user properties in the form builder.',
     TAG_PRODUCT_PATH,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_DOMAIN],
+    enabled_for_new_domains_after=datetime(2017, 5, 3, 12),  # noon UTC
 )
 
 SORT_CALCULATION_IN_CASE_LIST = StaticToggle(


### PR DESCRIPTION
This adds a new argument to `StaticToggle` which allows the feature to be automatically enabled for new domains created after a specified date.

@emord fyi @dimagi/team-commcare-hq 