### PR TITLE
migrate icds ucr

### DIFF
--- a/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
+++ b/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
             print(self.get_count(self.new_table))
             with connections['icds-ucr'].cursor() as cursor:
                 cursor.execute(sql_command)
-            print("count of old table %s: " % self.new_table)
+            print("count of new table %s: " % self.new_table)
             print(self.get_count(self.new_table))
 
     def get_count(self, table_name):

--- a/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
+++ b/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
@@ -78,8 +78,8 @@ class Command(BaseCommand):
         self.new_table = db_config.new_table
 
         # create a column string
-        self.column_string = ','.join(old_columns)
-        self.select_column_string = ','.join(['A.' + col for col in old_columns])
+        self.column_string = ', '.join(old_columns)
+        self.select_column_string = ', '.join(['A.' + col for col in old_columns])
 
         sql_command = self._sql_command(db_config.has_repeat_iteration)
 
@@ -114,7 +114,7 @@ class Command(BaseCommand):
 
         return (
            " INSERT INTO " + new_table + " ( " + self.column_string + " ) " +
-           " SELECT ( " + self.select_column_string + " ) " +
+           " SELECT " + self.select_column_string + " " +
            " FROM " + old_table + " A " +
            " LEFT JOIN " + new_table + " B " +
            " ON " + join + " " +

--- a/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
+++ b/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
@@ -1,0 +1,84 @@
+from __future__ import print_function
+import argparse
+from collections import namedtuple
+
+from django.core.management.base import BaseCommand
+from django.db import connections
+
+from corehq.apps.userreports.models import AsyncIndicator, get_datasource_config
+
+
+COMMON_PERSON_COLUMNS = ()
+COMMON_CHILD_HEALTH_COLUMNS = ()
+COMMON_CCS_RECORD_COLUMNS = ()
+
+DbConfig = namedtuple('DbConfig', ['old_table', 'new_table', 'old_config_id', 'new_config_id'])
+
+PERSON_DBS = DbConfig(
+    'config_report_icds-cas_static-person_cases_60bd77e9',
+    'config_report_icds-cas_static-person_cases_v2_b4b5d57a',
+    'static-icds-cas-static-person_cases',
+    'static-icds-cas-static-person_cases_v2',
+)
+
+CHILD_HEALTH_DBS = DbConfig(
+    'config_report_icds-cas_static-child_cases_monthly_tabl_d4032f37',
+    'config_report_icds-cas_static-child_cases_monthly_tabl_551fd064',
+    'static-icds-cas-static-child_cases_monthly_tableau',
+    'static-icds-cas-static-child_cases_monthly_tableau_v2',
+)
+
+CCS_RECORD_DBS = DbConfig(
+    'config_report_icds-cas_static-ccs_record_cases_monthly_33021c88',
+    'config_report_icds-cas_static-ccs_record_cases_monthly_d0e2e49e',
+    'static-icds-cas-static-ccs_record_cases_monthly_tableau',
+    'static-icds-cas-static-ccs_record_cases_monthly_tableau_v2',
+)
+
+DB_CONFIGS = {
+    'child_health': CHILD_HEALTH_DBS,
+    'ccs_record': CCS_RECORD_DBS,
+    'person': PERSON_DBS,
+}
+
+
+class Command(BaseCommand):
+    help = "One off for icds"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('case_type')
+
+    def handle(self, domain, case_type, **options):
+        db_config = DB_CONFIGS[case_type]
+        old_config, _ = get_datasource_config(db_config.old_config_id, 'icds-cas')
+        new_config, _ = get_datasource_config(db_config.new_config_id, 'icds-cas')
+        old_columns = [c.id for c in old_config.get_columns()]
+        new_columns = [c.id for c in new_config.get_columns()]
+        assert set(old_columns).issubset(set(new_columns))
+
+        async_indicator = (
+            AsyncIndicator.objects
+            .filter(domain=domain, indicator_config_ids__contains=db_config.old_config_id)
+        )
+
+        old_table = db_config.old_table
+        new_table = db_config.new_table
+
+        column_string = ','.join(old_columns)
+
+        for ind in async_indicator:
+            with connections['icds-ucr'].cursor() as cursor:
+                cursor.execute(
+                    "INSERT INTO " + new_table + " " +
+                    " (" + column_string + ") " +
+                    "SELECT " + column_string + " from " + old_table + " " +
+                    "WHERE " +
+                    "    doc_id = %s AND " +
+                    "    NOT EXISTS ( " +
+                    "        SELECT doc_id FROM " + new_table + "WHERE doc_id = %s " +
+                    "    ) ",
+                    [ind.doc_id, ind.doc_id]
+                )
+            ind.indicator_config_ids = ind.indicator_config_ids.remove(db_config.old_config_id)
+            ind.save()

--- a/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
+++ b/corehq/apps/userreports/management/commands/migrate_icds_ucr.py
@@ -86,8 +86,22 @@ class Command(BaseCommand):
         if options['dry_run']:
             print(sql_command)
         else:
+            print("count of old table %s: " % self.old_table)
+            print(self.get_count(self.old_table))
+            print("count of new table %s: " % self.new_table)
+            print(self.get_count(self.new_table))
             with connections['icds-ucr'].cursor() as cursor:
                 cursor.execute(sql_command)
+            print("count of old table %s: " % self.new_table)
+            print(self.get_count(self.new_table))
+
+    def get_count(self, table_name):
+        with connections['icds-ucr'].cursor() as cursor:
+            table = '"%s"' % table_name
+            cursor.execute(
+                'SELECT count(*) from ' + table
+            )
+            return cursor.fetchone()
 
     def _sql_command(self, has_repeat_iteration):
         if has_repeat_iteration:
@@ -95,11 +109,14 @@ class Command(BaseCommand):
         else:
             join = 'A.doc_id = B.doc_id'
 
+        old_table = '"%s"' % self.old_table
+        new_table = '"%s"' % self.new_table
+
         return (
-           " INSERT INTO " + self.new_table + " ( " + self.column_string + " ) " +
+           " INSERT INTO " + new_table + " ( " + self.column_string + " ) " +
            " SELECT ( " + self.select_column_string + " ) " +
-           " FROM " + self.old_table + " A " +
-           " LEFT JOIN " + self.new_table + " B " +
+           " FROM " + old_table + " A " +
+           " LEFT JOIN " + new_table + " B " +
            " ON " + join + " " +
            " WHERE B.doc_id IS NULL "
        )


### PR DESCRIPTION
@dimagi/scale-team A script to move old data into the new tables. Unfortunately I think we need to do it one case at a time since we need to check that it doesn't exist in the table already.

The way I'm thinking of rolling this out is:

1) run this script for child_health cases
2) change the dashboard/aggregation code/config to point to child_health_tableau_v2 table
3) remove the old config id from the async indicator queue
4) Remove the static config from icds-cas
5) repeat for ccs_record cases and person cases
6) eventually delete the old data.

@sheelio 