### PR TITLE
Add number of locations to admin restore page

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -31,6 +31,9 @@
                         Number of cases in this restore: <strong>{{num_cases}}</strong>
                     </div>
                     <div>
+                        Number of locations in this restore: <strong>{{num_locations}}</strong>
+                    </div>
+                    <div>
                         <ul class="nav nav-tabs" role="tablist">
                             <li role="presentation" class="active"><a href="#payload-tab" role="tab" data-toggle="tab">Payload</a></li>
                             <li role="presentation"><a href="#timing-tab" role="tab" data-toggle="tab">Timing</a></li>

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -30,4 +30,5 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'status_code': 500,
                 'timing_data': [],
                 'num_cases': 0,
+                'num_locations': 0,
             })

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -523,6 +523,7 @@ class AdminRestoreView(TemplateView):
                 xml_payload = E.error(message)
             restore_id_element = None
             num_cases = 0
+            num_locations = 0
         formatted_payload = etree.tostring(xml_payload, pretty_print=True)
         context.update({
             'payload': formatted_payload,

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -75,6 +75,7 @@ from corehq.util.supervisord.api import (
 )
 from corehq.util.timer import TimingContext
 from couchforms.models import XFormInstance
+from couchforms.openrosa_response import RESPONSE_XMLNS
 from dimagi.utils.couch.database import get_db, is_bigcouch
 from dimagi.utils.csv import UnicodeWriter
 from dimagi.utils.dates import add_months
@@ -505,6 +506,9 @@ class AdminRestoreView(TemplateView):
             xml_payload = etree.fromstring(string_payload)
             restore_id_element = xml_payload.find('{{{0}}}Sync/{{{0}}}restore_id'.format(SYNC_XMLNS))
             num_cases = len(xml_payload.findall('{http://commcarehq.org/case/transaction/v2}case'))
+            num_locations = len(
+                xml_payload.findall("{{{0}}}fixture[@id='locations']/{{{0}}}locations/{{{0}}}location"
+                                    .format(RESPONSE_XMLNS)))
         else:
             if response.status_code in (401, 404):
                 # corehq.apps.ota.views.get_restore_response couldn't find user or user didn't have perms
@@ -526,6 +530,7 @@ class AdminRestoreView(TemplateView):
             'status_code': response.status_code,
             'timing_data': timing_context.to_list(),
             'num_cases': num_cases,
+            'num_locations': num_locations,
         })
         return context
 


### PR DESCRIPTION
Finding myself searching for `</location>` a lot these days to get a count... so just add it to the page.
@snopoke 