### PR TITLE
person cases async

### DIFF
--- a/custom/icds_reports/ucr/data_sources/person_cases.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases.json
@@ -2548,6 +2548,7 @@
         "property_value": null
       }
     },
+    "asynchronous": true,
     "engine_id": "icds-ucr",
     "backend_id": "LABORATORY",
     "es_index_settings": {


### PR DESCRIPTION
We're 30 M change behind on the case-sql, 0 partition. Further partitions won't help because that first partition still has a ton of changes in it. I think the easiest way to fix this is to set this to be async until it's caught up. Also going to bump up the concurrency on the celery workers that process this

(EDIT: i'm going to do the same for ccs record monthly once this one is caught up)

@sheelio @dannyroberts 