### PR TITLE
Cache parent locations

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -38,6 +38,11 @@ class LocationSet(object):
         return item in self.by_id
 
 
+class FlatLocationSet(object):
+    def __init__(self, locations):
+        self.sorted_locations = sorted(locations, key=lambda loc: loc.site_code)
+
+
 def should_sync_locations(last_sync, location_db, restore_user):
     """
     Determine if any locations (already filtered to be relevant
@@ -81,7 +86,7 @@ class LocationFixtureProvider(FixtureProvider):
         if not self.serializer.should_sync(restore_user):
             return []
 
-        all_locations = restore_user.get_locations_to_sync()
+        all_locations = get_all_locations_to_sync(restore_user, self.serializer.location_set)
         if not should_sync_locations(restore_state.last_sync_log, all_locations, restore_user):
             return []
 
@@ -90,6 +95,7 @@ class LocationFixtureProvider(FixtureProvider):
 
 
 class HierarchicalLocationSerializer(object):
+    location_set = LocationSet
 
     def should_sync(self, restore_user):
         return should_sync_hierarchical_fixture(restore_user.project)
@@ -105,6 +111,7 @@ class HierarchicalLocationSerializer(object):
 
 
 class FlatLocationSerializer(object):
+    location_set = FlatLocationSet
 
     def should_sync(self, restore_user):
         return should_sync_flat_fixture(restore_user.project)
@@ -124,7 +131,7 @@ class FlatLocationSerializer(object):
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id, 'indexed': 'true'})
         outer_node = Element('locations')
         root_node.append(outer_node)
-        for location in sorted(all_locations.by_id.values(), key=lambda l: l.site_code):
+        for location in all_locations.sorted_locations:
             attrs = {
                 'type': location.location_type.code,
                 'id': location.location_id,
@@ -181,9 +188,9 @@ flat_location_fixture_generator = LocationFixtureProvider(
 )
 
 
-def get_all_locations_to_sync(user):
+def get_all_locations_to_sync(user, location_set=LocationSet):
     if toggles.SYNC_ALL_LOCATIONS.enabled(user.domain):
-        return LocationSet(SQLLocation.active_objects.filter(domain=user.domain))
+        return location_set(SQLLocation.active_objects.filter(domain=user.domain))
     else:
         all_locations = set()
 
@@ -205,7 +212,7 @@ def get_all_locations_to_sync(user):
 
             all_locations |= _get_include_without_expanding_locations(user.domain, location_type)
 
-        return LocationSet(all_locations)
+        return location_set(all_locations)
 
 
 def _get_expand_from_level(domain, user_location, expand_from):


### PR DESCRIPTION
@snopoke 
@esoergel 

FYI @ctsims 

For user `101624@enikshay.commcarehq.org`
```
from collections import namedtuple
from corehq.apps.users.models import CommCareUser
from casexml.apps.phone.fixtures import generator

FakeRestoreState = namedtuple('FakeRestoreState', 'restore_user last_sync_log')

user = CommCareUser.get_by_username('101624@enikshay.commcarehq.org')
ota_user = user.to_ota_restore_user()
providers = generator.get_providers(ota_user, version='2.0')
restore_state = FakeRestoreState(ota_user, None)
%prun -s cumulative providers[1](restore_state)
```

## before
```         
         26577929 function calls (26064233 primitive calls) in 106.830 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.024    0.024  108.000  108.000 <string>:1(<module>)
        1    0.000    0.000  107.976  107.976 fixtures.py:70(__call__)
    55205    0.785    0.000   96.498    0.002 related_descriptors.py:153(__get__)
25627/25624    0.436    0.000   82.389    0.003 query.py:1085(_fetch_all)
    54216    0.930    0.000   81.660    0.002 query.py:48(__iter__)
    25542    0.273    0.000   77.929    0.003 query.py:371(get)
584303/297755    0.554    0.000   72.845    0.000 {len}
    25543    0.114    0.000   72.530    0.003 query.py:237(__len__)
    25553    0.348    0.000   61.930    0.002 compiler.py:808(execute_sql)
        1    0.000    0.000   56.244   56.244 fixtures.py:112(get_xml_nodes)
        1    0.225    0.225   56.241   56.241 fixtures.py:123(_get_fixture_node)
      4/3    0.000    0.000   51.684   17.228 memoized.py:8(_inner)
      4/3    0.000    0.000   51.684   17.228 memoized.py:116(__call__)
        1    0.000    0.000   51.510   51.510 models.py:123(get_locations_to_sync)
        1    0.002    0.002   51.510   51.510 fixtures.py:184(get_all_locations_to_sync)
        1    0.006    0.006   41.568   41.568 fixtures.py:17(__init__)
     2769    0.027    0.000   41.561    0.015 fixtures.py:25(add_location)
     2769    0.102    0.000   41.479    0.015 fixtures.py:263(_valid_parent_type)
    25553    1.621    0.000   30.271    0.001 compiler.py:358(as_sql)
    25553    0.244    0.000   29.884    0.001 utils.py:58(execute)
    25553   27.762    0.001   29.552    0.001 {method 'execute' of 'psycopg2.extensions.cursor' objects}
    25553    0.328    0.000   23.693    0.001 compiler.py:40(pre_sql_setup)
    25553    0.268    0.000   22.175    0.001 compiler.py:34(setup_query)
    25553    2.358    0.000   21.756    0.001 compiler.py:165(get_select)
    51171    0.154    0.000   15.665    0.000 query.py:791(filter)
    51171    0.447    0.000   15.510    0.000 query.py:805(_filter_or_exclude)
576611/525461    2.898    0.000   14.754    0.000 compiler.py:348(compile)
    55056    0.406    0.000   11.855    0.000 compiler.py:783(results_iter)
    51171    1.191    0.000   11.427    0.000 query.py:1214(add_q)
    84/82    0.000    0.000    9.996    0.122 query.py:241(__iter__)
76711/51171    1.108    0.000    9.772    0.000 query.py:1232(_add_q)
    25552    1.428    0.000    7.439    0.000 compiler.py:764(get_converters)
   499920    2.161    0.000    7.387    0.000 expressions.py:657(as_sql)
    25551    2.151    0.000    6.467    0.000 compiler.py:475(get_default_columns)
   474339    1.861    0.000    5.572    0.000 expressions.py:667(get_db_converters)
  1025402    2.743    0.000    5.256    0.000 compiler.py:331(quote_name_unless_alias)
    25642    0.768    0.000    5.077    0.000 query.py:1101(build_filter)
    28669    0.225    0.000    5.064    0.000 base.py:559(from_db)
    76729    0.640    0.000    4.641    0.000 query.py:1071(_clone)
    28669    1.923    0.000    4.208    0.000 base.py:457(__init__)
    51140    0.314    0.000    3.987    0.000 compiler.py:1231(cursor_iter)
    76730    1.710    0.000    3.681    0.000 query.py:258(clone)
    51140    0.312    0.000    3.534    0.000 compiler.py:1237(<lambda>)
    12776    0.104    0.000    2.886    0.000 models.py:387(__init__)
    51141    0.288    0.000    2.766    0.000 utils.py:99(inner)
    25553    0.279    0.000    2.710    0.000 where.py:63(as_sql)
    25540    0.278    0.000    2.699    0.000 related_descriptors.py:106(get_queryset)
    82253    0.378    0.000    2.593    0.000 related.py:953(get_col)
    51140    0.606    0.000    2.380    0.000 {method 'fetchmany' of 'psycopg2.extensions.cursor' objects}
  2687627    2.319    0.000    2.319    0.000 {method 'append' of 'list' objects}
    25568    0.228    0.000    2.161    0.000 lookups.py:154(as_sql)
        1    0.001    0.001    2.156    2.156 fixtures.py:242(_get_include_without_expanding_locations)
564252/563698    0.733    0.000    2.142    0.000 {setattr}
  1051239    1.256    0.000    2.031    0.000 {isinstance}
   499910    1.301    0.000    1.991    0.000 operations.py:100(quote_name)
   102296    0.553    0.000    1.987    0.000 copy.py:66(copy)
1274417/1258595    1.913    0.000    1.957    0.000 {getattr}
    15539    0.094    0.000    1.886    0.000 models.py:139(__init__)
   556515    1.063    0.000    1.882    0.000 __init__.py:657(get_db_converters)
    25540    0.400    0.000    1.862    0.000 related.py:329(get_reverse_related_filter)
  1182470    1.779    0.000    1.779    0.000 {hasattr}
    25551    0.188    0.000    1.741    0.000 query.py:926(order_by)
   499993    1.346    0.000    1.705    0.000 __init__.py:342(get_col)
    25540    0.108    0.000    1.619    0.000 manager.py:132(db_manager)
215476/107730    0.571    0.000    1.579    0.000 functional.py:32(__get__)
   474339    1.050    0.000    1.546    0.000 __init__.py:460(__eq__)
    25553    0.199    0.000    1.426    0.000 base.py:225(cursor)
    13053    0.052    0.000    1.404    0.000 subclassing.py:36(__set__)
    13053    0.089    0.000    1.352    0.000 fields.py:64(pre_init)
    25568    0.399    0.000    1.307    0.000 lookups.py:144(process_lhs)
    46617    0.696    0.000    1.248    0.000 decimal.py:515(__new__)
    25565    0.189    0.000    1.247    0.000 query.py:1060(build_lookup)
    82254    0.198    0.000    1.192    0.000 related.py:853(target_field)
    13053    0.043    0.000    1.157    0.000 __init__.py:293(loads)
    76711    0.589    0.000    1.137    0.000 query.py:2030(update_join_types)
    13053    0.116    0.000    1.114    0.000 decoder.py:361(decode)
    51182    0.141    0.000    1.046    0.000 query.py:2023(add_votes)
    25553    0.105    0.000    1.020    0.000 query.py:1024(db)
   127791    0.680    0.000    1.019    0.000 query_utils.py:54(__init__)
    82933    0.523    0.000    1.001    0.000 related.py:593(foreign_related_fields)
   127893    0.342    0.000    0.987    0.000 collections.py:501(update)
```

## after 
```
         752329 function calls (745786 primitive calls) in 3.123 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.031    0.031    3.124    3.124 <string>:1(<module>)
        1    0.000    0.000    3.093    3.093 fixtures.py:76(__call__)
        1    0.000    0.000    2.094    2.094 fixtures.py:120(get_xml_nodes)
        1    0.061    0.061    2.089    2.089 fixtures.py:131(_get_fixture_node)
     2769    0.087    0.000    1.915    0.001 fixtures.py:330(_fill_in_location_element)
     2769    1.273    0.000    1.618    0.001 fixtures.py:313(_get_metadata_node)
        1    0.002    0.002    0.959    0.959 fixtures.py:206(get_all_locations_to_sync)
    21/15    0.004    0.000    0.916    0.061 query.py:1085(_fetch_all)
     11/8    0.000    0.000    0.898    0.112 query.py:241(__iter__)
     2815    0.011    0.000    0.716    0.000 query.py:48(__iter__)
     2800    0.016    0.000    0.407    0.000 base.py:559(from_db)
     2775    0.013    0.000    0.385    0.000 models.py:387(__init__)
        1    0.001    0.001    0.359    0.359 fixtures.py:265(_get_include_without_expanding_locations)
    55405    0.205    0.000    0.337    0.000 ElementTree.py:207(__init__)
     2800    0.101    0.000    0.311    0.000 base.py:457(__init__)
    61490    0.072    0.000    0.199    0.000 {setattr}
       19    0.000    0.000    0.197    0.010 compiler.py:808(execute_sql)
        3    0.000    0.000    0.193    0.064 query.py:663(_prefetch_related_objects)
        3    0.005    0.002    0.193    0.064 query.py:1387(prefetch_related_objects)
        3    0.009    0.003    0.185    0.062 query.py:1557(prefetch_one_level)
       19    0.000    0.000    0.170    0.009 utils.py:58(execute)
       19    0.169    0.009    0.170    0.009 {method 'execute' of 'psycopg2.extensions.cursor' objects}
    55403    0.097    0.000    0.146    0.000 ElementTree.py:300(append)
     8320    0.026    0.000    0.144    0.000 related.py:597(get_local_related_value)
     3655    0.005    0.000    0.128    0.000 compiler.py:783(results_iter)
     2775    0.007    0.000    0.125    0.000 subclassing.py:36(__set__)
     2775    0.016    0.000    0.118    0.000 fields.py:64(pre_init)
        3    0.003    0.001    0.111    0.037 related_descriptors.py:122(get_prefetch_queryset)
       70    0.001    0.000    0.106    0.002 compiler.py:1231(cursor_iter)
       70    0.000    0.000    0.105    0.002 compiler.py:1237(<lambda>)
       71    0.000    0.000    0.104    0.001 utils.py:99(inner)
       70    0.037    0.001    0.104    0.001 {method 'fetchmany' of 'psycopg2.extensions.cursor' objects}
     2775    0.007    0.000    0.084    0.000 __init__.py:293(loads)
    55655    0.080    0.000    0.080    0.000 {method 'copy' of 'dict' objects}
60991/55447    0.066    0.000    0.078    0.000 {getattr}
```