### PR TITLE
Remove redundant "delete_all_locations" calls

### DIFF
--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -9,7 +9,6 @@ from corehq.apps.commtrack.tests.util import make_loc
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
 from corehq.apps.locations.models import LocationType
-from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
@@ -20,7 +19,8 @@ class ImporterTest(TestCase):
 
     def setUp(self):
         super(ImporterTest, self).setUp()
-        self.domain = create_domain("importer-test").name
+        self.domain_obj = create_domain("importer-test")
+        self.domain = self.domain_obj.name
         self.default_case_type = 'importer-test-casetype'
 
         self.couch_user = WebUser.create(None, "test", "foobar")
@@ -36,8 +36,7 @@ class ImporterTest(TestCase):
 
     def tearDown(self):
         self.couch_user.delete()
-        delete_all_locations()
-        LocationType.objects.all().delete()
+        self.domain_obj.delete()
         super(ImporterTest, self).tearDown()
 
     def _config(self, col_names, search_column=None, case_type=None,

--- a/corehq/apps/hqadmin/tests/test_clone_domain.py
+++ b/corehq/apps/hqadmin/tests/test_clone_domain.py
@@ -4,7 +4,7 @@ from mock import patch
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import SQLLocation, LocationType
-from corehq.apps.locations.tests.util import setup_locations_and_types, delete_all_locations
+from corehq.apps.locations.tests.util import setup_locations_and_types
 from corehq.apps.repeaters.dbaccessors import delete_all_repeaters
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
@@ -17,9 +17,6 @@ class TestCloneDomain(TestCase):
     new_domain = "the-upside-down"
 
     def setUp(self):
-        delete_all_users()
-        delete_all_locations()
-        delete_all_repeaters()
         self.old_domain_obj = create_domain(self.old_domain)
         self.mobile_worker = CommCareUser.create(self.old_domain, 'will@normal-world.commcarehq.org', '123')
         self.web_user = WebUser.create(self.old_domain, 'barb@hotmail.com', '***', is_active=True)
@@ -57,7 +54,6 @@ class TestCloneDomain(TestCase):
         if new_domain_obj:
             new_domain_obj.delete()
         delete_all_users()
-        delete_all_locations()
         delete_all_repeaters()
 
     def test_same_locations(self):

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -2,12 +2,11 @@ from django.test import TestCase
 from corehq.apps.commtrack.tests.util import bootstrap_location_types
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from ..analytics import users_have_locations
 from ..dbaccessors import (get_users_by_location_id, get_user_ids_by_location,
                            get_one_user_at_location, get_user_docs_by_location,
                            get_all_users_by_location, get_users_assigned_to_locations)
-from .util import make_loc, delete_all_locations
+from .util import make_loc
 
 
 class TestUsersByLocation(TestCase):
@@ -15,8 +14,6 @@ class TestUsersByLocation(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestUsersByLocation, cls).setUpClass()
-        delete_all_locations()
-        delete_all_users()
         cls.domain = 'test-domain'
         cls.domain_obj = create_domain(cls.domain)
         bootstrap_location_types(cls.domain)
@@ -42,8 +39,8 @@ class TestUsersByLocation(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.george.delete()
         cls.domain_obj.delete()
-        delete_all_locations()
         super(TestUsersByLocation, cls).tearDownClass()
 
     def test_get_users_by_location_id(self):

--- a/corehq/apps/locations/tests/test_location_sync.py
+++ b/corehq/apps/locations/tests/test_location_sync.py
@@ -37,7 +37,6 @@ class TestLocationSync(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestLocationSync, cls).setUpClass()
-        delete_all_locations()
         cls.domain_obj = create_domain(DOMAIN)
         loc_types = setup_location_types(DOMAIN, ['state', 'county', 'city'])
         cls.state = loc_types['state']

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -23,7 +23,7 @@ from casexml.apps.case.tests.util import delete_all_xforms
 from corehq.util.test_utils import create_and_save_a_case
 from ..views import LocationsListView, EditLocationView
 from ..permissions import can_edit_form_location, user_can_access_case
-from .util import LocationHierarchyTestCase, delete_all_locations
+from .util import LocationHierarchyTestCase
 
 
 class FormEditRestrictionsMixin(object):
@@ -106,7 +106,6 @@ class FormEditRestrictionsMixin(object):
     @classmethod
     def extra_teardown(cls):
         delete_all_users()
-        delete_all_locations()
         delete_all_xforms()
 
     def assertCanEdit(self, user, form):

--- a/corehq/apps/locations/tests/test_reupholster.py
+++ b/corehq/apps/locations/tests/test_reupholster.py
@@ -69,12 +69,12 @@ class TestNoCouchLocationTypes(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestNoCouchLocationTypes, cls).setUpClass()
-        create_domain('test-domain')
+        cls.domain_obj = create_domain('test-domain')
         LocationType.objects.create(domain='test-domain', name='test-type')
 
     @classmethod
     def tearDownClass(cls):
-        LocationType.objects.all().delete()
+        cls.domain_obj.delete()
         super(TestNoCouchLocationTypes, cls).tearDownClass()
 
     def setUp(self):

--- a/corehq/apps/locations/tests/test_site_code.py
+++ b/corehq/apps/locations/tests/test_site_code.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from corehq.apps.commtrack.tests.util import bootstrap_domain
 from django.test import TestCase
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import Location, LocationType
-from corehq.apps.locations.tests.util import delete_all_locations
 
 
 class SiteCodeTest(TestCase):
@@ -14,13 +13,12 @@ class SiteCodeTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super(SiteCodeTest, cls).setUpClass()
-        cls.project = bootstrap_domain(cls.domain)
+        cls.project = create_domain(cls.domain)
         LocationType(domain=cls.domain, name='type').save()
 
     @classmethod
     def tearDownClass(cls):
         cls.project.delete()
-        delete_all_locations()
         super(SiteCodeTest, cls).tearDownClass()
 
     def testSimpleName(self):

--- a/corehq/apps/locations/tests/util.py
+++ b/corehq/apps/locations/tests/util.py
@@ -151,7 +151,6 @@ class LocationHierarchyTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        delete_all_locations()
         cls.domain_obj.delete()
         super(LocationHierarchyTestCase, cls).tearDownClass()
 
@@ -190,4 +189,3 @@ class LocationHierarchyPerTest(TestCase):
 
     def tearDown(self):
         self.domain_obj.delete()
-        delete_all_locations()

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -8,7 +8,6 @@ from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 from corehq.apps.es.fake.groups_fake import GroupESFake
 from corehq.apps.es.fake.users_fake import UserESFake
 from corehq.apps.groups.models import Group
-from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.reports_core.filters import Choice
 from corehq.apps.userreports.models import ReportConfiguration

--- a/corehq/apps/userreports/tests/test_location_data_source.py
+++ b/corehq/apps/userreports/tests/test_location_data_source.py
@@ -5,7 +5,6 @@ from kafka.common import KafkaUnavailableError
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import SQLLocation, LocationType
-from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.util.test_utils import trap_extra_setup
 
 from corehq.apps.userreports.app_manager import _clean_table_name
@@ -19,7 +18,6 @@ class TestLocationDataSource(TestCase):
     domain = "delos_corp"
 
     def setUp(self):
-        delete_all_locations()
         self.domain_obj = create_domain(self.domain)
 
         self.region = LocationType.objects.create(domain=self.domain, name="region")
@@ -52,7 +50,6 @@ class TestLocationDataSource(TestCase):
 
     def tearDown(self):
         self.domain_obj.delete()
-        delete_all_locations()
         self.data_source_config.delete()
 
     def _make_loc(self, name, location_type):

--- a/custom/ewsghana/tests/handlers/utils.py
+++ b/custom/ewsghana/tests/handlers/utils.py
@@ -7,13 +7,11 @@ from casexml.apps.stock.models import StockReport, StockTransaction
 from couchdbkit.exceptions import ResourceNotFound
 from couchforms.models import XFormInstance
 
-from corehq.apps.accounting.tests import generator
 from corehq.apps.commtrack.models import CommtrackConfig, CommtrackActionConfig, StockState, ConsumptionConfig
 from corehq.apps.commtrack.tests.util import make_loc
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_supply_point
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import Location, SQLLocation, LocationType
-from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.products.models import Product, SQLProduct
 from corehq.apps.sms.tests.util import setup_default_sms_test_backend, delete_domain_phone_numbers
 from corehq.apps.users.models import CommCareUser
@@ -190,7 +188,6 @@ class EWSScriptTest(EWSTestCase, TestScript):
         CommCareUser.get_by_username('stella').delete()
         CommCareUser.get_by_username('super').delete()
         FacilityInCharge.objects.all().delete()
-        delete_all_locations()
         LocationType.objects.all().delete()
         for product in Product.by_domain(TEST_DOMAIN):
             product.delete()


### PR DESCRIPTION
@mkangia
`domain.delete()` is usually being called anyways, and it includes
"delete_all_locations".  These calls actually have a noticeable cost to them too, so hopefully we'll see some minor test speed-up from this.