### PR TITLE
Call add_progress() to give some feedback when starting to import locations

### DIFF
--- a/corehq/util/workbook_json/excel_importer.py
+++ b/corehq/util/workbook_json/excel_importer.py
@@ -15,6 +15,7 @@ class ExcelImporter(object):
     def __init__(self, task, file_ref_id):
         self.task = task
         self.progress = 0
+        self.total_rows = 100
 
         if self.task:
             DownloadBase.set_progress(self.task, 0, 100)
@@ -55,4 +56,8 @@ class MultiExcelImporter(ExcelImporter):
     def __init__(self, task, file_ref_id):
         super(MultiExcelImporter, self).__init__(task, file_ref_id)
         self.worksheets = self.workbook.worksheets
-        self.total_rows = sum(ws.worksheet.get_highest_row() for ws in self.worksheets)
+        self.add_progress(2)  # Show the user we're on it
+        total_rows = sum(ws.worksheet.get_highest_row() for ws in self.worksheets)
+        # That took a non-negligible amount of time. Give the user some feedback.
+        self.add_progress(3)
+        self.total_rows = total_rows


### PR DESCRIPTION
Context: [FB 244450](http://manage.dimagi.com/default.asp?244450)

This provides a little feedback to the user when we first pick up the task to import locations. Without this feedback, the first time the progress bar moves is after the task has been picked off the queue, the workbook has been inspected, and the first chunk of locations have been created. Hopefully this will allay the creeping dread that nothing is ever going to happen.

@gcapalbo @orangejenny 
