### PR TITLE
default to since if a variable doesn't exist

### DIFF
--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -173,7 +173,7 @@
 
         $scope.$watch("formData.date_range", function(newDateRange) {
             if (!newDateRange) {
-                $scope.formData.date_range = "last7";
+                $scope.formData.date_range = "since";
             } else {
                 self._clearSubmitError();
             }


### PR DESCRIPTION
interrupt @benrudolph buddy @calellowitz 

if the variable doesn't exist then the export doesn't get filtered at all so it will be since project start. this makes the popup super confusing.

I don't know why some exports don't have this initialized. All new exports have this value from my testing.