### PR TITLE
Don't fetch all indices when we know the case will sync

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -348,20 +348,27 @@ def filter_cases_modified_since(case_accessor, case_ids, reference_date):
 
 
 def case_needs_to_sync(case, last_sync_log):
+    # initial sync or new owner IDs always sync down everything
+    if not last_sync_log:
+        return True
+
+    # if this is a new owner_id and the case wasn't previously on the phone
+    # if it's an extension, and it was already on the phone, don't sync it
     owner_id = case.owner_id or case.user_id  # need to fallback to user_id for v1 cases
-    extension_cases = [index for index in case.indices
-                       if index.relationship == CASE_INDEX_EXTENSION]
-    if (not last_sync_log or
-        (owner_id not in last_sync_log.owner_ids_on_phone and
-         not (extension_cases and case.case_id in last_sync_log.case_ids_on_phone))):
-        # initial sync or new owner IDs always sync down everything
-        # extension cases don't get synced again if they haven't changed
+    if (owner_id not in last_sync_log.owner_ids_on_phone and (
+            case.case_id not in last_sync_log.case_ids_on_phone or not _is_extension(case))):
         return True
     elif case.server_modified_on >= last_sync_log.date:
         return case.modified_since_sync(last_sync_log)
     # if the case wasn't touched since last sync, and the phone was aware of this owner_id last time
     # don't worry about it
     return False
+
+
+@memoized
+def _is_extension(case):
+    return len([index for index in case.indices
+                if index.relationship == CASE_INDEX_EXTENSION]) > 0
 
 
 def pop_ids(set_, how_many):


### PR DESCRIPTION
@snopoke 
FYI: @ctsims 

Haven't benchmarked this one, but `case_needs_to_sync` calls `indices` a lot of times. When this is a restore, we should just sync the case, we don't need to fetch all the indices from the db.

```
   89240    0.626    0.000   54.423    0.001 models.py:708(indices)
    12808    0.084    0.000   48.135    0.004 clean_owners.py:350(case_needs_to_sync)
    12808    0.193    0.000   46.427    0.004 models.py:699(_saved_indices)
    12808    0.247    0.000   46.109    0.004 dbaccessors.py:668(get_indices)
```

This is a subset of the `process_case_batches` time shown on the restore page.