### PR TITLE
Sk/double error

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -35,7 +35,6 @@ from corehq.apps.users.models import CouchUser, CommCareUser
 from corehq.apps.locations.permissions import location_safe
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
-from corehq.util.view_utils import json_error
 from dimagi.utils.decorators.memoized import memoized
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings
 from django.http import HttpResponse
@@ -47,7 +46,6 @@ from .utils import (
 
 
 @location_safe
-@json_error
 @handle_401_response
 @login_or_digest_or_basic_or_apikey_or_token()
 @check_domain_migration
@@ -78,7 +76,6 @@ def restore(request, domain, app_id=None):
 
 
 @location_safe
-@json_error
 @login_or_digest_or_basic_or_apikey()
 @check_domain_migration
 def search(request, domain):
@@ -170,7 +167,6 @@ def _handle_es_exception(request, exception, query_addition_debug_details):
 @location_safe
 @csrf_exempt
 @require_POST
-@json_error
 @login_or_digest_or_basic_or_apikey()
 @check_domain_migration
 def claim(request, domain):

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -139,7 +139,8 @@ class FormProcessorInterface(object):
             )
             from corehq.form_processor.submission_post import handle_unexpected_error
             handle_unexpected_error(self, forms.submitted, e, error_message)
-            raise
+            e.sentry_capture = False  # we've already notified
+            raise e
 
     def hard_delete_case_and_forms(self, case, xforms):
         domain = case.domain

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -130,8 +130,7 @@ class FormProcessorInterface(object):
                 stock_result=stock_result,
             )
         except BulkSaveError as e:
-            logging.error('BulkSaveError saving forms', exc_info=1,
-                          extra={'details': {'errors': e.errors}})
+            logging.exception('BulkSaveError saving forms', extra={'details': {'errors': e.errors}})
             raise
         except Exception as e:
             xforms_being_saved = [form.form_id for form in forms if form]

--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -34,6 +34,10 @@ def _is_rate_limited(rate_limit_key):
 
 class HQSentryClient(DjangoClient):
     def should_capture(self, exc_info):
+        capture = getattr(value, 'sentry_capture', True)
+        if not capture:
+            return False
+
         if not super(HQSentryClient, self).should_capture(exc_info):
             return False
 

--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -34,7 +34,8 @@ def _is_rate_limited(rate_limit_key):
 
 class HQSentryClient(DjangoClient):
     def should_capture(self, exc_info):
-        capture = getattr(value, 'sentry_capture', True)
+        ex_value = exc_info[1]
+        capture = getattr(ex_value, 'sentry_capture', True)
         if not capture:
             return False
 


### PR DESCRIPTION
Some exceptions are getting double reported.

* from notify_exception: https://sentry.io/dimagi/commcarehq/issues/263291223/
* from django logger: https://sentry.io/dimagi/commcarehq/issues/263291225/

Also not sure why we have `@json_error` decorator on non json views.

buddy @nickpell 
@dimagi/scale-team 
