### PR TITLE
Added multi_field_dynamic_choice_list to allowed filter types

### DIFF
--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -63,7 +63,8 @@ class FilterSpec(JsonObject):
     type = StringProperty(
         required=True,
         choices=[
-            'date', 'quarter', 'numeric', 'pre', 'choice_list', 'dynamic_choice_list', 'location_drilldown',
+            'date', 'quarter', 'numeric', 'pre', 'choice_list', 'dynamic_choice_list',
+            'multi_field_dynamic_choice_list', 'location_drilldown',
             'enikshay_location_hierarchy'
         ]
     )


### PR DESCRIPTION
@emord @NoahCarnahan 
Without this, it can't be used in non-static reports.