### PR TITLE
Webapps Permissions by user data

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -57,7 +57,11 @@ class ReportFixturesProvider(FixtureProvider):
         app_aware_sync_app = restore_state.params.app
         if app_aware_sync_app:
             apps = [app_aware_sync_app]
-        elif restore_state.params.device_id and "WebAppsLogin" in restore_state.params.device_id:
+        elif (
+                toggles.USERDATA_WEBAPPS_PERMISSIONS.enabled(restore_user.domain)
+                and restore_state.params.device_id
+                and "WebAppsLogin" in restore_state.params.device_id
+        ):
             # Only sync reports for apps the user has access to if this is a restore from webapps
             access = ApplicationAccess.get_by_domain(restore_user.domain)
             apps = [

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -8,6 +8,7 @@ from lxml.builder import E
 
 from casexml.apps.phone.fixtures import FixtureProvider
 from corehq import toggles
+from corehq.apps.cloudcare.models import ApplicationAccess
 from corehq.apps.app_manager.models import ReportModule
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import is_valid_mobile_select_filter_type
 from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
@@ -42,7 +43,6 @@ def _should_sync(restore_state):
     )
 
 
-
 class ReportFixturesProvider(FixtureProvider):
     id = 'commcare:reports'
 
@@ -54,8 +54,23 @@ class ReportFixturesProvider(FixtureProvider):
         if not toggles.MOBILE_UCR.enabled(restore_user.domain) or not _should_sync(restore_state):
             return []
 
