### PR TITLE
Fix stickler.yml file.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,8 +1,8 @@
 files:
   ignore:
-    - */migrations/*
-    - */south_migrations/*
-    - *.min.js
+    - '*/migrations/*'
+    - '*/south_migrations/*'
+    - '*.min.js'
     - localsettings.py
 
 linters:


### PR DESCRIPTION
YAML parsers assume strings starting with `*` are aliases, which these are not.