### PR TITLE
Simplify repeater payload generators

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -68,6 +68,12 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     password = StringProperty()
     friendly_name = _("Data")
 
+    _generators = None
+
+    @classmethod
+    def get_generators(cls):
+        return cls._generators
+
     @classmethod
     def get_custom_url(cls, domain):
         return None
@@ -260,8 +266,7 @@ class FormRepeater(Repeater):
 
     """
 
-    class Formats(object):
-        formats = [FormRepeaterXMLPayloadGenerator, FormRepeaterJsonPayloadGenerator]
+    _generators = [FormRepeaterXMLPayloadGenerator, FormRepeaterJsonPayloadGenerator]
 
     include_app_id_param = BooleanProperty(default=True)
     white_listed_form_xmlns = StringListProperty(default=[])  # empty value means all form xmlns are accepted
@@ -309,8 +314,7 @@ class CaseRepeater(Repeater):
 
     """
 
-    class Formats(object):
-        formats = [CaseRepeaterXMLPayloadGenerator, CaseRepeaterJsonPayloadGenerator]
+    _generators = [CaseRepeaterXMLPayloadGenerator, CaseRepeaterJsonPayloadGenerator]
 
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     white_listed_case_types = StringListProperty(default=[])  # empty value means all case-types are accepted
@@ -354,8 +358,7 @@ class ShortFormRepeater(Repeater):
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     friendly_name = _("Forward Form Stubs")
 
-    class Formats(object):
-        formats = [ShortFormRepeaterJsonPayloadGenerator]
+    _generators = [ShortFormRepeaterJsonPayloadGenerator]
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -378,8 +381,7 @@ class ShortFormRepeater(Repeater):
 class AppStructureRepeater(Repeater):
     friendly_name = _("Forward App Schema Changes")
 
-    class Formats(object):
-        formats = [AppStructureGenerator]
+    _generators = [AppStructureGenerator]
 
     def payload_doc(self, repeat_record):
         return None
@@ -388,8 +390,7 @@ class AppStructureRepeater(Repeater):
 class UserRepeater(Repeater):
     friendly_name = _("Forward Users")
 
-    class Formats(object):
-        formats = [UserPayloadGenerator]
+    _generators = [UserPayloadGenerator]
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -402,8 +403,7 @@ class UserRepeater(Repeater):
 class LocationRepeater(Repeater):
     friendly_name = _("Forward Locations")
 
-    class Formats(object):
-        formats = [LocationPayloadGenerator]
+    _generators = [LocationPayloadGenerator]
 
     @memoized
     def payload_doc(self, repeat_record):

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from datetime import datetime, timedelta
 import urllib
 import urlparse
@@ -262,11 +261,7 @@ class FormRepeater(Repeater):
     """
 
     class Formats(object):
-        formats = {
-            'form_xml': (FormRepeaterXMLPayloadGenerator, _('XML')),
-            'form_json': (FormRepeaterJsonPayloadGenerator, _('JSON')),
-        }
-        default_format = 'form_xml'
+        formats = [FormRepeaterXMLPayloadGenerator, FormRepeaterJsonPayloadGenerator]
 
     include_app_id_param = BooleanProperty(default=True)
     white_listed_form_xmlns = StringListProperty(default=[])  # empty value means all form xmlns are accepted
@@ -315,11 +310,7 @@ class CaseRepeater(Repeater):
     """
 
     class Formats(object):
