### PR TITLE
function to prune synclogs

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -6,7 +6,6 @@ from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from casexml.apps.case.mock import CaseStructure, CaseIndex, CaseFactory
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.tests.utils import use_sql_backend
-from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 
 
 class CaseRelationshipTest(SimpleTestCase):
@@ -177,7 +176,6 @@ class CaseFactoryTest(TestCase):
 
     def test_form_extras(self):
         domain = uuid.uuid4().hex
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
         token_id = uuid.uuid4().hex
         factory = CaseFactory(domain=domain)
         [case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}), form_extras={'last_sync_token': token_id})
@@ -188,7 +186,6 @@ class CaseFactoryTest(TestCase):
         domain = uuid.uuid4().hex
         # have to enable loose sync token validation for the domain or create actual SyncLog documents.
         # this is the easier path.
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
         token_id = uuid.uuid4().hex
         factory = CaseFactory(domain=domain, form_extras={'last_sync_token': token_id})
         case = factory.create_case()
@@ -197,7 +194,6 @@ class CaseFactoryTest(TestCase):
 
     def test_form_extras_override_defaults(self):
         domain = uuid.uuid4().hex
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
         token_id = uuid.uuid4().hex
         factory = CaseFactory(domain=domain, form_extras={'last_sync_token': token_id})
         [case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}), form_extras={'last_sync_token': 'differenttoken'})

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -10,7 +10,7 @@ from casexml.apps.case.signals import cases_received
 from casexml.apps.case.util import validate_phone_datetime
 from casexml.apps.phone.cleanliness import should_create_flags_on_submission
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
-from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION, EXTENSION_CASES_SYNC_ENABLED
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -130,10 +130,7 @@ def _update_sync_logs(xform, case_db, config, cases):
     try:
         relevant_log = xform.get_sync_token()
     except ResourceNotFound:
-        if LOOSE_SYNC_TOKEN_VALIDATION.enabled(xform.domain):
-            relevant_log = None
-        else:
-            raise
+        relevant_log = None
 
     if relevant_log:
         # in reconciliation mode, things can be unexpected

--- a/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
@@ -1,5 +1,5 @@
+from datetime import date
 from casexml.apps.phone.models import SyncLog, properly_wrap_sync_log
-from dimagi.utils.couch.database import get_db
 
 
 def get_last_synclog_for_user(user_id):
@@ -16,3 +16,15 @@ def get_last_synclog_for_user(user_id):
     if result:
         row, = result
         return properly_wrap_sync_log(row['doc'])
+
+
+def get_synclog_ids_before_date(before_date, limit=1000):
+    if isinstance(before_date, date):
+        before_date = before_date.strftime("%Y-%m-%d")
+    return [r['id'] for r in SyncLog.view(
+        "sync_logs_by_date/view",
+        endkey=[before_date],
+        limit=limit,
+        reduce=False,
+        include_docs=False
+    )]

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -18,8 +18,7 @@ from casexml.apps.phone.exceptions import (
     BadStateException, RestoreException, DateOpenedBugException,
 )
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
-from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION, EXTENSION_CASES_SYNC_ENABLED
-from corehq.util.soft_assert import soft_assert
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
 from corehq.util.timer import TimingContext
 from corehq.util.datadog.gauges import datadog_counter
 from dimagi.utils.decorators.memoized import memoized
@@ -675,12 +674,8 @@ class RestoreConfig(object):
         try:
             self.restore_state.validate_state()
         except InvalidSyncLogException as e:
-            if LOOSE_SYNC_TOKEN_VALIDATION.enabled(self.domain):
-                # This exception will get caught by the view and a 412 will be returned to the phone for resync
-                raise RestoreException(e)
-            else:
-                # This exception will fail hard and we'll get a 500 error message
-                raise
+            # This exception will get caught by the view and a 412 will be returned to the phone for resync
+            raise RestoreException(e)
 
     def get_payload(self):
         self.validate()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -20,11 +20,10 @@ from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
     use_sql_backend,
 )
-from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from corehq.util.test_utils import flag_enabled
 from casexml.apps.case.tests.util import (
     check_user_has_case, assert_user_doesnt_have_case,
-    assert_user_has_case, TEST_DOMAIN_NAME, assert_user_has_cases, check_payload_has_cases,
+    assert_user_has_case, TEST_DOMAIN_NAME, assert_user_has_cases,
     check_payload_has_case_ids, assert_user_doesnt_have_cases)
 from casexml.apps.phone.tests.utils import create_restore_user, has_cached_payload
 from casexml.apps.phone.models import SyncLog, get_properly_wrapped_sync_log, SimplifiedSyncLog, \
