### PR TITLE
enikshay custom report: Check location type codes, not names

### DIFF
--- a/custom/enikshay/ucr_filters.py
+++ b/custom/enikshay/ucr_filters.py
@@ -25,7 +25,7 @@ class ENikshayLocationHierarchyFilterValue(FilterValue):
         relevant_location_types = ["sto", "cto", "dto", "tu", "phi"]
         location = SQLLocation.objects.get(location_id=location_id)
 
-        if location.location_type.name not in relevant_location_types:
+        if location.location_type.code not in relevant_location_types:
             # This report could be filtered by a user who is not assigned to one of the pertinent location types.
             # In that case, the report should show nothing, so return a filter that is guaranteed not to match
             # any records.
@@ -33,15 +33,15 @@ class ENikshayLocationHierarchyFilterValue(FilterValue):
 
         filters = []
         for ancestor in location.get_ancestors(include_self=True):
-            if ancestor.location_type.name in relevant_location_types:
-                column = ancestor.location_type.name
+            if ancestor.location_type.code in relevant_location_types:
+                column = ancestor.location_type.code
                 parameter = "{slug}_{column}".format(slug=self.filter.slug, column=column)
                 value = ancestor.location_id
                 filters.append(
                     _LocationFilter(column, parameter, value)
                 )
 
-        below_column = "below_{}".format(location.location_type.name)
+        below_column = "below_{}".format(location.location_type.code)
         below_parameter = "{slug}_{column}".format(slug=self.filter.slug, column=below_column)
         filters.append(
             _LocationFilter(below_column, below_parameter, location.location_id)


### PR DESCRIPTION
The relevant location types ("sto", "cto", "dto", "tu", and "phi") currently have the same names as codes, but if the name ever changes, the code will not. This change insures that the filter won't break if the names change.
@dannyroberts 