### PR TITLE
Allow array data in export

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -281,6 +281,9 @@ class ExportColumn(DocumentSchema):
                 pass
         if value is None:
             value = MISSING_VALUE
+
+        if isinstance(value, list):
+            value = ' '.join(value)
         return value
 
     @staticmethod

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -230,7 +230,7 @@ class WriterTest(SimpleTestCase):
             'domain': 'my-domain',
             '_id': '12345',
             "form": {
-                "mc": ["one", "two"],
+                "array": ["one", "two"],
             }
         }
 
@@ -244,8 +244,8 @@ class WriterTest(SimpleTestCase):
                 path=[],
                 columns=[
                     ExportColumn(
-                        label="Scalar MC",
-                        item=ScalarItem(path=[PathNode(name='form'), PathNode(name='mc')]),
+                        label="Scalar Array",
+                        item=ScalarItem(path=[PathNode(name='form'), PathNode(name='array')]),
                         selected=True,
                     )
                 ]
@@ -260,7 +260,7 @@ class WriterTest(SimpleTestCase):
                 json.loads(export.read()),
                 {
                     u'My table': {
-                        u'headers': [u'Scalar MC'],
+                        u'headers': [u'Scalar Array'],
                         u'rows': [['one two']],
 
                     }

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -220,6 +220,53 @@ class WriterTest(SimpleTestCase):
                 }
             )
 
+    def test_array_data_in_scalar_question(self):
+        '''
+        This test ensures that when a question id has array data
+        that we return still return a string for scalar data.
+        This happens rarely
+        '''
+        doc = {
+            'domain': 'my-domain',
+            '_id': '12345',
+            "form": {
+                "mc": ["one", "two"],
+            }
+        }
+
+        export_instance = FormExportInstance(
+            export_format=Format.JSON,
+            domain=DOMAIN,
+            xmlns='xmlns',
+            tables=[TableConfiguration(
+                label="My table",
+                selected=True,
+                path=[],
+                columns=[
+                    ExportColumn(
+                        label="Scalar MC",
+                        item=ScalarItem(path=[PathNode(name='form'), PathNode(name='mc')]),
+                        selected=True,
+                    )
+                ]
+            )]
+        )
+        writer = _get_writer([export_instance])
+        with writer.open([export_instance]):
+            _write_export_instance(writer, export_instance, [doc])
+
+        with ExportFile(writer.path, writer.format) as export:
+            self.assertEqual(
+                json.loads(export.read()),
+                {
+                    u'My table': {
+                        u'headers': [u'Scalar MC'],
+                        u'rows': [['one two']],
+
+                    }
+                }
+            )
+
     def test_form_stock_columns(self):
         """Ensure that we can export stock properties in a form export"""
         docs = [{


### PR DESCRIPTION
@emord http://manage.dimagi.com/default.asp?255187 this was a strange one...
`sr2a` had array data associated with it. the raw form xml has this:

```
        <sr>
            ...
            <sr2a>0</sr2a>
            <sr2a>0</sr2a>
        </sr>
```

which as far as i know shouldn't ever happen. it's why exports was choking on it. even multi choice questions get saved as space separated datums. no clue how it got into this state, but this should at least alleviate the issue

cc: @mkangia 