### PR TITLE
Revert "Show HTML5 validation alert for select2 in report builder config"

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1297,7 +1297,7 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
                     _("Rows"),
                     _('Choose which property this report will group its results by. Each value of this property will be a row in the table. For example, if you choose a yes or no question, the report will show a row for "yes" and a row for "no."'),
                 ),
-                crispy.Field('group_by', required=True),
+                'group_by',
             ),
             self.user_filter_fieldset,
             self.default_filter_fieldset

--- a/corehq/apps/userreports/templates/userreports/base_report_builder.html
+++ b/corehq/apps/userreports/templates/userreports/base_report_builder.html
@@ -3,19 +3,6 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% block js-inline %}{{ block.super }}
-  <script type="text/javascript">
-    $(function () {
-      _.each($('.select2'), function (elem) {
-        if ($(elem).prop('required')) {
-          $(elem).prev().find('.select2-focusser').prop('required', true);
-          $(elem).removeProp('required');
-        }
-      });
-    })
-  </script>
-{% endblock %}
-
 {% block page_content %}
     {% crispy form %}
 {% endblock %}


### PR DESCRIPTION
Reverts dimagi/commcare-hq#15867

This PR prevented valid report builder forms from being submitted. This doesn't solve the problem of providing front end validation to this field, but until we can figure out how to do front end validation correctly, I think the previous state was better.

buddy @gcapalbo 