### PR TITLE
Minor reminder rule updates for existing framework

### DIFF
--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1563,7 +1563,7 @@ class CaseReminderHandler(Document):
         if not self.deleted():
             if self.start_condition_type == CASE_CRITERIA:
                 accessor = CaseAccessors(self.domain)
-                case_ids = accessor.get_case_ids_in_domain()
+                case_ids = accessor.get_case_ids_in_domain(self.case_type)
                 self.reset_rule_progress(len(case_ids))
 
                 for case in accessor.iter_cases(case_ids):

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1547,8 +1547,12 @@ class CaseReminderHandler(Document):
     def reset_rule_progress(self, total):
         try:
             client = get_redis_client()
-            client.set('reminder-rule-processing-current-%s' % self.get_id, 0)
-            client.set('reminder-rule-processing-total-%s' % self.get_id, total)
+            processing_current = 'reminder-rule-processing-current-%s' % self.get_id
+            processing_total = 'reminder-rule-processing-total-%s' % self.get_id
+            client.set(processing_current, 0)
+            client.set(processing_total, total)
+            client.expire(processing_current, 24 * 60 * 60)
+            client.expire(processing_total, 24 * 60 * 60)
         except:
             pass
 

--- a/corehq/apps/reminders/tests/test_responsiveness.py
+++ b/corehq/apps/reminders/tests/test_responsiveness.py
@@ -353,7 +353,7 @@ class ReminderResponsivenessTest(TestCase):
             self.assertEqual(reminder_instance.callback_try_count, 0)
 
     @run_with_all_backends
-    def test_case_type_match(self):
+    def test_case_type_mismatch(self):
         reminder = (CaseReminderHandler
             .create(self.domain, 'test')
             .set_case_criteria_start_condition('participant', 'status', MATCH_EXACT, 'green')
@@ -376,23 +376,7 @@ class ReminderResponsivenessTest(TestCase):
             update_case(self.domain, case.case_id, case_properties={'status': 'green'})
             self.assertEqual(self.get_reminders(), [])
 
-            reminder.set_case_criteria_start_condition('ex-participant', 'status', MATCH_EXACT, 'green')
-            reminder.save()
-
-            reminder_instance = self.assertOneReminder()
-            self.assertEqual(reminder_instance.domain, self.domain)
-            self.assertEqual(reminder_instance.handler_id, reminder.get_id)
-            self.assertTrue(reminder_instance.active)
-            self.assertEqual(reminder_instance.start_date, date(2016, 1, 1))
-            self.assertIsNone(reminder_instance.start_condition_datetime)
-            self.assertEqual(reminder_instance.next_fire, datetime(2016, 1, 1, 12, 0))
-            self.assertEqual(reminder_instance.case_id, case.case_id)
-            self.assertEqual(reminder_instance.schedule_iteration_num, 1)
-            self.assertEqual(reminder_instance.current_event_sequence_num, 0)
-            self.assertEqual(reminder_instance.callback_try_count, 0)
-
-            reminder.set_case_criteria_start_condition('participant', 'status', MATCH_EXACT, 'green')
-            reminder.save()
+            reminder.case_changed(case)
             self.assertEqual(self.get_reminders(), [])
 
     @run_with_all_backends


### PR DESCRIPTION
Now that we don't allow changing case type, we can filter for case type when getting ids.

Also while I was in here I updated the timeout on the progress stats since the default of 5 minutes was timing out too quickly for long-running rules.

@sravfeyn @snopoke 