### PR TITLE
Fix repeat record report's total docs count

### DIFF
--- a/corehq/apps/repeaters/dbaccessors.py
+++ b/corehq/apps/repeaters/dbaccessors.py
@@ -39,7 +39,7 @@ def get_repeat_record_count(domain, repeater_id=None, state=None):
         if not ids:
             return 0
         startkey = [domain, ids[0], state]
-        endkey = [domain, ids[-1], state]
+        endkey = [domain, ids[-1], state, {}]
 
     result = RepeatRecord.get_db().view('receiverwrapper/repeat_records',
         startkey=startkey,

--- a/corehq/apps/repeaters/tests/test_dbaccessors.py
+++ b/corehq/apps/repeaters/tests/test_dbaccessors.py
@@ -94,7 +94,7 @@ class TestRepeatRecordDBAccessors(TestCase):
 
     def test_get_repeat_record_count_with_state_and_no_repeater(self):
         count = get_repeat_record_count(self.domain, state=RECORD_PENDING_STATE)
-        self.assertEqual(count, 6)
+        self.assertEqual(count, 3)
 
     def test_get_repeat_record_count_with_repeater_id_and_no_state(self):
         count = get_repeat_record_count(self.domain, repeater_id=self.other_id)

--- a/corehq/apps/repeaters/tests/test_dbaccessors.py
+++ b/corehq/apps/repeaters/tests/test_dbaccessors.py
@@ -92,6 +92,14 @@ class TestRepeatRecordDBAccessors(TestCase):
         count = get_failure_repeat_record_count(self.domain, self.repeater_id)
         self.assertEqual(count, 2)
 
+    def test_get_repeat_record_count_with_state_and_no_repeater(self):
+        count = get_repeat_record_count(self.domain, state=RECORD_PENDING_STATE)
+        self.assertEqual(count, 6)
+
+    def test_get_repeat_record_count_with_repeater_id_and_no_state(self):
+        count = get_repeat_record_count(self.domain, repeater_id=self.other_id)
+        self.assertEqual(count, 1)
+
     def test_get_paged_repeat_records_with_state_and_no_records(self):
         count = get_repeat_record_count('wrong-domain', state=RECORD_PENDING_STATE)
         self.assertEqual(count, 0)


### PR DESCRIPTION
Replicates the view key logic in `get_paged_repeat_records()`, the function that is actually returning the individual records that we are counting.
Fixes http://manage.dimagi.com/default.asp?252801

@benrudolph @proteusvacuum 
buddy @sravfeyn 