### PR TITLE
Add separate path for expanding inline details

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -59,6 +59,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 "previewCommand": params.previewCommand,
                 "installReference": params.installReference,
                 "oneQuestionPerScreen": displayOptions.oneQuestionPerScreen,
+                "isPersistent": params.isPersistent,
             });
             options.url = formplayerUrl + '/' + route;
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -76,7 +76,8 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
         return Menus.API.queryFormplayer(options, 'navigate_menu');
     });
 
-    FormplayerFrontend.reqres.setHandler("entity:get:details", function (options) {
+    FormplayerFrontend.reqres.setHandler("entity:get:details", function (options, isPersistent) {
+        options.isPersistent = isPersistent;
         return Menus.API.queryFormplayer(options, 'get_details');
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -44,10 +44,10 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
             });
         },
 
-        selectDetail: function(caseId, detailIndex) {
+        selectDetail: function(caseId, detailIndex, isPersistent) {
             var urlObject = Util.currentUrlToObject();
             urlObject.addStep(caseId);
-            var fetchingDetails = FormplayerFrontend.request("entity:get:details", urlObject);
+            var fetchingDetails = FormplayerFrontend.request("entity:get:details", urlObject, isPersistent);
             $.when(fetchingDetails).done(function (detailResponse) {
                 Menus.Controller.showDetail(detailResponse, detailIndex, caseId);
             }).fail(function() {
@@ -179,7 +179,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
             $("#persistent-cell-layout-style").html(caseTileStyles[0]).data("css-polyfilled", false);
             // Style the grid (IE each tile has 6 rows, 12 columns)
             $("#persistent-cell-grid-style").html(caseTileStyles[1]).data("css-polyfilled", false);
-            return new Menus.Views.CaseTileView({
+            return new Menus.Views.PersistentCaseTileView({
                 model: detailModel,
                 styles: detailObject.styles,
                 tiles: detailObject.tiles,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -218,7 +218,7 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
 
         rowClick: function (e) {
             e.preventDefault();
-            FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0);
+            FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, false);
         },
 
         templateHelpers: function () {
@@ -245,6 +245,13 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
             var dict = Views.CaseTileView.__super__.templateHelpers.apply(this, arguments);
             dict['prefix'] = this.options.prefix;
             return dict;
+        },
+    });
+
+    Views.PersistentCaseTileView = Views.CaseTileView.extend({
+        rowClick: function (e) {
+            e.preventDefault();
+            FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, true);
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -218,7 +218,7 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
 
         rowClick: function (e) {
             e.preventDefault();
-            FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, false);
+            FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, false);
         },
 
         templateHelpers: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -59,8 +59,8 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
         listSettings: function() {
             FormplayerFrontend.Apps.Controller.listSettings();
         },
-        showDetail: function (caseId, detailTabIndex) {
-            FormplayerFrontend.Menus.Controller.selectDetail(caseId, detailTabIndex);
+        showDetail: function (caseId, detailTabIndex, isPersistent) {
+            FormplayerFrontend.Menus.Controller.selectDetail(caseId, detailTabIndex, isPersistent);
         },
         listSessions: function() {
             SessionNavigate.SessionList.Controller.listSessions();
@@ -178,8 +178,8 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
         API.listSettings();
     });
 
-    FormplayerFrontend.on("menu:show:detail", function (caseId, detailTabIndex) {
-        API.showDetail(caseId, detailTabIndex);
+    FormplayerFrontend.on("menu:show:detail", function (caseId, detailTabIndex, isPersistent) {
+        API.showDetail(caseId, detailTabIndex, isPersistent);
     });
 
     FormplayerFrontend.on("sessions", function () {


### PR DESCRIPTION
When clicking a case tile while on a case list this action was indistinguishable from clicking a case list row (IE both made a `get_details` call with the same step args). This fixes that by adding a slightly different path for persistent case tile expansion.

Fixes: https://manage.dimagi.com/default.asp?252775
cross-request: https://github.com/dimagi/formplayer/pull/413