### PR TITLE
properly handling signature header

### DIFF
--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -5,8 +5,8 @@ import json
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from django.conf import settings
 
-import settings
 from corehq.apps.analytics.tasks import track_clicked_deploy_on_hubspot, track_job_candidate_on_hubspot
 from corehq.apps.analytics.utils import get_meta
 
@@ -31,7 +31,7 @@ class GreenhouseCandidateView(View):
         digester = hmac.new(settings.GREENHOUSE_API_KEY, request.body, hashlib.sha256)
         calculated_signature = digester.hexdigest()
 
-        if str(calculated_signature) == str(request.META.get('HTTP_SIGNATURE', '')):
+        if str(calculated_signature) == str(request.META.get('HTTP_SIGNATURE'.split()[1], '')):
             body_unicode = request.body.decode('utf-8')
             data = json.loads(body_unicode)
             try:

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -31,7 +31,12 @@ class GreenhouseCandidateView(View):
         digester = hmac.new(settings.GREENHOUSE_API_KEY, request.body, hashlib.sha256)
         calculated_signature = digester.hexdigest()
 
-        if str(calculated_signature) == str(request.META.get('HTTP_SIGNATURE'.split()[1], '')):
+        signature_header = request.META.get('HTTP_SIGNATURE', '').split()
+        if len(signature_header) == 2:
+            signature_from_request = signature_header[1]
+        else:
+            return HttpResponse()
+        if str(calculated_signature) == str(signature_from_request):
             body_unicode = request.body.decode('utf-8')
             data = json.loads(body_unicode)
             try:


### PR DESCRIPTION
@millerdev 
This fixes an error in the code that handles our greenhouse web hook. The actual header format is `hash signature` not `signature`