### PR TITLE
Enikshay: Custom UCR filter for referral report

### DIFF
--- a/corehq/apps/userreports/reports/filters/__init__.py
+++ b/corehq/apps/userreports/reports/filters/__init__.py
@@ -1,1 +1,13 @@
+from __future__ import absolute_import
 
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
+from corehq.apps.userreports.reports.filters.specs import ReportFilter
+
+for type_name, path_to_class in settings.CUSTOM_UCR_REPORT_FILTER_VALUES:
+    ReportFilter._class_map[type_name] = import_string(path_to_class)
+
+for type_name, path_to_func in settings.CUSTOM_UCR_REPORT_FILTERS:
+    ReportFilterFactory.constructor_map[type_name] = import_string(path_to_func)

--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -32,17 +32,19 @@ class ReportFilter(JsonObject):
     display = DefaultProperty()
     compare_as_string = BooleanProperty(default=False)
 
+    _class_map = {
+        'quarter': QuarterFilterValue,
+        'date': DateFilterValue,
+        'numeric': NumericFilterValue,
+        'pre': PreFilterValue,
+        'choice_list': ChoiceListFilterValue,
+        'dynamic_choice_list': ChoiceListFilterValue,
+        'multi_field_dynamic_choice_list': MultiFieldChoiceListFilterValue,
+        'location_drilldown': LocationDrilldownFilterValue,
+    }
+
     def create_filter_value(self, value):
-        return {
-            'quarter': QuarterFilterValue,
-            'date': DateFilterValue,
-            'numeric': NumericFilterValue,
-            'pre': PreFilterValue,
-            'choice_list': ChoiceListFilterValue,
-            'dynamic_choice_list': ChoiceListFilterValue,
-            'multi_field_dynamic_choice_list': MultiFieldChoiceListFilterValue,
-            'location_drilldown': LocationDrilldownFilterValue,
-        }[self.type](self, value)
+        return self._class_map[self.type](self, value)
 
 
 class FilterChoice(JsonObject):

