### PR TITLE
Bring atwho into main HQ and use for case config

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-knockout-bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-knockout-bindings.js
@@ -74,20 +74,17 @@
     };
 }());
 
-ko.bindingHandlers.casePropertySelect2 = {
+ko.bindingHandlers.casePropertyAutocomplete = {
     /*
      * Strip "attachment:" prefix and show icon for attachment properties.
      * Replace any spaces in free text with underscores.
      */
     init: function (element, valueAccessor) {
-        var options = ko.bindingHandlers.autocompleteSelect2.select2Options(element),
-            old_createSearchChoice = options.createSearchChoice;
-        options.createSearchChoice = function(term, data) {
-            term = term.replace(/ /g, '_');
-            return old_createSearchChoice(term, data);
-        };
-
-        ko.bindingHandlers.autocompleteSelect2._init(element, options);
+        $(element).on('textchange', function() {
+            var $el = $(this);
+            $el.val($el.val().replace(/ /g, '_'));
+        });
+        ko.bindingHandlers.autocompleteAtwho.init(element, valueAccessor);
     },
     update: function (element, valueAccessor, allBindingsAccessor) {
         function wrappedValueAccessor() {
@@ -95,12 +92,12 @@ ko.bindingHandlers.casePropertySelect2 = {
                 if (value.indexOf("attachment:") === 0) {
                     var text = value.substring(11),
                         html = '<i class="fa fa-paperclip"></i> ' + text;
-                    return {id: text, text: html};
+                    return {name: text, content: html};
                 }
-                return {id: value, text: value};
+                return {name: value, content: value};
             })
         }
-        ko.bindingHandlers.autocompleteSelect2.update(element, wrappedValueAccessor, allBindingsAccessor);
+        ko.bindingHandlers.autocompleteAtwho.update(element, wrappedValueAccessor, allBindingsAccessor);
     },
 };
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/apps_base.html
@@ -57,6 +57,7 @@
     <script src="{% static 'jquery-ui/ui/minified/menu.min.js' %}"></script>
     <script src="{% static 'jquery-ui/ui/minified/sortable.min.js' %}"></script>
 
+    {% include 'style/includes/atwho.html' %}
     <script src="{% static 'select2-3.5.2-legacy/select2.js' %}"></script>
     <script src="{% static 'bootstrap3-typeahead/bootstrap3-typeahead.min.js' %}"></script>
     <script src="{% static 'style/js/bootstrap-multi-typeahead.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_config_ko_templates.html
@@ -64,7 +64,7 @@
         <input type="text" class="form-control" data-bind="
             valueDefault: property.key,
             default: property.defaultKey,
-            casePropertySelect2: suggestedProperties,
+            casePropertyAutocomplete: suggestedProperties,
         "/>
     </span>
     <span data-bind="visible: property.required()">

