### PR TITLE
App Manager v2: Turn on for new users on 5/15

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/managed_app.html
@@ -66,21 +66,23 @@
           </div>
         {% endif %}
 
-      <div class="appnav-toggle-label">
-          <div class="btn-group pull-right">
-            <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
-            <button type="button"
-                    class="btn btn-xs btn-default"
-                    data-toggle="modal"
-                    data-target="#rollout-revert-modal"
-                    data-redirect="{% url "view_app" domain app.id %}"
-            >{% trans "Off" %}</button>
+        {% if allow_v2_opt_out %}
+          <div class="appnav-toggle-label">
+              <div class="btn-group pull-right">
+                <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
+                <button type="button"
+                        class="btn btn-xs btn-default"
+                        data-toggle="modal"
+                        data-target="#rollout-revert-modal"
+                        data-redirect="{% url "view_app" domain app.id %}"
+                >{% trans "Off" %}</button>
+              </div>
+              {% trans "New App Builder" %}
+              <span class="hq-help-template"
+                    data-title="New App Builder"
+                    data-content="{% trans "Turn off new app builder for now." %}"></span>
           </div>
-          {% trans "New App Builder" %}
-          <span class="hq-help-template"
-                data-title="New App Builder"
-                data-content="{% trans "Turn off new app builder for now." %}"></span>
-      </div>
+        {% endif %}
 
         {% include 'app_manager/v2/partials/appnav_menu.html' %}
       {% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
@@ -20,7 +20,7 @@
  {% endblock %}
  
  {% block breadcrumbs %}
-@@ -25,281 +28,167 @@
+@@ -25,281 +28,169 @@
  {% endblock %}
  
  {% block page_navigation %}
@@ -98,7 +98,24 @@
 -                {% trans "Multimedia" %}
 -            </a>
 -        </li>
--        {% endif %}
++
++        {% if allow_v2_opt_out %}
++          <div class="appnav-toggle-label">
++              <div class="btn-group pull-right">
++                <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
++                <button type="button"
++                        class="btn btn-xs btn-default"
++                        data-toggle="modal"
++                        data-target="#rollout-revert-modal"
++                        data-redirect="{% url "view_app" domain app.id %}"
++                >{% trans "Off" %}</button>
++              </div>
++              {% trans "New App Builder" %}
++              <span class="hq-help-template"
++                    data-title="New App Builder"
++                    data-content="{% trans "Turn off new app builder for now." %}"></span>
++          </div>
+         {% endif %}
 -        {% if app.get_doc_type != "LinkedApplication" %}
 -        <li>
 -            <a href="{% url "view_app" domain app.id %}languages/#languages-and-translations" {% if is_app_view %}data-toggle="tab" data-pagetitle="{% trans "Languages" %}: {{ app.name }}"{% endif %}>
@@ -158,22 +175,7 @@
 -                            data-placement="top"
 -                            {% endif %}
 -                            ></i>
-+      <div class="appnav-toggle-label">
-+          <div class="btn-group pull-right">
-+            <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
-+            <button type="button"
-+                    class="btn btn-xs btn-default"
-+                    data-toggle="modal"
-+                    data-target="#rollout-revert-modal"
-+                    data-redirect="{% url "view_app" domain app.id %}"
-+            >{% trans "Off" %}</button>
-+          </div>
-+          {% trans "New App Builder" %}
-+          <span class="hq-help-template"
-+                data-title="New App Builder"
-+                data-content="{% trans "Turn off new app builder for now." %}"></span>
-+      </div>
- 
+-
 -                            <span {% if module.id == selected_module.id %}class="variable-module_name"{% endif %}>
 -                                {{ module.name|html_trans:langs }}
 -

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
@@ -20,7 +20,7 @@
  {% endblock %}
  
  {% block breadcrumbs %}
-@@ -25,281 +28,175 @@
+@@ -25,281 +28,177 @@
  {% endblock %}
  
  {% block page_navigation %}
@@ -82,24 +82,7 @@
 -                {% trans "Multimedia" %}
 -            </a>
 -        </li>
-+
-+        {% if allow_v2_opt_out %}
-+          <div class="appnav-toggle-label">
-+              <div class="btn-group pull-right">
-+                <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
-+                <button type="button"
-+                        class="btn btn-xs btn-default"
-+                        data-toggle="modal"
-+                        data-target="#rollout-revert-modal"
-+                        data-redirect="{% url "view_app" domain app.id %}"
-+                >{% trans "Off" %}</button>
-+              </div>
-+              {% trans "New App Builder" %}
-+              <span class="hq-help-template"
-+                    data-title="New App Builder"
-+                    data-content="{% trans "Turn off new app builder for now." %}"></span>
-+          </div>
-         {% endif %}
+-        {% endif %}
 -        {% if app.get_doc_type != "LinkedApplication" %}
 -        <li>
 -            <a href="{% url "view_app" domain app.id %}languages/#languages-and-translations" {% if is_app_view %}data-toggle="tab" data-pagetitle="{% trans "Languages" %}: {{ app.name }}"{% endif %}>
@@ -342,21 +325,23 @@
 +          </div>
 +        {% endif %}
 +
-+      <div class="appnav-toggle-label">
-+          <div class="btn-group pull-right">
-+            <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
-+            <button type="button"
-+                    class="btn btn-xs btn-default"
-+                    data-toggle="modal"
-+                    data-target="#rollout-revert-modal"
-+                    data-redirect="{% url "view_app" domain app.id %}"
-+            >{% trans "Off" %}</button>
++        {% if allow_v2_opt_out %}
++          <div class="appnav-toggle-label">
++              <div class="btn-group pull-right">
++                <button type="button" class="btn btn-xs btn-default active">{% trans "On" %}</button>
++                <button type="button"
++                        class="btn btn-xs btn-default"
++                        data-toggle="modal"
++                        data-target="#rollout-revert-modal"
++                        data-redirect="{% url "view_app" domain app.id %}"
++                >{% trans "Off" %}</button>
++              </div>
++              {% trans "New App Builder" %}
++              <span class="hq-help-template"
++                    data-title="New App Builder"
++                    data-content="{% trans "Turn off new app builder for now." %}"></span>
 +          </div>
-+          {% trans "New App Builder" %}
-+          <span class="hq-help-template"
-+                data-title="New App Builder"
-+                data-content="{% trans "Turn off new app builder for now." %}"></span>
-+      </div>
++        {% endif %}
 +
 +        {% include 'app_manager/v2/partials/appnav_menu.html' %}
 +      {% endif %}

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -296,6 +296,11 @@ def get_apps_base_context(request, domain, app):
             'show_shadow_forms': show_advanced,
         })
 
