### PR TITLE
Check aggregate['total_size'] is not None

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1550,7 +1550,10 @@ class DataFileDownloadList(BaseProjectDataView):
             return self.get(request, *args, **kwargs)
 
         aggregate = DataFile.objects.filter(domain=self.domain).aggregate(total_size=Sum('content_length'))
-        if aggregate['total_size'] + request.FILES['file'].size > MAX_DATA_FILE_SIZE_TOTAL:
+        if (
+            aggregate['total_size'] and
+            aggregate['total_size'] + request.FILES['file'].size > MAX_DATA_FILE_SIZE_TOTAL
+        ):
             messages.warning(
                 request,
                 _('Uploading this data file would exceed the total allowance of {} GB for this project space. '


### PR DESCRIPTION
If there are no DataFiles, then `aggregate['total_size']` will be `None`, not 0. Check this before assuming it's an integer.

@snopoke cc @gcapalbo @benrudolph 
