### PR TITLE
Replace `Application.get_form_by_xmlns()` (shadow forms related)

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6033,6 +6033,8 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         if not forms:
             return None
         else:
+            # If there are multiple forms with the same xmlns, then all but one are shadow forms, therefore they
+            # all have the same xform.
             return forms[0].wrapped_xform()
 
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6007,28 +6007,43 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             xmlns_map[form.xmlns].append(form)
         return xmlns_map
 
-    def get_form_by_xmlns(self, xmlns, log_missing=True):
+    def get_forms_by_xmlns(self, xmlns, log_missing=True):
+        """
+        Return the forms with the given xmlns.
+        This function could return multiple forms if there are shadow forms in the app.
+        """
         if xmlns == "http://code.javarosa.org/devicereport":
-            return None
+            return []
         forms = self.get_xmlns_map()[xmlns]
-        if len(forms) != 1:
-            if log_missing or len(forms) > 1:
+        if len(forms) < 1:
+            if log_missing:
                 logging.error('App %s in domain %s has %s forms with xmlns %s' % (
                     self.get_id,
                     self.domain,
                     len(forms),
                     xmlns,
                 ))
+            return []
+        non_shadow_forms = [form for form in forms if form.form_type != ShadowForm.form_type]
+        assert len(non_shadow_forms) <= 1
+        return forms
+
+    def get_xform_by_xmlns(self, xmlns, log_missing=True):
+        forms = self.get_forms_by_xmlns(xmlns, log_missing)
+        if not forms:
             return None
         else:
-            form, = forms
-        return form
+            return forms[0].wrapped_xform()
 
-    def get_questions(self, xmlns):
-        form = self.get_form_by_xmlns(xmlns)
-        if not form:
+
+    def get_questions(self, xmlns, langs=None, include_triggers=False, include_groups=False,
+                      include_translations=False):
+        forms = self.get_forms_by_xmlns(xmlns)
+        if not forms:
             return []
-        return form.get_questions(self.langs)
+        # If there are multiple forms with the same xmlns, then some of them are shadow forms, so all the questions
+        # will be the same.
+        return forms[0].get_questions(langs or self.langs, include_triggers, include_groups, include_translations)
 
     def check_subscription(self):
 

--- a/corehq/apps/export/models/deprecated.py
+++ b/corehq/apps/export/models/deprecated.py
@@ -113,9 +113,8 @@ class FormQuestionSchema(Document):
             self.save()
 
     def update_for_app(self, app):
-        form = app.get_form_by_xmlns(self.xmlns, log_missing=False)
-        if form:
-            xform = form.wrapped_xform()
+        xform = app.get_xform_by_xmlns(self.xmlns, log_missing=False)
+        if xform:
             prefix = '/{}/'.format(xform.data_node.tag_name)
 
             def to_json_path(xml_path):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -7,6 +7,7 @@ from collections import defaultdict, OrderedDict, namedtuple
 
 from couchdbkit import ResourceConflict
 from couchdbkit.ext.django.schema import IntegerProperty
+from django.utils.datastructures import OrderedSet
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from django.db import models
@@ -1552,16 +1553,23 @@ class FormExportDataSchema(ExportDataSchema):
 
     @classmethod
     def _process_app_build(cls, current_schema, app, form_xmlns):
-        form = app.get_form_by_xmlns(form_xmlns, log_missing=False)
-        if not form:
+        forms = app.get_forms_by_xmlns(form_xmlns, log_missing=False)
+        if not forms:
             return current_schema
 
-        case_updates = form.get_case_updates(form.get_module().case_type)
-        xform = form.wrapped_xform()
-        if isinstance(form.actions, AdvancedFormActions):
-            open_case_actions = form.actions.open_cases
-        else:
-            open_case_actions = form.actions.subcases
+        case_updates = OrderedSet()
+        for form in forms:
+            for update in form.get_case_updates(form.get_module().case_type):
+                case_updates.add(update)
+        xform = forms[0].wrapped_xform()  # This will be the same for any form in the list
+        open_case_actions = OrderedSet()
+        for form in forms:
+            if isinstance(form.actions, AdvancedFormActions):
+                actions = form.actions.open_cases
+            else:
+                actions = form.actions.subcases
+            for action in actions:
+                open_case_actions.add(action)
 
         repeats_with_subcases = {
             open_case_action for open_case_action in open_case_actions

--- a/corehq/apps/export/tests/test_form_schema.py
+++ b/corehq/apps/export/tests/test_form_schema.py
@@ -32,7 +32,7 @@ class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual(schema.question_schema['form.repeat_1.multi_level_1_repeat'].repeat_context, 'form.repeat_1')
 
         updated_form_xml = self.get_xml('question_schema_update_form')
-        app.get_form_by_xmlns(xmlns).source = updated_form_xml
+        app.get_forms_by_xmlns(xmlns)[0].source = updated_form_xml
         app.version = 2
 
         schema.update_for_app(app)
@@ -59,7 +59,7 @@ class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):
 
         # Change the question to a different type
         updated_form_xml = self.get_xml('question_schema_no_multi')
