### PR TITLE
Allow datasets to be sent immediately

### DIFF
--- a/corehq/apps/dhis2/tasks.py
+++ b/corehq/apps/dhis2/tasks.py
@@ -12,7 +12,7 @@ from toggle.shortcuts import find_domains_with_toggle_enabled
 
 
 @task(queue='background_queue')
-def send_datasets(domain_name):
+def send_datasets(domain_name, send_now=False):
     """
     Sends a data set of data values in the following format:
 
@@ -43,7 +43,7 @@ def send_datasets(domain_name):
         domain_name=domain_name,
     )
     for dataset_map in dataset_maps:
-        if dataset_map.should_send_on_date(datetime.today()):
+        if send_now or dataset_map.should_send_on_date(datetime.today()):
             api.post('dataValueSets', dataset_map.get_dataset())
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -646,7 +646,7 @@ def logo(request, domain):
 @require_POST
 @domain_admin_required
 def send_dhis2_data(request, domain):
-    send_datasets.delay(domain)
+    send_datasets.delay(domain, send_now=True)
     return json_response({'success': _('Data is being sent to DHIS2.')}, status_code=202)
 
 


### PR DESCRIPTION
If a user tells HQ to send data to DHIS2, it should send it regardless of what day it is. :roll_eyes: 

@calellowitz cc @sheelio 
