### PR TITLE
Ce/overwrite app

### DIFF
--- a/corehq/apps/app_manager/management/commands/overwrite_app.py
+++ b/corehq/apps/app_manager/management/commands/overwrite_app.py
@@ -28,6 +28,5 @@ class Command(BaseCommand):
     @property
     def report_map(self):
         if not self._report_map:
-            self._report_map = {}
-            self._report_map = get_static_report_mapping(self.from_domain, self.to_domain, self._report_map)
+            self._report_map = get_static_report_mapping(self.from_domain, self.to_domain, {})
         return self._report_map

--- a/corehq/apps/app_manager/management/commands/overwrite_app.py
+++ b/corehq/apps/app_manager/management/commands/overwrite_app.py
@@ -1,0 +1,47 @@
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.dbaccessors import get_current_app_doc, get_app, wrap_app
+from corehq.apps.app_manager.models import Application, ReportModule
+from corehq.apps.userreports.util import copy_static_reports
+
+
+class Command(BaseCommand):
+    """
+    Overwrites target application with other application
+    """
+
+    args = "<from_domain> ><from_app_id> <to_domain> <to_app_id>"
+
+    def add_arguments(self, parser):
+        parser.add_argument('from_domain')
+        parser.add_argument('from_app_id')
+        parser.add_argument('to_domain')
+        parser.add_argument('to_app_id')
+
+    def handle(self, from_domain, from_app_id, to_domain, to_app_id, *args, **options):
+        self.from_domain = from_domain
+        self.to_domain = to_domain
+        app = get_current_app_doc(self.to_domain, to_app_id)
+        latest_master_build = get_app(None, from_app_id, latest=True)
+        excluded_fields = set(Application._meta_fields).union(
+            ['date_created', 'build_profiles', 'copy_history', 'copy_of', 'name', 'comment', 'doc_type']
+        )
+        master_json = latest_master_build.to_json()
+        for key, value in master_json.iteritems():
+            if key not in excluded_fields:
+                app[key] = value
+        app['version'] = master_json['version']
+        wrapped_app = wrap_app(app)
+        for module in wrapped_app.modules:
+            if isinstance(module, ReportModule):
+                for config in module.report_configs:
+                    config.report_id = self.report_map[config.report_id]
+        wrapped_app.copy_attachments(latest_master_build)
+        wrapped_app.save(increment_version=False)
+
+    @property
+    def report_map(self):
+        if not self._report_map:
+            self._report_map = {}
+            copy_static_reports(self.from_domain, self.to_domain, self._report_map)
+        return self._report_map

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -7,9 +7,9 @@ from django.http import HttpResponseRedirect
 from django.template.loader import render_to_string
 
 from corehq import toggles
-from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.dbaccessors import get_app, wrap_app
 from corehq.apps.app_manager.decorators import require_deploy_apps
-
+from corehq.apps.app_manager.models import Application, ReportModule
 
 CASE_TYPE_CONFLICT_MSG = (
     "Warning: The form's new module "
@@ -125,3 +125,28 @@ def get_blank_form_xml(form_name):
         'xmlns': str(uuid.uuid4()).upper(),
         'name': form_name,
     })
+
+
+def overwrite_app(app, master_build, include_ucrs=False, report_map=None):
+    excluded_fields = set(Application._meta_fields).union(
+        ['date_created', 'build_profiles', 'copy_history', 'copy_of', 'name', 'comment', 'doc_type']
+    )
+    master_json = master_build.to_json()
+    for key, value in master_json.iteritems():
+        if key not in excluded_fields:
+            app[key] = value
+    app['version'] = master_json['version']
+    wrapped_app = wrap_app(app)
+    errors = False
+    for module in wrapped_app.modules:
+        if isinstance(module, ReportModule):
+            if include_ucrs and report_map is not None:
+                for config in module.report_configs:
+                    config.report_id = report_map[config.report_id]
+            else:
+                errors = True
+                break
+    if not errors:
+        wrapped_app.copy_attachments(master_build)
+        wrapped_app.save(increment_version=False)
+    return errors

--- a/corehq/apps/hqadmin/management/commands/clone_domain.py
+++ b/corehq/apps/hqadmin/management/commands/clone_domain.py
@@ -6,6 +6,7 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.calendar_fixture.models import CalendarFixtureSettings
 from corehq.apps.locations.models import LocationFixtureConfiguration
 from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain, get_datasources_for_domain
