### PR TITLE
Add title to excel dashboard in attempt to fix broken Excel 2016 integration

### DIFF
--- a/corehq/ex-submodules/couchexport/templates/couchexport/html_export.html
+++ b/corehq/ex-submodules/couchexport/templates/couchexport/html_export.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Dashboard</title>
 </head>
 <body>
 {% endif %}


### PR DESCRIPTION
I noticed that the html we generate for excel dashboards is technically invalid because it doesn't have a `title` element. Perhaps it is the source of [this bug](http://manage.dimagi.com/default.asp?253389#1336333)?

buddy @dannyroberts 