### PR TITLE
simplify format_angular_error and make log_errors required

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -673,13 +673,14 @@ class BaseDownloadExportView(ExportsPermissionsMixin, HQJSONResponseMixin, BaseP
         try:
             download_id = in_data['download_id']
         except KeyError:
-            return format_angular_error(_("Requires a download id"))
+            return format_angular_error(_("Requires a download id"), log_error=False)
         try:
             context = get_download_context(download_id)
         except TaskFailedError:
             return format_angular_error(
                 _("Download Task Failed to Start. It seems that the server "
-                  "might be under maintenance.")
+                  "might be under maintenance."),
+                log_error=False,
             )
         if context.get('is_ready', False):
             context.update({
@@ -775,14 +776,10 @@ class BaseDownloadExportView(ExportsPermissionsMixin, HQJSONResponseMixin, BaseP
         """
         try:
             download = self._get_download_task(in_data)
-        except ExportAsyncException as e:
-            return format_angular_error(e.message)
-        except Exception as e:
-            return format_angular_error(
-                e.message,
-                log_error=True,
-                exception=e,
-            )
+        except ExportAsyncException:
+            return format_angular_error(_("There was an error."), log_error=True)
+        except Exception:
+            return format_angular_error(_("There was an error."), log_error=True)
         return format_angular_success({
             'download_id': download.download_id,
         })
@@ -853,8 +850,8 @@ class DownloadFormExportView(BaseDownloadExportView):
                     export_object.app_id,
                     getattr(export_object, 'xmlns', '')
                 )
-        except Exception as e:
-            return format_angular_error(e.message)
+        except Exception:
+            return format_angular_error(_("There was an error"), log_error=True)
         return format_angular_success({
             'hasMultimedia': has_multimedia,
         })
@@ -880,8 +877,8 @@ class DownloadFormExportView(BaseDownloadExportView):
                                                           download.download_id)
             from corehq.apps.reports.tasks import build_form_multimedia_zip
             download.set_task(build_form_multimedia_zip.delay(**task_kwargs))
-        except Exception as e:
-            return format_angular_error(str(e))
+        except Exception:
+            return format_angular_error(_("There was an error"), log_error=True)
         return format_angular_success({
             'download_id': download.download_id,
         })
@@ -1191,7 +1188,6 @@ class BaseExportListView(ExportsPermissionsMixin, HQJSONResponseMixin, BaseProje
             return format_angular_error(
                 _("Issue fetching list of exports: {}").format(e),
                 log_error=True,
-                exception=e,
             )
         return format_angular_success({
             'exports': saved_exports,
@@ -1254,17 +1250,20 @@ class BaseExportListView(ExportsPermissionsMixin, HQJSONResponseMixin, BaseProje
             form_data = in_data['formData']
         except KeyError:
             return format_angular_error(
-                _("The form's data was not correctly formatted.")
+                _("The form's data was not correctly formatted."),
+                log_error=False,
             )
         try:
             create_url = self.get_create_export_url(form_data)
         except ExportFormValidationException:
             return format_angular_error(
-                _("The form did not validate.")
+                _("The form did not validate."),
+                log_error=False,
             )
         except Exception as e:
             return format_angular_error(
                 _("Problem getting link to custom export form: {}").format(e),
+                log_error=False,
             )
         return format_angular_success({
             'url': create_url,
@@ -1384,18 +1383,10 @@ class DailySavedExportListView(BaseExportListView):
         try:
             rmi_helper = ApplicationDataRMIHelper(self.domain, self.request.couch_user)
             response = rmi_helper.get_dual_model_rmi_response()
-        except Exception as e:
-            message = "Problem getting Create Daily Saved Export Form: {} {}"
-            notify_exception(
-                self.request,
-                message=message.format(
-                    e.__class__, e
-                )
-            )
+        except Exception:
             return format_angular_error(
-                _(message).format(
-                    e.__class__, e
-                ),
+                _("Problem getting Create Daily Saved Export Form"),
+                log_error=True,
             )
         return format_angular_success(response)
 
@@ -1457,11 +1448,12 @@ class DailySavedExportListView(BaseExportListView):
                     rebuild_export_task.delay(export_id)
                 return format_angular_success()
             else:
-                return format_angular_error("Problem saving dashboard feed filters: Invalid form")
-        except Exception as e:
-            msg = "Problem saving dashboard feed filters: {} {}"
-            notify_exception(self.request, message=msg.format(e.__class__, e))
-            return format_angular_error(_(msg).format(e.__class__, e))
+                return format_angular_error(
+                    _("Problem saving dashboard feed filters: Invalid form"),
+                    log_error=True)
+        except Exception:
+            return format_angular_error(_("Problem saving dashboard feed filters"),
+                                        log_error=True)
 
 
 @location_safe
@@ -1684,13 +1676,10 @@ class FormExportListView(BaseExportListView):
         try:
             rmi_helper = ApplicationDataRMIHelper(self.domain, self.request.couch_user)
             response = rmi_helper.get_form_rmi_response()
-        except Exception as e:
+        except Exception:
             return format_angular_error(
-                _("Problem getting Create Export Form: {} {}").format(
-                    e.__class__, e
-                ),
+                _("Problem getting Create Export Form"),
                 log_error=True,
-                exception=e,
             )
         return format_angular_success(response)
 
@@ -1831,11 +1820,10 @@ class CaseExportListView(BaseExportListView):
         try:
             rmi_helper = ApplicationDataRMIHelper(self.domain, self.request.couch_user)
             response = rmi_helper.get_case_rmi_response()
-        except Exception as e:
+        except Exception:
             return format_angular_error(
-                _("Problem getting Create Export Form: {}").format(e.message),
+                _("Problem getting Create Export Form"),
                 log_error=True,
-                exception=e,
             )
         return format_angular_success(response)
 

--- a/corehq/apps/style/utils.py
+++ b/corehq/apps/style/utils.py
@@ -1,8 +1,7 @@
 import logging
 
 
-def format_angular_error(error_msg, additional_data=None,
-                         log_error=False, exception=None):
+def format_angular_error(error_msg, log_error):
     """Gets the standard angular async error response.
     :param error_msg: A string that is the error message you'd like to return
     :param additional_data: a dictionary of additional data you'd like to pass
@@ -11,17 +10,11 @@ def format_angular_error(error_msg, additional_data=None,
         <...additional_data...>,
     }
     """
-    resp = {
-        'error': error_msg,
-    }
-    if log_error:
-        if exception:
-            logging.exception(exception)
-        else:
-            logging.error(error_msg)
+    resp = {'error': error_msg}
 
-    if isinstance(additional_data, dict):
-        resp.update(additional_data)
+    if log_error:
+        logging.exception(error_msg)
+
     return resp
 
 


### PR DESCRIPTION
This should make it harder to by mistake not log errors.

It also replaces all errors that are based on the exception message with the phrase "There was an error." To a user that is all an exception message means anyway, and to a dev just having the exception message is super not useful.