### PR TITLE
avoid keyError in case of invalid username

### DIFF
--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -25,7 +25,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
     password = forms.CharField(label=_("Password"), widget=forms.PasswordInput(attrs={'class': 'form-control'}))
 
     def clean_username(self):
-        username = self.cleaned_data['username'].lower()
+        username = self.cleaned_data.get('username', '').lower()
         return username
 
     def clean_password(self):


### PR DESCRIPTION
[issue](https://sentry.io/dimagi/commcarehq/issues/287905317/)

[origin](https://github.com/dimagi/commcare-hq/pull/15490/files#diff-d39e56548bf4e0c07edcb0998f4aef34R35)