### PR TITLE
Broadcast message view

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -376,6 +376,8 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
     # seconds between sending mobile UCRs to users. Can be overridden per user
     default_mobile_ucr_sync_interval = IntegerProperty()
 
+    uses_new_reminders = BooleanProperty(default=False)
+
     @classmethod
     def wrap(cls, data):
         # for domains that still use original_doc

--- a/corehq/apps/reminders/templates/reminders/broadcasts_list.html
+++ b/corehq/apps/reminders/templates/reminders/broadcasts_list.html
@@ -20,10 +20,10 @@
         <table id="upcoming-broadcasts-table" class="table table-striped table-bordered">
             <thead>
                 <tr>
-                    <th class="col-md-4">{% trans 'When' %}</th>
-                    <th class="col-md-4">{% trans 'Recipient(s)' %}</th>
-                    <th class="col-md-4">{% trans 'Content' %}</th>
-                    <th class="col-md-4">{% trans 'Action' %}</th>
+                    <th class="col-md-2">{% trans 'When' %}</th>
+                    <th class="col-md-3">{% trans 'Recipient(s)' %}</th>
+                    <th class="col-md-5">{% trans 'Content' %}</th>
+                    <th class="col-md-2">{% trans 'Action' %}</th>
                 </tr>
             </thead>
         </table>
@@ -33,10 +33,10 @@
         <table id="past-broadcasts-table" class="table table-striped table-bordered">
             <thead>
                 <tr>
-                    <th class="col-md-4">{% trans 'When' %}</th>
-                    <th class="col-md-4">{% trans 'Recipient(s)' %}</th>
-                    <th class="col-md-4">{% trans 'Content' %}</th>
-                    <th class="col-md-4">{% trans 'Action' %}</th>
+                    <th class="col-md-2">{% trans 'When' %}</th>
+                    <th class="col-md-3">{% trans 'Recipient(s)' %}</th>
+                    <th class="col-md-5">{% trans 'Content' %}</th>
+                    <th class="col-md-2">{% trans 'Action' %}</th>
                 </tr>
             </thead>
         </table>

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta, datetime, time
+from functools import wraps
 import json
 
 from couchdbkit import ResourceNotFound
@@ -84,6 +85,19 @@ def get_project_time_info(domain):
     now = pytz.utc.localize(datetime.utcnow())
     timezone_now = now.astimezone(timezone)
     return (timezone, now, timezone_now)
+
+
+def _requires_old_reminder_framework():
+    def decorate(fn):
+        @wraps(fn)
+        def wrapped(request, *args, **kwargs):
+            if not hasattr(request, 'project'):
+                request.project = Domain.get_by_name(request.domain)
+            if not request.project.uses_new_reminders:
+                return fn(request, *args, **kwargs)
+            raise Http404()
+        return wrapped
+    return decorate
 
 
 class ScheduledRemindersCalendarView(BaseMessagingSectionView):
@@ -705,6 +719,7 @@ class CreateBroadcastView(BaseMessagingSectionView):
     template_name = 'reminders/broadcast.html'
     force_create_new_broadcast = False
 
+    @method_decorator(_requires_old_reminder_framework())
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_jquery_ui
     @use_timepicker
@@ -873,6 +888,7 @@ class RemindersListView(BaseMessagingSectionView):
     urlname = "list_reminders_new"
     page_title = ugettext_noop("Reminder Definitions")
 
+    @method_decorator(_requires_old_reminder_framework())
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_datatables
     def dispatch(self, *args, **kwargs):
@@ -967,6 +983,7 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
     LIST_PAST = 'list_past'
     DELETE_BROADCAST = 'delete_broadcast'
 
