### PR TITLE
enable phone number but no AB test

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -68,6 +68,24 @@ class NewUserNumberAbTestMixin__Enabled(object):
         self._ab.update_response(response)
 
 
+class NewUserNumberAbTestMixin__NoAbEnabled(object):
+    @property
+    @memoized
+    def _ab(self):
+        return None
+
+    @property
+    def ab_show_number(self):
+        return True
+
+    @property
+    def ab_context(self):
+        return None
+
+    def ab_update_response(self, response):
+        pass
+
+
 class NewUserNumberAbTestMixin__Disabled(object):
     @property
     def ab_show_number(self):
@@ -81,7 +99,7 @@ class NewUserNumberAbTestMixin__Disabled(object):
         pass
 
 
-NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__Disabled
+NewUserNumberAbTestMixin = NewUserNumberAbTestMixin__NoAbEnabled
 
 
 class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View):


### PR DESCRIPTION
@calellowitz // cc @dannyroberts 
comms wants the phone number back and wants everyone to see it right now. still not a permanent change though.