### PR TITLE
Revert "Revert notifications changes to form designer"

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/form_designer.js
@@ -106,6 +106,17 @@ hqDefine("app_manager/js/form_designer.js", function() {
                 }
 
                 $('#formdesigner').vellum(VELLUM_OPTIONS);
+
+                var notification_options = initial_page_data("notification_options");
+                if (notification_options) {
+                    var notifications = hqImport('app_manager/js/app-notifications.js');
+                    // initialize redis
+                    WS4Redis({
+                        uri: notification_options.WEBSOCKET_URI + notification_options.notify_facility + '?subscribe-broadcast',
+                        receive_message: notifications.NotifyFunction(notification_options.user_id, $('#notify-bar')),
+                        heartbeat_msg: notification_options.WS4REDIS_HEARTBEAT,
+                    });
+                }
             });
         });
         analytics.workflow('Entered the Form Builder');

--- a/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_designer.html
@@ -24,18 +24,6 @@
 
 {% block js-inline %}{{ block.super }}
     {% if request.guided_tour %}{% include request.guided_tour.template %}{% endif %}
-    <script>
-        {% if notifications_enabled %}
-            var userId = '{{ request.couch_user.get_id }}';
-            var notifications = hqImport('app_manager/js/app-notifications.js');
-            // initialize redis
-            var ws4redis = WS4Redis({
-                uri: '{{ WEBSOCKET_URI }}{{ notify_facility }}?subscribe-broadcast',
-                receive_message: notifications.NotifyFunction(userId, $('#notify-bar')),
-                heartbeat_msg: {{ WS4REDIS_HEARTBEAT }},
-            });
-        {% endif %}
-    </script>
 {% endblock %}
 
 {% block title %}{{ form.name|clean_trans:langs }}{% endblock %}
@@ -46,6 +34,7 @@
     {% initial_page_data 'guided_tour' request.guided_tour %}
     {% initial_page_data 'requirejs_args' requirejs_args %}
     {% initial_page_data 'requirejs_url' requirejs_url|static %}
+    {% initial_page_data 'notification_options' notification_options %}
     {% initial_page_data 'vellum_debug' vellum_debug %}
     {% initial_page_data 'vellum_options' vellum_options %}
     <div id="formdesigner" class="clearfix"></div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_designer.html
@@ -34,18 +34,6 @@
 
 {% block js-inline %}{{ block.super }}
     {% if request.guided_tour %}{% include request.guided_tour.template %}{% endif %}
-    <script>
-        {% if notifications_enabled %}
-            var userId = '{{ request.couch_user.get_id }}';
-            var notifications = hqImport('app_manager/js/app-notifications.js');
-            // initialize redis
-            var ws4redis = WS4Redis({
-                uri: '{{ WEBSOCKET_URI }}{{ notify_facility }}?subscribe-broadcast',
-                receive_message: notifications.NotifyFunction(userId, $('#notify-bar')),
-                heartbeat_msg: {{ WS4REDIS_HEARTBEAT }},
-            });
-        {% endif %}
-    </script>
 {% endblock %}
 
 {% block title %}{{ form.name|clean_trans:langs }}{% endblock %}
@@ -57,6 +45,7 @@
     {% initial_page_data 'form_name' form.name|trans:app.langs %}
     {% initial_page_data 'form_comment' form.comment %}
     {% initial_page_data 'form_uses_cases' form.uses_cases %}
+    {% initial_page_data 'notification_options' notification_options %}
     {% initial_page_data 'requirejs_args' requirejs_args %}
     {% initial_page_data 'requirejs_url' requirejs_url|static %}
     {% initial_page_data 'vellum_debug' vellum_debug %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_designer.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_designer.html.diff.txt
@@ -28,15 +28,17 @@
      <script src="{% static 'app_manager/js/form_designer.js' %}"></script>
  {% endblock %}
  
-@@ -44,11 +54,113 @@
+@@ -32,12 +42,114 @@
      {% initial_page_data 'CKEDITOR_BASEPATH' CKEDITOR_BASEPATH|static %}
      {% initial_page_data 'days_since_created' request.couch_user.days_since_created %}
      {% initial_page_data 'guided_tour' request.guided_tour %}
 +    {% initial_page_data 'form_name' form.name|trans:app.langs %}
 +    {% initial_page_data 'form_comment' form.comment %}
 +    {% initial_page_data 'form_uses_cases' form.uses_cases %}
++    {% initial_page_data 'notification_options' notification_options %}
      {% initial_page_data 'requirejs_args' requirejs_args %}
      {% initial_page_data 'requirejs_url' requirejs_url|static %}
+-    {% initial_page_data 'notification_options' notification_options %}
      {% initial_page_data 'vellum_debug' vellum_debug %}
      {% initial_page_data 'vellum_options' vellum_options %}
 -    <div id="formdesigner" class="clearfix"></div>

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -48,6 +48,7 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import cachebuster
 from corehq.apps.tour import tours
 from corehq.apps.analytics import ab_tests
 from corehq.apps.domain.models import Domain
+from corehq.util.context_processors import websockets_override
 
 
 logger = logging.getLogger(__name__)
@@ -143,8 +144,6 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
         'nav_form': form,
         'formdesigner': True,
         'include_fullstory': include_fullstory,
-        'notifications_enabled': request.user.is_superuser,
-        'notify_facility': get_facility_for_form(domain, app_id, form.unique_id),
     })
     notify_form_opened(domain, request.couch_user, app_id, form.unique_id)
 
@@ -240,6 +239,14 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
         'vellum_options': vellum_options,
         'CKEDITOR_BASEPATH': "app_manager/js/vellum/lib/ckeditor/",
     })
+
+    if request.user.is_superuser:
+        notification_options = websockets_override(request)
+        notification_options.update({
+            'notify_facility': get_facility_for_form(domain, app_id, form.unique_id),
+            'user_id': request.couch_user.get_id,
+        })
+        context.update({'notification_options': notification_options})
 
     if not settings.VELLUM_DEBUG:
         context.update({'requirejs_url': "app_manager/js/vellum/src"})


### PR DESCRIPTION
This reverts commit e294f6b227b4f949a31d7e8fb5e8ae66e4532257.

This was previously released and seemed to cause issues with form notifications (the "Bob has also opened this form for editing" ones) showing up repeatedly. I've been testing it out on staging and haven't been able to replicate, going to try re-releasing and testing on prod.

@emord / @millerdev 
fyi @proteusvacuum 

