### PR TITLE
Fix Location import progress bar

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -420,17 +420,16 @@ class NewLocationImporter(object):
         for loc in location_stubs:
             loc.lookup_old_collection_data(self.old_collection)
 
-        with transaction.atomic():
-            type_objects = save_types(type_stubs, self.excel_importer)
-            save_locations(location_stubs, type_objects, self.domain, self.excel_importer)
-            # Since we updated LocationType objects in bulk, some of the post-save logic
-            #   that occurs inside LocationType.save needs to be explicitly called here
-            for lt in type_stubs:
-                if (not lt.do_delete and lt.needs_save):
-                    obj = type_objects[lt.code]
-                    if not lt.is_new:
-                        # supply_points would have been synced while SQLLocation.save() already
-                        obj.sync_administrative_status(sync_supply_points=False)
+        type_objects = save_types(type_stubs, self.excel_importer)
+        save_locations(location_stubs, type_objects, self.domain, self.excel_importer)
+        # Since we updated LocationType objects in bulk, some of the post-save logic
+        #   that occurs inside LocationType.save needs to be explicitly called here
+        for lt in type_stubs:
+            if (not lt.do_delete and lt.needs_save):
+                obj = type_objects[lt.code]
+                if not lt.is_new:
+                    # supply_points would have been synced while SQLLocation.save() already
+                    obj.sync_administrative_status(sync_supply_points=False)
 
         update_count = lambda items: sum(l.needs_save and not l.do_delete and not l.is_new for l in items)
         delete_count = lambda items: sum(l.do_delete for l in items)


### PR DESCRIPTION
Fixes another issue causing confusion with https://manage.dimagi.com/default.asp?253328.

The upload meter for the location import never works which makes it hard to track progress on large location imports. It doesn't work because all of its operations are wrapped in this outer transaction, which means even the updates to celery_taskmeta are also done within the transaction. So other threads, like the import status page, never see the progress on the task.

Another way to fix this issue is to just use redis as our celery result backend, but I'm proposing this PR as the solution because I'm not sure that it makes sense to wrap a location import in an outer transaction. Given that creating/saving locations also updates couch locations and supply point cases (which could be couch cases), I think you actually end up in a more dirty state if you rollback half-way through because you'd rollback changes to your postgres models but not your couch models. 

With this fix, even if the import fails half-way through, at least you're more likely to be able to clean up by just deleting unwanted locations, which should take care of the related couch models. In almost all cases it also seems like you would just rerun the same import if it failed, since it will only create the locations if they don't exist (by site code), and only update them if they need updating.

@esoergel @sravfeyn Does that make sense or is there a reason to wrap it in an outer transaction?

buddy @snopoke 