### PR TITLE
Format the xpath evaluator result with CodeMirror

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -484,6 +484,10 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
         $('.navbar-collapse').collapse('hide');
     };
 
+    self.afterRender = function() {
+        self.evalXPath.afterRender();
+    };
+
     self.updateDebugger = function(resp) {
         self.updating(false);
         self.formattedQuestionsHtml(resp.formattedQuestions);
@@ -546,6 +550,7 @@ Formplayer.ViewModels.EvaluateXPath = function() {
     self.selectedXPath = ko.observable('');
     self.recentXPathQueries = ko.observableArray();
     self.$xpath = null;
+    self.codeMirrorResult = null;
     self.result = ko.observable('');
     self.success = ko.observable(true);
     self.onSubmitXPath = function() {
@@ -561,13 +566,27 @@ Formplayer.ViewModels.EvaluateXPath = function() {
         self.xpath(query.xpath);
     };
     self.evaluate = function(xpath) {
-        var callback = function(result, status) {
-            self.result(result);
-            self.success(status === "accepted");
+        var callback = function(response) {
+            self.result(response.output);
+            self.success(response.status === "accepted");
         };
         $.publish('formplayer.' + Formplayer.Const.EVALUATE_XPATH, [xpath, callback]);
         window.analytics.workflow('[app-preview] User evaluated XPath');
     };
+
+    self.afterRender = function() {
+        var options = {
+            mode: 'xml',
+            viewportMargin: Infinity,
+            readOnly: true,
+            lineNumbers: true,
+        };
+        self.codeMirrorResult = CodeMirror.fromTextArea($('#evaluate-result')[0], options);
+    }
+
+    self.result.subscribe(function(newResult) {
+        self.codeMirrorResult.setValue(newResult);
+    });
 
     self.isSuccess = function(query) {
         return query.status === 'accepted';

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -378,7 +378,7 @@ WebFormSession.prototype.evaluateXPath = function(xpath, callback) {
             'xpath': xpath
         },
         function(resp) {
-            callback(resp.output, resp.status);
+            callback(resp);
         });
 };
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -182,6 +182,7 @@
                     <div role="tabpanel" class="tab-pane" id="debugger-evaluate">
                         <div data-bind="template: {
                             name: 'debugger-eval-ko-template',
+                            afterRender: afterRender,
                             data: evalXPath }">
                         </div>
                     </div>
@@ -214,13 +215,13 @@
           </div>
           </div>
           <div class="col-sm-12">
-              <div
+              <textarea
                   id="evaluate-result"
                   type="text"
                   data-bind="
-                      text: result,
+                      value: result,
                       css: { 'text-danger': !success() }
-              "></div>
+              "></textarea>
           </div>
       </form>
       <div class="row">

--- a/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
+++ b/corehq/apps/style/static/preview_app/less/preview_app/debugger.less
@@ -40,3 +40,8 @@
     height: @preview-tablet-height;
   }
 }
+
+.debugger .CodeMirror {
+  height: auto;
+  max-height: 200px;
+}


### PR DESCRIPTION
@wpride this sets the stage for some of the serialization work I've been doing. This is not dependent on any other PRs, so can merge this and it will work fine with the current implementation. Locally I got some cool stuff though with the new serializer:

<img width="506" alt="screen shot 2017-06-06 at 2 10 17 pm" src="https://user-images.githubusercontent.com/918514/26844927-0530f6c8-4ac3-11e7-8a9d-ee6114249202.png">
<img width="501" alt="screen shot 2017-06-06 at 2 09 58 pm" src="https://user-images.githubusercontent.com/918514/26844926-052db7e2-4ac3-11e7-84d9-058fbc2654dc.png">

buddy: @mkangia 
