### PR TITLE
Make repeaters fire for record side effect free

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -471,6 +471,12 @@ class LocationRepeater(Repeater):
         return "forwarding locations to: %s" % self.url
 
 
+class RepeatRecordAttempt(DocumentSchema):
+    datetime = DateTimeProperty()
+    succeeded = BooleanProperty(default=False)
+    failure_reason = StringProperty()
+
+
 class RepeatRecord(Document):
     """
     An record of a particular instance of something that needs to be forwarded

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -590,13 +590,12 @@ class RepeatRecord(Document):
             try:
                 attempt = self.repeater.fire_for_record(self)
             except Exception as e:
-                # todo: seems like this just does everything that handle_exception does but not as well.
-                # todo:   seems like they could be combined
                 attempt = self.handle_payload_exception(e)
-                self.add_attempt(attempt)
-                self.save()
                 raise
-            else:
+            finally:
+                # pycharm warns attempt might not be defined.
+                # that'll only happen if fire_for_record raise a non-Exception exception (e.g. SIGINT)
+                # or handle_payload_exception raises an exception. I'm okay with that. -DMR
                 self.add_attempt(attempt)
                 self.save()
 

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -465,11 +465,11 @@ class LocationRepeater(Repeater):
 
 
 class RepeatRecordAttempt(DocumentSchema):
+    cancelled = BooleanProperty(default=False)
     datetime = DateTimeProperty()
+    failure_reason = StringProperty()
     next_check = DateTimeProperty()
     succeeded = BooleanProperty(default=False)
-    failure_reason = StringProperty()
-    cancelled = BooleanProperty(default=False)
 
 
 class RepeatRecord(Document):
@@ -558,10 +558,11 @@ class RepeatRecord(Document):
 
         now = datetime.utcnow()
         return RepeatRecordAttempt(
+            cancelled=False,
             datetime=now,
+            failure_reason=failure_reason,
             next_check=now + window,
             succeeded=False,
-            failure_reason=failure_reason,
         )
 
     def try_now(self):
@@ -596,11 +597,11 @@ class RepeatRecord(Document):
         """
         now = datetime.utcnow()
         attempt = RepeatRecordAttempt(
+            cancelled=False,
             datetime=now,
+            failure_reason=None,
             next_check=None,
             succeeded=True,
-            cancelled=False,
-            failure_reason=None,
         )
         self.add_attempt(attempt)
 
@@ -631,11 +632,11 @@ class RepeatRecord(Document):
         else:
             now = datetime.utcnow()
             return RepeatRecordAttempt(
-                datetime=now,
-                next_check=None,
                 cancelled=True,
-                succeeded=False,
+                datetime=now,
                 failure_reason=reason,
+                next_check=None,
+                succeeded=False,
             )
 
     def cancel(self):

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -167,7 +167,8 @@ class RepeaterTest(BaseRepeaterTest):
         record = RepeatRecord(domain=self.domain, next_check=now)
         self.assertIsNone(record.last_checked)
 
-        record.set_next_try()
+        attempt = record.make_set_next_try_attempt(None)
+        record.add_attempt(attempt)
         self.assertTrue(record.last_checked > now)
         self.assertEqual(record.next_check, record.last_checked + MIN_RETRY_WAIT)
 


### PR DESCRIPTION
This is what I've been working towards. Not 100% about my approach: `self.cancel()` and `self.set_next_try()` were a bit more suggestive than then the `return RepeatRecordAttempt(...)` lines they've been replaced with, but I think the present change—isolating the side effects of a single attempt into a returnable object—is pretty necessary for keeping track of multiple attempts better.

This repeater still doesn't actually _change_ anything fundamentally behavior-wise; the next step—which should now be pretty easy—is to actually store these `RepeatRecordAttempt`s as a list on `RepeatRecord`. (And the step after that is to do something with that in the UI.)