### PR TITLE
Update diagnostic test task to show investigation name not id

### DIFF
--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -564,10 +564,18 @@ class EpisodeTestUpdate(object):
     def update_json(self):
         if self.diagnostic_tests:
             return {
-                'diagnostic_tests': ", ".join([diagnostic_test.get_case_property('investigation_id')
+                'diagnostic_tests': ", ".join([self._get_diagnostic_test_name(diagnostic_test)
                                                for diagnostic_test in self.diagnostic_tests]),
                 'diagnostic_test_results': ", ".join([diagnostic_test.get_case_property('result_grade')
                                                       for diagnostic_test in self.diagnostic_tests])
             }
         else:
             return {}
+
+    def _get_diagnostic_test_name(self, diagnostic_test):
+        site_specimen_name = diagnostic_test.get_case_property('site_specimen_name')
+        if site_specimen_name:
+            return "{}: {}".format(
+                diagnostic_test.get_case_property('investigation_type_name'), site_specimen_name)
+        else:
+            return diagnostic_test.get_case_property('investigation_type_name')

--- a/custom/enikshay/tests/test_diagnostic_results_task.py
+++ b/custom/enikshay/tests/test_diagnostic_results_task.py
@@ -1,6 +1,8 @@
 from mock import patch, MagicMock
 from django.test import TestCase, override_settings
 
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
+
 from custom.enikshay.tasks import EpisodeTestUpdate
 from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
 
@@ -10,6 +12,7 @@ from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
 class TestDiagnosticInvestigationsTask(ENikshayCaseStructureMixin, TestCase):
     def setUp(self):
         super(TestDiagnosticInvestigationsTask, self).setUp()
+        delete_all_users()
         self.cases = self.create_case_structure()
         self.updater = EpisodeTestUpdate(self.domain, self.cases[self.episode_id])
 
@@ -18,26 +21,29 @@ class TestDiagnosticInvestigationsTask(ENikshayCaseStructureMixin, TestCase):
             'enrolled_in_private': 'true',
             'date_reported': '2017-08-13',
             'purpose_of_test': 'diagnostic',
-            'investigation_id': 'ABC-ABC-ABC',
+            'investigation_type_name': 'X-Ray',
+            'site_specimen_name': 'Chest',
             'result_grade': 'TB Not Detected: scanty'
         })
         self.create_test_case(self.occurrence_id, {
             'enrolled_in_private': 'true',
             'date_reported': '2017-08-14',
             'purpose_of_test': 'diagnostic',
-            'investigation_id': 'DEF-DEF-DEF',
+            'investigation_type_name': 'CBNAAT',
+            'site_specimen_name': 'Sputum',
             'result_grade': 'TB Detected: 3+ scanty',
         })
         self.create_test_case(self.occurrence_id, {
             'enrolled_in_private': 'true',
             'date_reported': '2017-08-15',
             'purpose_of_test': 'followup',
-            'investigation_id': 'DEF-BCD-DEF',
+            'investigation_type_name': 'Sputum Microscopy',
+            'site_specimen_name': 'Sputum',
             'result_grade': 'TB Detected: 3+ scanty',
         })
 
         expected = {
-            'diagnostic_tests': u'ABC-ABC-ABC, DEF-DEF-DEF',
+            'diagnostic_tests': u'X-Ray: Chest, CBNAAT: Sputum',
             'diagnostic_test_results': u'TB Not Detected: scanty, TB Detected: 3+ scanty'
         }
 


### PR DESCRIPTION
This should load the investigation name, not the id
@snopoke buddy
@sravfeyn 