### PR TITLE
Mobile UCR: Button to copy placeholder values

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/graph-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/graph-config.js
@@ -1,3 +1,4 @@
+/* global Clipboard */
 hqDefine('app_manager/js/graph-config.js', function () {
     /**
      * Create a view model that is bound to an "Edit graph" button. The ui property
@@ -521,6 +522,16 @@ hqDefine('app_manager/js/graph-config.js', function () {
         self.xPlaceholder = ko.observable(origOrDefault('xPlaceholder',""));
         self.yFunction = ko.observable(origOrDefault('yFunction',""));
         self.yPlaceholder = ko.observable(origOrDefault('yPlaceholder',""));
+        self.copyPlaceholder = function(series, e) {
+            var $button = $(e.currentTarget);
+            var clipboard = new Clipboard($button[0]);
+            $button.tooltip({ title: gettext('Copied!') });
+            clipboard.on('success', function() {
+                $button.tooltip('show');
+                window.setTimeout(function() { $button.tooltip('hide'); }, 1000);
+            });
+            clipboard.onClick(e);
+        };
 
         var seriesValidationWarning = gettext(
             "It is recommended that you leave this value blank. Future changes to your report's "

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -5,7 +5,7 @@ hqDefine('app_manager/js/report-module.js', function () {
     var select2Separator = "\u001F";
 
     function GraphConfig(reportId, reportName, availableReportIds, reportCharts, graph_configs,
-                         columnXpathTemplate, lang, langs, changeSaveButton) {
+                         columnXpathTemplate, dataPathPlaceholders, lang, langs, changeSaveButton) {
         var self = this,
             columnTemplate = _.template(columnXpathTemplate);
 
@@ -26,8 +26,12 @@ hqDefine('app_manager/js/report-module.js', function () {
                 // Add series placeholders
                 _.each(currentChart.y_axis_columns, function(column, index) {
                     if (graph_config.series[index]) {
+                        var dataPathPlaceholder = dataPathPlaceholders && dataPathPlaceholders[currentReportId]
+                            ? dataPathPlaceholders[currentReportId][currentChart.chart_id]
+                            : "[path will be automatically generated]"
+                        ;
                         _.extend(graph_config.series[index], {
-                            data_path_placeholder: "[path will be automatically generated]",
+                            data_path_placeholder: dataPathPlaceholder,
                             x_placeholder: columnTemplate({ id: currentChart.x_axis_column }),
                             y_placeholder: columnTemplate({ id: column.column_id }),
                         });
@@ -191,7 +195,7 @@ hqDefine('app_manager/js/report-module.js', function () {
     function ReportConfig(report_id, display,
                           localizedDescription, xpathDescription, useXpathDescription,
                           showDataTable, uuid, availableReportIds,
-                          reportCharts, graph_configs, columnXpathTemplate,
+                          reportCharts, graph_configs, columnXpathTemplate, dataPathPlaceholders,
                           filterValues, reportFilters,
                           language, languages, changeSaveButton) {
         var self = this;
@@ -216,7 +220,8 @@ hqDefine('app_manager/js/report-module.js', function () {
         this.showDataTable.subscribe(changeSaveButton);
 
         self.graphConfig = new GraphConfig(this.reportId, this.display(), availableReportIds, reportCharts,
-                                           graph_configs, columnXpathTemplate, this.lang, languages, changeSaveButton);
+                                           graph_configs, columnXpathTemplate, dataPathPlaceholders,
+                                           this.lang, languages, changeSaveButton);
         this.display.subscribe(function(newValue) {
             self.graphConfig.name(newValue);
         });
@@ -269,6 +274,7 @@ hqDefine('app_manager/js/report-module.js', function () {
         self.reportFilters = {};
         self.reports = ko.observableArray([]);
         self.columnXpathTemplate = options.columnXpathTemplate || "";
+        self.dataPathPlaceholders = options.dataPathPlaceholders || {};
         for (var i = 0; i < availableReports.length; i++) {
             var report = availableReports[i];
             var report_id = report.report_id;
@@ -348,6 +354,7 @@ hqDefine('app_manager/js/report-module.js', function () {
                 self.reportCharts,
                 options.complete_graph_configs,
                 self.columnXpathTemplate,
+                self.dataPathPlaceholders,
                 options.filters,
                 self.reportFilters,
                 self.lang,

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -110,6 +110,16 @@ def _get_select_details(config):
     ).serialize().decode('utf-8'))
 
 
+def get_data_path(config, domain):
+    return (
+        "instance('reports')/reports/report[@id='{}']/rows/row[@is_total_row='False']{}"
+        .format(
+            config.uuid,
+            MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)
+        )
+    )
+
+
 def _get_summary_details(config, domain, module):
     def _get_graph_fields():
         from corehq.apps.userreports.reports.specs import MultibarChartSpec
@@ -143,12 +153,9 @@ def _get_summary_details(config, domain, module):
                 config.migrate_graph_configs(domain)
                 graph_config = config.complete_graph_configs.get(chart_config.chart_id, GraphConfiguration())
                 for index, column in enumerate(chart_config.y_axis_columns):
-                    graph_config.series[index].data_path = graph_config.series[index].data_path or (
-                        "instance('reports')/reports/report[@id='{}']/rows/row[@is_total_row='False']{}"
-                        .format(
-                            config.uuid,
-                            MobileSelectFilterHelpers.get_data_filter_xpath(config, domain)
-                        )
+                    graph_config.series[index].data_path = (
+                        graph_config.series[index].data_path or
+                        get_data_path(config, domain)
                     )
                     graph_config.series[index].x_function = (
                         graph_config.series[index].x_function

--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
@@ -5,6 +5,7 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
+    <script src="{% static "clipboard/dist/clipboard.js" %}"></script>
     <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
     <script src="{% static 'app_manager/js/report-module.js' %}"></script>
     <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/graph_configuration_modal.html
@@ -59,8 +59,17 @@
                                              data-bind="visible: showDataPath, css: {'has-warning': validateDataPath()}">
                                             <label class="col-sm-2 control-label">{% trans "Path" %}</label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control"
-                                                       data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
+                                                <div data-bind="css: {'input-group': !validateDataPath()}">
+                                                    <input type="text" class="form-control"
+                                                           data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
+                                                    <span class="input-group-btn" data-bind="visible: !validateDataPath()">
+                                                        <a class="btn btn-default"
+                                                           data-bind="click: copyPlaceholder,
+                                                                      attr: {'data-clipboard-text': dataPathPlaceholder}">
+                                                            <i class="fa fa-files-o"></i>
+                                                        </a>
+                                                    </span>
+                                                </div>
                                                 <span class="help-block" data-bind="text: validateDataPath"></span>
                                             </div>
                                         </div>
@@ -68,8 +77,17 @@
                                              data-bind="css: {'has-warning': validateX()}">
                                             <label class="col-sm-2 control-label" data-bind="text: xLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control"
-                                                       data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
+                                                <div data-bind="css: {'input-group': !validateX()}">
+                                                    <input type="text" class="form-control"
+                                                           data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
+                                                    <span class="input-group-btn" data-bind="visible: !validateX()">
+                                                        <a class="btn btn-default"
+                                                           data-bind="click: copyPlaceholder,
+                                                                      attr: {'data-clipboard-text': xPlaceholder}">
+                                                            <i class="fa fa-files-o"></i>
+                                                        </a>
+                                                    </span>
+                                                </div>
                                                 <span class="help-block" data-bind="text: validateX"></span>
                                             </div>
                                         </div>
@@ -77,8 +95,17 @@
                                              data-bind="css: {'has-warning': validateY()}">
                                             <label class="col-sm-2 control-label" data-bind="text: yLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control"
-                                                       data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
+                                                <div data-bind="css: {'input-group': !validateY()}">
+                                                    <input type="text" class="form-control"
+                                                           data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
+                                                    <span class="input-group-btn" data-bind="visible: !validateY()">
+                                                        <a class="btn btn-default"
+                                                           data-bind="click: copyPlaceholder,
+                                                                      attr: {'data-clipboard-text': yPlaceholder}">
+                                                            <i class="fa fa-files-o"></i>
+                                                        </a>
+                                                    </span>
+                                                </div>
                                                 <span class="help-block" data-bind="text: validateY"></span>
                                             </div>
                                         </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/report_configs_js.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/report_configs_js.html
@@ -28,6 +28,7 @@
             availableReports: {{ all_reports|JSON }}, // structure for all reports
             currentReports: {{ current_reports|JSON }}, // config data for app reports
             columnXpathTemplate: "{{ column_xpath_template|escapejs }}",
+            dataPathPlaceholders: {{ data_path_placeholders|JSON }},
             saveURL: saveURL,
             lang: {{ lang|JSON }},
             languages: {{ app.langs|JSON }},

--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
@@ -5,6 +5,7 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
+    <script src="{% static "clipboard/dist/clipboard.js" %}"></script>
     <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
     <script src="{% static 'app_manager/js/report-module.js' %}"></script>
     <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/graph_configuration_modal.html
@@ -59,8 +59,17 @@
                                              data-bind="visible: showDataPath, css: {'has-warning': validateDataPath()}">
                                             <label class="col-sm-2 control-label">{% trans "Path" %}</label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control"
-                                                       data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
+                                                <div data-bind="css: {'input-group': !validateDataPath()}">
+                                                    <input type="text" class="form-control"
+                                                           data-bind="value: dataPath, attr: {placeholder: dataPathPlaceholder}" />
+                                                    <span class="input-group-btn" data-bind="visible: !validateDataPath()">
+                                                        <a class="btn btn-default"
+                                                           data-bind="click: copyPlaceholder,
+                                                                      attr: {'data-clipboard-text': dataPathPlaceholder}">
+                                                            <i class="fa fa-files-o"></i>
+                                                        </a>
+                                                    </span>
+                                                </div>
                                                 <span class="help-block" data-bind="text: validateDataPath"></span>
                                             </div>
                                         </div>
@@ -68,8 +77,17 @@
                                              data-bind="css: {'has-warning': validateX()}">
                                             <label class="col-sm-2 control-label" data-bind="text: xLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control"
-                                                       data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
+                                                <div data-bind="css: {'input-group': !validateX()}">
+                                                    <input type="text" class="form-control"
+                                                           data-bind="value: xFunction, attr: {placeholder: xPlaceholder}" />
+                                                    <span class="input-group-btn" data-bind="visible: !validateX()">
+                                                        <a class="btn btn-default"
+                                                           data-bind="click: copyPlaceholder,
+                                                                      attr: {'data-clipboard-text': xPlaceholder}">
+                                                            <i class="fa fa-files-o"></i>
+                                                        </a>
+                                                    </span>
+                                                </div>
                                                 <span class="help-block" data-bind="text: validateX"></span>
                                             </div>
                                         </div>
@@ -77,8 +95,17 @@
                                              data-bind="css: {'has-warning': validateY()}">
                                             <label class="col-sm-2 control-label" data-bind="text: yLabel"></label>
                                             <div class="col-sm-4">
-                                                <input type="text" class="form-control"
-                                                       data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
+                                                <div data-bind="css: {'input-group': !validateY()}">
+                                                    <input type="text" class="form-control"
+                                                           data-bind="value: yFunction, attr: {placeholder: yPlaceholder}" />
+                                                    <span class="input-group-btn" data-bind="visible: !validateY()">
+                                                        <a class="btn btn-default"
+                                                           data-bind="click: copyPlaceholder,
+                                                                      attr: {'data-clipboard-text': yPlaceholder}">
+                                                            <i class="fa fa-files-o"></i>
+                                                        </a>
+                                                    </span>
+                                                </div>
                                                 <span class="help-block" data-bind="text: validateY"></span>
                                             </div>
                                         </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/report_configs_js.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/report_configs_js.html
@@ -28,6 +28,7 @@
             availableReports: {{ all_reports|JSON }}, // structure for all reports
             currentReports: {{ current_reports|JSON }}, // config data for app reports
             columnXpathTemplate: "{{ column_xpath_template|escapejs }}",
+            dataPathPlaceholders: {{ data_path_placeholders|JSON }},
             saveURL: saveURL,
             lang: {{ lang|JSON }},
             languages: {{ app.langs|JSON }},

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
@@ -6,7 +6,7 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load reports_core_tags %}
-@@ -8,24 +8,24 @@
+@@ -9,24 +9,24 @@
      <script src="{% static 'app_manager/js/graph-config.js' %}"></script>
      <script src="{% static 'app_manager/js/report-module.js' %}"></script>
      <script src="{% static 'reports_core/js/choice-list-api.js' %}"></script>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -292,7 +292,7 @@ def _get_report_module_context(app, module):
         {'slug': f.slug, 'description': f.short_description} for f in get_auto_filter_configurations()
 
     ]
-    from corehq.apps.app_manager.suite_xml.features.mobile_ucr import COLUMN_XPATH_CLIENT_TEMPLATE
+    from corehq.apps.app_manager.suite_xml.features.mobile_ucr import COLUMN_XPATH_CLIENT_TEMPLATE, get_data_path
     context = {
         'all_reports': [_report_to_config(r) for r in all_reports],
         'filter_choices': filter_choices,
@@ -301,10 +301,17 @@ def _get_report_module_context(app, module):
         'column_xpath_template': COLUMN_XPATH_CLIENT_TEMPLATE,
     }
     current_reports = []
+    data_path_placeholders = {}
     for r in module.report_configs:
         r.migrate_graph_configs(app.domain)
         current_reports.append(r.to_json())
-    context.update({'current_reports': current_reports})
+        data_path_placeholders[r.report_id] = {}
+        for chart_id in r.complete_graph_configs.keys():
+            data_path_placeholders[r.report_id][chart_id] = get_data_path(r, app.domain)
+    context.update({
+        'current_reports': current_reports,
+        'data_path_placeholders': data_path_placeholders,
+    })
     return context
 
 


### PR DESCRIPTION
It's useful to be able to copy the server-generated values for mobile UCR series to use in additional series...but you can't copy placeholders. Added a button to allow this to the x, y, and path inputs. It disappears when the placeholder isn't visible because there's a user-input value.

<img width="933" alt="screen shot 2017-05-08 at 5 27 01 pm" src="https://cloud.githubusercontent.com/assets/1486591/25826207/ed7a7948-3413-11e7-822d-9fc0d7a19259.png">

@nickpell 