### PR TITLE
Pillows support **kwargs

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -48,19 +48,19 @@ class KafkaProcessor(PillowProcessor):
             self._producer.send_change(get_topic(doc_meta), change_meta)
 
 
-def get_default_couch_db_change_feed_pillow(pillow_id):
+def get_default_couch_db_change_feed_pillow(pillow_id, **kwargs):
     return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
 
 
-def get_user_groups_db_kafka_pillow(pillow_id):
+def get_user_groups_db_kafka_pillow(pillow_id, **kwargs):
     return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(CommCareUser))
 
 
-def get_domain_db_kafka_pillow(pillow_id):
+def get_domain_db_kafka_pillow(pillow_id, **kwargs):
     return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain))
 
 
-def get_application_db_kafka_pillow(pillow_id):
+def get_application_db_kafka_pillow(pillow_id, **kwargs):
     from corehq.apps.app_manager.models import Application
     return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Application))
 

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -317,9 +317,9 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
         self._processor.rebuild_table(sql_adapter)
 
 
-# TODO(Emord) make other pillows support params dictionary
 def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
-                         include_ucrs=None, exclude_ucrs=None, topics=None):
+                         include_ucrs=None, exclude_ucrs=None, topics=None,
+                         **kwargs):
     topics = topics or KAFKA_TOPICS
     topics = [kafka_bytestring(t) for t in topics]
     return ConfigurableReportKafkaPillow(
@@ -336,7 +336,8 @@ def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
 
 
 def get_kafka_ucr_static_pillow(pillow_id='kafka-ucr-static', ucr_division=None,
-                                include_ucrs=None, exclude_ucrs=None, topics=None):
+                                include_ucrs=None, exclude_ucrs=None, topics=None,
+                                **kwargs):
     topics = topics or KAFKA_TOPICS
     topics = [kafka_bytestring(t) for t in topics]
     return ConfigurableReportKafkaPillow(

--- a/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
@@ -52,6 +52,20 @@ class Command(BaseCommand):
             default=None,
             help="Run a single specific pillow name from settings.PILLOWTOPS list",
         )
+        parser.add_argument(
+            '--num-processes',
+            action='store',
+            dest='num_processes',
+            default=1,
+            type=int,
+        )
+        parser.add_argument(
+            '--process-number',
+            action='store',
+            dest='process_number',
+            default=0,
+            type=int,
+        )
 
     def handle(self, **options):
         run_all = options['run_all']
@@ -59,6 +73,8 @@ class Command(BaseCommand):
         list_checkpoints = options['list_checkpoints']
         pillow_name = options['pillow_name']
         pillow_key = options['pillow_key']
+        num_processes = options['num_processes']
+        process_number = options['process_number']
         if list_all:
             print("\nPillows registered in system:")
             for config in get_all_pillow_configs():
@@ -81,7 +97,7 @@ class Command(BaseCommand):
                                   for config in settings.PILLOWTOPS[pillow_key]]
 
         elif not run_all and not pillow_key and pillow_name:
-            pillow = get_pillow_by_name(pillow_name)
+            pillow = get_pillow_by_name(pillow_name, num_processes=num_processes, process_num=process_number)
             start_pillow(pillow)
             sys.exit()
         elif list_checkpoints:

--- a/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
@@ -58,6 +58,7 @@ class Command(BaseCommand):
             dest='num_processes',
             default=1,
             type=int,
+            help="The number of processes that are expected to be run for this pillow",
         )
         parser.add_argument(
             '--process-number',
@@ -65,6 +66,8 @@ class Command(BaseCommand):
             dest='process_number',
             default=0,
             type=int,
+            help="The process number of this pillow process. Should be between 0 and num-processes. "
+                 "It's expected that there will only be one process for each number running at once",
         )
 
     def handle(self, **options):
@@ -75,6 +78,7 @@ class Command(BaseCommand):
         pillow_key = options['pillow_key']
         num_processes = options['num_processes']
         process_number = options['process_number']
+        assert 0 <= process_number < num_processes
         if list_all:
             print("\nPillows registered in system:")
             for config in get_all_pillow_configs():

--- a/corehq/ex-submodules/pillowtop/tests/test_import_pillows.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_import_pillows.py
@@ -44,7 +44,7 @@ class PillowImportTestCase(SimpleTestCase):
             get_pillow_by_name('MissingPillow')
 
 
-def make_fake_pillow(pillow_id):
+def make_fake_pillow(pillow_id, **kwargs):
     return make_fake_constructed_pillow(pillow_id, 'fake-constructed-pillow')
 
 

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from collections import namedtuple
+from copy import deepcopy
 from datetime import datetime
 import json
 import sys
