### PR TITLE
Fix report module JavaScript error

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -263,7 +263,7 @@ hqDefine('app_manager/js/report-module.js', function () {
         self.languages = options.languages;
         self.lang = options.lang;
         self.moduleName = options.moduleName;
-        self.moduleFilter = options.moduleFilter === "None" ? "" : options.moduleFilter;
+        self.moduleFilter = options.moduleFilter || "";
         self.currentModuleName = ko.observable(options.moduleName[self.lang]);
         self.currentModuleFilter = ko.observable(self.moduleFilter);
         self.menuImage = options.menuImage;


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?254410

The error is that `self.currentModuleFilter()` is undefined [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/static/app_manager/js/report-module.js#L318). I haven't been able to reproduce this locally, even with a blank module filter, so I'm somewhat just guessing that this will fix it. This logic definitely isn't needed anymore, though, now that report modules use initial page data.

@esoergel 