### PR TITLE
fix async restore

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -388,13 +388,7 @@ class CachedResponse(object):
         content_length = self.get_content_length()
         if content_length is not None:
             headers['Content-Length'] = content_length
-        return stream_response(self.payload.as_file(), headers)
-
-    def as_file(self):
-        if self.payload:
-            return self.payload.as_file()
-        else:
-            return None
+        return stream_response(self.payload, headers)
 
 
 class RestoreParams(object):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -385,7 +385,7 @@ class CachedResponse(object):
 
     def get_http_response(self):
         headers = {}
-        content_length = self.payload.get_content_length()
+        content_length = self.get_content_length()
         if content_length is not None:
             headers['Content-Length'] = content_length
         return stream_response(self.payload.as_file(), headers)


### PR DESCRIPTION
@benrudolph agrees this looks like just a typo—
self.payload is a file and we wouldn't expect it to respond to
`.get_content_length()`, whereas self has a specific method defined for
that (`get_content_length`)