### PR TITLE
Pass timeout as a kwarg.

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -78,7 +78,7 @@ def lock_locations(func):
     def func_wrapper(request, *args, **kwargs):
         key = location_lock_key(request.domain)
         client = get_redis_client()
-        lock = client.lock(key, LOCK_LOCATIONS_TIMEOUT)
+        lock = client.lock(key, timeout=LOCK_LOCATIONS_TIMEOUT)
         if lock.acquire(blocking=False):
             try:
                 return func(request, *args, **kwargs)


### PR DESCRIPTION
`timeout` is the third parameter of `cache.lock()`, not the second. Kudos, @gcapalbo, for finding this.

This doesn't resolve [FB 253058](https://manage.dimagi.com/default.asp?253058) but it helps a little.
