### PR TITLE
Simplify case list form

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -113,12 +113,6 @@ $(function () {
                 formSet = !!data.form_id,
                 formMissing = formSet && !formOptions[data.form_id];
 
-            self.toggleState = function(active) {
-                active = active && allowed;
-                $('#case_list_form-label').toggle(active);
-                $('#case_list_media').toggle(active);
-            };
-
             self.buildOptstr = function(extra) {
                 self.caseListFormOptstr = _.map(formOptions, function (label, value) {
                     return {value: value, label: label};
@@ -131,27 +125,8 @@ $(function () {
             self.allowed = allowed;
             self.formMissing = ko.observable(formMissing);
             self.caseListForm = ko.observable(data.form_id ? data.form_id : null);
-            self.caseListFormProxy = ko.observable(initialOption);
             self.caseListFormDisplay = formOptions[initialOption];
 
-            self.caseListFormProxy.subscribe(function (form_id) {
-                var disabled = form_id === 'disabled' || !formOptions[form_id];
-                self.caseListForm(disabled ? null : form_id);
-                self.toggleState(!disabled);
-            });
-
-            if (formMissing) {
-                var removeOld = self.caseListFormProxy.subscribe(function (oldValue) {
-                    if (formMissing && oldValue === initialOption) {
-                        // remove the missing form from the options once the user select a real form
-                        self.buildOptstr();
-                        removeOld.dispose();
-                        self.formMissing(false);
-                    }
-                }, null, "beforeChange");
-            }
-
-            self.toggleState(formSet && !formMissing);
             self.buildOptstr(formMissing ? data.form_id : false);
         };
         var case_list_form_options = initial_page_data('case_list_form_options'),

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -115,15 +115,18 @@ $(function () {
                 return self.caseListForm() && !formOptions[self.caseListForm()];
             });
 
-            // Show or hide associated multimedia. Not done in knockout because
-            // the multimedia section has its own separate set of knockout bindings
-            self.caseListForm.subscribe(function(form_id) {
-                if (form_id) {
+            var showMedia = function(formId) {
+                if (formId) {
                     $("#case_list_media").show();
                 } else {
                     $("#case_list_media").hide();
                 }
-            });
+            };
+
+            // Show or hide associated multimedia. Not done in knockout because
+            // the multimedia section has its own separate set of knockout bindings
+            showMedia(originalFormId);
+            self.caseListForm.subscribe(showMedia);
         };
         var case_list_form_options = initial_page_data('case_list_form_options');
             caseListForm = new CaseListForm(

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -119,10 +119,6 @@ $(function () {
                 $('#case_list_media').toggle(active);
             };
 
-            self.toggleMessage = function() {
-                self.messageVisible(!self.messageVisible());
-            };
-
             self.buildOptstr = function(extra) {
                 self.caseListFormOptstr = _.map(formOptions, function (label, value) {
                     return {value: value, label: label};
@@ -135,7 +131,6 @@ $(function () {
             self.allowed = allowed;
             self.now_allowed_reason = now_allowed_reason;
             self.formMissing = ko.observable(formMissing);
-            self.messageVisible = ko.observable(false);
             self.caseListForm = ko.observable(data.form_id ? data.form_id : null);
             self.caseListFormProxy = ko.observable(initialOption);
             self.caseListFormDisplay = formOptions[initialOption];

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -108,14 +108,20 @@ $(function () {
     // Registration in case list
     if ($('#case-list-form').length) {
         var CaseListForm = function (data, formOptions, allowed) {
-            var self = this,
-                initialOption = data.form_id ? data.form_id : 'disabled',
-                formSet = !!data.form_id;
-
+            var self = this;
             self.allowed = allowed;
             self.caseListForm = ko.observable(data.form_id ? data.form_id : null);
+            self.caseListForm.subscribe(function(form_id) {
+                if (self.formMissing() || !form_id) {
+                    $('#case_list_form-label').hide();
+                    $('#case_list_media').hide();
+                } else {
+                    $('#case_list_form-label').show();
+                    $('#case_list_media').show();
+                }
+            });
             self.formMissing = ko.computed(function() {
-                return !formOptions[self.caseListForm()];
+                return self.caseListForm() && !formOptions[self.caseListForm()];
             });
         };
         var case_list_form_options = initial_page_data('case_list_form_options'),
@@ -126,6 +132,7 @@ $(function () {
                 case_list_form_not_allowed_reason ? case_list_form_not_allowed_reason.allow : "",
             );
         $('#case-list-form').koApplyBindings(caseListForm);
+
         // Reset save button after bindings
         // see http://manage.dimagi.com/default.asp?145851
         var $form = $('#case-list-form').closest('form'),

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -107,29 +107,28 @@ $(function () {
 
     // Registration in case list
     if ($('#case-list-form').length) {
-        var CaseListForm = function (data, formOptions, allowed) {
+        var CaseListForm = function (originalFormId, formOptions) {
             var self = this;
-            self.allowed = allowed;
-            self.caseListForm = ko.observable(data.form_id ? data.form_id : null);
-            self.caseListForm.subscribe(function(form_id) {
-                if (self.formMissing() || !form_id) {
-                    $('#case_list_form-label').hide();
-                    $('#case_list_media').hide();
-                } else {
-                    $('#case_list_form-label').show();
-                    $('#case_list_media').show();
-                }
-            });
+
+            self.caseListForm = ko.observable(originalFormId);
             self.formMissing = ko.computed(function() {
                 return self.caseListForm() && !formOptions[self.caseListForm()];
             });
+
+            // Show or hide associated multimedia. Not done in knockout because
+            // the multimedia section has its own separate set of knockout bindings
+            self.caseListForm.subscribe(function(form_id) {
+                if (form_id) {
+                    $("#case_list_media").show();
+                } else {
+                    $("#case_list_media").hide();
+                }
+            });
         };
-        var case_list_form_options = initial_page_data('case_list_form_options'),
-            case_list_form_not_allowed_reason = initial_page_data('case_list_form_not_allowed_reason'),
+        var case_list_form_options = initial_page_data('case_list_form_options');
             caseListForm = new CaseListForm(
-                case_list_form_options ? case_list_form_options.form : {},
-                case_list_form_options ? case_list_form_options.options : [],
-                case_list_form_not_allowed_reason ? case_list_form_not_allowed_reason.allow : "",
+                case_list_form_options ? case_list_form_options.form.form_id : null,
+                case_list_form_options ? case_list_form_options.options : []
             );
         $('#case-list-form').koApplyBindings(caseListForm);
 

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -107,7 +107,7 @@ $(function () {
 
     // Registration in case list
     if ($('#case-list-form').length) {
-        var CaseListForm = function (data, formOptions, allowed, now_allowed_reason) {
+        var CaseListForm = function (data, formOptions, allowed) {
             var self = this,
                 initialOption = data.form_id ? data.form_id : 'disabled',
                 formSet = !!data.form_id,
@@ -129,7 +129,6 @@ $(function () {
             };
 
             self.allowed = allowed;
-            self.now_allowed_reason = now_allowed_reason;
             self.formMissing = ko.observable(formMissing);
             self.caseListForm = ko.observable(data.form_id ? data.form_id : null);
             self.caseListFormProxy = ko.observable(initialOption);
@@ -161,7 +160,6 @@ $(function () {
                 case_list_form_options ? case_list_form_options.form : {},
                 case_list_form_options ? case_list_form_options.options : [],
                 case_list_form_not_allowed_reason ? case_list_form_not_allowed_reason.allow : "",
-                case_list_form_not_allowed_reason ? case_list_form_not_allowed_reason.message : ""
             );
         $('#case-list-form').koApplyBindings(caseListForm);
         // Reset save button after bindings

--- a/corehq/apps/app_manager/static/app_manager/js/module-view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/module-view.js
@@ -110,24 +110,13 @@ $(function () {
         var CaseListForm = function (data, formOptions, allowed) {
             var self = this,
                 initialOption = data.form_id ? data.form_id : 'disabled',
-                formSet = !!data.form_id,
-                formMissing = formSet && !formOptions[data.form_id];
-
-            self.buildOptstr = function(extra) {
-                self.caseListFormOptstr = _.map(formOptions, function (label, value) {
-                    return {value: value, label: label};
-                });
-                if (extra) {
-                    self.caseListFormOptstr.push({value: extra, label: gettext("Unknown Form (missing)")});
-                }
-            };
+                formSet = !!data.form_id;
 
             self.allowed = allowed;
-            self.formMissing = ko.observable(formMissing);
             self.caseListForm = ko.observable(data.form_id ? data.form_id : null);
-            self.caseListFormDisplay = formOptions[initialOption];
-
-            self.buildOptstr(formMissing ? data.form_id : false);
+            self.formMissing = ko.computed(function() {
+                return !formOptions[self.caseListForm()];
+            });
         };
         var case_list_form_options = initial_page_data('case_list_form_options'),
             case_list_form_not_allowed_reason = initial_page_data('case_list_form_not_allowed_reason'),

--- a/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/partials/case_list_form_setting.html
@@ -1,76 +1,58 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 {% load i18n %}
-<div id="case-list-form">
-    <div class="form-group">
-        <label class="col-sm-2 control-label">
-            {% trans "Registration Form Accessible from Case List" %}
-            <span class="hq-help-template"
-                  data-title="{% trans "Registration Form Accessible from Case List" %}"
-                  data-content="{% blocktrans %}Minimize duplicate case registrations by requiring mobile workers
-                  to search the case list before they can enter a form that registers new cases.{% endblocktrans %}"
-            ></span>
-        </label>
-        <div class="col-sm-4">
-            <div data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
-                <select class="form-control" data-bind="
-                    optstr: caseListFormOptstr,
-                    value: caseListFormProxy
-                    "></select>
-                <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
-                <div data-bind="visible: formMissing()" class="help-block">
-                    {% trans "Error! The selected form does not exist." %}
-                </div>
-            </div>
-            <div class="btn-group" data-bind="visible: !allowed && !caseListForm()">
-                <button class="btn btn-default disabled" disabled="disabled">
-                    <span>{% trans "Not available" %}</span>
-                </button>
-                <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu">
-                    <li>
-                        <a href="#" data-bind="click: toggleMessage">
-                            {% trans "Why can't I select a registration form?" %}
-                        </a>
-                    </li>
-                </ul>
-            </div>
-            <div class="help-block" data-bind="visible: messageVisible">
-                <div>
-                    {% blocktrans %}
-                    Registration forms are only available from the case list when<br/>
-                    (1) The registration form is in a different module<br/>
-                    (2) Every form in the module updates or closes the case<br/>
-                    (3) The case list does not have parent case selection configured.<br/>
-                    (4) The module's "Menu Mode" is configured as "Display module and then forms".<br/>
-                    To learn more, see our <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates" target="_blank">Help Site</a>
-                    {% endblocktrans %}
-                </div>
-                <a href="#" class="btn btn-default btn-xs" data-bind="click: toggleMessage">
-                    {% trans "OK, close this" %}
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="form-group" id="case_list_form-label">
-        <label class="col-sm-2 control-label">
-            {% trans "Label for Registration Form" %}
-        </label>
-        <div class="col-sm-4">
-            {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
-            <div data-bind="visible: !allowed" class="help-block">
-                {%  trans "Error! Registration form will be ignored since this module is not allowed to have one for the following reason:" %}<br/>
-                <ul><li data-bind="text: now_allowed_reason"></li></ul>
-                {% blocktrans %}
-                    To learn more, see our
-                    <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates#MinimizeDuplicates-Limitations" target="_blank">Help Site</a>
-                {% endblocktrans %}
-            </div>
-        </div>
-    </div>
-</div>
-<div id="case_list_media">
-    {% include "app_manager/v1/partials/nav_menu_media.html" with item=multimedia.case_list_form qualifier='case_list_form_' ICON_LABEL="Registration Form Icon" AUDIO_LABEL="Registration Form Audio" %}
-</div>
+
+  <div id="case-list-form">
+      <div class="form-group">
+          <label class="col-sm-2 control-label">
+              {% trans "Registration Form Accessible from Case List" %}
+              <span class="hq-help-template"
+                    data-title="{% trans "Registration Form Accessible from Case List" %}"
+                    data-content="{% blocktrans %}Minimize duplicate registrations by requiring mobile workers to search the case list before registering a new case. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
+              ></span>
+          </label>
+          {% if not case_list_form_not_allowed_reasons %}
+              <div class="col-sm-4" data-bind="css: {'has-error': formMissing()}">
+                  <select class="form-control" data-bind="value: caseListForm">
+                    {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
+                        <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
+                    {% endif %}
+                    <option value="">{% trans "Don't Show" %}</option>
+                    {% for id, name in case_list_form_options.options.items %}
+                        <option value="{{ id }}">{{ name }}</option>
+                    {% endfor %}
+                  </select>
+                  <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
+                  <div data-bind="visible: formMissing()" class="help-block">
+                      {% trans "Error! The selected form does not exist." %}
+                  </div>
+              </div>
+          {% else %}
+              <div class="col-sm-8 alert alert-info">
+                      {% trans "Registration from the case list is not available because" %}
+                      {% if case_list_form_not_allowed_reasons|length == 1 %}
+                        {% for reason in case_list_form_not_allowed_reasons %}
+                            {{ reason }}
+                        {% endfor %}
+                      {% else %}
+                        <ul>
+                            {% for reason in case_list_form_not_allowed_reasons %}
+                                <li>{{ reason }}</li>
+                            {% endfor %}
+                        </ul>
+                      {% endif %}
+              </div>
+          {% endif %}
+      </div>
+      <div class="form-group" id="case_list_form-label" data-bind="visible: caseListForm()">
+          <label class="col-sm-2 control-label">
+              {% trans "Label for Registration Form" %}
+          </label>
+          <div class="col-sm-4">
+              {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
+          </div>
+      </div>
+  </div>
+  <div id="case_list_media">
+      {% include "app_manager/v1/partials/nav_menu_media.html" with item=multimedia.case_list_form qualifier='case_list_form_' ICON_LABEL="Registration Form Icon" AUDIO_LABEL="Registration Form Audio" %}
+  </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view.html
@@ -54,7 +54,7 @@
   {% initial_page_data 'js_options' js_options %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'case_list_form_options' case_list_form_options %}
-  {% initial_page_data 'case_list_form_allowed' case_list_form_allowed %}
+  {% initial_page_data 'case_list_form_not_allowed_reasons' case_list_form_not_allowed_reasons %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
   {% initial_page_data 'parent_modules' parent_modules %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/module_view.html
@@ -54,7 +54,7 @@
   {% initial_page_data 'js_options' js_options %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'case_list_form_options' case_list_form_options %}
-  {% initial_page_data 'case_list_form_not_allowed_reason' case_list_form_not_allowed_reason  %}
+  {% initial_page_data 'case_list_form_allowed' case_list_form_allowed %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
   {% initial_page_data 'parent_modules' parent_modules %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -10,50 +10,29 @@
               {% trans "Registration Form Accessible from Case List" %}
               <span class="hq-help-template"
                     data-title="{% trans "Registration Form Accessible from Case List" %}"
-                    data-content="{% blocktrans %}Include a registration form in the application's menu of forms.{% endblocktrans %}"
+                    data-content="{% blocktrans %}Minimize duplicate registrations by including a registration form in the application's list of cases. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
               ></span>
           </label>
-          <div class="col-sm-4">
-              <div data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
-                  <select class="form-control" data-bind="
-                      optstr: caseListFormOptstr,
-                      value: caseListFormProxy
-                      "></select>
-                  <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
-                  <div data-bind="visible: formMissing()" class="help-block">
-                      {% trans "Error! The selected form does not exist." %}
-                  </div>
+          <div class="col-sm-4" data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
+              <select class="form-control" data-bind="
+                  optstr: caseListFormOptstr,
+                  value: caseListFormProxy
+                  "></select>
+              <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
+              <div data-bind="visible: formMissing()" class="help-block">
+                  {% trans "Error! The selected form does not exist." %}
               </div>
-              <div class="btn-group" data-bind="visible: !allowed && !caseListForm()">
-                  <button class="btn btn-default disabled" disabled="disabled">
-                      <span>{% trans "Not available" %}</span>
-                  </button>
-                  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                      <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu">
-                      <li>
-                          <a href="#" data-bind="click: toggleMessage">
-                              {% trans "Why can't I select a registration form?" %}
-                          </a>
-                      </li>
-                  </ul>
-              </div>
-              <div class="help-block" data-bind="visible: messageVisible">
-                  <div>
-                      {% blocktrans %}
-                      Registration forms are only available from the case list when<br/>
-                      (1) The registration form is in a different module<br/>
-                      (2) Every form in the module updates or closes the case<br/>
-                      (3) The case list does not have parent case selection configured.<br/>
-                      (4) The module's "Menu Mode" is configured as "Display module and then forms".<br/>
-                      To learn more, see our <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates" target="_blank">Help Site</a>
-                      {% endblocktrans %}
-                  </div>
-                  <a href="#" class="btn btn-default btn-xs" data-bind="click: toggleMessage">
-                      {% trans "OK, close this" %}
-                  </a>
-              </div>
+          </div>
+          <div class="col-sm-8 alert alert-info" data-bind="visible: !allowed && !caseListForm()">
+              {% blocktrans %}
+                  Registration forms are only available from the case list when all of the following are true:
+                  <ol>
+                    <li>The registration form is in a different menu</li>
+                    <li>Every form in the menu updates or closes the case</li>
+                    <li>The case list does not have parent case selection configured.</li>
+                    <li>The module's "Menu Mode" is configured as "Display module and then forms".</li>
+                  </ol>
+              {% endblocktrans %}
           </div>
       </div>
       <div class="form-group" id="case_list_form-label">

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -13,11 +13,15 @@
                     data-content="{% blocktrans %}Minimize duplicate registrations by including a registration form in the application's list of cases. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
               ></span>
           </label>
-          <div class="col-sm-4" data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
-              <select class="form-control" data-bind="
-                  optstr: caseListFormOptstr,
-                  value: caseListFormProxy
-                  "></select>
+          <div class="col-sm-4" data-bind="visible: caseListForm() || allowed, css: { 'has-error': formMissing() || !allowed}">
+              <select class="form-control" data-bind="value: caseListForm">
+                {% if case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
+                    <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
+                {% endif %}
+                {% for id, name in case_list_form_options.options.items %}
+                    <option value="{{ id }}">{{ name }}</option>
+                {% endfor %}
+              </select>
               <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
               <div data-bind="visible: formMissing()" class="help-block">
                   {% trans "Error! The selected form does not exist." %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -13,7 +13,7 @@
                     data-content="{% blocktrans %}Minimize duplicate registrations by including a registration form in the application's list of cases. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
               ></span>
           </label>
-          {% if case_list_form_allowed %}
+          {% if not case_list_form_not_allowed_reasons %}
               <div class="col-sm-4" data-bind="css: {'has-error': formMissing()}">
                   <select class="form-control" data-bind="value: caseListForm">
                     {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
@@ -31,14 +31,18 @@
               </div>
           {% else %}
               <div class="col-sm-8 alert alert-info">
-                  {% blocktrans %}
-                      Registration forms are only available from the case list when all of the following are true:
-                      <ol>
-                        <li>Every form in the menu updates or closes the case. Any registration form(s) must go in a different menu.</li>
-                        <li>The case list does not have parent case selection configured.</li>
-                        <li>The module's "Menu Mode" is configured as "Display module and then forms".</li>
-                      </ol>
-                  {% endblocktrans %}
+                      {% trans "Registration from the case list is not available because" %}
+                      {% if case_list_form_not_allowed_reasons|length == 1 %}
+                        {% for reason in case_list_form_not_allowed_reasons %}
+                            {{ reason }}
+                        {% endfor %}
+                      {% else %}
+                        <ul>
+                            {% for reason in case_list_form_not_allowed_reasons %}
+                                <li>{{ reason }}</li>
+                            {% endfor %}
+                        </ul>
+                      {% endif %}
               </div>
           {% endif %}
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -10,7 +10,7 @@
               {% trans "Registration Form Accessible from Case List" %}
               <span class="hq-help-template"
                     data-title="{% trans "Registration Form Accessible from Case List" %}"
-                    data-content="{% blocktrans %}Minimize duplicate registrations by including a registration form in the application's list of cases. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
+                    data-content="{% blocktrans %}Minimize duplicate registrations by requiring mobile workers to search the case list before registering a new case. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
               ></span>
           </label>
           {% if not case_list_form_not_allowed_reasons %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -34,8 +34,7 @@
                   {% blocktrans %}
                       Registration forms are only available from the case list when all of the following are true:
                       <ol>
-                        <li>The registration form is in a different menu</li>
-                        <li>Every form in the menu updates or closes the case</li>
+                        <li>Every form in the menu updates or closes the case. Any registration form(s) must go in a different menu.</li>
                         <li>The case list does not have parent case selection configured.</li>
                         <li>The module's "Menu Mode" is configured as "Display module and then forms".</li>
                       </ol>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -41,14 +41,6 @@
           </label>
           <div class="col-sm-4">
               {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
-              <div data-bind="visible: !allowed" class="help-block">
-                  {%  trans "Error! Registration form will be ignored since this module is not allowed to have one for the following reason:" %}<br/>
-                  <ul><li data-bind="text: now_allowed_reason"></li></ul>
-                  {% blocktrans %}
-                      To learn more, see our
-                      <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates#MinimizeDuplicates-Limitations" target="_blank">Help Site</a>
-                  {% endblocktrans %}
-              </div>
           </div>
       </div>
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -15,9 +15,10 @@
           </label>
           <div class="col-sm-4" data-bind="visible: caseListForm() || allowed, css: { 'has-error': formMissing() || !allowed}">
               <select class="form-control" data-bind="value: caseListForm">
-                {% if case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
+                {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
                     <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
                 {% endif %}
+                <option value="">{% trans "Don't Show" %}</option>
                 {% for id, name in case_list_form_options.options.items %}
                     <option value="{{ id }}">{{ name }}</option>
                 {% endfor %}

--- a/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/v2/partials/case_list_form_setting.html
@@ -13,34 +13,37 @@
                     data-content="{% blocktrans %}Minimize duplicate registrations by including a registration form in the application's list of cases. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates'>Help Site</a>.{% endblocktrans %}"
               ></span>
           </label>
-          <div class="col-sm-4" data-bind="visible: caseListForm() || allowed, css: { 'has-error': formMissing() || !allowed}">
-              <select class="form-control" data-bind="value: caseListForm">
-                {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
-                    <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
-                {% endif %}
-                <option value="">{% trans "Don't Show" %}</option>
-                {% for id, name in case_list_form_options.options.items %}
-                    <option value="{{ id }}">{{ name }}</option>
-                {% endfor %}
-              </select>
-              <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
-              <div data-bind="visible: formMissing()" class="help-block">
-                  {% trans "Error! The selected form does not exist." %}
+          {% if case_list_form_allowed %}
+              <div class="col-sm-4" data-bind="css: {'has-error': formMissing()}">
+                  <select class="form-control" data-bind="value: caseListForm">
+                    {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
+                        <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
+                    {% endif %}
+                    <option value="">{% trans "Don't Show" %}</option>
+                    {% for id, name in case_list_form_options.options.items %}
+                        <option value="{{ id }}">{{ name }}</option>
+                    {% endfor %}
+                  </select>
+                  <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
+                  <div data-bind="visible: formMissing()" class="help-block">
+                      {% trans "Error! The selected form does not exist." %}
+                  </div>
               </div>
-          </div>
-          <div class="col-sm-8 alert alert-info" data-bind="visible: !allowed && !caseListForm()">
-              {% blocktrans %}
-                  Registration forms are only available from the case list when all of the following are true:
-                  <ol>
-                    <li>The registration form is in a different menu</li>
-                    <li>Every form in the menu updates or closes the case</li>
-                    <li>The case list does not have parent case selection configured.</li>
-                    <li>The module's "Menu Mode" is configured as "Display module and then forms".</li>
-                  </ol>
-              {% endblocktrans %}
-          </div>
+          {% else %}
+              <div class="col-sm-8 alert alert-info">
+                  {% blocktrans %}
+                      Registration forms are only available from the case list when all of the following are true:
+                      <ol>
+                        <li>The registration form is in a different menu</li>
+                        <li>Every form in the menu updates or closes the case</li>
+                        <li>The case list does not have parent case selection configured.</li>
+                        <li>The module's "Menu Mode" is configured as "Display module and then forms".</li>
+                      </ol>
+                  {% endblocktrans %}
+              </div>
+          {% endif %}
       </div>
-      <div class="form-group" id="case_list_form-label">
+      <div class="form-group" id="case_list_form-label" data-bind="visible: caseListForm()">
           <label class="col-sm-2 control-label">
               {% trans "Label for Case List Registration" %}
           </label>

--- a/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_form_setting.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/partials/case_list_form_setting.html.diff.txt
@@ -1,156 +1,29 @@
 --- 
 +++ 
-@@ -1,76 +1,80 @@
+@@ -1,6 +1,8 @@
  {% load xforms_extras %}
  {% load hq_shared_tags %}
  {% load i18n %}
--<div id="case-list-form">
--    <div class="form-group">
--        <label class="col-sm-2 control-label">
--            {% trans "Registration Form Accessible from Case List" %}
--            <span class="hq-help-template"
--                  data-title="{% trans "Registration Form Accessible from Case List" %}"
--                  data-content="{% blocktrans %}Minimize duplicate case registrations by requiring mobile workers
--                  to search the case list before they can enter a form that registers new cases.{% endblocktrans %}"
--            ></span>
--        </label>
--        <div class="col-sm-4">
--            <div data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
--                <select class="form-control" data-bind="
--                    optstr: caseListFormOptstr,
--                    value: caseListFormProxy
--                    "></select>
--                <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
--                <div data-bind="visible: formMissing()" class="help-block">
--                    {% trans "Error! The selected form does not exist." %}
--                </div>
--            </div>
--            <div class="btn-group" data-bind="visible: !allowed && !caseListForm()">
--                <button class="btn btn-default disabled" disabled="disabled">
--                    <span>{% trans "Not available" %}</span>
--                </button>
--                <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
--                    <span class="caret"></span>
--                </button>
--                <ul class="dropdown-menu">
--                    <li>
--                        <a href="#" data-bind="click: toggleMessage">
--                            {% trans "Why can't I select a registration form?" %}
--                        </a>
--                    </li>
--                </ul>
--            </div>
--            <div class="help-block" data-bind="visible: messageVisible">
--                <div>
--                    {% blocktrans %}
--                    Registration forms are only available from the case list when<br/>
--                    (1) The registration form is in a different module<br/>
--                    (2) Every form in the module updates or closes the case<br/>
--                    (3) The case list does not have parent case selection configured.<br/>
--                    (4) The module's "Menu Mode" is configured as "Display module and then forms".<br/>
--                    To learn more, see our <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates" target="_blank">Help Site</a>
--                    {% endblocktrans %}
--                </div>
--                <a href="#" class="btn btn-default btn-xs" data-bind="click: toggleMessage">
--                    {% trans "OK, close this" %}
--                </a>
--            </div>
--        </div>
--    </div>
--    <div class="form-group" id="case_list_form-label">
--        <label class="col-sm-2 control-label">
--            {% trans "Label for Registration Form" %}
--        </label>
--        <div class="col-sm-4">
--            {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
--            <div data-bind="visible: !allowed" class="help-block">
--                {%  trans "Error! Registration form will be ignored since this module is not allowed to have one for the following reason:" %}<br/>
--                <ul><li data-bind="text: now_allowed_reason"></li></ul>
--                {% blocktrans %}
--                    To learn more, see our
--                    <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates#MinimizeDuplicates-Limitations" target="_blank">Help Site</a>
--                {% endblocktrans %}
--            </div>
--        </div>
--    </div>
--</div>
--<div id="case_list_media">
--    {% include "app_manager/v1/partials/nav_menu_media.html" with item=multimedia.case_list_form qualifier='case_list_form_' ICON_LABEL="Registration Form Icon" AUDIO_LABEL="Registration Form Audio" %}
--</div>
 +
 +{% if app.advanced_app_builder or module.case_list_form.form_id %}
-+
-+  <div id="case-list-form">
-+      <div class="form-group">
-+          <label class="col-sm-2 control-label">
-+              {% trans "Registration Form Accessible from Case List" %}
-+              <span class="hq-help-template"
-+                    data-title="{% trans "Registration Form Accessible from Case List" %}"
-+                    data-content="{% blocktrans %}Include a registration form in the application's menu of forms.{% endblocktrans %}"
-+              ></span>
-+          </label>
-+          <div class="col-sm-4">
-+              <div data-bind="visible: caseListForm() || allowed, css: { 'alert alert-danger': formMissing() || !allowed}">
-+                  <select class="form-control" data-bind="
-+                      optstr: caseListFormOptstr,
-+                      value: caseListFormProxy
-+                      "></select>
-+                  <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
-+                  <div data-bind="visible: formMissing()" class="help-block">
-+                      {% trans "Error! The selected form does not exist." %}
-+                  </div>
-+              </div>
-+              <div class="btn-group" data-bind="visible: !allowed && !caseListForm()">
-+                  <button class="btn btn-default disabled" disabled="disabled">
-+                      <span>{% trans "Not available" %}</span>
-+                  </button>
-+                  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-+                      <span class="caret"></span>
-+                  </button>
-+                  <ul class="dropdown-menu">
-+                      <li>
-+                          <a href="#" data-bind="click: toggleMessage">
-+                              {% trans "Why can't I select a registration form?" %}
-+                          </a>
-+                      </li>
-+                  </ul>
-+              </div>
-+              <div class="help-block" data-bind="visible: messageVisible">
-+                  <div>
-+                      {% blocktrans %}
-+                      Registration forms are only available from the case list when<br/>
-+                      (1) The registration form is in a different module<br/>
-+                      (2) Every form in the module updates or closes the case<br/>
-+                      (3) The case list does not have parent case selection configured.<br/>
-+                      (4) The module's "Menu Mode" is configured as "Display module and then forms".<br/>
-+                      To learn more, see our <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates" target="_blank">Help Site</a>
-+                      {% endblocktrans %}
-+                  </div>
-+                  <a href="#" class="btn btn-default btn-xs" data-bind="click: toggleMessage">
-+                      {% trans "OK, close this" %}
-+                  </a>
-+              </div>
-+          </div>
-+      </div>
-+      <div class="form-group" id="case_list_form-label">
-+          <label class="col-sm-2 control-label">
+ 
+   <div id="case-list-form">
+       <div class="form-group">
+@@ -46,7 +48,7 @@
+       </div>
+       <div class="form-group" id="case_list_form-label" data-bind="visible: caseListForm()">
+           <label class="col-sm-2 control-label">
+-              {% trans "Label for Registration Form" %}
 +              {% trans "Label for Case List Registration" %}
-+          </label>
-+          <div class="col-sm-4">
-+              {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
-+              <div data-bind="visible: !allowed" class="help-block">
-+                  {%  trans "Error! Registration form will be ignored since this module is not allowed to have one for the following reason:" %}<br/>
-+                  <ul><li data-bind="text: now_allowed_reason"></li></ul>
-+                  {% blocktrans %}
-+                      To learn more, see our
-+                      <a href="https://help.commcarehq.org/display/commcarepublic/Minimize+Duplicates#MinimizeDuplicates-Limitations" target="_blank">Help Site</a>
-+                  {% endblocktrans %}
-+              </div>
-+          </div>
-+      </div>
-+  </div>
-+  <div id="case_list_media">
+           </label>
+           <div class="col-sm-4">
+               {% input_trans module.case_list_form.label langs input_name='case_list_form_label' %}
+@@ -54,5 +56,7 @@
+       </div>
+   </div>
+   <div id="case_list_media">
+-      {% include "app_manager/v1/partials/nav_menu_media.html" with item=multimedia.case_list_form qualifier='case_list_form_' ICON_LABEL="Registration Form Icon" AUDIO_LABEL="Registration Form Audio" %}
 +      {% include "app_manager/v2/partials/nav_menu_media.html" with item=multimedia.case_list_form qualifier='case_list_form_' ICON_LABEL="Registration Form Icon" AUDIO_LABEL="Registration Form Audio" %}
-+  </div>
+   </div>
 +
 +{% endif %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/module_view.html.diff.txt
@@ -71,7 +71,7 @@
 +  {% initial_page_data 'js_options' js_options %}
 +  {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
 +  {% initial_page_data 'case_list_form_options' case_list_form_options %}
-+  {% initial_page_data 'case_list_form_not_allowed_reason' case_list_form_not_allowed_reason  %}
++  {% initial_page_data 'case_list_form_not_allowed_reasons' case_list_form_not_allowed_reasons %}
 +  {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
 +  {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
 +  {% initial_page_data 'parent_modules' parent_modules %}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -366,7 +366,6 @@ def _case_list_form_options(app, module, case_type_, lang=None):
         for mod in app.get_modules() if module.unique_id != mod.unique_id
         for form in mod.get_forms() if form.is_registration_form(case_type_)
     ]
-    options['disabled'] = gettext_lazy("Don't Show")
     langs = None if lang is None else [lang]
     options.update({f.unique_id: trans(f.name, langs) for f in forms})
 


### PR DESCRIPTION
Did some cleanup of the ui for registration from case list, fixed some validation/messaging that wasn't working, and made the code more concise, largely by moving logic from js to django, since this widget isn't especially interactive.

Before, when reg from case list wasn't available, you saw a disabled dropdown and needed to click for more info:
<img width="493" alt="screen shot 2017-07-07 at 2 56 34 pm" src="https://user-images.githubusercontent.com/1486591/27972858-cdc1ce58-6325-11e7-95a7-e8a055861fc5.png">

After, when unavailable, you see only the reasons your particular module can't have reg from case list:
<img width="824" alt="screen shot 2017-07-07 at 2 56 51 pm" src="https://user-images.githubusercontent.com/1486591/27972904-ef2a9804-6325-11e7-815f-3d8fefb6a6f1.png">

Before, the error state (like the reg form being deleted) weren't all that clear:
<img width="499" alt="screen shot 2017-07-07 at 2 50 31 pm" src="https://user-images.githubusercontent.com/1486591/27972995-4d49964c-6326-11e7-8d29-7ef709c61581.png">

After, more specific error messaging:
<img width="506" alt="screen shot 2017-07-07 at 2 41 45 pm" src="https://user-images.githubusercontent.com/1486591/27973015-5dd69ffa-6326-11e7-8c45-f7b7eeef03ee.png">

`w=1`

@kaapstorm / @gcapalbo 