### PR TITLE
Display multi-line content correctly for all inline edit widgets

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/form_view.html
@@ -120,7 +120,6 @@
     <inline-edit params="
         name: 'comment',
         id:'comment-id',
-        readOnlyClass: 'app-comment',
         value: '{{ form.comment|escapejs }}',
         placeholder: '{% trans "Enter form description here"|escapejs %}',
         url: '{% url "edit_form_attr" domain app.id form.unique_id 'comment' %}',

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/app-settings.html
@@ -183,7 +183,6 @@
     url: '{% url "edit_app_attr" domain app.id 'comment' %}',
     placeholder: '{% trans "Enter app description here"|escapejs %}',
     saveValueName: 'comment',
-    readOnlyClass: 'app-comment',
     cols: 50,
 "></inline-edit>
 

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/module_view_heading.html
@@ -6,7 +6,6 @@
 <inline-edit params="
     name: 'comment',
     id:'comment-id',
-    readOnlyClass: 'app-comment',
     value: '{{ module.comment|escapejs }}',
     placeholder: '{% trans "Enter module description here"|escapejs %}',
     url: '{% url "edit_module_attr" domain app.id module.id 'comment' %}',

--- a/corehq/apps/app_manager/templates/app_manager/v2/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/app_view.html
@@ -57,7 +57,6 @@
         url: '{% url "edit_app_attr" domain app.id 'comment' %}',
         placeholder: '{% trans "Enter app description here"|escapejs %}',
         saveValueName: 'comment',
-        containerClass: 'app-comment',
         cols: 50,
     "></inline-edit>
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/form_view.html
@@ -91,7 +91,6 @@
       <inline-edit params="
           name: 'comment',
           id:'comment-id',
-          containerClass: 'app-comment',
           value: '{{ form.comment|escapejs }}',
           placeholder: '{% trans "Enter form description here"|escapejs %}',
           url: '{% url "edit_form_attr" domain app.id form.unique_id 'comment' %}',

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_view_heading.html
@@ -19,7 +19,6 @@
 <inline-edit params="
     name: 'comment',
     id:'comment-id',
-    containerClass: 'app-comment',
     value: '{{ module.comment|escapejs }}',
     placeholder: 'Enter {% if not module.is_surveys %}case list{% endif %} description here',
     url: '{% url "edit_module_attr" domain app.id module.id 'comment' %}',

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/app-settings.html.diff.txt
@@ -125,7 +125,7 @@
          <input type="number" class="col-sm-3 form-control" data-bind="
              value: visibleValue,
              valueUpdate: 'textchange',
-@@ -133,159 +134,155 @@
+@@ -133,158 +134,155 @@
  </script>
  
  <script type="text/html" id="CommcareSettings.widgets.textarea">
@@ -183,7 +183,6 @@
 -    url: '{% url "edit_app_attr" domain app.id 'comment' %}',
 -    placeholder: '{% trans "Enter app description here"|escapejs %}',
 -    saveValueName: 'comment',
--    readOnlyClass: 'app-comment',
 -    cols: 50,
 -"></inline-edit>
 -

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/module_view_heading.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/module_view_heading.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,14 +1,27 @@
+@@ -1,13 +1,26 @@
  {% load i18n %}
  {% load xforms_extras %}
 +{% load hq_shared_tags %}
@@ -24,15 +24,13 @@
  <inline-edit params="
      name: 'comment',
      id:'comment-id',
--    readOnlyClass: 'app-comment',
-+    containerClass: 'app-comment',
      value: '{{ module.comment|escapejs }}',
 -    placeholder: '{% trans "Enter module description here"|escapejs %}',
 +    placeholder: 'Enter {% if not module.is_surveys %}case list{% endif %} description here',
      url: '{% url "edit_module_attr" domain app.id module.id 'comment' %}',
      saveValueName: 'comment',
      cols: 50,
-@@ -16,14 +29,3 @@
+@@ -15,14 +28,3 @@
  <br />
  
  <div id="build_errors"></div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/app_view.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,204 +1,95 @@
+@@ -1,204 +1,94 @@
 -{% extends "app_manager/v1/managed_app.html" %}
 +{% extends "app_manager/v2/managed_app.html" %}
  {% load xforms_extras %}
@@ -96,7 +96,6 @@
 +        url: '{% url "edit_app_attr" domain app.id 'comment' %}',
 +        placeholder: '{% trans "Enter app description here"|escapejs %}',
 +        saveValueName: 'comment',
-+        containerClass: 'app-comment',
 +        cols: 50,
 +    "></inline-edit>
 +  </div>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/form_view.html.diff.txt
