### PR TITLE
More restore optimizations

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -873,7 +873,8 @@ class SimplifiedSyncLog(AbstractSyncLog):
         cases as available.
         """
         incoming_extensions = cached_map or _reverse_index_map(self.extension_index_tree.indices)
-        live = {case for case in available if case in self.primary_case_ids}
+        primary_case_ids = self.primary_case_ids
+        live = {case for case in available if case in primary_case_ids}
         new_live = set() | live
         checked = set()
         while new_live:

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -759,16 +759,6 @@ class SimplifiedSyncLog(AbstractSyncLog):
             self._purged_cases = set()
         return self._purged_cases
 
-    _frozen_closed_cases = None
-
-    @property
-    def frozen_closed_cases(self):
-        """Used so that we can memoize a function that requires this
-        """
-        if self._frozen_closed_cases is None:
-            self._frozen_closed_cases = frozenset(self.closed_cases)
-        return self._frozen_closed_cases
-
     def save(self, *args, **kwargs):
         # force doc type to SyncLog to avoid changing the couch view.
         self.doc_type = "SyncLog"
@@ -894,7 +884,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
             new_live = new_live | IndexTree.traverse_incoming_extensions(
                 case_to_check,
                 self.extension_index_tree,
-                self.frozen_closed_cases,
+                frozenset(self.closed_cases),
             ) - self.purged_cases
             new_live = new_live - checked
             live = live | new_live

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -890,7 +890,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
         else:
             incoming_extensions = cached_map
         primary_case_ids = self.primary_case_ids
-        live = {case for case in available if case in primary_case_ids}
+        live = available & primary_case_ids
         new_live = set() | live
         checked = set()
         while new_live:

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -623,13 +623,10 @@ class IndexTree(DocumentSchema):
     # and the values are the referenced case IDs
     indices = SchemaDictProperty()
 
-    _reverse_indices = None
-
     @property
+    @memoized
     def reverse_indices(self):
-        if self._reverse_indices is None:
-            self._reverse_indices = _reverse_index_map(self.indices)
-        return self._reverse_indices
+        return _reverse_index_map(self.indices)
 
     def __repr__(self):
         return json.dumps(self.indices, indent=2)

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -657,8 +657,11 @@ class IndexTree(DocumentSchema):
                     _recursive_call(indexed_case, all_cases, cached_child_map, cached_extension_map)
 
         all_cases = set()
-        cached_child_map = cached_child_map or _reverse_index_map(child_index_tree.indices)
-        cached_extension_map = cached_extension_map or _reverse_index_map(extension_index_tree.indices)
+        if cached_child_map is None:
+            cached_child_map = _reverse_index_map(child_index_tree.indices)
+        if cached_extension_map is None:
+            cached_extension_map = _reverse_index_map(extension_index_tree.indices)
+
         _recursive_call(case_id, all_cases, cached_child_map, cached_extension_map)
         return all_cases
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -680,7 +680,8 @@ class IndexTree(DocumentSchema):
         """traverse open incoming extensions"""
         all_cases = set([case_id])
         new_cases = set([case_id])
-        cached_map = cached_map or _reverse_index_map(extension_index_tree.indices)
+        if cached_map is None:
+            cached_map = _reverse_index_map(extension_index_tree.indices)
         while new_cases:
             case_to_check = new_cases.pop()
             open_incoming_extension_indices = {
@@ -695,7 +696,8 @@ class IndexTree(DocumentSchema):
         return all_cases
 
     def get_cases_that_directly_depend_on_case(self, case_id, cached_map=None):
-        cached_map = cached_map or _reverse_index_map(self.indices)
+        if cached_map is None:
+            cached_map = _reverse_index_map(self.indices)
         return cached_map.get(case_id, [])
 
     def delete_index(self, from_case_id, index_name):
@@ -819,8 +821,10 @@ class SimplifiedSyncLog(AbstractSyncLog):
         """
         _get_logger().debug("purging: {}".format(case_id))
         self.dependent_case_ids_on_phone.add(case_id)
-        cached_child_map = cached_child_map or _reverse_index_map(self.index_tree.indices)
-        cached_extension_map = cached_extension_map or _reverse_index_map(self.extension_index_tree.indices)
+        if cached_child_map is None:
+            cached_child_map = _reverse_index_map(self.index_tree.indices)
+        if cached_extension_map is None:
+            cached_extension_map = _reverse_index_map(self.extension_index_tree.indices)
         relevant = self._get_relevant_cases(case_id, cached_child_map, cached_extension_map)
         available = self._get_available_cases(relevant, cached_extension_map)
         live = self._get_live_cases(available, cached_extension_map)
