### PR TITLE
Fix the Manage Forms report

### DIFF
--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -188,6 +188,7 @@ class BulkFormManagementInterface(SubmitHistoryMixin, DataInterface, ProjectRepo
     name = ugettext_noop("Manage Forms")
     slug = "bulk_archive_forms"
     report_template_path = 'data_interfaces/interfaces/archive_forms.html'
+    asynchronous = False
 
     def __init__(self, request, **kwargs):
         super(BulkFormManagementInterface, self).__init__(request, **kwargs)


### PR DESCRIPTION
This was a hell of an issue to debug.  The report wasn't showing up, no js errors, no nothing.  Eventually I figured out that the template for the report wasn't being rendered at all, so I found where the template is rendered (no easy task with our view code), and saw that the base template was being rendered directly.  With asynchronous to False, it will use the correct template.

@biyeun @orangejenny any ideas as to what happened here?  I think there's been some recent report changes, but I couldn't find anything which could've caused this.  Does this look like the correct fix anyways?