### PR TITLE
add deprecated_format_names to payload generators

### DIFF
--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -29,6 +29,9 @@ class BasePayloadGenerator(object):
     format_name = ''
     format_label = ""
 
+    # if you ever change format_name, add the old format_name here for backwards compatability
+    deprecated_format_names = ()
+
     def __init__(self, repeater):
         self.repeater = repeater
 
@@ -132,7 +135,13 @@ class GeneratorCollection(object):
 
     def get_generator_by_format(self, format):
         """returns generator class given a format"""
-        return self.format_generator_map[format].generator_class
+        try:
+            return self.format_generator_map[format].generator_class
+        except KeyError:
+            for info in self.format_generator_map.values():
+                if format in info.generator_class.deprecated_format_names:
+                    return info.generator_class
+            raise
 
 
 class RegisterGenerator(object):
@@ -255,12 +264,16 @@ class CaseRepeaterJsonPayloadGenerator(BasePayloadGenerator):
 
 class AppStructureGenerator(BasePayloadGenerator):
 
+    deprecated_format_names = ('app_structure_xml',)
+
     def get_payload(self, repeat_record, payload_doc):
         # This is the id of the application, currently all we forward
         return repeat_record.payload_id
 
 
 class ShortFormRepeaterJsonPayloadGenerator(BasePayloadGenerator):
+
+    deprecated_format_names = ('short_form_json',)
 
     def get_payload(self, repeat_record, form):
         cases = cases_referenced_by_xform(form)
@@ -302,6 +315,8 @@ class FormRepeaterJsonPayloadGenerator(BasePayloadGenerator):
 
 class UserPayloadGenerator(BasePayloadGenerator):
 
+    deprecated_format_names = ('user_json',)
+
     @property
     def content_type(self):
         return 'application/json'
@@ -314,6 +329,8 @@ class UserPayloadGenerator(BasePayloadGenerator):
 
 
 class LocationPayloadGenerator(BasePayloadGenerator):
+
+    deprecated_format_names = ('user_json',)  # sic
 
     @property
     def content_type(self):

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -632,11 +632,13 @@ class TestRepeaterFormat(BaseRepeaterTest):
         class NewCaseGenerator(BasePayloadGenerator):
             format_name = 'new_format'
             format_label = 'XML'
+            deprecated_format_names = ('new_format_alias',)
 
             def get_payload(self, repeat_record, payload_doc):
                 return cls.payload
 
         RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator)
+        cls.new_generator = NewCaseGenerator
 
     def setUp(self):
         super(TestRepeaterFormat, self).setUp()
@@ -692,6 +694,13 @@ class TestRepeaterFormat(BaseRepeaterTest):
                 timeout=POST_TIMEOUT,
                 auth=self.repeater.get_auth(),
             )
+
+    def test_get_format_by_deprecated_name(self):
+        self.assertIsInstance(CaseRepeater(
+            domain=self.domain,
+            url='case-repeater-url',
+            format='new_format_alias',
+        ).generator, self.new_generator)
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)

