### PR TITLE
More .track-usage-link

### DIFF
--- a/corehq/apps/appstore/static/appstore/js/appstore_base.js
+++ b/corehq/apps/appstore/static/appstore/js/appstore_base.js
@@ -17,11 +17,4 @@ hqDefine('appstore/js/appstore_base.js', function () {
         assure_correct_spacing();
     }
     $(window).resize(assure_correct_spacing);
-
-    $(function(){
-        var app_ids = hqImport('hqwebapp/js/initial_page_data.js').get('app_ids');
-        _.each(app_ids, function(id) {
-            gaTrackLink($('#view_button_' + id), 'Exchange', 'View button', id);
-        });
-    });
 });

--- a/corehq/apps/appstore/templates/appstore/appstore_base.html
+++ b/corehq/apps/appstore/templates/appstore/appstore_base.html
@@ -208,7 +208,6 @@
 {% endblock %}
 
 {% block page_content %}
-{% initial_page_data 'app_ids' app_ids %}
 
 <h1>
     {% block store-header %}
@@ -251,9 +250,11 @@
                         {% endif %}
                     </a>
                     <p style="margin-top: .5em;">{% trans "Last updated" %}: {{ app.snapshot_time|date:"N j, Y" }}</p>
-                    <a class="btn btn-default"
+                    <a class="btn btn-default track-usage-link"
                        href="{% url "project_info" app.get_id %}"
-                       id="view_button_{{ app.get_id }}"
+                       data-category="Exchange"
+                       data-action="View button"
+                       data-label="{{ app.get_id }}"
                     >
                         {% trans "View" %} &raquo;
                     </a>

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -188,7 +188,6 @@ class CommCareExchangeHomeView(BaseCommCareExchangeSectionView):
     def page_context(self):
         return {
             'apps': self.selected_snapshots,
-            'app_ids': [app.get_id for app in self.selected_snapshots],
             'page': self.page,
             'prev_page': (self.page - 1),
             'next_page': (self.page + 1),

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -154,10 +154,6 @@
         $('#location_tree').koApplyBindings(model);
         model.load(locs);
     });
-
-    gaTrackLink($('#edit-org-levels'), 'Organization Structure', 'Edit Organization Levels');
-
-    gaTrackLink($('#edit-loc-fields'), 'Organization Structure', 'Edit Location Fields');
 </script>
 {% endblock %}
 
@@ -216,10 +212,12 @@
             >
                 <i class="fa fa-cloud-upload"></i> {% trans 'Bulk Upload' %}
             </a>
-            <a class="btn btn-default" href="{% url "location_types" domain %}" id="edit-org-levels">
+            <a class="btn btn-default track-usage-link" href="{% url "location_types" domain %}"
+               data-category="Organization Structure" data-action="Edit Organization Levels">
                 {% trans "Edit Organization Levels" %}
             </a>
-            <a class="btn btn-default" href="{% url "location_fields_view" domain %}" id="edit-loc-fields">
+            <a class="btn btn-default track-usage-link" href="{% url "location_fields_view" domain %}"
+               data-category="Organization Structure" data-action="Edit Location Fields">
                 {% trans "Edit Location Fields" %}
             </a>
         </div>

--- a/corehq/apps/reports/templates/reports/reports_home.html
+++ b/corehq/apps/reports/templates/reports/reports_home.html
@@ -16,7 +16,6 @@ $(function() {
         $(this).text("{% trans 'Saving' %}").prepend('<i class="fa fa-refresh fa-spin"></i> ').addClass('btn disabled').prop('disabled', true);
         $(this).parents('form').submit();
     });
-    gaTrackLink($('#create_scheduled_report'), 'Scheduled Reports', 'Configure a scheduled report');
 });
 </script>
 {% endblock %}
