### PR TITLE
soft asserts for form ordering bug

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -14,6 +14,7 @@ from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.soft_assert import soft_assert
 from couchforms.models import XFormInstance
 from casexml.apps.case.exceptions import (
     NoDomainProvided,
@@ -24,6 +25,7 @@ from casexml.apps.case import const
 from casexml.apps.case.xml.parser import case_update_from_block
 from dimagi.utils.logging import notify_exception
 
+_soft_assert = soft_assert(to="{}@{}.com".format('skelly', 'dimagi'), notify_admins=True)
 
 # Lightweight class used to store the dirtyness of a case/owner pair.
 DirtinessFlag = namedtuple('DirtinessFlag', ['case_id', 'owner_id'])
@@ -264,6 +266,16 @@ def _validate_indices(case_db, cases):
                     invalid = True
                 if invalid:
                     # fail hard on invalid indices
+                    from distutils.version import LooseVersion
+                    if case_db.cached_forms:
+                        commcare_version = case_db.cached_forms[0].metadata.commcare_version
+                        _soft_assert(
+                            commcare_version and commcare_version < LooseVersion("2.35"),
+                            "Invalid Case Index in CC version >= 2.35", {
+                                'domain': case_db.domain
+                                'version': str(commcare_version)
+                            }
+                        )
                     raise InvalidCaseIndex(
                         "Case '%s' references non-existent case '%s'" % (case.case_id, index.referenced_id)
                     )

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -270,7 +270,7 @@ def _validate_indices(case_db, cases):
                     if case_db.cached_forms:
                         commcare_version = case_db.cached_forms[0].metadata.commcare_version
                         _soft_assert(
-                            commcare_version and commcare_version < LooseVersion("2.35"),
+                            not commcare_version or commcare_version < LooseVersion("2.35"),
                             "Invalid Case Index in CC version >= 2.35", {
                                 'domain': case_db.domain
                                 'version': str(commcare_version)

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -272,7 +272,7 @@ def _validate_indices(case_db, cases):
                         _soft_assert(
                             not commcare_version or commcare_version < LooseVersion("2.35"),
                             "Invalid Case Index in CC version >= 2.35", {
-                                'domain': case_db.domain
+                                'domain': case_db.domain,
                                 'version': str(commcare_version)
                             }
                         )

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -267,8 +267,8 @@ def _validate_indices(case_db, cases):
                 if invalid:
                     # fail hard on invalid indices
                     from distutils.version import LooseVersion
-                    if case_db.cached_forms:
-                        commcare_version = case_db.cached_forms[0].metadata.commcare_version
+                    if case_db.cached_xforms:
+                        commcare_version = case_db.cached_xforms[0].metadata.commcare_version
                         _soft_assert(
                             not commcare_version or commcare_version < LooseVersion("2.35"),
                             "Invalid Case Index in CC version >= 2.35", {

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -268,14 +268,16 @@ def _validate_indices(case_db, cases):
                     # fail hard on invalid indices
                     from distutils.version import LooseVersion
                     if case_db.cached_xforms:
-                        commcare_version = case_db.cached_xforms[0].metadata.commcare_version
-                        _soft_assert(
-                            not commcare_version or commcare_version < LooseVersion("2.35"),
-                            "Invalid Case Index in CC version >= 2.35", {
-                                'domain': case_db.domain,
-                                'version': str(commcare_version)
-                            }
-                        )
+                        xform = case_db.cached_xforms[0]
+                        if xform.metadata and xform.metadata.commcare_version:
+                            commcare_version = xform.metadata.commcare_version
+                            _soft_assert(
+                                commcare_version < LooseVersion("2.35"),
+                                "Invalid Case Index in CC version >= 2.35", {
+                                    'domain': case_db.domain,
+                                    'version': str(commcare_version)
+                                }
+                            )
                     raise InvalidCaseIndex(
                         "Case '%s' references non-existent case '%s'" % (case.case_id, index.referenced_id)
                     )

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -87,6 +87,14 @@ class Metadata(DocumentSchema):
     appVersion = StringProperty()
     location = GeoPointProperty()
 
+    @property
+    def commcare_version(self):
+        from corehq.apps.receiverwrapper.util import get_commcare_version_from_appversion_text
+        from distutils.version import LooseVersion
+        version_text = get_commcare_version_from_appversion_text(self.appVersion)
+        if version_text:
+            return LooseVersion(version_text)
+
 
 class XFormOperation(DocumentSchema):
     """

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -150,17 +150,19 @@ class AbstractCaseDbCache(six.with_metaclass(ABCMeta)):
         """
         case = self.get(case_update.id)
         if case is None:
-            from distutils.version import LooseVersion
-            commcare_version = xform.metadata.commcare_version
-            _soft_assert(
-                case_update.creates_case() or (not commcare_version or commcare_version < LooseVersion("2.35")),
-                "Case created without create block in CC version >= 2.35", {
-                    'xform_id': xform.form_id,
-                    'case_id': case_update.id,
-                    'domain': xform.domain,
-                    'version': str(commcare_version)
-                }
-            )
+            if xform.metadata and xform.metadata.commcare_version:
+                from distutils.version import LooseVersion
+                if xform.metadata and xform.metadata.commcare_version:
+                    commcare_version = xform.metadata.commcare_version
+                    _soft_assert(
+                        case_update.creates_case() or commcare_version < LooseVersion("2.35"),
+                        "Case created without create block in CC version >= 2.35", {
+                            'xform_id': xform.form_id,
+                            'case_id': case_update.id,
+                            'domain': xform.domain,
+                            'version': str(commcare_version)
+                        }
+                    )
             case = self.case_update_strategy.case_from_case_update(case_update, xform)
             self.set(case.case_id, case)
             return CaseUpdateMetadata(case, is_creation=True, previous_owner_id=None)

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -153,7 +153,7 @@ class AbstractCaseDbCache(six.with_metaclass(ABCMeta)):
             from distutils.version import LooseVersion
             commcare_version = xform.metadata.commcare_version
             _soft_assert(
-                case_update.creates_case() or (commcare_version and commcare_version < LooseVersion("2.35")),
+                case_update.creates_case() or (not commcare_version or commcare_version < LooseVersion("2.35")),
                 "Case created without create block in CC version >= 2.35", {
                     'xform_id': xform.form_id,
                     'case_id': case_update.id,

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -150,10 +150,15 @@ class AbstractCaseDbCache(six.with_metaclass(ABCMeta)):
         """
         case = self.get(case_update.id)
         if case is None:
+            from distutils.version import LooseVersion
+            commcare_version = xform.metadata.commcare_version
             _soft_assert(
-                case_update.creates_case(), "Case created without create block", {
+                case_update.creates_case() or (commcare_version and commcare_version < LooseVersion("2.35")),
+                "Case created without create block in CC version >= 2.35", {
+                    'xform_id': xform.form_id,
                     'case_id': case_update.id,
-                    'domain': xform.domain
+                    'domain': xform.domain,
+                    'version': str(commcare_version)
                 }
             )
             case = self.case_update_strategy.case_from_case_update(case_update, xform)

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -305,8 +305,6 @@ class XFormInstanceSQL(PartitionedModel, models.Model, RedisLockableMixIn, Attac
         if const.TAG_META in self.form_data:
             return XFormPhoneMetadata.wrap(clean_metadata(self.form_data[const.TAG_META]))
 
-        return None
-
     def soft_delete(self):
         from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
         FormAccessorSQL.soft_delete_forms(self.domain, [self.form_id])
@@ -550,6 +548,14 @@ class XFormPhoneMetadata(jsonobject.JsonObject):
     username = jsonobject.StringProperty()
     appVersion = jsonobject.StringProperty()
     location = GeoPointProperty()
+
+    @property
+    def commcare_version(self):
+        from corehq.apps.receiverwrapper.util import get_commcare_version_from_appversion_text
+        from distutils.version import LooseVersion
+        version_text = get_commcare_version_from_appversion_text(self.appVersion)
+        if version_text:
+            return LooseVersion(version_text)
 
 
 class SupplyPointCaseMixin(object):

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -318,9 +318,28 @@ class FundamentalCaseTests(TestCase):
         self.assertIsNone(cache.get(cache_key))
 
     def test_update_case_without_creating_triggers_soft_assert(self):
-        case_id = uuid.uuid4().hex
-        with self.assertRaisesMessage(AssertionError, 'Case created without create block'):
-            _submit_case_block(False, case_id, user_id='user2', update={})
+        def _submit_form_with_cc_version(version):
+            xml = """<?xml version='1.0' ?>
+                            <system version="1" uiVersion="1" xmlns="http://commcarehq.org/case" xmlns:orx="http://openrosa.org/jr/xforms">
+                                <orx:meta xmlns:cc="http://commcarehq.org/xforms">
+                                    <orx:deviceID />
+                                    <orx:timeStart>2017-06-22T08:39:07.585584Z</orx:timeStart>
+                                    <orx:timeEnd>2017-06-22T08:39:07.585584Z</orx:timeEnd>
+                                    <orx:username>system</orx:username>
+                                    <orx:userID></orx:userID>
+                                    <orx:instanceID>{form_id}</orx:instanceID>
+                                    <cc:appVersion>CommCare Version "{version}"</cc:appVersion>
+                                </orx:meta>
+                                <case case_id="{case_id}" date_modified="2017-06-22T08:39:07.585427Z" user_id="user2" xmlns="http://commcarehq.org/case/transaction/v2" />
+                            </system>""".format(form_id=uuid.uuid4().hex, case_id=uuid.uuid4().hex, version=version)
+            submit_form_locally(
+                xml, domain=DOMAIN
+            )
+        with self.assertRaisesMessage(AssertionError, 'Case created without create block in CC version >= 2.35'):
+            _submit_form_with_cc_version("2.35")
+
+        # no assertion error raised
+        _submit_form_with_cc_version("2.34")
 
     def test_globally_unique_form_id(self):
         form_id = uuid.uuid4().hex


### PR DESCRIPTION
These updates should help validate that the form ordering bug isn't happening in CC > 2.35. They'll also help to identify any 'missing' form issues.