### PR TITLE
Allow specifying the es instance you want to use

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -104,8 +104,16 @@ import json
 
 from dimagi.utils.decorators.memoized import memoized
 
-from corehq.elastic import ES_META, ESError, run_query, scroll_query, SIZE_LIMIT, \
-    ScanResult, SCROLL_PAGE_SIZE_LIMIT
+from corehq.elastic import (
+    ES_META,
+    ES_DEFAULT_INSTANCE,
+    ESError,
+    run_query,
+    scroll_query,
+    SIZE_LIMIT,
+    ScanResult,
+    SCROLL_PAGE_SIZE_LIMIT,
+)
 
 from . import aggregations
 from . import filters
@@ -142,7 +150,7 @@ class ESQuery(object):
         "match_all": filters.match_all()
     }
 
-    def __init__(self, index=None, debug_host=None):
+    def __init__(self, index=None, debug_host=None, es_instance=ES_DEFAULT_INSTANCE):
         from corehq.apps.userreports.util import is_ucr_table
 
         self.index = index if index is not None else self.index
@@ -156,6 +164,7 @@ class ESQuery(object):
         self._facets = []
         self._aggregations = []
         self._source = None
+        self.es_instance = es_instance
         self.es_query = {"query": {
             "filtered": {
                 "filter": {"and": []},
@@ -209,7 +218,12 @@ class ESQuery(object):
     def run(self, include_hits=False):
         """Actually run the query.  Returns an ESQuerySet object."""
         query = self._clean_before_run(include_hits)
-        raw = run_query(query.index, query.raw_query, debug_host=query.debug_host)
+        raw = run_query(
+            query.index,
+            query.raw_query,
+            debug_host=query.debug_host,
+            es_instance=self.es_instance,
+        )
         return ESQuerySet(raw, deepcopy(query))
 
     def _clean_before_run(self, include_hits=False):
@@ -226,7 +240,7 @@ class ESQuery(object):
         query = deepcopy(self)
         if query._size is None:
             query._size = SCROLL_PAGE_SIZE_LIMIT
-        result = scroll_query(query.index, query.raw_query)
+        result = scroll_query(query.index, query.raw_query, es_instance=self.es_instance)
         return ScanResult(
             result.count,
             (ESQuerySet.normalize_result(query, r) for r in result)

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -150,7 +150,7 @@ class ESQuery(object):
         "match_all": filters.match_all()
     }
 
-    def __init__(self, index=None, debug_host=None, es_instance=ES_DEFAULT_INSTANCE):
+    def __init__(self, index=None, debug_host=None, es_instance_alias=ES_DEFAULT_INSTANCE):
         from corehq.apps.userreports.util import is_ucr_table
 
         self.index = index if index is not None else self.index
@@ -164,7 +164,7 @@ class ESQuery(object):
         self._facets = []
         self._aggregations = []
         self._source = None
-        self.es_instance = es_instance
+        self.es_instance_alias = es_instance_alias
         self.es_query = {"query": {
             "filtered": {
                 "filter": {"and": []},
@@ -222,7 +222,7 @@ class ESQuery(object):
             query.index,
             query.raw_query,
             debug_host=query.debug_host,
-            es_instance=self.es_instance,
+            es_instance_alias=self.es_instance_alias,
         )
         return ESQuerySet(raw, deepcopy(query))
 
@@ -240,7 +240,7 @@ class ESQuery(object):
         query = deepcopy(self)
         if query._size is None:
             query._size = SCROLL_PAGE_SIZE_LIMIT
-        result = scroll_query(query.index, query.raw_query, es_instance=self.es_instance)
+        result = scroll_query(query.index, query.raw_query, es_instance_alias=self.es_instance_alias)
         return ScanResult(
             result.count,
             (ESQuerySet.normalize_result(query, r) for r in result)

--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -9,7 +9,7 @@ from corehq.toggles import EXPORT_NO_SORT
 
 
 def get_form_export_base_query(domain, app_id, xmlns, include_errors):
-    query = (FormES(es_instance=ES_EXPORT_INSTANCE)
+    query = (FormES(es_instance_alias=ES_EXPORT_INSTANCE)
             .domain(domain)
             .app(app_id)
             .xmlns(xmlns)
@@ -25,7 +25,7 @@ def get_form_export_base_query(domain, app_id, xmlns, include_errors):
 
 
 def get_case_export_base_query(domain, case_type):
-    query = (CaseES(es_instance=ES_EXPORT_INSTANCE)
+    query = (CaseES(es_instance_alias=ES_EXPORT_INSTANCE)
             .domain(domain)
             .case_type(case_type))
 
@@ -36,7 +36,7 @@ def get_case_export_base_query(domain, case_type):
 
 
 def get_sms_export_base_query(domain):
-    return (SMSES(es_instance=ES_EXPORT_INSTANCE)
+    return (SMSES(es_instance_alias=ES_EXPORT_INSTANCE)
             .domain(domain)
             .processed_or_incoming_messages()
             .sort("date"))

--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -4,12 +4,12 @@ from corehq.apps.es import CaseES, GroupES, LedgerES
 from corehq.apps.es import FormES
 from corehq.apps.es.sms import SMSES
 from corehq.apps.es.aggregations import AggregationTerm, NestedTermAggregationsHelper
-from corehq.elastic import get_es_new
+from corehq.elastic import get_es_new, ES_EXPORT_INSTANCE
 from corehq.toggles import EXPORT_NO_SORT
 
 
 def get_form_export_base_query(domain, app_id, xmlns, include_errors):
-    query = (FormES()
+    query = (FormES(es_instance=ES_EXPORT_INSTANCE)
             .domain(domain)
             .app(app_id)
             .xmlns(xmlns)
@@ -25,7 +25,7 @@ def get_form_export_base_query(domain, app_id, xmlns, include_errors):
 
 
 def get_case_export_base_query(domain, case_type):
-    query = (CaseES()
+    query = (CaseES(es_instance=ES_EXPORT_INSTANCE)
             .domain(domain)
             .case_type(case_type))
 
@@ -36,7 +36,7 @@ def get_case_export_base_query(domain, case_type):
 
 
 def get_sms_export_base_query(domain):
-    return (SMSES()
+    return (SMSES(es_instance=ES_EXPORT_INSTANCE)
             .domain(domain)
             .processed_or_incoming_messages()
             .sort("date"))

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -13,7 +13,7 @@ from corehq.apps.case_search.models import CLAIM_CASE_TYPE, CaseSearchConfig, SE
     CaseSearchQueryAddition
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
-from corehq.elastic import get_es_new, SIZE_LIMIT
+from corehq.elastic import get_es_new, SIZE_LIMIT, ES_DEFAULT_INSTANCE
 from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.es.tests.utils import ElasticTestMixin
 from corehq.apps.ota.views import add_blacklisted_owner_ids
@@ -348,4 +348,9 @@ class CaseClaimEndpointTests(TestCase):
             },
             'size': CASE_SEARCH_MAX_RESULTS
         }
-        run_query_mock.assert_called_with("case_search", expected_query, debug_host=None)
+        run_query_mock.assert_called_with(
+            "case_search",
+            expected_query,
+            debug_host=None,
+            es_instance_alias=ES_DEFAULT_INSTANCE,
+        )

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -74,9 +74,9 @@ ES_INSTANCES = {
 }
 
 
-def get_es_instance(es_instance=ES_DEFAULT_INSTANCE):
-    assert es_instance in ES_INSTANCES
-    return ES_INSTANCES[es_instance]()
+def get_es_instance(es_instance_alias=ES_DEFAULT_INSTANCE):
+    assert es_instance_alias in ES_INSTANCES
+    return ES_INSTANCES[es_instance_alias]()
 
 
 def doc_exists_in_es(index_info, doc_id_or_dict):
@@ -179,7 +179,7 @@ class ESError(Exception):
     pass
 
 
-def run_query(index_name, q, debug_host=None, es_instance=ES_DEFAULT_INSTANCE):
+def run_query(index_name, q, debug_host=None, es_instance_alias=ES_DEFAULT_INSTANCE):
     # the debug_host parameter allows you to query another env for testing purposes
     if debug_host:
         if not settings.DEBUG:
@@ -189,7 +189,7 @@ def run_query(index_name, q, debug_host=None, es_instance=ES_DEFAULT_INSTANCE):
                                       'port': settings.ELASTICSEARCH_PORT}],
                                     timeout=3, max_retries=0)
     else:
-        es_instance = get_es_instance(es_instance)
+        es_instance = get_es_instance(es_instance_alias)
 
     try:
         es_meta = ES_META[index_name]
@@ -216,11 +216,11 @@ def mget_query(index_name, ids, source):
         raise ESError(e)
 
 
-def scroll_query(index_name, q, es_instance=ES_DEFAULT_INSTANCE):
+def scroll_query(index_name, q, es_instance_alias=ES_DEFAULT_INSTANCE):
     es_meta = ES_META[index_name]
     try:
         return scan(
-            get_es_instance(es_instance),
+            get_es_instance(es_instance_alias),
             index=es_meta.index,
             doc_type=es_meta.type,
             query=q,

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -23,25 +23,60 @@ from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 
 
+def _es_hosts():
+    es_hosts = getattr(settings, 'ELASTICSEARCH_HOSTS', None)
+    if not es_hosts:
+        es_hosts = [settings.ELASTICSEARCH_HOST]
+
+    hosts = [
+        {
+            'host': host,
+            'port': settings.ELASTICSEARCH_PORT,
+        }
+        for host in es_hosts
+    ]
+    return hosts
+
+
 def get_es_new():
     """
     Get a handle to the configured elastic search DB.
     Returns an elasticsearch.Elasticsearch instance.
     """
     if not getattr(get_es_new, '_es_client', None):
-        es_hosts = getattr(settings, 'ELASTICSEARCH_HOSTS', None)
-        if not es_hosts:
-            es_hosts = [settings.ELASTICSEARCH_HOST]
-
-        hosts = [
-            {
-                'host': host,
-                'port': settings.ELASTICSEARCH_PORT,
-            }
-            for host in es_hosts
-        ]
+        hosts = _es_hosts()
         get_es_new._es_client = Elasticsearch(hosts)
     return get_es_new._es_client
+
+
+def get_es_export():
+    """
+    Get a handle to the configured elastic search DB with settings geared towards exports.
+    Returns an elasticsearch.Elasticsearch instance.
+    """
+    if not getattr(get_es_export, '_es_client', None):
+        hosts = _es_hosts()
+        get_es_export._es_client = Elasticsearch(
+            hosts,
+            retry_on_timeout=True,
+            max_retries=3,
+            # Timeout in seconds for an elasticsearch query
+            timeout=30,
+        )
+    return get_es_export._es_client
+
+ES_DEFAULT_INSTANCE = 'default'
+ES_EXPORT_INSTANCE = 'export'
+
+ES_INSTANCES = {
+    ES_DEFAULT_INSTANCE: get_es_new,
+    ES_EXPORT_INSTANCE: get_es_export,
+}
+
+
+def get_es_instance(es_instance=ES_DEFAULT_INSTANCE):
+    assert es_instance in ES_INSTANCES
+    return ES_INSTANCES[es_instance]()
 
 
 def doc_exists_in_es(index_info, doc_id_or_dict):
@@ -144,7 +179,7 @@ class ESError(Exception):
     pass
 
 
-def run_query(index_name, q, debug_host=None):
+def run_query(index_name, q, debug_host=None, es_instance=ES_DEFAULT_INSTANCE):
     # the debug_host parameter allows you to query another env for testing purposes
     if debug_host:
         if not settings.DEBUG:
@@ -154,7 +189,7 @@ def run_query(index_name, q, debug_host=None):
                                       'port': settings.ELASTICSEARCH_PORT}],
                                     timeout=3, max_retries=0)
     else:
-        es_instance = get_es_new()
+        es_instance = get_es_instance(es_instance)
 
     try:
         es_meta = ES_META[index_name]
@@ -181,11 +216,11 @@ def mget_query(index_name, ids, source):
         raise ESError(e)
 
 
-def scroll_query(index_name, q):
+def scroll_query(index_name, q, es_instance=ES_DEFAULT_INSTANCE):
     es_meta = ES_META[index_name]
     try:
         return scan(
-            get_es_new(),
+            get_es_instance(es_instance),
             index=es_meta.index,
             doc_type=es_meta.type,
             query=q,


### PR DESCRIPTION
Some more robust configuration settings for exports. i think the ultimate goal would be able to detect a failure and the resume if we can, however i think that's going to be exceedingly difficult with the way es scroll queries work