### PR TITLE
initialize checkpoint to 0

### DIFF
--- a/corehq/ex-submodules/pillowtop/models.py
+++ b/corehq/ex-submodules/pillowtop/models.py
@@ -96,7 +96,7 @@ class KafkaCheckpoint(models.Model):
         for tp, offset in all_offsets.items():
             if tp not in already_created:
                 to_create.append(
-                    cls(checkpoint_id=checkpoint_id, topic=tp[0], partition=tp[1], offset=offset)
+                    cls(checkpoint_id=checkpoint_id, topic=tp[0], partition=tp[1], offset=0)
                 )
 
         cls.objects.bulk_create(to_create)


### PR DESCRIPTION
May or may not fix the issue @nickpell ran into on softlayer today 

Old pillows would initalize checkpoints to 0, so I think the pillow should fix the  checkpoint if necessary. Still need to do mroe testing though https://github.com/dimagi/commcare-hq/blob/je/pillowcheckpoints/corehq/ex-submodules/pillowtop/checkpoints/manager.py#L26