### PR TITLE
Refactor repeater error handling

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -545,11 +545,9 @@ class RepeatRecord(Document):
         return self.repeater.get_payload(self)
 
     def handle_payload_exception(self, exception):
-        # todo: this seems to just say that it failed but not actually cancel it
-        # todo:   or even change the last_checked or next_check
-        # todo:   so this will just get requeued indefinitely, right?
         self.succeeded = False
         self.failure_reason = unicode(exception)
+        self.cancel()
         self.save()
 
     def fire(self, force_send=False):

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -287,6 +287,8 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         try:
             payload = self.get_payload(repeat_record)
         except Exception as e:
+            # todo: seems like this just does everything that handle_exception does but not as well.
+            # todo:   seems like they could be combined
             repeat_record.handle_payload_exception(e)
             raise
 
@@ -543,6 +545,9 @@ class RepeatRecord(Document):
         return self.repeater.get_payload(self)
 
     def handle_payload_exception(self, exception):
+        # todo: this seems to just say that it failed but not actually cancel it
+        # todo:   or even change the last_checked or next_check
+        # todo:   so this will just get requeued indefinitely, right?
         self.succeeded = False
         self.failure_reason = unicode(exception)
         self.save()

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -168,17 +168,9 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         generator = self.get_payload_generator(self.format_or_default_format())
         return generator.get_payload(repeat_record, self.payload_doc(repeat_record))
 
-    def get_payload_or_none(self, repeat_record):
-        try:
-            return self.get_payload(repeat_record)
-        except ResourceNotFound:
-            return None
-
     def get_payload_and_save_exception(self, repeat_record):
         try:
-            return self.get_payload(repeat_record)
-        except ResourceNotFound as e:
-            repeat_record.handle_payload_exception(e)
+            self.get_payload(repeat_record)
         except Exception as e:
             repeat_record.handle_payload_exception(e)
             raise
@@ -549,7 +541,7 @@ class RepeatRecord(Document):
         return not self.succeeded
 
     def get_payload(self):
-        return self.repeater.get_payload_or_none(self)
+        return self.repeater.get_payload(self)
 
     def handle_payload_exception(self, exception):
         self.succeeded = False

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -178,13 +178,6 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         try:
             return self.get_payload(repeat_record)
         except ResourceNotFound as e:
-            # this repeater is pointing at a missing document
-            # quarantine it and tell it to stop trying.
-            logging.exception(
-                u'Repeater {} in domain {} references a missing or deleted document!'.format(
-                    repeat_record._id, self.domain,
-                ))
-
             repeat_record.handle_payload_exception(e)
         except Exception as e:
             repeat_record.handle_payload_exception(e)

--- a/custom/enikshay/reports/repeaters.py
+++ b/custom/enikshay/reports/repeaters.py
@@ -54,7 +54,7 @@ class ENikshayForwarderReport(DomainForwardingRepeatRecords):
 
     def _make_row(self, record):
         try:
-            payload = record.get_payload(save_failure=False)
+            payload = record.get_payload()
         except ENikshayException as error:
             payload = u"Error: {}".format(error)
         row = [


### PR DESCRIPTION
@proteusvacuum 

This lightly simplifies some of the error handling around `get_payload`, and in the process also gets rid of the special treatment of `ResourceNotFound`—I looked in email and this has happened once, in 2015, so I think it's fine not to treat it any special way at this point if it'll get in the way of reworking this code to make way for upcoming changes.

Good to review "🐡"