### PR TITLE
Django's UploadedFile has a fileno method, but you can't use it

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1559,7 +1559,7 @@ class DataFileDownloadList(BaseProjectDataView):
         data_file.content_type = request.FILES['file'].content_type
         data_file.content_length = request.FILES['file'].size
         data_file.save_blob(request.FILES['file'])
-        messages.success(request, _('Data file "{}" uploaded'.format(data_file.description)))
+        messages.success(request, _(u'Data file "{}" uploaded'.format(data_file.description)))
         return HttpResponseRedirect(reverse(self.urlname, kwargs={'domain': self.domain}))
 
 


### PR DESCRIPTION
S3BlobDB errors when trying to send a Django UploadedFile instance, because UploadedFile has a fileno() method but it throws an UnsupportedOperation exception if you try to use it.

This change catches that exception, and falls back to using tell().

Error: https://sentry.io/dimagi/commcarehq/issues/305236253/

@snopoke cc @gcapalbo @orangejenny 
