### PR TITLE
Add last_modified to user model

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1340,6 +1340,13 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         self.username = username
         self.save()
 
+    @classmethod
+    def save_docs(cls, docs, **kwargs):
+        utcnow = datetime.utcnow()
+        for doc in docs:
+            doc['last_modified'] = utcnow
+        super(CouchUser, cls).save_docs(docs, **kwargs)
+
     def save(self, **params):
         self.last_modified = datetime.utcnow()
         self.clear_quickcache_for_user()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -822,6 +822,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
     phone_numbers = ListProperty()
     created_on = DateTimeProperty(default=datetime(year=1900, month=1, day=1))
+    last_modified = DateTimeProperty()
     #    For now, 'status' is things like:
     #        ('auto_created',     'Automatically created from form submission.'),
     #        ('phone_registered', 'Registered from phone'),
@@ -1340,6 +1341,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         self.save()
 
     def save(self, **params):
+        self.last_modified = datetime.utcnow()
         self.clear_quickcache_for_user()
         with CriticalSection(['username-check-%s' % self.username], timeout=120):
             # test no username conflict

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -43,6 +43,12 @@ class UserModelTest(TestCase):
         user = CommCareUser.get(self.user._id)
         self.assertGreater(user.last_modified, lm)
 
+    def test_last_modified_bulk(self):
+        lm = self.user.last_modified
+        CommCareUser.save_docs([self.user])
+        user = CommCareUser.get(self.user._id)
+        self.assertGreater(user.last_modified, lm)
+
 
 class UserDeviceTest(SimpleTestCase):
 

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -37,6 +37,12 @@ class UserModelTest(TestCase):
         self.assertEqual(len(form_ids), 1)
         self.assertEqual(form_ids[0], '123')
 
+    def test_last_modified(self):
+        lm = self.user.last_modified
+        self.user.save()
+        user = CommCareUser.get(self.user._id)
+        self.assertGreater(user.last_modified, lm)
+
 
 class UserDeviceTest(SimpleTestCase):
 


### PR DESCRIPTION
@gcapalbo @emord i talked to danny a bit yesterday about the `auto_now_add` and it's going to be a little longer process. i have to make some updates to the jsonobject library and change the way we wire up the couchdbkit models in hq. it's not terrible, but given all i need is this one property to move forward, i'm writing this as an interim solution

buddy: @proteusvacuum 