### PR TITLE
Calendar case tile styling

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -146,7 +146,9 @@
             <div id="restore-as-region"></div>
             <div id="breadcrumb-region"></div>
             <section id="cloudcare-notifications" class="container notifications-container"></section>
-            <div id="persistent-case-tile" class="container"></div>
+            <div class="container case-tile-container">
+                <div id="persistent-case-tile"></div>
+            </div>
             <div id="menu-region" class="container"></div>
             <section id="webforms" data-bind="
                 template: {

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -18,7 +18,7 @@
       </div>
 
       <% if (useGrid) { %>
-        <section class="js-case-container"></section>
+        <section class="js-case-container clearfix"></section>
       <% } else { %>
         <div class="module-caselist-table-container">
           <table class="table module-table module-table-caselist">
@@ -148,8 +148,11 @@
         height: 0;
         padding-bottom: <%= model.heightPercentage %>%;
         display: inline-block;
-        border: 1px solid black;
+        border: 1px solid white;
         border-collapse: collapse;
+        vertical-align: top;
+        float: left;
+        background-color: #f2f2f1;
     }
 </script>
 
@@ -158,10 +161,8 @@
         display: grid;
         grid-template-columns: repeat(<%= model.numColumns %>, <%= model.widthPixels %>px) min-content 5px;
         grid-template-rows: repeat(<%= model.numRows %>, <%= model.heightPixels %>px) min-content 5px;
-        background-color: #fff;
+        background-color: transparent;
         color: #685c53;
-        border-color: #685c53;
-        max-height: 400 px;
         justify-items: center;
     }
 </script>

--- a/corehq/apps/style/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/style/static/cloudcare/less/formplayer-webapp/content.less
@@ -36,3 +36,11 @@ body {
 .page-header-apps h1 {
   padding-left: 0;
 }
+
+.case-tile-container {
+  background: transparent !important;
+  > div {
+    background: white;
+    margin-bottom: 20px;
+  }
+}


### PR DESCRIPTION
Some calendar styling courtesy of the legend @biyeun 

Before:
<img width="1197" alt="screen shot 2017-05-08 at 6 27 09 pm" src="https://cloud.githubusercontent.com/assets/2293064/25813995/0a035bd6-341c-11e7-91c1-9714fba8b6fc.png">
<img width="397" alt="screen shot 2017-05-08 at 6 27 59 pm" src="https://cloud.githubusercontent.com/assets/2293064/25814020/1ed4e5f2-341c-11e7-91ee-dd7d1cef9898.png">

After:
<img width="1177" alt="screen shot 2017-05-08 at 6 26 41 pm" src="https://cloud.githubusercontent.com/assets/2293064/25814003/0db5bad0-341c-11e7-95fa-0ff00cf19ab8.png">
<img width="346" alt="screen shot 2017-05-08 at 6 28 27 pm" src="https://cloud.githubusercontent.com/assets/2293064/25814032/291da986-341c-11e7-9ad3-f0b15b56e8d1.png">

