### PR TITLE
add ability to pick persisted case tile from another module

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2101,7 +2101,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
 
     persist_tile_on_forms = BooleanProperty()
     # use case tile context persisted over forms from another module
-    persistent_case_context_from_module = StringProperty()
+    persistent_case_tile_from_module = StringProperty()
     # If True, the in form tile can be pulled down to reveal all the case details.
     pull_down_tile = BooleanProperty()
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2100,6 +2100,8 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     custom_xml = StringProperty()
 
     persist_tile_on_forms = BooleanProperty()
+    # use case tile context persisted over forms from another module
+    persistent_case_context_from_module = StringProperty()
     # If True, the in form tile can be pulled down to reveal all the case details.
     pull_down_tile = BooleanProperty()
 

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -974,6 +974,8 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 this.persistTileOnForms = ko.observable(spec[this.columnKey].persist_tile_on_forms || false);
                 this.enableTilePullDown = ko.observable(spec[this.columnKey].pull_down_tile || false);
                 this.allowsEmptyColumns = options.allowsEmptyColumns;
+                this.persistentCaseContextFromModule = (
+                    ko.observable(spec[this.columnKey].persistent_case_context_from_module || ""));
 
                 this.fireChange = function() {
                     that.fire('change');
@@ -1056,6 +1058,9 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                     that.saveButton.fire('change');
                 });
                 this.persistTileOnForms.subscribe(function(){
+                    that.saveButton.fire('change');
+                });
+                this.persistentCaseContextFromModule.subscribe(function(){
                     that.saveButton.fire('change');
                 });
                 this.enableTilePullDown.subscribe(function(){
@@ -1157,6 +1162,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                     data.persistCaseContext = this.persistCaseContext();
                     data.persistentCaseContextXML = this.persistentCaseContextXML();
                     data.persistTileOnForms = this.persistTileOnForms();
+                    data.persistentCaseContextFromModule = this.persistentCaseContextFromModule();
                     data.enableTilePullDown = this.persistTileOnForms() ? this.enableTilePullDown() : false;
 
                     if (this.containsParentConfiguration) {

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -974,8 +974,8 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 this.persistTileOnForms = ko.observable(spec[this.columnKey].persist_tile_on_forms || false);
                 this.enableTilePullDown = ko.observable(spec[this.columnKey].pull_down_tile || false);
                 this.allowsEmptyColumns = options.allowsEmptyColumns;
-                this.persistentCaseContextFromModule = (
-                    ko.observable(spec[this.columnKey].persistent_case_context_from_module || ""));
+                this.persistentCaseTileFromModule = (
+                    ko.observable(spec[this.columnKey].persistent_case_tile_from_module || ""));
 
                 this.fireChange = function() {
                     that.fire('change');
@@ -1060,7 +1060,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 this.persistTileOnForms.subscribe(function(){
                     that.saveButton.fire('change');
                 });
-                this.persistentCaseContextFromModule.subscribe(function(){
+                this.persistentCaseTileFromModule.subscribe(function(){
                     that.saveButton.fire('change');
                 });
                 this.enableTilePullDown.subscribe(function(){
@@ -1162,7 +1162,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                     data.persistCaseContext = this.persistCaseContext();
                     data.persistentCaseContextXML = this.persistentCaseContextXML();
                     data.persistTileOnForms = this.persistTileOnForms();
-                    data.persistentCaseContextFromModule = this.persistentCaseContextFromModule();
+                    data.persistentCaseTileFromModule = this.persistentCaseTileFromModule();
                     data.enableTilePullDown = this.persistTileOnForms() ? this.enableTilePullDown() : false;
 
                     if (this.containsParentConfiguration) {

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -877,9 +877,9 @@ class EntriesHelper(object):
         if detail_enabled:
             # if configured to use persisted case tile context from another module which has case tiles
             # configured then get id_string for that module
-            if detail.persistent_case_context_from_module:
+            if detail.persistent_case_tile_from_module:
                 module_for_persistent_context = module.get_app().get_module_by_unique_id(
-                    detail.persistent_case_context_from_module
+                    detail.persistent_case_tile_from_module
                 )
                 if (module_for_persistent_context and
                         module_for_persistent_context.case_details.short.use_case_tiles):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -875,6 +875,15 @@ class EntriesHelper(object):
     def get_detail_persistent_attr(self, module, detail_module, detail_type="case_short"):
         detail, detail_enabled = self._get_detail_from_module(module, detail_type)
         if detail_enabled:
+            # if configured to use persisted case tile context from another module which has case tiles
+            # configured then get id_string for that module
+            if detail.persistent_case_context_from_module:
+                module_for_persistent_context = module.get_app().get_module_by_unique_id(
+                    detail.persistent_case_context_from_module
+                )
+                if (module_for_persistent_context and
+                        module_for_persistent_context.case_details.short.use_case_tiles):
+                    return id_strings.detail(module_for_persistent_context, detail_type)
             if self._has_persistent_tile(detail):
                 return id_strings.detail(detail_module, detail_type)
             if detail.persist_case_context and detail_type == "case_short":

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -58,7 +58,7 @@
     </div>
     {% endif %}
 
-    <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE'))|| COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
+    <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox">
             <label>
                 <input type="checkbox" data-bind="checked: persistTileOnForms">

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -76,7 +76,6 @@
     </div>
     {% endif %}
 
-    {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
     {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
     {% if request|toggle_enabled:'CASE_LIST_TILE' %}
     {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
@@ -100,7 +99,6 @@
         </div>
         {% endif %}
         {% endwith %}
-    {% endif %}
     {% endif %}
     {% endif %}
     {% include 'app_manager/v1/partials/case_list_properties.html' %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -80,10 +80,10 @@
         <div class="row">
             <div class="col-sm-6">
                 <label>
-                    {% trans "Use persistent case list tile from module" %}
+                    {% trans "Use persistent case tile from module" %}
                 </label>
                 <div>
-                    <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
+                    <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
                         <option value></option>
                         {% for other_mod in available_modules %}
                             <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -58,9 +58,7 @@
     </div>
     {% endif %}
 
-    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
-    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
-    <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
+    <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE'))|| COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox">
             <label>
                 <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -74,7 +72,6 @@
             </label>
         </div>
     </div>
-    {% endif %}
 
     {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
     {% if request|toggle_enabled:'CASE_LIST_TILE' %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -75,8 +75,6 @@
 
     {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
     {% if request|toggle_enabled:'CASE_LIST_TILE' %}
-    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
-    {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
         {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
         {% if available_modules %}
         <div class="row">
@@ -96,7 +94,6 @@
         </div>
         {% endif %}
         {% endwith %}
-    {% endif %}
     {% endif %}
     {% include 'app_manager/v1/partials/case_list_properties.html' %}
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -80,11 +80,13 @@
         <div class="row">
             <div class="col-sm-6">
                 <label>
-                    {% trans "Use persistent case tile from module" %}
+                    {% trans "Use persistent case tile from menu" %}
                 </label>
                 <div>
                     <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
-                        <option value></option>
+                        <option value>
+                            {% trans "Select Menu" %}
+                        </option>
                         {% for other_mod in available_modules %}
                             <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
                         {% endfor %}

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
+{% load app_manager_extras %}
+{% load xforms_extras %}
 
 {% include 'app_manager/v1/partials/case_list_missing_warning.html' %}
 
@@ -56,6 +58,8 @@
     </div>
     {% endif %}
 
+    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
+    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
     <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox">
             <label>
@@ -70,6 +74,35 @@
             </label>
         </div>
     </div>
+    {% endif %}
+
+    {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
+    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
+    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
+    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
+    {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
+        {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
+        {% if available_modules %}
+        <div class="row">
+            <div class="col-sm-6">
+                <label>
+                    {% trans "Use persistent case list tile from module" %}
+                </label>
+                <div>
+                    <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
+                        <option value></option>
+                        {% for other_mod in available_modules %}
+                            <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        {% endwith %}
+    {% endif %}
+    {% endif %}
+    {% endif %}
     {% include 'app_manager/v1/partials/case_list_properties.html' %}
 </div>
 

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -63,9 +63,7 @@
             </div>
         </div>
         {% endif %}
-        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
-        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
-        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
+        <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE')) || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
             <div class="checkbox">
                 <label>
                     <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -79,7 +77,6 @@
                 </label>
             </div>
         </div>
-        {% endif %}
 
         {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
         {% if request|toggle_enabled:'CASE_LIST_TILE' %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -63,7 +63,7 @@
             </div>
         </div>
         {% endif %}
-        <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE')) || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
+        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
             <div class="checkbox">
                 <label>
                     <input type="checkbox" data-bind="checked: persistTileOnForms">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -85,10 +85,10 @@
             <div class="row">
                 <div class="col-sm-6">
                     <label>
-                        {% trans "Use persistent case list tile from module" %}
+                        {% trans "Use persistent case tile from module" %}
                     </label>
                     <div>
-                        <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
+                        <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
                             <option value></option>
                             {% for other_mod in available_modules %}
                                 <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -80,8 +80,6 @@
 
         {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
         {% if request|toggle_enabled:'CASE_LIST_TILE' %}
-        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
-        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
             {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
             {% if available_modules %}
             <div class="row">
@@ -101,7 +99,6 @@
             </div>
             {% endif %}
             {% endwith %}
-        {% endif %}
         {% endif %}
         {% include 'app_manager/v2/partials/case_list_properties.html' %}
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -80,6 +80,7 @@
 
         {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
         {% if request|toggle_enabled:'CASE_LIST_TILE' %}
+        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
         {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
             {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
             {% if available_modules %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -85,11 +85,13 @@
             <div class="row">
                 <div class="col-sm-6">
                     <label>
-                        {% trans "Use persistent case tile from module" %}
+                        {% trans "Use persistent case tile from menu" %}
                     </label>
                     <div>
                         <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
-                            <option value></option>
+                            <option value>
+                                {% trans "Select Menu" %}
+                            </option>
                             {% for other_mod in available_modules %}
                                 <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
                             {% endfor %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -81,7 +81,6 @@
         </div>
         {% endif %}
 
-        {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
         {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
         {% if request|toggle_enabled:'CASE_LIST_TILE' %}
         {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
@@ -104,7 +103,6 @@
             </div>
             {% endif %}
             {% endwith %}
-        {% endif %}
         {% endif %}
         {% endif %}
         {% include 'app_manager/v2/partials/case_list_properties.html' %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
+{% load app_manager_extras %}
 {% load xforms_extras %}
 
 {% include 'app_manager/v2/partials/case_list_missing_warning.html' %}
@@ -62,6 +63,8 @@
             </div>
         </div>
         {% endif %}
+        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
+        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
         <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
             <div class="checkbox">
                 <label>
@@ -76,6 +79,34 @@
                 </label>
             </div>
         </div>
+        {% endif %}
+
+        {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
+        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
+        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
+        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
+            {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
+            {% if available_modules %}
+            <div class="row">
+                <div class="col-sm-6">
+                    <label>
+                        {% trans "Use persistent case list tile from module" %}
+                    </label>
+                    <div>
+                        <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
+                            <option value></option>
+                            {% for other_mod in available_modules %}
+                                <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+            {% endwith %}
+        {% endif %}
+        {% endif %}
+        {% endif %}
         {% include 'app_manager/v2/partials/case_list_properties.html' %}
     </div>
   </div>

--- a/corehq/apps/app_manager/templatetags/app_manager_extras.py
+++ b/corehq/apps/app_manager/templatetags/app_manager_extras.py
@@ -19,6 +19,6 @@ def get_available_modules_for_case_list_configuration(app, module):
 
 
 @register.filter
-def get_available_modules_for_case_tile_configuration(app, module):
-    valid_modules = get_available_modules_for_case_list_configuration(app, module)
+def get_available_modules_for_case_tile_configuration(app, for_module):
+    valid_modules = get_available_modules_for_case_list_configuration(app, for_module)
     return [m for m in valid_modules if m.case_details.short.use_case_tiles]

--- a/corehq/apps/app_manager/templatetags/app_manager_extras.py
+++ b/corehq/apps/app_manager/templatetags/app_manager_extras.py
@@ -19,6 +19,6 @@ def get_available_modules_for_case_list_configuration(app, module):
 
 
 @register.filter
-def get_available_modules_for_case_tile_configuration(app, for_module):
-    valid_modules = get_available_modules_for_case_list_configuration(app, for_module)
+def get_available_modules_for_case_tile_configuration(app, exclude_module):
+    valid_modules = get_available_modules_for_case_list_configuration(app, exclude_module)
     return [m for m in valid_modules if m.case_details.short.use_case_tiles]

--- a/corehq/apps/app_manager/templatetags/app_manager_extras.py
+++ b/corehq/apps/app_manager/templatetags/app_manager_extras.py
@@ -16,3 +16,9 @@ def get_available_modules_for_case_list_configuration(app, module):
             and m.module_type not in disallowed_module_types
             and m.case_type == module.case_type)
     ]
+
+
+@register.filter
+def get_available_modules_for_case_tile_configuration(app, module):
+    valid_modules = get_available_modules_for_case_list_configuration(app, module)
+    return [m for m in valid_modules if m.case_details.short.use_case_tiles]

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,279 +3,288 @@
+@@ -3,276 +3,285 @@
  {% load app_manager_extras %}
  {% load xforms_extras %}
  
@@ -72,9 +72,7 @@
 +            </div>
 +        </div>
 +        {% endif %}
-+        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
-+        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
-+        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
++        <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE')) || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
 +            <div class="checkbox">
 +                <label>
 +                    <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -88,7 +86,6 @@
 +                </label>
 +            </div>
 +        </div>
-+        {% endif %}
 +
 +        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 +        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
@@ -158,9 +155,7 @@
 -    </div>
 -    {% endif %}
 -
--    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
--    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
--    <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
+-    <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE'))|| COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
 -        <div class="checkbox">
 -            <label>
 -                <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -174,7 +169,6 @@
 -            </label>
 -        </div>
 -    </div>
--    {% endif %}
 -
 -    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 -    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
@@ -550,7 +544,7 @@
          <div class="form-group">
              <label class="control-label col-sm-2">
                  {% trans "Select Parent First" %}
-@@ -288,7 +297,7 @@
+@@ -285,7 +294,7 @@
          </div>
          <div class="form-group" data-bind="visible: active">
              <label class="control-label col-sm-2">
@@ -559,7 +553,7 @@
              </label>
              <div class="col-sm-4">
                  <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-@@ -301,15 +310,14 @@
+@@ -298,15 +307,14 @@
  
  {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -72,7 +72,7 @@
 +            </div>
 +        </div>
 +        {% endif %}
-+        <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE')) || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
++        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
 +            <div class="checkbox">
 +                <label>
 +                    <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -155,7 +155,7 @@
 -    </div>
 -    {% endif %}
 -
--    <div data-bind="visible: (useCaseTiles() == 'yes' && COMMCAREHQ.toggleEnabled('CASE_LIST_TILE'))|| COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
+-    <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
 -        <div class="checkbox">
 -            <label>
 -                <input type="checkbox" data-bind="checked: persistTileOnForms">

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,273 +3,283 @@
+@@ -3,275 +3,285 @@
  {% load app_manager_extras %}
  {% load xforms_extras %}
  
@@ -94,11 +94,13 @@
 +            <div class="row">
 +                <div class="col-sm-6">
 +                    <label>
-+                        {% trans "Use persistent case tile from module" %}
++                        {% trans "Use persistent case tile from menu" %}
 +                    </label>
 +                    <div>
 +                        <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
-+                            <option value></option>
++                            <option value>
++                                {% trans "Select Menu" %}
++                            </option>
 +                            {% for other_mod in available_modules %}
 +                                <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
 +                            {% endfor %}
@@ -175,11 +177,13 @@
 -        <div class="row">
 -            <div class="col-sm-6">
 -                <label>
--                    {% trans "Use persistent case tile from module" %}
+-                    {% trans "Use persistent case tile from menu" %}
 -                </label>
 -                <div>
 -                    <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
--                        <option value></option>
+-                        <option value>
+-                            {% trans "Select Menu" %}
+-                        </option>
 -                        {% for other_mod in available_modules %}
 -                            <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
 -                        {% endfor %}
@@ -538,7 +542,7 @@
          <div class="form-group">
              <label class="control-label col-sm-2">
                  {% trans "Select Parent First" %}
-@@ -282,7 +292,7 @@
+@@ -284,7 +294,7 @@
          </div>
          <div class="form-group" data-bind="visible: active">
              <label class="control-label col-sm-2">
@@ -547,7 +551,7 @@
              </label>
              <div class="col-sm-4">
                  <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-@@ -295,15 +305,14 @@
+@@ -297,15 +307,14 @@
  
  {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,12 +1,10 @@
 --- 
 +++ 
-@@ -1,250 +1,261 @@
- {% load i18n %}
- {% load hq_shared_tags %}
--
+@@ -3,281 +3,290 @@
+ {% load app_manager_extras %}
+ {% load xforms_extras %}
+ 
 -{% include 'app_manager/v1/partials/case_list_missing_warning.html' %}
-+{% load xforms_extras %}
-+
 +{% include 'app_manager/v2/partials/case_list_missing_warning.html' %}
  
  <div data-bind="saveButton: shortScreen.saveButton"></div>
@@ -50,8 +48,79 @@
 -        </div>
 -        <div class="spacer"></div>
 -    </div>
--</div>
--
++                <select data-bind="value: useCaseTiles" class="form-control">
++                    <option value="no">{% trans "Don't Use Case Tiles" %}</option>
++                    <option value="yes">{% trans "Use Case Tiles" %}</option>
++                </select>
++            </div>
++        </div>
++        {% endif %}
++        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
++        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
++        <div data-bind="visible: useCaseTiles() == 'no'">
++            <div class="checkbox">
++                <label>
++                    <input type="checkbox" data-bind="checked: persistCaseContext">
++                    {% trans "Show some information about the case at the top of the screen when filling out forms" %}
++                </label>
++            </div>
++            <div class="form-inline" data-bind="visible: persistCaseContext">
++                <label>
++                    {% trans "Case property to show" %}
++                </label>
++                <input class="form-control" type="text" data-bind="value: persistentCaseContextXML" placeholder="e.g. case_name" />
++            </div>
++        </div>
++        {% endif %}
++        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
++        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
++        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
++            <div class="checkbox">
++                <label>
++                    <input type="checkbox" data-bind="checked: persistTileOnForms">
++                    {% trans "Use this case list tile persistently in forms" %}
++                </label>
++            </div>
++            <div class="checkbox" data-bind="visible: persistTileOnForms()">
++                <label>
++                    <input type="checkbox" data-bind="checked: enableTilePullDown">
++                    {% trans "Embed case details in case tile pull-down" %}
++                </label>
++            </div>
++        </div>
++        {% endif %}
++
++        {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
++        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
++        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
++        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
++            {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
++            {% if available_modules %}
++            <div class="row">
++                <div class="col-sm-6">
++                    <label>
++                        {% trans "Use persistent case list tile from module" %}
++                    </label>
++                    <div>
++                        <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
++                            <option value></option>
++                            {% for other_mod in available_modules %}
++                                <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
++                            {% endfor %}
++                        </select>
++                    </div>
++                </div>
++            </div>
++            {% endif %}
++            {% endwith %}
++        {% endif %}
++        {% endif %}
++        {% endif %}
++        {% include 'app_manager/v2/partials/case_list_properties.html' %}
++    </div>
++  </div>
+ </div>
+ 
 -{% include 'app_manager/v1/partials/custom_detail_variables.html' with screen='shortScreen'%}
 -
 -<legend>
@@ -91,6 +160,8 @@
 -    </div>
 -    {% endif %}
 -
+-    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
+-    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
 -    <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
 -        <div class="checkbox">
 -            <label>
@@ -105,53 +176,203 @@
 -            </label>
 -        </div>
 -    </div>
+-    {% endif %}
+-
+-    {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
+-    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
+-    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
+-    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
+-    {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
+-        {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
+-        {% if available_modules %}
+-        <div class="row">
+-            <div class="col-sm-6">
+-                <label>
+-                    {% trans "Use persistent case list tile from module" %}
+-                </label>
+-                <div>
+-                    <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
+-                        <option value></option>
+-                        {% for other_mod in available_modules %}
+-                            <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
+-                        {% endfor %}
+-                    </select>
+-                </div>
+-            </div>
+-        </div>
+-        {% endif %}
+-        {% endwith %}
+-    {% endif %}
+-    {% endif %}
+-    {% endif %}
 -    {% include 'app_manager/v1/partials/case_list_properties.html' %}
--</div>
-+                <select data-bind="value: useCaseTiles" class="form-control">
-+                    <option value="no">{% trans "Don't Use Case Tiles" %}</option>
-+                    <option value="yes">{% trans "Use Case Tiles" %}</option>
-+                </select>
++
++{% if detail.type == 'case' %}
++<div class="panel panel-appmanager">
++  <div class="panel-heading">
++    <h4 class="panel-title panel-title-nolink">
++      {% trans "Filtering and Sorting" %}
++    </h4>
++  </div>
++  <div class="panel-body">
++    {% include 'app_manager/v2/partials/case_list_filtering.html' %}
++    <div data-bind="with: sortRows">
++        {% if app.enable_multi_sort %}
++            <div class="ui-sortable">
++                <table class="table table-condensed" data-bind="visible: showing">
++                    <thead>
++                        <tr>
++                            <th></th>
++                            <th>
++                                {% trans "Sort Property" %}
++                                <span class="hq-help-template"
++                                      data-title="{% trans "Sort Properties" %}"
++                                      data-content=
++                                          "{% blocktrans %}
++                                              Properties in this list determine how
++                                              cases are ordered in your case list. This
++                                              is useful if for example you want higher
++                                              priority cases to appear closer to the
++                                              top of the list. The case list will sort
++                                              by the first property, then the second,
++                                              etc.
++                                          {% endblocktrans %}" >
++                                </span>
++                            </th>
++                            <th>{% trans "Direction" %}</th>
++                            {% if app.enable_case_list_sort_blanks %}
++                                <th>
++                                    {% trans "Display Blanks" %}
++                                    <span class="hq-help-template"
++                                          data-title="{% trans "Display Blanks" %}"
++                                          data-content=
++                                              "{% blocktrans %}
++                                                  Should cases that don't have a value for the sort property
++                                                  appear at the top or the bottom of the case list?
++                                              {% endblocktrans %}" >
++                                    </span>
++                                </th>
++                            {% endif %}
++                            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
++                            <th>{% trans "Sort Calculation" %}</th>
++                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
++                              <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
++                            {% endif %}
++                            <th>{% trans "Format" %}</th>
++                            <th>
++                                {% trans "Display Text" %}
++                                <span class="hq-help-template"
++                                      data-title="{% trans "Display Text" %}"
++                                      data-content=
++                                          "{% blocktrans %}
++                                              The 'Display Text' is used for properties that are only listed as
++                                              Sort Properties and not as Display Properties above. The text appears
++                                              in the 'Sort By' menu on the mobile to allow the user to change the
++                                              sort ordering. If the display text is left blank then the option
++                                              for that sort property will not appear in the 'Sort By' menu.
++                                          {% endblocktrans %}" >
++                                </span>
++                            </th>
++                            <th></th>
++                        </tr>
++                    </thead>
++                    <tbody data-bind="foreach: sortRows(), sortableList: sortRows">
++                        <tr>
++                            <td>
++                                <i class="grip fa fa-arrows-v icon-blue"></i>
++                            </td>
++                            <td class="form-group" data-bind="css: {'has-error': showWarning}">
++                                <div data-bind="jqueryElement: textField.ui"></div>
++                                <div data-bind="visible: showWarning">
++                                    <span class="help-block" data-bind="
++                                        text: hqImport('app_manager/js/detail-screen-config.js').DetailScreenConfig.field_format_warning_message
++                                    "></span>
++                                </div>
++                            </td>
++                            <td>
++                                <select class="form-control" data-bind="value: direction">
++                                    <option value="ascending"
++                                            data-bind="text: ascendText">
++                                    </option>
++                                    <option value="descending"
++                                            data-bind="text: descendText">
++                                    </option>
++                                </select>
++                            </td>
++
++                            {% if app.enable_case_list_sort_blanks %}
++                                <td>
++                                    <select class="form-control" data-bind="value: blanks">
++                                        <option value="last">
++                                            {% trans "Bottom of list" %}
++                                        </option>
++                                        <option value="first">
++                                            {% trans "Top of list" %}
++                                        </option>
++                                    </select>
++                                </td>
++                            {% endif %}
++
++                            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
++                            <td>
++                                <input class="form-control" type='text' data-bind='value: sortCalculation'/>
++                            </td>
++                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
++                              <td></td>
++                            {% endif %}
++
++
++                            <td>
++                                <select class="form-control" data-bind="value: type">
++                                    <option value="plain">
++                                        {% trans "Plain" %}
++                                    </option>
++                                    <option value="date">
++                                        {% trans "Date" %}
++                                    </option>
++                                    <option value="int">
++                                        {% trans "Integer" %}
++                                    </option>
++                                    <option value="double">
++                                        {% trans "Decimal" %}
++                                    </option>
++                                    <option value="distance">
++                                        {% trans "Distance from current location" %}
++                                    </option>
++                                    {{ request|toggle_tag_info:"CACHE_AND_INDEX" }}
++                                    {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
++                                        <option value="index">
++                                            {% trans "Cache and Index" %}
++                                        </option>
++                                    {% endif %}
++                                </select>
++                            </td>
++                            <td>
++                                <input class="form-control" type='text' data-bind='value: display'/>
++                            </td>
++                            <td>
++                                <a data-bind="click: $root.sortRows.removeSortRow">
++                                    <i class="fa fa-remove icon-blue"></i>
++                                </a>
++                            </td>
++                        </tr>
++                    </tbody>
++                </table>
 +            </div>
-+        </div>
++            <div class="form-group">
++                <button class="btn btn-default btn-sm" data-bind="
++                    click: function(data){data.addSortRow('', '', '', '', '', true, '');}"
++                >
++                    <i class="fa fa-plus"></i>
++                    {% trans "Add sort property" %}
++                </button>
++            </div>
 +        {% endif %}
-+        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
-+        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
-+        <div data-bind="visible: useCaseTiles() == 'no'">
-+            <div class="checkbox">
-+                <label>
-+                    <input type="checkbox" data-bind="checked: persistCaseContext">
-+                    {% trans "Show some information about the case at the top of the screen when filling out forms" %}
-+                </label>
-+            </div>
-+            <div class="form-inline" data-bind="visible: persistCaseContext">
-+                <label>
-+                    {% trans "Case property to show" %}
-+                </label>
-+                <input class="form-control" type="text" data-bind="value: persistentCaseContextXML" placeholder="e.g. case_name" />
-+            </div>
-+        </div>
-+        {% endif %}
-+        <div data-bind="visible: useCaseTiles() == 'yes' || COMMCAREHQ.toggleEnabled('CASE_LIST_CUSTOM_XML')">
-+            <div class="checkbox">
-+                <label>
-+                    <input type="checkbox" data-bind="checked: persistTileOnForms">
-+                    {% trans "Use this case list tile persistently in forms" %}
-+                </label>
-+            </div>
-+            <div class="checkbox" data-bind="visible: persistTileOnForms()">
-+                <label>
-+                    <input type="checkbox" data-bind="checked: enableTilePullDown">
-+                    {% trans "Embed case details in case tile pull-down" %}
-+                </label>
-+            </div>
-+        </div>
-+        {% include 'app_manager/v2/partials/case_list_properties.html' %}
 +    </div>
 +  </div>
-+</div>
-+
- 
- {% if detail.type == 'case' %}
+ </div>
+-
+-{% if detail.type == 'case' %}
 -<legend>
 -    {% trans "Filtering and Sorting" %}
 -</legend>
@@ -316,169 +537,7 @@
 -    <div class="spacer"></div>
 -
 -{% endif %}
-+<div class="panel panel-appmanager">
-+  <div class="panel-heading">
-+    <h4 class="panel-title panel-title-nolink">
-+      {% trans "Filtering and Sorting" %}
-+    </h4>
-+  </div>
-+  <div class="panel-body">
-+    {% include 'app_manager/v2/partials/case_list_filtering.html' %}
-+    <div data-bind="with: sortRows">
-+        {% if app.enable_multi_sort %}
-+            <div class="ui-sortable">
-+                <table class="table table-condensed" data-bind="visible: showing">
-+                    <thead>
-+                        <tr>
-+                            <th></th>
-+                            <th>
-+                                {% trans "Sort Property" %}
-+                                <span class="hq-help-template"
-+                                      data-title="{% trans "Sort Properties" %}"
-+                                      data-content=
-+                                          "{% blocktrans %}
-+                                              Properties in this list determine how
-+                                              cases are ordered in your case list. This
-+                                              is useful if for example you want higher
-+                                              priority cases to appear closer to the
-+                                              top of the list. The case list will sort
-+                                              by the first property, then the second,
-+                                              etc.
-+                                          {% endblocktrans %}" >
-+                                </span>
-+                            </th>
-+                            <th>{% trans "Direction" %}</th>
-+                            {% if app.enable_case_list_sort_blanks %}
-+                                <th>
-+                                    {% trans "Display Blanks" %}
-+                                    <span class="hq-help-template"
-+                                          data-title="{% trans "Display Blanks" %}"
-+                                          data-content=
-+                                              "{% blocktrans %}
-+                                                  Should cases that don't have a value for the sort property
-+                                                  appear at the top or the bottom of the case list?
-+                                              {% endblocktrans %}" >
-+                                    </span>
-+                                </th>
-+                            {% endif %}
-+                            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-+                            <th>{% trans "Sort Calculation" %}</th>
-+                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
-+                              <th>{{ request|toggle_tag_info:"SORT_CALCULATION_IN_CASE_LIST" }}</th>
-+                            {% endif %}
-+                            <th>{% trans "Format" %}</th>
-+                            <th>
-+                                {% trans "Display Text" %}
-+                                <span class="hq-help-template"
-+                                      data-title="{% trans "Display Text" %}"
-+                                      data-content=
-+                                          "{% blocktrans %}
-+                                              The 'Display Text' is used for properties that are only listed as
-+                                              Sort Properties and not as Display Properties above. The text appears
-+                                              in the 'Sort By' menu on the mobile to allow the user to change the
-+                                              sort ordering. If the display text is left blank then the option
-+                                              for that sort property will not appear in the 'Sort By' menu.
-+                                          {% endblocktrans %}" >
-+                                </span>
-+                            </th>
-+                            <th></th>
-+                        </tr>
-+                    </thead>
-+                    <tbody data-bind="foreach: sortRows(), sortableList: sortRows">
-+                        <tr>
-+                            <td>
-+                                <i class="grip fa fa-arrows-v icon-blue"></i>
-+                            </td>
-+                            <td class="form-group" data-bind="css: {'has-error': showWarning}">
-+                                <div data-bind="jqueryElement: textField.ui"></div>
-+                                <div data-bind="visible: showWarning">
-+                                    <span class="help-block" data-bind="
-+                                        text: hqImport('app_manager/js/detail-screen-config.js').DetailScreenConfig.field_format_warning_message
-+                                    "></span>
-+                                </div>
-+                            </td>
-+                            <td>
-+                                <select class="form-control" data-bind="value: direction">
-+                                    <option value="ascending"
-+                                            data-bind="text: ascendText">
-+                                    </option>
-+                                    <option value="descending"
-+                                            data-bind="text: descendText">
-+                                    </option>
-+                                </select>
-+                            </td>
-+
-+                            {% if app.enable_case_list_sort_blanks %}
-+                                <td>
-+                                    <select class="form-control" data-bind="value: blanks">
-+                                        <option value="last">
-+                                            {% trans "Bottom of list" %}
-+                                        </option>
-+                                        <option value="first">
-+                                            {% trans "Top of list" %}
-+                                        </option>
-+                                    </select>
-+                                </td>
-+                            {% endif %}
-+
-+                            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-+                            <td>
-+                                <input class="form-control" type='text' data-bind='value: sortCalculation'/>
-+                            </td>
-+                            {% elif request|toggle_enabled:'SHOW_DEV_TOGGLE_INFO' %}
-+                              <td></td>
-+                            {% endif %}
-+
-+
-+                            <td>
-+                                <select class="form-control" data-bind="value: type">
-+                                    <option value="plain">
-+                                        {% trans "Plain" %}
-+                                    </option>
-+                                    <option value="date">
-+                                        {% trans "Date" %}
-+                                    </option>
-+                                    <option value="int">
-+                                        {% trans "Integer" %}
-+                                    </option>
-+                                    <option value="double">
-+                                        {% trans "Decimal" %}
-+                                    </option>
-+                                    <option value="distance">
-+                                        {% trans "Distance from current location" %}
-+                                    </option>
-+                                    {{ request|toggle_tag_info:"CACHE_AND_INDEX" }}
-+                                    {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
-+                                        <option value="index">
-+                                            {% trans "Cache and Index" %}
-+                                        </option>
-+                                    {% endif %}
-+                                </select>
-+                            </td>
-+                            <td>
-+                                <input class="form-control" type='text' data-bind='value: display'/>
-+                            </td>
-+                            <td>
-+                                <a data-bind="click: $root.sortRows.removeSortRow">
-+                                    <i class="fa fa-remove icon-blue"></i>
-+                                </a>
-+                            </td>
-+                        </tr>
-+                    </tbody>
-+                </table>
-+            </div>
-+            <div class="form-group">
-+                <button class="btn btn-default btn-sm" data-bind="
-+                    click: function(data){data.addSortRow('', '', '', '', '', true, '');}"
-+                >
-+                    <i class="fa fa-plus"></i>
-+                    {% trans "Add sort property" %}
-+                </button>
-+            </div>
-+        {% endif %}
-+    </div>
-+  </div>
- </div>
+-</div>
  {% endif %}
  
  {% if detail.parent_select %}
@@ -495,7 +554,7 @@
          <div class="form-group">
              <label class="control-label col-sm-2">
                  {% trans "Select Parent First" %}
-@@ -257,7 +268,7 @@
+@@ -290,7 +299,7 @@
          </div>
          <div class="form-group" data-bind="visible: active">
              <label class="control-label col-sm-2">
@@ -504,7 +563,7 @@
              </label>
              <div class="col-sm-4">
                  <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-@@ -270,15 +281,14 @@
+@@ -303,15 +312,14 @@
  
  {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,276 +3,285 @@
+@@ -3,276 +3,286 @@
  {% load app_manager_extras %}
  {% load xforms_extras %}
  
@@ -89,6 +89,7 @@
 +
 +        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 +        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
++        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
 +        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
 +            {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
 +            {% if available_modules %}
@@ -544,7 +545,7 @@
          <div class="form-group">
              <label class="control-label col-sm-2">
                  {% trans "Select Parent First" %}
-@@ -285,7 +294,7 @@
+@@ -285,7 +295,7 @@
          </div>
          <div class="form-group" data-bind="visible: active">
              <label class="control-label col-sm-2">
@@ -553,7 +554,7 @@
              </label>
              <div class="col-sm-4">
                  <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-@@ -298,15 +307,14 @@
+@@ -298,15 +308,14 @@
  
  {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,281 +3,290 @@
+@@ -3,279 +3,288 @@
  {% load app_manager_extras %}
  {% load xforms_extras %}
  
@@ -90,7 +90,6 @@
 +        </div>
 +        {% endif %}
 +
-+        {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
 +        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 +        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
 +        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
@@ -113,7 +112,6 @@
 +            </div>
 +            {% endif %}
 +            {% endwith %}
-+        {% endif %}
 +        {% endif %}
 +        {% endif %}
 +        {% include 'app_manager/v2/partials/case_list_properties.html' %}
@@ -178,7 +176,6 @@
 -    </div>
 -    {% endif %}
 -
--    {% if request|feature_preview_enabled:"SHARE_CASE_TILE_CONTEXT" %}
 -    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 -    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
 -    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
@@ -202,7 +199,6 @@
 -        </div>
 -        {% endif %}
 -        {% endwith %}
--    {% endif %}
 -    {% endif %}
 -    {% endif %}
 -    {% include 'app_manager/v1/partials/case_list_properties.html' %}
@@ -554,7 +550,7 @@
          <div class="form-group">
              <label class="control-label col-sm-2">
                  {% trans "Select Parent First" %}
-@@ -290,7 +299,7 @@
+@@ -288,7 +297,7 @@
          </div>
          <div class="form-group" data-bind="visible: active">
              <label class="control-label col-sm-2">
@@ -563,7 +559,7 @@
              </label>
              <div class="col-sm-4">
                  <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-@@ -303,15 +312,14 @@
+@@ -301,15 +310,14 @@
  
  {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -94,10 +94,10 @@
 +            <div class="row">
 +                <div class="col-sm-6">
 +                    <label>
-+                        {% trans "Use persistent case list tile from module" %}
++                        {% trans "Use persistent case tile from module" %}
 +                    </label>
 +                    <div>
-+                        <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
++                        <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
 +                            <option value></option>
 +                            {% for other_mod in available_modules %}
 +                                <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
@@ -175,10 +175,10 @@
 -        <div class="row">
 -            <div class="col-sm-6">
 -                <label>
--                    {% trans "Use persistent case list tile from module" %}
+-                    {% trans "Use persistent case tile from module" %}
 -                </label>
 -                <div>
--                    <select name='persistent_case_context_from_module' class='form-control' data-bind="value: persistentCaseContextFromModule">
+-                    <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
 -                        <option value></option>
 -                        {% for other_mod in available_modules %}
 -                            <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,276 +3,286 @@
+@@ -3,273 +3,283 @@
  {% load app_manager_extras %}
  {% load xforms_extras %}
  
@@ -89,8 +89,6 @@
 +
 +        {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 +        {% if request|toggle_enabled:'CASE_LIST_TILE' %}
-+        {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
-+        {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
 +            {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
 +            {% if available_modules %}
 +            <div class="row">
@@ -110,7 +108,6 @@
 +            </div>
 +            {% endif %}
 +            {% endwith %}
-+        {% endif %}
 +        {% endif %}
 +        {% include 'app_manager/v2/partials/case_list_properties.html' %}
 +    </div>
@@ -173,8 +170,6 @@
 -
 -    {{ request|toggle_tag_info:"CASE_LIST_TILE" }}
 -    {% if request|toggle_enabled:'CASE_LIST_TILE' %}
--    {{ request|toggle_tag_info:"SHOW_PERSIST_CASE_CONTEXT_SETTING" }}
--    {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
 -        {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
 -        {% if available_modules %}
 -        <div class="row">
@@ -192,11 +187,6 @@
 -                </div>
 -            </div>
 -        </div>
--        {% endif %}
--        {% endwith %}
--    {% endif %}
--    {% endif %}
--    {% include 'app_manager/v1/partials/case_list_properties.html' %}
 +
 +{% if detail.type == 'case' %}
 +<div class="panel panel-appmanager">
@@ -358,7 +348,10 @@
 +                    {% trans "Add sort property" %}
 +                </button>
 +            </div>
-+        {% endif %}
+         {% endif %}
+-        {% endwith %}
+-    {% endif %}
+-    {% include 'app_manager/v1/partials/case_list_properties.html' %}
 +    </div>
 +  </div>
  </div>
@@ -545,7 +538,7 @@
          <div class="form-group">
              <label class="control-label col-sm-2">
                  {% trans "Select Parent First" %}
-@@ -285,7 +295,7 @@
+@@ -282,7 +292,7 @@
          </div>
          <div class="form-group" data-bind="visible: active">
              <label class="control-label col-sm-2">
@@ -554,7 +547,7 @@
              </label>
              <div class="col-sm-4">
                  <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-@@ -298,15 +308,14 @@
+@@ -295,15 +305,14 @@
  
  {{ request|toggle_tag_info:"CASE_LIST_LOOKUP" }}
  {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -620,7 +620,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         ensure_module_session_datum_xml('')
 
         # configured to use other module's persistent case tile
-        module1.case_details.short.persistent_case_context_from_module = module0.unique_id
+        module1.case_details.short.persistent_case_tile_from_module = module0.unique_id
         ensure_module_session_datum_xml('detail-persistent="m0_case_short"')
 
         # set to use persistent case tile of its own as well but it would still

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -783,7 +783,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     persistent_case_context_xml = params.get('persistentCaseContextXML', None)
     use_case_tiles = params.get('useCaseTiles', None)
     persist_tile_on_forms = params.get("persistTileOnForms", None)
-    persistent_case_context_from_module = params.get("persistentCaseContextFromModule", None)
+    persistent_case_tile_from_module = params.get("persistentCaseTileFromModule", None)
     pull_down_tile = params.get("enableTilePullDown", None)
     print_template = params.get('printTemplate', None)
     case_list_lookup = params.get("case_list_lookup", None)
@@ -818,8 +818,8 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
             detail.short.use_case_tiles = use_case_tiles
         if persist_tile_on_forms is not None:
             detail.short.persist_tile_on_forms = persist_tile_on_forms
-        if persistent_case_context_from_module is not None:
-            detail.short.persistent_case_context_from_module = persistent_case_context_from_module
+        if persistent_case_tile_from_module is not None:
+            detail.short.persistent_case_tile_from_module = persistent_case_tile_from_module
         if pull_down_tile is not None:
             detail.short.pull_down_tile = pull_down_tile
         if case_list_lookup is not None:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -783,6 +783,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     persistent_case_context_xml = params.get('persistentCaseContextXML', None)
     use_case_tiles = params.get('useCaseTiles', None)
     persist_tile_on_forms = params.get("persistTileOnForms", None)
+    persistent_case_context_from_module = params.get("persistentCaseContextFromModule", None)
     pull_down_tile = params.get("enableTilePullDown", None)
     print_template = params.get('printTemplate', None)
     case_list_lookup = params.get("case_list_lookup", None)
@@ -817,6 +818,8 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
             detail.short.use_case_tiles = use_case_tiles
         if persist_tile_on_forms is not None:
             detail.short.persist_tile_on_forms = persist_tile_on_forms
+        if persistent_case_context_from_module is not None:
+            detail.short.persistent_case_context_from_module = persistent_case_context_from_module
         if pull_down_tile is not None:
             detail.short.pull_down_tile = pull_down_tile
         if case_list_lookup is not None:

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -127,12 +127,3 @@ VELLUM_ADVANCED_ITEMSETS = FeaturePreview(
     ),
     privilege=LOOKUP_TABLES,
 )
-
-
-SHARE_CASE_TILE_CONTEXT = FeaturePreview(
-    slug="share_case_tile_context",
-    label=_("Share case tile between modules"),
-    description=_(
-        "Configure a module to use persistent case tile from another module"
-    )
-)

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -127,3 +127,12 @@ VELLUM_ADVANCED_ITEMSETS = FeaturePreview(
     ),
     privilege=LOOKUP_TABLES,
 )
+
+
+SHARE_CASE_TILE_CONTEXT = FeaturePreview(
+    slug="share_case_tile_context",
+    label=_("Share case tile between modules"),
+    description=_(
+        "Configure a module to use persistent case tile from another module"
+    )
+)


### PR DESCRIPTION
extracted from #16477 
[trello card](https://trello.com/c/wekRPsTb/137-app-builder-changes-for-enikshay-phase-2b?menu=filter)

This adds ability to use a different module for
1. case tiles in case list
2. case tiles persisted over the forms

🏛 