-        formats = {
-            'case_xml': (CaseRepeaterXMLPayloadGenerator, _('XML')),
-            'case_json': (CaseRepeaterJsonPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_xml'
+        formats = [CaseRepeaterXMLPayloadGenerator, CaseRepeaterJsonPayloadGenerator]
 
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     white_listed_case_types = StringListProperty(default=[])  # empty value means all case-types are accepted
@@ -364,7 +355,7 @@ class ShortFormRepeater(Repeater):
     friendly_name = _("Forward Form Stubs")
 
     class Formats(object):
-        generator = ShortFormRepeaterJsonPayloadGenerator
+        formats = [ShortFormRepeaterJsonPayloadGenerator]
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -388,7 +379,7 @@ class AppStructureRepeater(Repeater):
     friendly_name = _("Forward App Schema Changes")
 
     class Formats(object):
-        generator = AppStructureGenerator
+        formats = [AppStructureGenerator]
 
     def payload_doc(self, repeat_record):
         return None
@@ -398,7 +389,7 @@ class UserRepeater(Repeater):
     friendly_name = _("Forward Users")
 
     class Formats(object):
-        generator = UserPayloadGenerator
+        formats = [UserPayloadGenerator]
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -412,7 +403,7 @@ class LocationRepeater(Repeater):
     friendly_name = _("Forward Locations")
 
     class Formats(object):
-        generator = LocationPayloadGenerator
+        formats = [LocationPayloadGenerator]
 
     @memoized
     def payload_doc(self, repeat_record):

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -68,11 +68,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     password = StringProperty()
     friendly_name = _("Data")
 
-    _generators = None
-
-    @classmethod
-    def get_generators(cls):
-        return cls._generators
+    payload_generator_classes = ()
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -266,7 +262,7 @@ class FormRepeater(Repeater):
 
     """
 
-    _generators = [FormRepeaterXMLPayloadGenerator, FormRepeaterJsonPayloadGenerator]
+    payload_generator_classes = (FormRepeaterXMLPayloadGenerator, FormRepeaterJsonPayloadGenerator)
 
     include_app_id_param = BooleanProperty(default=True)
     white_listed_form_xmlns = StringListProperty(default=[])  # empty value means all form xmlns are accepted
@@ -314,7 +310,7 @@ class CaseRepeater(Repeater):
 
     """
 
-    _generators = [CaseRepeaterXMLPayloadGenerator, CaseRepeaterJsonPayloadGenerator]
+    payload_generator_classes = (CaseRepeaterXMLPayloadGenerator, CaseRepeaterJsonPayloadGenerator)
 
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     white_listed_case_types = StringListProperty(default=[])  # empty value means all case-types are accepted
@@ -358,7 +354,7 @@ class ShortFormRepeater(Repeater):
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     friendly_name = _("Forward Form Stubs")
 
-    _generators = [ShortFormRepeaterJsonPayloadGenerator]
+    payload_generator_classes = (ShortFormRepeaterJsonPayloadGenerator,)
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -381,7 +377,7 @@ class ShortFormRepeater(Repeater):
 class AppStructureRepeater(Repeater):
     friendly_name = _("Forward App Schema Changes")
 
-    _generators = [AppStructureGenerator]
+    payload_generator_classes = (AppStructureGenerator,)
 
     def payload_doc(self, repeat_record):
         return None
@@ -390,7 +386,7 @@ class AppStructureRepeater(Repeater):
 class UserRepeater(Repeater):
     friendly_name = _("Forward Users")
 
-    _generators = [UserPayloadGenerator]
+    payload_generator_classes = (UserPayloadGenerator,)
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -403,7 +399,7 @@ class UserRepeater(Repeater):
 class LocationRepeater(Repeater):
     friendly_name = _("Forward Locations")
 
-    _generators = [LocationPayloadGenerator]
+    payload_generator_classes = (LocationPayloadGenerator,)
 
     @memoized
     def payload_doc(self, repeat_record):

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -360,14 +360,11 @@ class ShortFormRepeater(Repeater):
 
     """
 
-    class Formats(object):
-        formats = {
-            'short_form_json': (ShortFormRepeaterJsonPayloadGenerator, _('Default JSON')),
-        }
-        default_format = 'short_form_json'
-
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     friendly_name = _("Forward Form Stubs")
+
+    class Formats(object):
+        generator = ShortFormRepeaterJsonPayloadGenerator
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -391,10 +388,7 @@ class AppStructureRepeater(Repeater):
     friendly_name = _("Forward App Schema Changes")
 
     class Formats(object):
-        formats = {
-            'id': (AppStructureGenerator, _('ID Only')),
-        }
-        default_format = 'app_structure_id'
+        generator = AppStructureGenerator
 
     def payload_doc(self, repeat_record):
         return None
@@ -404,10 +398,7 @@ class UserRepeater(Repeater):
     friendly_name = _("Forward Users")
 
     class Formats(object):
-        formats = {
-            'user_json': (UserPayloadGenerator, _("JSON")),
-        }
-        default_format = 'user_json'
+        generator = UserPayloadGenerator
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -421,10 +412,7 @@ class LocationRepeater(Repeater):
     friendly_name = _("Forward Locations")
 
     class Formats(object):
-        formats = {
-            'location_json': (LocationPayloadGenerator, _("JSON")),
-        }
-        default_format = 'location_json'
+        generator = LocationPayloadGenerator
 
     @memoized
     def payload_doc(self, repeat_record):

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -164,8 +164,16 @@ class RegisterGenerator(object):
     @classmethod
     def get_collection(cls, repeater_class):
         if repeater_class not in cls.generators:
-            formats = repeater_class.Formats.formats
-            default_format = repeater_class.Formats.default_format
+            if hasattr(repeater_class.Formats, 'generator'):
+                # in the case where there's exactly one format
+                # the format slug and display name aren't used so they don't matter
+                formats = {
+                    '': (repeater_class.Formats.generator, '')
+                }
+                default_format = ''
+            else:
+                formats = repeater_class.Formats.formats
+                default_format = repeater_class.Formats.default_format
             if default_format not in formats:
                 raise DuplicateFormatException(
                     'default_format {!r} is not in formats {!r}'.format(default_format, formats))

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -189,20 +189,17 @@ class RegisterGenerator(object):
     @classmethod
     def generator_class_by_repeater_format(cls, repeater_class, format_name):
         """Return generator class given a Repeater class and format_name"""
-        generator_collection = cls.get_collection(repeater_class)
-        return generator_collection.get_generator_by_format(format_name)
+        return cls.get_collection(repeater_class).get_generator_by_format(format_name)
 
     @classmethod
     def all_formats_by_repeater(cls, repeater_class, for_domain=None):
         """Return all formats for a given Repeater class"""
-        generator_collection = cls.get_collection(repeater_class)
-        return generator_collection.get_all_formats(for_domain=for_domain)
+        return cls.get_collection(repeater_class).get_all_formats(for_domain=for_domain)
 
     @classmethod
     def default_format_by_repeater(cls, repeater_class):
         """Return default format_name for a Repeater class"""
-        generator_collection = cls.get_collection(repeater_class)
-        return generator_collection.get_default_format()
+        return cls.get_collection(repeater_class).get_default_format()
 
 
 class FormRepeaterXMLPayloadGenerator(BasePayloadGenerator):

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -3,6 +3,7 @@ import json
 
 from datetime import datetime
 from uuid import uuid4
+import warnings
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import ugettext_lazy as _
@@ -157,14 +158,20 @@ class RegisterGenerator(object):
         self.is_default = is_default
 
     def __call__(self, generator_class):
-        collection = self.get_collection(self.repeater_cls)
-        collection.add_new_format(self.format_name, self.format_label, generator_class,
-                                  is_default=self.is_default)
-        return generator_class
+        warnings.warn(
+            "Usage of @RegisterGenerator as a decorator is deprecated. "
+            "Please put your payload generator classes in a tuple on your repeater class "
+            "called payload_generator_classes instead.",
+            DeprecationWarning)
+        return self.register_generator(generator_class, self.repeater_cls, self.format_name,
+                                       self.format_label, is_default=self.is_default)
 
     @classmethod
-    def register_generator(cls, generator_class, repeater_class, format_name, format_label, is_default):
-        return cls(repeater_class, format_name, format_label, is_default)(generator_class)
+    def register_generator(cls, generator_class, repeater_class, format_name, format_label,
+                           is_default):
+        collection = cls.get_collection(repeater_class)
+        collection.add_new_format(format_name, format_label, generator_class, is_default)
+        return generator_class
 
     @classmethod
     def get_collection(cls, repeater_class):

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -170,7 +170,7 @@ class RegisterGenerator(object):
     def get_collection(cls, repeater_class):
         if repeater_class not in cls.generators:
             cls.generators[repeater_class] = GeneratorCollection(repeater_class)
-            generator_classes = repeater_class.get_generators()
+            generator_classes = repeater_class.payload_generator_classes
             default_generator_class = generator_classes[0]
             for generator_class in generator_classes:
                 cls.register_generator(

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -200,8 +200,7 @@ class RegisterGenerator(object):
     def default_format_by_repeater(cls, repeater_class):
         """Return default format_name for a Repeater class"""
         generator_collection = cls.get_collection(repeater_class)
-        default_format = generator_collection.get_default_format()
-        return default_format
+        return generator_collection.get_default_format()
 
 
 class FormRepeaterXMLPayloadGenerator(BasePayloadGenerator):

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -157,14 +157,9 @@ class RegisterGenerator(object):
         self.is_default = is_default
 
     def __call__(self, generator_class):
-        if not self.repeater_cls in RegisterGenerator.generators:
-            RegisterGenerator.generators[self.repeater_cls] = GeneratorCollection(self.repeater_cls)
-        RegisterGenerator.generators[self.repeater_cls].add_new_format(
-            self.format_name,
-            self.format_label,
-            generator_class,
-            is_default=self.is_default
-        )
+        collection = self.get_collection(self.repeater_cls)
+        collection.add_new_format(self.format_name, self.format_label, generator_class,
+                                  is_default=self.is_default)
         return generator_class
 
     @classmethod
@@ -173,9 +168,9 @@ class RegisterGenerator(object):
 
     @classmethod
     def get_collection(cls, repeater_class):
-        if hasattr(repeater_class, 'Formats') and \
-                not getattr(repeater_class.Formats, 'processed', False):
-            generator_classes = repeater_class.Formats.formats
+        if repeater_class not in cls.generators:
+            cls.generators[repeater_class] = GeneratorCollection(repeater_class)
+            generator_classes = repeater_class.get_generators()
             default_generator_class = generator_classes[0]
             for generator_class in generator_classes:
                 cls.register_generator(
@@ -185,7 +180,6 @@ class RegisterGenerator(object):
                     format_label=generator_class.format_label,
                     is_default=(generator_class is default_generator_class),
                 )
-            repeater_class.Formats.processed = True
 
         return cls.generators[repeater_class]
 

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -581,11 +581,14 @@ class IgnoreDocumentTest(BaseRepeaterTest):
     def setUpClass(cls):
         super(IgnoreDocumentTest, cls).setUpClass()
 
-        @RegisterGenerator(FormRepeater, 'new_format', 'XML')
         class NewFormGenerator(BasePayloadGenerator):
+            format_name = 'new_format'
+            format_label = 'XML'
 
             def get_payload(self, repeat_record, payload_doc):
                 raise IgnoreDocument
+
+        RegisterGenerator.get_collection(FormRepeater).add_new_format(NewFormGenerator)
 
     def setUp(self):
         super(IgnoreDocumentTest, self).setUp()
@@ -626,11 +629,14 @@ class TestRepeaterFormat(BaseRepeaterTest):
         super(TestRepeaterFormat, cls).setUpClass()
         cls.payload = 'some random case'
 
-        @RegisterGenerator(CaseRepeater, 'new_format', 'XML')
         class NewCaseGenerator(BasePayloadGenerator):
+            format_name = 'new_format'
+            format_label = 'XML'
 
             def get_payload(self, repeat_record, payload_doc):
                 return cls.payload
+
+        RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator)
 
     def setUp(self):
         super(TestRepeaterFormat, self).setUp()
@@ -652,20 +658,26 @@ class TestRepeaterFormat(BaseRepeaterTest):
         super(TestRepeaterFormat, self).tearDown()
 
     def test_new_format_same_name(self):
-        with self.assertRaises(DuplicateFormatException):
-            @RegisterGenerator(CaseRepeater, 'case_xml', 'XML', is_default=False)
-            class NewCaseGenerator(BasePayloadGenerator):
+        class NewCaseGenerator(BasePayloadGenerator):
+            format_name = 'case_xml'
+            format_label = 'XML'
 
-                def get_payload(self, repeat_record, payload_doc):
-                    return self.payload
+            def get_payload(self, repeat_record, payload_doc):
+                return self.payload
+
+        with self.assertRaises(DuplicateFormatException):
+            RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator)
 
     def test_new_format_second_default(self):
-        with self.assertRaises(DuplicateFormatException):
-            @RegisterGenerator(CaseRepeater, 'rubbish', 'XML', is_default=True)
-            class NewCaseGenerator(BasePayloadGenerator):
+        class NewCaseGenerator(BasePayloadGenerator):
+            format_name = 'rubbish'
+            format_label = 'XML'
 
-                def get_payload(self, repeat_record, payload_doc):
-                    return self.payload
+            def get_payload(self, repeat_record, payload_doc):
+                return self.payload
+
+        with self.assertRaises(DuplicateFormatException):
+            RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator, is_default=True)
 
     @run_with_all_backends
     def test_new_format_payload(self):

--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -8,7 +8,7 @@ from pytz import timezone
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.repeaters.exceptions import RequestConnectionError
-from corehq.apps.repeaters.repeater_generators import RegisterGenerator, BasePayloadGenerator
+from corehq.apps.repeaters.repeater_generators import BasePayloadGenerator
 from custom.enikshay.case_utils import update_case, get_person_case_from_episode
 from custom.enikshay.const import (
     DATE_FULFILLED,
@@ -26,9 +26,6 @@ from custom.enikshay.integrations.bets.const import (
     LOCATION_TYPE_MAP,
     CHEMIST_VOUCHER_EVENT, LAB_VOUCHER_EVENT, TOTAL_DAY_THRESHOLDS)
 from custom.enikshay.exceptions import NikshayLocationNotFound
-from custom.enikshay.integrations.bets.repeaters import BETS180TreatmentRepeater, \
-    BETSDrugRefillRepeater, BETSSuccessfulTreatmentRepeater, BETSDiagnosisAndNotificationRepeater, \
-    BETSAYUSHReferralRepeater, ChemistBETSVoucherRepeater, LabBETSVoucherRepeater
 
 
 class BETSPayload(jsonobject.JsonObject):
@@ -263,12 +260,10 @@ class BaseBETSVoucherPayloadGenerator(BETSBasePayloadGenerator):
         return json.dumps(VoucherPayload.create_voucher_payload(voucher_case).to_json())
 
 
-@RegisterGenerator(ChemistBETSVoucherRepeater, 'case_json', 'JSON', is_default=True)
 class ChemistBETSVoucherPayloadGenerator(BaseBETSVoucherPayloadGenerator):
     event_id = CHEMIST_VOUCHER_EVENT
 
 
-@RegisterGenerator(LabBETSVoucherRepeater, 'case_json', 'JSON', is_default=True)
 class LabBETSVoucherPayloadGenerator(BaseBETSVoucherPayloadGenerator):
     event_id = LAB_VOUCHER_EVENT
 
@@ -286,7 +281,6 @@ class IncentivePayloadGenerator(BETSBasePayloadGenerator):
         ).to_json())
 
 
-@RegisterGenerator(BETS180TreatmentRepeater, "case_json", "JSON", is_default=True)
 class BETS180TreatmentPayloadGenerator(IncentivePayloadGenerator):
     event_id = TREATMENT_180_EVENT
 
@@ -294,12 +288,12 @@ class BETS180TreatmentPayloadGenerator(IncentivePayloadGenerator):
         return json.dumps(IncentivePayload.create_180_treatment_payload(episode_case).to_json())
 
 
-@RegisterGenerator(BETSDrugRefillRepeater, "case_json", "JSON", is_default=True)
 class BETSDrugRefillPayloadGenerator(IncentivePayloadGenerator):
     event_id = DRUG_REFILL_EVENT
 
     @staticmethod
     def _get_prescription_threshold_to_send(episode_case_properties):
+        from custom.enikshay.integrations.bets.repeaters import BETSDrugRefillRepeater
         thresholds_to_send = [
             n for n in TOTAL_DAY_THRESHOLDS
             if BETSDrugRefillRepeater.prescription_total_days_threshold_in_trigger_state(
@@ -352,7 +346,6 @@ class BETSDrugRefillPayloadGenerator(IncentivePayloadGenerator):
             )
 
 
-@RegisterGenerator(BETSSuccessfulTreatmentRepeater, "case_json", "JSON", is_default=True)
 class BETSSuccessfulTreatmentPayloadGenerator(IncentivePayloadGenerator):
     event_id = SUCCESSFUL_TREATMENT_EVENT
 
@@ -360,7 +353,6 @@ class BETSSuccessfulTreatmentPayloadGenerator(IncentivePayloadGenerator):
         return json.dumps(IncentivePayload.create_successful_treatment_payload(episode_case).to_json())
 
 
-@RegisterGenerator(BETSDiagnosisAndNotificationRepeater, "case_json", "JSON", is_default=True)
 class BETSDiagnosisAndNotificationPayloadGenerator(IncentivePayloadGenerator):
     event_id = DIAGNOSIS_AND_NOTIFICATION_EVENT
 
@@ -368,7 +360,6 @@ class BETSDiagnosisAndNotificationPayloadGenerator(IncentivePayloadGenerator):
         return json.dumps(IncentivePayload.create_diagnosis_and_notification_payload(episode_case).to_json())
 
 
-@RegisterGenerator(BETSAYUSHReferralRepeater, "case_json", "JSON", is_default=True)
 class BETSAYUSHReferralPayloadGenerator(IncentivePayloadGenerator):
     event_id = AYUSH_REFERRAL_EVENT
 

--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -10,6 +10,11 @@ from custom.enikshay.const import ENROLLED_IN_PRIVATE, PRESCRIPTION_TOTAL_DAYS_T
 from custom.enikshay.integrations.bets.const import TREATMENT_180_EVENT, DRUG_REFILL_EVENT, SUCCESSFUL_TREATMENT_EVENT, \
     DIAGNOSIS_AND_NOTIFICATION_EVENT, AYUSH_REFERRAL_EVENT, CHEMIST_VOUCHER_EVENT, LAB_VOUCHER_EVENT, \
     TOTAL_DAY_THRESHOLDS
+from custom.enikshay.integrations.bets.repeater_generators import \
+    BETS180TreatmentPayloadGenerator, LabBETSVoucherPayloadGenerator, \
+    ChemistBETSVoucherPayloadGenerator, BETSAYUSHReferralPayloadGenerator, \
+    BETSDiagnosisAndNotificationPayloadGenerator, BETSSuccessfulTreatmentPayloadGenerator, \
+    BETSDrugRefillPayloadGenerator
 from custom.enikshay.integrations.utils import case_properties_changed, is_valid_episode_submission, \
     is_valid_voucher_submission, is_valid_archived_submission
 
@@ -60,6 +65,12 @@ class ChemistBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = CHEMIST_VOUCHER_EVENT
     voucher_type = "prescription"
 
+    class Format(object):
+        formats = {
+            'case_json': (ChemistBETSVoucherPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
+
     @classmethod
     def get_custom_url(cls, domain):
         from custom.enikshay.integrations.bets.views import ChemistBETSVoucherRepeaterView
@@ -70,6 +81,12 @@ class LabBETSVoucherRepeater(BaseBETSVoucherRepeater):
     friendly_name = _("BETS - Lab Voucher Forwarding (voucher case type)")
     event_id = LAB_VOUCHER_EVENT
     voucher_type = "test"
+
+    class Format(object):
+        formats = {
+            'case_json': (LabBETSVoucherPayloadGenerator, _("JSON")),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -89,6 +106,12 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
         "BETS - MBBS+ Providers: 180 days of private OR govt. "
         "FDCs with treatment outcome reported (episode case type)"
     )
+
+    class Format(object):
+        formats = {
+            'case_json': (BETS180TreatmentPayloadGenerator, _("JSON")),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -120,6 +143,12 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
 
 class BETSDrugRefillRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on subsequent drug refill (episode case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (BETSDrugRefillPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -190,6 +219,12 @@ class BETSDrugRefillRepeater(BaseBETSRepeater):
 class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on successful treatment completion (episode case type)")
 
+    class Format(object):
+        formats = {
+            'case_json': (BETSSuccessfulTreatmentPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
+
     @classmethod
     def get_custom_url(cls, domain):
         from custom.enikshay.integrations.bets.views import BETSSuccessfulTreatmentRepeaterView
@@ -222,6 +257,12 @@ class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
 class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
+    class Format(object):
+        formats = {
+            'case_json': (BETSDiagnosisAndNotificationPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
+
     @classmethod
     def get_custom_url(cls, domain):
         from custom.enikshay.integrations.bets.views import BETSDiagnosisAndNotificationRepeaterView
@@ -245,6 +286,12 @@ class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
 
 class BETSAYUSHReferralRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (BETSAYUSHReferralPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -66,7 +66,7 @@ class ChemistBETSVoucherRepeater(BaseBETSVoucherRepeater):
     voucher_type = "prescription"
 
     class Formats(object):
-        generator = ChemistBETSVoucherPayloadGenerator
+        formats = [ChemistBETSVoucherPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -80,7 +80,7 @@ class LabBETSVoucherRepeater(BaseBETSVoucherRepeater):
     voucher_type = "test"
 
     class Formats(object):
-        generator = LabBETSVoucherPayloadGenerator
+        formats = [LabBETSVoucherPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -102,7 +102,7 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
     )
 
     class Formats(object):
-        generator = BETS180TreatmentPayloadGenerator
+        formats = [BETS180TreatmentPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -136,7 +136,7 @@ class BETSDrugRefillRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on subsequent drug refill (episode case type)")
 
     class Formats(object):
-        generator = BETSDrugRefillPayloadGenerator
+        formats = [BETSDrugRefillPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -208,7 +208,7 @@ class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on successful treatment completion (episode case type)")
 
     class Formats(object):
-        generator = BETSSuccessfulTreatmentPayloadGenerator
+        formats = [BETSSuccessfulTreatmentPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -243,7 +243,7 @@ class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
     class Formats(object):
-        generator = BETSDiagnosisAndNotificationPayloadGenerator
+        formats = [BETSDiagnosisAndNotificationPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -270,7 +270,7 @@ class BETSAYUSHReferralRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
     class Formats(object):
-        generator = BETSAYUSHReferralPayloadGenerator
+        formats = [BETSAYUSHReferralPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -65,7 +65,7 @@ class ChemistBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = CHEMIST_VOUCHER_EVENT
     voucher_type = "prescription"
 
-    _generators = [ChemistBETSVoucherPayloadGenerator]
+    payload_generator_classes = (ChemistBETSVoucherPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -78,7 +78,7 @@ class LabBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = LAB_VOUCHER_EVENT
     voucher_type = "test"
 
-    _generators = [LabBETSVoucherPayloadGenerator]
+    payload_generator_classes = (LabBETSVoucherPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -99,7 +99,7 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
         "FDCs with treatment outcome reported (episode case type)"
     )
 
-    _generators = [BETS180TreatmentPayloadGenerator]
+    payload_generator_classes = (BETS180TreatmentPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -132,7 +132,7 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
 class BETSDrugRefillRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on subsequent drug refill (episode case type)")
 
-    _generators = [BETSDrugRefillPayloadGenerator]
+    payload_generator_classes = (BETSDrugRefillPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -203,7 +203,7 @@ class BETSDrugRefillRepeater(BaseBETSRepeater):
 class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on successful treatment completion (episode case type)")
 
-    _generators = [BETSSuccessfulTreatmentPayloadGenerator]
+    payload_generator_classes = (BETSSuccessfulTreatmentPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -237,7 +237,7 @@ class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
 class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
-    _generators = [BETSDiagnosisAndNotificationPayloadGenerator]
+    payload_generator_classes = (BETSDiagnosisAndNotificationPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -263,7 +263,7 @@ class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
 class BETSAYUSHReferralRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
-    _generators = [BETSAYUSHReferralPayloadGenerator]
+    payload_generator_classes = (BETSAYUSHReferralPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -65,11 +65,8 @@ class ChemistBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = CHEMIST_VOUCHER_EVENT
     voucher_type = "prescription"
 
-    class Format(object):
-        formats = {
-            'case_json': (ChemistBETSVoucherPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = ChemistBETSVoucherPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -82,11 +79,8 @@ class LabBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = LAB_VOUCHER_EVENT
     voucher_type = "test"
 
-    class Format(object):
-        formats = {
-            'case_json': (LabBETSVoucherPayloadGenerator, _("JSON")),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = LabBETSVoucherPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -107,11 +101,8 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
         "FDCs with treatment outcome reported (episode case type)"
     )
 
-    class Format(object):
-        formats = {
-            'case_json': (BETS180TreatmentPayloadGenerator, _("JSON")),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = BETS180TreatmentPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -144,11 +135,8 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
 class BETSDrugRefillRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on subsequent drug refill (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (BETSDrugRefillPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = BETSDrugRefillPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -219,11 +207,8 @@ class BETSDrugRefillRepeater(BaseBETSRepeater):
 class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on successful treatment completion (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (BETSSuccessfulTreatmentPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = BETSSuccessfulTreatmentPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -257,11 +242,8 @@ class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
 class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (BETSDiagnosisAndNotificationPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = BETSDiagnosisAndNotificationPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -287,11 +269,8 @@ class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
 class BETSAYUSHReferralRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (BETSAYUSHReferralPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = BETSAYUSHReferralPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -65,8 +65,7 @@ class ChemistBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = CHEMIST_VOUCHER_EVENT
     voucher_type = "prescription"
 
-    class Formats(object):
-        formats = [ChemistBETSVoucherPayloadGenerator]
+    _generators = [ChemistBETSVoucherPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -79,8 +78,7 @@ class LabBETSVoucherRepeater(BaseBETSVoucherRepeater):
     event_id = LAB_VOUCHER_EVENT
     voucher_type = "test"
 
-    class Formats(object):
-        formats = [LabBETSVoucherPayloadGenerator]
+    _generators = [LabBETSVoucherPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -101,8 +99,7 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
         "FDCs with treatment outcome reported (episode case type)"
     )
 
-    class Formats(object):
-        formats = [BETS180TreatmentPayloadGenerator]
+    _generators = [BETS180TreatmentPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -135,8 +132,7 @@ class BETS180TreatmentRepeater(BaseBETSRepeater):
 class BETSDrugRefillRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on subsequent drug refill (episode case type)")
 
-    class Formats(object):
-        formats = [BETSDrugRefillPayloadGenerator]
+    _generators = [BETSDrugRefillPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -207,8 +203,7 @@ class BETSDrugRefillRepeater(BaseBETSRepeater):
 class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Patients: Cash transfer on successful treatment completion (episode case type)")
 
-    class Formats(object):
-        formats = [BETSSuccessfulTreatmentPayloadGenerator]
+    _generators = [BETSSuccessfulTreatmentPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -242,8 +237,7 @@ class BETSSuccessfulTreatmentRepeater(BaseBETSRepeater):
 class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
-    class Formats(object):
-        formats = [BETSDiagnosisAndNotificationPayloadGenerator]
+    _generators = [BETSDiagnosisAndNotificationPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -269,8 +263,7 @@ class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
 class BETSAYUSHReferralRepeater(BaseBETSRepeater):
     friendly_name = _("BETS - Providers: For diagnosis and notification of TB case (episode case type)")
 
-    class Formats(object):
-        formats = [BETSAYUSHReferralPayloadGenerator]
+    _generators = [BETSAYUSHReferralPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/nikshay/repeater_generator.py
+++ b/custom/enikshay/integrations/nikshay/repeater_generator.py
@@ -4,7 +4,7 @@ import socket
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.repeaters.exceptions import RequestConnectionError
-from corehq.apps.repeaters.repeater_generators import RegisterGenerator, BasePayloadGenerator
+from corehq.apps.repeaters.repeater_generators import BasePayloadGenerator
 from custom.enikshay.const import (
     PRIMARY_PHONE_NUMBER,
     BACKUP_PHONE_NUMBER,
@@ -23,12 +23,6 @@ from custom.enikshay.case_utils import (
     get_open_episode_case_from_occurrence,
     get_person_case_from_occurrence,
     get_lab_referral_from_test)
-from custom.enikshay.integrations.nikshay.repeaters import (
-    NikshayRegisterPatientRepeater,
-    NikshayHIVTestRepeater,
-    NikshayTreatmentOutcomeRepeater,
-    NikshayFollowupRepeater,
-)
 from custom.enikshay.integrations.nikshay.exceptions import NikshayResponseException
 from custom.enikshay.exceptions import NikshayLocationNotFound, NikshayRequiredValueMissing
 from custom.enikshay.integrations.nikshay.field_mappings import (
@@ -83,7 +77,6 @@ class BaseNikshayPayloadGenerator(BasePayloadGenerator):
         }
 
 
-@RegisterGenerator(NikshayRegisterPatientRepeater, 'case_json', 'JSON', is_default=True)
 class NikshayRegisterPatientPayloadGenerator(BaseNikshayPayloadGenerator):
     def get_payload(self, repeat_record, episode_case):
         """
@@ -142,7 +135,6 @@ class NikshayRegisterPatientPayloadGenerator(BaseNikshayPayloadGenerator):
             update_case(repeat_record.domain, repeat_record.payload_id, {"nikshay_error": unicode(exception)})
 
 
-@RegisterGenerator(NikshayTreatmentOutcomeRepeater, 'case_json', 'JSON', is_default=True)
 class NikshayTreatmentOutcomePayload(BaseNikshayPayloadGenerator):
 
     def get_payload(self, repeat_record, episode_case):
@@ -179,7 +171,6 @@ class NikshayTreatmentOutcomePayload(BaseNikshayPayloadGenerator):
                                 "treatment_outcome_nikshay_registered", "treatment_outcome_nikshay_error")
 
 
-@RegisterGenerator(NikshayHIVTestRepeater, 'case_json', 'JSON', is_default=True)
 class NikshayHIVTestPayloadGenerator(BaseNikshayPayloadGenerator):
     @property
     def content_type(self):
@@ -227,7 +218,6 @@ class NikshayHIVTestPayloadGenerator(BaseNikshayPayloadGenerator):
                                 "hiv_test_nikshay_registered", "hiv_test_nikshay_error")
 
 
