### PR TITLE
Fix basic auth for repeater tests and add digest auth support

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -54,6 +54,7 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_ca
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.locations.forms import LocationFixtureForm
 from corehq.apps.locations.models import LocationFixtureConfiguration
+from corehq.apps.repeaters.models import BASIC_AUTH, DIGEST_AUTH
 from corehq.apps.repeaters.repeater_generators import RegisterGenerator
 
 from corehq.const import USER_DATE_FORMAT
@@ -606,9 +607,9 @@ def test_repeater(request, domain):
 
         username = request.POST.get('username')
         password = request.POST.get('password')
-        if auth_type == 'basic':
+        if auth_type == BASIC_AUTH:
             auth = HTTPBasicAuth(username, password)
-        elif auth_type == 'digest':
+        elif auth_type == DIGEST_AUTH:
             auth = HTTPDigestAuth(username, password)
         else:
             auth = None

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -14,6 +14,8 @@ from corehq.apps.users.util import raw_username
 
 from dimagi.utils.decorators.memoized import memoized
 
+from .models import BASIC_AUTH, DIGEST_AUTH
+
 
 class GenericRepeaterForm(forms.Form):
 
@@ -26,8 +28,8 @@ class GenericRepeaterForm(forms.Form):
     auth_type = forms.ChoiceField(
         choices=[
             (None, "None"),
-            ("basic", "Basic"),
-            ("digest", "Digest"),
+            (BASIC_AUTH, "Basic"),
+            (DIGEST_AUTH, "Digest"),
         ],
         required=False,
         label=_("Authentication protocol"),

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -51,6 +51,8 @@ def log_repeater_timeout_in_datadog(domain):
 
 
 DELETED = "-Deleted"
+BASIC_AUTH = "basic"
+DIGEST_AUTH = "digest"
 
 
 class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
@@ -64,7 +66,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     url = StringProperty()
     format = StringProperty()
 
-    auth_type = StringProperty(choices=("basic", "digest"), required=False)
+    auth_type = StringProperty(choices=(BASIC_AUTH, DIGEST_AUTH), required=False)
     username = StringProperty()
     password = StringProperty()
     friendly_name = _("Data")
@@ -210,16 +212,10 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         # to be overridden
         return self.generator.get_headers()
 
-    def _use_basic_auth(self):
-        return self.auth_type == "basic"
-
-    def _use_digest_auth(self):
-        return self.auth_type == "digest"
-
     def get_auth(self):
-        if self._use_basic_auth():
+        if self.auth_type == BASIC_AUTH:
             return HTTPBasicAuth(self.username, self.password)
-        elif self._use_digest_auth():
+        elif self.auth_type == DIGEST_AUTH:
             return HTTPDigestAuth(self.username, self.password)
         return None
 

--- a/corehq/apps/repeaters/utils.py
+++ b/corehq/apps/repeaters/utils.py
@@ -13,9 +13,10 @@ def get_all_repeater_types():
 
 
 def migrate_repeater(repeater_doc):
+    from .models import BASIC_AUTH
     if "use_basic_auth" in repeater_doc:
         use_basic_auth = repeater_doc['use_basic_auth'] is True
         del repeater_doc['use_basic_auth']
         if use_basic_auth:
-            repeater_doc["auth_type"] = "basic"
+            repeater_doc["auth_type"] = BASIC_AUTH
         return DocUpdate(repeater_doc)

--- a/corehq/apps/repeaters/utils.py
+++ b/corehq/apps/repeaters/utils.py
@@ -12,11 +12,6 @@ def get_all_repeater_types():
     ])
 
 
-def get_repeater_auth_header(headers, username, password):
-    user_pass = base64.encodestring(':'.join((username, password))).replace('\n', '')
-    return {'Authorization': 'Basic ' + user_pass}
-
-
 def migrate_repeater(repeater_doc):
     if "use_basic_auth" in repeater_doc:
         use_basic_auth = repeater_doc['use_basic_auth'] is True


### PR DESCRIPTION
Looks like this was inadvertently broken [here](https://github.com/dimagi/commcare-hq/pull/15949/files) when the parameter name was changed.
This fixes basic auth and adds support for digest auth when testing repeaters.
@nickpell @dannyroberts @proteusvacuum