+    @method_decorator(_requires_old_reminder_framework())
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_datatables
     def dispatch(self, *args, **kwargs):

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -987,7 +987,7 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_datatables
     def dispatch(self, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+        return super(BroadcastListView, self).dispatch(*args, **kwargs)
 
     @property
     @memoized

--- a/corehq/messaging/scheduling/static/scheduling/js/broadcasts_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/broadcasts_list.js
@@ -1,11 +1,9 @@
 hqDefine("scheduling/js/broadcasts_list.js", function() {
     $(function() {
-        var immediate_table,
-            scheduled_table,
-            list_broadcasts_url = hqImport("hqwebapp/js/urllib.js").reverse("new_list_broadcasts"),
+        var list_broadcasts_url = hqImport("hqwebapp/js/urllib.js").reverse("new_list_broadcasts"),
             loader_src = hqImport("hqwebapp/js/initial_page_data.js").get("loader_src");
 
-        scheduled_table = $("#scheduled-table").dataTable({
+        $("#scheduled-table").dataTable({
             "lengthChange": false,
             "filter": false,
             "sort": false,
@@ -55,7 +53,8 @@ hqDefine("scheduling/js/broadcasts_list.js", function() {
                 },
             ],
         });
-        immediate_table = $("#immediate-table").dataTable({
+
+        $("#immediate-table").dataTable({
             "lengthChange": false,
             "filter": false,
             "sort": false,

--- a/corehq/messaging/scheduling/static/scheduling/js/broadcasts_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/broadcasts_list.js
@@ -1,0 +1,88 @@
+hqDefine("scheduling/js/broadcasts_list.js", function() {
+    $(function() {
+        var past_table,
+            list_broadcasts_url = hqImport("hqwebapp/js/urllib.js").reverse("new_list_broadcasts"),
+            loader_src = hqImport("hqwebapp/js/initial_page_data.js").get("loader_src");
+
+        scheduled_table = $("#scheduled-table").dataTable({
+            "lengthChange": false,
+            "filter": false,
+            "sort": false,
+            "displayLength": 5,
+            "processing": true,
+            "serverSide": true,
+            "ajaxSource": list_broadcasts_url,
+            "fnServerParams": function(aoData) {
+                aoData.push({"name": "action", "value": "list_scheduled"});
+            },
+            "sDom": "rtp",
+            "language": {
+                "emptyTable": gettext('There are no messages to display.'),
+                "infoEmpty": gettext('There are no messages to display.'),
+                "lengthMenu": gettext('Show _MENU_ messages per page'),
+                "processing": '<img src="' + loader_src + '" /> ' + gettext('Loading messages...'),
+                "info": gettext('Showing _START_ to _END_ of _TOTAL_ broadcasts'),
+                "infoFiltered": gettext('(filtered from _MAX_ total broadcasts)'),
+            },
+            "columnDefs": [
+                {
+                    "targets": [0],
+                    "render": function(data) {
+                        // TODO construct this from ID
+                        return 'Delete button';
+                    },
+                },
+                {
+                    "targets": [1],
+                    "render": function(data) {
+                        // TODO link this to the view
+                        return data;
+                    },
+                },
+                {
+                    "targets": [3],
+                    "render": function(data) {
+                        return data ? gettext("Active") : gettext("Inactive");
+                    },
+                },
+                {
+                    "targets": [4],
+                    "render": function(data) {
+                        // TODO construct this from ID
+                        return 'activate or deactivate button';
+                    },
+                },
+            ],
+        });
+        immediate_table = $("#immediate-table").dataTable({
+            "lengthChange": false,
+            "filter": false,
+            "sort": false,
+            "displayLength": 5,
+            "processing": true,
+            "serverSide": true,
+            "ajaxSource": list_broadcasts_url,
+            "fnServerParams": function(aoData) {
+                aoData.push({"name": "action", "value": "list_immediate"});
+            },
+            "dom": "rtp",
+            "language": {
+                "emptyTable": gettext('There are no messages to display.'),
+                "infoEmpty": gettext('There are no messages to display.'),
+                "lengthMenu": gettext('Show _MENU_ messages per page'),
+                "processing": '<img src="' + loader_src + '" /> ' + gettext('Loading Messages...'),
+                "info": gettext('Showing _START_ to _END_ of _TOTAL_ messages'),
+                "infoFiltered": gettext('(filtered from _MAX_ total messages)'),
+            },
+            "columnDefs": [
+                {
+                    "targets": [0],
+                    "render": function(data) {
+                        // TODO link this to the view
+                        return data;
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/corehq/messaging/scheduling/static/scheduling/js/broadcasts_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/broadcasts_list.js
@@ -1,6 +1,7 @@
 hqDefine("scheduling/js/broadcasts_list.js", function() {
     $(function() {
-        var past_table,
+        var immediate_table,
+            scheduled_table,
             list_broadcasts_url = hqImport("hqwebapp/js/urllib.js").reverse("new_list_broadcasts"),
             loader_src = hqImport("hqwebapp/js/initial_page_data.js").get("loader_src");
 
@@ -27,7 +28,7 @@ hqDefine("scheduling/js/broadcasts_list.js", function() {
             "columnDefs": [
                 {
                     "targets": [0],
-                    "render": function(data) {
+                    "render": function() {
                         // TODO construct this from ID
                         return 'Delete button';
                     },
@@ -47,7 +48,7 @@ hqDefine("scheduling/js/broadcasts_list.js", function() {
                 },
                 {
                     "targets": [4],
-                    "render": function(data) {
+                    "render": function() {
                         // TODO construct this from ID
                         return 'activate or deactivate button';
                     },

--- a/corehq/messaging/scheduling/templates/scheduling/broadcasts_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/broadcasts_list.html
@@ -1,0 +1,37 @@
+{% extends "style/base_section.html" %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% block js %} {{ block.super }}
+    <script src="{% static "scheduling/js/broadcasts_list.js" %}"></script>
+{% endblock %}
+
+{% block page_content %}
+    {% registerurl 'new_list_broadcasts' domain %}
+    {% initial_page_data 'loader_src' 'hqwebapp/images/ajax-loader.gif'|static %}
+    <h4>{% trans 'Scheduled Messages' %}</h4>
+    <div>
+        <table id="scheduled-table" class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th class="col-md-1">{% trans 'Delete' %}</th>
+                    <th class="col-md-4">{% trans 'Name' %}</th>
+                    <th class="col-md-3">{% trans 'Last Sent' %}</th>
+                    <th class="col-md-2">{% trans 'Status' %}</th>
+                    <th class="col-md-2">{% trans 'Action' %}</th>
+                </tr>
+            </thead>
+        </table>
+    </div>
+    <h4 style="clear: both">{% trans 'Immediate Messages' %}</h4>
+    <div>
+        <table id="immediate-table" class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th class="col-md-8">{% trans 'Name' %}</th>
+                    <th class="col-md-4">{% trans 'Sent' %}</th>
+                </tr>
+            </thead>
+        </table>
+    </div>
+{% endblock %}

--- a/corehq/messaging/scheduling/urls.py
+++ b/corehq/messaging/scheduling/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from corehq.messaging.scheduling.views import BroadcastListView
+
+urlpatterns = [
+    url(r'^broadcasts/$', BroadcastListView.as_view(), name=BroadcastListView.urlname),
+]

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -10,6 +10,12 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.apps.style.decorators import use_datatables
 from corehq.apps.hqwebapp.views import DataTablesAJAXPaginationMixin
+from corehq.messaging.scheduling.models import (
+    ImmediateBroadcast,
+    ScheduledBroadcast
+)
+from corehq.const import SERVER_DATETIME_FORMAT
+from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 
 from dimagi.utils.decorators.memoized import memoized
@@ -29,10 +35,12 @@ def _requires_new_reminder_framework():
 
 
 class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin):
-    # TODO: should use template in its own folder
-    template_name = 'reminders/broadcasts_list.html'
+    template_name = 'scheduling/broadcasts_list.html'
     urlname = 'new_list_broadcasts'
     page_title = ugettext_lazy('Schedule a Message')
+
+    LIST_SCHEDULED = 'list_scheduled'
+    LIST_IMMEDIATE = 'list_immediate'
 
     @method_decorator(_requires_new_reminder_framework())
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
@@ -44,3 +52,54 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
     @memoized
     def project_timezone(self):
         return get_timezone_for_user(None, self.domain)
+
+    def _format_time(self, time):
+        user_time = ServerTime(time).user_time(self.project_timezone)
+        return user_time.ui_string(SERVER_DATETIME_FORMAT)
+
+    def get_scheduled_ajax_response(self):
+        query = (
+            ScheduledBroadcast.objects
+            .filter(domain=self.domain)
+            .order_by('-last_sent_timestamp')
+        )
+        total_records = query.count()
+        query = query.select_related('schedule')
+        broadcasts = query[self.display_start:self.display_start + self.display_length]
+
+        data = []
+        for broadcast in broadcasts:
+            data.append([
+                broadcast.id,
+                broadcast.name,
+                self._format_time(broadcast.last_sent_timestamp),
+                broadcast.schedule.active,
+            ])
+        return self.datatables_ajax_response(data, total_records)
+
+    def get_immediate_ajax_response(self):
+        query = (
+            ImmediateBroadcast.objects
+            .filter(domain=self.domain)
+            .order_by('-last_sent_timestamp')
+        )
+        total_records = query.count()
+        broadcasts = query[self.display_start:self.display_start + self.display_length]
+
+        data = []
+        for broadcast in broadcasts:
+            data.append([
+                broadcast.name,
+                self._format_time(broadcast.last_sent_timestamp),
+                broadcast.id,
+            ])
+        return self.datatables_ajax_response(data, total_records)
+
+    def get(self, request, *args, **kwargs):
+        action = request.GET.get('action')
+        if action == self.LIST_SCHEDULED:
+            return self.get_scheduled_ajax_response()
+        elif action == self.LIST_IMMEDIATE:
+            return self.get_immediate_ajax_response()
+
+        return super(BroadcastListView, self).get(*args, **kwargs)

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -1,0 +1,46 @@
+from functools import wraps
+
+from django.http import Http404
+from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext_lazy
+
+from corehq import privileges
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.domain.models import Domain
+from corehq.apps.sms.views import BaseMessagingSectionView
+from corehq.apps.style.decorators import use_datatables
+from corehq.apps.hqwebapp.views import DataTablesAJAXPaginationMixin
+from corehq.util.timezones.utils import get_timezone_for_user
+
+from dimagi.utils.decorators.memoized import memoized
+
+
+def _requires_new_reminder_framework():
+    def decorate(fn):
+        @wraps(fn)
+        def wrapped(request, *args, **kwargs):
+            if not hasattr(request, 'project'):
+                request.project = Domain.get_by_name(request.domain)
+            if request.project.uses_new_reminders:
+                return fn(request, *args, **kwargs)
+            raise Http404()
+        return wrapped
+    return decorate
+
+
+class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin):
+    # TODO: should use template in its own folder
+    template_name = 'reminders/broadcasts_list.html'
+    urlname = 'new_list_broadcasts'
+    page_title = ugettext_lazy('Schedule a Message')
+
+    @method_decorator(_requires_new_reminder_framework())
+    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
+    @use_datatables
+    def dispatch(self, *args, **kwargs):
+        return super(BroadcastListView, self).dispatch(*args, **kwargs)
+
+    @property
+    @memoized
+    def project_timezone(self):
+        return get_timezone_for_user(None, self.domain)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -893,6 +893,7 @@ class MessagingTab(UITab):
     view = "sms_default"
 
     url_prefix_formats = (
+        '/a/{domain}/messaging/',
         '/a/{domain}/sms/',
         '/a/{domain}/reminders/',
         '/a/{domain}/data/edit/case_groups/',
@@ -1005,10 +1006,20 @@ class MessagingTab(UITab):
 
         if self.can_access_reminders:
             if self.project.uses_new_reminders:
-                pass
+                from corehq.messaging.scheduling.views import (
+                    BroadcastListView as NewBroadcastListView,
+                )
+                messages_urls.extend([
+                    {
+                        'title': _("Schedule a Message"),
+                        'url': reverse(NewBroadcastListView.urlname, args=[self.domain]),
+                        'subpages': [],
+                        'show_in_dropdown': True,
+                    },
+                ])
             else:
                 from corehq.apps.reminders.views import (
-                    BroadcastListView,
+                    BroadcastListView as OldBroadcastListView,
                     CreateBroadcastView,
                     EditBroadcastView,
                     CopyBroadcastView,
@@ -1016,7 +1027,7 @@ class MessagingTab(UITab):
                 messages_urls.extend([
                     {
                         'title': _("Broadcast Messages"),
-                        'url': reverse(BroadcastListView.urlname, args=[self.domain]),
+                        'url': reverse(OldBroadcastListView.urlname, args=[self.domain]),
                         'subpages': [
                             {
                                 'title': _("Edit Broadcast"),

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1004,33 +1004,36 @@ class MessagingTab(UITab):
             ])
 
         if self.can_access_reminders:
-            from corehq.apps.reminders.views import (
-                BroadcastListView,
-                CreateBroadcastView,
-                EditBroadcastView,
-                CopyBroadcastView,
-            )
-            messages_urls.extend([
-                {
-                    'title': _("Broadcast Messages"),
-                    'url': reverse(BroadcastListView.urlname, args=[self.domain]),
-                    'subpages': [
-                        {
-                            'title': _("Edit Broadcast"),
-                            'urlname': EditBroadcastView.urlname,
-                        },
-                        {
-                            'title': _("New Broadcast"),
-                            'urlname': CreateBroadcastView.urlname,
-                        },
-                        {
-                            'title': _("Copy Broadcast"),
-                            'urlname': CopyBroadcastView.urlname,
-                        },
-                    ],
-                    'show_in_dropdown': True,
-                },
-            ])
+            if self.project.uses_new_reminders:
+                pass
+            else:
+                from corehq.apps.reminders.views import (
+                    BroadcastListView,
+                    CreateBroadcastView,
+                    EditBroadcastView,
+                    CopyBroadcastView,
+                )
+                messages_urls.extend([
+                    {
+                        'title': _("Broadcast Messages"),
+                        'url': reverse(BroadcastListView.urlname, args=[self.domain]),
+                        'subpages': [
+                            {
+                                'title': _("Edit Broadcast"),
+                                'urlname': EditBroadcastView.urlname,
+                            },
+                            {
+                                'title': _("New Broadcast"),
+                                'urlname': CreateBroadcastView.urlname,
+                            },
+                            {
+                                'title': _("Copy Broadcast"),
+                                'urlname': CopyBroadcastView.urlname,
+                            },
+                        ],
+                        'show_in_dropdown': True,
+                    },
+                ])
 
         return messages_urls
 

--- a/urls.py
+++ b/urls.py
@@ -61,6 +61,7 @@ domain_specific = [
     url(r'^indicators/mvp/', include('mvp.urls')),
     url(r'^indicators/', include('corehq.apps.indicators.urls')),
     url(r'^reports/', include('corehq.apps.reports.urls')),
+    url(r'^messaging/', include('corehq.messaging.scheduling.urls')),
     url(r'^data/', include('corehq.apps.data_interfaces.urls')),
     url(r'^data_dictionary/', include('corehq.apps.data_dictionary.urls')),
     url(r'^', include(hqwebapp_domain_specific)),


### PR DESCRIPTION
@gcapalbo This implements the first view of the spec. I used the old Broadcast Messages view as a template to make this one

I also blocked the old "Broadcast Messages" UI, but I think that "Compose a Message" and maybe "Reminders" should be blocked as well for the framework. Is that correct?

![image](https://user-images.githubusercontent.com/1471773/27557669-63b94f90-5a88-11e7-9edc-a5e53d2b5482.png)

buddy @calellowitz 