+    if toggles.APP_MANAGER_V2.enabled(request.user.username):
+        rollout = toggles.APP_MANAGER_V2.enabled_for_new_users_after
+        if not toggles.was_user_created_after(request.user.username, rollout):
+            context.update({'allow_v2_opt_out': True})
+
     return context
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -52,7 +52,8 @@ class StaticToggle(object):
 
     def __init__(self, slug, label, tag, namespaces=None, help_link=None,
                  description=None, save_fn=None, always_enabled=None,
-                 always_disabled=None, enabled_for_new_domains_after=None):
+                 always_disabled=None, enabled_for_new_domains_after=None,
+                 enabled_for_new_users_after=None):
         self.slug = slug
         self.label = label
         self.tag = tag
@@ -65,6 +66,7 @@ class StaticToggle(object):
         self.always_enabled = always_enabled or set()
         self.always_disabled = always_disabled or set()
         self.enabled_for_new_domains_after = enabled_for_new_domains_after
+        self.enabled_for_new_users_after = enabled_for_new_users_after
         if namespaces:
             self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
         else:
@@ -80,9 +82,13 @@ class StaticToggle(object):
             # short circuit if we're checking an item that isn't supported by this toggle
             return False
 
-        enabled_after = self.enabled_for_new_domains_after
-        if (enabled_after is not None and NAMESPACE_DOMAIN in self.namespaces
-            and was_domain_created_after(item, enabled_after)):
+        domain_enabled_after = self.enabled_for_new_domains_after
+        if (domain_enabled_after is not None and NAMESPACE_DOMAIN in self.namespaces
+            and was_domain_created_after(item, domain_enabled_after)):
+            return True
+
+        user_enabled_after = self.enabled_for_new_users_after
+        if (user_enabled_after is not None and was_user_created_after(item, user_enabled_after)):
             return True
 
         namespaces = self.namespaces if namespace is Ellipsis else [namespace]
@@ -153,6 +159,22 @@ def was_domain_created_after(domain, checkpoint):
         domain_obj is not None and
         domain_obj.date_created is not None and
         domain_obj.date_created > checkpoint
+    )
+
+
+def was_user_created_after(username, checkpoint):
+    """
+    Return true if user was created after checkpoint
+
+    :param username: Web User username (string).
+    :param checkpoint: datetime object.
+    """
+    from corehq.apps.users.models import WebUser
+    user = WebUser.get_by_username(username)
+    return (
+        user is not None and
+        user.created_on is not None and
+        user.created_on > checkpoint
     )
 
 
@@ -1003,7 +1025,8 @@ APP_MANAGER_V2 = StaticToggle(
     'app_manager_v2',
     'Prototype for case management onboarding (App Manager V2)',
     TAG_PRODUCT_PATH,
-    [NAMESPACE_USER]
+    [NAMESPACE_USER],
+    enabled_for_new_users_after=datetime(2017, 5, 15, 20),  # 8pm UTC
 )
 
 USER_TESTING_SIMPLIFY = StaticToggle(


### PR DESCRIPTION
- Mimic https://github.com/dimagi/commcare-hq/pull/15940 to add `enabled_for_new_users_after` to `StaticToggle`
- Apply it to app manager v2 as of Monday's planned release
- Don't allow new users to opt out of v2, since they've never known v1

@biyeun / @nickpell / @millerdev 