### PR TITLE
attempt to find appid in domain if export doesn't have appid

### DIFF
--- a/corehq/apps/export/tests/data/saved_export_schemas/missing_app_id.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/missing_app_id.json
@@ -1,0 +1,81 @@
+{
+    "_id": "2f1b9a5edd9f0710e6ddbffd6173f2b7",
+    "_rev": "3-0be1a2b246f8f6dd72d287de54f05f7d",
+    "default_format": "csv",
+    "doc_type": "SavedExportSchema",
+    "filter_function": "",
+    "index": "[\"aspace\", \"missing-xmlns\"]", 
+    "name": "alex_audit",
+    "schema_id": "2f1b9a5edd9f0710e6ddbffd6173f435",
+    "tables": [
+        {
+            "columns": [
+                {
+                    "display": "form.meta.username",
+                    "doc_type": "ExportColumn", 
+                    "index": "form.meta.username"
+                }, 
+                {
+                    "display": "form.respondent", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.respondent"
+                }, 
+                {
+                    "display": "form.explain", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.explain"
+                }, 
+                {
+                    "display": "form.barcode", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.barcode"
+                }, 
+                {
+                    "display": "form.meta.userID", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.meta.userID"
+                }, 
+                {
+                    "display": "form.visit", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.visit"
+                }, 
+                {
+                    "display": "form.meta.timeStart", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.meta.timeStart"
+                }, 
+                {
+                    "display": "form.meta.deviceID", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.meta.deviceID"
+                }, 
+                {
+                    "display": "form.friendly", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.friendly"
+                }, 
+                {
+                    "display": "form.number_individuals", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.number_individuals"
+                }, 
+                {
+                    "display": "form.meta.timeEnd", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.meta.timeEnd"
+                }, 
+                {
+                    "display": "form.verify_address", 
+                    "doc_type": "ExportColumn", 
+                    "index": "form.verify_address"
+                }
+            ], 
+            "display": "alex_audit", 
+            "doc_type": "ExportTable", 
+            "index": "#", 
+            "order": []
+        }
+    ], 
+    "type": "form"
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/missing_app_id.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/missing_app_id.json
@@ -14,61 +14,6 @@
                     "display": "form.meta.username",
                     "doc_type": "ExportColumn", 
                     "index": "form.meta.username"
-                }, 
-                {
-                    "display": "form.respondent", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.respondent"
-                }, 
-                {
-                    "display": "form.explain", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.explain"
-                }, 
-                {
-                    "display": "form.barcode", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.barcode"
-                }, 
-                {
-                    "display": "form.meta.userID", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.meta.userID"
-                }, 
-                {
-                    "display": "form.visit", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.visit"
-                }, 
-                {
-                    "display": "form.meta.timeStart", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.meta.timeStart"
-                }, 
-                {
-                    "display": "form.meta.deviceID", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.meta.deviceID"
-                }, 
-                {
-                    "display": "form.friendly", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.friendly"
-                }, 
-                {
-                    "display": "form.number_individuals", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.number_individuals"
-                }, 
-                {
-                    "display": "form.meta.timeEnd", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.meta.timeEnd"
-                }, 
-                {
-                    "display": "form.verify_address", 
-                    "doc_type": "ExportColumn", 
-                    "index": "form.verify_address"
                 }
             ], 
             "display": "alex_audit", 

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -28,6 +28,7 @@ from corehq.apps.export.models import (
     ExportColumn,
 )
 from corehq.apps.reports.models import HQGroupExportConfiguration
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.models import Domain, Application, RemoteApp, Module
 from corehq.apps.export.utils import (
     convert_saved_export_to_export_instance,
@@ -182,6 +183,49 @@ class TestConvertBase(TestCase, TestFileMixin):
                 )
 
         return instance, meta
+
+
+@mock.patch(
+    'corehq.apps.export.models.new.get_request',
+    return_value=MockRequest(domain='my-domain'),
+)
+@mock.patch(
+    'corehq.apps.export.utils._is_remote_app_conversion',
+    return_value=False,
+)
+class TestConvertMissingAppID(TestConvertBase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestConvertMissingAppID, cls).setUpClass()
+        factory = AppFactory(cls.domain)
+        m1, m1f1 = factory.new_basic_module('open_case', 'house')
+        m1f1.xmlns = 'missing-xmlns'
+        cls.app = factory.app
+        cls.app.save()
+
+        cls.project = create_domain(cls.domain)
+        cls.schema = FormExportDataSchema(
+            domain=cls.domain,
+            app_id='123',
+            xmlns='myxmlns',
+            group_schemas=[
+                ExportGroupSchema(
+                    path=MAIN_TABLE,
+                    items=[],
+                ),
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.delete()
+        cls.project.delete()
+        super(TestConvertMissingAppID, cls).tearDownClass()
+
+    def test_convert_missing_app_id(self, _, __):
+        instance, _ = self._convert_form_export('missing_app_id')
+        self.assertIsNotNone(instance.app_id)
 
 
 @mock.patch(


### PR DESCRIPTION
During export migration old old saved exports didn't save the app id. this attempts to find one based on the xmlns

buddy: @proteusvacuum 