### PR TITLE
paging device ids for infinite scroll without counts

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -280,10 +280,10 @@ class DeviceLogFilter(LoginAndDomainMixin, JSONResponseMixin, View):
             .values_list(self.field, flat=True)
             .order_by(self.field)
         )
-        values = query_set[self._offset():self._offset() + self._page_limit()]
+        values = query_set[self._offset():self._offset() + self._page_limit() + 1]
         return self.render_json_response({
-            'results': [{'id': v, 'text': v} for v in values],
-            'total': query_set.count(),
+            'results': [{'id': v, 'text': v} for v in values[:self._page_limit()]],
+            'more': len(values) > self._page_limit(),
         })
 
     def _page_limit(self):

--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -61,7 +61,7 @@
                          };
                     },
                     results: function (data, page) {
-                        var more = (page * 10) < data.total;
+                        var more = data.more || (page * 10) < data.total;
                         return {results: data.results, more: more};
                     }
                 },


### PR DESCRIPTION
@kaapstorm cc: @benrudolph @emord @NoahCarnahan 
This should fix the device log filters once and for all. The count call was taking forever since it was counting over subquery that did a `SELECT DISTINCT` on all device ids.