### PR TITLE
Replace ignore patterns in custom query variables

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -128,7 +128,7 @@ class QueryMergeException(Exception):
     pass
 
 
-def replace_custom_query_variables(query_addition, criteria):
+def replace_custom_query_variables(query_addition, criteria, ignore_patterns):
     """Replaces values in custom queries with user input
 
     - In the custom query add '__{case_property_name}' as the value for the
@@ -145,6 +145,13 @@ def replace_custom_query_variables(query_addition, criteria):
     }
     query_addition = json.dumps(query_addition)
     for key, value in replaceable_criteria.iteritems():
+        if ignore_patterns:
+            remove_char_regexs = ignore_patterns.filter(
+                case_property=re.sub('^__', '', key)
+            )
+            for removal_regex in remove_char_regexs:
+                to_remove = re.escape(removal_regex.regex)
+                value = re.sub(to_remove, '', value)
         query_addition = re.sub(key, value, query_addition)
 
     return json.loads(query_addition)

--- a/corehq/apps/case_search/tests/test_query_additions.py
+++ b/corehq/apps/case_search/tests/test_query_additions.py
@@ -1,6 +1,6 @@
 from corehq.apps.case_search.models import merge_queries, QueryMergeException
-from django.test import SimpleTestCase
-
+from django.test import SimpleTestCase, TestCase
+from corehq.apps.case_search.models import CaseSearchConfig, IgnorePatterns,
 from corehq.util.test_utils import generate_cases
 
 from corehq.apps.case_search.models import SEARCH_QUERY_CUSTOM_VALUE, replace_custom_query_variables
@@ -41,8 +41,17 @@ def test_merge(self, base_query, addition, expected):
     self.assertDictEqual(new, expected)
 
 
-class TestCustomQueryValues(SimpleTestCase):
+class TestCustomQueryValues(TestCase):
     def test_custom_values(self):
+        config, created = CaseSearchConfig.objects.get_or_create(pk='domain', enabled=True)
+        rc = IgnorePatterns(
+            domain='domain',
+            case_type='case_type',
+            case_property='thing_1',
+            regex=' removed',
+        )
+        rc.save()
+        config.ignore_patterns.add(rc)
         initial_custom_query = {
             "nested": {
                 "path": "case_properties",
@@ -67,7 +76,7 @@ class TestCustomQueryValues(SimpleTestCase):
         }
 
         search_criteria = {
-            "{}__thing_1".format(SEARCH_QUERY_CUSTOM_VALUE): "boop",
+            "{}__thing_1".format(SEARCH_QUERY_CUSTOM_VALUE): "boop removed",
             "name": "Jon Snow",
         }
 
@@ -95,5 +104,9 @@ class TestCustomQueryValues(SimpleTestCase):
         }
         self.assertDictEqual(
             expected,
-            replace_custom_query_variables(initial_custom_query, search_criteria)
+            replace_custom_query_variables(
+                initial_custom_query,
+                search_criteria,
+                config.ignore_patterns.filter(domain='domain', case_type='case_type')
+            )
         )

--- a/corehq/apps/case_search/tests/test_query_additions.py
+++ b/corehq/apps/case_search/tests/test_query_additions.py
@@ -1,6 +1,6 @@
 from corehq.apps.case_search.models import merge_queries, QueryMergeException
 from django.test import SimpleTestCase, TestCase
-from corehq.apps.case_search.models import CaseSearchConfig, IgnorePatterns,
+from corehq.apps.case_search.models import CaseSearchConfig, IgnorePatterns
 from corehq.util.test_utils import generate_cases
 
 from corehq.apps.case_search.models import SEARCH_QUERY_CUSTOM_VALUE, replace_custom_query_variables

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -1,0 +1,117 @@
+import re
+
+from corehq.apps.es.case_search import CaseSearchES
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
+
+from corehq.apps.case_search.models import (
+    CaseSearchConfig,
+    merge_queries,
+    replace_custom_query_variables,
+    CaseSearchQueryAddition,
+    SEARCH_QUERY_ADDITION_KEY,
+    SEARCH_QUERY_CUSTOM_VALUE,
+    FuzzyProperties,
+    CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
+    UNSEARCHABLE_KEYS,
+)
+
+
+class CaseSearchCriteria(object):
+    """Compiles the case search object for the view
+    """
+
+    def __init__(self, domain, case_type, criteria):
+        self.domain = domain
+        self.case_type = case_type
+        self.criteria = criteria
+        self.query_addition_debug_details = {}
+
+        self.config = self._get_config()
+        self.search_es = self._get_initial_search_es()
+
+        self._assemble_optional_search_params()
+
+    def _get_config(self):
+        try:
+            config = (CaseSearchConfig.objects
+                      .prefetch_related('fuzzy_properties')
+                      .prefetch_related('ignore_patterns')
+                      .get(domain=self.domain))
+        except CaseSearchConfig.DoesNotExist as e:
+            from corehq.util.soft_assert import soft_assert
+            _soft_assert = soft_assert(
+                to="{}@{}.com".format('frener', 'dimagi'),
+                notify_admins=False, send_to_ops=False
+            )
+            _soft_assert(
+                False,
+                u"Someone in domain: {} tried accessing case search without a config".format(self.domain),
+                e
+            )
+            config = CaseSearchConfig(domain=self.domain)
+        return config
+
+    def _get_initial_search_es(self):
+        search_es = (CaseSearchES()
+                     .domain(self.domain)
+                     .case_type(self.case_type)
+                     .size(CASE_SEARCH_MAX_RESULTS))
+        return search_es
+
+    def _assemble_optional_search_params(self):
+        self._add_include_closed()
+        self._add_owner_id()
+        self._add_blacklisted_owner_ids()
+        self._add_case_property_queries()
+        self._add_case_search_additions()
+
+    def _add_include_closed(self):
+        try:
+            include_closed = self.criteria.pop('include_closed')
+        except KeyError:
+            include_closed = False
+        if include_closed != 'True':
+            self.search_es = self.search_es.is_closed(False)
+
+    def _add_owner_id(self):
+        owner_id = self.criteria.pop('owner_id', False)
+        if owner_id:
+            self.search_es = self.search_es.owner(owner_id)
+
+    def _add_blacklisted_owner_ids(self):
+        blacklisted_owner_ids = self.criteria.pop(CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY, None)
+        if blacklisted_owner_ids is not None:
+            for blacklisted_owner_id in blacklisted_owner_ids.split(' '):
+                self.search_es = self.search_es.blacklist_owner_id(blacklisted_owner_id)
+
+    def _add_case_property_queries(self):
+        try:
+            fuzzies = self.config.fuzzy_properties.get(
+                domain=self.domain, case_type=self.case_type).properties
+        except FuzzyProperties.DoesNotExist:
+            fuzzies = []
+
+        for key, value in self.criteria.items():
+            if key in UNSEARCHABLE_KEYS or key.startswith(SEARCH_QUERY_CUSTOM_VALUE):
+                continue
+            remove_char_regexs = self.config.ignore_patterns.filter(
+                domain=self.domain,
+                case_type=self.case_type,
+                case_property=key,
+            )
+            for removal_regex in remove_char_regexs:
+                to_remove = re.escape(removal_regex.regex)
+                value = re.sub(to_remove, '', value)
+            self.search_es = self.search_es.case_property_query(key, value, fuzzy=(key in fuzzies))
+
+    def _add_case_search_additions(self):
+        query_addition_id = self.criteria.pop(SEARCH_QUERY_ADDITION_KEY, None)
+        if query_addition_id:
+            query_addition = CaseSearchQueryAddition.objects.get(
+                id=query_addition_id, domain=self.domain).query_addition
+            query_addition = replace_custom_query_variables(query_addition, self.criteria)
+            self.query_addition_debug_details['original_query'] = self.search_es.get_query()
+            self.query_addition_debug_details['query_addition'] = query_addition
+            new_query = merge_queries(self.search_es.get_query(), query_addition)
+            self.query_addition_debug_details['new_query'] = new_query
+            self.search_es = self.search_es.set_query(new_query)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -107,9 +107,10 @@ class CaseSearchCriteria(object):
     def _add_case_search_additions(self):
         query_addition_id = self.criteria.pop(SEARCH_QUERY_ADDITION_KEY, None)
         if query_addition_id:
+            ignore_patterns = self.config.ignore_patterns.filter(domain=self.domain, case_type=self.case_type)
             query_addition = CaseSearchQueryAddition.objects.get(
                 id=query_addition_id, domain=self.domain).query_addition
-            query_addition = replace_custom_query_variables(query_addition, self.criteria)
+            query_addition = replace_custom_query_variables(query_addition, self.criteria, ignore_patterns)
             self.query_addition_debug_details['original_query'] = self.search_es.get_query()
             self.query_addition_debug_details['query_addition'] = query_addition
             new_query = merge_queries(self.search_es.get_query(), query_addition)

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -18,10 +18,9 @@ from corehq.apps.case_search.models import (
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
-from corehq.elastic import get_es_new, SIZE_LIMIT, ES_DEFAULT_INSTANCE
-from corehq.apps.es.case_search import CaseSearchES
+from corehq.elastic import get_es_new, ES_DEFAULT_INSTANCE
 from corehq.apps.es.tests.utils import ElasticTestMixin
-from corehq.apps.ota.views import _add_blacklisted_owner_ids, _add_case_property_queries
+from corehq.apps.case_search.utils import CaseSearchCriteria
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.pillows.case_search import get_case_search_reindexer
@@ -33,7 +32,7 @@ from corehq.pillows.mappings.case_search_mapping import (
 from corehq.util.elastic import ensure_index_deleted
 from pillowtop.es_utils import initialize_index_and_mapping
 
-DOMAIN = 'test-domain'
+DOMAIN = 'swashbucklers'
 USERNAME = 'testy_mctestface'
 PASSWORD = '123'
 CASE_NAME = 'Jamie Hand'
@@ -50,15 +49,19 @@ DATE_PATTERN = r'\d{4}-\d{2}-\d{2}'
 class CaseSearchTests(TestCase, ElasticTestMixin):
     def setUp(self):
         super(CaseSearchTests, self).setUp()
-        self.search_es = CaseSearchES().domain('swashbucklers')
+        self.config, created = CaseSearchConfig.objects.get_or_create(pk=DOMAIN, enabled=True)
 
     def test_add_blacklisted_ids(self):
-        blacklisted_owner_ids = "id1 id2 id3,id4"
+        criteria = {
+            "commcare_blacklisted_owner_ids": "id1 id2 id3,id4"
+        }
         expected = {'query':
                     {'filtered':
                      {'filter':
                       {'and': [
                           {'term': {'domain.exact': 'swashbucklers'}},
+                          {"term": {"type.exact": "case_type"}},
+                          {"term": {"closed": False}},
                           {'not': {'term': {'owner_id': 'id1'}}},
                           {'not': {'term': {'owner_id': 'id2'}}},
                           {'not': {'term': {'owner_id': 'id3,id4'}}},
@@ -67,14 +70,14 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                       "query": {
                           "match_all": {}
                       }}},
-                    'size': SIZE_LIMIT}
+                    'size': CASE_SEARCH_MAX_RESULTS}
+
         self.checkQuery(
-            _add_blacklisted_owner_ids(self.search_es, blacklisted_owner_ids),
+            CaseSearchCriteria(DOMAIN, 'case_type', criteria).search_es,
             expected
         )
 
     def test_add_ignore_pattern_queries(self):
-        config, created = CaseSearchConfig.objects.get_or_create(pk=DOMAIN, enabled=True)
         rc = IgnorePatterns(
             domain=DOMAIN,
             case_type='case_type',
@@ -82,7 +85,7 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
             regex=' word',
         )                       # remove ' word' from the name case property
         rc.save()
-        config.ignore_patterns.add(rc)
+        self.config.ignore_patterns.add(rc)
         rc = IgnorePatterns(
             domain=DOMAIN,
             case_type='case_type',
@@ -90,7 +93,7 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
             regex=' gone',
         )                       # remove ' gone' from the name case property
         rc.save()
-        config.ignore_patterns.add(rc)
+        self.config.ignore_patterns.add(rc)
         rc = IgnorePatterns(
             domain=DOMAIN,
             case_type='case_type',
@@ -98,8 +101,8 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
             regex='-',
         )                       # remove '-' from the special id case property
         rc.save()
-        config.ignore_patterns.add(rc)
-        config.save()
+        self.config.ignore_patterns.add(rc)
+        self.config.save()
         rc = IgnorePatterns(
             domain=DOMAIN,
             case_type='case_type',
@@ -107,8 +110,8 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
             regex='+',
         )                       # remove '+' from the phone_number case property
         rc.save()
-        config.ignore_patterns.add(rc)
-        config.save()
+        self.config.ignore_patterns.add(rc)
+        self.config.save()
 
         criteria = {
             'name': "this word should be gone",
@@ -124,6 +127,16 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                         {
                             "term": {
                                 "domain.exact": "swashbucklers"
+                            }
+                        },
+                        {
+                            "term": {
+                                "type.exact": "case_type"
+                            }
+                        },
+                        {
+                            "term": {
+                                "closed": False
                             }
                         },
                         {
@@ -227,11 +240,10 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                 }
             }
         },
-            "size": SIZE_LIMIT,
+            "size": CASE_SEARCH_MAX_RESULTS,
         }
-
         self.checkQuery(
-            _add_case_property_queries(DOMAIN, 'case_type', self.search_es, criteria),
+            CaseSearchCriteria(DOMAIN, 'case_type', criteria).search_es,
             expected,
         )
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -20,18 +20,8 @@ from corehq import toggles, privileges
 from corehq.const import OPENROSA_VERSION_MAP, OPENROSA_DEFAULT_VERSION
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.case_search.models import (
-    CaseSearchConfig,
-    merge_queries,
-    replace_custom_query_variables,
-    CaseSearchQueryAddition,
-    SEARCH_QUERY_ADDITION_KEY,
-    SEARCH_QUERY_CUSTOM_VALUE,
-    QueryMergeException,
-    FuzzyProperties,
-    CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
-    UNSEARCHABLE_KEYS,
-)
+from corehq.apps.case_search.models import QueryMergeException
+from corehq.apps.case_search.utils import CaseSearchCriteria
 from corehq.apps.domain.decorators import (
     domain_admin_required,
     login_or_digest_or_basic_or_apikey,
@@ -41,14 +31,13 @@ from corehq.apps.domain.decorators import (
 from corehq.util.datadog.gauges import datadog_counter, datadog_histogram
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import DomainViewMixin, EditMyProjectSettingsView
-from corehq.apps.es.case_search import CaseSearchES, flatten_result
+from corehq.apps.es.case_search import flatten_result
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.ota.forms import PrimeRestoreCacheForm, AdvancedPrimeRestoreCacheForm
 from corehq.apps.ota.tasks import queue_prime_restore
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.locations.permissions import location_safe
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
 from dimagi.utils.decorators.memoized import memoized
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings
 from django.http import HttpResponse
@@ -99,109 +88,20 @@ def search(request, domain):
         case_type = criteria.pop('case_type')
     except KeyError:
         return HttpResponse('Search request must specify case type', status=400)
-    search_es = (CaseSearchES()
-                 .domain(domain)
-                 .case_type(case_type)
-                 .size(CASE_SEARCH_MAX_RESULTS))
-
-    search_es = _add_include_closed(search_es, criteria)
-
-    owner_id = criteria.pop('owner_id', False)
-    if owner_id:
-        search_es = search_es.owner(owner_id)
-
-    blacklisted_owner_ids = criteria.pop(CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY, None)
-    if blacklisted_owner_ids is not None:
-        search_es = _add_blacklisted_owner_ids(search_es, blacklisted_owner_ids)
-
-    search_es = _add_case_property_queries(domain, case_type, search_es, criteria)
-
-    query_addition_id = criteria.pop(SEARCH_QUERY_ADDITION_KEY, None)
-    query_addition_debug_details = {}
     try:
-        search_es = _add_case_search_addition(
-            request, domain, search_es, query_addition_id, query_addition_debug_details, criteria
-        )
+        case_search_criteria = CaseSearchCriteria(domain, case_type, criteria)
+        search_es = case_search_criteria.search_es
     except QueryMergeException as e:
         return _handle_query_merge_exception(request, e)
     try:
         results = search_es.values()
     except Exception as e:
-        return _handle_es_exception(request, e, query_addition_debug_details)
+        return _handle_es_exception(request, e, case_search_criteria.query_addition_debug_details)
 
     # Even if it's a SQL domain, we just need to render the results as cases, so CommCareCase.wrap will be fine
     cases = [CommCareCase.wrap(flatten_result(result)) for result in results]
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
-
-
-def _add_include_closed(search_es, criteria):
-    try:
-        include_closed = criteria.pop('include_closed')
-    except KeyError:
-        include_closed = False
-    if include_closed != 'True':
-        search_es = search_es.is_closed(False)
-    return search_es
-
-
-def _add_blacklisted_owner_ids(search_es, blacklisted_owner_ids):
-    for blacklisted_owner_id in blacklisted_owner_ids.split(' '):
-            search_es = search_es.blacklist_owner_id(blacklisted_owner_id)
-    return search_es
-
-
-def _add_case_property_queries(domain, case_type, search_es, criteria):
-    try:
-        config = (CaseSearchConfig.objects
-                  .prefetch_related('fuzzy_properties')
-                  .prefetch_related('ignore_patterns')
-                  .get(domain=domain))
-    except CaseSearchConfig.DoesNotExist as e:
-        from corehq.util.soft_assert import soft_assert
-        _soft_assert = soft_assert(
-            to="{}@{}.com".format('frener', 'dimagi'),
-            notify_admins=False, send_to_ops=False
-        )
-        _soft_assert(
-            False,
-            u"Someone in domain: {} tried accessing case search without a config".format(domain),
-            e
-        )
-        config = CaseSearchConfig(domain=domain)
-
-    try:
-        fuzzies = config.fuzzy_properties.get(domain=domain, case_type=case_type).properties
-    except FuzzyProperties.DoesNotExist:
-        fuzzies = []
-
-    for key, value in criteria.items():
-        if key in UNSEARCHABLE_KEYS or key.startswith(SEARCH_QUERY_CUSTOM_VALUE):
-            continue
-        remove_char_regexs = config.ignore_patterns.filter(
-            domain=domain,
-            case_type=case_type,
-            case_property=key,
-        )
-        for removal_regex in remove_char_regexs:
-            to_remove = re.escape(removal_regex.regex)
-            value = re.sub(to_remove, '', value)
-        search_es = search_es.case_property_query(key, value, fuzzy=(key in fuzzies))
-
-    return search_es
-
-
-def _add_case_search_addition(request, domain, search_es, query_addition_id,
-                              query_addition_debug_details, criteria):
-    if query_addition_id:
-        query_addition = CaseSearchQueryAddition.objects.get(id=query_addition_id, domain=domain).query_addition
-        query_addition = replace_custom_query_variables(query_addition, criteria)
-        query_addition_debug_details['original_query'] = search_es.get_query()
-        query_addition_debug_details['query_addition'] = query_addition
-        new_query = merge_queries(search_es.get_query(), query_addition)
-        query_addition_debug_details['new_query'] = new_query
-        search_es = search_es.set_query(new_query)
-    return search_es
 
 
 def _handle_query_merge_exception(request, exception):


### PR DESCRIPTION
Removes "ignore patterns" from user generated input in custom queries.
We need this for eNikshay where we are doing some funky "or" search clause against an id case property that we also want to remove certain characters from (namely, the `-` character). 

First commit is a refactor that moves the compilation of the case search es query into its own class. 
Second commit adds the extra functionality. 

@snopoke 