### PR TITLE
require specifying monthly_fee for product rate in bootstrap configs

### DIFF
--- a/corehq/apps/accounting/bootstrap/config/enterprise.py
+++ b/corehq/apps/accounting/bootstrap/config/enterprise.py
@@ -9,7 +9,7 @@ from corehq.apps.accounting.models import (
 BOOTSTRAP_CONFIG = {
     (SoftwarePlanEdition.ENTERPRISE, False, False): {
         'role': 'enterprise_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('0.00')),
+        'product_rate_monthly_fee': Decimal('0.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
             FeatureType.SMS: dict(monthly_limit=UNLIMITED_FEATURE_USAGE),

--- a/corehq/apps/accounting/bootstrap/config/report_builder_v0.py
+++ b/corehq/apps/accounting/bootstrap/config/report_builder_v0.py
@@ -8,7 +8,7 @@ from corehq.apps.accounting.models import (
 BOOTSTRAP_CONFIG = {
     (SoftwarePlanEdition.STANDARD, False, True): {
         'role': 'standard_plan_report_builder_v0',
-        'product_rate': dict(monthly_fee=Decimal('100.00')),
+        'product_rate_monthly_fee': Decimal('100.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=100, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=100),
@@ -16,7 +16,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.PRO, False, True): {
         'role': 'pro_plan_report_builder_v0',
-        'product_rate': dict(monthly_fee=Decimal('500.00')),
+        'product_rate_monthly_fee': Decimal('500.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=500),
@@ -24,7 +24,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.ADVANCED, False, True): {
         'role': 'advanced_plan_report_builder_v0',
-        'product_rate': dict(monthly_fee=Decimal('1000.00')),
+        'product_rate_monthly_fee': Decimal('1000.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=1000, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=1000),

--- a/corehq/apps/accounting/bootstrap/config/resellers_and_managed_hosting.py
+++ b/corehq/apps/accounting/bootstrap/config/resellers_and_managed_hosting.py
@@ -8,7 +8,7 @@ from corehq.apps.accounting.models import (
 BOOTSTRAP_CONFIG = {
     (SoftwarePlanEdition.MANAGED_HOSTING, False, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('1000.00')),
+        'product_rate_monthly_fee': Decimal('1000.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=0, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=0),
@@ -16,7 +16,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.RESELLER, False, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('1000.00')),
+        'product_rate_monthly_fee': Decimal('1000.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=10, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=0),

--- a/corehq/apps/accounting/bootstrap/config/testing.py
+++ b/corehq/apps/accounting/bootstrap/config/testing.py
@@ -10,7 +10,7 @@ from corehq.apps.accounting.models import (
 BOOTSTRAP_CONFIG_TESTING = {
     (SoftwarePlanEdition.COMMUNITY, False, False): {
         'role': 'community_plan_v0',
-        'product_rate': dict(),
+        'product_rate_monthly_fee': Decimal('0.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=2, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=0),
@@ -18,7 +18,7 @@ BOOTSTRAP_CONFIG_TESTING = {
     },
     (SoftwarePlanEdition.STANDARD, False, False): {
         'role': 'standard_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('100.00')),
+        'product_rate_monthly_fee': Decimal('100.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=4, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=3),
@@ -26,7 +26,7 @@ BOOTSTRAP_CONFIG_TESTING = {
     },
     (SoftwarePlanEdition.PRO, False, False): {
         'role': 'pro_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('500.00')),
+        'product_rate_monthly_fee': Decimal('500.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=6, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=5),
@@ -34,7 +34,7 @@ BOOTSTRAP_CONFIG_TESTING = {
     },
     (SoftwarePlanEdition.ADVANCED, False, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('1000.00')),
+        'product_rate_monthly_fee': Decimal('1000.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=8, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=7),
@@ -42,7 +42,7 @@ BOOTSTRAP_CONFIG_TESTING = {
     },
     (SoftwarePlanEdition.ADVANCED, True, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(),
+        'product_rate_monthly_fee': Decimal('0.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=2, per_excess_fee=Decimal('1.00')),
             FeatureType.SMS: dict(monthly_limit=0),
@@ -50,7 +50,7 @@ BOOTSTRAP_CONFIG_TESTING = {
     },
     (SoftwarePlanEdition.ENTERPRISE, False, False): {
         'role': 'enterprise_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('0.00')),
+        'product_rate_monthly_fee': Decimal('0.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
             FeatureType.SMS: dict(monthly_limit=UNLIMITED_FEATURE_USAGE),

--- a/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
+++ b/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
@@ -32,7 +32,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.ADVANCED, False, False): {
         'role': 'advanced_plan_v0',
-        'product_rate-monthly_fee': Decimal('1000.00'),
+        'product_rate_monthly_fee': Decimal('1000.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=50),

--- a/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
+++ b/corehq/apps/accounting/bootstrap/config/user_buckets_jan_2017.py
@@ -8,7 +8,7 @@ from corehq.apps.accounting.models import (
 BOOTSTRAP_CONFIG = {
     (SoftwarePlanEdition.COMMUNITY, False, False): {
         'role': 'community_plan_v1',
-        'product_rate': dict(),
+        'product_rate_monthly_fee': Decimal('0.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=10, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=0),
@@ -16,7 +16,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.STANDARD, False, False): {
         'role': 'standard_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('100.00')),
+        'product_rate_monthly_fee': Decimal('100.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=50, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=50),
@@ -24,7 +24,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.PRO, False, False): {
         'role': 'pro_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('500.00')),
+        'product_rate_monthly_fee': Decimal('500.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=250, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=50),
@@ -32,7 +32,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.ADVANCED, False, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(monthly_fee=Decimal('1000.00')),
+        'product_rate-monthly_fee': Decimal('1000.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=50),
@@ -40,7 +40,7 @@ BOOTSTRAP_CONFIG = {
     },
     (SoftwarePlanEdition.ADVANCED, True, False): {
         'role': 'advanced_plan_v0',
-        'product_rate': dict(),
+        'product_rate_monthly_fee': Decimal('0.00'),
         'feature_rates': {
             FeatureType.USER: dict(monthly_limit=10, per_excess_fee=Decimal('2.00')),
             FeatureType.SMS: dict(monthly_limit=0),

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -30,7 +30,7 @@ def ensure_plans(config, verbose, apps):
             return
 
         product, product_rate = _ensure_product_and_rate(
-            plan_deets['product_rate'], edition,
+            plan_deets['product_rate_monthly_fee'], edition,
             verbose=verbose, apps=apps,
         )
         feature_rates = _ensure_feature_rates(
@@ -106,7 +106,7 @@ def _ensure_role(role_slug, apps):
     return role
 
 
-def _ensure_product_and_rate(product_rate, edition, verbose, apps):
+def _ensure_product_and_rate(monthly_fee, edition, verbose, apps):
     """
     Ensures that all the necessary SoftwareProducts and SoftwareProductRates are created for the plan.
     """
@@ -121,7 +121,7 @@ def _ensure_product_and_rate(product_rate, edition, verbose, apps):
     if edition == SoftwarePlanEdition.ENTERPRISE:
         product.name = "Dimagi Only %s" % product.name
 
-    product_rate = SoftwareProductRate(**product_rate)
+    product_rate = SoftwareProductRate(monthly_fee=monthly_fee)
     try:
         product = SoftwareProduct.objects.get(name=product.name)
         if verbose:


### PR DESCRIPTION
Goal is to prevent the monthly fee from defaulting to zero if somebody forgets to include it in the config (has happened before)

@millerdev 