### PR TITLE
The marriage of mobile UCR and case detail graphing

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -129,6 +129,16 @@ def _create_custom_app_strings(app, lang, for_default=False):
                         id_strings.report_column_header(config.uuid, column.column_id),
                         column.get_header(lang)
                     )
+                for chart_id, graph_config in config.complete_graph_configs.iteritems():
+                    for index, item in enumerate(graph_config.annotations):
+                        yield id_strings.mobile_ucr_annotation(module, config.uuid, index), trans(item.values)
+                    for property, values in graph_config.locale_specific_config.iteritems():
+                        yield id_strings.mobile_ucr_configuration(module, config.uuid, property), trans(values)
+                    for index, item in enumerate(graph_config.series):
+                        for property, values in item.locale_specific_config.iteritems():
+                            yield id_strings.mobile_ucr_series_configuration(
+                                module, config.uuid, index, property
+                            ), trans(values)
 
         if hasattr(module, 'case_list'):
             if module.case_list.show:

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -472,87 +472,34 @@ class Graph(FormattedDetailColumn):
 
     @property
     def template(self):
-        template = sx.GraphTemplate(
-            form=self.template_form,
-            graph=sx.Graph(
-                type=self.column.graph_configuration.graph_type,
-                series=[
-                    sx.Series(
-                        nodeset=s.data_path,
-                        x_function=s.x_function,
-                        y_function=s.y_function,
-                        radius_function=s.radius_function,
-                        configuration=sx.ConfigurationGroup(
-                            configs=(
-                                [
-                                    # TODO: It might be worth wrapping
-                                    #       these values in quotes (as appropriate)
-                                    #       to prevent the user from having to
-                                    #       figure out why their unquoted colors
-                                    #       aren't working.
-                                    sx.ConfigurationItem(id=k, xpath_function=v)
-                                    for k, v in s.config.iteritems()
-                                ] + [
-                                    sx.ConfigurationItem(
-                                        id=k,
-                                        locale_id=self.id_strings.graph_series_configuration(
-                                            self.module,
-                                            self.detail_type,
-                                            self.column,
-                                            index,
-                                            k
-                                        )
-                                    )
-                                    for k, v in s.locale_specific_config.iteritems()
-                                ]
-                            )
-                        )
-                    )
-                    for index, s in enumerate(self.column.graph_configuration.series)],
-                configuration=sx.ConfigurationGroup(
-                    configs=(
-                        [
-                            sx.ConfigurationItem(id=k, xpath_function=v)
-                            for k, v
-                            in self.column.graph_configuration.config.iteritems()
-                        ] + [
-                            sx.ConfigurationItem(
-                                id=k,
-                                locale_id=self.id_strings.graph_configuration(
-                                    self.module,
-                                    self.detail_type,
-                                    self.column,
-                                    k
-                                )
-                            )
-                            for k, v
-                            in self.column.graph_configuration.locale_specific_config.iteritems()
-                        ]
-                    )
-                ),
-                annotations=[
-                    sx.Annotation(
-                        x=sx.Text(xpath_function=a.x),
-                        y=sx.Text(xpath_function=a.y),
-                        text=sx.Text(
-                            locale_id=self.id_strings.graph_annotation(
-                                self.module,
-                                self.detail_type,
-                                self.column,
-                                i
-                            )
-                        )
-                    )
-                    for i, a in enumerate(
-                        self.column.graph_configuration.annotations
-                    )]
+        def _locale_config(key):
+            return self.id_strings.graph_configuration(
+                self.module,
+                self.detail_type,
+                self.column,
+                key
             )
-        )
 
-        # TODO: what are self.variables and do I need to care about them here?
-        # (see FormattedDetailColumn.template)
+        def _locale_series_config(index, key):
+            return self.id_strings.graph_series_configuration(
+                self.module,
+                self.detail_type,
+                self.column,
+                index,
+                key
+            )
 
-        return template
+        def _locale_annotation(index):
+            return self.id_strings.graph_annotation(
+                self.module,
+                self.detail_type,
+                self.column,
+                index
+            )
+
+        return sx.GraphTemplate.build(self.template_form, self.column.graph_configuration,
+                                      locale_config=_locale_config, locale_series_config=_locale_series_config,
+                                      locale_annotation=_locale_annotation)
 
 
 @register_type_processor(const.FIELD_TYPE_ATTACHMENT)

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -116,6 +116,15 @@ def graph_configuration(module, detail_type, column, key):
     )
 
 
+@pattern('m%d.%s.graph.key.%s')
+def mobile_ucr_configuration(module, uuid, key):
+    return u"m{module.id}.{uuid}.graph.key.{key}".format(
+        module=module,
+        uuid=uuid,
+        key=key
+    )
+
+
 @pattern('m%d.%s.%s_%s_%s.graph.series_%d.key.%s')
 def graph_series_configuration(module, detail_type, column, series_index, key):
     field = column.field.replace('#', '')
@@ -130,6 +139,16 @@ def graph_series_configuration(module, detail_type, column, series_index, key):
     )
 
 
+@pattern('m%d.%s.graph.series_%d.key.%s')
+def mobile_ucr_series_configuration(module, uuid, series_index, key):
+    return u"m{module.id}.{uuid}.graph.series_{series_index}.key.{key}".format(
+        module=module,
+        uuid=uuid,
+        series_index=series_index,
+        key=key
+    )
+
+
 @pattern('m%d.%s.%s_%s_%s.graph.a.%d')
 def graph_annotation(module, detail_type, column, annotation_index):
     field = column.field.replace('#', '')
@@ -139,6 +158,15 @@ def graph_annotation(module, detail_type, column, annotation_index):
         d=column,
         field=field,
         d_id=column.id + 1,
+        a_id=annotation_index
+    )
+
+
+@pattern('m%d.%s.graph.a.%d')
+def mobile_ucr_annotation(module, uuid, annotation_index):
+    return u"m{module.id}.{uuid}.graph.a.{a_id}".format(
+        module=module,
+        uuid=uuid,
         a_id=annotation_index
     )
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4198,11 +4198,11 @@ class ReportAppConfig(DocumentSchema):
     graph_configs = DictProperty(ReportGraphConfig) # deprecated
     complete_graph_configs = DictProperty(GraphConfiguration)
 
-    def migrate_graph_configs(self, config, domain):
+    def migrate_graph_configs(self, domain):
         graph_configs = {}
         from corehq.apps.userreports.reports.specs import MultibarChartSpec
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import MobileSelectFilterHelpers
-        for chart_config in config.report(domain).charts:
+        for chart_config in self.report(domain).charts:
             if isinstance(chart_config, MultibarChartSpec):
                 limited_graph_config = self.graph_configs.get(chart_config.chart_id, ReportGraphConfig())
                 graph_configs[chart_config.chart_id] = GraphConfiguration(
@@ -4214,8 +4214,8 @@ class ReportAppConfig(DocumentSchema):
                         data_path=(
                             "instance('reports')/reports/report[@id='{}']/rows/row[@is_total_row='False']{}"
                             .format(
-                                config.uuid,
-                                MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)
+                                self.uuid,
+                                MobileSelectFilterHelpers.get_data_filter_xpath(self, domain)
                             )
                         ),
                         x_function="column[@id='{}']".format(chart_config.x_axis_column),

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4214,15 +4214,9 @@ class ReportAppConfig(DocumentSchema):
                     series=[GraphSeries(
                         config=limited_graph_config.series_configs.get(c.column_id, {}),
                         locale_specific_config={},
-                        data_path=(
-                            "instance('reports')/reports/report[@id='{}']/rows/row[@is_total_row='False']{}"
-                            .format(
-                                self.uuid,
-                                MobileSelectFilterHelpers.get_data_filter_xpath(self, domain)
-                            )
-                        ),
-                        x_function="column[@id='{}']".format(chart_config.x_axis_column),
-                        y_function="column[@id='{}']".format(c.column_id),
+                        data_path="",
+                        x_function="",
+                        y_function="",
                     ) for c in chart_config.y_axis_columns],
                     locale_specific_config={},
                     annotations=[]

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4201,7 +4201,7 @@ class ReportAppConfig(DocumentSchema):
     def complete_graph_configs(self, config, domain):
         graph_configs = {}
         from corehq.apps.userreports.reports.specs import MultibarChartSpec