-        app.get_form_by_xmlns(xmlns).source = updated_form_xml
+        app.get_forms_by_xmlns(xmlns)[0].source = updated_form_xml
         app.version = 2
 
         schema.update_for_app(app)

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -242,8 +242,8 @@ def get_questions(domain, app_id, xmlns):
             _("Remote apps are not supported")
         )
 
-    form = app.get_form_by_xmlns(xmlns)
-    if not form:
+    xform = app.get_xform_by_xmlns(xmlns)
+    if not xform:
         if xmlns == 'http://code.javarosa.org/devicereport':
             raise QuestionListNotFound(
                 _("This is a Device Report")
@@ -257,7 +257,7 @@ def get_questions(domain, app_id, xmlns):
     # to bootstrap a test and have it print out your form xml
     # uncomment this line. Ghetto but it works.
     # print form.wrapped_xform().render()
-    return get_questions_from_xform_node(form.wrapped_xform(), app.langs)
+    return get_questions_from_xform_node(xform, app.langs)
 
 
 def get_questions_from_xform_node(xform, langs):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -96,7 +96,7 @@ from soil.tasks import prepare_download
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_json_response
 from corehq.apps.app_manager.const import USERCASE_TYPE, USERCASE_ID
-from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.models import Application, ShadowForm
 from corehq.apps.cloudcare.touchforms_api import get_user_contributions_to_touchforms_session
 from corehq.apps.data_interfaces.dispatcher import DataInterfaceDispatcher
 from corehq.apps.domain.decorators import (
@@ -1727,10 +1727,11 @@ class EditFormInstance(View):
         except ResourceNotFound:
             raise Http404(_('Application not found.'))
 
-        form = build.get_form_by_xmlns(instance.xmlns)
-        if not form:
+        forms = build.get_forms_by_xmlns(instance.xmlns)
+        if not forms:
             raise Http404(_('Missing module or form information!'))
-        return form
+        non_shadow_forms = [form for form in forms if form.form_type != ShadowForm.form_type]
+        return non_shadow_forms[0]
 
     @staticmethod
     def _form_instance_to_context_url(domain, instance):

--- a/corehq/apps/zapier/api/v0_5.py
+++ b/corehq/apps/zapier/api/v0_5.py
@@ -90,10 +90,9 @@ class ZapierCustomTriggerFieldFormResource(BaseZapierCustomFieldResource):
         except ResourceNotFound:
             raise NotFound
 
-        form = app.get_form_by_xmlns(xmlns)
         custom_fields = []
 
-        for idx, question in enumerate(form.get_questions(app.langs)):
+        for idx, question in enumerate(app.get_questions(xmlns)):
             if self._has_default_label(question):
                 label = question['label'].split('/')[-1]
             else:

--- a/corehq/apps/zapier/views.py
+++ b/corehq/apps/zapier/views.py
@@ -48,7 +48,7 @@ class SubscribeView(View):
 
         if data['event'] == EventTypes.NEW_FORM:
             application = Application.get(data['application'])
-            if not application or not application.get_form_by_xmlns(data['form']):
+            if not application or not application.get_forms_by_xmlns(data['form']):
                 return HttpResponse(status=400)
             ZapierSubscription.objects.create(
                 domain=domain,

--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -52,10 +52,8 @@ class AbtSupervisorExpressionSpec(JsonObject):
     @classmethod
     @quickcache(['app_id', 'xmlns', 'lang'])
     def _get_questions(cls, app_id, xmlns, lang):
-        form = Application.get(app_id).get_form_by_xmlns(xmlns)
-        return {
-            q['value']: q for q in form.get_questions([lang], include_groups=True)
-        }
+        questions = Application.get(app_id).get_questions(xmlns, [lang], include_groups=True)
+        return {q['value']: q for q in questions}
 
     @classmethod
     def _get_question_options(cls, item, question_path):

--- a/custom/eqa/expressions.py
+++ b/custom/eqa/expressions.py
@@ -121,7 +121,7 @@ class EQAActionItemSpec(JsonObject):
                         ]
                     )
                     application = Application.get(latest_form.app_id)
-                    form = application.get_form_by_xmlns(self.xmlns)
+                    form = application.get_forms_by_xmlns(self.xmlns)[0]
                     question_list = application.get_questions(self.xmlns)
                     questions = {x['value']: x for x in question_list}
                     return {


### PR DESCRIPTION
`Application.get_form_by_xmlns()` doesn't make sense any more now that shadow forms allow for multiple forms with the same xmlns. This PR replaces that method with `get_forms_by_xmlns()`.
@orangejenny 
@dannyroberts 