### PR TITLE
Filter out cases belonging to specific owners in case search

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -62,3 +62,5 @@ STOCK_QUESTION_TAG_NAMES = [
 ]
 
 DEFAULT_FETCH_LIMIT = 5
+
+CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = u'commcare_blacklisted_owner_ids'

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2147,6 +2147,7 @@ class CaseSearch(DocumentSchema):
     search_button_display_condition = StringProperty()
     include_closed = BooleanProperty(default=False)
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
+    blacklisted_owner_ids_expression = StringProperty()
 
 
 class ParentSelect(DocumentSchema):

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -222,7 +222,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
     };
 
     var searchViewModel = function (searchProperties, includeClosed, defaultProperties, lang,
-                                    searchButtonDisplayCondition, saveButton) {
+                                    searchButtonDisplayCondition, blacklistedOwnerIdsExpression, saveButton) {
         var self = this,
             DEFAULT_CLAIM_RELEVANT= "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0";
 
@@ -258,6 +258,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         self.includeClosed = ko.observable(includeClosed);
         self.searchProperties = ko.observableArray();
         self.defaultProperties = ko.observableArray();
+        self.blacklistedOwnerIdsExpression = ko.observable(blacklistedOwnerIdsExpression);
 
         if (searchProperties.length > 0) {
             for (var i = 0; i < searchProperties.length; i++) {
@@ -342,6 +343,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 search_button_display_condition: self.searchButtonDisplayCondition(),
                 include_closed: self.includeClosed(),
                 default_properties: self._getDefaultProperties(),
+                blacklisted_owner_ids_expression: self.blacklistedOwnerIdsExpression(),
             };
         };
 
@@ -358,6 +360,9 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
             saveButton.fire('change');
         });
         self.searchButtonDisplayCondition.subscribe(function () {
+            saveButton.fire('change');
+        });
+        self.blacklistedOwnerIdsExpression.subscribe(function () {
             saveButton.fire('change');
         });
     };
@@ -1351,6 +1356,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                         spec.defaultProperties,
                         spec.lang,
                         spec.searchButtonDisplayCondition,
+                        spec.blacklistedOwnerIdsExpression,
                         this.shortScreen.saveButton
                     );
                 }

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -40,6 +40,7 @@ $(function () {
                 includeClosed: options.include_closed,
                 defaultProperties: options.default_properties || [],
                 searchButtonDisplayCondition: options.search_button_display_condition,
+                blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
             });
 
             var $list_home = $("#" + detail.type + "-detail-screen-config-tab");

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -1,5 +1,6 @@
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
+from corehq.apps.app_manager.const import CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY
 from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper, get_instances_for_module
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Command,
@@ -125,6 +126,13 @@ class RemoteRequestFactory(object):
             QueryData(key=u"{}".format(c.property), ref=u"{}".format(c.defaultValue))
             for c in self.module.search_config.default_properties
         ]
+        if self.module.search_config.blacklisted_owner_ids_expression:
+            extra_query_datums.append(
+                QueryData(
+                    key=CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
+                    ref=u"{}".format(self.module.search_config.blacklisted_owner_ids_expression)
+                )
+            )
         return default_query_datums + extra_query_datums
 
     def _build_query_prompts(self):

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_search_properties.html
@@ -110,11 +110,12 @@
                     >
                     <p class="help-block">
                         {% blocktrans %}
-                        If this xpath expression evaluates to false, the case search button will not be
-                        displayed. If no expression is given, the button will always be displayed.
+                            If this XPath expression evaluates to false, the case search button will not be
+                            displayed. If no expression is given, the button will always be displayed.
                         {% endblocktrans %}
                     </p>
-
+                </div>
+                <div class="form-group">
                     <label for="claim-relevant-condition" >
                         {% trans "Only claim cases that fulfill the following condition" %}
                     </label>
@@ -124,14 +125,28 @@
                            id="claim-relevant-condition"
                            spellcheck="false"
                     />
-                </div>
-                <div class="form-group">
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" data-bind="checked: default_relevant">
                             {% trans "Don't claim cases already owned by the user" %}
                         </label>
                     </div>