-@RegisterGenerator(NikshayFollowupRepeater, 'case_json', 'JSON', is_default=True)
 class NikshayFollowupPayloadGenerator(BaseNikshayPayloadGenerator):
     def get_payload(self, repeat_record, test_case):
         occurence_case = get_occurrence_case_from_test(test_case.domain, test_case.get_id)

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -43,7 +43,7 @@ class NikshayRegisterPatientRepeater(BaseNikshayRepeater):
     friendly_name = _("Forward eNikshay Patients to Nikshay (episode case type)")
 
     class Formats(object):
-        generator = NikshayRegisterPatientPayloadGenerator
+        formats = [NikshayRegisterPatientPayloadGenerator]
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -84,7 +84,7 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
     friendly_name = _("Forward eNikshay Patient's HIV Test to Nikshay (person case type)")
 
     class Formats(object):
-        generator = NikshayHIVTestPayloadGenerator
+        formats = [NikshayHIVTestPayloadGenerator]
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -127,7 +127,7 @@ class NikshayTreatmentOutcomeRepeater(BaseNikshayRepeater):
     friendly_name = _("Forward Treatment Outcomes to Nikshay (episode case type)")
 
     class Formats(object):
-        generator = NikshayTreatmentOutcomePayload
+        formats = [NikshayTreatmentOutcomePayload]
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -162,7 +162,7 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
     friendly_name = _("Forward eNikshay Patient's Follow Ups to Nikshay (test case type)")
 
     class Formats(object):
