### PR TITLE
Ethiopian date transform

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -88,6 +88,7 @@ An overview of the design, API and data structures used here.
             - [Round to the nearest whole number](#round-to-the-nearest-whole-number)
             - [Always round to 3 decimal places](#always-round-to-3-decimal-places)
         - [Date formatting](#date-formatting)
+        - [Converting an ethiopian date string to a gregorian date](#ethiopian-transform)
     - [Charts](#charts)
         - [Pie charts](#pie-charts)
         - [Aggregate multibar charts](#aggregate-multibar-charts)
@@ -1696,6 +1697,19 @@ If there is an error formatting the date, the transform is not applied to that v
 {
    "type": "date_format", 
    "format": "%Y-%m-%d %H:%M"
+}
+```
+
+
+### Converting an ethiopian date string to a gregorian date
+Converts a string in the YYYY-MM-DD format to a gregorian date. For example,
+2009-09-11 is converted date(2017, 5, 19). If it is unable to convert the date,
+it will return an empty string.
+
+```json
+{
+   "type": "custom",
+   "custom_type": "ethiopian_date_to_gregorian_date"
 }
 ```
 

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from django.test import SimpleTestCase
 from mock import patch
 
@@ -51,6 +51,27 @@ class NumberFormatTransformTest(SimpleTestCase):
 ), NumberFormatTransformTest)
 def test_number_format_transform_strings(self, input, expected_result):
     self.assertEqual(expected_result, self.transform(input))
+
+
+class TestEthiopianConversion(SimpleTestCase):
+    '''Tests converting ethiopian string dates to gregorian dates'''
+
+    def setUp(self):
+        self.transform = TransformFactory.get_transform({
+            "type": "custom",
+            "custom_type": "ethiopian_date_to_gregorian_date",
+        }).get_transform_function()
+
+
+@generate_cases((
+    ('2009-09-11 ', date(2017, 5, 19)),
+    ('2009-13-11 ', date(2017, 9, 16)),
+    ('2009_13_11 ', ''),
+    ('abc-13-11', ''),
+    (None, ''),
+), TestEthiopianConversion)
+def test_ethiopian_to_gregorian(self, date_string, expected_result):
+    self.assertEqual(expected_result, self.transform(date_string))
 
 
 class CustomTransformTest(SimpleTestCase):

--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -1,5 +1,6 @@
 import calendar
 from datetime import datetime
+from ethiopian_date import EthiopianDateConverter
 from dimagi.utils.dates import force_to_datetime
 
 
@@ -14,3 +15,26 @@ def days_elapsed_from_date(date):
     date = force_to_datetime(date)
     now = datetime.utcnow()
     return (now - date).days
+
+
+def get_ethiopian_to_gregorian(date_string):
+    '''
+    Takes a string ethiopian date and converts it to
+    the equivalent gregorian date
+
+    :param date_string: A date string that is in the format YYYY-MM-DD
+    :returns: A gregorian datetime or ''
+    '''
+    if not date_string:
+        return ''
+
+    try:
+        year, month, day = date_string.split('-')
+        year, month, day = int(year), int(month), int(day)
+    except ValueError:
+        return ''
+
+    try:
+        return EthiopianDateConverter.to_gregorian(year, month, day)
+    except Exception:
+        return ''

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -3,7 +3,11 @@ from django.utils.translation import get_language
 from dimagi.ext.jsonobject import DictProperty, JsonObject, StringProperty
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.util import localize
-from corehq.apps.userreports.transforms.custom.date import get_month_display, days_elapsed_from_date
+from corehq.apps.userreports.transforms.custom.date import (
+    get_month_display,
+    days_elapsed_from_date,
+    get_ethiopian_to_gregorian,
+)
 from corehq.apps.userreports.transforms.custom.numeric import \
     get_short_decimal_display
 from corehq.apps.userreports.transforms.custom.users import (
@@ -28,6 +32,7 @@ _CUSTOM_TRANSFORM_MAP = {
     'owner_display': get_owner_display,
     'user_without_domain_display': get_user_without_domain_display,
     'short_decimal_display': get_short_decimal_display,
+    'ethiopian_date_to_gregorian_date': get_ethiopian_to_gregorian,
 }
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -98,3 +98,4 @@ raven==6.0.0
 quickcache==0.0.1
 django_fsm==2.5.0
 zeep==1.6.0
+ethiopian_date==0.1.1


### PR DESCRIPTION
Transforms ethiopian date strings to gregorian dates. mainly useful for l10k

the package i chose to use it quite old (last updated 2010), but i reviewed the code and it looked sound and was tested. didn't seem like something we should duplicate. https://github.com/rgaudin/tools/blob/master/ethiopian_date/ethiopian_date/ethiopian_date.py#L71-L133

if need be we can copy the logic

fyi @lwyszomi this should be useful for building ucr reports
<img width="312" alt="screen shot 2017-05-19 at 3 23 19 pm" src="https://cloud.githubusercontent.com/assets/918514/26249604/8e6156ce-3ca7-11e7-9012-42df2e0ec5af.png">
