### PR TITLE
Added celery task to clear expired sessions.

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -132,3 +132,8 @@ def pprint_stats(stats, outstream):
         )
         for user in sorted(list(users)):
             outstream.write("        {}\n".format(user))
+
+
+@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+def clear_expired_sessions():
+    call_command('clearsessions')


### PR DESCRIPTION
@dimagi/scale-team turns out our django_sessions table is huge for no reason. this [command] will clear out any expired sessions from our db. From prod (reduces the table by 98%....):

```
commcarehq=> select count(*) from django_session where expire_date < now();
  count   
----------
 65369587
(1 row)

commcarehq=> select count(*) from django_session where expire_date > now();
  count  
---------
 1621639
(1 row)
```

[command]: https://github.com/django/django/blob/stable/1.10.x/django/contrib/sessions/management/commands/clearsessions.py