-        from corehq.apps.app_manager.suite_xml.features.mobile_ucr import _MobileSelectFilterHelpers
+        from corehq.apps.app_manager.suite_xml.features.mobile_ucr import MobileSelectFilterHelpers
         for chart_config in config.report(domain).charts:
             if isinstance(chart_config, MultibarChartSpec):
                 limited_graph_config = self.graph_configs.get(chart_config.chart_id, ReportGraphConfig())
@@ -4215,7 +4215,7 @@ class ReportAppConfig(DocumentSchema):
                             "instance('reports')/reports/report[@id='{}']/rows/row[@is_total_row='False']{}"
                             .format(
                                 config.uuid,
-                                _MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)
+                                MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)
                             )
                         ),
                         x_function="column[@id='{}']".format(chart_config.x_axis_column),

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4199,13 +4199,16 @@ class ReportAppConfig(DocumentSchema):
     complete_graph_configs = DictProperty(GraphConfiguration)
 
     def migrate_graph_configs(self, domain):
-        graph_configs = {}
+        if len(self.complete_graph_configs):
+            return
+
+        self.complete_graph_configs = {}
         from corehq.apps.userreports.reports.specs import MultibarChartSpec
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import MobileSelectFilterHelpers
         for chart_config in self.report(domain).charts:
             if isinstance(chart_config, MultibarChartSpec):
                 limited_graph_config = self.graph_configs.get(chart_config.chart_id, ReportGraphConfig())
