### PR TITLE
soft rollout ucr

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -13,7 +13,7 @@ from corehq.apps.app_manager.suite_xml.features.mobile_ucr import is_valid_mobil
 from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
 from corehq.util.xml_utils import serialize
 
-from corehq.apps.userreports.const import UCR_SUPPORT_BOTH_BACKENDS
+from corehq.apps.userreports.const import UCR_ES_BACKEND, UCR_LABORATORY_BACKEND, UCR_SUPPORT_BOTH_BACKENDS
 from corehq.apps.userreports.exceptions import UserReportsError, ReportConfigurationNotFoundError
 from corehq.apps.userreports.models import get_report_config
 from corehq.apps.userreports.reports.factory import ReportFactory
@@ -135,6 +135,9 @@ class ReportFixturesProvider(FixtureProvider):
     def _get_report_and_data_source(report_id, domain):
         report = get_report_config(report_id, domain)[0]
         data_source = ReportFactory.from_spec(report, include_prefilters=True)
+        if report.soft_rollout != 0 and data_source.config.backend_id == UCR_LABORATORY_BACKEND:
+            if random.randint(0, report.soft_rollout) == report.soft_rollout:
+                data_source.override_backend_id(UCR_ES_BACKEND)
         return report, data_source
 
     @staticmethod

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -135,8 +135,8 @@ class ReportFixturesProvider(FixtureProvider):
     def _get_report_and_data_source(report_id, domain):
         report = get_report_config(report_id, domain)[0]
         data_source = ReportFactory.from_spec(report, include_prefilters=True)
-        if report.soft_rollout != 0 and data_source.config.backend_id == UCR_LABORATORY_BACKEND:
-            if random.randint(0, report.soft_rollout) == report.soft_rollout:
+        if report.soft_rollout > 0 and data_source.config.backend_id == UCR_LABORATORY_BACKEND:
+            if random.random() < report.soft_rollout:
                 data_source.override_backend_id(UCR_ES_BACKEND)
         return report, data_source
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -19,7 +19,13 @@ from dimagi.ext.couchdbkit import (
     SchemaProperty,
     StringListProperty,
 )
-from dimagi.ext.couchdbkit import StringProperty, DictProperty, ListProperty, IntegerProperty
+from dimagi.ext.couchdbkit import (
+    DecimalProperty,
+    DictProperty,
+    IntegerProperty,
+    ListProperty,
+    StringProperty,
+)
 from dimagi.ext.jsonobject import JsonObject
 from corehq.apps.cachehq.mixins import (
     CachedCouchDocumentMixin,
@@ -363,7 +369,7 @@ class ReportConfiguration(UnicodeMixIn, QuickCachedDocumentMixin, Document):
     columns = ListProperty()
     configured_charts = ListProperty()
     sort_expression = ListProperty()
-    soft_rollout = IntegerProperty(default=0)
+    soft_rollout = DecimalProperty(default=0)
     report_meta = SchemaProperty(ReportMeta)
 
     def __unicode__(self):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -363,6 +363,7 @@ class ReportConfiguration(UnicodeMixIn, QuickCachedDocumentMixin, Document):
     columns = ListProperty()
     configured_charts = ListProperty()
     sort_expression = ListProperty()
+    soft_rollout = IntegerProperty(default=0)
     report_meta = SchemaProperty(ReportMeta)
 
     def __unicode__(self):

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -59,6 +59,7 @@ class ConfigurableReportEditForm(DocumentFormBase):
     columns = JsonField(expected_type=list)
     configured_charts = JsonField(expected_type=list)
     sort_expression = JsonField(expected_type=list)
+    soft_rollout = forms.IntegerField()
 
     def __init__(self, domain, instance=None, read_only=False, *args, **kwargs):
         super(ConfigurableReportEditForm, self).__init__(instance, read_only, *args, **kwargs)
@@ -85,6 +86,7 @@ class ConfigurableReportEditForm(DocumentFormBase):
                 'columns',
                 'configured_charts',
                 'sort_expression',
+                'soft_rollout',
             ),
         )
         # Restrict edit for static reports

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -59,7 +59,7 @@ class ConfigurableReportEditForm(DocumentFormBase):
     columns = JsonField(expected_type=list)
     configured_charts = JsonField(expected_type=list)
     sort_expression = JsonField(expected_type=list)
-    soft_rollout = forms.IntegerField()
+    soft_rollout = forms.DecimalField(min_value=0, max_value=1)
 
     def __init__(self, domain, instance=None, read_only=False, *args, **kwargs):
         super(ConfigurableReportEditForm, self).__init__(instance, read_only, *args, **kwargs)


### PR DESCRIPTION
@snopoke the other day you mentioned a soft rollout option for reports. This will allow us to specify a soft rollout per report. works by 1/n will go to ES