### PR TITLE
Tweak web apps anonymous login page

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -101,22 +101,15 @@
 
 <script id="landing-page-app-template" type="text/template">
   <div class="container">
-    <h1>Welcome to <%= appName %></h1>
-    <div class="row">
-        <div class="lead col-xs-12">
-          Ready to start using CommCare now?
+    <div class="spacer"></div>
+      <div class="col-xs-6 col-sm-4 col-xs-offset-3 col-sm-offset-4">
+        <div class="appicon appicon-default js-start-app">
+          <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+          <div class="appicon-title">
+            <h3><%= appName %></h3>
+          </div>
         </div>
-        <div class="lead col-xs-12">
-          <button class="btn btn-success js-start-app">Start!</button>
-        </div>
-    </div>
-    <div class="row">
-        <div class="lead col-xs-12">
-          Already have an account with CommCare? Please use your login.
-        </div>
-        <div class="lead col-xs-12">
-          <button class="btn btn-default js-start-app">Login</button>
-        </div>
+      </div>
     </div>
   </div>
 </script>


### PR DESCRIPTION
@benrudolph what do you think of this? My main thought was to make the login look more like web apps in general. I'm also guessing that people who hit this page are just going to be confused by the option to log in with a real account and also that they won't know what "CommCare" means, so I removed those elements.

before
![screen shot 2017-05-25 at 1 35 22 pm](https://cloud.githubusercontent.com/assets/1486591/26462515/1fe25368-414f-11e7-9635-bff86cbc8d92.png)

after
![screen shot 2017-05-25 at 1 35 28 pm](https://cloud.githubusercontent.com/assets/1486591/26462520/24ed9cb4-414f-11e7-8ecf-dbacc3f4e634.png)

cc @esoergel 