### PR TITLE
Remove CodeMirror from admin restore pages

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
@@ -1,19 +1,6 @@
 /* globals hqDefine */
 hqDefine('hqadmin/js/admin_restore.js', function () {
     $(function() {
-        var payloadElement = document.getElementById('payload');
-        var myCodeMirror = CodeMirror(function(elt) {
-            payloadElement.parentNode.replaceChild(elt, payloadElement);
-        }, {
-            value: payloadElement.textContent,
-            readOnly: true,
-            lineNumbers: true,
-            mode: {name: "text/xml", json: true},
-            viewportMargin: Infinity,
-            foldGutter: true,
-            gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
-        });
-
         $("#timingTable").treetable();
     });
 });

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -5,31 +5,15 @@
         <title>Restore Response</title>
 
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'bootstrap/dist/css/bootstrap.min.css' %}"/>
-        <link type="text/css" rel="stylesheet" href="{% static 'codemirror/lib/codemirror.css' %}" />
-        <link type="text/css" rel="stylesheet" href="{% static 'codemirror/addon/fold/foldgutter.css' %}"/>
         <link type="text/css" rel="stylesheet" href="{% static 'jquery-treetable/css/jquery.treetable.css' %}"/>
 
         {% compress js %}
             <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
             <script src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
             <script src="{% static 'jquery-treetable/jquery.treetable.js' %}"></script>
-            <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
-            <script src="{% static 'codemirror/mode/xml/xml.js' %}"></script>
-            <script src="{% static 'codemirror/addon/fold/foldcode.js' %}"></script>
-            <script src="{% static 'codemirror/addon/fold/foldgutter.js' %}"></script>
-            <script src="{% static 'codemirror/addon/fold/xml-fold.js' %}"></script>
             <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
             <script src="{% static 'hqadmin/js/admin_restore.js' %}"></script>
         {% endcompress %}
-
-        <style>
-            .CodeMirror {
-                height: auto;
-            }
-            .branch {
-                background-color: #f0f0f0;
-            }
-        </style>
 
     </head>
     <body>


### PR DESCRIPTION
Because that page contains useful information, and codemirror kills your browser.

The restore is still well indented, it just isn't foldable or syntax highlighted. If you want that, click "Raw" and your browser will do that for you in a much nicer way. 

@benrudolph 