### PR TITLE
Use file download instead of cache

### DIFF
--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -7,7 +7,7 @@ from couchdbkit.resource import ResourceNotFound
 from corehq.apps.app_manager.util import get_app_manager_template
 from dimagi.ext.couchdbkit import Document
 from dimagi.utils.web import json_response
-from soil import DownloadBase
+from soil import FileDownload
 
 from corehq.apps.hqmedia.tasks import build_application_zip
 from corehq.apps.app_manager.views.utils import get_langs
@@ -119,7 +119,7 @@ def direct_ccz(request, domain):
         )
 
     app.set_media_versions(None)
-    download = DownloadBase()
+    download = FileDownload(u'application-{}-{}'.format(app_id, version))
     errors = build_application_zip(
         include_multimedia_files=include_multimedia,
         include_index_files=True,
@@ -134,4 +134,4 @@ def direct_ccz(request, domain):
             errors,
             status_code=400,
         )
-    return DownloadBase.get(download.download_id).toHttpResponse()
+    return FileDownload.get(download.download_id).toHttpResponse()


### PR DESCRIPTION
Realized while looking into the application download errors that we load the entire application zip into memory when we use `DownloadBase` because it defaults to using the cache... This switches it to use the FileDownload. I think this'll help install speeds for the enikshay app since that app is so large