@@ -2070,14 +2069,6 @@ class SyncTokenReprocessingTestSQL(SyncTokenReprocessingTest):
 
 class LooseSyncTokenValidationTest(SyncBaseTest):
 
-    def test_submission_with_bad_log_default(self):
-        with self.assertRaises(ResourceNotFound):
-            post_case_blocks(
-                [CaseBlock(create=True, case_id='bad-log-default').as_xml()],
-                form_extras={"last_sync_token": 'not-a-valid-synclog-id'},
-                domain='some-domain-without-toggle',
-            )
-
     def test_submission_with_bad_log_toggle_enabled(self):
         domain = 'submission-domain-with-toggle'
 
@@ -2088,24 +2079,8 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 domain=domain,
             )
 
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, False, namespace='domain')
-        with self.assertRaises(ResourceNotFound):
-            _test()
-
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
         # this is just asserting that an exception is not raised after the toggle is set
         _test()
-
-    def test_restore_with_bad_log_default(self):
-        with self.assertRaises(MissingSyncLog):
-            RestoreConfig(
-                project=Domain(name="test_restore_with_bad_log_default"),
-                restore_user=self.user,
-                params=RestoreParams(
-                    version=V2,
-                    sync_log_id='not-a-valid-synclog-id',
-                ),
-            ).get_payload()
 
     def test_restore_with_bad_log_toggle_enabled(self):
         domain = 'restore-domain-with-toggle'
@@ -2120,12 +2095,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 )
             ).get_payload()
 
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, False, namespace='domain')
-        with self.assertRaises(MissingSyncLog):
-            _test()
-
-        LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
-        # when the toggle is set the exception should be a RestoreException instead
         with self.assertRaises(RestoreException):
             _test()
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2079,7 +2079,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 domain=domain,
             )
 
-        # this is just asserting that an exception is not raised after the toggle is set
+        # this is just asserting that an exception is not raised when there's no synclog
         _test()
 
     def test_restore_with_bad_log_toggle_enabled(self):

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -7,3 +7,11 @@ def get_restore_response_class(domain):
     if BLOBDB_RESTORE.enabled(domain):
         return BlobRestoreResponse
     return FileRestoreResponse
+
+
+def delete_sync_logs(before_date, limit=1000):
+    from casexml.apps.phone.dbaccessors.sync_logs_by_user import get_synclog_ids_before_date
+    from casexml.apps.phone.models import SyncLog
+    from dimagi.utils.couch.database import iter_bulk_delete_with_doc_type_verification
+    sync_log_ids = get_synclog_ids_before_date(before_date, limit)
+    return iter_bulk_delete_with_doc_type_verification(SyncLog.get_db(), sync_log_ids, 'SyncLog')

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -510,13 +510,6 @@ STOCK_AND_RECEIPT_SMS_HANDLER = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-LOOSE_SYNC_TOKEN_VALIDATION = StaticToggle(
-    'loose_sync_token_validation',
-    "Don't fail hard on missing or deleted sync tokens.",
-    TAG_EXPERIMENTAL,
-    [NAMESPACE_DOMAIN]
-)
-
 # This toggle offers the "multiple_apps_unlimited" mobile flag to non-Dimagi users
 MOBILE_PRIVILEGES_FLAG = StaticToggle(
     'mobile_privileges_flag',


### PR DESCRIPTION
https://trello.com/c/ylowaGGK/90-purge-old-synclogs

Sync logs are growing pretty quickly these days. it's > 150 GB on icds after compaction.

I wasn't sure about the correct thresholds to use, but this will allow us to do some pruning manually before making a periodic celery task.

When is it safe to start deleting synclogs? A day ago, week ago, month ago?
How many docs can you safely delete at once in couch without causing too much load on view reindexes? (we likely won't know that until we hit it)
Should these parameters be configurable based on environment? (would likely need to happen in localsettings)
Is it worth it to do something smarter? Like don't delete if this is the users latest sync? I think that would add a lot of load to couch or would at least take a lot of requests

@snopoke @dannyroberts 