### PR TITLE
Allow Named Filters to Reference Each Other

### DIFF
--- a/corehq/apps/userreports/filters/factory.py
+++ b/corehq/apps/userreports/filters/factory.py
@@ -57,6 +57,8 @@ def _build_boolean_expression_filter(spec, context):
 
 def _build_named_filter(spec, context):
     wrapped = NamedFilterSpec.wrap(spec)
+    if wrapped.name not in context.named_filters:
+        raise BadSpecError(u'Name {} not found in list of named filters!'.format(wrapped.name))
     return context.named_filters[wrapped.name]
 
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -207,7 +207,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
                 try:
                     named_filters[name] = FilterFactory.from_spec(
                         named_filter,
-                        FactoryContext(self.named_expression_objects, self.named_filter_objects)
+                        FactoryContext(self.named_expression_objects, named_filters)
                     )
                     number_generated += 1
                     del named_filter_specs[name]

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -199,8 +199,27 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     @property
     @memoized
     def named_filter_objects(self):
-        return {name: FilterFactory.from_spec(filter, FactoryContext(self.named_expression_objects, {}))
-                for name, filter in self.named_filters.items()}
+        named_filter_specs = copy(self.named_filters)
+        named_filters = {}
+        while named_filter_specs:
+            number_generated = 0
+            for name, named_filter in named_filter_specs.items():
+                try:
+                    named_filters[name] = FilterFactory.from_spec(
+                        named_filter,
+                        FactoryContext(self.named_expression_objects, self.named_filter_objects)
+                    )
+                    number_generated += 1
+                    del named_filter_specs[name]
+                except BadSpecError as spec_error:
+                    # maybe a nested name resolution issue, try again on the next pass
+                    pass
+            if number_generated == 0 and named_filter_specs:
+                # we unsuccessfully generated anything on this pass and there are still unresolved
+                # references. we have to fail.
+                assert spec_error is not None
+                raise spec_error
+        return named_filters
 
     def get_factory_context(self):
         return FactoryContext(self.named_expression_objects, self.named_filter_objects)

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -347,6 +347,10 @@ class IndicatorNamedFilterTest(SimpleTestCase):
                     },
                     'operator': 'eq',
                     'property_value': 'yes',
+                },
+                'named_filter_reference': {
+                   'type': 'named',
+                   'name': 'has_alibi',
                 }
             },
             'configured_filter': {
@@ -462,3 +466,25 @@ class IndicatorNamedFilterTest(SimpleTestCase):
         i = 3
         self.assertEqual('laugh_sound', values[i].column.id)
         self.assertEqual('hehe', values[i].value)
+
+    def test_no_self_lookups(self):
+        bad_config = DataSourceConfiguration.wrap(self.indicator_configuration.to_json())
+        bad_config.named_filters['broken'] = {
+            "type": "named",
+            "name": "broken",
+        }
+        with self.assertRaises(BadSpecError):
+            bad_config.validate()
+
+    def test_no_recursive_lookups(self):
+        bad_config = DataSourceConfiguration.wrap(self.indicator_configuration.to_json())
+        bad_config.named_filters['broken'] = {
+            "type": "named",
+            "name": "also_broken",
+        }
+        bad_config.named_filters['also_broken'] = {
+            "type": "named",
+            "name": "broken",
+        }
+        with self.assertRaises(BadSpecError):
+            bad_config.validate()


### PR DESCRIPTION
This is following the same model as for named expressions.