### PR TITLE
don't include builds when getting case types from app

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -357,6 +357,7 @@ def get_case_types_from_apps(domain):
     """
     q = (AppES()
          .domain(domain)
+         .is_build(False)
          .size(0)
          .terms_aggregation('modules.case_type.exact', 'case_types'))
     return set(q.run().aggregations.case_types.keys)


### PR DESCRIPTION
@sheelio @NoahCarnahan 

This is only used in case importer and data dictionary so we shouldn't look at builds to generate the list of cases

http://manage.dimagi.com/default.asp?252590#1331632

buddy @calellowitz 