### PR TITLE
upgrade simpleeval

### DIFF
--- a/corehq/apps/userreports/expressions/utils.py
+++ b/corehq/apps/userreports/expressions/utils.py
@@ -51,7 +51,7 @@ def eval_statements(statement, variable_context):
     # variable values should be numbers
     var_types = set(type(value) for value in variable_context.values())
     if not var_types.issubset({float, Decimal, date, datetime, NoneType, bool}.union(set(six.integer_types))):
-        raise InvalidExpression
+        raise InvalidExpression('Context contains disallowed types')
 
     evaluator = EvalNoMethods(operators=SAFE_OPERATORS, names=variable_context, functions=FUNCTIONS)
     return evaluator.eval(statement)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1008,6 +1008,7 @@ def test_invalid_eval_expression(self, source_doc, statement, context):
     ("a and b", {"a": 0, "b": 1}, False),
     # ranges > 100 items aren't supported
     ("range(200)", {}, None),
+    ("a and not b", {"a": 1, "b": 0}, True),
 ])
 def test_supported_evaluator_statements(self, eq, context, expected_value):
     self.assertEqual(eval_statements(eq, context), expected_value)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1023,7 +1023,6 @@ def test_supported_evaluator_statements(self, eq, context, expected_value):
     ("a**b", {"a": 2, "b": 23}),
     # lambda not supported
     ("lambda x: x*x", {"a": 2}),
-    ("int(10 in range(1,20))", {"a": 2}),
     # max function not defined
     ("max(a, b)", {"a": 3, "b": 5}),
     # method calls not allowed

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1024,6 +1024,8 @@ def test_supported_evaluator_statements(self, eq, context, expected_value):
     ("lambda x: x*x", {"a": 2}),
     ("int(10 in range(1,20))", {"a": 2}),
     ("max(a, b)", {"a": 3, "b": 5}),
+    # method calls not allowed
+    ('"WORD".lower()', {"a": 5}),
 ])
 def test_unsupported_evaluator_statements(self, eq, context):
     with self.assertRaises(InvalidExpression):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1017,12 +1017,14 @@ def test_supported_evaluator_statements(self, eq, context, expected_value):
 @generate_cases([
     # variables can't be strings
     ("a + b", {"a": 2, "b": 'text'}),
-    # missing context
+    # missing context, b not defined
     ("a + (a*b)", {"a": 2}),
     # power function not supported
     ("a**b", {"a": 2, "b": 23}),
+    # lambda not supported
     ("lambda x: x*x", {"a": 2}),
     ("int(10 in range(1,20))", {"a": 2}),
+    # max function not defined
     ("max(a, b)", {"a": 3, "b": 5}),
     # method calls not allowed
     ('"WORD".lower()', {"a": 5}),

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ django-statici18n==1.3.0
 django-simple-captcha==0.5.5
 httpagentparser==1.7.8
 boto3==1.4.4
-simpleeval==0.8.7
+simpleeval==0.9.5
 laboratory==0.2.0
 ConcurrentLogHandler==0.9.1
 github3.py==1.0.0a4


### PR DESCRIPTION
To support `not`.

There are a bunch of other changes as well including method invocation on objects. I've disabled that as a precaution.

Changes since last version: danthedeckie/simpleeval@fdca17b...77876f3