### PR TITLE
Delay the start of import_locations_async until after the current request finishes

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -824,6 +824,9 @@ class LocationImportView(BaseLocationView):
             expiry=ONE_HOUR,
             file_extension=file_extention_from_filename(upload.name),
         )
+        # We need to start this task after this current request finishes because this
+        # request uses the lock_locations decorator which acquires the same lock that
+        # the task will try to acquire.
         task = import_locations_async.apply_async(args=[domain, file_ref.download_id], countdown=10)
         # put the file_ref.download_id in cache to lookup from elsewhere
         cache.set(import_locations_task_key(domain), file_ref.download_id, ONE_HOUR)

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -824,10 +824,7 @@ class LocationImportView(BaseLocationView):
             expiry=ONE_HOUR,
             file_extension=file_extention_from_filename(upload.name),
         )
-        task = import_locations_async.delay(
-            domain,
-            file_ref.download_id,
-        )
+        task = import_locations_async.apply_async(args=[domain, file_ref.download_id], countdown=10)
         # put the file_ref.download_id in cache to lookup from elsewhere
         cache.set(import_locations_task_key(domain), file_ref.download_id, ONE_HOUR)
         file_ref.set_task(task)


### PR DESCRIPTION
Fixes one of the issues that was causing confusion with https://manage.dimagi.com/default.asp?253328

When you'd start a new location import and the main queue had capacity, the task would be picked up before the request returned, and since the request uses the same lock key as the serial task for upload does, the import status page would show an error saying that the task failed because it couldn't acquire the lock.

But the task would then try again 5 minutes later (per the settings [here](https://github.com/dimagi/commcare-hq/blob/9ab6fed9127278655df2aa306d95829905de33bf/corehq/apps/commtrack/tasks.py#L11)), which is why people were reporting seeing the error but then the import would go through.

If the main queue was full when starting an import, this wouldn't happen which is why it didn't happen every time.

buddy @snopoke 