### PR TITLE
Updates to Navigation Text (wrapping)

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
@@ -15,11 +15,6 @@
    data-moduleid="{{ module.id }}"
    data-formid="{{ form.id }}"
    data-updateprop="href"
-   title="{{ form.name|html_trans_prefix_delim:langs }}"
-   data-toggle="tooltip"
-   data-placement="bottom"
-   data-container="body"
-   data-delay='{"show": 1000, "hide": 100}'
    data-category="App Builder"
    data-action="Open Form"
    data-label="Edit Pen"

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_link_primary.html
@@ -8,11 +8,6 @@
    data-moduleid="{{ module.id }}"
    data-updateprop="href"
    data-updatevalue="{% url "view_module" domain app.id 'replacewithmoduleid' %}"
-   title="{{ module.name|html_trans_prefix_delim:langs }}"
-   data-toggle="tooltip"
-   data-placement="bottom"
-   data-container="body"
-   data-delay='{"show": 1000, "hide": 100}'
    class="appnav-title{% if module.doc_type != 'CareplanModule' and module.doc_type != 'ReportModule' and module.doc_type != 'ShadowModule' %} appnav-title-secondary{% endif %} appnav-responsive">
     <i class="drag_handle appnav-drag-icon js-appnav-drag-module"></i>
     {% if module.module_type == 'advanced' %}

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
@@ -149,11 +149,30 @@
   }
 }
 
-.appmanager-edit-title .ko-inline-edit {
-  margin-left: -12px;
+.appmanager-edit-title {
+  margin-right: 185px;
+  .ko-inline-edit {}
+}
 
+.appmanager-edit-title .ko-inline-edit {
+  width: 100%;
+  .read-only {
+    margin-left: 15px;
+    margin-top: 8px;
+  }
+  .read-only .prefixed-icon {
+    margin-left: -30px;
+  }
+  .read-write {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
   .read-write.h3 input{
-    margin-left: 12px;
+    margin-left: 0;
+    width: 100%
+  }
+  .read-write .form-group:first-child {
+    min-width: 80%;
   }
 }
 .appmanager-edit-description .ko-inline-edit {

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/navigation.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/navigation.less
@@ -47,8 +47,8 @@ nav.appmanager-content {
 .appnav-primary-icon {
   font-size: 1.7rem;
   margin-right: 5px;
-  top: 1px;
-  position: relative;
+  top: 6px;
+  position: absolute;
   color: lighten(@cc-text, 20);
 }
 
@@ -69,6 +69,7 @@ nav.appmanager-content {
     cursor: pointer;
     width: @appnav-trash-width;
     height: @appnav-item-height;
+    vertical-align: top;
     line-height: @appnav-item-height;
     .transition(margin .5s);
     position: relative;
@@ -82,13 +83,14 @@ nav.appmanager-content {
 
 .appnav-menu > li > .appnav-item a.appnav-title {
   width: @appnav-width - @appnav-trash-width;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   position: relative;
 
   > span {
     position: relative;
+    line-height: 14px;
+    display: inline-block;
+    margin-left: 22px;
+    padding: 8px 0;
   }
 
   > .appnav-drag-icon {
@@ -97,7 +99,8 @@ nav.appmanager-content {
     right: 10px;
     text-align: center;
     width: @appnav-trash-width;
-    height: @appnav-item-height;
+    min-height: @appnav-item-height;
+    height: 100%;
     line-height: @appnav-item-height;
     opacity: 0;
     .transition(all 1s);
@@ -163,12 +166,14 @@ nav.appmanager-content {
   box-sizing: content-box;
   width: @appnav-width;
   .clearfix();
+  overflow: hidden;
 
   &:hover, &:focus {
+    background-color: rgba(255,255,255,0.6);
+
     a {
       text-decoration: none;
       outline: none;
-      background-color: rgba(255,255,255,0.6);
       &.appnav-delete {
         i {
           margin-left: 0;
@@ -190,6 +195,7 @@ nav.appmanager-content {
 .appnav-menu-nested {
   > li > .appnav-item > a.appnav-title {
     padding-left: 10px;
+    border-left: 1px solid lighten(@cc-text, 60);
   }
   > li > .appnav-item > a.appnav-title {
     position: relative;
@@ -198,14 +204,18 @@ nav.appmanager-content {
       font-family: "WorkflowFontRegular";
       content: '\f00a';
       position: absolute;
-      left: -13px;
+      left: -15px;
       top: -5px;
       font-size: 4.6rem;
       color: lighten(@cc-text, 60);
     }
   }
+  > li:last-child > .appnav-item > a.appnav-title {
+    border: none;
+  }
   > li:last-child > .appnav-item > a.appnav-title:before {
     content: '\f00b';
+      left: -14px;
   }
   > .appnav-primary-icon {
     margin-left: 2px;
@@ -329,8 +339,11 @@ nav.appmanager-content {
 }
 
 .appnav-menu > li > .appnav-item.active {
+  background-color: @cc-brand-low;
+  .appnav-title {
+    border-color: darken(@cc-bg, 2);
+  }
   a {
-    background-color: @cc-brand-low;
     color: white;
 
     > .appnav-drag-icon {
@@ -351,10 +364,16 @@ nav.appmanager-content {
     color: @cc-att-neg-hi;
   }
   .appnav-secondary {
+    color: darken(@cc-att-pos-hi, 5);
+
     &:hover, &:focus {
-      color: darken(@cc-att-pos-hi, 5);
-      &.appnav-settings {
-        color: @cc-brand-hi;
+      text-shadow: 0 0 10px #000;
+    }
+    &.appnav-settings {
+      color: @cc-brand-hi;
+      &:hover, &:focus {
+        color: darken(@cc-brand-hi, 20);
+        text-shadow: 0 0 10px #0000;
       }
     }
   }


### PR DESCRIPTION
@orangejenny 
cc @benrudolph // @proteusvacuum 
@ctsims 

- allow wrapping of lines in navigation
- fixes titles to properly wrap around the actions bar in the content pane
- make the title input a little wider for easier editing
- minor navigation color fixes

<img width="1178" alt="screen shot 2017-06-16 at 3 24 08 pm" src="https://user-images.githubusercontent.com/716573/27241786-311903ec-52a8-11e7-8f22-e976b2466efb.png">
<img width="1156" alt="screen shot 2017-06-16 at 3 24 25 pm" src="https://user-images.githubusercontent.com/716573/27241787-3129542c-52a8-11e7-86d8-399ad9c5fa1e.png">
