### PR TITLE
Add static label to static report/data source names

### DIFF
--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -30,7 +30,12 @@
         {% with report as selected_report %}
         {% for report in reports %}
         <li {% if report.get_id == selected_report.get_id %} class="active"{% endif %}>
-            <a href="{% url 'edit_configurable_report' domain report.get_id %}">{{ report.title }}</a>
+            <a href="{% url 'edit_configurable_report' domain report.get_id %}">
+                {{ report.title }}
+                {% if report.is_static %}
+                    <span class="label label-default">static</span>
+                {% endif %}
+            </a>
         </li>
         {% endfor %}
         {% endwith %}
@@ -51,7 +56,12 @@
         {% with data_source as selected_data_source %}
         {% for data_source in data_sources %}
         <li{% if data_source.get_id == selected_data_source.get_id %} class="active"{% endif %}>
-            <a href="{% url 'edit_configurable_data_source' domain data_source.get_id %}">{{ data_source.display_name }}</a>
+            <a href="{% url 'edit_configurable_data_source' domain data_source.get_id %}">
+                {{ data_source.display_name }}
+                {% if data_source.is_static %}
+                    <span class="label label-default">static</span>
+                {% endif %}
+            </a>
         </li>
         {% endfor %}
         {% endwith %}


### PR DESCRIPTION
This makes it easier to tell at a glance which are static and which are not without having to add (static) to the name of ever data source and report. These labels only show on the internal UCR pages, not on the general report pages.

@proteusvacuum 
buddy @dannyroberts 

Screen shot:
<img width="239" alt="screen shot 2017-05-19 at 1 40 26 pm" src="https://cloud.githubusercontent.com/assets/2117127/26259858/ea9eeb40-3c98-11e7-917a-c0d3baf37feb.png">
