### PR TITLE
Don't process bad case in UCR or ES pillows

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -214,6 +214,11 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Pil
 
     def process_change(self, pillow_instance, change):
         self.bootstrap_if_needed()
+        if change.id == '79f25f76-7828-4237-9f10-ca80909550f0':
+            # TODO: Remove this. It was added because a runaway repeater
+            # created lots of form submissions against this case, filling up
+            # the change feed
+            return
         if change.deleted:
             # we don't currently support hard-deletions at all.
             # we may want to change this at some later date but seem ok for now.

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -35,13 +35,20 @@ def transform_case_for_elasticsearch(doc_dict):
     return doc_ret
 
 
+def remove_bad_cases(doc_dict):
+    # TODO: Remove this. It was added because a runaway repeater created lots
+    # of form submissions against this case, filling up the change feed
+    return doc_dict.get('_id') == '79f25f76-7828-4237-9f10-ca80909550f0'
+
+
 def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow', **kwargs):
     assert pillow_id == 'CaseToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_INDEX_INFO)
     case_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
-        doc_prep_fn=transform_case_for_elasticsearch
+        doc_prep_fn=transform_case_for_elasticsearch,
+        doc_filter_fn=remove_bad_cases,
     )
     kafka_change_feed = KafkaChangeFeed(topics=topics.CASE_TOPICS, group_id='cases-to-es')
     return ConstructedPillow(

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -25,6 +25,8 @@ from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.change_providers.case import get_domain_case_change_provider
 from pillowtop.reindexer.reindexer import PillowChangeProviderReindexer
 
+from corehq.pillows.case import remove_bad_cases
+
 
 def transform_case_for_elasticsearch(doc_dict):
     doc = {
@@ -75,7 +77,8 @@ def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearch
     case_processor = CaseSearchPillowProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_SEARCH_INDEX_INFO,
-        doc_prep_fn=transform_case_for_elasticsearch
+        doc_prep_fn=transform_case_for_elasticsearch,
+        doc_filter_fn=remove_bad_cases,
     )
     change_feed = KafkaChangeFeed(topics=topics.CASE_TOPICS, group_id='cases-to-es')
     return ConstructedPillow(


### PR DESCRIPTION
Not sure if this is a good approach or not.
I can revert this once the changes have been processed, and the offending forms against that case have been archived.
@emord @NoahCarnahan 