### PR TITLE
Match base class method signature

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -774,7 +774,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             return None
 
     @staticmethod
-    def get_case_ids_in_domain(domain, type_=None, deleted=False):
+    def get_case_ids_in_domain(domain, type_=None):
         return CaseAccessorSQL._get_case_ids_in_domain(domain, case_type=type_)
 
     @staticmethod


### PR DESCRIPTION
`AbstractCaseAccessor. get_case_ids_in_domain()` doesn't have a deleted kwarg, and this method doesn't do anything with it anyways.
@dannyroberts 