@@ -74,10 +75,12 @@ class PillowConfig(namedtuple('PillowConfig', ['section', 'name', 'class_name', 
     def get_class(self):
         return _import_class_or_function(self.class_name)
 
-    def get_instance(self):
+    def get_instance(self, **kwargs):
         if self.instance_generator:
             instance_generator_fn = _import_class_or_function(self.instance_generator)
-            return instance_generator_fn(self.name, **self.params)
+            params = deepcopy(self.params)  # parameters defined in settings file
+            params.update(kwargs)  # parameters passed in via run_ptop
+            return instance_generator_fn(self.name, **params)
         else:
             return _get_pillow_instance(self.class_name)
 
@@ -103,10 +106,10 @@ def get_pillow_config_from_setting(section, pillow_config_string_or_dict):
         )
 
 
-def get_pillow_by_name(pillow_class_name, instantiate=True, params=None):
-    params = params or {}
+def get_pillow_by_name(pillow_class_name, instantiate=True, **kwargs):
+    # todo(emord) get rid of instantiate (only needed in fluff reindex)
     config = get_pillow_config_by_name(pillow_class_name)
-    return config.get_instance() if instantiate else config.get_class()
+    return config.get_instance(**kwargs) if instantiate else config.get_class()
 
 
 def get_pillow_config_by_name(pillow_name):

--- a/corehq/pillows/app_submission_tracker.py
+++ b/corehq/pillows/app_submission_tracker.py
@@ -17,7 +17,7 @@ from pillowtop.processors.form import FormSubmissionMetadataTrackerProcessor
 from pillowtop.reindexer.reindexer import Reindexer
 
 
-def get_form_submission_metadata_tracker_pillow(pillow_id='FormSubmissionMetadataTrackerProcessor'):
+def get_form_submission_metadata_tracker_pillow(pillow_id='FormSubmissionMetadataTrackerProcessor', **kwargs):
     """
     This gets a pillow which iterates through all forms and marks the corresponding app
     as having submissions. This could be expanded to be more generic and include

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -17,7 +17,7 @@ def transform_app_for_es(doc_dict):
     return doc.to_json()
 
 
-def get_app_to_elasticsearch_pillow(pillow_id='ApplicationToElasticsearchPillow'):
+def get_app_to_elasticsearch_pillow(pillow_id='ApplicationToElasticsearchPillow', **kwargs):
     assert pillow_id == 'ApplicationToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, APP_INDEX_INFO)
     app_processor = ElasticProcessor(

--- a/corehq/pillows/cacheinvalidate.py
+++ b/corehq/pillows/cacheinvalidate.py
@@ -72,12 +72,12 @@ class CacheInvalidateProcessor(PillowProcessor):
             )
 
 
-def get_main_cache_invalidation_pillow(pillow_id):
+def get_main_cache_invalidation_pillow(pillow_id, **kwargs):
     from couchforms.models import XFormInstance
     return _get_cache_invalidation_pillow(pillow_id, XFormInstance.get_db(), couch_filter="hqadmin/not_case_form")
 
 
-def get_user_groups_cache_invalidation_pillow(pillow_id):
+def get_user_groups_cache_invalidation_pillow(pillow_id, **kwargs):
     from corehq.apps.users.models import CommCareUser
     return _get_cache_invalidation_pillow(pillow_id, CommCareUser.get_db())
 

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -35,7 +35,7 @@ def transform_case_for_elasticsearch(doc_dict):
     return doc_ret
 
 
-def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow'):
+def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow', **kwargs):
     assert pillow_id == 'CaseToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_INDEX_INFO)
     case_processor = ElasticProcessor(

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -69,7 +69,7 @@ class CaseSearchPillowProcessor(ElasticProcessor):
             super(CaseSearchPillowProcessor, self).process_change(pillow_instance, change)
 
 
-def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearchPillow'):
+def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearchPillow', **kwargs):
     assert pillow_id == 'CaseSearchToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_SEARCH_INDEX_INFO)
     case_processor = CaseSearchPillowProcessor(

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -29,7 +29,7 @@ def transform_domain_for_elasticsearch(doc_dict):
     return doc_ret
 
 
-def get_domain_kafka_to_elasticsearch_pillow(pillow_id='KafkaDomainPillow'):
+def get_domain_kafka_to_elasticsearch_pillow(pillow_id='KafkaDomainPillow', **kwargs):
     assert pillow_id == 'KafkaDomainPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, DOMAIN_INDEX_INFO)
     domain_processor = ElasticProcessor(

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -11,7 +11,7 @@ from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer
 
 
-def get_group_pillow(pillow_id='GroupPillow'):
+def get_group_pillow(pillow_id='GroupPillow', **kwargs):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """

--- a/corehq/pillows/groups_to_user.py
+++ b/corehq/pillows/groups_to_user.py
@@ -23,7 +23,7 @@ class GroupsToUsersProcessor(PillowProcessor):
             update_es_user_with_groups(change.get_document(), self._es)
 
 
-def get_group_to_user_pillow(pillow_id='GroupToUserPillow'):
+def get_group_to_user_pillow(pillow_id='GroupToUserPillow', **kwargs):
     assert pillow_id == 'GroupToUserPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     processor = GroupsToUsersProcessor()

--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -55,7 +55,7 @@ def _get_daily_consumption_for_ledger(ledger):
     return daily_consumption
 
 
-def get_ledger_to_elasticsearch_pillow(pillow_id='LedgerToElasticsearchPillow'):
+def get_ledger_to_elasticsearch_pillow(pillow_id='LedgerToElasticsearchPillow', **kwargs):
     assert pillow_id == 'LedgerToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, LEDGER_INDEX_INFO)
     processor = ElasticProcessor(

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -32,7 +32,7 @@ def transform_case_to_report_es(doc_dict):
     return doc_ret
 
 
-def get_report_case_to_elasticsearch_pillow(pillow_id='ReportCaseToElasticsearchPillow'):
+def get_report_case_to_elasticsearch_pillow(pillow_id='ReportCaseToElasticsearchPillow', **kwargs):
     assert pillow_id == 'ReportCaseToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, REPORT_CASE_INDEX_INFO)
     form_processor = ElasticProcessor(

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -35,7 +35,7 @@ def transform_xform_for_report_forms_index(doc_dict):
     return doc_ret
 
 
-def get_report_xform_to_elasticsearch_pillow(pillow_id='ReportXFormToElasticsearchPillow'):
+def get_report_xform_to_elasticsearch_pillow(pillow_id='ReportXFormToElasticsearchPillow', **kwargs):
     assert pillow_id == 'ReportXFormToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, REPORT_XFORM_INDEX_INFO)
     form_processor = ElasticProcessor(

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -13,7 +13,7 @@ from pillowtop.reindexer.reindexer import ElasticPillowReindexer
 SMS_PILLOW_KAFKA_CONSUMER_GROUP_ID = 'sql-sms-to-es'
 
 
-def get_sql_sms_pillow(pillow_id='SqlSMSPillow'):
+def get_sql_sms_pillow(pillow_id='SqlSMSPillow', **kwargs):
     assert pillow_id == 'SqlSMSPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, SMS_INDEX_INFO)
     processor = ElasticProcessor(

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -77,7 +77,7 @@ class UnknownUsersProcessor(PillowProcessor):
         update_unknown_user_from_form_if_necessary(self._es, change.get_document())
 
 
-def get_unknown_users_pillow(pillow_id='unknown-users-pillow'):
+def get_unknown_users_pillow(pillow_id='unknown-users-pillow', **kwargs):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
@@ -102,7 +102,7 @@ def add_demo_user_to_user_index():
     )
 
 
-def get_user_pillow(pillow_id='UserPillow'):
+def get_user_pillow(pillow_id='UserPillow', **kwargs):
     assert pillow_id == 'UserPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     user_processor = ElasticProcessor(

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -129,7 +129,7 @@ def transform_xform_for_elasticsearch(doc_dict):
     return doc_ret
 
 
-def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow'):
+def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', **kwargs):
     assert pillow_id == 'XFormToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, XFORM_INDEX_INFO)
     form_processor = ElasticProcessor(


### PR DESCRIPTION
It's too hard to follow the changes in #15773 so going to be splitting it into multiple PRs. and doing a little refactoring from it

This enables passing the number of processes and process number to a pillow. For example if the kafka-ucr-main pillow has a number of processes of 4, then we would expect the following to be running:

```
./manage.py run_ptop --pillow-name kafka-ucr-main --num-processes 4 --process-num 0
./manage.py run_ptop --pillow-name kafka-ucr-main --num-processes 4 --process-num 1
./manage.py run_ptop --pillow-name kafka-ucr-main --num-processes 4 --process-num 2
./manage.py run_ptop --pillow-name kafka-ucr-main --num-processes 4 --process-num 3
```

For now everything will only be running one process, but this will enable merging my multiple pillow machine deploy PRs https://github.com/dimagi/commcare-hq/pull/15854 https://github.com/dimagi/commcare-hq-deploy/pull/242

@dimagi/scale-team buddy @dannyroberts 