### PR TITLE
Don't exclude 'deleted' users from export user type filter

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -830,6 +830,7 @@ class AbstractExportFilterBuilder(object):
                  .domain(self.domain_object.name)
                  .OR(*user_filters)
                  .show_inactive()
+                 .remove_default_filter('not_deleted')
                  .fields([]))
         user_ids = query.run().doc_ids
 


### PR DESCRIPTION
Some forms submitted by "unknown" user ids were being excluded from form exports with the "Unknown Users" filter selected. This is because the query for unknown user ids includes a clause like `{"term": {"base_doc": "couchuser"}}`, but unknown user docs created for totally unknown user ids don't even have the `base_doc` field.

This bug specifically affected user ids that were totally unrecognized, ids in the `WEIRD_USER_IDS` list, and web users were not affected. This change may result in previously excluded deleted web users now being included in the export as well. However, I don't think that's such a bad thing, because I would think that "Unknown Users" basically would include all data.

@benrudolph 
cc @sravfeyn 
http://manage.dimagi.com/default.asp?254077