### PR TITLE
Add TimestampDocument to couch models

### DIFF
--- a/corehq/apps/casegroups/models.py
+++ b/corehq/apps/casegroups/models.py
@@ -1,10 +1,11 @@
 from couchdbkit.ext.django.schema import StringProperty, ListProperty
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from dimagi.utils.couch.undo import UndoableDocument, DeleteDocRecord
+from dimagi.utils.couch.undo import UndoableMixin, DeleteDocRecord
+from dimagi.ext.couchdbkit import Document
 
 
-class CommCareCaseGroup(UndoableDocument):
+class CommCareCaseGroup(Document, UndoableMixin):
     """
         This is a group of CommCareCases. Useful for managing cases in larger projects.
     """


### PR DESCRIPTION
@gcapalbo how do you feel about this approach to adding last modified? on one hand i like that this is just a mixin to add. however i hate subclassing `Document`. other option could be to just define the two properties on each model and override the save function. (we don't have to add created_on, but i've always wanted it and this felt like a good excuse)

cc: @proteusvacuum 