### PR TITLE
app manager v2: Float case properties refresh button right

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_ko_templates.html
@@ -197,7 +197,7 @@
 </script>
 
 <script type="text/html" id="case-config:refresh-form-questions">
-  <p>
+  <p class="pull-right">
     <button class="btn btn-info refresh-form-questions"
             type="button"
              data-bind="click: function(data, event){

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_ko_templates.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_ko_templates.html.diff.txt
@@ -203,7 +203,7 @@
 -                    refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{module.id}}', '{{form.id}}', event);
 -                    analytics.usage('Refresh case management', 'Button Clicked');
 -                    }">
-+  <p>
++  <p class="pull-right">
 +    <button class="btn btn-info refresh-form-questions"
 +            type="button"
 +             data-bind="click: function(data, event){


### PR DESCRIPTION
Looks a little awkward still on the usercase screen, but less so than when it was on the left.

<img width="1015" alt="screen shot 2017-05-11 at 11 54 42 am" src="https://cloud.githubusercontent.com/assets/1486591/25959193/fb7ffcc8-3640-11e7-89c7-d5ee13d494f0.png">

<img width="1013" alt="screen shot 2017-05-11 at 11 54 49 am" src="https://cloud.githubusercontent.com/assets/1486591/25959200/fe8ec6a6-3640-11e7-9413-340a129081ca.png">

@biyeun / @nickpell 