-        app = restore_state.params.app
-        apps = [app] if app else [a for a in get_apps_in_domain(restore_user.domain, include_remote=False)]
+        app_aware_sync_app = restore_state.params.app
+        if app_aware_sync_app:
+            apps = [app_aware_sync_app]
+        elif restore_state.params.device_id and "WebAppsLogin" in restore_state.params.device_id:
+            # Only sync reports for apps the user has access to if this is a restore from webapps
+            access = ApplicationAccess.get_by_domain(restore_user.domain)
+            apps = [
+                app for app
+                in get_apps_in_domain(restore_user.domain, include_remote=False)
+                if access.user_can_access_app(restore_user, app)
+            ]
+        else:
+            apps = [
+                app for app
+                in get_apps_in_domain(restore_user.domain, include_remote=False)
+            ]
+
         report_configs = [
             report_config
             for app_ in apps

--- a/corehq/apps/cloudcare/models.py
+++ b/corehq/apps/cloudcare/models.py
@@ -9,6 +9,8 @@ from dimagi.ext.couchdbkit import (
 from corehq.apps.app_manager.models import Application
 from corehq.apps.groups.models import Group
 from dimagi.utils.decorators.memoized import memoized
+from corehq.apps.users.models import WebUser
+from casexml.apps.phone.models import OTARestoreWebUser
 
 
 class AppGroup(DocumentSchema):
@@ -52,12 +54,29 @@ class AppGroup(DocumentSchema):
             }
 
 
+class UserDataPermission(DocumentSchema):
+    user_data_key = StringProperty()
+    user_data_value = StringProperty()
+
+
+class AppUserDataPermission(DocumentSchema):
+    app_id = StringProperty()
+    user_data_permissions = SchemaListProperty(UserDataPermission, default=[])
+
+    def user_has_permission(self, user):
+        return any(
+            user.user_data.get(permission.user_data_key) == permission.user_data_value
+            for permission in self.user_data_permissions
+        )
+
+
 class ApplicationAccess(Document):
     """
     This is used to control which users/groups can access which applications on cloudcare.
     """
     domain = StringProperty()
     app_groups = SchemaListProperty(AppGroup, default=[])
+    app_userdata_permissions = SchemaListProperty(AppUserDataPermission, default=[])
     restrict = BooleanProperty(default=False)
 
     @classmethod
@@ -68,34 +87,59 @@ class ApplicationAccess(Document):
         return self or cls(domain=domain)
 
     def user_can_access_app(self, user, app):
-        user_id = user['_id']
         app_id = app['_id']
-        if not self.restrict or user['doc_type'] == 'WebUser':
+        app_ids = (app_id, app['copy_of'] or ())
+
+        if not self.restrict or isinstance(user, (WebUser, OTARestoreWebUser)):
             return True
+
+        return self.group_permitted(app_ids, user) or self.userdata_permitted(app_ids, user)
+
+    def group_permitted(self, app_ids, user):
         app_group = None
         for app_group in self.app_groups:
-            if app_group.app_id in (app_id, app['copy_of'] or ()):
+            if app_group.app_id in app_ids:
                 break
         if app_group:
-            return Group.user_in_group(user_id, app_group.group_id)
-        else:
-            return False
+            return Group.user_in_group(user.user_id, app_group.group_id)
+
+    def userdata_permitted(self, app_ids, user):
+        if isinstance(app_ids, basestring):
+            app_ids = [app_ids]
+        permissions = [
+            userdata_permission for userdata_permission in self.app_userdata_permissions
+            if userdata_permission.app_id in app_ids
+        ]
+        return any([permission.user_has_permission(user) for permission in permissions])
 
     @classmethod
     def get_template_json(cls, domain, apps):
-        app_ids = dict([(app['_id'], app) for app in apps])
+        app_ids = {app['_id'] for app in apps}
         self = ApplicationAccess.get_by_domain(domain)
         j = self.to_json()
-        merged_access_list = []
-        for a in j['app_groups']:
-            app_id = a['app_id']
-            if app_id in app_ids:
-                merged_access_list.append(a)
-                del app_ids[app_id]
-        for app in app_ids.values():
-            merged_access_list.append({
-                'app_id': app['_id'],
-                'group_id': None
-            })
-        j['app_groups'] = merged_access_list
+
+        app_group_apps = {
+            app_group['app_id']: app_group
+            for app_group in j['app_groups']
+            if app_group['app_id'] in app_ids
+        }
+        userdata_apps = {
+            userdata_app['app_id']: userdata_app
+            for userdata_app in j['app_userdata_permissions']
+            if userdata_app['app_id'] in app_ids
+        }
+
+        for app_id in app_ids:
+            if app_id not in app_group_apps:
+                app_group_apps[app_id] = {
+                    'app_id': app_id,
+                    'group_id': None,
+                }
+            if app_id not in userdata_apps:
+                userdata_apps[app_id] = {
+                    'app_id': app_id,
+                    'user_data_permissions': []
+                }
+        j['app_groups'] = app_group_apps.values()
+        j['app_userdata_permissions'] = userdata_apps.values()
         return j

--- a/corehq/apps/cloudcare/templates/cloudcare/config.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/config.html
@@ -36,6 +36,7 @@
             var self = this;
             self.restrict = addJsonAccess(ko.observable());
             self.app_groups = ko.observableArray();
+            self.app_userdata_permissions = ko.observableArray();
             self._lock = ko.observable(false);
         };
         ApplicationAccess.wrap = function(o) {
@@ -43,6 +44,11 @@
             self.restrict(o.restrict);
             for (var i = 0; i < o.app_groups.length; i++) {
                 self.app_groups.push(AppGroup.wrap(o.app_groups[i]));
+            }
+            for (var i = 0; i < o.app_userdata_permissions.length; i++) {
+                self.app_userdata_permissions.push(
+                    AppUserDataPermission.wrap(o.app_userdata_permissions[i])
+                )
             }
             self._id = o._id;
             self._rev = o._rev;
@@ -61,18 +67,38 @@
             return self;
         };
 
