### PR TITLE
sentry rate limit RequestFailed (couchdb)

### DIFF
--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -9,6 +9,7 @@ RATE_LIMITED_EXCEPTIONS = {
     'socket.error': 'rabbitmq',
     'redis.exceptions.ConnectionError': 'redis',
     'restkit.errors.RequestError': 'couchdb',
+    'restkit.errors.RequestFailed': 'couchdb',
 }
 
 


### PR DESCRIPTION
e.g. https://sentry.io/dimagi/commcarehq/issues/251997829/