### PR TITLE
ICDS: Scheduling for user indicators

### DIFF
--- a/custom/icds/tasks.py
+++ b/custom/icds/tasks.py
@@ -105,7 +105,7 @@ def get_language_code(user_id, telugu_user_ids, marathi_user_ids):
 
 
 @periodic_task(
-    run_every=crontab(hour=9, minute=0, day_of_week='mon'),
+    run_every=crontab(hour=9, minute=0, day_of_week='tue'),
     queue=settings.CELERY_PERIODIC_QUEUE,
     ignore_result=True
 )

--- a/custom/icds/tasks.py
+++ b/custom/icds/tasks.py
@@ -105,7 +105,7 @@ def get_language_code(user_id, telugu_user_ids, marathi_user_ids):
 
 
 @periodic_task(
-    run_every=crontab(hour=3, minute=30, day_of_week='mon'),
+    run_every=crontab(hour=9, minute=0, day_of_week='mon'),
     queue=settings.CELERY_PERIODIC_QUEUE,
     ignore_result=True
 )


### PR DESCRIPTION
Makes them run at 9am now that celery beat uses IST.
Also temporarily makes them run on Tuesday for next week's run.

@emord 