### PR TITLE
update doctypemigrations

### DIFF
--- a/corehq/doctypemigrations/djangomigrations.py
+++ b/corehq/doctypemigrations/djangomigrations.py
@@ -29,6 +29,13 @@ https://github.com/dimagi/commcare-hq/blob/master/corehq/doctypemigrations/READM
 
 Instead of the "current" release, use the path to this release.
 (This simply has the effect of running the process on up-to-date code.)
+
+NOTE: If you are seeing this on a fresh install of CommCareHQ, then you can
+ignore the above. Instead, the first time you run migrate, run it with the
+following command (this command assumes a linux environment - for other platforms
+you just need to run python manage.py migrate with a temporary environment
+variable CCHQ_IS_FRESH_INSTALL set to 1):
+    env CCHQ_IS_FRESH_INSTALL=1 python manage.py migrate
 """
 
 

--- a/corehq/doctypemigrations/management/commands/run_doctype_migration.py
+++ b/corehq/doctypemigrations/management/commands/run_doctype_migration.py
@@ -52,6 +52,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            'migrator_slug',
+        )
+        parser.add_argument(
             '--initial',
             action='store_true',
             default=False,
@@ -83,7 +86,7 @@ class Command(BaseCommand):
             default=False,
         )
 
-    def handle(self, migrator_slug=None, initial=None, continuous=None, cleanup=None,
+    def handle(self, migrator_slug, initial=None, continuous=None, cleanup=None,
                stats=None, erase_continuous_progress=None, **options):
         try:
             migrator = get_migrator_by_slug(migrator_slug)


### PR DESCRIPTION
I'm guessing this was broken when we upgraded to django 1.10.

@millerdev 