### PR TITLE
username, not email address

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1020,14 +1020,14 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         label="Partner contact",
         required=False,
         help_text=(
-            "Primary partner point of contact going forward (type email of existing web user)."
+            "Primary partner point of contact going forward (type username of existing web user)."
         ),
     )
     dimagi_contact = CharField(
         label="Dimagi contact",
         required=False,
         help_text=(
-            "Primary Dimagi point of contact going forward (type email of existing web user)."
+            "Primary Dimagi point of contact going forward (type username of existing web user)."
         ),
     )
     send_handoff_email = forms.BooleanField(


### PR DESCRIPTION
Context: [FB 253042](https://manage.dimagi.com/default.asp?253042)

Web users are identified by their username, not their email address. Usually they are the same, but not always.

@NoahCarnahan buddy @mkangia 
