### PR TITLE
Make locations list page show all results

### DIFF
--- a/corehq/apps/locations/resources/v0_1.py
+++ b/corehq/apps/locations/resources/v0_1.py
@@ -105,6 +105,7 @@ class LocationResource(HqBaseResource):
         object_class = SQLLocation
         resource_name = 'location'
         limit = 0
+        max_limit = 10000
 
 
 @location_safe


### PR DESCRIPTION
(even for eNikshay).  The default limit is 1000 at a time, which eNikshay exceeds.  This will likely need a better solution (pagination) soon, as I'm betting browsers will have trouble loading this many.

@proteusvacuum this will inelegantly fix the issue you ran into today.