### PR TITLE
Increase number of ucrs to be compared

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -20,7 +20,7 @@ from corehq.apps.userreports.reports.factory import ReportFactory
 from corehq.apps.userreports.tasks import compare_ucr_dbs
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 
-MOBILE_UCR_RANDOM_THRESHOLD = 10 ** 5
+MOBILE_UCR_RANDOM_THRESHOLD = 100
 
 
 def _should_sync(restore_state):


### PR DESCRIPTION
It appears that this hasn't ever been logged. It seems surprising since we have 100k restores a day.

I initially put it at 100k because we were having load issues and I didn't want to contribute to that. but now we have stabilized and UCRs arent generated for every restore now

@dimagi/scale-team buddy @calellowitz 