### PR TITLE
Use separate properties for MERM refill reminders

### DIFF
--- a/custom/enikshay/const.py
+++ b/custom/enikshay/const.py
@@ -12,14 +12,16 @@ MERM_ID = 'merm_id'
 MERM_DAILY_REMINDER_STATUS = 'merm_daily_reminder_status'
 MERM_DAILY_REMINDER_TIME = "merm_daily_reminder_time"
 MERM_REFILL_REMINDER_STATUS = "merm_refill_reminder_status"
-MERM_REFILL_REMINDER_DATETIME = "merm_refill_reminder_datetime"
+MERM_REFILL_REMINDER_DATE = "merm_refill_reminder_date"
+MERM_REFILL_REMINDER_TIME = "merm_refill_reminder_time"
 MERM_RT_HOURS = "merm_rt_hours"
 MERM_PROPERTIES = [
     MERM_ID,
     MERM_DAILY_REMINDER_STATUS,
     MERM_DAILY_REMINDER_TIME,
     MERM_REFILL_REMINDER_STATUS,
-    MERM_REFILL_REMINDER_DATETIME,
+    MERM_REFILL_REMINDER_DATE,
+    MERM_REFILL_REMINDER_TIME,
     MERM_RT_HOURS,
 ]
 

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -34,7 +34,8 @@ from custom.enikshay.const import (
     MERM_DAILY_REMINDER_STATUS,
     MERM_DAILY_REMINDER_TIME,
     MERM_REFILL_REMINDER_STATUS,
-    MERM_REFILL_REMINDER_DATETIME,
+    MERM_REFILL_REMINDER_DATE,
+    MERM_REFILL_REMINDER_TIME,
     MERM_RT_HOURS,
 )
 from custom.enikshay.exceptions import ENikshayCaseNotFound
@@ -45,9 +46,8 @@ class MermParams(jsonobject.JsonObject):
     daily_reminder_status = jsonobject.IntegerProperty(required=False, choices=(1, 0), exclude_if_none=True)
     daily_reminder_time = jsonobject.TimeProperty(required=False, exclude_if_none=True)  # HH:mm
     refill_reminder_status = jsonobject.IntegerProperty(required=False, choices=(1, 0), exclude_if_none=True)
-    refill_reminder_datetime = jsonobject.DateTimeProperty(
+    refill_reminder_datetime = jsonobject.StringProperty(
         required=False,
-        exact=True,
         exclude_if_none=True
     )  # yy/MM/dd HH:mm:ss
     RT_hours = jsonobject.IntegerProperty(
@@ -97,12 +97,19 @@ class PatientPayload(jsonobject.JsonObject):
                 he_code=person_locations.pcp,
             )
 
+        refill_reminder_date = episode_case_properties.get(MERM_REFILL_REMINDER_DATE, None)
+        refill_reminder_time = episode_case_properties.get(MERM_REFILL_REMINDER_TIME, None)
+        if refill_reminder_time and refill_reminder_date:
+            refill_reminder_datetime = "{}T{}".format(refill_reminder_date, refill_reminder_time)
+        else:
+            refill_reminder_datetime = None
+
         merm_params = MermParams(
             IMEI=episode_case_properties.get(MERM_ID, None),
             daily_reminder_status=episode_case_properties.get(MERM_DAILY_REMINDER_STATUS, None),
             daily_reminder_time=episode_case_properties.get(MERM_DAILY_REMINDER_TIME, None),
             refill_reminder_status=episode_case_properties.get(MERM_REFILL_REMINDER_STATUS, None),
-            refill_reminder_datetime=episode_case_properties.get(MERM_REFILL_REMINDER_DATETIME, None),
+            refill_reminder_datetime=refill_reminder_datetime,
             RT_hours=episode_case_properties.get(MERM_RT_HOURS, None),
         )
 


### PR DESCRIPTION
HQ munges dates that come in timezone agnostic. So save this as 2 properties

@NoahCarnahan @esoergel 