### PR TITLE
Revert "attempt fix docker biuld"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ COPY requirements/requirements.txt \
 RUN git config --global url."https://".insteadOf git:// \
  && pip install --upgrade pip \
  && pip install \
-    -r requirements/requirements.txt \
-    -r requirements/dev-requirements.txt \
+    -r /vendor/requirements.txt \
+    -r /vendor/dev-requirements.txt \
     --user --upgrade \
  && rm -rf /root/.cache/pip
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#16223 didn't work, but it's more obvious to me why it doesn't work.

Will likely need to change https://github.com/dimagi/commcare-hq/blob/master/requirements/requirements.txt#L99 to a git endpoint. @dannyroberts why did you choose to install it locally from submodule instead of using a git endpoint?