+        var AppUserDataPermission = function () {
+            var self = this;
+            self.app_id = linkToDB(appDB, ko.observable());
+            self.user_data_permissions = ko.observableArray();
+            self.add = function(){
+                self.user_data_permissions.push(
+                    {'user_data_key': '', 'user_data_value': ''}
+                )
+            }
+            self.remove = function(item){
+                self.user_data_permissions.remove(item);
+            }
+        };
+        AppUserDataPermission.wrap = function (o) {
+            var self = new AppUserDataPermission();
+            self.app_id(o.app_id);
+            self.user_data_permissions(o.user_data_permissions)
+            return self;
+        };
+
         var linkToDB = function (db, o) {
             o.obj = function () {
                 return db[o()];
             };
             return o;
         };
-
         var $home = $('#cloudcare-app-settings');
         var Controller = function (options) {
             var self = this;
             self.groupDB = options.groupDB;
             self.appDB = options.appDB;
+            self.user_fields = {{ user_fields | JSON }};
             self.applicationAccess = ApplicationAccess.wrap(options.access);
             self.saveButton = COMMCAREHQ.SaveButton.init({
                 save: function () {
@@ -196,6 +222,58 @@
                     </ul>
                     <p>{% blocktrans %}...and all other mobile workers do not have access to any Web Apps applications.{% endblocktrans %}</p>
                 </div>
+                <table class="table table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>{% trans 'Application' %}</th>
+                            <th>{% trans 'User Data Property' %}</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: app_userdata_permissions">
+                        <tr>
+                            <td data-bind="text: app_id.obj().name"></td>
+                            <td>
+                                <table class="table table-striped" >
+                                    <thead>
+                                        <tr>
+                                            <th width="50%">{% trans "Property Name" %}</th>
+                                            <th>{% trans "Property Value" %}</th>
+                                            <th>{% trans "Delete" %}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody data-bind="foreach: {data: user_data_permissions, as: 'permission'}" >
+                                        <tr>
+                                            <td>
+                                                <select class="form-control" data-bind="
+                                                               options: $root.user_fields,
+                                                               optionsText: 'slug',
+                                                               optionsValue: 'slug',
+                                                               optionsCaption: 'None',
+                                                               value: permission.user_data_key
+                                                               "></select>
+                                            </td>
+                                            <td>
+                                                <input data-bind="value: permission.user_data_value" type="text"/>
+                                            </td>
+                                            <td>
+                                                <button type="button"
+                                                        class="btn btn-danger pull-right"
+                                                        data-bind="click: $parent.remove">
+                                                    <i class="fa fa-trash"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <button type="button"
+                                        class="btn btn-primary"
+                                        data-bind="click: add">
+                                    <i class="fa fa-plus"></i> {% trans "Add userdata property" %}
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
                 <div data-bind="if: !app_groups().length">
                     {% trans 'No Web Apps applications available' %}
                 </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/config.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/config.html
@@ -222,6 +222,7 @@
                     </ul>
                     <p>{% blocktrans %}...and all other mobile workers do not have access to any Web Apps applications.{% endblocktrans %}</p>
                 </div>
+                {% if enable_userdata_permissions %}
                 <table class="table table-bordered table-striped">
                     <thead>
                         <tr>
@@ -274,6 +275,7 @@
                         </tr>
                     </tbody>
                 </table>
+                {% endif %}
                 <div data-bind="if: !app_groups().length">
                     {% trans 'No Web Apps applications available' %}
                 </div>

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -893,6 +893,7 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
             'groups': groups,
             'access': access,
             'user_fields': user_fields,
+            'enable_userdata_permissions': toggles.USERDATA_WEBAPPS_PERMISSIONS.enabled(self.domain),
         }
 
     def put(self, request, *args, **kwargs):

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.userreports.tests.utils import (
     get_sample_report_config, mock_datasource_config, mock_sql_backend
 )
+from corehq.apps.cloudcare.models import ApplicationAccess, AppUserDataPermission, UserDataPermission
 
 
 class AppAwareSyncTests(TestCase):
@@ -93,6 +94,40 @@ class AppAwareSyncTests(TestCase):
             with mock_sql_backend():
                 with mock_datasource_config():
                     fixtures = call_fixture_generator(report_fixture_generator, self.user, app=self.app1)
+        reports = fixtures[0].findall('.//report')
+        self.assertEqual(len(reports), 1)
+        self.assertEqual(reports[0].attrib.get('id'), '123456')
+
+    def test_report_fixtures_provider_with_cloudcare(self):
+        """
+        ReportFixturesProvider should iterate only allowed apps if sync is from cloudcare
+        """
+        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
+        access = ApplicationAccess(
+            domain=self.domain,
+            restrict=True,
+            app_userdata_permissions=[AppUserDataPermission(
+                app_id=self.app1._id,
+                user_data_permissions=[
+                    UserDataPermission(
+                        user_data_key='foo',
+                        user_data_value='bar')
+                ]
+
+            )]
+        )
+        access.save()
+        self.user.user_data.update({'foo': 'bar'})
+
+        with patch.object(ConfigurableReportDataSource, 'get_data') as get_data_mock:
+            get_data_mock.return_value = self.rows
+            with mock_sql_backend():
+                with mock_datasource_config():
+                    fixtures = call_fixture_generator(
+                        report_fixture_generator,
+                        self.user,
+                        device_id="WebAppsLogin|user@project.commcarehq.org"
+                    )
         reports = fixtures[0].findall('.//report')
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0].attrib.get('id'), '123456')

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from mock import patch
 
+from corehq.util.test_utils import flag_enabled
+
 from casexml.apps.phone.tests.utils import create_restore_user, call_fixture_generator
 from corehq import toggles
 from corehq.apps.app_manager.fixtures.mobile_ucr import report_fixture_generator
@@ -98,6 +100,7 @@ class AppAwareSyncTests(TestCase):
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0].attrib.get('id'), '123456')
 