-        generator = NikshayFollowupPayloadGenerator
+        formats = [NikshayFollowupPayloadGenerator]
 
     @classmethod
     def available_for_domain(cls, domain):

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -17,6 +17,9 @@ from custom.enikshay.case_utils import (
 )
 from custom.enikshay.exceptions import ENikshayCaseNotFound
 from custom.enikshay.const import TREATMENT_OUTCOME, EPISODE_PENDING_REGISTRATION
+from custom.enikshay.integrations.nikshay.repeater_generator import \
+    NikshayRegisterPatientPayloadGenerator, NikshayHIVTestPayloadGenerator, \
+    NikshayTreatmentOutcomePayload, NikshayFollowupPayloadGenerator
 from custom.enikshay.integrations.utils import (
     is_valid_person_submission,
     is_valid_test_submission,
@@ -38,6 +41,12 @@ class NikshayRegisterPatientRepeater(BaseNikshayRepeater):
 
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patients to Nikshay (episode case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (NikshayRegisterPatientPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -76,6 +85,12 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
 
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's HIV Test to Nikshay (person case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (NikshayHIVTestPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -117,6 +132,12 @@ class NikshayTreatmentOutcomeRepeater(BaseNikshayRepeater):
 
     friendly_name = _("Forward Treatment Outcomes to Nikshay (episode case type)")
 
+    class Format(object):
+        formats = {
+            'case_json': (NikshayTreatmentOutcomePayload, _('JSON')),
+        }
+        default_format = 'case_json'
+
     @classmethod
     def available_for_domain(cls, domain):
         return NIKSHAY_INTEGRATION.enabled(domain)
@@ -148,6 +169,12 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
 
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's Follow Ups to Nikshay (test case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (NikshayFollowupPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def available_for_domain(cls, domain):

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -42,8 +42,7 @@ class NikshayRegisterPatientRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patients to Nikshay (episode case type)")
 
-    class Formats(object):
-        formats = [NikshayRegisterPatientPayloadGenerator]
+    _generators = [NikshayRegisterPatientPayloadGenerator]
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -83,8 +82,7 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's HIV Test to Nikshay (person case type)")
 
-    class Formats(object):
-        formats = [NikshayHIVTestPayloadGenerator]
+    _generators = [NikshayHIVTestPayloadGenerator]
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -126,8 +124,7 @@ class NikshayTreatmentOutcomeRepeater(BaseNikshayRepeater):
 
     friendly_name = _("Forward Treatment Outcomes to Nikshay (episode case type)")
 
-    class Formats(object):
-        formats = [NikshayTreatmentOutcomePayload]
+    _generators = [NikshayTreatmentOutcomePayload]
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -161,8 +158,7 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's Follow Ups to Nikshay (test case type)")
 
-    class Formats(object):
-        formats = [NikshayFollowupPayloadGenerator]
+    _generators = [NikshayFollowupPayloadGenerator]
 
     @classmethod
     def available_for_domain(cls, domain):

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -42,7 +42,7 @@ class NikshayRegisterPatientRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patients to Nikshay (episode case type)")
 
-    _generators = [NikshayRegisterPatientPayloadGenerator]
+    payload_generator_classes = (NikshayRegisterPatientPayloadGenerator,)
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -82,7 +82,7 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's HIV Test to Nikshay (person case type)")
 
-    _generators = [NikshayHIVTestPayloadGenerator]
+    payload_generator_classes = (NikshayHIVTestPayloadGenerator,)
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -124,7 +124,7 @@ class NikshayTreatmentOutcomeRepeater(BaseNikshayRepeater):
 
     friendly_name = _("Forward Treatment Outcomes to Nikshay (episode case type)")
 
-    _generators = [NikshayTreatmentOutcomePayload]
+    payload_generator_classes = (NikshayTreatmentOutcomePayload,)
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -158,7 +158,7 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's Follow Ups to Nikshay (test case type)")
 
-    _generators = [NikshayFollowupPayloadGenerator]
+    payload_generator_classes = (NikshayFollowupPayloadGenerator,)
 
     @classmethod
     def available_for_domain(cls, domain):

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -42,11 +42,8 @@ class NikshayRegisterPatientRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patients to Nikshay (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (NikshayRegisterPatientPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = NikshayRegisterPatientPayloadGenerator
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -86,11 +83,8 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's HIV Test to Nikshay (person case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (NikshayHIVTestPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = NikshayHIVTestPayloadGenerator
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -132,11 +126,8 @@ class NikshayTreatmentOutcomeRepeater(BaseNikshayRepeater):
 
     friendly_name = _("Forward Treatment Outcomes to Nikshay (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (NikshayTreatmentOutcomePayload, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = NikshayTreatmentOutcomePayload
 
     @classmethod
     def available_for_domain(cls, domain):
@@ -170,11 +161,8 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
     include_app_id_param = False
     friendly_name = _("Forward eNikshay Patient's Follow Ups to Nikshay (test case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (NikshayFollowupPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = NikshayFollowupPayloadGenerator
 
     @classmethod
     def available_for_domain(cls, domain):

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -4,17 +4,8 @@ import phonenumbers
 import jsonobject
 from django.utils.dateparse import parse_date
 
-from corehq.apps.repeaters.repeater_generators import (
-    BasePayloadGenerator,
-    RegisterGenerator,
-)
+from corehq.apps.repeaters.repeater_generators import BasePayloadGenerator
 from corehq.apps.repeaters.exceptions import RequestConnectionError
-from custom.enikshay.integrations.ninetyninedots.repeaters import (
-    NinetyNineDotsRegisterPatientRepeater,
-    NinetyNineDotsUpdatePatientRepeater,
-    NinetyNineDotsAdherenceRepeater,
-    NinetyNineDotsTreatmentOutcomeRepeater,
-)
 from custom.enikshay.case_utils import (
     get_occurrence_case_from_episode,
     get_person_case_from_occurrence,
@@ -103,7 +94,6 @@ class NinetyNineDotsBasePayloadGenerator(BasePayloadGenerator):
             })
 
 
-@RegisterGenerator(NinetyNineDotsRegisterPatientRepeater, 'case_json', 'JSON', is_default=True)
 class RegisterPatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
     def get_test_payload(self, domain):
@@ -148,7 +138,6 @@ class RegisterPatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
             )
 
 
-@RegisterGenerator(NinetyNineDotsUpdatePatientRepeater, 'case_json', 'JSON', is_default=True)
 class UpdatePatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
     def get_test_payload(self, domain):
@@ -207,7 +196,6 @@ class UpdatePatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
             )
 
 
-@RegisterGenerator(NinetyNineDotsAdherenceRepeater, 'case_json', 'JSON', is_default=True)
 class AdherencePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
     def get_payload(self, repeat_record, adherence_case):
@@ -257,7 +245,6 @@ class AdherencePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
             )
 
 
-@RegisterGenerator(NinetyNineDotsTreatmentOutcomeRepeater, 'case_json', 'JSON', is_default=True)
 class TreatmentOutcomePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
     def get_payload(self, repeat_record, episode_case):

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -7,6 +7,9 @@ from corehq.form_processor.models import CommCareCaseSQL
 from corehq.apps.repeaters.models import CaseRepeater
 from corehq.apps.repeaters.signals import create_repeat_records
 from casexml.apps.case.signals import case_post_save
+from custom.enikshay.integrations.ninetyninedots.repeater_generators import \
+    RegisterPatientPayloadGenerator, UpdatePatientPayloadGenerator, AdherencePayloadGenerator, \
+    TreatmentOutcomePayloadGenerator
 
 from custom.enikshay.integrations.utils import (
     is_valid_person_submission,
@@ -50,6 +53,12 @@ class NinetyNineDotsRegisterPatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Registration (episode case type)")
 
+    class Format(object):
+        formats = {
+            'case_json': (RegisterPatientPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
+
     @classmethod
     def get_custom_url(cls, domain):
         from custom.enikshay.integrations.ninetyninedots.views import RegisterPatientRepeaterView
@@ -85,6 +94,12 @@ class NinetyNineDotsUpdatePatientRepeater(Base99DOTSRepeater):
     """
 
     friendly_name = _("99DOTS Patient Update (person & episode case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (UpdatePatientPayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -133,6 +148,12 @@ class NinetyNineDotsAdherenceRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Adherence (adherence case type)")
 
+    class Format(object):
+        formats = {
+            'case_json': (AdherencePayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
+
     @classmethod
     def get_custom_url(cls, domain):
         from custom.enikshay.integrations.ninetyninedots.views import UpdateAdherenceRepeaterView
@@ -174,6 +195,12 @@ class NinetyNineDotsTreatmentOutcomeRepeater(Base99DOTSRepeater):
 
     """
     friendly_name = _("99DOTS Update Treatment Outcome (episode case type)")
+
+    class Format(object):
+        formats = {
+            'case_json': (TreatmentOutcomePayloadGenerator, _('JSON')),
+        }
+        default_format = 'case_json'
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -53,8 +53,7 @@ class NinetyNineDotsRegisterPatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Registration (episode case type)")
 
-    class Formats(object):
-        formats = [RegisterPatientPayloadGenerator]
+    _generators = [RegisterPatientPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -92,8 +91,7 @@ class NinetyNineDotsUpdatePatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Update (person & episode case type)")
 
-    class Formats(object):
-        formats = [UpdatePatientPayloadGenerator]
+    _generators = [UpdatePatientPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -142,8 +140,7 @@ class NinetyNineDotsAdherenceRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Adherence (adherence case type)")
 
-    class Formats(object):
-        formats = [AdherencePayloadGenerator]
+    _generators = [AdherencePayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -187,8 +184,7 @@ class NinetyNineDotsTreatmentOutcomeRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Treatment Outcome (episode case type)")
 
-    class Formats(object):
-        formats = [TreatmentOutcomePayloadGenerator]
+    _generators = [TreatmentOutcomePayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -53,11 +53,8 @@ class NinetyNineDotsRegisterPatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Registration (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (RegisterPatientPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = RegisterPatientPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -95,11 +92,8 @@ class NinetyNineDotsUpdatePatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Update (person & episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (UpdatePatientPayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = UpdatePatientPayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -148,11 +142,8 @@ class NinetyNineDotsAdherenceRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Adherence (adherence case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (AdherencePayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = AdherencePayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -196,11 +187,8 @@ class NinetyNineDotsTreatmentOutcomeRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Treatment Outcome (episode case type)")
 
-    class Format(object):
-        formats = {
-            'case_json': (TreatmentOutcomePayloadGenerator, _('JSON')),
-        }
-        default_format = 'case_json'
+    class Formats(object):
+        generator = TreatmentOutcomePayloadGenerator
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -53,7 +53,7 @@ class NinetyNineDotsRegisterPatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Registration (episode case type)")
 
-    _generators = [RegisterPatientPayloadGenerator]
+    payload_generator_classes = (RegisterPatientPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -91,7 +91,7 @@ class NinetyNineDotsUpdatePatientRepeater(Base99DOTSRepeater):
 
     friendly_name = _("99DOTS Patient Update (person & episode case type)")
 
-    _generators = [UpdatePatientPayloadGenerator]
+    payload_generator_classes = (UpdatePatientPayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -140,7 +140,7 @@ class NinetyNineDotsAdherenceRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Adherence (adherence case type)")
 
-    _generators = [AdherencePayloadGenerator]
+    payload_generator_classes = (AdherencePayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -184,7 +184,7 @@ class NinetyNineDotsTreatmentOutcomeRepeater(Base99DOTSRepeater):
     """
     friendly_name = _("99DOTS Update Treatment Outcome (episode case type)")
 
-    _generators = [TreatmentOutcomePayloadGenerator]
+    payload_generator_classes = (TreatmentOutcomePayloadGenerator,)
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -54,7 +54,7 @@ class NinetyNineDotsRegisterPatientRepeater(Base99DOTSRepeater):
     friendly_name = _("99DOTS Patient Registration (episode case type)")
 
     class Formats(object):
-        generator = RegisterPatientPayloadGenerator
+        formats = [RegisterPatientPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -93,7 +93,7 @@ class NinetyNineDotsUpdatePatientRepeater(Base99DOTSRepeater):
     friendly_name = _("99DOTS Patient Update (person & episode case type)")
 
     class Formats(object):
-        generator = UpdatePatientPayloadGenerator
+        formats = [UpdatePatientPayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -143,7 +143,7 @@ class NinetyNineDotsAdherenceRepeater(Base99DOTSRepeater):
     friendly_name = _("99DOTS Update Adherence (adherence case type)")
 
     class Formats(object):
-        generator = AdherencePayloadGenerator
+        formats = [AdherencePayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):
@@ -188,7 +188,7 @@ class NinetyNineDotsTreatmentOutcomeRepeater(Base99DOTSRepeater):
     friendly_name = _("99DOTS Update Treatment Outcome (episode case type)")
 
     class Formats(object):
-        generator = TreatmentOutcomePayloadGenerator
+        formats = [TreatmentOutcomePayloadGenerator]
 
     @classmethod
     def get_custom_url(cls, domain):


### PR DESCRIPTION
@proteusvacuum this is kind of what we'd talked about.

This PR just simplifies the payload configuration so it's inside the repeater rather than registered through a decorator, but it also retains support for the decorator-style matching. (~If you try to use both in the same repeater though, that behavior's not well defined.~ Update: Ended up supporting this for test.) In a later PR I can gut the code around this which I think can be greatly simplified as well.