### PR TITLE
make repeat record view safer

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.views.generic import RedirectView
 
 from corehq.apps.callcenter.views import CallCenterOwnerOptionsView
-from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.forms import ConfidentialPasswordResetForm, HQSetPasswordForm
 from corehq.apps.domain.views import (
     ActivateTransferDomainView,
@@ -155,7 +154,7 @@ domain_settings = [
         name=InternalSubscriptionManagementView.urlname),
     url(r'^billing_information/$', EditExistingBillingAccountView.as_view(),
         name=EditExistingBillingAccountView.urlname),
-    url(r'^repeat_record/', login_and_domain_required(RepeatRecordView.as_view()), name=RepeatRecordView.urlname),
+    url(r'^repeat_record/', RepeatRecordView.as_view(), name=RepeatRecordView.urlname),
     url(r'^repeat_record_report/cancel/', cancel_repeat_record, name='cancel_repeat_record'),
     url(r'^repeat_record_report/requeue/', requeue_repeat_record, name='requeue_repeat_record'),
     url(r'^forwarding/$', DomainForwardingOptionsView.as_view(), name=DomainForwardingOptionsView.urlname),

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.views.generic import RedirectView
 
 from corehq.apps.callcenter.views import CallCenterOwnerOptionsView
+from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.forms import ConfidentialPasswordResetForm, HQSetPasswordForm
 from corehq.apps.domain.views import (
     ActivateTransferDomainView,
@@ -154,7 +155,7 @@ domain_settings = [
         name=InternalSubscriptionManagementView.urlname),
     url(r'^billing_information/$', EditExistingBillingAccountView.as_view(),
         name=EditExistingBillingAccountView.urlname),
-    url(r'^repeat_record/', RepeatRecordView.as_view(), name=RepeatRecordView.urlname),
+    url(r'^repeat_record/', login_and_domain_required(RepeatRecordView.as_view()), name=RepeatRecordView.urlname),
     url(r'^repeat_record_report/cancel/', cancel_repeat_record, name='cancel_repeat_record'),
     url(r'^repeat_record_report/requeue/', requeue_repeat_record, name='requeue_repeat_record'),
     url(r'^forwarding/$', DomainForwardingOptionsView.as_view(), name=DomainForwardingOptionsView.urlname),

--- a/corehq/apps/repeaters/views.py
+++ b/corehq/apps/repeaters/views.py
@@ -4,6 +4,7 @@ from django.http import Http404
 
 from django.urls import reverse
 from django.views.generic import View
+from corehq.apps.domain.decorators import LoginAndDomainMixin
 
 from dimagi.utils.web import json_response
 
@@ -35,7 +36,7 @@ class AddCaseRepeaterView(AddRepeaterView):
         return repeater
 
 
-class RepeatRecordView(View):
+class RepeatRecordView(LoginAndDomainMixin, View):
 
     urlname = 'repeat_record'
     http_method_names = ['get', 'post']

--- a/corehq/apps/repeaters/views.py
+++ b/corehq/apps/repeaters/views.py
@@ -59,7 +59,7 @@ class RepeatRecordView(LoginAndDomainMixin, View):
             record.repeater.format_or_default_format()
         ).content_type
         try:
-            payload = record.get_payload(record)
+            payload = record.get_payload()
         except XFormNotFound:
             return json_response({
                 'error': u'Odd, could not find payload for: {}'.format(record.payload_id)


### PR DESCRIPTION
- check domain of record
- require login (and domain)

Fun demo, try opening https://www.commcarehq.org/a/hahahahahaha-not-really-a-domain/settings/project/repeat_record/?record_id=8f0906c8511a126d09dcab5cea7b67c0 in an incognito window. (Don't worry, it's fake data.) To exploit this vulnerability you would need to know a repeat record id (but don't have to even be logged in!), which may not be trivial to discover if you're not in the know, but definitely not treated by our team as a "secret" (we paste each other links, etc.).

@benrudolph