### PR TITLE
Fix string comparison in EpisodeAdherenceUpdate

### DIFF
--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -215,7 +215,7 @@ class EpisodeAdherenceUpdate(object):
             else:
                 valid_cases = filter(
                     lambda case: (
-                        case['adherence_source'] is 'enikshay' and
+                        case['adherence_source'] == 'enikshay' and
                         (not case['closed'] or (case['closed'] and
                          case['adherence_closure_reason'] == HISTORICAL_CLOSURE_REASON))
                     ),


### PR DESCRIPTION
I believe that this faulty comparison is causing this web adherence report QA bug:
https://manage.dimagi.com/default.asp?254727

We may want to consider kicking off the enikshay task that updates adherence dose counts early, as this could be affecting other cases.

buddy @proteusvacuum 
FYI @sravfeyn 
