### PR TITLE
don't wrap metadata

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -113,10 +113,8 @@ class ESXFormInstance(DictObject):
     @property
     def metadata(self):
         from corehq.form_processor.utils import clean_metadata
-        from couchforms.models import Metadata
         if const.TAG_META in self.form_data:
-            return Metadata.wrap(clean_metadata(self.form_data[const.TAG_META]))
-
+            return clean_metadata(self.form_data[const.TAG_META])
         return None
 
     @property


### PR DESCRIPTION
The meta block in ES has `commcare_version` which used to just get
set on `Meta` as a dynamic property but now we have a real property
called `commcare_version` so the wrapping was failing.

I don't think we gain anything by wrapping it though.