### PR TITLE
add riak errors to sentry rate limited errors

### DIFF
--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -5,6 +5,8 @@ from corehq.util.datadog.gauges import datadog_counter
 
 RATE_LIMITED_EXCEPTIONS = {
     'botocore.vendored.requests.packages.urllib3.exceptions.ProtocolError': 'riak',
+    'botocore.vendored.requests.ReadTimeout': 'riak',
+    'botocore.exceptions.ClientError': 'riak',
     'OperationalError': 'postgres',  # could be psycopg2._psycopg or django.db.utils
     'socket.error': 'rabbitmq',
     'redis.exceptions.ConnectionError': 'redis',


### PR DESCRIPTION
@calellowitz 

We got a lot of the errors last night on icds, but they don't show up under the ICDS success dashboard