@@ -87,9 +86,10 @@ $(function() {
 
     {% if report.show %}
     <div class="tab-pane" id="scheduled-reports">
-        <p><a class="btn btn-success"
+        <p><a class="btn btn-success track-usage-link"
               href="{% url "edit_scheduled_report" domain %}"
-              id="create_scheduled_report">
+              data-category="Scheduled Reports"
+              data-action="Configure a scheduled report">
             <i class="fa fa-plus"></i>
             {% trans "Create a New Scheduled Report" %}
         </a></p>

--- a/corehq/apps/style/templates/style/includes/global_navigation_bar.html
+++ b/corehq/apps/style/templates/style/includes/global_navigation_bar.html
@@ -4,22 +4,10 @@
 {% load tzmigration %}
 
 {% if request.couch_user %}
-    {% addtoblock js-inline %}
-    <script>
-        gaTrackLink($('#settingsmenu-projectSettings'), 'Nav Bar', 'Click Gear Icon');
-        gaTrackLink($('#settingsmenu-help'), 'Nav Bar', 'Click Question Mark');
-        gaTrackLink($('#menuitem-projectsettings'), 'Nav Bar', 'Gear Icon', 'Update Project Settings');
-        gaTrackLink($('#menuitem-currentsubscription'), 'Nav Bar', 'Gear Icon', 'Current Subscription');
-        gaTrackLink($('#menuitem-accountsettings'), 'Nav Bar', 'Gear Icon', 'My Account Settings');
-        gaTrackLink($('#menuitem-signout'), 'Nav Bar', 'Gear Icon', 'Sign Out');
-        gaTrackLink($('#menuitem-helpsite'), 'Nav Bar', 'Question Mark', 'Visit the Help Site');
-        gaTrackLink($('#menuitem-userforum'), 'Nav Bar', 'Question Mark', 'User Forum');
-        gaTrackLink($('#menuitem-issue'), 'Nav Bar', 'Question Mark', 'Report an Issue');
-    </script>
-    {% endaddtoblock %}
 <ul class="nav navbar-nav" role="menu">
     <li class="dropdown">
-        <a href="#" id="settingsmenu-projectSettings" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
+        <a href="#" class="dropdown-toggle dropdown-toggle-with-icon track-usage-link"
+           data-toggle="dropdown" data-category="Nav Bar" data-action="Click Gear Icon">
             <i class="fa fa-cog nav-main-icon"></i> <span class="responsive-label">{% trans "Manage" %}</span>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
@@ -47,13 +35,15 @@
             <li class="nav-divider divider"></li>
             <li class="dropdown-header nav-header">{% trans 'Manage Project' %}</li>
             <li>
-                <a href="{% url "domain_settings_default" domain %}" id="menuitem-projectsettings">
+                <a href="{% url "domain_settings_default" domain %}" class="track-usage-link"
+                   data-category="Nav Bar" data-action="Gear Icon" data-label="Update Project Settings">
                     <i class="fa fa-cogs icon-cogs dropdown-icon"></i> {% trans "Project Settings" %}
                 </a>
             </li>
             {% if not enterprise_mode %}
             <li>
-                <a href="{% url "domain_subscription_view" domain %}" id="menuitem-currentsubscription">
+                <a href="{% url "domain_subscription_view" domain %}" class="track-usage-link"
+                   data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
                     <i class="fa fa-dashboard icon-dashboard dropdown-icon"></i> {% trans "Current Subscription" %}
                 </a>
             </li>
@@ -71,12 +61,14 @@
             <li class="nav-divider divider"></li>
             <li class="dropdown-header nav-header">{% trans 'Manage Account' %}</li>
             <li>
-                <a href="{% url "my_account_settings" %}" id="menuitem-accountsettings">
+                <a href="{% url "my_account_settings" %}" class="track-usage-link"
+                   data-category="Nav Bar" data-action="Gear Icon" data-label="My Account Settings">
                     <i class="fa fa-user icon-user dropdown-icon"></i> {% trans 'My Account Settings' %}
                 </a>
             </li>
             <li>
-                <a href="{% url "logout" %}" id="menuitem-signout">
+                <a href="{% url "logout" %}" class="track-usage-link"
+                   data-category="Nav Bar" data-action="Gear Icon" data-label="Sign Out">
                     <i class="icon-signout fa fa-sign-out"></i>
                     {% trans 'Sign Out' %}
                 </a>
@@ -84,7 +76,8 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" id="settingsmenu-help" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
+        <a href="#" class="dropdown-toggle dropdown-toggle-with-icon track-usage-link"
+           data-toggle="dropdown" data-category="Nav Bar" data-action="Click Question Mark">
             <i class="fa fa-question-circle nav-main-icon"></i> <span class="responsive-label">{% trans "Help &amp; Resources" %}</span>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
@@ -94,17 +87,20 @@
             {% endblocktrans %}
             </li>
             <li>
-                <a href="{% trans 'https://wiki.commcarehq.org/display/commcarepublic/Home' %}" id="menuitem-helpsite" target="_blank">
+                <a href="{% trans 'https://wiki.commcarehq.org/display/commcarepublic/Home' %}" class="track-usage-link" target="_blank"
+                   data-category="Nav Bar" data-action="Question Mark" data-label="Visit the Help Site">
                     <i class="fa fa-question-circle icon-question-sign dropdown-icon"></i> {% trans "Visit the Help Site" %}
                 </a>
             </li>
             <li>
-                <a href="{% trans 'http://groups.google.com/group/commcare-users/subscribe' %}" id="menuitem-userforum" target="_blank">
+                <a href="{% trans 'http://groups.google.com/group/commcare-users/subscribe' %}" class="track-usage-link" target="_blank"
+                   data-category="Nav Bar" data-action="Question Mark" data-label="User Forum">
                     <i class="fa fa-comments icon-comments dropdown-icon"></i> {% trans "User Forum" %}
                 </a>
             </li>
             <li>
-                <a href="#modalReportIssue" data-toggle="modal" id="menuitem-issue">
+                <a href="#modalReportIssue" data-toggle="modal" class="track-usage-link"
+                   data-category="Nav Bar" data-action="Question Mark" data-label="Report an Issue">
                     <i class="fa fa-exclamation-triangle icon-warning-sign dropdown-icon"></i> {% trans "Report an Issue" %}
                 </a>
             </li>

--- a/corehq/apps/userreports/static/userreports/js/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_report.js
@@ -1,4 +1,4 @@
-/* globals gaTrackLink, HQReport */
+/* globals HQReport */
 hqDefine("userreports/js/configurable_report.js", function() {
     var initial_page_data = hqImport("hqwebapp/js/initial_page_data.js").get;
 
@@ -15,11 +15,8 @@ hqDefine("userreports/js/configurable_report.js", function() {
             $applyFiltersButton.click(function(){
                 window.analytics.usage("Report Viewer", "Apply Filters", type);
             });
-            gaTrackLink($editReportButton, 'Report Builder', 'Edit Report', type);
             window.analytics.trackWorkflowLink($editReportButton, "Clicked Edit to enter the Report Builder");
             window.analytics.usage("Report Viewer", "View Report", type);
-        } else {
-            gaTrackLink($editReportButton, 'Edit UCR', 'Edit UCR');
         }
 
         _.each(initial_page_data("report_builder_events"), function(e) {

--- a/corehq/apps/userreports/templates/userreports/partials/edit_report_button.html
+++ b/corehq/apps/userreports/templates/userreports/partials/edit_report_button.html
@@ -1,11 +1,16 @@
 {% load i18n %}
-<a id="edit-report-link" class="btn btn-primary" href="
+<a class="btn btn-primary track-usage-link" id="edit-report-link"
     {% if report.spec.report_meta.created_by_builder %}
-        {% url 'edit_report_in_builder' domain report.report_config_id %}
+        href="{% url 'edit_report_in_builder' domain report.report_config_id %}"
+        data-category="Report Builder"
+        data-action="Edit Report"
+        data-label="{{ builder_report_type }}"
     {% else %}
-        {% url 'edit_configurable_report' domain report.report_config_id %}
+        href="{% url 'edit_configurable_report' domain report.report_config_id %}"
+        data-category="Edit UCR"
+        data-action="Edit UCR"
     {% endif %}
-">
+>
     <i class="fa fa-pencil"></i>&nbsp;
     {% trans "Edit Report" %}
 </a>

--- a/custom/icds_reports/templates/icds_reports/tableau.html
+++ b/custom/icds_reports/templates/icds_reports/tableau.html
@@ -89,7 +89,7 @@
                 <div class="nav-settings-bar pull-right">
                     <ul class="nav navbar-nav" role="menu">
                         <li class="dropdown">
-                            <a href="#" id="settingsmenu-projectSettings" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
+                            <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
                                 <i class="fa fa-cog nav-main-icon"></i> <span class="responsive-label">{% trans "Manage" %}</span>
                             </a>
                             <ul class="dropdown-menu dropdown-menu-right" role="menu">
@@ -116,12 +116,12 @@
                                 <li class="nav-divider divider"></li>
                                 <li class="dropdown-header nav-header">{% trans 'Manage Account' %}</li>
                                 <li>
-                                    <a href="{% url "my_account_settings" %}" id="menuitem-accountsettings">
+                                    <a href="{% url "my_account_settings" %}">
                                         <i class="fa fa-user icon-user dropdown-icon"></i> {% trans 'My Account Settings' %}
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="{% url "logout" %}" id="menuitem-signout">
+                                    <a href="{% url "logout" %}">
                                         <i class="icon-signout fa fa-sign-out"></i>
                                         {% trans 'Sign Out' %}
                                     </a>


### PR DESCRIPTION
I don't think this needs to be the only way to call `gaTrackLink`, it's just nicer in the basic case where we give an element an id/class just for analytics and then stick a `gaTrackLink` call somewhere fairly random in js. In places like [this](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/static/reports/js/export.manager.js#L158) where there's more js logic going on, I left the `gaTrackLink` call in js.

@nickpell 