### PR TITLE
fix Repeater caching

### DIFF
--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -136,6 +136,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         return True
 
     def clear_caches(self):
+        super(Repeater, self).clear_caches()
         if self.__class__ == Repeater:
             cls = self.get_class_from_doc_type(self.doc_type)
         else:


### PR DESCRIPTION
This hasn't yet been a problem, but only because we don't have interfaces for editing repeaters. Once we do (pretty necessary for a more complex configuration like the one we'll need for openmrs), having this PR's fix in will make it so that changes on save go into effect immediately (rather than remaining stale in the cache for some time).