### PR TITLE
set case server_modified_on to edited_on date during edit form workflow

### DIFF
--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -165,12 +165,13 @@ class EditFormTest(TestCase, TestFileMixin):
                 'property': 'edited value'
             }
         ).as_string()
-        submit_case_blocks(case_block, domain=self.domain, form_id=form_id)
+        xform, _ = submit_case_blocks(case_block, domain=self.domain, form_id=form_id)
 
         case = self.casedb.get_case(case_id)
         self.assertEqual(case.type, 'newtype')
         self.assertEqual(case.dynamic_case_properties()['property'], 'edited value')
         self.assertEqual([form_id], case.xform_ids)
+        self.assertEqual(case.server_modified_on, xform.edited_on)
 
         if not getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(2, len(case.actions))

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -191,7 +191,9 @@ class FormProcessorSQL(object):
                     is_creation = True
                     case_db.set(case_id, case)
                 previous_owner = case.owner_id
-                case = FormProcessorSQL._rebuild_case_from_transactions(case, rebuild_detail, updated_xforms=xforms)
+                case, _ = FormProcessorSQL._rebuild_case_from_transactions(
+                    case, rebuild_detail, updated_xforms=xforms
+                )
                 if case:
                     touched_cases[case.case_id] = CaseUpdateMetadata(
                         case=case, is_creation=is_creation, previous_owner_id=previous_owner,
@@ -220,9 +222,11 @@ class FormProcessorSQL(object):
             case = CommCareCaseSQL(case_id=case_id, domain=domain)
             found = False
 
-        case = FormProcessorSQL._rebuild_case_from_transactions(case, detail)
+        case, rebuild_transaction = FormProcessorSQL._rebuild_case_from_transactions(case, detail)
         if case.is_deleted and not found:
             return None
+
+        case.server_modified_on = rebuild_transaction.server_date
         CaseAccessorSQL.save_case(case)
         publish_case_saved(case)
         return case
@@ -242,7 +246,7 @@ class FormProcessorSQL(object):
         strategy.rebuild_from_transactions(
             transactions, rebuild_transaction, unarchived_form_id=unarchived_form_id
         )
-        return case
+        return case, rebuild_transaction
 
     @staticmethod
     def get_case_forms(case_id):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -233,6 +233,8 @@ class FormProcessorSQL(object):
         strategy = SqlCaseUpdateStrategy(case)
 
         rebuild_transaction = CaseTransaction.rebuild_transaction(case, detail)
+        if updated_xforms:
+            rebuild_transaction.server_date = updated_xforms[0].edited_on
         unarchived_form_id = None
         if detail.type == CaseTransaction.TYPE_REBUILD_FORM_ARCHIVED and not detail.archived:
             # we're rebuilding because a form was un-archived

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -258,8 +258,6 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
         if not self.case.modified_on:
             self.case.modified_on = rebuild_transaction.server_date
 
-        self.case.server_modified_on = rebuild_transaction.server_date
-
     def _delete_old_related_models(self, original_models_by_id, models_to_keep):
         for model in models_to_keep:
             original_models_by_id.pop(model.identifier, None)

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -258,6 +258,8 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
         if not self.case.modified_on:
             self.case.modified_on = rebuild_transaction.server_date
 
+        self.case.server_modified_on = rebuild_transaction.server_date
+
     def _delete_old_related_models(self, original_models_by_id, models_to_keep):
         for model in models_to_keep:
             original_models_by_id.pop(model.identifier, None)

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -245,9 +245,7 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
 
         real_transactions = []
         for transaction in transactions:
-            if not transaction.is_relevant:
-                continue
-            elif transaction.is_form_transaction:
+            if transaction.is_form_transaction and transaction.is_relevant:
                 self._apply_form_transaction(transaction)
                 real_transactions.append(transaction)
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -588,6 +588,7 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
     opened_by = models.CharField(max_length=255, null=True)
 
     modified_on = models.DateTimeField(null=False)
+    # represents the max date from all case transactions
     server_modified_on = models.DateTimeField(null=False, db_index=True)
     modified_by = models.CharField(max_length=255)
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -262,7 +262,10 @@ class SubmissionPost(object):
         case_result = process_cases_with_casedb(xforms, case_db)
         stock_result = process_stock(xforms, case_db)
 
-        cases = case_db.get_cases_for_saving(instance.received_on)
+        modified_on_date = instance.received_on
+        if getattr(instance, 'edited_on', None) and instance.edited_on > instance.received_on:
+            modified_on_date = instance.edited_on
+        cases = case_db.get_cases_for_saving(modified_on_date)
         stock_result.populate_models()
 
         return CaseStockProcessingResult(


### PR DESCRIPTION
There is a known issue that after editing a form that touches cases those cases won't get re-synced to a users phone. The reason for this is that the cases `server_modified_on` date doesn't get changed by the form edit.

This change will set `case.server_modified_on` to the time of the edit (which seems more correct anyway).