@@ -833,12 +837,17 @@ class SimplifiedSyncLog(AbstractSyncLog):
         and extension indexes, as well as all incoming extension indexes,
         mark all touched cases relevant.
         """
+        if cached_child_map is None:
+            cached_child_map = _reverse_index_map(self.index_tree.indices)
+        if cached_extension_map is None:
+            cached_extension_map = _reverse_index_map(self.extension_index_tree.indices)
+
         relevant = IndexTree.get_all_dependencies(
             case_id,
             child_index_tree=self.index_tree,
             extension_index_tree=self.extension_index_tree,
-            cached_child_map=cached_child_map or _reverse_index_map(self.index_tree.indices),
-            cached_extension_map=cached_extension_map or _reverse_index_map(self.extension_index_tree.indices),
+            cached_child_map=cached_child_map,
+            cached_extension_map=cached_extension_map,
         )
         _get_logger().debug("Relevant cases of {}: {}".format(case_id, relevant))
         return relevant
@@ -849,7 +858,10 @@ class SimplifiedSyncLog(AbstractSyncLog):
         as available. Traverse incoming extension indexes which don't lead to closed
         cases, mark all touched cases as available
         """
-        incoming_extensions = cached_map or _reverse_index_map(self.extension_index_tree.indices)
+        if cached_map is None:
+            incoming_extensions = _reverse_index_map(self.extension_index_tree.indices)
+        else:
+            incoming_extensions = cached_map
         available = {case for case in relevant
                      if case not in self.closed_cases
                      and (not self.extension_index_tree.indices.get(case) or self.index_tree.indices.get(case))}
