### PR TITLE
Refactor repeater fire

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -298,7 +298,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
             return HTTPDigestAuth(self.username, self.password)
         return None
 
-    def post_for_record(self, repeat_record):
+    def fire_for_record(self, repeat_record):
         headers = self.get_headers(repeat_record)
         auth = self.get_auth()
         payload = self.get_payload_and_handle_exception(repeat_record)
@@ -564,7 +564,7 @@ class RepeatRecord(Document):
     def fire(self, force_send=False):
         if self.try_now() or force_send:
             self.overall_tries += 1
-            self.repeater.post_for_record(self)
+            self.repeater.fire_for_record(self)
             self.save()
 
     def handle_success(self, response):

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -307,7 +307,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
             response = simple_post(payload, url, headers=headers, timeout=POST_TIMEOUT, auth=auth)
         except (Timeout, ConnectionError) as error:
             log_repeater_timeout_in_datadog(self.domain)
-            raise RequestConnectionError(error)
+            self.handle_response(RequestConnectionError(error), repeat_record)
         except Exception as e:
             self.handle_response(e, repeat_record)
         else:

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -297,10 +297,9 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         auth = self.get_auth()
         payload = repeat_record.get_payload()
         url = self.get_url(repeat_record)
-        domain = repeat_record.domain  # todo: does this ever not equal self.domain?
         try:
-            response = simple_post_with_logged_timeout(domain, payload, url, headers=headers, timeout=POST_TIMEOUT,
-                                                       auth=auth)
+            response = simple_post_with_logged_timeout(self.domain, payload, url, headers=headers,
+                                                       timeout=POST_TIMEOUT, auth=auth)
         except Exception as e:
             repeat_record.handle_exception(e)
         else:

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -317,7 +317,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         except Exception as e:
             repeat_record.handle_exception(e)
         else:
-            return repeat_record.handle_response(response)
+            repeat_record.handle_response(response)
 
     def handle_success(self, response, repeat_record):
         """handle a successful post
@@ -555,9 +555,9 @@ class RepeatRecord(Document):
 
     def handle_response(self, response):
         if 200 <= response.status_code < 300:
-            return self.handle_success(response)
+            self.handle_success(response)
         else:
-            return self.handle_failure(response)
+            self.handle_failure(response)
 
     def handle_success(self, response):
         """Do something with the response if the repeater succeeds

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -12,7 +12,6 @@ from corehq.form_processor.exceptions import XFormNotFound
 from corehq.util.datadog.metrics import REPEATER_ERROR_COUNT
 from corehq.util.datadog.gauges import datadog_counter
 from corehq.util.quickcache import quickcache
-from utils import get_repeater_auth_header
 
 from dimagi.ext.couchdbkit import *
 from couchdbkit.exceptions import ResourceNotFound

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -186,12 +186,11 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
                 ))
 
             if save_failure:
-                repeat_record.handle_payload_exception(e, reraise=False)
+                repeat_record.handle_payload_exception(e)
         except Exception as e:
             if save_failure:
-                repeat_record.handle_payload_exception(e, reraise=True)
-            else:
-                raise
+                repeat_record.handle_payload_exception(e)
+            raise
 
     def register(self, payload, next_check=None):
         if not self.allowed_to_forward(payload):
@@ -550,12 +549,10 @@ class RepeatRecord(Document):
         warnings.warn("RepeatRecord.get_paylod is deprecated. Use Repeater._get_payload instead.")
         return self.repeater.get_payload_and_handle_exception(self, save_failure=save_failure)
 
-    def handle_payload_exception(self, exception, reraise=False):
+    def handle_payload_exception(self, exception):
         self.succeeded = False
         self.failure_reason = unicode(exception)
         self.save()
-        if reraise:
-            raise
 
     def fire(self, force_send=False):
         self.repeater.fire_for_record(self, force_send=force_send)

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -538,13 +538,10 @@ class RepeatRecord(Document):
         auth = self.repeater.get_auth()
         if self.try_now() or force_send:
             self.overall_tries += 1
-            tries = 0
-            post_info = PostInfo(self.get_payload(), headers, auth)
-            self.post(post_info, tries=tries)
+            self.post(PostInfo(self.get_payload(), headers, auth))
             self.save()
 
-    def post(self, post_info, tries=0):
-        tries += 1
+    def post(self, post_info):
         try:
             response = simple_post_with_logged_timeout(
                 self.domain,
@@ -557,13 +554,13 @@ class RepeatRecord(Document):
         except Exception as e:
             self.handle_exception(e)
         else:
-            return self.handle_response(response, post_info, tries)
+            return self.handle_response(response)
 
-    def handle_response(self, response, post_info, tries):
+    def handle_response(self, response):
         if 200 <= response.status_code < 300:
             return self.handle_success(response)
         else:
-            return self.handle_failure(response, post_info, tries)
+            return self.handle_failure(response)
 
     def handle_success(self, response):
         """Do something with the response if the repeater succeeds
@@ -573,7 +570,7 @@ class RepeatRecord(Document):
         self.succeeded = True
         self.repeater.handle_success(response, self)
 
-    def handle_failure(self, response, post_info, tries):
+    def handle_failure(self, response):
         """Do something with the response if the repeater fails
         """
         self._fail(

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -552,7 +552,8 @@ class RepeatRecord(Document):
         return not self.succeeded
 
     def get_payload(self, save_failure=True):
-        warnings.warn("RepeatRecord.get_paylod is deprecated. Use Repeater._get_payload instead.")
+        warnings.warn("RepeatRecord.get_payload is deprecated. Use Repeater.get_payload_and_handle_exception.",
+                      DeprecationWarning)
         return self.repeater.get_payload_and_handle_exception(self, save_failure=save_failure)
 
     def handle_payload_exception(self, exception):


### PR DESCRIPTION
The main thrust of the change is to move more of the controlling logic into the `Repeater`. It generally seems like a better place for them regardless, but this may help make it easier to write custom repeaters that handle the action portion differently (multiple requests, say, or something else).

Easiest to review commit by commit (🐡 if you will)