### PR TITLE
don't remove media reference is there are form errors

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -714,6 +714,8 @@ class HQMediaMixin(Document):
             If not, then that item is removed from the multimedia map.
         """
         map_changed = False
+        if self.check_media_state()['has_form_errors']:
+            return
         paths = self.multimedia_map.keys() if self.multimedia_map else []
         permitted_paths = self.all_media_paths | self.logo_paths
         for path in paths:


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?255929

If there are form errors it shouldn't get to this stage but it could still be the case that the validation fails due to Formplayer error. If that happens any media in the forms that fail will get removed.