### PR TITLE
Doc transation exists

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -124,8 +124,8 @@ class IndicatorSqlAdapter(IndicatorAdapter):
             connection.execute(delete)
 
     def doc_exists(self, doc):
-        query = self.get_query_object().filter_by(doc_id=doc['_id'])
         try:
+            query = self.get_query_object().filter_by(doc_id=doc['_id'])
             return self.session_helper.Session.query(query.exists()).scalar()
         finally:
             self.session_helper.Session.commit()

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -125,7 +125,10 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
     def doc_exists(self, doc):
         query = self.get_query_object().filter_by(doc_id=doc['_id'])
-        return self.session_helper.Session.query(query.exists()).scalar()
+        try:
+            return self.session_helper.Session.query(query.exists()).scalar()
+        finally:
+            self.session_helper.Session.commit()
 
 
 class ErrorRaisingIndicatorSqlAdapter(IndicatorSqlAdapter):

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -124,11 +124,9 @@ class IndicatorSqlAdapter(IndicatorAdapter):
             connection.execute(delete)
 
     def doc_exists(self, doc):
-        try:
-            query = self.get_query_object().filter_by(doc_id=doc['_id'])
-            return self.session_helper.Session.query(query.exists()).scalar()
-        finally:
-            self.session_helper.Session.commit()
+        with self.session_helper.session_context() as session:
+            query = session.query(self.get_table()).filter_by(doc_id=doc['_id'])
+            return session.query(query.exists()).scalar()
 
 
 class ErrorRaisingIndicatorSqlAdapter(IndicatorSqlAdapter):


### PR DESCRIPTION
@snopoke @emord more deadlocks on the db today, and they also happened on prod, so i no longer think it's load related. i looked a bit into `AccessShareLock`, and i believe it's occurring because we aren't closing the transaction.

locally i was able to run the exists query and examine the locks:
```
>>> doc_exists(doc)  # run from test
```
generated this
```
commcarehq=# SELECT query,state,waiting,pid FROM pg_stat_activity;
                                                               query                                                               |        state        | waiting |  pid
-----------------------------------------------------------------------------------------------------------------------------------+---------------------+---------+-------
SELECT EXISTS (SELECT 1                                                                                                          +| idle in transaction | f       | 31544
 FROM "config_report_user-reports_sample_7554612a"                                                                                +|                     |         |
 WHERE "config_report_user-reports_sample_7554612a".doc_id = 'a81ae4f23c754479b12fd1107d3da866') AS anon_1                         |                     |         |
```
After the query that transaction stayed there. then i ran this command:

```
>>> self.session_helper.Session.commit()
```
which removed that transaction
```
commcarehq=# SELECT query,state,waiting,pid FROM pg_stat_activity;
````

the original locked query looks like this:

```
postgres=# SELECT pid, datname, query_start, now() - query_start as duration, state, query as current_or_last_query FROM pg_stat_activity WHERE pid = 23135;
  pid  |    datname     |          query_start          |    duration     |        state        |                                                       current_or_last_query
-------+----------------+-------------------------------+-----------------+---------------------+-----------------------------------------------------------------------------------------------------------------------------------
 23135 | commcarehq_ucr | 2017-05-31 09:55:59.411232+00 | 00:00:01.146303 | idle in transaction | SELECT EXISTS (SELECT 1                                                                                                          +
       |                |                               |                 |                     | FROM "config_report_mz-lad_9f8fe6438331497e9059a9237d3f4262_1aa746fb"                                                            +
       |                |                               |                 |                     | WHERE "config_report_mz-lad_9f8fe6438331497e9059a9237d3f4262_1aa746fb".doc_id = '98b96318-9a3e-4c18-9f30-8d6f1e67e30c') AS anon_1
(1 row)
```

the confusing thing to me is that i would not have expected that the lock that it grabs would block other requests from reading the database. i also so it lock on another query too, but i now forget which one that is. essentially we should always be committing. 

cc: @mkangia fyi: @lwyszomi 