### PR TITLE
App manager v2: reload page on rearrange forms/modules

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -276,40 +276,6 @@ hqDefine('app_manager/js/app_manager.js', function () {
                 $(related).data(name, value);
             });
         }
-        function resetIndexes($sortable) {
-            if (COMMCAREHQ.toggleEnabled('APP_MANAGER_V2')) {
-                var parentVar = $sortable.data('parentvar');
-                var parentValue = $sortable.closest("[data-indexVar='" + parentVar + "']").data('index');
-                _.each($sortable.find('> .js-sorted-li'), function (elem, i) {
-                    $(elem).data('index', i);
-                    var indexVar = $(elem).data('indexvar');
-                    updateRelatedTags($(elem), indexVar, i);
-                    if (parentVar) {
-                        $(elem).data(parentVar, parentValue);
-                        updateRelatedTags($(elem), parentVar, parentValue);
-                    }
-                });
-                _.each($('[data-updateprop]'), function (tag) {
-                    var tagName = $(tag).data('updateprop'),
-                        tagVal = $(tag).data('updatevalue'),
-                        moduleId = $(tag).data('moduleid'),
-                        formId = $(tag).data('formid');
-                    var processedVal = tagVal
-                        .replace('replacewithmoduleid', moduleId)
-                        .replace('replacewithformid', formId);
-                    $(tag).prop(tagName, processedVal);
-                });
-            } else {
-                var $sortables = $sortable.children.get(),
-                    i;
-                for (i in $sortables) {
-                    if ($sortables.hasOwnProperty(i)) {
-                        $($sortables[i]).data('index', i);
-                    }
-                }
-            }
-        }
-        COMMCAREHQ.resetIndexes = resetIndexes;
 
         $('.sortable .sort-action').addClass('sort-disabled');
         $('.drag_handle').addClass(COMMCAREHQ.icons.GRIP);
@@ -396,29 +362,15 @@ hqDefine('app_manager/js/app_manager.js', function () {
                             }
 
                             if (COMMCAREHQ.toggleEnabled('APP_MANAGER_V2')) {
-                                resetIndexes($sortable);
-                                if (from_module_id !== to_module_id) {
-                                    var $parentSortable = $sortable.parents(".sortable"),
-                                        $fromSortable = $parentSortable.find("[data-index=" + from_module_id + "] .sortable");
-                                    resetIndexes($fromSortable);
-                                }
-                                $.post($form.attr('action'), $form.serialize(), function (data) {});
+                                // Show loading screen and disable rearranging
+                                $('#js-appmanager-body.appmanager-settings-content').addClass('hide');
+                                $sortable.find('.drag_handle').remove();
                             } else {
                                 // disable sortable
                                 $sortable.find('.drag_handle').css('color', 'transparent').removeClass('drag_handle');
                                 $sortable.sortable('option', 'disabled', true);
-                                if ($form.find('input[name="ajax"]').first().val() === "true") {
-                                    resetIndexes($sortable);
-                                    $.post($form.attr('action'), $form.serialize(), function (data) {
-                                        module.updateDOM(JSON.parse(data).update);
-                                        // re-enable sortable
-                                        $sortable.sortable('option', 'disabled', false);
-                                        $sortable.find('.drag_handle').show(1000);
-                                    });
-                                } else {
-                                    $form.submit();
-                                }
                             }
+                            $form.submit();
                         }
                     }
                 };

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
@@ -7,14 +7,9 @@
 <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar"
    {% if form.no_vellum %}
    href="{% url "view_form" domain app.id module.id form.id %}"
-   data-updatevalue="{% url "view_form" domain app.id 'replacewithmoduleid' 'replacewithformid' %}"
    {% else %}
    href="{% url "form_source" domain app.id module.id form.id %}"
-   data-updatevalue="{% url "form_source" domain app.id 'replacewithmoduleid' 'replacewithformid' %}"
    {% endif %}
-   data-moduleid="{{ module.id }}"
-   data-formid="{{ form.id }}"
-   data-updateprop="href"
    data-category="App Builder"
    data-action="Open Form"
    data-label="Edit Pen"

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_secondary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_secondary.html
@@ -6,10 +6,6 @@
 
 {% if not form.no_vellum %}
     <a href="{% url "view_form" domain app.id module.id form.id %}"
-       data-moduleid="{{ module.id }}"
-       data-formid="{{ form.id }}"
-       data-updateprop="href"
-       data-updatevalue="{% url "view_form" domain app.id 'replacewithmoduleid' 'replacewithformid' %}"
        data-category="App Builder"
        data-action="View Form"
        data-label="Sidebar"

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_link_primary.html
@@ -5,9 +5,6 @@
 {# For APP BUILDER PROTOTYPE use only #}
 
 <a href="{% url "view_module" domain app.id module.id %}"
-   data-moduleid="{{ module.id }}"
-   data-updateprop="href"
-   data-updatevalue="{% url "view_module" domain app.id 'replacewithmoduleid' %}"
    class="appnav-title{% if module.doc_type != 'CareplanModule' and module.doc_type != 'ReportModule' and module.doc_type != 'ShadowModule' %} appnav-title-secondary{% endif %} appnav-responsive">
     <i class="drag_handle appnav-drag-icon js-appnav-drag-module"></i>
     {% if module.module_type == 'advanced' %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/module_link_secondary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/module_link_secondary.html
@@ -7,8 +7,6 @@
   <a href="#"
      class="appnav-secondary js-add-new-item"
      data-slug="form"
-     data-updateprop="data-moduleid"
-     data-updatevalue="replacewithmoduleid"
      data-moduleid="{{ module.id }}"
      data-show-survey="{% if module.is_surveys %}1{% endif %}"
      data-show-followup="{% if not module.is_surveys and module.doc_type != "AdvancedModule" %}1{% endif %}"


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?256730

For once I'm unhappy to be deleting code. Rearranging forms/modules without refreshing the page is a better experience. But there are quite a few urls that use the index-based id, and missing updating one of them has rather severe consequences (overwriting a module/form's settings).

@benrudolph / @biyeun 