### PR TITLE
allow revoking both is_staff and is_superuser in SuperuserManagement

### DIFF
--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -110,7 +110,9 @@ class SuperuserManagementForm(forms.Form):
         choices=[
             ('is_superuser', 'Mark as superuser'),
         ],
-        widget=forms.CheckboxSelectMultiple())
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+    )
 
     def clean(self):
         from email.utils import parseaddr


### PR DESCRIPTION
previously if you selected nothing
the form would fail (shallowly) with a validation error