+from corehq.apps.userreports.util import copy_static_reports
 from corehq.blobs.mixin import BlobMixin
 from corehq.apps.userreports.models import (
     CUSTOM_REPORT_PREFIX,
@@ -252,25 +253,7 @@ class Command(BaseCommand):
 
             old_id, new_id = self.save_couch_copy(report, self.new_domain)
             report_map[old_id] = new_id
-        for static_report in StaticReportConfiguration.by_domain(self.existing_domain):
-            if static_report.get_id.startswith(STATIC_PREFIX):
-                report_id = static_report.get_id.replace(
-                    STATIC_PREFIX + self.existing_domain + '-',
-                    ''
-                )
-                is_custom_report = False
-            else:
-                report_id = static_report.get_id.replace(
-                    CUSTOM_REPORT_PREFIX + self.existing_domain + '-',
-                    ''
-                )
-                is_custom_report = True
-            new_id = StaticReportConfiguration.get_doc_id(
-                self.new_domain, report_id, is_custom_report
-            )
-            # check that new report is in new domain's list of static reports
-            StaticReportConfiguration.by_id(new_id)
-            report_map[static_report.get_id] = new_id
+        copy_static_reports(self.existing_domain, self.new_domain, report_map)
         return report_map
 
     def copy_ucr_datasources(self):

--- a/corehq/apps/hqadmin/management/commands/clone_domain.py
+++ b/corehq/apps/hqadmin/management/commands/clone_domain.py
@@ -282,15 +282,6 @@ class Command(BaseCommand):
 
             old_id, new_id = self.save_couch_copy(datasource, self.new_domain)
             datasource_map[old_id] = new_id
-        for static_datasource in StaticDataSourceConfiguration.by_domain(self.existing_domain):
-            table_id = static_datasource.get_id.replace(
-                StaticDataSourceConfiguration._datasource_id_prefix + self.existing_domain + '-',
-                ''
-            )
-            new_id = StaticDataSourceConfiguration.get_doc_id(self.new_domain, table_id)
-            # check that new datasource is in new domain's list of static datasources
-            StaticDataSourceConfiguration.by_id(new_id)
-            datasource_map[static_datasource.get_id] = new_id
         return datasource_map
 
     def copy_auto_case_update_rules(self):

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -190,7 +190,7 @@ def get_async_indicator_modify_lock_key(doc_id):
     return 'async_indicator_save-{}'.format(doc_id)
 
 
-def copy_static_reports(from_domain, to_domain, report_map):
+def get_static_report_mapping(from_domain, to_domain, report_map):
     from corehq.apps.userreports.models import StaticReportConfiguration, STATIC_PREFIX, \
         CUSTOM_REPORT_PREFIX
 
@@ -213,3 +213,4 @@ def copy_static_reports(from_domain, to_domain, report_map):
         # check that new report is in new domain's list of static reports
         StaticReportConfiguration.by_id(new_id)
         report_map[static_report.get_id] = new_id
+        return report_map

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -3,11 +3,9 @@ import collections
 import hashlib
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
 
-from corehq.apps.userreports.models import StaticDataSourceConfiguration, StaticReportConfiguration, STATIC_PREFIX, \
+from corehq.apps.userreports.models import StaticReportConfiguration, STATIC_PREFIX, \
     CUSTOM_REPORT_PREFIX
-from corehq.util.soft_assert import soft_assert
 from corehq import privileges, toggles
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.userreports.const import (
@@ -20,7 +18,6 @@ from corehq.apps.userreports.const import (
 from django_prbac.utils import has_privilege
 
 from corehq.apps.userreports.dbaccessors import get_all_es_data_sources
-from corehq.apps.userreports.exceptions import BadBuilderConfigError
 
 
 def localize(value, lang):

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -4,8 +4,6 @@ import hashlib
 
 from django.conf import settings
 
-from corehq.apps.userreports.models import StaticReportConfiguration, STATIC_PREFIX, \
-    CUSTOM_REPORT_PREFIX
 from corehq import privileges, toggles
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.userreports.const import (
@@ -193,6 +191,9 @@ def get_async_indicator_modify_lock_key(doc_id):
 
 
 def copy_static_reports(from_domain, to_domain, report_map):
+    from corehq.apps.userreports.models import StaticReportConfiguration, STATIC_PREFIX, \
+        CUSTOM_REPORT_PREFIX
+
     for static_report in StaticReportConfiguration.by_domain(from_domain):
         if static_report.get_id.startswith(STATIC_PREFIX):
             report_id = static_report.get_id.replace(


### PR DESCRIPTION
@snopoke cc: @kaapstorm @sheelio 
New management command for copying the icds apps back after the ucr migration. This can easily be expanded to allow linked apps to work with static ucrs so I am going to work on adding that in after this.

(This assumes all relevant UCRs are static, if that is not the case I figure out the rest)