### PR TITLE
clean up es facets

### DIFF
--- a/corehq/apps/data_analytics/esaccessors.py
+++ b/corehq/apps/data_analytics/esaccessors.py
@@ -13,6 +13,7 @@ from dimagi.utils.dates import add_months
 
 
 def get_app_submission_breakdown_es(domain_name, monthspan):
+    # takes > 1 m to load at 50k worker scale
     terms = [
         AggregationTerm('app_id', 'app_id'),
         AggregationTerm('device_id', 'form.meta.deviceID'),

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -339,7 +339,7 @@ def calced_props(dom, id, all_stats):
         "cp_n_active_cc_users": int(CALC_FNS["mobile_users"](dom)),
         "cp_n_cc_users": int(all_stats["commcare_users"].get(dom, 0)),
         "cp_n_active_cases": int(CALC_FNS["cases_in_last"](dom, 120)),
-        "cp_n_users_submitted_form": total_distinct_users([dom]),
+        "cp_n_users_submitted_form": total_distinct_users(dom),
         "cp_n_inactive_cases": int(CALC_FNS["inactive_cases_in_last"](dom, 120)),
         "cp_n_30_day_cases": int(CALC_FNS["cases_in_last"](dom, 30)),
         "cp_n_60_day_cases": int(CALC_FNS["cases_in_last"](dom, 60)),

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -86,7 +86,7 @@ as the ``debug_host`` to the constructor:
 Language
 --------
 
- * es_query - the entire query, filters, query, pagination, facets
+ * es_query - the entire query, filters, query, pagination
  * filters - a list of the individual filters
  * query - the query, used for searching, not filtering
  * field - a field on the document. User docs have a 'domain' field.
@@ -161,7 +161,6 @@ class ESQuery(object):
 
         self.debug_host = debug_host
         self._default_filters = deepcopy(self.default_filters)
-        self._facets = []
         self._aggregations = []
         self._source = None
         self.es_instance_alias = es_instance_alias

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -37,10 +37,8 @@ from corehq.apps.domain.calculations import (
     all_domain_stats,
     calced_props,
     CALC_FNS,
-    total_distinct_users,
 )
 from corehq.apps.es.domains import DomainES
-from corehq.apps.indicators.utils import get_mvp_domains
 from corehq.elastic import (
     stream_es_query,
     send_to_elasticsearch,


### PR DESCRIPTION
When looking at the ES cluster I remembered that something blocking us from upgrading to 2.x is facets. I got rid of a couple of easy wins. I think the  remaining parts that would need to migrate are:

- admin reports
- exchange
- pact reports
- bihar reports (I think this project spun down though, so wecan remove that?)

admin reports will probably be the worst to migrate, but I don't see anything at the moment that would block us 

buddy @orangejenny 