### PR TITLE
do not try to adjust repeat record attempt numbers

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -517,9 +517,8 @@ class RepeatRecord(Document):
         self.failure_reason = attempt.failure_reason
 
     def get_numbered_attempts(self):
-        offset = self.overall_tries - len(self.attempts)
         for i, attempt in enumerate(self.attempts):
-            yield i + 1 + offset, attempt
+            yield i + 1, attempt
 
     def make_set_next_try_attempt(self, failure_reason):
         # we use an exponential back-off to avoid submitting to bad urls


### PR DESCRIPTION
this was originally for repeat records that had been tried a few times
but were created before attempts were all saved.
This logic did not quite work, because overall_tries is reset to 0 when you requeue.
Decided it was not really that important, so just removing it.

Prompted because I was seeing weird numbering for records that had been requeued:
<img width="115" alt="screen shot 2017-05-24 at 4 59 45 pm" src="https://cloud.githubusercontent.com/assets/137212/26425353/6cd7c700-40a2-11e7-9e0a-ee3edd3cc7c1.png">
