### PR TITLE
Fix reports-inline-js blocks in custom reports

### DIFF
--- a/custom/ewsghana/templates/ewsghana/base_template.html
+++ b/custom/ewsghana/templates/ewsghana/base_template.html
@@ -13,7 +13,6 @@
 
 {% block reports-js-inline %}
     {{ block.super }}
-    <script>
         var show_hide_line_chart_data = function() {
             var data = JSON.parse(JSON.stringify(line_chart_data));
             var productCodes = [];
@@ -68,7 +67,6 @@
 
         // Filters should be always visible
         $('#reportFilters').collapse('show');
-     </script>
 {% endblock %}
 
 {% block reports-css %}

--- a/custom/ilsgateway/templates/ilsgateway/base_template.html
+++ b/custom/ilsgateway/templates/ilsgateway/base_template.html
@@ -26,8 +26,6 @@
 {% endblock %}
 
 {% block reports-js-inline %}{{ block.super }}
-    <script type="text/javascript">
-
         function get_export_url(format) {
             var params = window.location.search.substr(1);
             if (params.length <= 1) {
@@ -111,6 +109,4 @@
             defaultItem: defaultConfig,
             saveUrl: '{% url "add_report_config" domain %}'
         });
-
-    </script>
 {% endblock %}


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/16866 moved the `reports-inline-js` block inside of script tags.