### PR TITLE
Update continuous indexing frequency

### DIFF
--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -11,7 +11,7 @@ def run_continuous_indexing_task():
     preindex_couch_views.delay()
 
 
-@serial_task('couch-continuous-indexing', timeout=60 * 60, queue='background_queue', max_retries=0)
+@serial_task('couch-continuous-indexing', timeout=60 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
 def preindex_couch_views():
     for design in get_preindex_designs():
         index_design_doc(design)

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -4,7 +4,7 @@ from celery.task.base import periodic_task
 from corehq.preindex.accessors import index_design_doc, get_preindex_designs
 
 
-@periodic_task(run_every=crontab(minute=0), queue='background_queue')
+@periodic_task(run_every=crontab(minute='*/5'), queue='background_queue')
 def preindex_couch_views():
     for design in get_preindex_designs():
         index_design_doc(design)

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -2,9 +2,16 @@ from celery.schedules import crontab
 from celery.task.base import periodic_task
 
 from corehq.preindex.accessors import index_design_doc, get_preindex_designs
+from corehq.util.decorators import serial_task
+from django.conf import settings
 
 
-@periodic_task(run_every=crontab(minute='*/5'), queue='background_queue')
+@periodic_task(run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)
+def run_continuous_indexing_task():
+    preindex_couch_views.delay()
+
+
+@serial_task('couch-continuous-indexing', timeout=60 * 60, queue='background_queue', max_retries=0)
 def preindex_couch_views():
     for design in get_preindex_designs():
         index_design_doc(design)


### PR DESCRIPTION
Seems like the couch timings spike on the hour, which might be related to this task.

![hourly-couch-slowness](https://user-images.githubusercontent.com/1028814/27224070-43ffd25c-5261-11e7-863c-fbf90a2d045a.png)

This makes the task run every 5 minutes which should reduce the amount of indexing needed.

Alternatively, we could also only run this task off-hours.

@dimagi/scale-team 