### PR TITLE
Global admin reports: only include report_loader.html once

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/indicator_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/indicator_report.html
@@ -13,8 +13,6 @@
 {% endblock %}
 
 {% block js-inline %}{{ block.super }}
-    {% include "reports/standard/partials/report_loader.html" %}
-
     <script>
         var visualizations = {
             {% for indicator, data in indicator_data.items %}


### PR DESCRIPTION
Already included in faceted_report.html. The double include causes a js error that appears harmless but is distracting.

![screen shot 2017-06-30 at 3 47 45 pm](https://user-images.githubusercontent.com/1486591/27751696-82b84196-5dab-11e7-97d7-65ce0686a291.png)

@benrudolph / @emord (admin reports ownership?)