### PR TITLE
update django otp

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -73,6 +73,7 @@ git+git://github.com/smartfile/django-transfer.git@6e0dc94c3341c358fca8eb2bf74e2
 Pygments==2.0.2
 tinys3==0.1.11
 django-formtools==2.0
+django-otp==0.3.13
 django-two-factor-auth==1.6.0
 datadog==0.15.0
 django-websocket-redis==0.4.6


### PR DESCRIPTION
django otp gets installed implicitly by django-two-factor, so it's whatever's latest at time of install. doing this here to get rid of some of the deprecation warnings

@dannyroberts 