### PR TITLE
Add score to case search

### DIFF
--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -119,23 +119,24 @@
                             <th>{% trans "Closed" %}</th>
                             <th>{% trans "Properties" %}</th>
                             <th>{% trans "Indices" %}</th>
+                            <th>{% trans "Score" %}</th>
                         </tr>
                     </thead>
-                    <tbody data-bind="foreach: results">
+                    <tbody data-bind="foreach: {data: results, as: 'result' }">
                         <tr>
                             <td>
-                                <a data-bind="attr: {href: $parent.case_data_url.replace('___', $data._id)}, text: name"></a>
+                                <a data-bind="attr: {href: $parent.case_data_url.replace('___', $data._id)}, text: result['_source']['name']"></a>
                             </td>
-                            <td data-bind="text: type"></td>
-                            <td data-bind="text: closed"></td>
+                            <td data-bind="text: result['_source']['type']"></td>
+                            <td data-bind="text: result['_source']['closed']"></td>
                             <td>
-                                <div data-bind="foreach: case_properties">
+                                <div data-bind="foreach: result['_source']['case_properties']">
                                     <small data-bind="text:$data['key']"></small>:
                                     <strong data-bind="text:$data['value']"></strong><br />
                                 </div>
                             </td>
                             <td>
-                                <ul data-bind="foreach: indices">
+                                <ul data-bind="foreach: result['_source']['indices']">
                                     <li>
                                         <span class="label label-default"
                                               data-bind="text: relationship"></span>
@@ -144,6 +145,7 @@
                                     </li>
                                 </ul>
                             </td>
+                            <td data-bind="text: result['_score']"></td>
                         </tr>
                     </tbody>
                 </table>

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -60,5 +60,5 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
             new_query = merge_queries(search.get_query(), addition.query_addition)
             search = search.set_query(new_query)
-        search_results = search.values()
+        search_results = search.run().raw_hits
         return json_response({'values': search_results})

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -16,6 +16,7 @@ from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_ALIAS
 
 
 PATH = "case_properties"
+RELEVANCE_SCORE = "commcare_search_score"
 
 
 class CaseSearchES(CaseES):
@@ -90,13 +91,15 @@ def blacklist_owner_id(owner_id):
     return filters.NOT(owner(owner_id))
 
 
-def flatten_result(result):
+def flatten_result(hit):
     """Flattens a result from CaseSearchES into the format that Case serializers
     expect
 
     i.e. instead of {'name': 'blah', 'case_properties':{'key':'foo', 'value':'bar'}} we return
     {'name': 'blah', 'foo':'bar'}
     """
+    result = hit['_source']
+    result[RELEVANCE_SCORE] = hit['_score']
     case_properties = result.pop('case_properties', [])
     for case_property in case_properties:
         key = case_property.get('key')

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from corehq.apps.es.case_search import CaseSearchES, flatten_result
+from corehq.apps.es.case_search import CaseSearchES, flatten_result, RELEVANCE_SCORE
 from corehq.apps.es.tests.utils import ElasticTestMixin
 from corehq.elastic import SIZE_LIMIT
 
@@ -142,14 +142,17 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
         self.checkQuery(query, json_output)
 
     def test_flatten_result(self):
-        expected = {'name': 'blah', 'foo': 'bar', 'baz': 'buzz'}
+        expected = {'name': 'blah', 'foo': 'bar', 'baz': 'buzz', RELEVANCE_SCORE: "1.095"}
         self.assertEqual(
             flatten_result(
                 {
-                    'name': 'blah',
-                    'case_properties': [
-                        {'key': 'foo', 'value': 'bar'},
-                        {'key': 'baz', 'value': 'buzz'}]
+                    "_score": "1.095",
+                    "_source": {
+                        'name': 'blah',
+                        'case_properties': [
+                            {'key': 'foo', 'value': 'bar'},
+                            {'key': 'baz', 'value': 'buzz'}]
+                    }
                 }
             ),
             expected

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -402,6 +402,7 @@ class CaseClaimEndpointTests(TestCase):
             '<last_modified>2016-04-17T10:13:06.588694Z</last_modified>'
             '<external_id>Jamie Hand</external_id>'
             '<date_opened>2016-04-17</date_opened>'
+            '<commcare_search_score>xxx</commcare_search_score>'
             '<location_id>None</location_id>'
             '<referrals>None</referrals>'
             '</case>'
@@ -416,8 +417,13 @@ class CaseClaimEndpointTests(TestCase):
         client.login(username=USERNAME, password=PASSWORD)
         url = reverse('remote_search', kwargs={'domain': DOMAIN})
         response = client.get(url, {'name': 'Jamie Hand', 'case_type': CASE_TYPE})
+        score_regex = re.compile(r'(<commcare_search_score>)(\d+.\d+)(<\/commcare_search_score>)')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(re.sub(DATE_PATTERN, FIXED_DATESTAMP, re.sub(PATTERN, TIMESTAMP, response.content)), known_result)
+        self.assertEqual(
+            score_regex.sub(r'\1xxx\3',
+                            re.sub(DATE_PATTERN, FIXED_DATESTAMP,
+                                   re.sub(PATTERN, TIMESTAMP, response.content))),
+            known_result)
 
     @patch('corehq.apps.es.es_query.run_query')
     def test_search_query_addition(self, run_query_mock):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -94,12 +94,12 @@ def search(request, domain):
     except QueryMergeException as e:
         return _handle_query_merge_exception(request, e)
     try:
-        results = search_es.values()
+        hits = search_es.run().raw_hits
     except Exception as e:
         return _handle_es_exception(request, e, case_search_criteria.query_addition_debug_details)
 
-    # Even if it's a SQL domain, we just need to render the results as cases, so CommCareCase.wrap will be fine
-    cases = [CommCareCase.wrap(flatten_result(result)) for result in results]
+    # Even if it's a SQL domain, we just need to render the hits as cases, so CommCareCase.wrap will be fine
+    cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
 


### PR DESCRIPTION
Adds a property `commcare_search_score` to the case when it is returned from a search so that case lists can be sorted by relevance.

@snopoke 
FYI @wpride 