### PR TITLE
Change action order in shadow forms

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3050,28 +3050,34 @@ class ShadowForm(AdvancedForm):
 
     @staticmethod
     def _merge_actions(source_actions, extra_actions):
-        new_actions = OrderedDict(
-            (action.case_tag, LoadUpdateAction.wrap(action.to_json()))
+
+        new_actions = []
+        source_action_map = {
+            action.case_tag: action
             for action in source_actions.load_update_cases
-        )
+        }
+        overwrite_properties = [
+            "case_type",
+            "details_module",
+            "auto_select",
+            "load_case_from_fixture",
+            "show_product_stock",
+            "product_program",
+            "case_index",
+        ]
+
         for action in extra_actions.load_update_cases:
-            new_action = new_actions.get(action.case_tag, LoadUpdateAction(case_tag=action.case_tag))
-            overwrite_properties = [
-                "case_type",
-                "details_module",
-                "auto_select",
-                "load_case_from_fixture",
-                "show_product_stock",
-                "product_program",
-                "case_index",
-            ]
+            if action.case_tag in source_action_map:
+                new_action = LoadUpdateAction.wrap(source_action_map[action.case_tag].to_json())
+            else:
+                new_action = LoadUpdateAction(case_tag=action.case_tag)
+
             for prop in overwrite_properties:
                 setattr(new_action, prop, getattr(action, prop))
-            if action.case_tag not in new_actions:
-                new_actions[action.case_tag] = new_action
+            new_actions.append(new_action)
 
         return AdvancedFormActions(
-            load_update_cases=new_actions.values(),
+            load_update_cases=new_actions,
             open_cases=source_actions.open_cases,  # Shadow form is not allowed to specify any open case actions
         )
 

--- a/corehq/apps/app_manager/tests/test_shadow_forms.py
+++ b/corehq/apps/app_manager/tests/test_shadow_forms.py
@@ -33,6 +33,14 @@ class ShadowFormSuiteTest(SimpleTestCase, TestXmlMixin):
 
         self.shadow_form = self.factory.new_shadow_form(self.advanced_module)
         self.shadow_form.shadow_parent_form_id = self.form0.unique_id
+        # Shadow form load_update_case actions should contain all case tags from the parent
+        self.shadow_form.extra_actions.load_update_cases = [
+            LoadUpdateAction(
+                case_type="patient",
+                case_tag="load_0",
+                details_module=self.advanced_module.unique_id,
+            )
+        ]
 
         self.basic_module = self.factory.new_basic_module("basic_module", "doctor", with_form=False)
 
@@ -73,8 +81,14 @@ class ShadowFormSuiteTest(SimpleTestCase, TestXmlMixin):
 
     def test_shadow_form_action_additions(self):
         # Confirm that shadow form action additions are reflected in the suite file
+        original_actions = self.shadow_form.extra_actions.load_update_cases
         try:
             self.shadow_form.extra_actions.load_update_cases = [
+                LoadUpdateAction(
+                    case_type="patient",
+                    case_tag="load_0",
+                    details_module=self.advanced_module.unique_id,
+                ),
                 LoadUpdateAction(
                     case_tag="load_1",
                     case_type="doctor",
@@ -84,7 +98,7 @@ class ShadowFormSuiteTest(SimpleTestCase, TestXmlMixin):
             suite = self.factory.app.create_suite()
         finally:
             # reset the actions
-            self.shadow_form.extra_actions = AdvancedFormActions()
+            self.shadow_form.extra_actions.load_update_cases = original_actions
 
         # Confirm that the source session has not changed:
         expected_source_session = """
@@ -129,6 +143,7 @@ class ShadowFormSuiteTest(SimpleTestCase, TestXmlMixin):
 
     def test_shadow_form_action_modifications(self):
         # Confirm that shadow form action modifications are reflected in the suite file
+        original_actions = self.shadow_form.extra_actions.load_update_cases
         try:
             self.shadow_form.extra_actions.load_update_cases = [
                 LoadUpdateAction(
@@ -140,7 +155,7 @@ class ShadowFormSuiteTest(SimpleTestCase, TestXmlMixin):
             suite = self.factory.app.create_suite()
         finally:
             # reset the actions
-            self.shadow_form.extra_actions = AdvancedFormActions()
+            self.shadow_form.extra_actions.load_update_cases = original_actions
 
         # Confirm that the source session has not changed:
         expected_source_session = """


### PR DESCRIPTION
There was a slight misunderstanding about the spec for this feature. I had implemented it so that the action order for the shadow form would match the order specified in the source form. But the desired behavior is for the actions to appear in the order specified by the shadow form.

This PR fixes that. The first commit also corrects a slight error in the way the test app was set up.
buddy @gcapalbo 

enikshay app builders need this asap, so would be great to have this deployed today. 