--- a/corehq/apps/app_manager/templates/app_manager/v2/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/apps_base.html
@@ -38,6 +38,7 @@ appmanager-main-container{% if formdesigner %} formdesigner-content-wrapper{% en
     <script src="{% static 'jquery-ui/ui/minified/menu.min.js' %}"></script>
     <script src="{% static 'jquery-ui/ui/minified/sortable.min.js' %}"></script>
 
+    {% include 'style/includes/atwho.html' %}
     <script src="{% static 'select2-3.5.2-legacy/select2.js' %}"></script>
     <script src="{% static 'bootstrap3-typeahead/bootstrap3-typeahead.min.js' %}"></script>
     <script src="{% static 'style/js/bootstrap-multi-typeahead.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_config_ko_templates.html
@@ -66,7 +66,7 @@
         <input type="text" class="form-control" data-bind="
             valueDefault: property.key,
             default: property.defaultKey,
-            casePropertySelect2: suggestedProperties
+            casePropertyAutocomplete: suggestedProperties
         "/>
     </span>
     <span data-bind="visible: property.required()">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_ko_templates.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_config_ko_templates.html.diff.txt
@@ -35,8 +35,8 @@
          <input type="text" class="form-control" data-bind="
              valueDefault: property.key,
              default: property.defaultKey,
--            casePropertySelect2: suggestedProperties,
-+            casePropertySelect2: suggestedProperties
+-            casePropertyAutocomplete: suggestedProperties,
++            casePropertyAutocomplete: suggestedProperties
          "/>
      </span>
      <span data-bind="visible: property.required()">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/apps_base.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/apps_base.html.diff.txt
@@ -55,7 +55,7 @@
  {% endblock %}
  
  {% block js %}{{ block.super }}
-@@ -64,37 +45,17 @@
+@@ -65,37 +46,17 @@
      <script src="{% static 'style/js/ui-element.js' %}"></script>
      <script src="{% static 'langcodes/js/langcodes.js' %}"></script>
      <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
@@ -97,7 +97,7 @@
       id="js-appmanager-body">
      {% if app %}
          {% if error %}
-@@ -119,7 +80,7 @@
+@@ -120,7 +81,7 @@
                  {% endblocktrans %}
              </p>
              <br>
@@ -106,7 +106,7 @@
          </div>
      {% endif %}
  </div>
-@@ -153,3 +114,5 @@
+@@ -154,3 +115,5 @@
      </div>
      {% endif %}
  {% endblock modals %}

--- a/corehq/apps/style/static/style/js/atwho.js
+++ b/corehq/apps/style/static/style/js/atwho.js
@@ -1,0 +1,60 @@
+hqDefine('style/js/atwho', function () {
+    var _init = function($input, options, afterInsert) {
+        $input.atwho(options).on("inserted.atwho", function(event, $li, otherEvent) {
+            $input.val($input.data("selected-value")).change();
+
+            if (afterInsert) {
+                afterInsert();
+            }
+        });
+    };
+
+    /**
+     * Apply an atwho-based autocomplete to the given input. Options:
+     *  ajax: Overrides for ajax call if data is to be fetched form server.
+     *      Suggest at least overriding url and data.
+     *  afterInsert: will be called after new value is selected.
+     */
+    var init = function($input, options) {
+        var atwhoOptions = {
+            at: "",
+            limit: Infinity,
+            maxLen: Infinity,
+            suffix: "",
+            tabSelectsMatch: false,
+            callbacks: {
+                filter: function(query, data, searchKey) {
+                    return _.filter(data, function(item) {
+                        return item.name.indexOf(query) !== -1;
+                    });
+                },
+                matcher: function(flag, subtext, should_startWithSpace) {
+                    return $input.val();
+                },
+                beforeInsert: function(value, $li) {
+                    // This and the inserted.atwho handler below ensure that the entire
+                    // input's value is replaced, regardless of where the cursor is
+                    $input.data("selected-value", value);
+                },
+            },
+        };
+
+        if (options.ajax && options.ajax.url) {
+            $input.one('focus', function () {
+                $.ajax(_.defaults(options.ajax, {
+                    success: function (data) {
+                        atwhoOptions.data = data;
+                        _init($input, atwhoOptions, options.afterInsert);
+                        $input.atwho('run');
+                    },
+                }));
+            });
+        } else {
+            _init($input, atwhoOptions, options.afterInsert);
+        }
+    };
+
+    return {
+        init: init,
+    };
+});

--- a/corehq/apps/style/static/style/js/knockout_bindings.ko.js
+++ b/corehq/apps/style/static/style/js/knockout_bindings.ko.js
@@ -555,6 +555,34 @@ ko.bindingHandlers.autocompleteSelect2 = new function(){
     };
 }();
 
+/**
+ * Autocomplete widget based on atwho.
+ */
+ko.bindingHandlers.autocompleteAtwho = {
+    init: function(element, valueAccessor) {
+        var $element = $(element);
+        if (!$element.atwho) {
+            throw new Error("The typeahead binding requires Atwho.js and Caret.js");
+        }
+
+        hqImport('style/js/atwho').init($element, {
+            afterInsert: function() {
+                $element.trigger('textchange');
+            },
+        });
+
+        $element.on("textchange", function() {
+            if ($element.val()) {
+                $element.change();
+              }
+          });
+    },
+
+    update: function(element, valueAccessor, allBindings){
+        $(element).atwho('load', '', ko.utils.unwrapObservable(valueAccessor()));
+    },
+};
+
 ko.bindingHandlers.multiTypeahead = {
     init: function(element, valueAccessor) {
         var contacts = valueAccessor();

--- a/corehq/apps/style/templates/style/includes/atwho.html
+++ b/corehq/apps/style/templates/style/includes/atwho.html
@@ -1,0 +1,10 @@
++{% load hq_shared_tags %}
+{% load compress %}
+
+{% compress css %}
+    <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
+{% endcompress %}
+
+<script src="{% static 'Caret.js/dist/jquery.caret.min.js' %}"></script>
+<script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
+<script src="{% static 'style/js/atwho.js' %}"></script>


### PR DESCRIPTION
I did this a while ago and ended up rolling it back because of compatibility issues with jQuery's caret plugin. We don't use the caret plugin anymore, and there are some slight usability differences between select2 and atwho (http://manage.dimagi.com/default.asp?248233 is the catalyst for this PR), so let's have both widgets available in HQ.

Mostly re-applying changes from https://github.com/dimagi/commcare-hq/pull/13731

@esoergel / @emord 