### PR TITLE
"domain" -> "project space"

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -744,7 +744,7 @@ class UserInvitationView(object):
 
     @property
     def success_msg(self):
-        return 'You have been added to the "%s" project space.' % self.domain
+        return _('You have been added to the "%s" project space.') % self.domain
 
     @property
     def redirect_to_on_success(self):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -744,7 +744,7 @@ class UserInvitationView(object):
 
     @property
     def success_msg(self):
-        return "You have been added to the %s domain" % self.domain
+        return 'You have been added to the "%s" project space.' % self.domain
 
     @property
     def redirect_to_on_success(self):


### PR DESCRIPTION
Apparently they're called "project spaces" now. :stuck_out_tongue_winking_eye: 

Noticed this, and figured I'd change it.

@gcapalbo 