### PR TITLE
One view query instead of one per global ID

### DIFF
--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -27,12 +27,12 @@ def get_fixture_data_types_in_domain(domain):
     ))
 
 
-@quickcache(['domain', 'data_type_id'], timeout=60 * 60, memoize_timeout=60, skip_arg='bypass_cache')
-def get_fixture_items_by_data_type(domain, data_type_id, bypass_cache=False):
+@quickcache(['domain', 'data_type_ids'], timeout=60 * 60, memoize_timeout=60, skip_arg='bypass_cache')
+def get_fixture_items_for_data_types(domain, data_type_ids, bypass_cache=False):
     from corehq.apps.fixtures.models import FixtureDataItem
     return list(FixtureDataItem.view(
         'fixtures/data_items_by_domain_type',
-        key=[domain, data_type_id],
+        keys=[[domain, id] for id in data_type_ids],
         reduce=False,
         include_docs=True,
         descending=True

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -62,10 +62,10 @@ class ItemListsProvider(FixtureProvider):
             # have to do another db trip later
             item._data_type = data_type
 
-        for global_fixture in global_types.values():
-            items = FixtureDataItem.by_data_type(restore_user.domain, global_fixture)
-            _ = [_set_cached_type(item, global_fixture) for item in items]
-            items_by_type[global_fixture._id] = items
+        items = FixtureDataItem.by_data_types(restore_user.domain, global_types)
+        for item in items:
+            _set_cached_type(item, global_types[item.data_type_id])
+            items_by_type[item.data_type_id].append(item)
 
         if set(all_types) - set(global_types):
             # only query ownership models if there are non-global types

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -413,7 +413,7 @@ class FixtureDataItem(Document):
 
     @classmethod
     def by_data_types(cls, domain, data_types, bypass_cache=False):
-        data_type_ids = frozenset(_id_from_doc(d) for d in data_types)
+        data_type_ids = set(_id_from_doc(d) for d in data_types)
         return get_fixture_items_for_data_types(domain, data_type_ids, bypass_cache)
 
     @classmethod

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -6,7 +6,7 @@ from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.fixtures.dbaccessors import (
     get_owner_ids_by_type,
     get_fixture_data_types_in_domain,
-    get_fixture_items_by_data_type
+    get_fixture_items_for_data_types
 )
 from corehq.apps.fixtures.exceptions import FixtureException, FixtureTypeCheckError
 from corehq.apps.fixtures.utils import clean_fixture_field_name, \
@@ -409,8 +409,12 @@ class FixtureDataItem(Document):
 
     @classmethod
     def by_data_type(cls, domain, data_type, bypass_cache=False):
-        data_type_id = _id_from_doc(data_type)
-        return get_fixture_items_by_data_type(domain, data_type_id, bypass_cache)
+        return cls.by_data_types(domain, [data_type], bypass_cache)
+
+    @classmethod
+    def by_data_types(cls, domain, data_types, bypass_cache=False):
+        data_type_ids = frozenset(_id_from_doc(d) for d in data_types)
+        return get_fixture_items_for_data_types(domain, data_type_ids, bypass_cache)
 
     @classmethod
     def by_domain(cls, domain):


### PR DESCRIPTION
There are 16 global fixture data types for UATBC, and the fixture code had been executing a separate couch query for each one. My rough time measurements showed that that can take up to 20s. Combining them all in a single query takes ~2.5s. The 20s time could be offset somewhat by caching, but I think this is still a win because it should make the slow (empty cache) case faster. Also, the results are now all cached together so it may even improve cache effects.

The combined query currently returns nearly 1000 items, so it still looks promising to not send item set fixtures that have not changed since the user's last sync. Just compiling the XML for that many items can take a while.

@proteusvacuum @dannyroberts 