-                graph_configs[chart_config.chart_id] = GraphConfiguration(
+                self.complete_graph_configs[chart_config.chart_id] = GraphConfiguration(
                     graph_type=limited_graph_config.graph_type,
                     config=limited_graph_config.config,
                     series=[GraphSeries(
@@ -4224,8 +4227,6 @@ class ReportAppConfig(DocumentSchema):
                     locale_specific_config={},
                     annotations=[]
                 )
-        self.complete_graph_configs = graph_configs
-        return self.complete_graph_configs
 
     filters = SchemaDictProperty(ReportAppFilter)
     uuid = StringProperty(required=True)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4195,10 +4195,10 @@ class ReportAppConfig(DocumentSchema):
     xpath_description = StringProperty()
     use_xpath_description = BooleanProperty(default=False)
     show_data_table = BooleanProperty(default=True)
-    graph_configs = DictProperty(ReportGraphConfig)
-    #complete_graph_configs = DictProperty(GraphConfiguration)
+    graph_configs = DictProperty(ReportGraphConfig) # deprecated
+    complete_graph_configs = DictProperty(GraphConfiguration)
 
-    def complete_graph_configs(self, config, domain):
+    def migrate_graph_configs(self, config, domain):
         graph_configs = {}
         from corehq.apps.userreports.reports.specs import MultibarChartSpec
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import MobileSelectFilterHelpers
@@ -4224,7 +4224,8 @@ class ReportAppConfig(DocumentSchema):
                     locale_specific_config={},
                     annotations=[]
                 )
-        return graph_configs
+        self.complete_graph_configs = graph_configs
+        return self.complete_graph_configs
 
     filters = SchemaDictProperty(ReportAppFilter)
     uuid = StringProperty(required=True)

--- a/corehq/apps/app_manager/static/app_manager/js/graph-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/graph-config.js
@@ -153,8 +153,11 @@ hqDefine('app_manager/js/graph-config.js', function () {
 
                 series.selectedSource = {'text':'custom', 'value':'custom'};
                 series.dataPath = s.data_path;
+                series.dataPathPlaceholder = s.data_path_placeholder;
                 series.xFunction = s.x_function;
+                series.xPlaceholder = s.x_placeholder;
                 series.yFunction = s.y_function;
+                series.yPlaceholder = s.y_placeholder;
                 if (s.radius_function !== undefined){
                     series.radiusFunction = s.radius_function;
                 }
@@ -512,9 +515,12 @@ hqDefine('app_manager/js/graph-config.js', function () {
             self.selectedSource(source);
         }
         self.dataPath = ko.observable(origOrDefault('dataPath', self.getDefaultDataPath(self.selectedSource().value)));
+        self.dataPathPlaceholder = ko.observable(origOrDefault('dataPathPlaceholder', ""));
         self.showDataPath = ko.observable(origOrDefault('showDataPath', false));
         self.xFunction = ko.observable(origOrDefault('xFunction',""));
+        self.xPlaceholder = ko.observable(origOrDefault('xPlaceholder',""));
         self.yFunction = ko.observable(origOrDefault('yFunction',""));
+        self.yPlaceholder = ko.observable(origOrDefault('yPlaceholder',""));
         self.xLabel = "X";
         self.yLabel = "Y";
         self.configPropertyOptions = [

--- a/corehq/apps/app_manager/static/app_manager/js/graph-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/graph-config.js
@@ -522,7 +522,7 @@ hqDefine('app_manager/js/graph-config.js', function () {
         self.yFunction = ko.observable(origOrDefault('yFunction',""));
         self.yPlaceholder = ko.observable(origOrDefault('yPlaceholder',""));
 
-        var seriesValidationError = gettext(
+        var seriesValidationWarning = gettext(
             "It is recommended that you leave this value blank. Future changes to your report's "
             + "chart configuration will not be reflected here."
         );
@@ -531,19 +531,19 @@ hqDefine('app_manager/js/graph-config.js', function () {
                 return;
             }
             self.showDataPath(true);
-            return seriesValidationError;
+            return seriesValidationWarning;
         });
         self.validateX = ko.computed(function() {
             if (!self.xPlaceholder() || !self.xFunction()) {
                 return;
             }
-            return seriesValidationError;
+            return seriesValidationWarning;
         });
         self.validateY = ko.computed(function() {
             if (!self.yPlaceholder() || !self.yFunction()) {
                 return;
             }
-            return seriesValidationError;
+            return seriesValidationWarning;
         });
         self.xLabel = "X";
         self.yLabel = "Y";

--- a/corehq/apps/app_manager/static/app_manager/js/graph-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/graph-config.js
@@ -521,6 +521,30 @@ hqDefine('app_manager/js/graph-config.js', function () {
         self.xPlaceholder = ko.observable(origOrDefault('xPlaceholder',""));
         self.yFunction = ko.observable(origOrDefault('yFunction',""));
         self.yPlaceholder = ko.observable(origOrDefault('yPlaceholder',""));
+
+        var seriesValidationError = gettext(
+            "It is recommended that you leave this value blank. Future changes to your report's "
+            + "chart configuration will not be reflected here."
+        );
+        self.validateDataPath = ko.computed(function() {
+            if (!self.dataPathPlaceholder() || !self.dataPath()) {
+                return;
+            }
+            self.showDataPath(true);
+            return seriesValidationError;
+        });
+        self.validateX = ko.computed(function() {
+            if (!self.xPlaceholder() || !self.xFunction()) {
+                return;
+            }
+            return seriesValidationError;
+        });
+        self.validateY = ko.computed(function() {
+            if (!self.yPlaceholder() || !self.yFunction()) {
+                return;
+            }
+            return seriesValidationError;
+        });
         self.xLabel = "X";
         self.yLabel = "Y";
         self.configPropertyOptions = [

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -4,7 +4,7 @@ hqDefine('app_manager/js/report-module.js', function () {
     //       also defined corehq.apps.userreports.reports.filters.CHOICE_DELIMITER
     var select2Separator = "\u001F";
 
-    function GraphConfig(report_id, reportId, availableReportIds, reportCharts, graph_configs, changeSaveButton) {
+    function GraphConfig(report_id, reportId, availableReportIds, reportCharts, graph_configs, lang, langs, changeSaveButton) {
         var self = this;
 
         graph_configs = graph_configs || {};
@@ -20,9 +20,9 @@ hqDefine('app_manager/js/report-module.js', function () {
                 var graph_el = new GraphConfigurationUiElement({
                     childCaseTypes: [],
                     fixtures: [],
-                    lang: 'en',
-                    langs: ['en'],
-                    name: 'some graph', // TODO (langs on the above two lines, too)
+                    lang: lang,
+                    langs: langs,
+                    name: 'some graph', // TODO
                 }, graph_config);
                 self.graphUiElements[currentReportId][currentChart.chart_id] = graph_el;
 
@@ -167,7 +167,7 @@ hqDefine('app_manager/js/report-module.js', function () {
                           showDataTable, uuid, availableReportIds,
                           reportCharts, graph_configs,
                           filterValues, reportFilters,
-                          language, changeSaveButton) {
+                          language, languages, changeSaveButton) {
         var self = this;
         this.lang = language;
         this.fullDisplay = display || {};
@@ -189,7 +189,8 @@ hqDefine('app_manager/js/report-module.js', function () {
         this.useXpathDescription.subscribe(changeSaveButton);
         this.showDataTable.subscribe(changeSaveButton);
 
-        this.graphConfig = new GraphConfig(report_id, this.reportId, availableReportIds, reportCharts, graph_configs, changeSaveButton);
+        this.graphConfig = new GraphConfig(report_id, this.reportId, availableReportIds, reportCharts,
+                                           graph_configs, this.lang, languages, changeSaveButton);
         this.filterConfig = new FilterConfig(report_id, this.reportId, filterValues, reportFilters, changeSaveButton);
 
         this.toJSON = function () {
@@ -225,6 +226,7 @@ hqDefine('app_manager/js/report-module.js', function () {
         var availableReports = options.availableReports || [];
         var saveURL = options.saveURL;
         self.staticFilterData = options.staticFilterData;
+        self.languages = options.languages;
         self.lang = options.lang;
         self.moduleName = options.moduleName;
         self.moduleFilter = options.moduleFilter === "None" ? "" : options.moduleFilter;
@@ -318,6 +320,7 @@ hqDefine('app_manager/js/report-module.js', function () {
                 options.filters,
                 self.reportFilters,
                 self.lang,
+                self.languages,
                 self.changeSaveButton
             );
             report.reportId.subscribe(function (reportId) {

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -18,18 +18,12 @@ hqDefine('app_manager/js/report-module.js', function () {
                 var currentChart = reportCharts[currentReportId][j];
                 var graph_config = graph_configs[currentChart.chart_id] || {
                     graph_type: 'bar',
-                    series: _.map(currentChart.y_axis_columns, function(c) {
-                        return {
-                            data_path: "instance('reports')/reports/report[@id='<UUID>']/rows/row[@is_total_row='False']",
-                            x_function: "column[@id='" + currentChart.x_axis_column + "']",
-                            y_function: "column[@id='" + c.column_id + "']",
-                        };
-                    }),
+                    series: _.map(currentChart.y_axis_columns, function(c) { return {}; }),
                 };
 
                 // Add series placeholders
                 _.each(currentChart.y_axis_columns, function(column, index) {
-                    uuid = uuid || "<UUID>";
+                    uuid = uuid || "#UUID";
                     if (graph_config.series[index]) {
                         _.extend(graph_config.series[index], {
                             data_path_placeholder: "instance('reports')/reports/report[@id='" + uuid + "']/rows/row[@is_total_row='False']",

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -444,5 +444,11 @@ ko.bindingHandlers.editGraph = {
             name: 'some graph', // TODO (langs on the above two lines, too)
         }, valueAccessor());
         $(element).find(".guts").replaceWith(graph_el.ui);
+
+        // TODO: fire save button on change
+        graph_el.on("change", function() {
+            console.log("do something");
+            // self.saveButton.fire('change');
+        });
     },
 };

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -4,7 +4,7 @@ hqDefine('app_manager/js/report-module.js', function () {
     //       also defined corehq.apps.userreports.reports.filters.CHOICE_DELIMITER
     var select2Separator = "\u001F";
 
-    function GraphConfig(reportId, reportName, availableReportIds, reportCharts, graph_configs, lang, langs, changeSaveButton) {
+    function GraphConfig(reportId, uuid, reportName, availableReportIds, reportCharts, graph_configs, lang, langs, changeSaveButton) {
         var self = this;
 
         graph_configs = graph_configs || {};
@@ -21,14 +21,24 @@ hqDefine('app_manager/js/report-module.js', function () {
                     series: _.map(currentChart.y_axis_columns, function(c) {
                         return {
                             data_path: "instance('reports')/reports/report[@id='<UUID>']/rows/row[@is_total_row='False']",
-                            data_path_placeholder: "instance('reports')/reports/report[@id='<UUID>']/rows/row[@is_total_row='False']",
                             x_function: "column[@id='" + currentChart.x_axis_column + "']",
-                            x_placeholder: "column[@id='" + currentChart.x_axis_column + "']",
                             y_function: "column[@id='" + c.column_id + "']",
-                            y_placeholder: "column[@id='" + c.column_id + "']",
                         };
                     }),
                 };
+
+                // Add series placeholders
+                _.each(currentChart.y_axis_columns, function(column, index) {
+                    uuid = uuid || "<UUID>";
+                    if (graph_config.series[index]) {
+                        _.extend(graph_config.series[index], {
+                            data_path_placeholder: "instance('reports')/reports/report[@id='" + uuid + "']/rows/row[@is_total_row='False']",
+                            x_placeholder: "column[@id='" + currentChart.x_axis_column + "']",
+                            y_placeholder: "column[@id='" + column.column_id + "']",
+                        });
+                    }
+                });
+
                 var graph_el = new GraphConfigurationUiElement({
                     childCaseTypes: [],
                     fixtures: [],
@@ -210,7 +220,7 @@ hqDefine('app_manager/js/report-module.js', function () {
         this.useXpathDescription.subscribe(changeSaveButton);
         this.showDataTable.subscribe(changeSaveButton);
 
-        self.graphConfig = new GraphConfig(this.reportId, this.display(), availableReportIds, reportCharts,
+        self.graphConfig = new GraphConfig(this.reportId, this.uuid, this.display(), availableReportIds, reportCharts,
                                            graph_configs, this.lang, languages, changeSaveButton);
         this.display.subscribe(function(newValue) {
             self.graphConfig.name(newValue);

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -175,7 +175,7 @@ hqDefine('app_manager/js/report-module.js', function () {
                 });
 
                 if(filter.choices !== undefined && filter.show_all) {
-                    filter.choices.unshift({value: "_all", display: "Show All"}); // TODO: translate
+                    filter.choices.unshift({value: "_all", display: gettext("Show All")});
                 }
             }
         });

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -67,7 +67,7 @@ hqDefine('app_manager/js/report-module.js', function () {
         });
 
         this.getCurrentGraphUiElement = function(chart_id) {
-            return self.currentGraphUiElements()[chart_id]; // TODO: what if it doesn't exist? what's the empty case?
+            return self.currentGraphUiElements()[chart_id];
         };
 
         this.toJSON = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -4,7 +4,7 @@ hqDefine('app_manager/js/report-module.js', function () {
     //       also defined corehq.apps.userreports.reports.filters.CHOICE_DELIMITER
     var select2Separator = "\u001F";
 
-    function GraphConfig(report_id, reportId, availableReportIds, reportCharts, graph_configs, lang, langs, changeSaveButton) {
+    function GraphConfig(reportId, reportName, availableReportIds, reportCharts, graph_configs, lang, langs, changeSaveButton) {
         var self = this;
 
         graph_configs = graph_configs || {};
@@ -22,8 +22,8 @@ hqDefine('app_manager/js/report-module.js', function () {
                     fixtures: [],
                     lang: lang,
                     langs: langs,
-                    name: 'some graph', // TODO
                 }, graph_config);
+                graph_el.setName(reportName);
                 self.graphUiElements[currentReportId][currentChart.chart_id] = graph_el;
 
                 graph_el.on("change", function() {
@@ -31,6 +31,15 @@ hqDefine('app_manager/js/report-module.js', function () {
                 });
             }
         }
+
+        this.name = ko.observable(reportName);
+        this.name.subscribe(function(newValue) {
+            _.each(self.graphUiElements, function(reportGraphElements) {
+                _.each(reportGraphElements, function(uiElement) {
+                    uiElement.setName(newValue);
+                });
+            });
+        });
 
         this.currentGraphUiElements = ko.computed(function() {
             return self.graphUiElements[reportId()];
@@ -189,8 +198,11 @@ hqDefine('app_manager/js/report-module.js', function () {
         this.useXpathDescription.subscribe(changeSaveButton);
         this.showDataTable.subscribe(changeSaveButton);
 
-        this.graphConfig = new GraphConfig(report_id, this.reportId, availableReportIds, reportCharts,
+        self.graphConfig = new GraphConfig(this.reportId, this.display(), availableReportIds, reportCharts,
                                            graph_configs, this.lang, languages, changeSaveButton);
+        this.display.subscribe(function(newValue) {
+            self.graphConfig.name(newValue);
+        });
         this.filterConfig = new FilterConfig(report_id, this.reportId, filterValues, reportFilters, changeSaveButton);
 
         this.toJSON = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -21,8 +21,11 @@ hqDefine('app_manager/js/report-module.js', function () {
                     series: _.map(currentChart.y_axis_columns, function(c) {
                         return {
                             data_path: "instance('reports')/reports/report[@id='<UUID>']/rows/row[@is_total_row='False']",
+                            data_path_placeholder: "instance('reports')/reports/report[@id='<UUID>']/rows/row[@is_total_row='False']",
                             x_function: "column[@id='" + currentChart.x_axis_column + "']",
+                            x_placeholder: "column[@id='" + currentChart.x_axis_column + "']",
                             y_function: "column[@id='" + c.column_id + "']",
+                            y_placeholder: "column[@id='" + c.column_id + "']",
                         };
                     }),
                 };

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -33,6 +33,8 @@ hqDefine('app_manager/js/report-module.js', function () {
 
     function GraphConfig(report_id, reportId, availableReportIds, reportCharts, graph_configs, changeSaveButton) {
         var self = this;
+        self.completeGraphConfigs = graph_configs;
+        // TODO: is the rest of this function still needed?
 
         graph_configs = graph_configs || {};
 
@@ -72,8 +74,13 @@ hqDefine('app_manager/js/report-module.js', function () {
             return reportCharts[reportId()];
         });
 
+        // TODO: delete? this and maybe other code?
         this.getCurrentGraphConfig = function(chart_id) {
             return self.currentGraphConfigs()[chart_id] || {config: {keyValuePairs: []}};
+        };
+
+        this.getCompleteGraphConfig = function(chart_id) {
+            return self.completeGraphConfigs[chart_id]; // TODO: what if it doesn't exist? what's the empty case?
         };
 
         this.toJSON = function () {
@@ -384,7 +391,7 @@ hqDefine('app_manager/js/report-module.js', function () {
                 options.uuid,
                 self.availableReportIds,
                 self.reportCharts,
-                options.graph_configs,
+                options.complete_graph_configs,
                 options.filters,
                 self.reportFilters,
                 self.lang,
@@ -425,3 +432,17 @@ hqDefine('app_manager/js/report-module.js', function () {
         select2Separator: select2Separator
     };
 });
+
+ko.bindingHandlers.editGraph = {
+    init: function (element, valueAccessor) {
+        var GraphConfigurationUiElement = hqImport('app_manager/js/graph-config.js').GraphConfigurationUiElement;
+        var graph_el = new GraphConfigurationUiElement({
+            childCaseTypes: [],
+            fixtures: [],
+            lang: 'en',
+            langs: ['en'],
+            name: 'some graph', // TODO (langs on the above two lines, too)
+        }, valueAccessor());
+        $(element).find(".guts").replaceWith(graph_el.ui);
+    },
+};

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -431,6 +431,6 @@ hqDefine('app_manager/js/report-module.js', function () {
 
 ko.bindingHandlers.editGraph = {
     init: function (element, valueAccessor) {
-        $(element).find(".guts").replaceWith(valueAccessor().ui);
+        $(element).find(":first").replaceWith(valueAccessor().ui);
     },
 };

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -54,6 +54,10 @@ hqDefine('app_manager/js/report-module.js', function () {
                     name: 'some graph', // TODO (langs on the above two lines, too)
                 }, graph_config);
                 self.graphConfigUiElements[currentReportId][currentChart.chart_id] = graph_el;
+
+                graph_el.on("change", function() {
+                    changeSaveButton();
+                });
             }
         }
 
@@ -428,11 +432,5 @@ hqDefine('app_manager/js/report-module.js', function () {
 ko.bindingHandlers.editGraph = {
     init: function (element, valueAccessor) {
         $(element).find(".guts").replaceWith(valueAccessor().ui);
-
-        // TODO: fire save button on change
-        /*graph_el.on("change", function() {
-            console.log("do something");
-            // self.saveButton.fire('change');
-        });*/
     },
 };

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -16,7 +16,16 @@ hqDefine('app_manager/js/report-module.js', function () {
             self.graphUiElements[currentReportId] = {};
             for (var j = 0; j < reportCharts[currentReportId].length; j++) {
                 var currentChart = reportCharts[currentReportId][j];
-                var graph_config = graph_configs[currentChart.chart_id] || {};
+                var graph_config = graph_configs[currentChart.chart_id] || {
+                    graph_type: 'bar',
+                    series: _.map(currentChart.y_axis_columns, function(c) {
+                        return {
+                            data_path: "instance('reports')/reports/report[@id='<UUID>']/rows/row[@is_total_row='False']",
+                            x_function: "column[@id='" + currentChart.x_axis_column + "']",
+                            y_function: "column[@id='" + c.column_id + "']",
+                        };
+                    }),
+                };
                 var graph_el = new GraphConfigurationUiElement({
                     childCaseTypes: [],
                     fixtures: [],

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -115,7 +115,7 @@ def _get_summary_details(config, domain):
             if isinstance(chart_config, MultibarChartSpec):
                 all_graph_configs = config.complete_graph_configs
                 if not len(all_graph_configs) and len(config.graph_configs):
-                    all_graph_configs = config.migrate_graph_configs(config, domain)
+                    all_graph_configs = config.migrate_graph_configs(domain)
                     # TODO: save module, now that it's migrated?
                 graph_config = all_graph_configs.get(chart_config.chart_id, GraphConfiguration())
 

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -111,7 +111,11 @@ def _get_summary_details(config, domain):
         from corehq.apps.app_manager.models import GraphConfiguration
         for chart_config in config.report(domain).charts:
             if isinstance(chart_config, MultibarChartSpec):
-                graph_config = config.complete_graph_configs(config, domain).get(chart_config.chart_id, GraphConfiguration())
+                all_graph_configs = config.complete_graph_configs
+                if not len(all_graph_configs) and len(config.graph_configs):
+                    all_graph_configs = config.migrate_graph_configs(config, domain)
+                    # TODO: save module, now that it's migrated?
+                graph_config = all_graph_configs.get(chart_config.chart_id, GraphConfiguration())
 
                 # GraphSeries => xml_models.Series 
                 def _series_to_series(series):

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -33,9 +33,9 @@ class ReportModuleSuiteHelper(object):
     def get_details(self):
         _load_reports(self.report_module)
         for config in self.report_module.report_configs:
-            for filter_slug, f in _MobileSelectFilterHelpers.get_filters(config, self.domain):
-                yield (_MobileSelectFilterHelpers.get_select_detail_id(config, filter_slug),
-                       _MobileSelectFilterHelpers.get_select_details(config, filter_slug, self.domain), True)
+            for filter_slug, f in MobileSelectFilterHelpers.get_filters(config, self.domain):
+                yield (MobileSelectFilterHelpers.get_select_detail_id(config, filter_slug),
+                       MobileSelectFilterHelpers.get_select_details(config, filter_slug, self.domain), True)
             yield (_get_select_detail_id(config), _get_select_details(config), True)
             yield (_get_summary_detail_id(config), _get_summary_details(config, self.domain), True)
 
@@ -55,12 +55,12 @@ def _get_config_entry(config, domain):
         ),
         datums=[
             SessionDatum(
-                detail_select=_MobileSelectFilterHelpers.get_select_detail_id(config, filter_slug),
-                id=_MobileSelectFilterHelpers.get_datum_id(config, filter_slug),
-                nodeset=_MobileSelectFilterHelpers.get_options_nodeset(config, filter_slug),
+                detail_select=MobileSelectFilterHelpers.get_select_detail_id(config, filter_slug),
+                id=MobileSelectFilterHelpers.get_datum_id(config, filter_slug),
+                nodeset=MobileSelectFilterHelpers.get_options_nodeset(config, filter_slug),
                 value='./@value',
             )
-            for filter_slug, f in _MobileSelectFilterHelpers.get_filters(config, domain)
+            for filter_slug, f in MobileSelectFilterHelpers.get_filters(config, domain)
         ] + [
             SessionDatum(
                 detail_confirm=_get_summary_detail_id(config),
@@ -281,7 +281,7 @@ def _get_data_detail(config, domain):
 
     return Detail(
         id='reports.{}.data'.format(config.uuid),
-        nodeset='rows/row{}'.format(_MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)),
+        nodeset='rows/row{}'.format(MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)),
         title=Text(
             locale=Locale(id=id_strings.report_data_table()),
         ),
@@ -289,7 +289,7 @@ def _get_data_detail(config, domain):
     )
 
 
-class _MobileSelectFilterHelpers(object):
+class MobileSelectFilterHelpers(object):
 
     @staticmethod
     def get_options_nodeset(config, filter_slug):
@@ -316,7 +316,7 @@ class _MobileSelectFilterHelpers(object):
     @staticmethod
     def get_select_details(config, filter_slug, domain):
         detail = Detail(
-            id=_MobileSelectFilterHelpers.get_select_detail_id(config, filter_slug),
+            id=MobileSelectFilterHelpers.get_select_detail_id(config, filter_slug),
             title=Text(config.report(domain).get_ui_filter(filter_slug).label),
             fields=[
                 Field(
@@ -336,8 +336,8 @@ class _MobileSelectFilterHelpers(object):
         return ''.join([
             "[column[@id='{column_id}']=instance('commcaresession')/session/data/{datum_id}]".format(
                 column_id=config.report(domain).get_ui_filter(slug).field,
-                datum_id=_MobileSelectFilterHelpers.get_datum_id(config, slug))
-            for slug, f in _MobileSelectFilterHelpers.get_filters(config, domain)])
+                datum_id=MobileSelectFilterHelpers.get_datum_id(config, slug))
+            for slug, f in MobileSelectFilterHelpers.get_filters(config, domain)])
 
 
 def is_valid_mobile_select_filter_type(ui_filter):

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -10,6 +10,10 @@ from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.util.quickcache import quickcache
 
 
+COLUMN_XPATH_TEMPLATE = "column[@id='{}']"
+COLUMN_XPATH_CLIENT_TEMPLATE = "column[@id='<%= id %>']"
+
+
 @quickcache(['report_module.unique_id'])
 def _load_reports(report_module):
     if not report_module._loaded:
@@ -148,11 +152,11 @@ def _get_summary_details(config, domain, module):
                     )
                     graph_config.series[index].x_function = (
                         graph_config.series[index].x_function
-                        or "column[@id='{}']".format(chart_config.x_axis_column)
+                        or COLUMN_XPATH_TEMPLATE.format(chart_config.x_axis_column)
                     )
                     graph_config.series[index].y_function = (
                         graph_config.series[index].y_function
-                        or "column[@id='{}']".format(column.column_id)
+                        or COLUMN_XPATH_TEMPLATE.format(column.column_id)
                     )
                 yield Field(
                     header=Header(text=Text()),

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -107,6 +107,8 @@ def _get_select_details(config):
 
 def _get_summary_details(config, domain):
     def _get_graph_fields():
+        # TODO: this doesn't write annotations or locale-specific config.
+        # Share code with case detail graph suite generation?
         from corehq.apps.userreports.reports.specs import MultibarChartSpec
         from corehq.apps.app_manager.models import GraphConfiguration
         for chart_config in config.report(domain).charts:

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -138,6 +138,22 @@ def _get_summary_details(config, domain, module):
             if isinstance(chart_config, MultibarChartSpec):
                 config.migrate_graph_configs(domain)
                 graph_config = config.complete_graph_configs.get(chart_config.chart_id, GraphConfiguration())
+                for index, column in enumerate(chart_config.y_axis_columns):
+                    graph_config.series[index].data_path = graph_config.series[index].data_path or (
+                        "instance('reports')/reports/report[@id='{}']/rows/row[@is_total_row='False']{}"
+                        .format(
+                            config.uuid,
+                            MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)
+                        )
+                    )
+                    graph_config.series[index].x_function = (
+                        graph_config.series[index].x_function
+                        or "column[@id='{}']".format(chart_config.x_axis_column)
+                    )
+                    graph_config.series[index].y_function = (
+                        graph_config.series[index].y_function
+                        or "column[@id='{}']".format(column.column_id)
+                    )
                 yield Field(
                     header=Header(text=Text()),
                     template=GraphTemplate.build('graph', graph_config,

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -113,11 +113,9 @@ def _get_summary_details(config, domain):
         from corehq.apps.app_manager.models import GraphConfiguration
         for chart_config in config.report(domain).charts:
             if isinstance(chart_config, MultibarChartSpec):
-                all_graph_configs = config.complete_graph_configs
-                if not len(all_graph_configs) and len(config.graph_configs):
-                    all_graph_configs = config.migrate_graph_configs(domain)
-                    # TODO: save module, now that it's migrated?
-                graph_config = all_graph_configs.get(chart_config.chart_id, GraphConfiguration())
+                config.migrate_graph_configs(domain)
+                graph_config = config.complete_graph_configs.get(chart_config.chart_id,
+                                                                 GraphConfiguration())
 
                 # GraphSeries => xml_models.Series 
                 def _series_to_series(series):

--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
@@ -5,6 +5,7 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
+    <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
     <script src="{% static 'app_manager/js/report-module.js' %}"></script>
     <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>
     {% include "app_manager/v1/partials/xpathValidator.html" %}
@@ -20,6 +21,8 @@
 
 {% block modals %}{{ block.super }}
 {% include "app_manager/v1/partials/nav_menu_media_modals.html" %}
+{% include 'style/partials/key_value_mapping.html' %}
+{% include 'app_manager/v1/partials/graph_configuration_modal.html' %}
 {% endblock modals %}
 
 {% block breadcrumbs %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <div data-bind="foreach: { data: graphConfig.currentCharts, as: 'chart' }">
-    <div data-bind="editGraph: report.graphConfig.getCompleteGraphConfig(chart.chart_id)">
+    <div data-bind="editGraph: report.graphConfig.getCurrentGraphConfigurationUiElement(chart.chart_id)">
         <!-- ko stopBinding: true -->
             <div class="guts"></div>
         <!-- /ko -->

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
@@ -1,5 +1,5 @@
 <div data-bind="foreach: { data: graphConfig.currentCharts, as: 'chart' }">
-    <div data-bind="editGraph: report.graphConfig.getCurrentGraphConfigurationUiElement(chart.chart_id)">
+    <div data-bind="editGraph: report.graphConfig.getCurrentGraphUiElement(chart.chart_id)">
         <!--
             graph-config.js will take care of replacing the inner div
             with the graphing ui and applying bindings to it

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
@@ -1,9 +1,11 @@
-{% load i18n %}
-
 <div data-bind="foreach: { data: graphConfig.currentCharts, as: 'chart' }">
     <div data-bind="editGraph: report.graphConfig.getCurrentGraphConfigurationUiElement(chart.chart_id)">
+        <!--
+            graph-config.js will take care of replacing the inner div
+            with the graphing ui and applying bindings to it
+        -->
         <!-- ko stopBinding: true -->
-            <div class="guts"></div>
+            <div></div>
         <!-- /ko -->
     </div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configs.html
@@ -1,72 +1,9 @@
 {% load i18n %}
 
 <div data-bind="foreach: { data: graphConfig.currentCharts, as: 'chart' }">
-
-    <h4>
-        {% trans 'Chart' %}: <span data-bind="text: chart.title"></span>
-    </h4>
-
-    <div class="form-inline">
-        <div class="form-group">
-            <label>{% trans 'Chart type' %}</label>
-            <select type="text" class="form-control" data-bind="
-                options: report.graphConfig.allGraphTypes,
-                value: report.graphConfig.getCurrentGraphConfig(chart.chart_id).graph_type
-            "></select>
-        </div>
+    <div data-bind="editGraph: report.graphConfig.getCompleteGraphConfig(chart.chart_id)">
+        <!-- ko stopBinding: true -->
+            <div class="guts"></div>
+        <!-- /ko -->
     </div>
-
-    <fieldset>
-        <h4>{% trans 'Chart Configuration' %}</h4>
-        <div data-bind="foreach: { data: report.graphConfig.getCurrentGraphConfig(chart.chart_id).config.keyValuePairs, as: 'keyValuePair' }">
-            <div class="form-group row">
-                <div class="col-sm-5">
-                    <input class="form-control" type="text" data-bind="value: keyValuePair.key" />
-                </div>
-                <div class="col-sm-1">
-                    <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-sm-5">
-                    <input class="form-control" type="text" data-bind="value: keyValuePair.value" />
-                </div>
-                <div class="col-sm-1">
-                    <i class="fa fa-remove icon-blue" style="cursor: pointer;" data-bind="click: keyValuePair.remove"></i>
-                </div>
-            </div>
-        </div>
-        <button class="btn btn-default" data-bind="click: report.graphConfig.getCurrentGraphConfig(chart.chart_id).config.addConfig">
-            <i class="fa fa-plus"></i>
-            {% trans "Add Configuration Item" %}
-        </button>
-    </fieldset>
-
-    <div data-bind="foreach: { data: report.graphConfig.getCurrentGraphConfig(chart.chart_id).chart_series, as: 'series' }">
-        <fieldset>
-            <h4>
-                {% trans 'Series Configuration' %}:
-                <span data-bind="text: series"></span>
-            </h4>
-            <div data-bind="foreach: { data: report.graphConfig.getCurrentGraphConfig(chart.chart_id).series_configs[series].keyValuePairs, as: 'keyValuePair' }">
-                <div class="form-group row">
-                    <div class="col-sm-5">
-                        <input class="form-control" type="text" data-bind="value: keyValuePair.key">
-                    </div>
-                    <div class="col-sm-1">
-                        <i class="fa fa-arrow-right"></i>
-                    </div>
-                    <div class="col-sm-5">
-                        <input class="form-control" type="text" data-bind="value: keyValuePair.value">
-                    </div>
-                    <div class="col-sm-1">
-                        <i class="fa fa-remove icon-blue" style="cursor: pointer;" data-bind="click: keyValuePair.remove"></i>
-                    </div>
-                </div>
-            </div>
-            <button class="btn btn-default" data-bind="click: report.graphConfig.getCurrentGraphConfig(chart.chart_id).series_configs[series].addConfig">
-                <i class="fa fa-plus"></i>
-                {% trans "Add Series Configuration Item" %}
-            </button>
-        </fieldset>
-    </div>
-    <div data-bind="event: {onload: report.graphConfig.addSubscribersToSaveButton()}"></div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configuration_modal.html
@@ -58,19 +58,22 @@
                                         <div class="form-group" data-bind="visible: showDataPath">
                                             <label class="col-sm-2 control-label">{% trans "Path" %}</label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control" data-bind="value: dataPath" />
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
                                             </div>
                                         </div>
                                         <div class="form-group">
                                             <label class="col-sm-2 control-label" data-bind="text: xLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control" data-bind="value: xFunction" />
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
                                             </div>
                                         </div>
                                         <div class="form-group">
                                             <label class="col-sm-2 control-label" data-bind="text: yLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control" data-bind="value: yFunction" />
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
                                             </div>
                                         </div>
                                         <!-- ko if: 'radiusFunction' in $data -->

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configuration_modal.html
@@ -55,25 +55,31 @@
                                                     "></a>
                                             </div>
                                         </div>
-                                        <div class="form-group" data-bind="visible: showDataPath">
+                                        <div class="form-group"
+                                             data-bind="visible: showDataPath, css: {'has-warning': validateDataPath()}">
                                             <label class="col-sm-2 control-label">{% trans "Path" %}</label>
                                             <div class="col-sm-4">
                                                 <input type="text" class="form-control"
                                                        data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
+                                                <span class="help-block" data-bind="text: validateDataPath"></span>
                                             </div>
                                         </div>
-                                        <div class="form-group">
+                                        <div class="form-group"
+                                             data-bind="css: {'has-warning': validateX()}">
                                             <label class="col-sm-2 control-label" data-bind="text: xLabel"></label>
                                             <div class="col-sm-4">
                                                 <input type="text" class="form-control"
                                                        data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
+                                                <span class="help-block" data-bind="text: validateX"></span>
                                             </div>
                                         </div>
-                                        <div class="form-group">
+                                        <div class="form-group"
+                                             data-bind="css: {'has-warning': validateY()}">
                                             <label class="col-sm-2 control-label" data-bind="text: yLabel"></label>
                                             <div class="col-sm-4">
                                                 <input type="text" class="form-control"
                                                        data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
+                                                <span class="help-block" data-bind="text: validateY"></span>
                                             </div>
                                         </div>
                                         <!-- ko if: 'radiusFunction' in $data -->

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/report_configs_js.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/report_configs_js.html
@@ -29,6 +29,7 @@
             currentReports: {{ current_reports|JSON }}, // config data for app reports
             saveURL: saveURL,
             lang: {{ lang|JSON }},
+            languages: {{ app.langs|JSON }},
             menuImage: navMenuMedia.menuImage,
             menuAudio: navMenuMedia.menuAudio,
             containerId: "#settings"

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/report_configs_js.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/report_configs_js.html
@@ -27,6 +27,7 @@
             moduleFilter: "{{ module.module_filter|escapejs }}",
             availableReports: {{ all_reports|JSON }}, // structure for all reports
             currentReports: {{ current_reports|JSON }}, // config data for app reports
+            columnXpathTemplate: "{{ column_xpath_template|escapejs }}",
             saveURL: saveURL,
             lang: {{ lang|JSON }},
             languages: {{ app.langs|JSON }},

--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
@@ -5,6 +5,7 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
+    <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
     <script src="{% static 'app_manager/js/report-module.js' %}"></script>
     <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>
     {% include "app_manager/v2/partials/xpathValidator.html" %}
@@ -20,6 +21,8 @@
 
 {% block modals %}{{ block.super }}
 {% include "app_manager/v2/partials/nav_menu_media_modals.html" %}
+{% include 'style/partials/key_value_mapping.html' %}
+{% include 'app_manager/v2/partials/graph_configuration_modal.html' %}
 {% endblock modals %}
 
 {% block breadcrumbs %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configs.html
@@ -1,72 +1,11 @@
-{% load i18n %}
-
 <div data-bind="foreach: { data: graphConfig.currentCharts, as: 'chart' }">
-
-    <h4>
-        {% trans 'Chart' %}: <span data-bind="text: chart.title"></span>
-    </h4>
-
-    <div class="form-inline">
-        <div class="form-group">
-            <label>{% trans 'Chart type' %}</label>
-            <select type="text" class="form-control" data-bind="
-                options: report.graphConfig.allGraphTypes,
-                value: report.graphConfig.getCurrentGraphConfig(chart.chart_id).graph_type
-            "></select>
-        </div>
+    <div data-bind="editGraph: report.graphConfig.getCurrentGraphConfigurationUiElement(chart.chart_id)">
+        <!--
+            graph-config.js will take care of replacing the inner div
+            with the graphing ui and applying bindings to it
+        -->
+        <!-- ko stopBinding: true -->
+            <div></div>
+        <!-- /ko -->
     </div>
-
-    <fieldset>
-        <h4>{% trans 'Chart Configuration' %}</h4>
-        <div data-bind="foreach: { data: report.graphConfig.getCurrentGraphConfig(chart.chart_id).config.keyValuePairs, as: 'keyValuePair' }">
-            <div class="form-group row">
-                <div class="col-sm-5">
-                    <input class="form-control" type="text" data-bind="value: keyValuePair.key" />
-                </div>
-                <div class="col-sm-1">
-                    <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-sm-5">
-                    <input class="form-control" type="text" data-bind="value: keyValuePair.value" />
-                </div>
-                <div class="col-sm-1">
-                    <i class="fa fa-remove icon-blue" style="cursor: pointer;" data-bind="click: keyValuePair.remove"></i>
-                </div>
-            </div>
-        </div>
-        <button class="btn btn-default" data-bind="click: report.graphConfig.getCurrentGraphConfig(chart.chart_id).config.addConfig">
-            <i class="fa fa-plus"></i>
-            {% trans "Add Configuration Item" %}
-        </button>
-    </fieldset>
-
-    <div data-bind="foreach: { data: report.graphConfig.getCurrentGraphConfig(chart.chart_id).chart_series, as: 'series' }">
-        <fieldset>
-            <h4>
-                {% trans 'Series Configuration' %}:
-                <span data-bind="text: series"></span>
-            </h4>
-            <div data-bind="foreach: { data: report.graphConfig.getCurrentGraphConfig(chart.chart_id).series_configs[series].keyValuePairs, as: 'keyValuePair' }">
-                <div class="form-group row">
-                    <div class="col-sm-5">
-                        <input class="form-control" type="text" data-bind="value: keyValuePair.key">
-                    </div>
-                    <div class="col-sm-1">
-                        <i class="fa fa-arrow-right"></i>
-                    </div>
-                    <div class="col-sm-5">
-                        <input class="form-control" type="text" data-bind="value: keyValuePair.value">
-                    </div>
-                    <div class="col-sm-1">
-                        <i class="fa fa-remove icon-blue" style="cursor: pointer;" data-bind="click: keyValuePair.remove"></i>
-                    </div>
-                </div>
-            </div>
-            <button class="btn btn-default" data-bind="click: report.graphConfig.getCurrentGraphConfig(chart.chart_id).series_configs[series].addConfig">
-                <i class="fa fa-plus"></i>
-                {% trans "Add Series Configuration Item" %}
-            </button>
-        </fieldset>
-    </div>
-    <div data-bind="event: {onload: report.graphConfig.addSubscribersToSaveButton()}"></div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configs.html
@@ -1,5 +1,5 @@
 <div data-bind="foreach: { data: graphConfig.currentCharts, as: 'chart' }">
-    <div data-bind="editGraph: report.graphConfig.getCurrentGraphConfigurationUiElement(chart.chart_id)">
+    <div data-bind="editGraph: report.graphConfig.getCurrentGraphUiElement(chart.chart_id)">
         <!--
             graph-config.js will take care of replacing the inner div
             with the graphing ui and applying bindings to it

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configuration_modal.html
@@ -58,19 +58,22 @@
                                         <div class="form-group" data-bind="visible: showDataPath">
                                             <label class="col-sm-2 control-label">{% trans "Path" %}</label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control" data-bind="value: dataPath" />
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
                                             </div>
                                         </div>
                                         <div class="form-group">
                                             <label class="col-sm-2 control-label" data-bind="text: xLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control" data-bind="value: xFunction" />
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
                                             </div>
                                         </div>
                                         <div class="form-group">
                                             <label class="col-sm-2 control-label" data-bind="text: yLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control" data-bind="value: yFunction" />
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
                                             </div>
                                         </div>
                                         <!-- ko if: 'radiusFunction' in $data -->

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configuration_modal.html
@@ -55,25 +55,31 @@
                                                     "></a>
                                             </div>
                                         </div>
-                                        <div class="form-group" data-bind="visible: showDataPath">
+                                        <div class="form-group"
+                                             data-bind="visible: showDataPath, css: {'has-warning': validateDataPath()}">
                                             <label class="col-sm-2 control-label">{% trans "Path" %}</label>
                                             <div class="col-sm-4">
                                                 <input type="text" class="form-control"
                                                        data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
+                                                <span class="help-block" data-bind="text: validateDataPath"></span>
                                             </div>
                                         </div>
-                                        <div class="form-group">
+                                        <div class="form-group"
+                                             data-bind="css: {'has-warning': validateX()}">
                                             <label class="col-sm-2 control-label" data-bind="text: xLabel"></label>
                                             <div class="col-sm-4">
                                                 <input type="text" class="form-control"
                                                        data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
+                                                <span class="help-block" data-bind="text: validateX"></span>
                                             </div>
                                         </div>
-                                        <div class="form-group">
+                                        <div class="form-group"
+                                             data-bind="css: {'has-warning': validateY()}">
                                             <label class="col-sm-2 control-label" data-bind="text: yLabel"></label>
                                             <div class="col-sm-4">
                                                 <input type="text" class="form-control"
                                                        data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
+                                                <span class="help-block" data-bind="text: validateY"></span>
                                             </div>
                                         </div>
                                         <!-- ko if: 'radiusFunction' in $data -->

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/report_configs_js.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/report_configs_js.html
@@ -29,6 +29,7 @@
             currentReports: {{ current_reports|JSON }}, // config data for app reports
             saveURL: saveURL,
             lang: {{ lang|JSON }},
+            languages: {{ app.langs|JSON }},
             menuImage: navMenuMedia.menuImage,
             menuAudio: navMenuMedia.menuAudio,
             containerId: "#settings"

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/report_configs_js.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/report_configs_js.html
@@ -27,6 +27,7 @@
             moduleFilter: "{{ module.module_filter|escapejs }}",
             availableReports: {{ all_reports|JSON }}, // structure for all reports
             currentReports: {{ current_reports|JSON }}, // config data for app reports
+            columnXpathTemplate: "{{ column_xpath_template|escapejs }}",
             saveURL: saveURL,
             lang: {{ lang|JSON }},
             languages: {{ app.langs|JSON }},

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
@@ -6,8 +6,8 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load reports_core_tags %}
-@@ -7,22 +7,22 @@
- {% block js %}{{ block.super }}
+@@ -8,24 +8,24 @@
+     <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
      <script src="{% static 'app_manager/js/report-module.js' %}"></script>
      <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>
 -    {% include "app_manager/v1/partials/xpathValidator.html" %}
@@ -28,6 +28,9 @@
  {% block modals %}{{ block.super }}
 -{% include "app_manager/v1/partials/nav_menu_media_modals.html" %}
 +{% include "app_manager/v2/partials/nav_menu_media_modals.html" %}
+ {% include 'style/partials/key_value_mapping.html' %}
+-{% include 'app_manager/v1/partials/graph_configuration_modal.html' %}
++{% include 'app_manager/v2/partials/graph_configuration_modal.html' %}
  {% endblock modals %}
  
  {% block breadcrumbs %}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict, namedtuple
 import json
 import logging
+import re
 from lxml import etree
 
 from django.template.loader import render_to_string
@@ -909,6 +910,10 @@ def edit_report_module(request, domain, app_id, module_id):
 
     try:
         module.report_configs = [ReportAppConfig.wrap(spec) for spec in params['reports']]
+        for report_config in module.report_configs:
+            for chart_id, graph_config in report_config.complete_graph_configs.iteritems():
+                for series in graph_config.series:
+                    series.data_path = re.sub(r'<UUID>', report_config.uuid, series.data_path)
     except Exception:
         notify_exception(
             request,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -302,7 +302,8 @@ def _get_report_module_context(app, module):
     }
     current_reports = []
     for r in module.report_configs:
-        r.migrate_graph_configs(r, app.domain)  # TODO: DRYer, shouldn't pass r
+        if not len(r.complete_graph_configs):
+            r.migrate_graph_configs(r, app.domain)  # TODO: DRYer, shouldn't pass r
         current_reports.append(r.to_json())
         # TODO: save at this point?
     context.update({'current_reports': current_reports})

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -294,13 +294,19 @@ def _get_report_module_context(app, module):
         {'slug': f.slug, 'description': f.short_description} for f in get_auto_filter_configurations()
 
     ]
-    return {
+    context = {
         'all_reports': [_report_to_config(r) for r in all_reports],
-        'current_reports': [r.to_json() for r in module.report_configs],
         'filter_choices': filter_choices,
         'auto_filter_choices': auto_filter_choices,
         'daterange_choices': [choice._asdict() for choice in get_simple_dateranges()],
     }
+    current_reports = []
+    for r in module.report_configs:
+        r.migrate_graph_configs(r, app.domain)  # TODO: DRYer, shouldn't pass r
+        current_reports.append(r.to_json())
+        # TODO: save at this point?
+    context.update({'current_reports': current_reports})
+    return context
 
 
 def _get_fixture_columns_by_type(domain):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -2,7 +2,6 @@
 from collections import OrderedDict, namedtuple
 import json
 import logging
-import re
 from lxml import etree
 
 from django.template.loader import render_to_string
@@ -295,11 +294,13 @@ def _get_report_module_context(app, module):
         {'slug': f.slug, 'description': f.short_description} for f in get_auto_filter_configurations()
 
     ]
+    from corehq.apps.app_manager.suite_xml.features.mobile_ucr import COLUMN_XPATH_CLIENT_TEMPLATE
     context = {
         'all_reports': [_report_to_config(r) for r in all_reports],
         'filter_choices': filter_choices,
         'auto_filter_choices': auto_filter_choices,
         'daterange_choices': [choice._asdict() for choice in get_simple_dateranges()],
+        'column_xpath_template': COLUMN_XPATH_CLIENT_TEMPLATE,
     }
     current_reports = []
     for r in module.report_configs:
@@ -910,11 +911,6 @@ def edit_report_module(request, domain, app_id, module_id):
 
     try:
         module.report_configs = [ReportAppConfig.wrap(spec) for spec in params['reports']]
-        for report_config in module.report_configs:
-            for chart_id, graph_config in report_config.complete_graph_configs.iteritems():
-                for series in graph_config.series:
-                    if series.data_path:
-                        series.data_path = re.sub(r'#UUID', report_config.uuid, series.data_path)
     except Exception:
         notify_exception(
             request,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -303,7 +303,7 @@ def _get_report_module_context(app, module):
     current_reports = []
     for r in module.report_configs:
         if not len(r.complete_graph_configs):
-            r.migrate_graph_configs(r, app.domain)  # TODO: DRYer, shouldn't pass r
+            r.migrate_graph_configs(app.domain)
         current_reports.append(r.to_json())
         # TODO: save at this point?
     context.update({'current_reports': current_reports})

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -302,10 +302,8 @@ def _get_report_module_context(app, module):
     }
     current_reports = []
     for r in module.report_configs:
-        if not len(r.complete_graph_configs):
-            r.migrate_graph_configs(app.domain)
+        r.migrate_graph_configs(app.domain)
         current_reports.append(r.to_json())
-        # TODO: save at this point?
     context.update({'current_reports': current_reports})
     return context
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -913,7 +913,8 @@ def edit_report_module(request, domain, app_id, module_id):
         for report_config in module.report_configs:
             for chart_id, graph_config in report_config.complete_graph_configs.iteritems():
                 for series in graph_config.series:
-                    series.data_path = re.sub(r'<UUID>', report_config.uuid, series.data_path)
+                    if series.data_path:
+                        series.data_path = re.sub(r'#UUID', report_config.uuid, series.data_path)
     except Exception:
         notify_exception(
             request,


### PR DESCRIPTION
I've wanted to do this for a long time; doing it now because Ali wants to modify the series x value for one of her projects, which mobile UCR's UI doesn't allow. As a positive side effect, mobile UCR now also supports locale-specific configuration (axis titles, etc.) and annotations. This will also make it easier to support custom threshold lines in the future (although there's some mobile work that needs to be done first, because mobile doesn't support mixed bar/line graphs yet).

There's a lazy migration in here for `ReportAppConfig`, to convert its graph configs from `ReportGraphConfig` to `GraphConfiguration`. I'm planning to follow this up with a real migration and then deprecate `ReportGraphConfig` but didn't want to block this PR.

<img width="1065" alt="screen shot 2017-05-05 at 3 08 57 pm" src="https://cloud.githubusercontent.com/assets/1486591/25760517/0da3e270-31a5-11e7-97c1-ec95f725bab0.png">

<img width="926" alt="screen shot 2017-05-05 at 3 11 31 pm" src="https://cloud.githubusercontent.com/assets/1486591/25760535/28e1e7a8-31a5-11e7-9acc-9c5b55444772.png">

The "default" values that mobile UCR uses for x, y, and nodeset are populated in the UI as placeholders. If the user leaves them alone, they'll continue to be populated during suite creation, based on the UCR's current chart configuration. If the user overrides any of these values, they'll get a warning that value will not be updated if they change the report's chart config in the future:

<img width="920" alt="screen shot 2017-05-05 at 3 35 28 pm" src="https://cloud.githubusercontent.com/assets/1486591/25761393/aa062026-31a8-11e7-8063-e983050b4971.png">

Easiest to review by commit. Would be nice to review soon-ish, because Ali's waiting on this.

code buddy / mobile UCR @nickpell 
app manager @dannyroberts / @snopoke 