### PR TITLE
Remove name in excel web query

### DIFF
--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -487,10 +487,10 @@ class WriterTest(SimpleTestCase):
         with writer.open([export_instance]):
             _write_export_instance(writer, export_instance, docs)
         with ExportFile(writer.path, writer.format) as export:
-            exported_tables = [table for table in re.findall('<h2>(.*)</h2>', export.read())]
+            exported_tables = [table for table in re.findall('<table>', export.read())]
 
         expected_tables = [t.label for t in tables]
-        self.assertEqual(expected_tables, exported_tables)
+        self.assertEqual(len(expected_tables), len(exported_tables))
 
     def test_multiple_write_export_instance_calls(self):
         """

--- a/corehq/ex-submodules/couchexport/templates/couchexport/html_export.html
+++ b/corehq/ex-submodules/couchexport/templates/couchexport/html_export.html
@@ -9,7 +9,6 @@
 {% endif %}
 
 {% if section == "table_begin" %}
-    <h2>{{ name }}</h2>
     <table>
 {% endif %}
 


### PR DESCRIPTION
@NoahCarnahan @emord this thing has been driving me nuts. in the end i decided to remove the name after trying various number of things with this html page: https://benrudolph.github.io/excel-web-query/. i still have to ensure it won't break old excel queries

http://manage.dimagi.com/default.asp?253389
http://manage.dimagi.com/default.asp?254400