### PR TITLE
Move prime restore tasks off of main queue

### DIFF
--- a/corehq/apps/ota/tasks.py
+++ b/corehq/apps/ota/tasks.py
@@ -33,7 +33,7 @@ def queue_prime_restore(domain, usernames_or_ids, version=V1, cache_timeout_hour
     return group(tasks)()
 
 
-@task
+@task(queue='prime_restore_queue')
 def prime_restore(username_or_id, domain, version, cache_timeout_hours,
                   overwrite_cache, check_cache_only):
     couch_user = get_user(username_or_id, domain)


### PR DESCRIPTION
I wasn't sure if these should be moved to a different queue (like background_queue or async_restore_queue) or a new queue. For now this moves to a new one, but happy to change that if we can reuse another one we already have.

@calellowitz @snopoke @benrudolph 