### PR TITLE
making sure not to miss anyone confirming account

### DIFF
--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -6,10 +6,14 @@ from corehq.apps.analytics.tasks import (
     update_hubspot_properties,
 )
 from corehq.apps.analytics.utils import get_meta
+from corehq.apps.registration.views import ProcessRegistrationView
 from corehq.util.decorators import handle_uncaught_exceptions
+from corehq.util.soft_assert import soft_assert
 from .tasks import identify
 
 from django.dispatch import receiver
+from django.urls import reverse
+
 
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.apps.accounting.models import (
@@ -24,6 +28,9 @@ from corehq.apps.accounting.signals import subscription_upgrade_or_downgrade
 from corehq.apps.domain.signals import commcare_domain_post_save
 from corehq.apps.users.signals import couch_user_post_save
 from corehq.apps.analytics.utils import get_instance_string
+
+
+_no_cookie_soft_assert = soft_assert('{}@{}'.format('cellowitz', 'dimagi.com'), send_to_ops=False)
 
 
 @receiver(couch_user_post_save)
@@ -143,7 +150,12 @@ def track_user_login(sender, request, user, **kwargs):
     if couch_user and couch_user.is_web_user():
         if not request or HUBSPOT_COOKIE not in request.COOKIES:
             # API calls, form submissions etc.
-            return
+
+            user_confirming = request.path.startswith(reverse(ProcessRegistrationView.urlname))
+            if user_confirming:
+                _no_cookie_soft_assert(False, 'User confirmed account but had no cookie')
+            else:
+                return
 
         meta = get_meta(request)
         track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES, meta, request.path)


### PR DESCRIPTION
@kaapstorm 
some users who confirm their accounts are not getting marked as such in hubspot. this is to fix a possible cause, and alert me if it turned out to be the cause