### PR TITLE
add Subscription.get_active_subscription_by_domain()

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1558,43 +1558,34 @@ class Subscription(models.Model):
             self.account.save()
 
     @classmethod
-    def _get_plan_by_subscriber(cls, subscriber):
-        active_subscriptions = cls.objects\
-            .filter(subscriber=subscriber, is_active=True)\
-            .order_by('-date_created')[:2]\
-            .select_related('plan_version__role')
-
-        if not active_subscriptions:
-            return None, None
-
-        if len(active_subscriptions) > 1:
-            log_accounting_error(
-                "There seem to be multiple ACTIVE subscriptions for the "
-                "subscriber %s. Odd, right? The latest one by "
-                "date_created was used, but consider this an issue."
-                % subscriber
+    def get_active_subscription_by_domain(cls, domain_name):
+        try:
+            return cls.objects.select_related(
+                'plan_version__role'
+            ).get(
+                is_active=True,
+                subscriber__domain=domain_name,
             )
-        current_subscription = active_subscriptions[0]
-        return current_subscription.plan_version, current_subscription
+        except cls.DoesNotExist:
+            return None
 
     @classmethod
     def get_subscribed_plan_by_domain(cls, domain):
         """
-        Returns SoftwarePlanVersion, Subscription for the given domain.
+        Returns SoftwarePlanVersion for the given domain.
         """
         domain_obj = ensure_domain_instance(domain)
         if domain_obj is None:
             try:
-                plan_version = DefaultProductPlan.get_default_plan_version()
-                return plan_version, None
+                return DefaultProductPlan.get_default_plan_version()
             except DefaultProductPlan.DoesNotExist:
                 raise ProductPlanNotFoundError
-        domain = domain_obj
-        subscriber = Subscriber.objects.safe_get(domain=domain.name)
-        plan_version, subscription = cls._get_plan_by_subscriber(subscriber) if subscriber else (None, None)
-        if plan_version is None:
-            plan_version = DefaultProductPlan.get_default_plan_version()
-        return plan_version, subscription
+        else:
+            active_subscription = cls.get_active_subscription_by_domain(domain_obj.name)
+            if active_subscription is not None:
+                return active_subscription.plan_version
+            else:
+                return DefaultProductPlan.get_default_plan_version()
 
     @classmethod
     def new_domain_subscription(cls, account, domain, plan_version,

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -639,7 +639,7 @@ def send_overdue_reminders(today=None):
                 .aggregate(Sum('balance'))['balance__sum']
             if total >= 100:
                 domain = Domain.get_by_name(invoice.get_domain())
-                current_subscription = Subscription.get_subscribed_plan_by_domain(domain)[1]
+                current_subscription = Subscription.get_active_subscription_by_domain(domain.name)
                 if (
                     current_subscription.plan_version.plan.edition != SoftwarePlanEdition.COMMUNITY
                     and not current_subscription.skip_auto_downgrade

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -68,7 +68,7 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
         )
 
     def _subscribe_to_pro_with_rb(self):
-        subscription = Subscription.get_subscribed_plan_by_domain(self.project)[1]
+        subscription = Subscription.get_active_subscription_by_domain(self.project.name)
 
         new_subscription = subscription.change_plan(
             self.pro_rb_version,

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -119,7 +119,7 @@ def domain_has_privilege_cache_args(domain, privilege_slug, **assignment):
 def domain_has_privilege(domain, privilege_slug, **assignment):
     from corehq.apps.accounting.models import Subscription
     try:
-        plan_version = Subscription.get_subscribed_plan_by_domain(domain)[0]
+        plan_version = Subscription.get_subscribed_plan_by_domain(domain)
         privilege = Role.get_privilege(privilege_slug, assignment)
         if privilege is None:
             return False
@@ -132,10 +132,10 @@ def domain_has_privilege(domain, privilege_slug, **assignment):
     return False
 
 
-@quickcache(['domain'], timeout=15 * 60)
-def domain_is_on_trial(domain):
+@quickcache(['domain_name'], timeout=15 * 60)
+def domain_is_on_trial(domain_name):
     from corehq.apps.accounting.models import Subscription
-    subscription = Subscription.get_subscribed_plan_by_domain(domain)[1]
+    subscription = Subscription.get_active_subscription_by_domain(domain_name)
     return subscription.is_trial
 
 

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -76,7 +76,8 @@ def get_subscription_properties_by_user(couch_user):
     paying_subscribed_editions = []
     subscribed_editions = []
     for domain_name in couch_user.domains:
-        plan_version, subscription = Subscription.get_subscribed_plan_by_domain(domain_name)
+        subscription = Subscription.get_active_subscription_by_domain(domain_name)
+        plan_version = subscription.plan_version
         subscribed_editions.append(plan_version.plan.edition)
         if subscription is not None:
             all_subscriptions.append(subscription)

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -13,6 +13,7 @@ from django.dispatch import receiver
 
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.apps.accounting.models import (
+    DefaultProductPlan,
     ProBonoStatus,
     SoftwarePlanEdition,
     SoftwarePlanVisibility,
@@ -77,7 +78,11 @@ def get_subscription_properties_by_user(couch_user):
     subscribed_editions = []
     for domain_name in couch_user.domains:
         subscription = Subscription.get_active_subscription_by_domain(domain_name)
-        plan_version = subscription.plan_version
+        plan_version = (
+            subscription.plan_version
+            if subscription is not None
+            else DefaultProductPlan.get_default_plan_version()
+        )
         subscribed_editions.append(plan_version.plan.edition)
         if subscription is not None:
             all_subscriptions.append(subscription)

--- a/corehq/apps/analytics/tests/test_subscription_properties.py
+++ b/corehq/apps/analytics/tests/test_subscription_properties.py
@@ -87,7 +87,7 @@ class TestSubscriptionProperties(TestCase):
         self.assertEqual(properties['_is_on_extended_trial_plan'], 'yes')
 
     def _change_to_probono(self, domain_name, pro_bono_status):
-        plan, subscription = Subscription.get_subscribed_plan_by_domain(domain_name)
+        subscription = Subscription.get_active_subscription_by_domain(domain_name)
         subscription.update_subscription(
             pro_bono_status=pro_bono_status,
             date_start=datetime.date.today() - datetime.timedelta(days=1),
@@ -95,7 +95,7 @@ class TestSubscriptionProperties(TestCase):
         )
 
     def _change_to_extended_trial(self, domain_name):
-        plan, subscription = Subscription.get_subscribed_plan_by_domain(domain_name)
+        subscription = Subscription.get_active_subscription_by_domain(domain_name)
         subscription.update_subscription(
             service_type=SubscriptionType.EXTENDED_TRIAL,
             date_start=datetime.date.today() - datetime.timedelta(days=1),

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -53,7 +53,8 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
                            if subscription is not None else None),
             "date_end": (subscription.date_end
                          if subscription is not None else None),
-            "plan_version": subscription.plan_version,
+            "plan_version": (subscription.plan_version
+                             if subscription is not None else None),
         }
 
     def dehydrate_calculated_properties(self, bundle):

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -47,15 +47,13 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
 
     def dehydrate_billing_properties(self, bundle):
         domain = _get_domain(bundle)
-        plan_version, subscription = (
-            Subscription.get_subscribed_plan_by_domain(domain)
-        )
+        subscription = Subscription.get_active_subscription_by_domain(domain.name)
         return {
             "date_start": (subscription.date_start
                            if subscription is not None else None),
             "date_end": (subscription.date_end
                          if subscription is not None else None),
-            "plan_version": plan_version,
+            "plan_version": subscription.plan_version,
         }
 
     def dehydrate_calculated_properties(self, bundle):

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -87,7 +87,7 @@ def _terminate_subscriptions(domain_name):
     today = date.today()
 
     with transaction.atomic():
-        current_subscription = Subscription.get_subscribed_plan_by_domain(domain_name)[1]
+        current_subscription = Subscription.get_active_subscription_by_domain(domain_name)
 
         if current_subscription:
             current_subscription.date_end = today

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1824,7 +1824,7 @@ class InternalSubscriptionManagementForm(forms.Form):
     @property
     @memoized
     def current_subscription(self):
-        return Subscription.get_subscribed_plan_by_domain(self.domain)[1]
+        return Subscription.get_active_subscription_by_domain(self.domain)
 
     @property
     @memoized

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -5,10 +5,12 @@ from django.template.response import TemplateResponse
 
 # External imports
 from django.utils.deprecation import MiddlewareMixin
-from corehq.apps.accounting.exceptions import AccountingError
-from corehq.apps.accounting.models import Subscription
+
+from corehq.apps.accounting.models import (
+    DefaultProductPlan,
+    Subscription,
+)
 from corehq.toggles import DATA_MIGRATION
-from django_prbac.models import Role
 
 
 class CCHQPRBACMiddleware(MiddlewareMixin):
@@ -32,20 +34,17 @@ class CCHQPRBACMiddleware(MiddlewareMixin):
 
     @classmethod
     def apply_prbac(cls, request):
-        if hasattr(request, 'domain'):
-            try:
-                plan_version, subscription = Subscription.get_subscribed_plan_by_domain(request.domain)
-                request.role = plan_version.role
-                request.plan = plan_version
-                request.subscription = subscription
-                return None
-            except AccountingError:
-                pass
-        privilege = Role.get_privilege('community_plan_v1')
-        if privilege is not None:
-            request.role = privilege.role
+        subscription = (
+            Subscription.get_active_subscription_by_domain(request.domain)
+            if hasattr(request, 'domain') else None
+        )
+        if subscription:
+            plan_version = subscription.plan_version
+            request.role = plan_version.role
+            request.plan = plan_version
+            request.subscription = subscription
         else:
-            request.role = Role()  # A fresh Role() has no privileges
+            request.role = DefaultProductPlan.get_default_plan_version().role
 
 
 class DomainHistoryMiddleware(MiddlewareMixin):

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -44,7 +44,9 @@ class CCHQPRBACMiddleware(MiddlewareMixin):
             request.plan = plan_version
             request.subscription = subscription
         else:
-            request.role = DefaultProductPlan.get_default_plan_version().role
+            plan_version = DefaultProductPlan.get_default_plan_version()
+            request.role = plan_version.role
+            request.plan = plan_version
 
 
 class DomainHistoryMiddleware(MiddlewareMixin):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -677,7 +677,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
     @memoized
     def plan(self):
         subscription = Subscription.get_active_subscription_by_domain(self.domain)
-        plan_version = subscription.plan_version
+        plan_version = subscription.plan_version if subscription else DefaultProductPlan.get_default_plan_version()
         date_end = None
         next_subscription = {
             'exists': False,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -661,7 +661,7 @@ class DomainAccountingSettings(BaseProjectSettingsView):
 
     @property
     def current_subscription(self):
-        return Subscription.get_subscribed_plan_by_domain(self.domain_object)[1]
+        return Subscription.get_active_subscription_by_domain(self.domain)
 
 
 class DomainSubscriptionView(DomainAccountingSettings):
@@ -676,7 +676,8 @@ class DomainSubscriptionView(DomainAccountingSettings):
     @property
     @memoized
     def plan(self):
-        plan_version, subscription = Subscription.get_subscribed_plan_by_domain(self.domain_object)
+        subscription = Subscription.get_active_subscription_by_domain(self.domain)
+        plan_version = subscription.plan_version
         date_end = None
         next_subscription = {
             'exists': False,
@@ -1134,7 +1135,7 @@ class CreditsStripePaymentView(BaseStripePaymentView):
             self.get_or_create_payment_method(),
             self.domain,
             self.account,
-            subscription=Subscription.get_subscribed_plan_by_domain(self.domain_object)[1],
+            subscription=Subscription.get_active_subscription_by_domain(self.domain),
             post_data=self.request.POST.copy(),
         )
 
@@ -1337,7 +1338,7 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
     def page_context(self):
         return {
             'is_form_editable': self.is_form_editable,
-            'plan_name': Subscription.get_subscribed_plan_by_domain(self.domain)[0],
+            'plan_name': Subscription.get_subscribed_plan_by_domain(self.domain),
             'select_subscription_type_form': self.select_subscription_type_form,
             'subscription_management_forms': self.slug_to_form.values(),
             'today': datetime.date.today(),
@@ -1365,7 +1366,7 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
             })
 
         subscription_type = None
-        subscription = Subscription.get_subscribed_plan_by_domain(self.domain_object)[1]
+        subscription = Subscription.get_active_subscription_by_domain(self.domain)
         if subscription is None:
             subscription_type = None
         else:
@@ -1554,10 +1555,11 @@ class ConfirmSelectedPlanView(SelectPlanView):
 
     @property
     def downgrade_messages(self):
-        current_plan_version, subscription = Subscription.get_subscribed_plan_by_domain(self.domain_object)
-        if subscription is None:
-            current_plan_version = None
-        downgrades = get_change_status(current_plan_version, self.selected_plan_version)[1]
+        subscription = Subscription.get_active_subscription_by_domain(self.domain)
+        downgrades = get_change_status(
+            subscription.plan_version if subscription else None,
+            self.selected_plan_version
+        )[1]
         downgrade_handler = DomainDowngradeStatusHandler(
             self.domain_object, self.selected_plan_version, downgrades,
         )
@@ -1683,7 +1685,7 @@ class SubscriptionMixin(object):
     @property
     @memoized
     def subscription(self):
-        subscription = Subscription.get_subscribed_plan_by_domain(self.domain_object)[1]
+        subscription = Subscription.get_active_subscription_by_domain(self.domain)
         if subscription is None:
             raise Http404
         if subscription.is_renewed:

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -301,8 +301,7 @@ class ReportBuilderPaywallBase(BaseDomainView):
     @property
     @memoized
     def plan_name(self):
-        plan_version, _ = Subscription.get_subscribed_plan_by_domain(self.domain)
-        return plan_version.plan.name
+        return Subscription.get_subscribed_plan_by_domain(self.domain).plan.name
 
 
 class ReportBuilderPaywallPricing(ReportBuilderPaywallBase):

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -176,7 +176,7 @@ def can_add_extra_mobile_workers(request):
     if user_limit == -1 or num_web_users < user_limit:
         return True
     if not has_privilege(request, privileges.ALLOW_EXCESS_USERS):
-        current_subscription = Subscription.get_subscribed_plan_by_domain(request.domain)[1]
+        current_subscription = Subscription.get_active_subscription_by_domain(request.domain)
         if current_subscription is None or current_subscription.account.date_confirmed_extra_charges is None:
             return False
     return True

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1385,7 +1385,7 @@ class ProjectSettingsTab(UITab):
                     DomainBillingStatementsView, ConfirmSubscriptionRenewalView,
                     InternalSubscriptionManagementView,
                 )
-                current_subscription = Subscription.get_subscribed_plan_by_domain(self.domain)[1]
+                current_subscription = Subscription.get_active_subscription_by_domain(self.domain)
                 subscription = [
                     {
                         'title': _(DomainSubscriptionView.page_title),


### PR DESCRIPTION
This is the second half to https://github.com/dimagi/commcare-hq/pull/15852 (wanted to wait one invoicing period to make sure nothing unexpectedly broke).

Since we can now know that there is at most one active subscription per domain, we're able to clean up the query to find a domain's active subscription (https://github.com/dimagi/commcare-hq/commit/39188fd4f0b3e45922649b67365bfb1485981b42).

@orangejenny 