### PR TITLE
simplify query for subscriptions in invoicing period

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -70,11 +70,9 @@ class DomainInvoiceFactory(object):
 
     def _get_subscriptions(self):
         subscriptions = Subscription.objects.filter(
-            subscriber=self.subscriber, date_start__lte=self.date_end
-        ).filter(
-            Q(date_end=None) | Q(date_end__gt=self.date_start)
-        ).filter(
-            Q(date_end=None) | Q(date_end__gt=F('date_start'))
+            Q(date_end=None) | (Q(date_end__gt=self.date_start) & Q(date_end__gt=F('date_start'))),
+            subscriber=self.subscriber,
+            date_start__lte=self.date_end
         ).order_by('date_start', 'date_end').all()
         return list(subscriptions)
 

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -70,7 +70,10 @@ class DomainInvoiceFactory(object):
 
     def _get_subscriptions(self):
         subscriptions = Subscription.objects.filter(
-            Q(date_end=None) | (Q(date_end__gt=self.date_start) & Q(date_end__gt=F('date_start'))),
+            Q(date_end=None) | (
+                Q(date_end__gt=self.date_start)
+                & Q(date_end__gt=F('date_start'))
+            ),
             subscriber=self.subscriber,
             date_start__lte=self.date_end
         ).order_by('date_start', 'date_end').all()


### PR DESCRIPTION
The before-and-after queries are logically equivalent.  In my opinion the latter is clearer.

@millerdev 