### PR TITLE
Don't fetch case attachments if not needed

### DIFF
--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from couchdbkit import ResourceNotFound
 from django.test import SimpleTestCase, TestCase
 from mock import patch
+from corehq.util.test_utils import flag_enabled
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
@@ -94,6 +95,7 @@ def mock_fetch_case_attachment(case_id, attachments):
 class ExplodeCasesTest(SimpleTestCase, TestXmlMixin):
     maxDiff = 1000000
 
+    @flag_enabled('MM_CASE_PROPERTIES')
     def test_make_creating_casexml(self):
         for input, files, output in TESTS:
             with mock_fetch_case_attachment(input.case_id, files):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -22,7 +22,7 @@ from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
-from corehq.util.test_utils import TestFileMixin, trap_extra_setup
+from corehq.util.test_utils import TestFileMixin, trap_extra_setup, flag_enabled
 
 TEST_CASE_ID = "EOL9FIAKIQWOFXFOH0QAMWU64"
 CREATE_XFORM_ID = "6RGAZTETE3Z2QC0PE2DKM88MO"
@@ -236,11 +236,13 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
             attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
             self.assertEqual(2, len(attach_actions))
 
+    @flag_enabled('MM_CASE_PROPERTIES')
     def testOTARestoreSingle(self):
         _, case = self._doCreateCaseWithMultimedia()
         restore_attachments = ['fruity_file']
         self._validateOTARestore(case.case_id, restore_attachments)
 
+    @flag_enabled('MM_CASE_PROPERTIES')
     def testOTARestoreMultiple(self):
         _, case = self._doCreateCaseWithMultimedia()
         restore_attachments = ['commcare_logo_file', 'dimagi_logo_file']

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -203,7 +203,7 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
                 element.append(attachment_elem)
 
 
-@quickcache(['domain'])
+@quickcache(['domain'], memoize_timeout=12 * 60 * 60, timeout=12 * 60 * 60)
 def _sync_attachments(domain):
     return MM_CASE_PROPERTIES.enabled(domain)
 

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -4,6 +4,7 @@ import logging
 from dimagi.utils.parsing import json_format_datetime, json_format_date
 from dateutil.parser import parse as parse_datetime
 
+from corehq.toggles import MM_CASE_PROPERTIES
 
 def datetime_to_xml_string(datetime_string):
     if isinstance(datetime_string, basestring):
@@ -186,17 +187,18 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
             element.append(index_elem)
 
     def add_attachments(self, element):
-        if self.case.case_attachments:
-            attachment_elem = safe_element("attachment")
-            for k, a in self.case.case_attachments.items():
-                aroot = safe_element(k)
-                # moved to attrs in v2
-                aroot.attrib = {
-                    "src": self.case.get_attachment_server_url(k),
-                    "from": "remote"
-                }
-                attachment_elem.append(aroot)
-            element.append(attachment_elem)
+        if MM_CASE_PROPERTIES.enabled(self.case.domain):
+            if self.case.case_attachments:
+                attachment_elem = safe_element("attachment")
+                for k, a in self.case.case_attachments.items():
+                    aroot = safe_element(k)
+                    # moved to attrs in v2
+                    aroot.attrib = {
+                        "src": self.case.get_attachment_server_url(k),
+                        "from": "remote"
+                    }
+                    attachment_elem.append(aroot)
+                element.append(attachment_elem)
 
 
 def get_generator(version, case):

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -1,3 +1,4 @@
+import settings
 from casexml.apps.case.xml import V1, V2, V3, check_version, V2_NAMESPACE
 from xml.etree import ElementTree
 import logging
@@ -203,7 +204,10 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
                 element.append(attachment_elem)
 
 
-@quickcache(['domain'], memoize_timeout=12 * 60 * 60, timeout=12 * 60 * 60)
+@quickcache(['domain'],
+            skip_arg=lambda _: settings.UNIT_TESTING,
+            memoize_timeout=12 * 60 * 60,
+            timeout=12 * 60 * 60)
 def _sync_attachments(domain):
     return MM_CASE_PROPERTIES.enabled(domain)
 

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -5,6 +5,8 @@ from dimagi.utils.parsing import json_format_datetime, json_format_date
 from dateutil.parser import parse as parse_datetime
 
 from corehq.toggles import MM_CASE_PROPERTIES
+from corehq.util.quickcache import quickcache
+
 
 def datetime_to_xml_string(datetime_string):
     if isinstance(datetime_string, basestring):
@@ -187,7 +189,7 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
             element.append(index_elem)
 
     def add_attachments(self, element):
-        if MM_CASE_PROPERTIES.enabled(self.case.domain):
+        if _sync_attachments(self.case.domain):
             if self.case.case_attachments:
                 attachment_elem = safe_element("attachment")
                 for k, a in self.case.case_attachments.items():
@@ -199,6 +201,11 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
                     }
                     attachment_elem.append(aroot)
                 element.append(attachment_elem)
+
+
+@quickcache(['domain'])
+def _sync_attachments(domain):
+    return MM_CASE_PROPERTIES.enabled(domain)
 
 
 def get_generator(version, case):


### PR DESCRIPTION
@snopoke 
FYI @ctsims 

## Before
```
    12808    0.048    0.000   28.342    0.002 generator.py:188(add_attachments)
    12808    0.062    0.000   27.103    0.002 models.py:771(case_attachments)
    12808    0.099    0.000   27.024    0.002 models.py:97(get_attachments)
    12808    0.160    0.000   26.774    0.002 models.py:737(_get_attachments_from_db)
    12808    0.246    0.000   26.614    0.002 dbaccessors.py:756(get_attachments)
```

## after
```
    12808    0.047    0.000    7.570    0.001 generator.py:191(add_attachments)
```

I'm not sure why this is still taking so long, but it does hit `quickcache` for every single case. I bumped the memoized timeout after I took this measurement, so hopefully that will help.