### PR TITLE
Remove duplicate requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -98,5 +98,4 @@ raven==6.0.0
 quickcache==0.0.1
 zeep==1.6.0
 django_fsm==2.5.0
-zeep==1.6.0
 ethiopian_date==0.1.1


### PR DESCRIPTION
Prod and india must be running different versions of pip, because this duplicate requirement causes deploy to fail on india but not prod.
@emord 