### PR TITLE
JS error in reports home

### DIFF
--- a/corehq/apps/reports/static/reports/js/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/standard_hq_report.js
@@ -50,7 +50,7 @@ hqDefine("reports/js/standard_hq_report.js", function() {
             return asyncReport;
         }
 
-        var reportOptions = initial_page_data('js_options');
+        var reportOptions = initial_page_data('js_options') || {};
         if (reportOptions.slug && reportOptions.async) {
             var asyncHQReport = new HQAsyncReport({
                 standardReport: getStandard(),


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/16866 causes a js error on the default reports page.

@dannyroberts 
@esoergel this needs to get in today's deploy, please