### PR TITLE
Prevent knockout applying bindings twice for report modules

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/module_view_report.html
@@ -15,7 +15,6 @@
     {% include 'hqmedia/partials/multimedia_js.html' %}
     <script src="{% static 'app_manager/js/nav_menu_media_common.js' %}"></script>
     <script src="{% static 'app_manager/js/app_manager_media.js' %}"></script>
-    <script src="{% static 'app_manager/js/nav_menu_media.js' %}"></script>
     <script src="{% static 'app_manager/js/module_view_report.js' %}"></script>
 {% endblock %}
 {% block form-view %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view_report.html
@@ -15,7 +15,6 @@
     {% include 'hqmedia/partials/multimedia_js.html' %}
     <script src="{% static 'app_manager/js/nav_menu_media_common.js' %}"></script>
     <script src="{% static 'app_manager/js/app_manager_media.js' %}"></script>
-    <script src="{% static 'app_manager/js/nav_menu_media.js' %}"></script>
     <script src="{% static 'app_manager/js/module_view_report.js' %}"></script>
 {% endblock %}
 {% block form-view %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view_report.html.diff.txt
@@ -15,7 +15,7 @@
  {% endblock %}
  {% block js-inline %}{{ block.super }}
      {% include 'hqmedia/partials/multimedia_js.html' %}
-@@ -30,17 +30,17 @@
+@@ -29,17 +29,17 @@
      {% registerurl 'choice_list_api' domain 'report_id' 'filter_id' %}
      {% registerurl "edit_report_module" domain app.id module.id %}
      {% registerurl "validate_module_for_build" domain app.id module.id %}


### PR DESCRIPTION
Copy-paste bug in https://github.com/dimagi/commcare-hq/pull/16464 : `module_view_report.html` didn't include `nav_menu_media_js.html` so I shouldn't have added `nav_menu_media.js` to it.

@emord / @millerdev 