### PR TITLE
Log _validate_case_removal soft asserts to a file instead of email

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -921,13 +921,14 @@ class SimplifiedSyncLog(AbstractSyncLog):
         if case_to_remove == checked_case_id:
             return
 
-        for index in deleted_indices.values():
-            if not (quiet_errors or _domain_has_legacy_toggle_set()):
-                # unblocking http://manage.dimagi.com/default.asp?185850
-                _assert = soft_assert(send_to_ops=False, log_to_file=True, exponential_backoff=True,
-                                      fail_if_debug=True, include_breadcrumbs=True)
-                _assert(index in (all_to_remove | set([checked_case_id])),
-                        "expected {} in {} but wasn't".format(index, all_to_remove))
+        # Logging removed temporarily: https://github.com/dimagi/commcare-hq/pull/16259#issuecomment-303176217
+        # for index in deleted_indices.values():
+        #     if not (quiet_errors or _domain_has_legacy_toggle_set()):
+        #         # unblocking http://manage.dimagi.com/default.asp?185850
+        #         _assert = soft_assert(send_to_ops=False, log_to_file=True, exponential_backoff=True,
+        #                               fail_if_debug=True, include_breadcrumbs=True)
+        #         _assert(index in (all_to_remove | set([checked_case_id])),
+        #                 "expected {} in {} but wasn't".format(index, all_to_remove))
 
     def _add_primary_case(self, case_id):
         self.case_ids_on_phone.add(case_id)

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -924,7 +924,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
         for index in deleted_indices.values():
             if not (quiet_errors or _domain_has_legacy_toggle_set()):
                 # unblocking http://manage.dimagi.com/default.asp?185850
-                _assert = soft_assert(notify_admins=True, exponential_backoff=True,
+                _assert = soft_assert(send_to_ops=False, log_to_file=True, exponential_backoff=True,
                                       fail_if_debug=True, include_breadcrumbs=True)
                 _assert(index in (all_to_remove | set([checked_case_id])),
                         "expected {} in {} but wasn't".format(index, all_to_remove))

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 
 from corehq.apps.hqwebapp.tasks import send_mail_async, mail_admins_async
@@ -5,6 +7,7 @@ from corehq.util.log import get_sanitized_request_repr
 from corehq.util.global_request import get_request
 from corehq.util.soft_assert.core import SoftAssert
 
+logger = logging.getLogger('soft_asserts')
 
 def _send_message(info, backend):
     request = get_request()
@@ -24,7 +27,7 @@ def _send_message(info, backend):
 
 def soft_assert(to=None, notify_admins=False,
                 fail_if_debug=False, exponential_backoff=True, skip_frames=0,
-                send_to_ops=True, include_breadcrumbs=False):
+                send_to_ops=True, log_to_file=False, include_breadcrumbs=False):
     """
     send an email with stack trace if assertion is not True
 
@@ -43,6 +46,7 @@ def soft_assert(to=None, notify_admins=False,
       last frame in the stack trace, then pass in skip_frames=1.
       This affects both the traceback in the email as the "key" by which
       errors are grouped.
+    - log_to_file: write the message to a log file
 
     For the purposes of grouping errors into email threads,
     counting occurrences (sent in the email), and implementing exponential
@@ -87,19 +91,20 @@ def soft_assert(to=None, notify_admins=False,
             message=message,
         )
 
-    if to and notify_admins:
-        def send(info):
-            _send_message(info, backend=send_to_admins)
-            _send_message(info, backend=send_to_recipients)
-    elif to:
-        def send(info):
-            _send_message(info, backend=send_to_recipients)
-    elif notify_admins:
-        def send(info):
-            _send_message(info, backend=send_to_admins)
-    else:
+    def write_to_log_file(subject, message):
+        logger.debug(message)
+
+    if not (notify_admins or to or log_to_file):
         raise ValueError('You must call soft assert with either a '
                          'list of recipients or notify_admins=True')
+
+    def send(info):
+        if to:
+            _send_message(info, backend=send_to_recipients)
+        if notify_admins:
+            _send_message(info, backend=send_to_admins)
+        if log_to_file:
+            _send_message(info, backend=write_to_log_file)
 
     if fail_if_debug:
         debug = settings.DEBUG

--- a/settings.py
+++ b/settings.py
@@ -118,6 +118,7 @@ UCR_DIFF_FILE = "%s/%s" % (FILEPATH, "ucr.diff.log")
 UCR_EXCEPTION_FILE = "%s/%s" % (FILEPATH, "ucr.exception.log")
 NIKSHAY_DATAMIGRATION = "%s/%s" % (FILEPATH, "nikshay_datamigration.log")
 PRIVATE_SECTOR_DATAMIGRATION = "%s/%s" % (FILEPATH, "private_sector_datamigration.log")
+SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}
@@ -1143,6 +1144,14 @@ LOGGING = {
             'level': 'ERROR',
             'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
         },
+        'soft_asserts': {
+            "level": "DEBUG",
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'verbose',
+            'filename': SOFT_ASSERTS_LOG_FILE,
+            'maxBytes': 10 * 1024 * 1024,  # 10 MB
+            'backupCount': 200  # Backup 2000 MB of logs
+        }
     },
     'loggers': {
         '': {
@@ -1242,6 +1251,11 @@ LOGGING = {
         },
         'sentry.errors.uncaught': {
             'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'soft_asserts': {
+            'handlers': ['soft_asserts', 'console'],
             'level': 'DEBUG',
             'propagate': False,
         },


### PR DESCRIPTION
This soft assert is generating like 500 MB of email messages per day, which would fill an empty inbox in 60 days. This PR logs those messages to a file instead.

@dannyroberts because soft assert/buddy
@snopoke @millerdev because I think you two might be working on `_validate_case_removal`?