### PR TITLE
Fix custom enikshay ucr expressions

### DIFF
--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -174,12 +174,8 @@ def get_open_episode_case_from_person(domain, person_case_id):
 
 
 def get_open_referral_case_from_person(domain, person_case_id):
-    try:
-        episode = get_open_episode_case_from_person(domain, person_case_id)
-    except ENikshayCaseNotFound:
-        return None
     case_accessor = CaseAccessors(domain)
-    reverse_indexed_cases = case_accessor.get_reverse_indexed_cases([episode.case_id])
+    reverse_indexed_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
     open_referral_cases = [
         case for case in reverse_indexed_cases
         if not case.closed and case.type == CASE_TYPE_REFERRAL
@@ -195,9 +191,8 @@ def get_open_referral_case_from_person(domain, person_case_id):
 
 
 def get_latest_trail_case_from_person(domain, person_case_id):
-    episode = get_open_episode_case_from_person(domain, person_case_id)
     case_accessor = CaseAccessors(domain)
-    reverse_indexed_cases = case_accessor.get_reverse_indexed_cases([episode.case_id])
+    reverse_indexed_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
     trail_cases = [
         case for case in reverse_indexed_cases
         if case.type == CASE_TYPE_TRAIL

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -147,7 +147,7 @@ def get_adherence_case_structure(case_id, indexed_episode_id, adherence_date, ex
     )
 
 
-def get_referral_case_structure(case_id, indexed_episode_id, extra_update=None):
+def get_referral_case_structure(case_id, indexed_person_id, extra_update=None):
     extra_update = extra_update or {}
     return CaseStructure(
         case_id=case_id,
@@ -157,7 +157,7 @@ def get_referral_case_structure(case_id, indexed_episode_id, extra_update=None):
             "update": extra_update
         },
         indices=[CaseIndex(
-            CaseStructure(case_id=indexed_episode_id, attrs={"create": False}),
+            CaseStructure(case_id=indexed_person_id, attrs={"create": False}),
             identifier='host',
             relationship=CASE_INDEX_EXTENSION,
             related_type='episode',
@@ -361,7 +361,7 @@ class ENikshayCaseStructureMixin(object):
 
     def create_referral_case(self, case_id):
         return self.factory.create_or_update_cases([
-            get_referral_case_structure(case_id, self.episode_id)
+            get_referral_case_structure(case_id, self.person_id)
         ])
 
 


### PR DESCRIPTION
Whoops, looks like `trail` and `referral` cases are related to `person` cases, not `episode`s, so these expressions weren't working.
@proteusvacuum 