### PR TITLE
Fix js error when loading case from fixture

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -1093,8 +1093,7 @@ hqDefine('app_manager/js/case-config-ui-advanced.js', function () {
             ],
         },
         wrap: function (data, action) {
-            var self = ko.mapping.fromJS(data, LoadCaseFromFixture.mapping);
-            self.action = action;
+            var self = _.extend({}, action, ko.mapping.fromJS(data, LoadCaseFromFixture.mapping));
             self.isBlank = ko.computed(function () {
                 return !self.fixture_nodeset() &&
                     !self.fixture_tag() &&


### PR DESCRIPTION
Noticed js error (`self.caseConfig` undefined [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js#L1109)) while testing https://github.com/dimagi/commcare-hq/pull/16402 , assumed I'd broken something, and dug into it. Ultimately turned out it's always thrown an error (I think) but one that doesn't cause any user-facing problems. Still, might as well fix it.

@emord 