### PR TITLE
check shadow form string

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5999,7 +5999,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                     xmlns,
                 ))
             return []
-        non_shadow_forms = [form for form in forms if form.form_type != ShadowForm.form_type]
+        non_shadow_forms = [form for form in forms if form.form_type != 'shadow_form']
         assert len(non_shadow_forms) <= 1
         return forms
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?254122

this is gross and should really use a constant or something, but if you look around appmanager lots of places just use a string 'shadow_form' or 'advanced_form'

You can't use `ShadowForm.form_type` because when loading a couch doc that is interpreted as a stringproperty

@benrudolph @NoahCarnahan @orangejenny 