@@ -872,7 +884,10 @@ class SimplifiedSyncLog(AbstractSyncLog):
         extension indexes which don't lead to closed cases, mark all touched
         cases as available.
         """
-        incoming_extensions = cached_map or _reverse_index_map(self.extension_index_tree.indices)
+        if cached_map is None:
+            incoming_extensions = _reverse_index_map(self.extension_index_tree.indices)
+        else:
+            incoming_extensions = cached_map
         primary_case_ids = self.primary_case_ids
         live = {case for case in available if case in primary_case_ids}
         new_live = set() | live

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -663,6 +663,7 @@ class IndexTree(DocumentSchema):
         return all_cases
 
     @staticmethod
+    @memoized
     def get_all_outgoing_cases(case_id, child_index_tree, extension_index_tree):
         """traverse all outgoing child and extension indices"""
         all_cases = set([case_id])

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -654,11 +654,11 @@ class SyncTokenUpdateTest(SyncBaseTest):
 
     def test_index_chain_with_closed_parents(self):
         grandparent = CaseStructure(
-            case_id=uuid.uuid4().hex,
+            case_id='grandparent',
             attrs={'close': True, 'create': True}
         )
         parent = CaseStructure(
-            case_id=uuid.uuid4().hex,
+            case_id='parent',
             attrs={'close': True, 'create': True},
             indices=[CaseIndex(
                 grandparent,
@@ -667,7 +667,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
             )]
         )
         child = CaseStructure(
-            case_id=uuid.uuid4().hex,
+            case_id='child',
             indices=[CaseIndex(
                 parent,
                 relationship=CHILD_RELATIONSHIP,


### PR DESCRIPTION
@calellowitz made a few more changes

CC: @snopoke 

I ran (i.e. timings also include all reports, and fixtures)
```py
from corehq.apps.users.models import CommCareUser
from corehq.apps.ota.views import get_restore_response
user = CommCareUser.get_by_username('101624@enikshay.commcarehq.org')
%prun restore = get_restore_response('enikshay', user, version='2.0', overwrite_cache=True)
```

before (with user `101624@enikshay.commcarehq.org`)
```
279502322 function calls (275633510 primitive calls) in 890.520 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    92867  232.743    0.003  613.947    0.007 models.py:727(_reverse_index_map)
  1445693  228.319    0.000  228.319    0.000 {method 'items' of 'dict' objects}
199164653  154.866    0.000  154.866    0.000 {method 'values' of 'dict' objects}
    52121   49.428    0.001   52.716    0.001 {method 'execute' of 'psycopg2.extensions.cursor' objects}
7578292/7578032    7.361    0.000    8.796    0.000 {isinstance}
       63    5.142    0.082    5.142    0.082 {_socket.getaddrinfo}
  3422630    4.262    0.000    4.269    0.000 {hasattr}
  4679936    3.937    0.000    3.937    0.000 {method 'append' of 'list' objects}
    12704    3.918    0.000    4.862    0.000 clean_owners.py:111(_add_unchecked_indices_to_be_checked)
302639/12834    3.795    0.000    8.229    0.001 ElementTree.py:899(_serialize_xml)
   839875    3.770    0.000    9.470    0.000 base_properties.py:71(__get__)
    24830    3.539    0.000    3.539    0.000 {method 'remove' of 'list' objects}
   641645    3.075    0.000    3.581    0.000 base_properties.py:20(__init__)
580534/528267    2.828    0.000   14.294    0.000 compiler.py:348(compile)
1944677/1915950    2.799    0.000    2.902    0.000 {getattr}
   732962    2.787    0.000    8.456    0.000 expressions.py:667(get_db_converters)
  1031313    2.702    0.000    5.101    0.000 compiler.py:331(quote_name_unless_alias)
    54333    2.480    0.000    5.664    0.000 base.py:457(__init__)
2586906/2196750    2.318    0.000   70.212    0.000 {len}
    25715    2.303    0.000   21.225    0.001 compiler.py:165(get_select)
    12834    2.213    0.000    7.798    0.001 ElementTree.py:831(_namespaces)
    51343    2.147    0.000   11.267    0.000 compiler.py:764(get_converters)
    51141    2.105    0.000   50.316    0.001 query.py:1233(__iter__)
  1197943    2.104    0.000    2.106    0.000 {built-in method __new__ of type object at 0x919120}
    25707    2.095    0.000    6.395    0.000 compiler.py:475(get_default_columns)
400912/1913    2.076    0.000    5.470    0.003 copy.py:145(deepcopy)
   141727    2.072    0.000    8.413    0.000 inspect.py:895(getcallargs)
   759286    2.060    0.000    2.563    0.000 __init__.py:342(get_col)
   502793    2.051    0.000    7.118    0.000 expressions.py:657(as_sql)
1234731/315149    2.019    0.000    2.019    0.000 ElementTree.py:471(iter)
   497544    1.948    0.000    5.160    0.000 base_properties.py:224(value_to_property)
   830550    1.928    0.000    2.699    0.000 base.py:95(__getitem__)

```

after:
```
         80671674 function calls (76821377 primitive calls) in 272.946 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function) 
    52071   46.792    0.001   50.036    0.001 {method 'execute' of 'psycopg2.extensions.cursor' objects}
8289613/8289353    8.061    0.000    9.498    0.000 {isinstance}
  3429180    4.270    0.000    4.276    0.000 {hasattr}
  4560357    3.893    0.000    3.893    0.000 {method 'append' of 'list' objects}
    12704    3.875    0.000    4.827    0.000 clean_owners.py:111(_add_unchecked_indices_to_be_checked)
302527/12834    3.795    0.000    8.268    0.001 ElementTree.py:899(_serialize_xml) 
    24833    3.500    0.000    3.500    0.000 {method 'remove' of 'list' objects}
   616722    3.051    0.000    6.723    0.000 base_properties.py:224(value_to_property)
   705327    2.996    0.000    7.611    0.000 base_properties.py:71(__get__)
580174/527939    2.896    0.000   14.545    0.000 compiler.py:348(compile)
1941856/1913138    2.805    0.000    2.907    0.000 {getattr}
   732666    2.780    0.000    8.361    0.000 expressions.py:667(get_db_converters)
   772700    2.698    0.000    3.318    0.000 base_properties.py:20(__init__)
    54315    2.683    0.000    5.621    0.000 base.py:457(__init__)
  1030673    2.681    0.000    5.132    0.000 compiler.py:331(quote_name_unless_alias)
132428/41372    2.655    0.000   30.835    0.001 containers.py:111(__init__)
  1214072    2.583    0.000    2.585    0.000 {built-in method __new__ of type object at 0x919120}
    25699    2.346    0.000   21.676    0.001 compiler.py:165(get_select)
   150634    2.284    0.000    9.158    0.000 inspect.py:895(getcallargs)
      735    2.259    0.003    2.259    0.003 {built-in method read}
2487687/2097715    2.249    0.000   71.223    0.000 {len}
    12834    2.234    0.000    7.842    0.001 ElementTree.py:831(_namespaces)
    51327    2.099    0.000   11.115    0.000 compiler.py:764(get_converters)
    25691    2.092    0.000    6.678    0.000 compiler.py:475(get_default_columns)
    51141    2.086    0.000   50.897    0.001 query.py:1233(__iter__)
   502481    2.063    0.000    7.166    0.000 expressions.py:657(as_sql)
1234511/315109    2.013    0.000    2.013    0.000 ElementTree.py:471(iter)
   758974    1.951    0.000    2.463    0.000 __init__.py:342(get_col)
  1385477    1.884    0.000    1.884    0.000 {method 'items' of 'dict' objects}
    25629    1.829    0.000    8.404    0.000 query.py:1222(resolve_model_init_order)
    77433    1.741    0.000    3.705    0.000 query.py:258(clone)
   512840    1.731    0.000    3.466    0.000 query.py:1315(model_fields)
   293870    1.636    0.000    2.592    0.000 base_properties.py:241(value_to_python)
    25699    1.596    0.000   30.842    0.001 compiler.py:358(as_sql)
   732666    1.546    0.000    2.282    0.000 __init__.py:460(__eq__)
   840743    1.532    0.000    2.693    0.000 __init__.py:657(get_db_converters)
   696980    1.520    0.000    2.153    0.000 base.py:95(__getitem__)
281447/1915    1.408    0.000    3.719    0.002 copy.py:145(deepcopy)

``` 