+                </div>
+                <div class="form-group">
+                    <label for="blacklisted-user-ids" >
+                        {% trans "Don't search cases owned by the following ids" %}
+                    </label>
+                    <input type="text"
+                           data-bind="value: blacklistedOwnerIdsExpression"
+                           class="form-control"
+                           id="blacklisted-user-ids"
+                           spellcheck="false"
+                    />
+                    <p class="help-block">
+                        {% blocktrans %}
+                            An XPath expression that will evaluate to a space separated list of ids. For example: instance('commcaresession')/session/context/userid or 'a1c0148dc2120c6b1762f5ac5aba2a15'
+                        {% endblocktrans %}
+                    </p>
                 </div>
                 <div class="form-group">
                     <div class="checkbox">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_search_properties.html
@@ -110,11 +110,12 @@
                     >
                     <p class="help-block">
                         {% blocktrans %}
-                        If this xpath expression evaluates to false, the case search button will not be
-                        displayed. If no expression is given, the button will always be displayed.
+                            If this XPath expression evaluates to false, the case search button will not be
+                            displayed. If no expression is given, the button will always be displayed.
                         {% endblocktrans %}
                     </p>
-
+                </div>
+                <div class="form-group">
                     <label for="claim-relevant-condition" >
                         {% trans "Only claim cases that fulfill the following condition" %}
                     </label>
@@ -124,14 +125,28 @@
                            id="claim-relevant-condition"
                            spellcheck="false"
                     />
-                </div>
-                <div class="form-group">
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" data-bind="checked: default_relevant">
                             {% trans "Don't claim cases already owned by the user" %}
                         </label>
                     </div>
+                </div>
+                <div class="form-group">
+                    <label for="blacklisted-user-ids" >
+                        {% trans "Don't search cases owned by the following ids" %}
+                    </label>
+                    <input type="text"
+                           data-bind="value: blacklistedOwnerIdsExpression"
+                           class="form-control"
+                           id="blacklisted-user-ids"
+                           spellcheck="false"
+                    />
+                    <p class="help-block">
+                        {% blocktrans %}
+                            An XPath expression that will evaluate to a space separated list of ids. For example: instance('commcaresession')/session/context/userid or 'a1c0148dc2120c6b1762f5ac5aba2a15'
+                        {% endblocktrans %}
+                    </p>
                 </div>
                 <div class="form-group">
                     <div class="checkbox">

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -1,0 +1,45 @@
+<partial>
+  <remote-request>
+    <post url="https://www.example.com/a/test_domain/phone/claim-case/"
+          relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">
+      <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+    </post>
+    <command id="search_command.m0">
+      <display>
+        <text>
+          <locale id="case_search.m0"/>
+        </text>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
+    <instance id="reports" src="jr://fixture/commcare:reports"/>
+    <session>
+      <query url="https://www.example.com/a/test_domain/phone/search/"
+             storage-instance="results"
+             template="case">
+        <data key="case_type" ref="'case'"/>
+        <data key="include_closed" ref="'False'"/>
+        <data key="commcare_blacklisted_owner_ids" ref="instance('commcaresession')/session/context/userid"/>
+        <prompt key="name">
+          <display>
+            <text>
+              <locale id="search_property.m0.name"/>
+            </text>
+          </display>
+        </prompt>
+      </query>
+      <datum id="case_id"
+             nodeset="instance('results')/results/case[@case_type='case']"
+             value="./@case_id"
+             detail-confirm="m0_case_long"
+             detail-select="m0_case_short"/>
+    </session>
+    <stack>
+      <push>
+        <rewind value="instance('commcaresession')/session/data/case_id"/>
+      </push>
+    </stack>
+  </remote-request>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -112,3 +112,15 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             get_url_base_patch.return_value = 'https://www.example.com'
             suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_default_only'), suite, "./remote-request[1]")
+
+    def test_blacklisted_owner_ids(self):
+        self.module.search_config = CaseSearch(
+            properties=[
+                CaseSearchProperty(name='name', label={'en': 'Name'}),
+            ],
+            blacklisted_owner_ids_expression="instance('commcaresession')/session/context/userid",
+        )
+        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
+            get_url_base_patch.return_value = 'https://www.example.com'
+            suite = self.app.create_suite()
+        self.assertXmlPartialEqual(self.get_xml('search_config_blacklisted_owners'), suite, "./remote-request[1]")

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -151,6 +151,8 @@ def _get_shared_module_view_context(app, module, case_property_builder, lang=Non
             'default_properties': module.search_config.default_properties if module_offers_search(module) else [],
             'search_button_display_condition':
                 module.search_config.search_button_display_condition if module_offers_search(module) else "",
+            'blacklisted_owner_ids_expression': (
+                module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else "",)
         }
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -899,6 +901,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
                 ),
                 include_closed=bool(search_properties.get('include_closed')),
                 search_button_display_condition=search_properties.get('search_button_display_condition', ""),
