### PR TITLE
Only run indexing tax before work day

### DIFF
--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -6,7 +6,7 @@ from corehq.util.decorators import serial_task
 from django.conf import settings
 
 
-@periodic_task(run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute='*/5', hour='0-5'), queue=settings.CELERY_PERIODIC_QUEUE)
 def run_continuous_indexing_task():
     preindex_couch_views.delay()
 

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -6,7 +6,7 @@ from corehq.util.decorators import serial_task
 from django.conf import settings
 
 
-@periodic_task(run_every=crontab(minute='*/5', hour='0-5'), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute='*/30', hour='0-5'), queue=settings.CELERY_PERIODIC_QUEUE)
 def run_continuous_indexing_task():
     preindex_couch_views.delay()
 


### PR DESCRIPTION
@dimagi/scale-team Seems strange to me that running this often would cause a lot of load, but it would be good to get rid of as many variables as possible