### PR TITLE
App manager v2: position footer properly

### DIFF
--- a/corehq/apps/style/static/style/js/layout.js
+++ b/corehq/apps/style/static/style/js/layout.js
@@ -4,7 +4,7 @@ var hqLayout = {};
 hqLayout.selector = {
     navigation: '#hq-navigation',
     content: '#hq-content',
-    appmanager: '#js-appmanager-body.appmanager-content',
+    appmanager: '#js-appmanager-body',
     footer: '#hq-footer',
     sidebar: '#hq-sidebar',
     breadcrumbs: '#hq-breadcrumbs',


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?254078

Layout logic wasn't running because `base_summary_view_v2.html`'s `#js-appmanager-body` doesn't (and can't) use `.appmanager-content`. `apps_base.html` is the only other place `#js-appmanager-body` is used, where it *is* paired with `.appmanager-content` (in both v1 and v2). So it should be fine to just use the id as the selector here.

@biyeun / @nickpell 