### PR TITLE
App manager v2: allow rearranging of registration forms

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/form_link_primary.html
@@ -26,9 +26,7 @@
           {% else %}appnav-title-survey
           {% endif %}
           appnav-responsive">
-    {% if form.get_action_type != 'open' %}
         <i class="drag_handle appnav-drag-icon"></i>
-    {% endif %}
     <i
     {% if form.get_action_type == 'open' %}
         class="fcc fcc-app-createform appnav-primary-icon appnav-primary-icon-lg"


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?256712

@biyeun Could turn this into an add-on instead, but after mulling it over, I don't think making reg forms come first is likely to enhance people's understanding of case management (or that they'll understand why they can't rearrange the reg forms), I think it's enough that case lists are created with the reg form first. Let me know if you think this is an important constraint for us to have.

cc @benrudolph 