### PR TITLE
Add some metrics for export duration

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import tempfile
 import time
+import sys
 from collections import Counter
 
 import datetime
@@ -356,26 +357,70 @@ def _write_export_instance(writer, export_instance, documents, progress_tracker=
     if progress_tracker:
         DownloadBase.set_progress(progress_tracker, 0, documents.count)
 
-    start = int(time.time() * 1000)
+    start = _time_in_milliseconds()
+    total_bytes = 0
+    total_rows = 0
+
     for row_number, doc in enumerate(documents):
+        doc_bytes = sys.getsizeof(doc)
+        total_bytes += doc_bytes
         for table in export_instance.selected_tables:
+            compute_start = _time_in_milliseconds()
             rows = table.get_rows(
                 doc,
                 row_number,
                 split_columns=export_instance.split_multiselects,
                 transform_dates=export_instance.transform_dates,
             )
+            compute_end = _time_in_milliseconds()
+            _record_datadog_export_compute_rows(compute_start, compute_end, doc_bytes, len(rows))
+
+            write_start = _time_in_milliseconds()
             for row in rows:
                 # It might be bad to write one row at a time when you can do more (from a performance perspective)
                 # Regardless, we should handle the batching of rows in the _Writer class, not here.
                 writer.write(table, row)
+            write_end = _time_in_milliseconds()
+
+            _record_datadog_export_write_rows(write_start, write_end, doc_bytes, len(rows))
+
+            total_rows += len(rows)
+
         if progress_tracker:
             DownloadBase.set_progress(progress_tracker, row_number + 1, documents.count)
 
-    end = int(time.time() * 1000)
-    if documents.count:
-        datadog_histogram('commcare.export_duration', end - start)
-        datadog_histogram('commcare.normalized_export_duration', (end - start) / (documents.count))
+    end = _time_in_milliseconds()
+    _record_datadog_export_write_rows(start, end, total_bytes, total_rows)
+
+
+def _time_in_milliseconds():
+    return int(time.time() * 1000)
+
+
+def _record_datadog_export_compute_rows(start, end, doc_bytes, n_rows):
+    __record_datadog_export(start, end, doc_bytes, n_rows, 'commcare.compute_export_rows_duration')
+
+
+def _record_datadog_export_write_rows(start, end, doc_bytes, n_rows):
+    __record_datadog_export(start, end, doc_bytes, n_rows, 'commcare.write_export_rows_duration')
+
+
+def _record_datadog_export_duration(start, end, doc_bytes, n_rows):
+    __record_datadog_export(start, end, doc_bytes, n_rows, 'commcare.export_duration')
+
+
+def __record_datadog_export(start, end, doc_bytes, n_rows, metric):
+    datadog_histogram(metric, end - start)
+    if doc_bytes:
+        datadog_histogram(
+            '{}_normalized_by_size'.format(metric),
+            (end - start) / doc_bytes,
+        )
+    if n_rows:
+        datadog_histogram(
+            '{}_normalized_by_rows'.format(metric),
+            (end - start) / n_rows,
+        )
 
 
 def _get_base_query(export_instance):

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -390,7 +390,7 @@ def _write_export_instance(writer, export_instance, documents, progress_tracker=
     end = _time_in_milliseconds()
     _record_datadog_export_write_rows(write_total, total_bytes, total_rows)
     _record_datadog_export_compute_rows(compute_total, total_bytes, total_rows)
-    _record_datadog_export_write_rows(end - start, total_bytes, total_rows)
+    _record_datadog_export_duration(end - start, total_bytes, total_rows, tags)
 
 
 def _time_in_milliseconds():


### PR DESCRIPTION
@snopoke couldn't think of any reasonable tags to add here. it'd be kind of nice to correlate with size of document. worth bucketing the average doc size as a tag? otherwise i think domain will generate too many metrics

cc: @mkangia 