### PR TITLE
use correct value in es filter

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -174,7 +174,7 @@ class NumericFilterValue(FilterValue):
             return None
 
         filter_class = self.operators_to_filters[self.value['operator']].es
-        return filter_class(self.filter.field, self.filter.value)
+        return filter_class(self.filter.field, self.value['operand'])
 
 
 class BasicBetweenFilter(BasicFilter):


### PR DESCRIPTION
found while going through icds errors. Looks like we don't have any end to end tests for filters. Will think about the best way to write those.

@orangejenny 