+    @flag_enabled('USERDATA_WEBAPPS_PERMISSIONS')
     def test_report_fixtures_provider_with_cloudcare(self):
         """
         ReportFixturesProvider should iterate only allowed apps if sync is from cloudcare

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -90,6 +90,10 @@ class OTARestoreUser(object):
         "User's primary SQLLocation"
         return self._couch_user.get_sql_location(self.domain)
 
+    @property
+    def user_data(self):
+        return self._couch_user.user_data
+
     def get_sql_locations(self, domain):
         return self._couch_user.get_sql_locations(domain)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -119,14 +119,14 @@ def has_cached_payload(sync_log, version, prefix=RESTORE_CACHE_KEY_PREFIX):
     )))
 
 
-def call_fixture_generator(gen, restore_user, project=None, last_sync=None, app=None):
+def call_fixture_generator(gen, restore_user, project=None, last_sync=None, app=None, device_id=''):
     """
     Convenience function for use in unit tests
     """
     from casexml.apps.phone.restore import RestoreState
     from casexml.apps.phone.restore import RestoreParams
     from corehq.apps.domain.models import Domain
-    params = RestoreParams(version=V2, app=app)
+    params = RestoreParams(version=V2, app=app, device_id=device_id)
     restore_state = RestoreState(
         project or Domain(name=restore_user.domain),
         restore_user,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -509,6 +509,15 @@ EXTENSION_CASES_SYNC_ENABLED = StaticToggle(
     always_enabled={'enikshay'},
 )
 
+
+USERDATA_WEBAPPS_PERMISSIONS = StaticToggle(
+    'userdata_webapps_permissions',
+    'Toggle which webapps to see based on userdata',
+    TAG_PRODUCT_PATH,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
+
 SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     'search_claim',
     'Enable synchronous mobile searching and case claiming',


### PR DESCRIPTION
This allows you to set which webapps you see by user data.

The primary reason for this is to only sync reports to eNikshay users that are actually pertinent to the apps that they will use. 
For now, behind a flag until we can make this play nicely in the WebApps Login-As UI.

🐡 / 🐡 

@snopoke buddy
FYI @ctsims 
@benrudolph (we talked about this before you went offline)