### PR TITLE
fix ucr named expression cache

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+import hashlib
+import json
+
 from jsonobject.base_properties import DefaultProperty
 from simpleeval import InvalidExpression
 import six
@@ -79,11 +82,12 @@ class NamedExpressionSpec(JsonObject):
             raise BadSpecError(u'Name {} not found in list of named expressions!'.format(self.name))
         self._context = context
 
-    def _context_cache_key(self):
-        return 'named_expression-{}'.format(self.name)
+    def _context_cache_key(self, item):
+        item_hash = hashlib.md5(json.dumps(item, sort_keys=True)).hexdigest()
+        return 'named_expression-{}-{}'.format(self.name, item_hash)
 
     def __call__(self, item, context=None):
-        key = self._context_cache_key()
+        key = self._context_cache_key(item)
         if context and context.exists_in_cache(key):
             return context.get_cache_value(key)
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import hashlib
 import json
 
+from django.core.serializers.json import DjangoJSONEncoder
 from jsonobject.base_properties import DefaultProperty
 from simpleeval import InvalidExpression
 import six
@@ -83,7 +84,7 @@ class NamedExpressionSpec(JsonObject):
         self._context = context
 
     def _context_cache_key(self, item):
-        item_hash = hashlib.md5(json.dumps(item, sort_keys=True)).hexdigest()
+        item_hash = hashlib.md5(json.dumps(item, cls=DjangoJSONEncoder, sort_keys=True)).hexdigest()
         return 'named_expression-{}-{}'.format(self.name, item_hash)
 
     def __call__(self, item, context=None):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -521,6 +521,79 @@ class NestedExpressionTest(SimpleTestCase):
         )
         self.assertEqual(3, expression({}))
 
+    def test_caching(self):
+        doc = {
+            "indices": [
+                {
+                    "doc_type": "CommCareCaseIndex",
+                    "identifier": "parent",
+                    "referenced_type": "pregnancy",
+                    "referenced_id": "my_parent_id"
+                },
+                {
+                    "doc_type": "CommCareCaseIndex",
+                    "identifier": "parent",
+                    "referenced_type": "pregnancy",
+                    "referenced_id": "my_parent_id2"
+                }
+            ]
+        }
+
+        named_expression = {
+            "type": "property_name",
+            "property_name": "referenced_id"
+        }
+
+        evaluation_context = EvaluationContext(doc)
+        factory_context = FactoryContext({
+            'test_named_expression': ExpressionFactory.from_spec(named_expression)
+        }, evaluation_context)
+
+        expression1 = ExpressionFactory.from_spec(
+            {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "array_index",
+                    "array_expression": {
+                        "type": "property_name",
+                        "property_name": "indices"
+                    },
+                    "index_expression": {
+                        "type": "constant",
+                        "constant": 0
+                    }
+                },
+                "value_expression": {
+                    "type": "named",
+                    "name": "test_named_expression"
+                }
+            },
+            context=factory_context
+        )
+        expression2 = ExpressionFactory.from_spec(
+            {
+                "type": "nested",
+                "argument_expression": {
+                    "type": "array_index",
+                    "array_expression": {
+                        "type": "property_name",
+                        "property_name": "indices"
+                    },
+                    "index_expression": {
+                        "type": "constant",
+                        "constant": 1
+                    }
+                },
+                "value_expression": {
+                    "type": "named",
+                    "name": "test_named_expression"
+                }
+            },
+            context=factory_context
+        )
+        self.assertEqual(expression1(doc, evaluation_context), 'my_parent_id')
+        self.assertEqual(expression2(doc, evaluation_context), 'my_parent_id2')
+
 
 class IteratorExpressionTest(SimpleTestCase):
 


### PR DESCRIPTION
@kkrampa Thanks for catching this and for the test! I cherry-picked your commit from #16062 

Named expressions use the iteration cache and that cache is reset on every iteration through a doc, so I'm not quite sure this is a bug. Could you link me to a fogbugz case or the UCR you found this on?

Either way, it seems like having a the item as part of the cache is an improvement so went ahead and implemented it.

@dannyroberts 