### PR TITLE
remove small es ICDS ucrs from laboratory

### DIFF
--- a/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
+++ b/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
@@ -408,10 +408,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
@@ -902,10 +902,6 @@
         ]
       }
     },
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/hardware_cases.json
+++ b/custom/icds_reports/ucr/data_sources/hardware_cases.json
@@ -531,10 +531,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -1352,10 +1352,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
+++ b/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
@@ -139,10 +139,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
@@ -417,10 +417,6 @@
         "property_value": "ls"
       }
     },
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/vhnd_form.json
@@ -709,10 +709,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
+++ b/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
@@ -326,10 +326,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }


### PR DESCRIPTION
I don't think that this is going to help the ES cluster health, but I don't think these indexes are much use when they are this small. Once we have a smarter rebuild function, it should be simple to rebuild these if they become necessary later

UCR | # docs | size of ES index
--------|-----------|------------------------
hardware | 25 K | 18 MB
tech issues | 6 K | 4 MB
child delivery | 54 K | 18.6 MB
vhnd form | 14 K | 7.5 MB
visitor book | 16 K | 6.5 MB
AWC mgmt | 159 | 147 KB
infratructure | 48 K | 45 MB
LS home visits | 89 | 129 KB

@dimagi/scale-team  @orangejenny 