### PR TITLE
Enable vellum data browser in registration form when user properties are enabled

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -57,7 +57,10 @@ logger = logging.getLogger(__name__)
 def form_designer(request, domain, app_id, module_id=None, form_id=None):
 
     def _form_uses_case(module, form):
-        return module and module.case_type and form.requires_case()
+        return (
+            (module and module.case_type and form.requires_case()) or
+            is_usercase_in_use(domain)
+        )
 
     def _form_is_basic(form):
         return form.doc_type == 'Form'


### PR DESCRIPTION
Got some questions recently about how to browse user properties in registration forms. This should fix that.

@orangejenny @emord cc @biyeun 