### PR TITLE
ReportConfigs might use old slug

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -86,7 +86,10 @@ class ApplicationStatusReport(DeploymentsReport):
     @property
     @memoized
     def users(self):
-        mobile_user_and_group_slugs = self.request.GET.getlist(LocationRestrictedMobileWorkerFilter.slug)
+        mobile_user_and_group_slugs = set(
+            self.request.GET.getlist(LocationRestrictedMobileWorkerFilter.slug) +
+            self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)  # Cater for old ReportConfigs
+        )
 
         limit_user_ids = []
         if self.selected_app_id:


### PR DESCRIPTION
Context: [FB 251023](https://manage.dimagi.com/default.asp?251023), PR #16063.

Saved or e-mailed reports use ReportConfig instances that might store their filters keyed by old slugs. This allows the Application Status report to accept users specified with either the new or the old slug. (Changing the filter will use the new slug.)

I'm branching the first commit in PR #16063 into this PR, which will allow the user to continue. I'll add a test to the original PR, and follow up there shortly.

@mkangia cc @snopoke 
