### PR TITLE
Show all delivery attempts on RepeatRecord

### DIFF
--- a/corehq/apps/domain/templates/domain/repeat_record_report.html
+++ b/corehq/apps/domain/templates/domain/repeat_record_report.html
@@ -17,7 +17,10 @@
 {% block js-inline %}{{ block.super }}
 <script>
     $(function() {
-
+        $('#report-content').on('click', '.toggle-next-pre', function (e) {
+            $(this).nextAll('pre').toggle();
+            e.preventDefault();
+        });
         var codeMirror = null;
         $('#view-record-payload-modal').on('shown.bs.modal', function(event) {
             var recordData = $(event.relatedTarget).data(),

--- a/corehq/apps/domain/templates/domain/repeaters/partials/attempt_history.html
+++ b/corehq/apps/domain/templates/domain/repeaters/partials/attempt_history.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+<ul class="list-unstyled">
+{% for attempt_number, attempt in record.get_numbered_attempts %}
+    <li><strong>Attempt #{{ attempt_number }}</strong>
+    {% if attempt.succeeded %}
+        <br/><i class="fa fa-check"></i> {% trans "Success" %}
+    {% elif attempt.failure_reason %}
+        <br/><i class="fa fa-exclamation-triangle"></i> {% trans "Failed" %} <a href="#" class="toggle-next-pre">…</a>
+        <pre style="display: none">{{ attempt.failure_reason }}</pre>
+    {% endif %}
+    {% if attempt.cancelled %}
+        <br/><i class="fa fa-remove"></i> {% trans "Cancelled" %}
+    {% endif %}
+    </li>
+{% endfor %}
+</ul>

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -33,7 +33,6 @@ from django.views.decorators.http import require_POST
 from PIL import Image
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.contrib.auth.models import User
-from django.utils.html import escape
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
@@ -95,7 +94,7 @@ from corehq.toggles import NAMESPACE_DOMAIN, all_toggles, CAN_EDIT_EULA, TRANSFE
 from custom.openclinica.forms import OpenClinicaSettingsForm
 from custom.openclinica.models import OpenClinicaSettings
 from dimagi.utils.couch.resource_conflict import retry_resource
-from dimagi.utils.web import json_request, json_response
+from dimagi.utils.web import json_request
 from corehq import privileges, feature_previews
 from django_prbac.utils import has_privilege
 from corehq.apps.accounting.models import (
@@ -2388,8 +2387,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             record.url if record.url else _(u'Unable to generate url for record'),
             self._format_date(record.last_checked) if record.last_checked else '---',
             self._format_date(record.next_check) if record.next_check else '---',
-            escape(record.failure_reason) if not record.succeeded else None,
-            record.overall_tries if record.overall_tries > 0 else None,
+            render_to_string('domain/repeaters/partials/attempt_history.html', {'record': record}),
             self._make_view_payload_button(record.get_id),
             self._make_resend_payload_button(record.get_id),
             self._make_requeue_payload_button(record.get_id) if record.cancelled and not record.succeeded
@@ -2409,8 +2407,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             DataTablesColumn(_('URL')),
             DataTablesColumn(_('Last sent date')),
             DataTablesColumn(_('Retry Date')),
-            DataTablesColumn(_('Failure Reason')),
-            DataTablesColumn(_('Failure Count')),
+            DataTablesColumn(_('Delivery Attempts')),
             DataTablesColumn(_('View payload')),
             DataTablesColumn(_('Resend')),
             DataTablesColumn(_('Cancel or Requeue payload'))

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -560,8 +560,7 @@ class RepeatRecord(Document):
         self.next_check = attempt.next_check
         self.succeeded = attempt.succeeded
         self.cancelled = attempt.cancelled
-        if attempt.failure_reason is not None:
-            self.failure_reason = attempt.failure_reason
+        self.failure_reason = attempt.failure_reason
 
     def make_set_next_try_attempt(self, failure_reason):
         # we use an exponential back-off to avoid submitting to bad urls

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -562,6 +562,11 @@ class RepeatRecord(Document):
         self.cancelled = attempt.cancelled
         self.failure_reason = attempt.failure_reason
 
+    def get_numbered_attempts(self):
+        offset = self.overall_tries - len(self.attempts)
+        for i, attempt in enumerate(self.attempts):
+            yield i + 1 + offset, attempt
+
     def make_set_next_try_attempt(self, failure_reason):
         # we use an exponential back-off to avoid submitting to bad urls
         # too frequently.

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -639,7 +639,7 @@ class RepeatRecord(Document):
         """Do something with the response if the repeater fails
         """
         return self._make_failure_attempt(
-            u'{}: {}. {}'.format(response.status_code, response.reason, getattr(response, 'content', None)),
+            u'{}: {}.\n{}'.format(response.status_code, response.reason, getattr(response, 'content', None)),
             response
         )
 

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -478,21 +478,22 @@ class RepeatRecord(Document):
     An record of a particular instance of something that needs to be forwarded
     with a link to the proper repeater object
     """
+
+    domain = StringProperty()
+    repeater_id = StringProperty()
+    repeater_type = StringProperty()
+    payload_id = StringProperty()
+
     overall_tries = IntegerProperty(default=0)
     max_possible_tries = IntegerProperty(default=3)
 
-    repeater_id = StringProperty()
-    repeater_type = StringProperty()
-    domain = StringProperty()
+    attempts = ListProperty(RepeatRecordAttempt)
 
+    cancelled = BooleanProperty(default=False)
     last_checked = DateTimeProperty()
+    failure_reason = StringProperty()
     next_check = DateTimeProperty()
     succeeded = BooleanProperty(default=False)
-    failure_reason = StringProperty()
-    cancelled = BooleanProperty(default=False)
-
-    payload_id = StringProperty()
-    attempts = ListProperty(RepeatRecordAttempt)
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/repeaters/views.py
+++ b/corehq/apps/repeaters/views.py
@@ -42,9 +42,9 @@ class RepeatRecordView(LoginAndDomainMixin, View):
     http_method_names = ['get', 'post']
 
     @staticmethod
-    def get_record_or_404(request, domain):
+    def get_record_or_404(request, domain, record_id):
         try:
-            record = RepeatRecord.get(request.GET.get('record_id'))
+            record = RepeatRecord.get(record_id)
         except ResourceNotFound:
             raise Http404()
 
@@ -54,7 +54,8 @@ class RepeatRecordView(LoginAndDomainMixin, View):
         return record
 
     def get(self, request, domain):
-        record = self.get_record_or_404(request, domain)
+        record_id = request.GET.get('record_id')
+        record = self.get_record_or_404(request, domain, record_id)
         content_type = record.repeater.generator.content_type
         try:
             payload = record.get_payload()
@@ -75,7 +76,8 @@ class RepeatRecordView(LoginAndDomainMixin, View):
 
     def post(self, request, domain):
         # Retriggers a repeat record
-        record = self.get_record_or_404(request, domain)
+        record_id = request.POST.get('record_id')
+        record = self.get_record_or_404(request, domain, record_id)
         record.fire(force_send=True)
         return json_response({
             'success': record.succeeded,


### PR DESCRIPTION
You can now see all attempts at delivering a repeat record:

<img width="1189" alt="screen shot 2017-05-12 at 5 55 29 pm" src="https://cloud.githubusercontent.com/assets/137212/26018348/438deeb6-373c-11e7-8a1e-531184f81f31.png">

You can also expand the [...] to see the error message (`failure_reason`):

<img width="1177" alt="screen shot 2017-05-12 at 5 55 41 pm" src="https://cloud.githubusercontent.com/assets/137212/26018350/46542ebc-373c-11e7-9922-f49584b26c73.png">
