### PR TITLE
Don't allow mobile workers to see "Edit Form" and "Archive Form" buttons

### DIFF
--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -154,8 +154,7 @@ def render_form(form, domain, options):
         user_info = get_doc_info_by_id(domain, meta_userID)
 
     user_can_edit = (
-        request and user and request.domain
-        and (user.can_edit_data() or user.is_commcare_user())
+        request and user and request.domain and user.can_edit_data()
     )
     show_edit_options = (
         user_can_edit


### PR DESCRIPTION
These views already 403 for mobile workers, but the buttons weren't hidden from the UI.
buddy @sravfeyn 
http://manage.dimagi.com/default.asp?252001