### PR TITLE
App manager v2: case label

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view.html
@@ -154,7 +154,7 @@
 
         {% if not module.is_surveys %}
           {% for detail in details %}
-            <div class="tab-pane" id="{{ detail.type }}-detail-screen-config-tab">
+            <div class="tab-pane ko-template" id="{{ detail.type }}-detail-screen-config-tab">
               {% include 'app_manager/v2/partials/case_list.html' %}
             </div>
             {% if detail.long %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -1,9 +1,8 @@
 {% load i18n %}
 {% load hq_shared_tags %}
+{% load xforms_extras %}
 
 {% include 'app_manager/v2/partials/case_list_missing_warning.html' %}
-
-<div data-bind="saveButton: shortScreen.saveButton"></div>
 
 <div class="panel panel-appmanager">
   <div class="panel-heading">
@@ -15,9 +14,11 @@
     </h4>
   </div>
   <div class="panel-body">
-    <div class="row"><div class="col-sm-3"><input type="text" name="case_label" class="form-control" /></div></div>
+    {% inline_edit_trans_v2 module.case_label langs edit_case_label_url saveValueName='case_label' %}
   </div>
 </div>
+
+<div data-bind="saveButton: shortScreen.saveButton"></div>
 
 <div data-bind="with: customXMLViewModel">
   <div class="panel panel-appmanager" data-bind="visible: enabled">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -4,19 +4,13 @@
 
 {% include 'app_manager/v2/partials/case_list_missing_warning.html' %}
 
-<div class="panel panel-appmanager">
-  <div class="panel-heading">
-    <h4 class="panel-title panel-title-nolink">
-      {% trans "Title" %}
-      <span class="hq-help-template"
-            data-title="{% trans "Label on Phone" %}"
-            data-content="{% trans "This label will appear at the top of the phone's case select screen." %}"></span>
-    </h4>
-  </div>
-  <div class="panel-body">
-    {% inline_edit_trans_v2 module.case_label langs edit_case_label_url saveValueName='case_label' %}
-  </div>
+<div class="ko-inline-edit-with-help">
+    {% inline_edit_trans_v2 module.case_label langs edit_case_label_url containerClass='h4' saveValueName='case_label' %}
+    <span class="hq-help-template"
+          data-title="{% trans "Label on Phone" %}"
+          data-content="{% trans "This label will appear at the top of the phone's case select screen." %}"></span>
 </div>
+<div class="spacer"></div>
 
 <div data-bind="saveButton: shortScreen.saveButton"></div>
 

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,28 +1,24 @@
 --- 
 +++ 
-@@ -1,284 +1,276 @@
+@@ -1,284 +1,271 @@
  {% load i18n %}
  {% load hq_shared_tags %}
- 
+-
 -{% include 'app_manager/v1/partials/case_list_missing_warning.html' %}
++{% load xforms_extras %}
++
 +{% include 'app_manager/v2/partials/case_list_missing_warning.html' %}
++
++<div class="ko-inline-edit-with-help">
++    {% inline_edit_trans_v2 module.case_label langs edit_case_label_url containerClass='h4' saveValueName='case_label' %}
++    <span class="hq-help-template"
++          data-title="{% trans "Label on Phone" %}"
++          data-content="{% trans "This label will appear at the top of the phone's case select screen." %}"></span>
++</div>
++<div class="spacer"></div>
  
  <div data-bind="saveButton: shortScreen.saveButton"></div>
  
-+<div class="panel panel-appmanager">
-+  <div class="panel-heading">
-+    <h4 class="panel-title panel-title-nolink">
-+      {% trans "Title" %}
-+      <span class="hq-help-template"
-+            data-title="{% trans "Label on Phone" %}"
-+            data-content="{% trans "This label will appear at the top of the phone's case select screen." %}"></span>
-+    </h4>
-+  </div>
-+  <div class="panel-body">
-+    <div class="row"><div class="col-sm-3"><input type="text" name="case_label" class="form-control" /></div></div>
-+  </div>
-+</div>
-+
  <div data-bind="with: customXMLViewModel">
 -    <div data-bind="visible: enabled">
 -        <legend>{% trans "Custom Case List XML" %}</legend>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
@@ -155,7 +155,7 @@
 +
 +        {% if not module.is_surveys %}
 +          {% for detail in details %}
-+            <div class="tab-pane" id="{{ detail.type }}-detail-screen-config-tab">
++            <div class="tab-pane ko-template" id="{{ detail.type }}-detail-screen-config-tab">
 +              {% include 'app_manager/v2/partials/case_list.html' %}
 +            </div>
 +            {% if detail.long %}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -100,10 +100,8 @@ def get_module_template(user, module):
 def get_module_view_context(app, module, lang=None):
     # shared context
     context = {
-        'edit_name_url': reverse(
-            'edit_module_attr',
-            args=[app.domain, app.id, module.id, 'name']
-        )
+        'edit_name_url': reverse('edit_module_attr', args=[app.domain, app.id, module.id, 'name']),
+        'edit_case_label_url': reverse('edit_module_attr', args=[app.domain, app.id, module.id, 'case_label']),
     }
     module_brief = {
         'id': module.id,

--- a/corehq/apps/style/static/style/less/_hq/forms.less
+++ b/corehq/apps/style/static/style/less/_hq/forms.less
@@ -222,6 +222,12 @@ textarea.vertical-resize {
     resize: vertical;
 }
 
+.ko-inline-edit-with-help {
+    .hq-help {
+        vertical-align: middle;
+    }
+}
+
 .ko-inline-edit {
     &.inline {
         display: inline-block;


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?253565

@biyeun any objections to moving the case label up above save so it's more like a title? I think it makes sense conceptually, and it's simpler to implement (because everything else on the page is part of the detail, but case_label is a module attribute, saving gets messy).

Before:
<img width="1048" alt="screen shot 2017-05-08 at 9 50 46 am" src="https://cloud.githubusercontent.com/assets/1486591/25807157/d8397434-33d3-11e7-9caa-828d940db61f.png">

After:
<img width="1052" alt="screen shot 2017-05-08 at 9 46 08 am" src="https://cloud.githubusercontent.com/assets/1486591/25807170/dfecd3ce-33d3-11e7-8fe5-ff743b49d49f.png">

code buddy @nickpell 