### PR TITLE
Empty text node, not blank xpath function

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -76,7 +76,7 @@ class DetailContributor(SectionContributor):
                                     if detail.print_template:
                                         print_template_path = detail.print_template['path']
                                     locale_id = id_strings.detail_title_locale(detail_type)
-                                    title = Text(locale_id=locale_id) if locale_id else Text(xpath_function="")
+                                    title = Text(locale_id=locale_id) if locale_id else Text()
                                     d = self.build_detail(
                                         module,
                                         detail_type,

--- a/corehq/apps/app_manager/tests/data/suite/careplan-own-module.xml
+++ b/corehq/apps/app_manager/tests/data/suite/careplan-own-module.xml
@@ -87,9 +87,7 @@
   </detail>
   <detail id="m1_careplan_goal_short">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -128,9 +126,7 @@
   </detail>
   <detail id="m1_careplan_goal_long">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -171,9 +167,7 @@
   </detail>
   <detail id="m1_careplan_task_short">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -212,9 +206,7 @@
   </detail>
   <detail id="m1_careplan_task_long">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>

--- a/corehq/apps/app_manager/tests/data/suite/careplan.xml
+++ b/corehq/apps/app_manager/tests/data/suite/careplan.xml
@@ -87,9 +87,7 @@
   </detail>
   <detail id="m1_careplan_goal_short">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -128,9 +126,7 @@
   </detail>
   <detail id="m1_careplan_goal_long">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -171,9 +167,7 @@
   </detail>
   <detail id="m1_careplan_task_short">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -212,9 +206,7 @@
   </detail>
   <detail id="m1_careplan_task_long">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
@@ -130,9 +130,7 @@
   </detail>
   <detail id="m1_product_short">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>
@@ -214,9 +212,7 @@
   </detail>
   <detail id="m2_product_short">
     <title>
-      <text>
-        <xpath function=""/>
-      </text>
+      <text/>
     </title>
     <field>
       <header>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?255007

Caused by https://github.com/dimagi/commcare-hq/pull/16267 where I should have used `<xpath function="''"/>` not `<xpath function=""/>` which breaks. But using an empty text node seems to work fine.