### PR TITLE
Fix deploy page scrolling

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -319,8 +319,11 @@ hqDefine('app_manager/js/releases.js', function () {
                     self.fetchState('');
                     if (scroll) {
                         // Scroll so the bottom of main content (and the "View More" button) aligns with the bottom of the window
-                        var $content = $("#hq-content");
-                        window.scrollTo(0, $content.position().top + $content.height() - window.innerHeight);
+                        // Wait for animation to finish first
+                        _.defer(function() {
+                            var $content = $("#releases");
+                            window.scrollTo(0, $content.offset().top + $content.outerHeight(true) - window.innerHeight);
+                        });
                     }
                 },
                 error: function () {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?253348

`#hq-content` grows as the left-hand menu grows, so in apps with a lot of modules, the deploy page ends up scrolling to the bottom of the page instead of the bottom of the releases list. Use `#releases` instead.

Tested in app manager v1 and v2.

@nickpell / @biyeun 