@@ -15,7 +15,7 @@
      {% include 'hqmedia/partials/multimedia_js.html' %}
      <script src="{% static 'app_manager/js/nav_menu_media_common.js' %}"></script>
      <script src="{% static 'app_manager/js/app_manager_media.js' %}"></script>
-@@ -68,6 +68,39 @@
+@@ -68,6 +68,38 @@
      {% if request|toggle_enabled:"CUSTOM_INSTANCES"%}
          <script src="{% static 'app_manager/js/custom_instances.js' %}"></script>
      {% endif %}
@@ -42,7 +42,6 @@
 +      <inline-edit params="
 +          name: 'comment',
 +          id:'comment-id',
-+          containerClass: 'app-comment',
 +          value: '{{ form.comment|escapejs }}',
 +          placeholder: '{% trans "Enter form description here"|escapejs %}',
 +          url: '{% url "edit_form_attr" domain app.id form.unique_id 'comment' %}',
@@ -55,7 +54,7 @@
  {% endblock %}
  
  {% block form-view %}
-@@ -104,81 +137,21 @@
+@@ -104,80 +136,21 @@
      {% initial_page_data 'uses_form_workflow' uses_form_workflow %}
      {% registerurl "get_form_datums" domain app.id %}
  
@@ -75,7 +74,6 @@
 -    <inline-edit params="
 -        name: 'comment',
 -        id:'comment-id',
--        readOnlyClass: 'app-comment',
 -        value: '{{ form.comment|escapejs }}',
 -        placeholder: '{% trans "Enter form description here"|escapejs %}',
 -        url: '{% url "edit_form_attr" domain app.id form.unique_id 'comment' %}',
@@ -146,7 +144,7 @@
              {% if form.form_type == 'module_form' %}{% if allow_usercase or form.uses_usercase %}
              <li>
                  <a id="usercase-configuration-tab" href="#usercase-configuration" data-toggle="tab">
-@@ -186,35 +159,36 @@
+@@ -185,35 +158,36 @@
                  </a>
              </li>
              {% endif %}{% endif %}
@@ -200,7 +198,7 @@
                      <div class="alert alert-warning">
                          {% trans "You are viewing a shadow form, therefore:" %}
                          <ul>
-@@ -226,77 +200,72 @@
+@@ -225,77 +199,72 @@
                              <li>{% trans 'You are not allowed to specify case closures here'%}</li>
                          </ul>
                      </div>
@@ -328,7 +326,7 @@
                          {% endblock %}
                      </div>
                  {% else %}
-@@ -305,14 +274,15 @@
+@@ -304,14 +273,15 @@
                      </p>
                  {% endif %}
              </div>
@@ -346,7 +344,7 @@
              {% endif %}
          </div>
      </div>
-@@ -320,12 +290,13 @@
+@@ -319,12 +289,13 @@
  {% endblock %}
  
  {% block modals %}{{ block.super }}

--- a/corehq/apps/style/static/app_manager/less/app_manager/form_editing.less
+++ b/corehq/apps/style/static/app_manager/less/app_manager/form_editing.less
@@ -1,8 +1,3 @@
-// Poor man's markdown for in-app comments
-.app-comment {
-  white-space: pre-wrap;
-}
-
 /* has to be more specific than the existing rule */
 #xform-source .syntaxhighlighter {
   overflow: visible !important;

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/content.less
@@ -144,9 +144,6 @@
      margin-top: 7.5px;
      margin-bottom: 2px;
   }
-  .read-write.app-comment {
-    white-space: normal;
-  }
 }
 
 .appmanager-edit-title {
@@ -185,9 +182,6 @@
 }
 .appmanager-edit-description .ko-inline-edit {
   margin-left: -8px;
-  .read-write.app-comment {
-    margin-left: 8px;
-  }
 }
 
 .appmanager-page-actions {

--- a/corehq/apps/style/static/app_manager/less/new_appmanager/form_editing.less
+++ b/corehq/apps/style/static/app_manager/less/new_appmanager/form_editing.less
@@ -1,8 +1,3 @@
-// Poor man's markdown for in-app comments
-.app-comment {
-  white-space: pre-wrap;
-}
-
 /* has to be more specific than the existing rule */
 #xform-source .syntaxhighlighter {
   overflow: visible !important;

--- a/corehq/apps/style/static/style/less/_hq/forms.less
+++ b/corehq/apps/style/static/style/less/_hq/forms.less
@@ -253,6 +253,10 @@ textarea.vertical-resize {
             margin-left: 5px;
             margin-top: 2px;
         }
+
+        .text {
+            white-space: pre-wrap;
+        }
     }
 
     .read-write {


### PR DESCRIPTION
...Instead of only for app comments.

Won't have any effect on the inline edit widgets that don't accept multiple lines (e.g., module/form names).

@benrudolph / @biyeun 