### PR TITLE
ICDS ucr improvements

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -232,7 +232,8 @@ def _queue_indicators(indicators):
             _queue_chunk(to_queue)
             to_queue = []
 
-    _queue_chunk(to_queue)
+    if to_queue:
+        _queue_chunk(to_queue)
 
 
 @quickcache(['config_id'])

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -197,7 +197,6 @@ class FormsInDateExpressionSpec(JsonObject):
 
         forms = (
             FormES()
-            .domain(context.root_doc['domain'])
             .doc_id(xform_ids)
             .source(['form.meta.timeEnd', 'xmlns', '_id'])
         ).run().hits


### PR DESCRIPTION
- Catches any couch and ES errors and attempts to continue with the other doc ids
- Won't queue empty queues
- Removes a filter for domain on forms. This won't help on ICDS and the xform ids come from a case id anyways, so it's useless

@dimagi/scale-team 

cc @millerdev 