### PR TITLE
PhoneLoadBalancingMixin - Use hashed load balancing instead of round robin

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import base64
+import hashlib
 import jsonfield
 import uuid
 from dimagi.ext.couchdbkit import *
@@ -2201,10 +2202,7 @@ class PhoneLoadBalancingMixin(object):
     is an instance of this mixin for performing various operations.)
     """
 
-    def get_load_balance_redis_key(self):
-        return 'load-balance-phones-for-backend-%s' % self.pk
-
-    def get_next_phone_number(self):
+    def get_next_phone_number(self, destination_phone_number):
         if (
             not isinstance(self.load_balancing_numbers, list) or
             len(self.load_balancing_numbers) == 0
@@ -2217,8 +2215,9 @@ class PhoneLoadBalancingMixin(object):
             # process to figure out which one is next.
             return self.load_balancing_numbers[0]
 
-        redis_key = self.get_load_balance_redis_key()
-        return load_balance(redis_key, self.load_balancing_numbers)
+        hashed_destination_phone_number = hashlib.sha1(destination_phone_number).hexdigest()
+        index = long(hashed_destination_phone_number, base=16) % len(self.load_balancing_numbers)
+        return self.load_balancing_numbers[index]
 
 
 class BackendMap(object):

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -138,7 +138,7 @@ def handle_outgoing(msg):
     orig_phone_number = None
 
     if use_load_balancing:
-        orig_phone_number = backend.get_next_phone_number()
+        orig_phone_number = backend.get_next_phone_number(msg.phone_number)
 
     if use_rate_limit:
         if use_load_balancing:

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -1196,56 +1196,52 @@ class LoadBalancingAndRateLimitingTestCase(BaseSMSTest):
         self.domain_obj.delete()
         super(LoadBalancingAndRateLimitingTestCase, self).tearDown()
 
-    def create_outgoing_sms(self, backend):
+    def create_outgoing_sms(self, backend, phone_number):
         sms = QueuedSMS(
             domain=self.domain,
             date=datetime.utcnow(),
             direction='O',
-            phone_number='9991234567',
+            phone_number=phone_number,
             text='message',
             backend_id=backend.couch_id
         )
         sms.save()
         return sms
 
-    def delete_load_balancing_keys(self, backend):
-        # This should only be necessary when running tests locally, but doesn't
-        # hurt to run all the time.
-        client = get_redis_client().client.get_client()
-        client.delete(backend.get_load_balance_redis_key())
-
-    def assertRequeue(self, backend):
-        requeue_flag = handle_outgoing(self.create_outgoing_sms(backend))
+    def assertRequeue(self, backend, phone_number):
+        requeue_flag = handle_outgoing(self.create_outgoing_sms(backend, phone_number))
         self.assertTrue(requeue_flag)
 
-    def assertNotRequeue(self, backend):
-        requeue_flag = handle_outgoing(self.create_outgoing_sms(backend))
+    def assertNotRequeue(self, backend, phone_number):
+        requeue_flag = handle_outgoing(self.create_outgoing_sms(backend, phone_number))
         self.assertFalse(requeue_flag)
 
     def test_load_balance(self):
         backend = LoadBalanceBackend.objects.create(
             name='BACKEND',
             is_global=True,
-            load_balancing_numbers=['9990001', '9990002', '9990003'],
+            load_balancing_numbers=['+9990001', '+9990002', '+9990003'],
             hq_api_id=LoadBalanceBackend.get_api_id()
         )
-        self.delete_load_balancing_keys(backend)
+        self.addCleanup(backend.delete)
 
-        for i in range(5):
+        for i in range(2):
             with patch('corehq.apps.sms.tests.test_backends.LoadBalanceBackend.send') as mock_send:
-                self.assertNotRequeue(backend)
+                self.assertNotRequeue(backend, '+9991111111')
                 self.assertTrue(mock_send.called)
-                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '9990001')
+                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '+9990002')
 
-                self.assertNotRequeue(backend)
+        for i in range(2):
+            with patch('corehq.apps.sms.tests.test_backends.LoadBalanceBackend.send') as mock_send:
+                self.assertNotRequeue(backend, '+9992222222')
                 self.assertTrue(mock_send.called)
-                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '9990002')
+                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '+9990001')
 
-                self.assertNotRequeue(backend)
+        for i in range(2):
+            with patch('corehq.apps.sms.tests.test_backends.LoadBalanceBackend.send') as mock_send:
+                self.assertNotRequeue(backend, '+9993333333')
                 self.assertTrue(mock_send.called)
-                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '9990003')
-
-        backend.delete()
+                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '+9990003')
 
     def test_rate_limit(self):
         backend = RateLimitBackend.objects.create(
@@ -1253,54 +1249,55 @@ class LoadBalancingAndRateLimitingTestCase(BaseSMSTest):
             is_global=True,
             hq_api_id=RateLimitBackend.get_api_id()
         )
+        self.addCleanup(backend.delete)
 
         # Requeue flag should be False until we hit the limit
         for i in range(backend.get_sms_rate_limit()):
             with patch('corehq.apps.sms.tests.test_backends.RateLimitBackend.send') as mock_send:
-                self.assertNotRequeue(backend)
+                self.assertNotRequeue(backend, '+9991111111')
                 self.assertTrue(mock_send.called)
 
         # Requeue flag should be True after hitting the limit
         with patch('corehq.apps.sms.tests.test_backends.RateLimitBackend.send') as mock_send:
-            self.assertRequeue(backend)
+            self.assertRequeue(backend, '+9991111111')
             self.assertFalse(mock_send.called)
-
-        backend.delete()
 
     def test_load_balance_and_rate_limit(self):
         backend = LoadBalanceAndRateLimitBackend.objects.create(
             name='BACKEND',
             is_global=True,
-            load_balancing_numbers=['9990001', '9990002', '9990003'],
+            load_balancing_numbers=['+9990001', '+9990002', '+9990003'],
             hq_api_id=LoadBalanceAndRateLimitBackend.get_api_id()
         )
-        self.delete_load_balancing_keys(backend)
+        self.addCleanup(backend.delete)
 
         for i in range(backend.get_sms_rate_limit()):
             with patch('corehq.apps.sms.tests.test_backends.LoadBalanceAndRateLimitBackend.send') as mock_send:
-                self.assertNotRequeue(backend)
+                self.assertNotRequeue(backend, '+9991111111')
                 self.assertTrue(mock_send.called)
-                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '9990001')
+                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '+9990002')
 
-                self.assertNotRequeue(backend)
+            with patch('corehq.apps.sms.tests.test_backends.LoadBalanceAndRateLimitBackend.send') as mock_send:
+                self.assertNotRequeue(backend, '+9992222222')
                 self.assertTrue(mock_send.called)
-                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '9990002')
+                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '+9990001')
 
-                self.assertNotRequeue(backend)
+            with patch('corehq.apps.sms.tests.test_backends.LoadBalanceAndRateLimitBackend.send') as mock_send:
+                self.assertNotRequeue(backend, '+9993333333')
                 self.assertTrue(mock_send.called)
-                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '9990003')
+                self.assertEqual(mock_send.call_args[1]['orig_phone_number'], '+9990003')
 
         with patch('corehq.apps.sms.tests.test_backends.LoadBalanceAndRateLimitBackend.send') as mock_send:
-            self.assertRequeue(backend)
+            self.assertRequeue(backend, '+9991111111')
             self.assertFalse(mock_send.called)
 
-            self.assertRequeue(backend)
+        with patch('corehq.apps.sms.tests.test_backends.LoadBalanceAndRateLimitBackend.send') as mock_send:
+            self.assertRequeue(backend, '+9992222222')
             self.assertFalse(mock_send.called)
 
-            self.assertRequeue(backend)
+        with patch('corehq.apps.sms.tests.test_backends.LoadBalanceAndRateLimitBackend.send') as mock_send:
+            self.assertRequeue(backend, '+9993333333')
             self.assertFalse(mock_send.called)
-
-        backend.delete()
 
 
 class SQLMobileBackendMappingTestCase(TestCase):

--- a/docs/messaging/sms_backends.rst
+++ b/docs/messaging/sms_backends.rst
@@ -147,8 +147,9 @@ If you want to load balance the Outbound SMS traffic automatically across multip
    sending. This is always sent to the send() method, even if there is just one phone number to load balance over.
 
 From there, the framework will automatically handle managing the phone numbers through the create/edit gateway UI
-and balancing the load across the numbers when sending. A simple round robin approach is taken when balancing the
-load.
+and balancing the load across the numbers when sending. When choosing the originating phone number, the
+destination number is hashed and that hash is used to choose from the list of load balancing phone numbers, so that
+a recipient always receives messages from the same originating number.
 
 If your backend uses load balancing and rate limiting, the framework applies the rate limit to each phone number
 separately as you would expect.


### PR DESCRIPTION
https://trello.com/c/44fIudWN/691-sms-load-balancing%3A-allow-hashed-load-balancing-as-an-alternative-to-round-robin

@sravfeyn @snopoke 