### PR TITLE
index child cases by case_id

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -223,7 +223,7 @@ class ESCase(DictObject, CaseToXMLMixin):
         from corehq.apps.api.util import case_to_es_case
         accessor = CaseAccessors(self.domain)
         return {
-            index.identifier: case_to_es_case(accessor.get_case(index.case_id))
+            index.case_id: case_to_es_case(accessor.get_case(index.case_id))
             for index in self._reverse_indices
         }
 


### PR DESCRIPTION
since it's possible to have more than one child case with the same relationship identifier