### PR TITLE
fix datadog metric for topics given by partitioned kafka feed

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -17,6 +17,8 @@ def _topic_for_ddog(topic):
     # can be a string for couch pillows, but otherwise is topic, partition
     if isinstance(topic, TopicAndPartition):
         return 'topic:{}-{}'.format(topic.topic, topic.partition)
+    elif isinstance(topic, tuple) and len(topic) == 2:
+        return 'topic:{}-{}'.format(topic[0], topic[1])
     else:
         return 'topic:{}'.format(topic)
 


### PR DESCRIPTION
The partitioned kafka feed has been incorrectly reporting. Should get in before ICDS deploy @calellowitz 

Long term I think we should separate topic and partition in datadog, but doing this for now since it's what we've been doing.

buddy @orangejenny 