### PR TITLE
Close all extensions of closed case

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -190,7 +190,7 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertFalse(cases[2].closed)
 
         self.factory.create_or_update_case(CaseStructure(
-            case_id=self.extension_ids[0],
+            case_id=self.extension_ids[1],
             attrs={'close': True}
         ))
         cases = {
@@ -198,9 +198,9 @@ class AutoCloseExtensionsTest(TestCase):
             for case in CaseAccessors(self.domain).get_cases([self.host_id] + self.extension_ids)
         }
         self.assertFalse(cases[self.host_id])
-        self.assertTrue(cases[self.extension_ids[0]])
-        self.assertFalse(cases[self.extension_ids[1]])
-        self.assertFalse(cases[self.extension_ids[2]])
+        self.assertFalse(cases[self.extension_ids[0]])
+        self.assertTrue(cases[self.extension_ids[1]])
+        self.assertTrue(cases[self.extension_ids[2]])
 
         self.factory.create_or_update_case(CaseStructure(
             case_id=self.host_id,

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -289,9 +289,7 @@ def get_all_extensions_to_close(domain, case_updates):
 
 
 def get_extensions_to_close(case, domain):
-    outgoing_extension_indices = [index.relationship for index in case.indices
-                                  if index.relationship == CASE_INDEX_EXTENSION]
-    if not outgoing_extension_indices and case.closed and EXTENSION_CASES_SYNC_ENABLED.enabled(domain):
+    if case.closed and EXTENSION_CASES_SYNC_ENABLED.enabled(domain):
         return CaseAccessors(domain).get_extension_chain([case.case_id])
     else:
         return set()


### PR DESCRIPTION
I think this is OK to do, since those other cases don't get synced, anyway:
https://github.com/dimagi/commcare-hq/blob/981957b01367ef8004910fb04421ae21d86ba920/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json#L672-L693

@snopoke I know you had looked at this earlier. 

I'm really not sure why I implemented that check in the first place. I think I'd maybe confused myself about the syncing semantics. However, in the case where we have a closed extension in a chain, its extensions don't get synced anyway, so it makes sense that they are closed.

buddy: @NoahCarnahan 
FYI: @ctsims, @sheelio 