--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -261,10 +261,12 @@ class BaseBETSVoucherPayloadGenerator(BETSBasePayloadGenerator):
 
 
 class ChemistBETSVoucherPayloadGenerator(BaseBETSVoucherPayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = CHEMIST_VOUCHER_EVENT
 
 
 class LabBETSVoucherPayloadGenerator(BaseBETSVoucherPayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = LAB_VOUCHER_EVENT
 
 
@@ -282,6 +284,7 @@ class IncentivePayloadGenerator(BETSBasePayloadGenerator):
 
 
 class BETS180TreatmentPayloadGenerator(IncentivePayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = TREATMENT_180_EVENT
 
     def get_payload(self, repeat_record, episode_case):
@@ -289,6 +292,7 @@ class BETS180TreatmentPayloadGenerator(IncentivePayloadGenerator):
 
 
 class BETSDrugRefillPayloadGenerator(IncentivePayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = DRUG_REFILL_EVENT
 
     @staticmethod
@@ -347,6 +351,7 @@ class BETSDrugRefillPayloadGenerator(IncentivePayloadGenerator):
 
 
 class BETSSuccessfulTreatmentPayloadGenerator(IncentivePayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = SUCCESSFUL_TREATMENT_EVENT
 
     def get_payload(self, repeat_record, episode_case):
@@ -354,6 +359,7 @@ class BETSSuccessfulTreatmentPayloadGenerator(IncentivePayloadGenerator):
 
 
 class BETSDiagnosisAndNotificationPayloadGenerator(IncentivePayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = DIAGNOSIS_AND_NOTIFICATION_EVENT
 
     def get_payload(self, repeat_record, episode_case):
@@ -361,6 +367,7 @@ class BETSDiagnosisAndNotificationPayloadGenerator(IncentivePayloadGenerator):
 
 
 class BETSAYUSHReferralPayloadGenerator(IncentivePayloadGenerator):
+    deprecated_format_names = ('case_json',)
     event_id = AYUSH_REFERRAL_EVENT
 
     def get_payload(self, repeat_record, episode_case):

--- a/custom/enikshay/integrations/nikshay/repeater_generator.py
+++ b/custom/enikshay/integrations/nikshay/repeater_generator.py
@@ -78,6 +78,8 @@ class BaseNikshayPayloadGenerator(BasePayloadGenerator):
 
 
 class NikshayRegisterPatientPayloadGenerator(BaseNikshayPayloadGenerator):
+    deprecated_format_names = ('case_json',)
+
     def get_payload(self, repeat_record, episode_case):
         """
         https://docs.google.com/document/d/1yUWf3ynHRODyVVmMrhv5fDhaK_ufZSY7y0h9ke5rBxU/edit#heading=h.a9uhx3ql595c
@@ -136,6 +138,7 @@ class NikshayRegisterPatientPayloadGenerator(BaseNikshayPayloadGenerator):
 
 
 class NikshayTreatmentOutcomePayload(BaseNikshayPayloadGenerator):
+    deprecated_format_names = ('case_json',)
 
     def get_payload(self, repeat_record, episode_case):
         """
@@ -172,6 +175,8 @@ class NikshayTreatmentOutcomePayload(BaseNikshayPayloadGenerator):
 
 
 class NikshayHIVTestPayloadGenerator(BaseNikshayPayloadGenerator):
+    deprecated_format_names = ('case_json',)
+
     @property
     def content_type(self):
         return 'application/json'
@@ -219,6 +224,8 @@ class NikshayHIVTestPayloadGenerator(BaseNikshayPayloadGenerator):
 
 
 class NikshayFollowupPayloadGenerator(BaseNikshayPayloadGenerator):
+    deprecated_format_names = ('case_json',)
+
     def get_payload(self, repeat_record, test_case):
         occurence_case = get_occurrence_case_from_test(test_case.domain, test_case.get_id)
         episode_case = get_open_episode_case_from_occurrence(test_case.domain, occurence_case.get_id)

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -95,6 +95,7 @@ class NinetyNineDotsBasePayloadGenerator(BasePayloadGenerator):
 
 
 class RegisterPatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
+    deprecated_format_names = ('case_json',)
 
     def get_test_payload(self, domain):
         return json.dumps(PatientPayload(
@@ -139,6 +140,7 @@ class RegisterPatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
 
 class UpdatePatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
+    deprecated_format_names = ('case_json',)
 
     def get_test_payload(self, domain):
         return json.dumps(PatientPayload(
@@ -197,6 +199,7 @@ class UpdatePatientPayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
 
 class AdherencePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
+    deprecated_format_names = ('case_json',)
 
     def get_payload(self, repeat_record, adherence_case):
         domain = adherence_case.domain
@@ -246,6 +249,7 @@ class AdherencePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
 
 class TreatmentOutcomePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
+    deprecated_format_names = ('case_json',)
 
     def get_payload(self, repeat_record, episode_case):
         domain = episode_case.domain


### PR DESCRIPTION
to store aliases for backwards compatability

I made this change on master but decided to cherry pick this commit directly on top of the last commit in https://github.com/dimagi/commcare-hq/pull/16214 so that you can see the "whole" change together (i.e. that PR + this PR): [16214 + 16316](https://github.com/dimagi/commcare-hq/compare/79ac1b9746de1ffd51138c127d736cfd969f4c93...deprecated_format_names?diff=unified). That view was helpful in convincing me that I had in fact found all of the places where I needed to set `deprecated_format_names` because the diff includes what they were set to before.