### PR TITLE
Fix `AncestorLocationTypeFilter.get_filter_value`

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4160,14 +4160,18 @@ class AncestorLocationTypeFilter(ReportAppFilter):
 
     def get_filter_value(self, user, ui_filter):
         from corehq.apps.locations.models import SQLLocation
+        from corehq.apps.reports_core.filters import REQUEST_USER_KEY
 
+        kwargs = {REQUEST_USER_KEY: user}
         try:
             ancestor = user.sql_location.get_ancestors(include_self=True).\
                 get(location_type__name=self.ancestor_location_type_name)
+            kwargs[ui_filter.name] = ancestor.location_id
         except (AttributeError, SQLLocation.DoesNotExist):
             # user.sql_location is None, or location does not have an ancestor of that type
-            return None
-        return ancestor.location_id
+            pass
+
+        return ui_filter.value(**kwargs)
 
 
 class NumericFilter(ReportAppFilter):

--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -15,7 +15,9 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import SQLLocation, LocationType
-from corehq.apps.reports_core.filters import Choice
+from corehq.apps.reports_core.filters import Choice, DynamicChoiceListFilter
+from corehq.apps.userreports.reports.filters.choice_providers import DataSourceColumnChoiceProvider
+from corehq.apps.userreports.reports.filters.values import dynamic_choice_list_url
 from corehq.apps.users.models import CommCareUser
 
 
@@ -290,12 +292,35 @@ class AutoFilterTests(TestCase):
         result = _filter_by_user_id(self.sheel, None)
         self.assertEqual(result, Choice(value=self.sheel._id, display=None))
 
+    def _get_dynamic_choice_list_ui_filter(self):
+        return DynamicChoiceListFilter(
+            "my name",
+            "my_field",
+            "string",
+            "my label",
+            True,
+            dynamic_choice_list_url,
+            DataSourceColumnChoiceProvider(None, None)
+        )
+
     # AncestorLocationTypeFilter is not an AutoFilter, but we'll hitch a ride here to reuse setup and teardown
     def test_ancestor_location_type_filter(self):
-        filt = AncestorLocationTypeFilter(ancestor_location_type_name='state')
-        nate_state = filt.get_filter_value(self.nate, None)
-        self.assertEqual(nate_state, self.massachusetts.location_id)
+        ucr_filter = AncestorLocationTypeFilter(ancestor_location_type_name='state')
+        ui_filter = self._get_dynamic_choice_list_ui_filter()
+        ancestor_state_value = ucr_filter.get_filter_value(self.nate, ui_filter)
+        self.assertEqual(
+            ancestor_state_value,
+            [Choice(
+                value=self.massachusetts.location_id,
+                display=self.massachusetts.location_id
+            )]
+        )
 
+    def test_ancestor_location_type_filter_with_no_location_found(self):
+        ucr_filter = AncestorLocationTypeFilter(ancestor_location_type_name='banana')
+        ui_filter = self._get_dynamic_choice_list_ui_filter()
+        ancestor_state_value = ucr_filter.get_filter_value(self.nate, ui_filter)
+        self.assertEqual(ancestor_state_value, ui_filter.default_value())
 
 class NumericFilterTests(TestCase):
 


### PR DESCRIPTION
`AncestorLocationTypeFilter.get_filter_value()` should use the corresponding ui filter to get a value of the correct type. The other mobile UCR filters already do this e.g. the [location_id AutoFilter](https://github.com/dimagi/commcare-hq/blob/cce1537355777a89c69abb0a8a97c0a4d42e708a/corehq/apps/app_manager/models.py#L3938).

This function was returning strings, but when the `AncestorLocationTypeFilter` is used with a `DynamicChocieListFilter` for instance, functions further down the line were expecting [`Choice`](https://github.com/dimagi/commcare-hq/blob/cce1537355777a89c69abb0a8a97c0a4d42e708a/corehq/apps/reports_core/filters.py#L303) objects. In fact, I'm not sure I understand how this feature was ever working. @kaapstorm, does it seem like I'm missing something about how this is supposed to work? Do you know if other projects used this mobile ucr filter successfully somewhere?

buddy @sravfeyn 