--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -62,7 +62,10 @@ class FilterSpec(JsonObject):
     """
     type = StringProperty(
         required=True,
-        choices=['date', 'quarter', 'numeric', 'pre', 'choice_list', 'dynamic_choice_list', 'location_drilldown']
+        choices=[
+            'date', 'quarter', 'numeric', 'pre', 'choice_list', 'dynamic_choice_list', 'location_drilldown',
+            'enikshay_location_hierarchy'
+        ]
     )
     # this shows up as the ID in the filter HTML.
     slug = StringProperty(required=True)

--- a/custom/enikshay/tests/test_location_hierarchy_filter.py
+++ b/custom/enikshay/tests/test_location_hierarchy_filter.py
@@ -26,8 +26,8 @@ class LocationHierarchyFilterTests(ENikshayLocationStructureMixin, TestCase):
 
         else:
             # Need to implement other filter types
-            raise NotImplementedError, "assertFiltersEqual has not been defined for {} type filters".format(
-                type(filter_1)
+            raise NotImplementedError(
+                "assertFiltersEqual has not been defined for {} type filters".format(type(filter_1))
             )
 
     def test_filter(self):

--- a/custom/enikshay/tests/test_location_hierarchy_filter.py
+++ b/custom/enikshay/tests/test_location_hierarchy_filter.py
@@ -1,0 +1,77 @@
+from django.test import override_settings, TestCase
+from mock import MagicMock, patch
+
+from sqlagg.filters import EQ, OR
+
+from corehq.apps.userreports.models import ReportConfiguration, DataSourceConfiguration
+from corehq.apps.userreports.reports.factory import ReportFactory
+from corehq.apps.userreports.reports.view import get_filter_values
+from custom.enikshay.tests.utils import ENikshayLocationStructureMixin
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+class LocationHierarchyFilterTests(ENikshayLocationStructureMixin, TestCase):
+
+    domain = "location-filter-test-domain"
+
+    def assertFiltersEqual(self, filter_1, filter_2):
+        self.assertEqual(type(filter_1), type(filter_2))
+        if isinstance(filter_1, OR):
+            self.assertEqual(len(filter_1.filters), len(filter_2.filters))
+            for i in range(len(filter_1.filters)):
+                self.assertFiltersEqual(filter_1.filters[i], filter_2.filters[i])
+        elif isinstance(filter_1, EQ):
+            self.assertEqual(filter_1.column_name, filter_2.column_name)
+            self.assertEqual(filter_1.parameter, filter_2.parameter)
+
+        else:
+            # Need to implement other filter types
+            raise NotImplementedError, "assertFiltersEqual has not been defined for {} type filters".format(type(filter_1))
+
+    def test_filter(self):
+        slug = "hierarchy_filter_slug"
+        filter_spec = {
+            "type": "enikshay_location_hierarchy",
+            "display": "location hierarchy",
+            "datatype": "string",
+            "slug": slug,
+            "field": "does_not_matter",
+        }
+        data_source_config = DataSourceConfiguration(
+            domain=self.domain,
+            referenced_doc_type="",
+            table_id="123",
+        )
+
+        with patch("corehq.apps.userreports.reports.data_source.get_datasource_config", MagicMock(return_value=(data_source_config, None))):
+            report_config = ReportConfiguration(
+                config_id="123",
+                filters=[filter_spec]
+            )
+            report = ReportFactory().from_spec(report_config)
+            filter_values = get_filter_values(
+                report_config.ui_filters,
+                {slug: self.sto.location_id},
+                user=MagicMock(),
+            )
+            report.set_filter_values(filter_values)
+
+
+        expected_filter_vals = {
+            '{}_ctd'.format(slug): self.ctd.location_id,
+            '{}_below_sto'.format(slug): self.sto.location_id,
+        }
+        expected_filter = OR([
+            EQ("ctd", "{}_ctd".format(slug)),
+            EQ("below_sto", "{}_below_sto".format(slug))
+        ])
+
+        self.assertEqual(len(report.data_source.filters), 1)
+        self.assertFiltersEqual(
+            report.data_source.filters[0],
+            expected_filter
+        )
+        self.assertEqual(
+            report.data_source.filter_values,
+            expected_filter_vals
+        )

--- a/custom/enikshay/tests/test_location_hierarchy_filter.py
+++ b/custom/enikshay/tests/test_location_hierarchy_filter.py
@@ -26,7 +26,9 @@ class LocationHierarchyFilterTests(ENikshayLocationStructureMixin, TestCase):
 
         else:
             # Need to implement other filter types
-            raise NotImplementedError, "assertFiltersEqual has not been defined for {} type filters".format(type(filter_1))
+            raise NotImplementedError, "assertFiltersEqual has not been defined for {} type filters".format(
+                type(filter_1)
+            )
 
     def test_filter(self):
         slug = "hierarchy_filter_slug"
@@ -43,7 +45,10 @@ class LocationHierarchyFilterTests(ENikshayLocationStructureMixin, TestCase):
             table_id="123",
         )
 
-        with patch("corehq.apps.userreports.reports.data_source.get_datasource_config", MagicMock(return_value=(data_source_config, None))):
+        with patch(
+                "corehq.apps.userreports.reports.data_source.get_datasource_config",
+                MagicMock(return_value=(data_source_config, None))
+        ):
             report_config = ReportConfiguration(
                 config_id="123",
                 filters=[filter_spec]
@@ -55,7 +60,6 @@ class LocationHierarchyFilterTests(ENikshayLocationStructureMixin, TestCase):
                 user=MagicMock(),
             )
             report.set_filter_values(filter_values)
-
 
         expected_filter_vals = {
             '{}_ctd'.format(slug): self.ctd.location_id,

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -372,6 +372,9 @@ class ENikshayLocationStructureMixin(object):
         self.project.save()
         _, locations = setup_enikshay_locations(self.domain)
         self.locations = locations
+
+        self.ctd = locations['CTD']
+
         self.sto = locations['STO']
         self.sto.metadata = {
             'nikshay_code': 'MH',

--- a/custom/enikshay/ucr_filters.py
+++ b/custom/enikshay/ucr_filters.py
@@ -60,6 +60,27 @@ class ENikshayLocationHierarchyFilterValue(FilterValue):
 
 
 class EnikshayLocationHiearachyFilter(DynamicChoiceListFilter):
+    """
+    A custom ucr report filter for the enikshay Referral Report.
+    This filter will use the selected filter to filter against multiple fields.
+    https://docs.google.com/document/d/1ejESqYoqSff0u4X72Fq0TYi7ll3IvH5KX3VWXzLyMQs/edit
+
+    Each referral in the data source has fields like:
+        cto
+        dto
+        sto
+        ...
+        below_cto
+        below_dto
+        below_sto
+        ...
+    corresponding to the location hieararchy levels.
+    If a person was referred to a location below a given level, then the below_<location_level> column will
+    contain the id of the location at <location_level>. The <location_level> column corresponding to the location
+    that the person was referred to will contain the location id, and the other location level columns will be
+    blank.
+    """
+
     def __init__(self, name, label, choice_provider, url_generator, css_id=None):
 
         super(EnikshayLocationHiearachyFilter, self).__init__(

--- a/custom/enikshay/ucr_filters.py
+++ b/custom/enikshay/ucr_filters.py
@@ -1,0 +1,85 @@
+from collections import namedtuple
+
+from sqlagg.filters import ORFilter, EQFilter
+
+from dimagi.utils.decorators.memoized import memoized
+
+from corehq.apps.es import filters
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.reports_core.filters import DynamicChoiceListFilter
+from corehq.apps.userreports.reports.filters.choice_providers import LocationChoiceProvider
+from corehq.apps.userreports.reports.filters.specs import FilterSpec
+from corehq.apps.userreports.reports.filters.values import FilterValue, dynamic_choice_list_url
+
+_LocationFilter = namedtuple("_LocationFilter", "column parameter_slug filter_value")
+
+
+class ENikshayLocationHierarchyFilterValue(FilterValue):
+
+    @memoized
+    def get_hierarchy(self, location_id):
+        """
+        Return a list of _LocationFilter(column, parameter_slug, filter_value) objects to be used in constructing
+        the filter.
+        """
+        location = SQLLocation.objects.get(location_id=location_id)
+        filters = []
+        for ancestor in location.get_ancestors():
+            column = ancestor.location_type.name
+            parameter = "{slug}_{column}".format(slug=self.filter.slug, column=column)
+            value = ancestor.location_id
+            filters.append(
+                _LocationFilter(column, parameter, value)
+            )
+
+        below_column = "below_{}".format(location.location_type.name)
+        below_parameter = "{slug}_{column}".format(slug=self.filter.slug, column=below_column)
+        filters.append(
+            _LocationFilter(below_column, below_parameter, location.location_id)
+        )
+        return filters
+
+    def to_sql_filter(self):
+        location_id = self.value[0].value
+        return ORFilter([
+            EQFilter(x.column, x.parameter_slug) for x in self.get_hierarchy(location_id)
+        ])
+
+    def to_sql_values(self):
+        location_id = self.value[0].value
+        return {
+            x.parameter_slug: x.filter_value for x in self.get_hierarchy(location_id)
+        }
+
+    def to_es_filter(self):
+        location_id = self.value[0].value
+        fs = [
+            filters.term(x.column, x.filter_value) for x in self.get_hierarchy(location_id)
+        ]
+        return filters.OR(fs)
+
+
+class EnikshayLocationHiearachyFilter(DynamicChoiceListFilter):
+    def __init__(self, name, label, choice_provider, url_generator, css_id=None):
+
+        super(EnikshayLocationHiearachyFilter, self).__init__(
+            name=name,
+            field=None,
+            datatype="string",
+            label=label,
+            show_all=None,
+            choice_provider=choice_provider,
+            url_generator=url_generator,
+            css_id=css_id,
+        )
+
+def _build_enikshay_location_hierarchy(spec, report):
+    wrapped = FilterSpec.wrap(spec)
+    choice_provider = LocationChoiceProvider(report, wrapped.slug)
+    choice_provider.configure({})
+    return EnikshayLocationHiearachyFilter(
+        name=wrapped.slug,
+        label=wrapped.get_display(),
+        choice_provider=choice_provider,
+        url_generator=dynamic_choice_list_url,
+    )

--- a/custom/enikshay/ucr_filters.py
+++ b/custom/enikshay/ucr_filters.py
@@ -94,6 +94,7 @@ class EnikshayLocationHiearachyFilter(DynamicChoiceListFilter):
             css_id=css_id,
         )
 
+
 def _build_enikshay_location_hierarchy(spec, report):
     wrapped = FilterSpec.wrap(spec)
     choice_provider = LocationChoiceProvider(report, wrapped.slug)

--- a/settings.py
+++ b/settings.py
@@ -1980,9 +1980,11 @@ CUSTOM_UCR_EXPRESSION_LISTS = [
 ]
 
 CUSTOM_UCR_REPORT_FILTERS = [
+    ('enikshay_location_hierarchy', "custom.enikshay.ucr_filters._build_enikshay_location_hierarchy"),
 ]
 
 CUSTOM_UCR_REPORT_FILTER_VALUES = [
+    ("enikshay_location_hierarchy", "custom.enikshay.ucr_filters.ENikshayLocationHierarchyFilterValue"),
 ]
 
 CUSTOM_MODULES = [

--- a/settings.py
+++ b/settings.py
@@ -1979,6 +1979,12 @@ CUSTOM_UCR_EXPRESSION_LISTS = [
     ('custom.ucr_ext.expressions.CUSTOM_UCR_EXPRESSIONS'),
 ]
 
+CUSTOM_UCR_REPORT_FILTERS = [
+]
+
+CUSTOM_UCR_REPORT_FILTER_VALUES = [
+]
+
 CUSTOM_MODULES = [
     'custom.apps.crs_reports',
     'custom.ilsgateway',


### PR DESCRIPTION
This should hopefully be the last piece of custom code needed for the enikshay [Referral Report](https://docs.google.com/document/d/1ejESqYoqSff0u4X72Fq0TYi7ll3IvH5KX3VWXzLyMQs/edit). This report calls for users to see data above and below them in the location hierarchy, but not laterally. To achieve this, each row in the data source will store the ids of its parent locations, and also its own location.

Consider the following example:

Suppose this is the location structure:
```
      A1
     /  \
  B1	  B2
/   \    /  \
C1  C2  C3   C4
```

Then for the following cases, the data source indicators will look as follow:

```
|---------------------|  |--------------------------------------------------------| 
| Cases               |  | Data source indicators                                 |
|----------|----------|  |--------------|--------------|--------|--------|--------| 
| Name     | Location |  | below_levelA | below_levelB | levelA | levelB | levelC | 
|----------|----------|  |--------------|--------------|--------|--------|--------| 
| Person 1 | C1       |  | A1           | B1           |        |        | C1     | 
| Person 2 | B1       |  | A1           |              |        | B1     |        | 
| Person3  | A1       |  |              |              | A1     |        |        | 
| Person4  | B2       |  | A1           |              |        | B2     |        | 
|----------|----------|  |--------------|--------------|--------|--------|--------| 
```

Now lets consider what query would be necessary for a given location.
For a user at location C1, we would want the following query: 
```
LevelA = A1
OR LevelB = B1
OR LevelC = C1	
```

A user at location B1, we would do a query like:
```
LevalA = A1
OR LevelB = B1
OR below_levelB = B1
```

So this custom filter essentially translates a user's choice of a location into these sets of filters.

Best reviewed commit-by-commit
@nickpell 