### PR TITLE
App manager v2: fix sidebar width

### DIFF
--- a/corehq/apps/style/static/app_manager/less/new_appmanager/navigation.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/navigation.less
@@ -3,6 +3,7 @@
   min-width: @app-manager-sidebar-width;
   width: auto !important;
   width: @app-manager-sidebar-width;
+  max-width: @app-manager-sidebar-width;
   float: left;
 }
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?255291

This is happening because "Nuevo Desarrollador de Aplicaciones" is so much longer than "New App Builder", it's pushing the gear, etc. underneath the main app manager content.

@biyeun I'm not sure why there are two widths, plus the min-width, decided the least risky thing was to just add in a max-width. Definitely open to suggestions.

code buddy @emord 