### PR TITLE
Don't recurse in get_all_dependencies

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -693,6 +693,7 @@ class IndexTree(DocumentSchema):
                 all_cases.add(incoming_case)
         return all_cases
 
+    @memoized
     def get_cases_that_directly_depend_on_case(self, case_id):
         return self.reverse_indices.get(case_id, [])
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -642,23 +642,16 @@ class IndexTree(DocumentSchema):
         cases_to_check = set([case_id])
         while cases_to_check:
             case_to_check = cases_to_check.pop()
-            if case_to_check not in all_cases:
-                all_cases.add(case_to_check)
-                incoming_extension_indices = extension_index_tree.get_cases_that_directly_depend_on_case(
-                    case_to_check
-                )
-                all_incoming_indices = itertools.chain(
-                    child_index_tree.get_cases_that_directly_depend_on_case(case_to_check),
-                    incoming_extension_indices,
-                )
-                for dependent_case in all_incoming_indices:
-                    # incoming indices
-                    if dependent_case not in all_cases:
-                        cases_to_check.add(dependent_case)
-                for indexed_case in extension_index_tree.indices.get(case_to_check, {}).values():
-                    # outgoing extension indices
-                    if indexed_case not in all_cases:
-                        cases_to_check.add(indexed_case)
+            all_cases.add(case_to_check)
+            incoming_extension_indices = extension_index_tree.get_cases_that_directly_depend_on_case(
+                case_to_check
+            )
+            incoming_child_indices = child_index_tree.get_cases_that_directly_depend_on_case(case_to_check)
+            all_incoming_indices = incoming_extension_indices | incoming_child_indices
+            new_outgoing_cases_to_check = set(extension_index_tree.indices.get(case_to_check, {}).values())
+            new_cases_to_check = (new_outgoing_cases_to_check | all_incoming_indices) - all_cases
+
+            cases_to_check |= new_cases_to_check
 
         return all_cases
 
@@ -696,7 +689,7 @@ class IndexTree(DocumentSchema):
 
     @memoized
     def get_cases_that_directly_depend_on_case(self, case_id):
-        return self.reverse_indices.get(case_id, [])
+        return set(self.reverse_indices.get(case_id, []))
 
     def delete_index(self, from_case_id, index_name):
         prior_ids = self.indices.pop(from_case_id, {})


### PR DESCRIPTION
This doesn't actually help how fast this is -- this method currently takes ~1s per run for user `101624@enikshay.commcarehq.org`, and I'm not sure why. It might just be the size of the sets. 

This PR mostly makes it easier to understand what is going on.

@snopoke 

FYI @calellowitz 
