### PR TITLE
Speed up mobile reports permission check

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -183,6 +183,15 @@ def get_app_ids_in_domain(domain):
     )]
 
 
+def get_apps_by_id(domain, app_ids):
+    from .models import Application
+    from corehq.apps.app_manager.util import get_correct_app_class
+    if isinstance(app_ids, basestring):
+        app_ids = [app_ids]
+    docs = iter_docs(Application.get_db(), app_ids)
+    return [get_correct_app_class(doc).wrap(doc) for doc in docs]
+
+
 def get_built_app_ids(domain):
     """
     Returns the app ids of all apps in the domain that have at least one build.

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -69,6 +69,9 @@ class ReportFixturesProvider(FixtureProvider):
                     in get_apps_in_domain(restore_user.domain, include_remote=False)
                     if role.permissions.view_web_app(app)
                 ]
+            else:
+                # If there is no role, allow access to all apps
+                apps = get_apps_in_domain(restore_user.domain, include_remote=False)
         else:
             apps = [
                 app for app

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -14,6 +14,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_build_doc,
     get_latest_app_ids_and_versions,
     get_latest_released_app_doc,
+    get_apps_by_id,
 )
 from corehq.apps.app_manager.models import Application, RemoteApp, Module
 from corehq.apps.domain.models import Domain
@@ -259,3 +260,8 @@ class TestAppGetters(TestCase):
     def test_get_specific_version(self):
         app_doc = get_build_doc_by_version(self.domain, self.app_id, version=2)
         self.assertEqual(app_doc['version'], 2)
+
+    def test_get_apps_by_id(self):
+        apps = get_apps_by_id(self.domain, [self.app_id])
+        self.assertEqual(1, len(apps))
+        self.assertEqual(apps[0].version, 4)


### PR DESCRIPTION
Wrapping the eNikshay app currently takes ~2s. We only need to wrap the full app if it is required for a report.
This adds an extra db roundtrip, to fetch the full pertinent app, but I think it will be faster overall. 

@snopoke 