### PR TITLE
Fix check for persist_tile_on_forms only when tiles are actually present

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -89,7 +89,9 @@ class DetailContributor(SectionContributor):
                                     )
                                     if d:
                                         r.append(d)
-                        if detail.persist_case_context and not detail.persist_tile_on_forms:
+                        # add the persist case context if needed and if
+                        # case tiles are present and have their own persistent block
+                        if detail.persist_case_context and not (detail.use_case_tiles and detail.persist_tile_on_forms):
                             d = self._get_persistent_case_context_detail(module, detail.persistent_case_context_xml)
                             r.append(d)
                 if module.fixture_select.active:

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -91,7 +91,8 @@ class DetailContributor(SectionContributor):
                                         r.append(d)
                         # add the persist case context if needed and if
                         # case tiles are present and have their own persistent block
-                        if detail.persist_case_context and not (detail.use_case_tiles and detail.persist_tile_on_forms):
+                        if (detail.persist_case_context and
+                                not (detail.use_case_tiles and detail.persist_tile_on_forms)):
                             d = self._get_persistent_case_context_detail(module, detail.persistent_case_context_xml)
                             r.append(d)
                 if module.fixture_select.active:

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -636,6 +636,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         module, form = factory.new_advanced_module("my_module", "person")
         factory.form_requires_case(form, "person")
         module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
+        module.case_details.short.use_case_tiles = True
         module.case_details.short.persist_tile_on_forms = True
         module.case_details.short.persist_case_context = True
         suite = factory.app.create_suite()


### PR DESCRIPTION
If `detail.persist_case_context` is True and `persist_tile_on_forms` is set to True 
but no case tiles are present (for ex when a user selects to not use case tiles but does not uncheck the persist tile on forms option) 

The persistent context block is not added which causes app to break.