### PR TITLE
Temporarily disable the custom setup rules

### DIFF
--- a/custom/enikshay/tests/test_user_setup.py
+++ b/custom/enikshay/tests/test_user_setup.py
@@ -26,6 +26,7 @@ from ..models import IssuerId
 
 
 @flag_enabled('ENIKSHAY')
+@mock.patch('custom.enikshay.user_setup.skip_custom_setup', lambda *args: False)
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class TestUserSetupUtils(TestCase):
     domain = 'enikshay-user-setup'

--- a/custom/enikshay/user_setup.py
+++ b/custom/enikshay/user_setup.py
@@ -35,6 +35,7 @@ LOC_TYPES_TO_USER_TYPES = {
 
 
 def skip_custom_setup(domain, request_user):
+    return True  # We're gonna revisit this, turning off for now
     return not toggles.ENIKSHAY.enabled(domain) or request_user.is_domain_admin(domain)
 
 


### PR DESCRIPTION
@proteusvacuum
we're pushing this back, and it's confusing in it's current state, so I figure it's best to just disable
https://trello.com/c/R2ZKRcmc/84-orgs-custom-user-location-management-rules