### PR TITLE
Use elasticsearch for device log users filter

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -280,7 +280,7 @@ class DeviceLogFilter(LoginAndDomainMixin, JSONResponseMixin, View):
             .values_list(self.field, flat=True)
             .order_by(self.field)
         )
-        values = query_set[self._offset():self._offset()+self._page_limit()]
+        values = query_set[self._offset():self._offset() + self._page_limit()]
         return self.render_json_response({
             'results': [{'id': v, 'text': v} for v in values],
             'total': query_set.count(),

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -10,6 +10,7 @@ from braces.views import JSONResponseMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.filters.case_list import CaseListFilterUtils
+from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.elastic import ESError
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.logging import notify_exception
@@ -304,7 +305,20 @@ class DeviceLogFilter(LoginAndDomainMixin, JSONResponseMixin, View):
 
 
 class DeviceLogUsers(DeviceLogFilter):
-    field = 'username'
+
+    def get(self, request, domain):
+        q = self.request.GET.get('q', None)
+        users_query = (get_search_users_in_domain_es_query(domain, q, self._page_limit(), self._offset())
+            .show_inactive()
+            .remove_default_filter("not_deleted")
+            .source("username")
+        )
+        values = [x['username'].split("@")[0] for x in users_query.run().hits]
+        count = users_query.count()
+        return self.render_json_response({
+            'results': [{'id': v, 'text': v} for v in values],
+            'total': count,
+        })
 
 
 class DeviceLogIds(DeviceLogFilter):


### PR DESCRIPTION
Previously, the users filter select2 was populated by querying unique values in the username column of the `DeviceReportEntry` table. However, this table can have 10s of millions of rows, so the query is slow. This changes that select2 to be populated by elasticsearch instead.

@dannyroberts 
http://manage.dimagi.com/default.asp?254116