### PR TITLE
identificationTypeId: 'Others' => 'none'

### DIFF
--- a/custom/enikshay/private_sector_datamigration/models.py
+++ b/custom/enikshay/private_sector_datamigration/models.py
@@ -196,6 +196,7 @@ class Beneficiary_Jun30(models.Model):
             '18': 'drivers_license',
             '19': 'ration_card',
             '20': 'voter_card',
+            '21': 'none',
             None: 'none',
         }[self.identificationTypeId]
 


### PR DESCRIPTION
40 patients in UATBC have this set to 'Others', which is not available in eNikshay, so handle that gracefully

@proteusvacuum @NoahCarnahan 