### PR TITLE
preindex couch periodically

### DIFF
--- a/corehq/preindex/accessors.py
+++ b/corehq/preindex/accessors.py
@@ -53,10 +53,11 @@ def copy_design_doc(design, temp=None, delete=True):
     )
 
 
-def sync_design_doc(design, temp=None):
+def sync_design_doc(design, temp=None, force_index=False):
     sync_docs.sync_design_docs(
         db=design.db,
         design_dir=design.design_path,
         design_name=design.app_label,
         temp=temp,
+        force_index=force_index,
     )

--- a/corehq/preindex/accessors.py
+++ b/corehq/preindex/accessors.py
@@ -53,11 +53,20 @@ def copy_design_doc(design, temp=None, delete=True):
     )
 
 
-def sync_design_doc(design, temp=None, force_index=False):
+def sync_design_doc(design, temp=None):
     sync_docs.sync_design_docs(
         db=design.db,
         design_dir=design.design_path,
         design_name=design.app_label,
         temp=temp,
-        force_index=force_index,
+    )
+
+
+def index_design_doc(design):
+    design_name = design.app_label
+    docid = "_design/%s" % design_name
+    sync_docs.index_design_docs(
+        db=design.db,
+        docid=docid,
+        design_name=design_name,
     )

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -1,10 +1,10 @@
 from celery.schedules import crontab
 from celery.task.base import periodic_task
 
-from corehq.preindex.accessors import sync_design_doc, get_preindex_designs
+from corehq.preindex.accessors import index_design_doc, get_preindex_designs
 
 
 @periodic_task(run_every=crontab(minute=0), queue='background_queue')
 def preindex_couch_views():
     for design in get_preindex_designs():
-        sync_design_doc(design, force_index=True)
+        index_design_doc(design)

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -7,4 +7,4 @@ from corehq.preindex.accessors import sync_design_doc, get_preindex_designs
 @periodic_task(run_every=crontab(minute=0), queue='background_queue')
 def preindex_couch_views():
     for design in get_preindex_designs():
-        sync_design_doc(design)
+        sync_design_doc(design, force_index=True)

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -1,0 +1,10 @@
+from celery.schedules import crontab
+from celery.task.base import periodic_task
+
+from corehq.preindex.accessors import sync_design_doc, get_preindex_designs
+
+
+@periodic_task(run_every=crontab(minute=0), queue='background_queue')
+def preindex_couch_views():
+    for design in get_preindex_designs():
+        sync_design_doc(design)


### PR DESCRIPTION
@dimagi/scale-team preindexing couch takes quite a while when we don't deploy often (sometimes hours), so this will make sure it's up to date every hour. I think this will have little to none effect on prod or softlayer or swiss, but big gains on nic and maybe l10k/enikshay in the future

buddy @orangejenny 