### PR TITLE
App manager v2: Fix passwordSetter binding

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -489,4 +489,4 @@ ko.bindingHandlers.passwordSetter = {
             observableValue($(element).val());
         });
     }
-}
+};

--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -481,14 +481,12 @@ hqDefine('app_manager/js/commcaresettings.js', function () {
     };
 });
 
-$(function () {
-    ko.bindingHandlers.passwordSetter = {
-        init: function (element, valueAccessor) {
-            var observableValue = valueAccessor();
-            $(element).password_setter();
-            $(element).on('textchange change', function () {
-                observableValue($(element).val());
-            });
-        }
+ko.bindingHandlers.passwordSetter = {
+    init: function (element, valueAccessor) {
+        var observableValue = valueAccessor();
+        $(element).password_setter();
+        $(element).on('textchange change', function () {
+            observableValue($(element).val());
+        });
     }
-});
+}


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?252926

Didn't investigate why this was working in v1 but not v2, just verified that taking it out of the document ready handler works in both v1 and v2.

@dannyroberts / @biyeun 