### PR TITLE
Allow overriding CommCare HQ in page titles

### DIFF
--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -3,8 +3,11 @@
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
         {% captureas title_block %}{% block title %}{% endblock title %}{% endcaptureas %}
+        {% captureas title_context_block %}{% block title_context %}{% endblock title_context %}{% endcaptureas %}
         <title>
-            {% if title_block %}{{ title_block }} - {% endif %}CommCare HQ
+            {% if title_block %}{{ title_block }}{% endif %}
+            {% if title_block %}{% if title_context_block.strip or not title_context_block %}- {{ title_context_block }}{% endif %}{% endif %}
+            {% if not title_context_block %}CommCare HQ{% endif %}
         </title>
 
         <meta charset="utf-8">

--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 
 {% block title %}{% trans "Login to ICDS CAS" %}{% endblock title %}
+{% block title_context %} {% endblock %}
 
 <!-- get rid of navigation menu -->
 {% block navigation %}


### PR DESCRIPTION
https://trello.com/c/wqF3v5fq/154-removing-the-word-commcare-hq-from-the-search-result-of-icds-cas

@nickpell 