### PR TITLE
Reduce ASYNC_RETRY_AFTER

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/const.py
+++ b/corehq/ex-submodules/casexml/apps/phone/const.py
@@ -11,7 +11,7 @@ INITIAL_SYNC_CACHE_THRESHOLD = 60  # 1 minute
 INITIAL_ASYNC_TIMEOUT_THRESHOLD = 10
 # The Retry-After header parameter. Ask the phone to retry in this many seconds
 # to see if the task is done.
-ASYNC_RETRY_AFTER = 15
+ASYNC_RETRY_AFTER = 5
 
 ASYNC_RESTORE_CACHE_KEY_PREFIX = "async-restore-task"
 RESTORE_CACHE_KEY_PREFIX = "ota-restore"


### PR DESCRIPTION
If your sync takes 41 seconds long to compute, then it will actually take 55s to return (10+15*3), which seems silly. This just tells the phone to ping the server to see if it is complete more frequently

@snopoke 

FYI @amstone326 @ctsims 