### PR TITLE
EOF 'Previous Screen' incorrect for child module form

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -83,6 +83,9 @@ class WorkflowHelper(PostProcessor):
             datums_list = self.root_module_datums
         else:
             datums_list = module_datums.values()  # [ [datums for f0], [datums for f1], ...]
+            root_module = target_form.get_module().root_module
+            if root_module:
+                datums_list = datums_list + self.get_module_datums(id_strings.menu_id(root_module)).values()
 
         common_datums = commonprefix(datums_list)
         remaining_datums = form_datums[len(common_datums):]

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -47,7 +47,7 @@ class WorkflowHelper(PostProcessor):
 
                 self.create_workflow_stack(form_command, stack_frames)
 
-    def get_frame_children(self, target_form, module_only=False):
+    def get_frame_children(self, target_form, module_only=False, include_target_root=False):
         """
         For a form return the list of stack frame children that are required
         to navigate to that form.
@@ -84,7 +84,7 @@ class WorkflowHelper(PostProcessor):
         else:
             datums_list = module_datums.values()  # [ [datums for f0], [datums for f1], ...]
             root_module = target_form.get_module().root_module
-            if root_module:
+            if root_module and include_target_root:
                 datums_list = datums_list + self.get_module_datums(id_strings.menu_id(root_module)).values()
 
         common_datums = commonprefix(datums_list)
@@ -269,7 +269,7 @@ class EndOfFormNavigationWorkflow(object):
                 frame_children = frame_children_for_module(root_module)
                 return StackFrameMeta(xpath, frame_children)
             elif form_workflow == WORKFLOW_PREVIOUS:
-                frame_children = self.helper.get_frame_children(form)
+                frame_children = self.helper.get_frame_children(form, include_target_root=True)
 
                 # since we want to go the 'previous' screen we need to drop the last
                 # datum

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -159,6 +159,10 @@ class AppFactory(object):
         else:
             AppFactory.advanced_form_autoloads(form, AUTO_SELECT_USERCASE, None)
 
+    @staticmethod
+    def form_workflow(form, mode):
+        form.post_form_workflow = mode
+
     @classmethod
     def case_list_form_app_factory(cls):
         factory = cls(build_version='2.9')

--- a/corehq/apps/app_manager/tests/data/suite/child-module-form-workflow-previous.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-form-workflow-previous.xml
@@ -1,0 +1,36 @@
+<partial>
+  <entry>
+    <command id="m0-f0">
+      <text>
+        <locale id="forms.m0f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+      <datum id="case_id_new_guppy_0" function="uuid()" />
+    </session>
+  </entry>
+  <entry>
+    <command id="m1-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
+      <datum id="case_id_new_guppy_0" function="uuid()" />
+      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m1'"/>
+        <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
+        <datum id="case_id_new_guppy_0" value="uuid()"/>
+        <command value="'m1-f0'"/>
+      </create>
+    </stack>
+  </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -7,6 +7,7 @@ from corehq.apps.app_manager.models import (
     Module,
     PreloadAction,
 )
+from corehq.apps.app_manager.models import WORKFLOW_PREVIOUS
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 
 DOMAIN = 'domain'
@@ -17,7 +18,7 @@ class ModuleAsChildTestBase(TestXmlMixin):
     child_module_class = None
 
     def setUp(self):
-        self.factory = AppFactory(domain=DOMAIN)
+        self.factory = AppFactory(build_version='2.9', domain=DOMAIN)
         self.module_0, _ = self.factory.new_basic_module('parent', 'gold-fish')
         self.module_1, _ = self.factory.new_module(self.child_module_class, 'child', 'guppy', parent_module=self.module_0)
 
@@ -172,6 +173,9 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         self.factory.form_requires_case(m1f0, 'guppy', parent_case_type='gold-fish')
 
         self.assertXmlPartialEqual(self.get_xml('child-module-entry-datums-added-basic'), self.app.create_suite(), "./entry")
+
+        self.factory.form_workflow(m1f0, WORKFLOW_PREVIOUS)
+        self.assertXmlPartialEqual(self.get_xml('child-module-form-workflow-previous'), self.app.create_suite(), "./entry")
 
     def test_grandparent_as_child_module(self):
         """


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?256661

The logic that generates datums needed by each form in the module didn't include the parent module, so the [longest list of common datums](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/suite_xml/post_process/workflow.py#L230-L231) wasn't correct and the frames generated were out of order.

@benrudolph / @snopoke 