### PR TITLE
Catch SMTPException

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -4,6 +4,7 @@ from django.contrib.auth.views import (
     password_change_done,
     password_reset_complete,
     password_reset_done,
+    password_reset,
 )
 from django.utils.translation import ugettext as _
 from django.conf import settings
@@ -58,7 +59,6 @@ from corehq.apps.domain.views import (
     calculated_properties,
     cancel_repeat_record,
     drop_repeater,
-    exception_safe_password_reset,
     requeue_repeat_record,
     select,
     set_published_snapshot,
@@ -85,7 +85,7 @@ urlpatterns = [
          'extra_context': {'current_page': {'page_name': _('Password Change Complete')}}},
         name='password_change_done'),
 
-    url(r'^accounts/password_reset_email/$', exception_safe_password_reset,
+    url(r'^accounts/password_reset_email/$', password_reset,
         {'template_name': 'login_and_password/password_reset_form.html',
          'password_reset_form': ConfidentialPasswordResetForm, 'from_email': settings.DEFAULT_FROM_EMAIL,
          'extra_context': {'current_page': {'page_name': _('Password Reset')}}},

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -3256,25 +3256,3 @@ class PasswordResetView(View):
         couch_user = CouchUser.from_django_user(user)
         clear_login_attempts(couch_user)
         return response
-
-
-def exception_safe_password_reset(request, *args, **kwargs):
-    """
-    Django's password reset function raises SMTP errors if there's any
-    problem with the mailserver. Catch that more elegantly with a simple wrapper.
-    """
-    # Django docs on password reset are weak. See these links instead:
-    #
-    # http://streamhacker.com/2009/09/19/django-ia-auth-password-reset/
-    # http://www.rkblog.rk.edu.pl/w/p/password-reset-django-10/
-    # http://blog.montylounge.com/2009/jul/12/django-forgot-password/
-    try:
-        return password_reset(request, *args, **kwargs)
-    except SMTPException:
-        context = {
-            'current_page': {'page_name': _('Oops!')},
-            'error_msg': 'There was a problem with your request',
-            'error_details': sys.exc_info(),
-            'show_homepage_link': True,
-        }
-        return render_to_response('error.html', context)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -5,7 +5,6 @@ import logging
 import json
 import cStringIO
 import sys
-from smtplib import SMTPException
 
 import pytz
 from couchdbkit import ResourceNotFound

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -5,6 +5,7 @@ import logging
 import json
 import cStringIO
 import sys
+from smtplib import SMTPException
 
 import pytz
 from couchdbkit import ResourceNotFound
@@ -3269,11 +3270,11 @@ def exception_safe_password_reset(request, *args, **kwargs):
     # http://blog.montylounge.com/2009/jul/12/django-forgot-password/
     try:
         return password_reset(request, *args, **kwargs)
-    except None:
-        vals = {
+    except SMTPException:
+        context = {
             'current_page': {'page_name': _('Oops!')},
             'error_msg': 'There was a problem with your request',
             'error_details': sys.exc_info(),
-            'show_homepage_link': 1,
+            'show_homepage_link': True,
         }
-        return render_to_response('error.html', vals, context_instance=RequestContext(request))
+        return render_to_response('error.html', context)


### PR DESCRIPTION
@proteusvacuum this will catch the exception that the function's docstring refers to ... 

cc @gcapalbo @orangejenny 

... but I'm labelling "hold off" because if we do encounter an SMTPException it's most likely because HQ is not configured properly, and not something the user would be able to do anything about. A Sad Danny might be more appropriate, which I'm sure is what would have been happening up to now.

If we do want to give the user more information about the error, I'm not convinced that we want to show them a traceback;
```
exc_info() -> (type, value, traceback)

Return information about the most recent exception caught by an except
clause in the current stack frame or in an older stack frame.
```

Instead of fixing this `except` clause, I'm inclined to just remove it.
