### PR TITLE
Parse adherence dates properly

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -2,9 +2,7 @@ import uuid
 import json
 import phonenumbers
 import jsonobject
-import pytz
-
-from django.utils.dateparse import parse_datetime
+from django.utils.dateparse import parse_date
 
 from corehq.apps.repeaters.repeater_generators import (
     BasePayloadGenerator,
@@ -30,7 +28,6 @@ from custom.enikshay.case_utils import (
 from custom.enikshay.const import (
     PRIMARY_PHONE_NUMBER,
     BACKUP_PHONE_NUMBER,
-    ENIKSHAY_TIMEZONE,
     MERM_ID,
     PERSON_FIRST_NAME,
     PERSON_LAST_NAME,
@@ -223,9 +220,7 @@ class AdherencePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
             ).case_id
         )
         adherence_case_properties = adherence_case.dynamic_case_properties()
-        date = (parse_datetime(adherence_case.dynamic_case_properties().get('adherence_date'))
-                .astimezone(pytz.timezone(ENIKSHAY_TIMEZONE))
-                .date())
+        date = parse_date(adherence_case.dynamic_case_properties().get('adherence_date'))
         payload = {
             'beneficiary_id': person_case.case_id,
             'adherence_date': date.isoformat(),

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, date
 from django.test import TestCase, override_settings
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -400,9 +400,8 @@ class TestAdherencePayloadGenerator(TestPayloadGeneratorBase):
         return AdherencePayloadGenerator(None).get_payload(None, casedb['adherence'])
 
     def test_get_payload(self):
-        date = datetime(2017, 2, 20)
         cases = self.create_case_structure()
-        cases['adherence'] = self.create_adherence_cases([date])[0]
+        cases['adherence'] = self.create_adherence_cases([date(2017, 2, 20)])[0]
         expected_payload = json.dumps(
             {
                 "adherence_value": "unobserved_dose",


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/269856877/
We store adherence_date as a date, not a datetime.

@NoahCarnahan 
cc: @benrudolph 