### PR TITLE
add sync ID and device ID to async restore cache key

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -636,8 +636,6 @@ class RestoreConfig(object):
             self.cache_settings.overwrite_cache
         )
 
-        self.asyc = async
-
         self.force_cache = self.cache_settings.force_cache or self.async
         self.cache_timeout = self.cache_settings.cache_timeout
         self.overwrite_cache = self.cache_settings.overwrite_cache

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -653,7 +653,13 @@ class RestoreConfig(object):
 
     @property
     def async_cache_key(self):
-        return restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, self.restore_user.user_id)
+        return restore_cache_key(
+            self.domain,
+            ASYNC_RESTORE_CACHE_KEY_PREFIX,
+            self.restore_user.user_id,
+            sync_log_id=self.sync_log._id if self.sync_log else '',
+            device_id=self.params.device_id,
+        )
 
     @property
     def _restore_cache_key(self):


### PR DESCRIPTION
- device ID added to prevent edge case where the same user syncs from different devices
- synclog ID doesn't seem likely to have any effect but also doesn't harm