### PR TITLE
ICDS: Remove elasticsearch from the process that spawns run_indicator tasks

### DIFF
--- a/corehq/apps/locations/dbaccessors.py
+++ b/corehq/apps/locations/dbaccessors.py
@@ -148,6 +148,19 @@ def generate_user_ids_from_primary_location_ids(domain, location_ids):
             yield user_id
 
 
+def generate_user_ids_from_primary_location_ids_from_couch(domain, location_ids):
+    """
+    Creates a generator for iterating through the user ids of the all the
+    mobile workers in the given domain whose primary location is given in
+    the list of location_ids.
+
+    Retrieves the information from couch instead of elasticsearch.
+    """
+    for location_id in location_ids:
+        for user_id in get_user_ids_by_location(domain, location_id):
+            yield user_id
+
+
 def get_location_ids_with_location_type(domain, location_type_code):
     """
     Returns a QuerySet with the location_ids of all the unarchived SQLLocations in the

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -5,7 +5,8 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from ..analytics import users_have_locations
 from ..dbaccessors import (get_users_by_location_id, get_user_ids_by_location,
                            get_one_user_at_location, get_user_docs_by_location,
-                           get_all_users_by_location, get_users_assigned_to_locations)
+                           get_all_users_by_location, get_users_assigned_to_locations,
+                           generate_user_ids_from_primary_location_ids_from_couch)
 from .util import make_loc
 
 
@@ -82,3 +83,13 @@ class TestUsersByLocation(TestCase):
             [self.varys._id, self.tyrion._id, self.daenerys._id, self.george._id]
         )
         other_user.delete()
+
+    def test_generate_user_ids_from_primary_location_ids_from_couch(self):
+        self.assertItemsEqual(
+            list(
+                generate_user_ids_from_primary_location_ids_from_couch(
+                    self.domain, [self.pentos.location_id, self.meereen.location_id]
+                )
+            ),
+            [self.varys._id, self.tyrion._id, self.daenerys._id]
+        )

--- a/custom/icds/tasks.py
+++ b/custom/icds/tasks.py
@@ -2,7 +2,7 @@ import pytz
 from celery.schedules import crontab
 from celery.task import task, periodic_task
 from corehq.apps.locations.dbaccessors import (
-    generate_user_ids_from_primary_location_ids,
+    generate_user_ids_from_primary_location_ids_from_couch,
     get_location_ids_with_location_type,
 )
 from corehq.apps.locations.models import SQLLocation
@@ -92,7 +92,7 @@ def get_user_ids_under_location(domain, site_code):
 
     location = SQLLocation.objects.get(domain=domain, site_code=site_code)
     location_ids = list(location.get_descendants(include_self=False).filter(is_archived=False).location_ids())
-    return set(generate_user_ids_from_primary_location_ids(domain, location_ids))
+    return set(generate_user_ids_from_primary_location_ids_from_couch(domain, location_ids))
 
 
 def get_language_code(user_id, telugu_user_ids, marathi_user_ids):
@@ -125,7 +125,8 @@ def run_weekly_indicators(phased_rollout=True):
         hindi_user_ids |= get_user_ids_under_location(domain, JHARKHAND_SITE_CODE)
         user_ids_to_send_to = telugu_user_ids | hindi_user_ids
 
-        for user_id in generate_user_ids_from_primary_location_ids(domain, get_awc_location_ids(domain)):
+        for user_id in generate_user_ids_from_primary_location_ids_from_couch(domain,
+                get_awc_location_ids(domain)):
             if phased_rollout and user_id not in user_ids_to_send_to:
                 continue
             language_code = get_language_code(user_id, telugu_user_ids, marathi_user_ids)
@@ -135,7 +136,8 @@ def run_weekly_indicators(phased_rollout=True):
 
             run_indicator.delay(domain, user_id, AWWSubmissionPerformanceIndicator, language_code)
 
-        for user_id in generate_user_ids_from_primary_location_ids(domain, get_supervisor_location_ids(domain)):
+        for user_id in generate_user_ids_from_primary_location_ids_from_couch(domain,
+                get_supervisor_location_ids(domain)):
             if phased_rollout and user_id not in user_ids_to_send_to:
                 continue
             language_code = get_language_code(user_id, telugu_user_ids, marathi_user_ids)

--- a/custom/icds/tests/test_periodic_task.py
+++ b/custom/icds/tests/test_periodic_task.py
@@ -1,4 +1,3 @@
-from corehq.apps.es.fake.users_fake import UserESFake
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.tests.util import (
     LocationStructure,
@@ -23,7 +22,6 @@ TEST_DOMAIN = 'icds-indicator-periodic-task'
 
 
 @override_settings(ICDS_SMS_INDICATOR_DOMAINS=[TEST_DOMAIN])
-@patch('corehq.apps.locations.dbaccessors.UserES', UserESFake)
 @patch('custom.icds.tasks.get_user_ids_under_location')
 @patch('custom.icds.tasks.is_first_week_of_month')
 @patch('custom.icds.tasks.run_indicator.delay')
@@ -64,7 +62,6 @@ class TestIndicatorPeriodicTask(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        UserESFake.reset_docs()
         cls.domain_obj.delete()
         super(TestIndicatorPeriodicTask, cls).tearDownClass()
 
@@ -72,7 +69,6 @@ class TestIndicatorPeriodicTask(TestCase):
     def _make_user(cls, name, location):
         user = CommCareUser.create(cls.domain, name, 'password')
         user.set_location(location)
-        UserESFake.save_doc(user._doc)
         return user
 
     def test_periodic_task_during_first_week_of_month(self, run_indicator_mock, is_first_week_of_month_mock,


### PR DESCRIPTION
ES is having trouble fetching the results for this part of the process. I don't think it will be too bad for couch to handle it, and it's done serially anyway.

@emord 
cc @kaapstorm 