### PR TITLE
Handle inconsistent datatypes in reports

### DIFF
--- a/custom/intrahealth/sqldata.py
+++ b/custom/intrahealth/sqldata.py
@@ -284,9 +284,13 @@ class TauxDeRuptures(BaseSqlData):
             conventure_data_rows = conventure.rows
             total = conventure_data_rows[0][2]["html"] if conventure_data_rows else 0
 
+        def get_value(x):
+            """x can be a value or a sort_key/html dict"""
+            return x["sort_key"] if isinstance(x, dict) else x
+
         for row in rows:
-            row.append(dict(sort_key=1L if any([x["sort_key"] for x in row[1:]]) else 0L,
-                            html=1L if any([x["sort_key"] for x in row[1:]]) else 0L))
+            value = 1L if any(get_value(x) for x in row[1:]) else 0L
+            row.append({'sort_key': value, 'html': value})
 
         total_row = list(calculate_total_row(rows))
 


### PR DESCRIPTION
@emord
https://manage.dimagi.com/default.asp?257259
https://sentry.io/dimagi/commcarehq/issues/298931135/
It looks like these values are all either '1' or '{"sort_key": 0, "html": 0}'
It's supposed to represent a boolean, so a better fix would be to always format
that as either 0 or 1, but I'm not confident in my ability to test out
potentially wide-reaching changes, so I'd rather just put in this quick fix.