### PR TITLE
Create 24 Hour Registration reminder email

### DIFF
--- a/corehq/apps/registration/models.py
+++ b/corehq/apps/registration/models.py
@@ -42,6 +42,27 @@ class RegistrationRequest(Document):
         return result[0]['value']
 
     @classmethod
+    def get_requests_24hrs_ago(cls):
+        today = datetime.datetime.utcnow()
+        yesterday = today - datetime.timedelta(1)
+        join_on_start = datetime.datetime(
+            yesterday.year, yesterday.month, yesterday.day, yesterday.hour, 0, 0, 0)
+        join_on_end = datetime.datetime(
+            yesterday.year, yesterday.month, yesterday.day, yesterday.hour, 59, 59, 59)
+        result = cls.view(
+            "registration/requests_by_time",
+            startkey=join_on_start.isoformat(),
+            endkey=join_on_end.isoformat(),
+            include_docs=True,
+            reduce=False
+        ).all()
+        return filter(
+            lambda doc: (doc.new_user_username == doc.requesting_user_username
+                         and doc.confirm_time is None),
+            result
+        )
+
+    @classmethod
     def get_request_for_username(cls, username):
         result = cls.view("registration/requests_by_username",
             key=username,

--- a/corehq/apps/registration/tasks.py
+++ b/corehq/apps/registration/tasks.py
@@ -1,0 +1,50 @@
+from celery.schedules import crontab
+from celery.task import periodic_task
+from django.core.urlresolvers import reverse
+from django.conf import settings
+from django.template.loader import render_to_string
+
+from django.utils.translation import ugettext
+
+from dimagi.utils.web import get_site_domain
+
+from corehq.apps.registration.models import RegistrationRequest
+from corehq.apps.users.models import WebUser
+from corehq.apps.hqwebapp.tasks import send_html_email_async
+
+
+@periodic_task(
+    run_every=crontab(minute=0),  # execute once every hour
+    queue='background_queue',
+)
+def activation_24hr_reminder_email():
+    """
+    Reminds inactive users registered 24 hrs ago to activate their account.
+    """
+    request_reminders = RegistrationRequest.get_requests_24hrs_ago()
+
+    DNS_name = get_site_domain()
+
+    for request in request_reminders:
+        user = WebUser.get_by_username(request.new_user_username)
+        registration_link = 'http://' + DNS_name + reverse(
+            'registration_confirm_domain') + request.activation_guid + '/'
+        email_context = {
+            "domain": request.domain,
+            "registration_link": registration_link,
+            "full_name": user.full_name,
+            'url_prefix': '' if settings.STATIC_CDN else 'http://' + DNS_name,
+        }
+
+        message_plaintext = render_to_string(
+            'registration/email/confirm_account_reminder.txt', email_context)
+        message_html = render_to_string(
+            'registration/email/confirm_account.html', email_context)
+        subject = ugettext('Reminder to Activate your CommCare project')
+
+        send_html_email_async.delay(
+            subject, request.new_user_username, message_html,
+            text_content=message_plaintext,
+            email_from=settings.DEFAULT_FROM_EMAIL,
+            ga_track=True
+        )

--- a/corehq/apps/registration/templates/registration/email/confirm_account_reminder.html
+++ b/corehq/apps/registration/templates/registration/email/confirm_account_reminder.html
@@ -1,0 +1,33 @@
+{% extends 'registration/email/confirm_account.html' %}
+{% load i18n %}
+
+{% block content %}
+    <p>{% blocktrans %}Dear {{ full_name }},{% endblocktrans %}</p>
+
+    <p>
+        {% blocktrans %}Welcome to CommCare!{% endblocktrans %}
+        {% blocktrans %}We noticed that you registered for an account yesterday,
+          but it seems you haven't confirmed your email address yet.{% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans %}Please click the button below to activate your CommCare project <strong>{{ domain }}</strong>.{% endblocktrans %}
+    </p>
+    <p style="text-align: center;">
+        <a class="btn"
+           href="{{ registration_link }}"
+           style="color: #ffffff; text-decoration: none; padding: 10px 15px; background-color: #004ebc; border-radius: 5px; font-size: 20px; -moz-border-radius: 5px; -webkit-border-radius: 5px; display: inline-block; cursor: pointer;">
+            {% trans "Activate CommCare" %}
+        </a>
+    </p>
+    <p>
+        {% blocktrans %}
+        Once you do this, our team will be in touch with some helpful tips for getting started!
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans %}
+        Cheers,<br />
+        The CommCare Team
+        {% endblocktrans %}
+    </p>
+{% endblock %}

--- a/corehq/apps/registration/templates/registration/email/confirm_account_reminder.txt
+++ b/corehq/apps/registration/templates/registration/email/confirm_account_reminder.txt
@@ -1,0 +1,23 @@
+Dear {{ full_name }},
+
+Welcome to CommCare! We noticed that you registered for an account yesterday,
+but it seems you haven't confirmed your email address yet.
+
+Please confirm your email address and activate your new CommCare project titled:
+{{ domain }}. You will not be able to use your project until you have confirmed
+your email address.
+
+{{ registration_link }}
+
+Once you have confirmed, our team will be in touch with some helpful tips for
+getting started!
+
+Cheers,
+The CommCare Team
+
+Dimagi, Inc.
+585 Massachusetts Ave, Suite 4
+Cambridge,  MA 02139 United States
+
+You received this message because we received a New User request
+www.commcarehq.org with your email address.


### PR DESCRIPTION
@orangejenny // cc: @esoergel 

Per request from comms to resend the confirmation reminder email after 24 hours and no activation has been made.