### PR TITLE
App manager v2: odd word wrapping on deploy page comments

### DIFF
--- a/corehq/apps/style/static/app_manager/less/new_appmanager/panel.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/panel.less
@@ -122,7 +122,8 @@
 .panel-release > .panel-body {
   padding: 5px 15px;
   .prefixed-icon {
-    margin-left: -30px;
+    position: absolute;
+    left: 30px;
     padding-right: 10px;
   }
   .read-only {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?253961

Something about the icon's margin is causing the adjacent text to wrap funny. Not clear on why this is happening, but switching to absolute positioning fixes it.

@biyeun / @nickpell 