### PR TITLE
Add case type to case changes tab

### DIFF
--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -297,8 +297,8 @@ requires imports/proptable.html to be included in the main template
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h4 class="panel-title accordion-toggle">
-                        {% if case_data.valid_case and case_data.case_type %}
-                            <span class="label label-primary">{{case_data.case_type}}</span>
+                        {% if case_data.valid_case and case_data.case_type and cases|length > 1 %}
+                            <span class="label label-default">{{case_data.case_type}}</span>
                         {% endif %}
                         <a data-toggle="collapse"
                            href="#form-case-acc-{{ forloop.counter }}">

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -297,8 +297,11 @@ requires imports/proptable.html to be included in the main template
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h4 class="panel-title accordion-toggle">
-                        <a data-toggle="collapse" 
-                            href="#form-case-acc-{{ forloop.counter }}">
+                        {% if case_data.valid_case and case_data.case_type %}
+                            <span class="label label-primary">{{case_data.case_type}}</span>
+                        {% endif %}
+                        <a data-toggle="collapse"
+                           href="#form-case-acc-{{ forloop.counter }}">
                             {% if case_data.valid_case and case_data.name %}
                             {{ case_data.name }}
                             {% else %}

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -218,7 +218,8 @@ def _get_cases_changed_context(domain, form, case_id=None):
             "name": case_inline_display(this_case),
             "table": get_tables_as_columns(b, definition, timezone=get_timezone_for_request()),
             "url": url,
-            "valid_case": valid_case
+            "valid_case": valid_case,
+            "case_type": this_case.type if valid_case else None,
         })
 
     return {


### PR DESCRIPTION
When you have lots of cases in the case changes tab, it is hard to figure out what each of them is. 

![screenshot from 2017-06-01 10-42-34](https://cloud.githubusercontent.com/assets/146896/26685086/0eb0d034-46b7-11e7-9ded-92a99139289a.png)

@NoahCarnahan 
@orangejenny for feedback