+                blacklisted_owner_ids_expression=search_properties.get('blacklisted_owner_ids_expression', ""),
                 default_properties=[
                     DefaultCaseSearchProperty.wrap(p)
                     for p in search_properties.get('default_properties')

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -11,7 +11,7 @@ from corehq.apps.es import case_search as case_search_es
 """
 from . import filters, queries
 
-from corehq.apps.es.cases import CaseES
+from corehq.apps.es.cases import CaseES, owner
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_ALIAS
 
 
@@ -23,7 +23,7 @@ class CaseSearchES(CaseES):
 
     @property
     def builtin_filters(self):
-        return [case_property_filter] + super(CaseSearchES, self).builtin_filters
+        return [case_property_filter, blacklist_owner_id] + super(CaseSearchES, self).builtin_filters
 
     @property
     def _case_property_queries(self):
@@ -84,6 +84,10 @@ def case_property_filter(key, value):
             filters.term("{}.value".format(PATH), value),
         )
     )
+
+
+def blacklist_owner_id(owner_id):
+    return filters.NOT(owner(owner_id))
 
 
 def flatten_result(result):

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -154,3 +154,20 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
             ),
             expected
         )
+
+    def test_blacklisted_owner_ids(self):
+        query = self.es.domain('swashbucklers').blacklist_owner_id('123').owner('234')
+        expected = {'query':
+                    {'filtered':
+                     {'filter':
+                      {'and': [
+                          {'term': {'domain.exact': 'swashbucklers'}},
+                          {'not': {'term': {'owner_id': '123'}}},
+                          {'term': {'owner_id': '234'}},
+                          {'match_all': {}}
+                      ]},
+                      "query": {
+                          "match_all": {}
+                      }}},
+                    'size': SIZE_LIMIT}
+        self.checkQuery(query, expected)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -35,7 +35,7 @@ from corehq.apps.es.case_search import CaseSearchES, flatten_result
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.ota.forms import PrimeRestoreCacheForm, AdvancedPrimeRestoreCacheForm
 from corehq.apps.ota.tasks import queue_prime_restore
-from corehq.apps.users.models import CouchUser, CommCareUser
+from corehq.apps.users.models import CommCareUser
 from corehq.apps.locations.permissions import location_safe
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
@@ -112,7 +112,11 @@ def search(request, domain):
             to="{}@{}.com".format('frener', 'dimagi'),
             notify_admins=False, send_to_ops=False
         )
-        _soft_assert(False, u"Someone in domain: {} tried accessing case search without a config".format(domain), e)
+        _soft_assert(
+            False,
+            u"Someone in domain: {} tried accessing case search without a config".format(domain),
+            e
+        )
         config = CaseSearchConfig(domain=domain)
 
     query_addition_id = criteria.pop(SEARCH_QUERY_ADDITION_KEY, None)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -127,8 +127,7 @@ def search(request, domain):
 
     blacklisted_owner_ids = criteria.pop(CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY, None)
     if blacklisted_owner_ids is not None:
-        for blacklisted_owner_id in blacklisted_owner_ids.split(' '):
-            search_es = search_es.blacklist_owner_id(blacklisted_owner_id)
+        search_es = add_blacklisted_owner_ids(search_es, blacklisted_owner_ids)
 
     fuzzies = config.config.get_fuzzy_properties_for_case_type(case_type)
     for key, value in criteria.items():
@@ -150,6 +149,12 @@ def search(request, domain):
     cases = [CommCareCase.wrap(flatten_result(result)) for result in results]
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
+
+
+def add_blacklisted_owner_ids(search_es, blacklisted_owner_ids):
+    for blacklisted_owner_id in blacklisted_owner_ids.split(' '):
+            search_es = search_es.blacklist_owner_id(blacklisted_owner_id)
+    return search_es
 
 
 def _add_case_search_addition(request, domain, search_es, query_addition_id, query_addition_debug_details):


### PR DESCRIPTION
Allows adding either an XPath expression or a space separated list of valid owner ids to filter out of search results. 
![screenshot from 2017-05-17 19-48-11](https://cloud.githubusercontent.com/assets/146896/26180816/cb6c598e-3b39-11e7-918b-47200f28c6ca.png)

@sheelio @ctsims FYI
@benrudolph Buddy 🐟 / 🐡 