### PR TITLE
Count the bytes deleted

### DIFF
--- a/corehq/blobs/tasks.py
+++ b/corehq/blobs/tasks.py
@@ -14,15 +14,18 @@ def delete_expired_blobs():
 
     db = get_blob_db()
     paths = []
+    bytes_deleted = 0
     for blob_expiration in blob_expirations:
         paths.append(db.get_path(blob_expiration.identifier, blob_expiration.bucket))
+        bytes_deleted += blob_expiration.length
 
     db.bulk_delete(paths)
     blob_expirations.update(deleted=True)
     datadog_counter(
         'commcare.temp_blobs.bytes_deleted',
-        value=sum(map(lambda be: be.length, blob_expirations))
+        value=bytes_deleted,
     )
+    return bytes_deleted
 
 
 def _utcnow():

--- a/corehq/blobs/tests/test_blob_timeout.py
+++ b/corehq/blobs/tests/test_blob_timeout.py
@@ -35,7 +35,9 @@ class BlobExpireTest(TestCase):
 
         self.assertIsNotNone(self.db.get(self.identifier, self.bucket))
         with patch('corehq.blobs.tasks._utcnow', return_value=now + timedelta(minutes=61)):
-            delete_expired_blobs()
+            bytes_deleted = delete_expired_blobs()
+
+        self.assertEqual(bytes_deleted, len('content'))
 
         with self.assertRaises(NotFound):
             self.db.get(self.identifier, self.bucket)


### PR DESCRIPTION
Was wondering why the datadog metric kept showing that 0 bytes were deleted. Did some digging and realized that when i called `blob_expirations.update` and then tried to reiterate through the `blob_expirations` all of them would be removed. Django must actually redo the query each time it does an iteration

cc: @proteusvacuum 