### PR TITLE
Missing dependency on hqmediauploaders.js

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view.html
@@ -19,6 +19,7 @@
     <script src="{% static 'hqwebapp/js/key-value-mapping.js' %}"></script>
     <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
     {% if request|toggle_enabled:"CASE_DETAIL_PRINT" %}
+        <script src="{% static "hqmedia/js/hqmediauploaders.js" %}"></script>
         <script src="{% static 'hqmedia/js/hqmedia.reference_controller.js' %}"></script>
     {% endif %}
     <script src="{% static 'app_manager/js/module-view.js' %}"></script>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
@@ -6,7 +6,11 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load i18n %}
-@@ -22,30 +22,30 @@
+@@ -19,34 +19,33 @@
+     <script src="{% static 'hqwebapp/js/key-value-mapping.js' %}"></script>
+     <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
+     {% if request|toggle_enabled:"CASE_DETAIL_PRINT" %}
+-        <script src="{% static "hqmedia/js/hqmediauploaders.js" %}"></script>
          <script src="{% static 'hqmedia/js/hqmedia.reference_controller.js' %}"></script>
      {% endif %}
      <script src="{% static 'app_manager/js/module-view.js' %}"></script>
@@ -50,7 +54,7 @@
  
      <script>
      var print_ref;
-@@ -99,78 +99,83 @@
+@@ -100,78 +99,83 @@
      </script>
  {% endblock %}
  
@@ -203,7 +207,7 @@
  <script type="text/html" id="module-forms-template">
      <div class="checkbox">
          <label>
-@@ -184,7 +189,7 @@
+@@ -185,7 +189,7 @@
  {% endblock %}
  
  {% block modals %}{{ block.super }}
@@ -212,7 +216,7 @@
  {% if request|toggle_enabled:"CASE_DETAIL_PRINT" %}
      {% with print_uploader as uploader %}
          {% include 'hqmedia/partials/multimedia_uploader.html' %}
-@@ -194,5 +199,5 @@
+@@ -195,5 +199,5 @@
  
  {% block breadcrumbs %}
      {{ block.super }}


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/15952 : now all usages of `hqmedia.reference_controller.js` have to also include `hqmediauploaders.js`.

Causes js error on module view, so it'd be nice to get this merged soon, but only affects domains that use case detail printing, which is only one prod domain.

@dannyroberts / @millerdev 