### PR TITLE
Only add user types if user types exist

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -82,9 +82,11 @@ class ItemListsProvider(FixtureProvider):
         return self._generate_fixture_from_type(restore_user, items_by_type, types_sorted_by_tag)
 
     def get_user_items(self, restore_user, all_types, global_types):
-        if set(all_types) - set(global_types):
+        user_type_ids = set(all_types) - set(global_types)
+        if user_type_ids:
             # only query ownership models if there are non-global types
-            types_sorted_by_tag = sorted(all_types.iteritems(), key=lambda (id_, type_): type_.tag)
+            user_types = {user_type_id: all_types[user_type_id] for user_type_id in user_type_ids}
+            types_sorted_by_tag = sorted(user_types.iteritems(), key=lambda (id_, type_): type_.tag)
 
             items_by_type = defaultdict(list)
             for item in restore_user.get_fixture_data_items():

--- a/corehq/apps/fixtures/tests/test_location_ownership.py
+++ b/corehq/apps/fixtures/tests/test_location_ownership.py
@@ -120,24 +120,24 @@ class TestLocationOwnership(LocationHierarchyTestCase):
         latte_type.save()
 
         latte_item = FixtureDataItem(
-                domain=self.domain,
-                data_type_id=latte_type.get_id,
-                fields={
-                    "cost": FieldList(
-                        field_list=[FixtureItemField(
-                            field_value='5.75',
-                            properties={},
-                        )]
-                    ),
-                    "location_name": FieldList(
-                        field_list=[FixtureItemField(
-                            field_value="Boston",
-                            properties={},
-                        )]
-                    ),
-                },
-                item_attributes={},
-            )
+            domain=self.domain,
+            data_type_id=latte_type.get_id,
+            fields={
+                "cost": FieldList(
+                    field_list=[FixtureItemField(
+                        field_value='5.75',
+                        properties={},
+                    )]
+                ),
+                "location_name": FieldList(
+                    field_list=[FixtureItemField(
+                        field_value="Boston",
+                        properties={},
+                    )]
+                ),
+            },
+            item_attributes={},
+        )
         latte_item.save()
 
         fixture_xml = list(generator.get_fixtures(self.boston_user.to_ota_restore_user()))

--- a/corehq/apps/fixtures/tests/test_location_ownership.py
+++ b/corehq/apps/fixtures/tests/test_location_ownership.py
@@ -1,3 +1,4 @@
+from casexml.apps.phone.fixtures import generator
 from corehq.apps.fixtures.dbaccessors import get_fixture_data_types_in_domain
 from corehq.apps.fixtures.models import FixtureDataType, FixtureTypeField, \
     FixtureDataItem, FieldList, FixtureItemField, FixtureOwnership
@@ -29,6 +30,7 @@ class TestLocationOwnership(LocationHierarchyTestCase):
         data_type = FixtureDataType(
             domain=cls.domain,
             tag=cls.tag,
+            is_global=False,
             name="Big Mac Index",
             fields=[
                 FixtureTypeField(field_name="cost", properties=[]),
@@ -102,3 +104,51 @@ class TestLocationOwnership(LocationHierarchyTestCase):
     def test_has_no_assigned_fixture(self):
         fixture_items = FixtureDataItem.by_user(self.middlesex_user)
         self.assertEqual(len(fixture_items), 0)
+
+    def test_fixture_generation(self):
+        latte_type = FixtureDataType(
+            domain=self.domain,
+            tag="latte-index",
+            is_global=True,
+            name="Tall Latte index",
+            fields=[
+                FixtureTypeField(field_name="cost", properties=[]),
+                FixtureTypeField(field_name="region", properties=[]),
+            ],
+            item_attributes=[],
+        )
+        latte_type.save()
+
+        latte_item = FixtureDataItem(
+                domain=self.domain,
+                data_type_id=latte_type.get_id,
+                fields={
+                    "cost": FieldList(
+                        field_list=[FixtureItemField(
+                            field_value='5.75',
+                            properties={},
+                        )]
+                    ),
+                    "location_name": FieldList(
+                        field_list=[FixtureItemField(
+                            field_value="Boston",
+                            properties={},
+                        )]
+                    ),
+                },
+                item_attributes={},
+            )
+        latte_item.save()
+
+        fixture_xml = list(generator.get_fixtures(self.boston_user.to_ota_restore_user()))
+        # make sure each fixture is there, and only once
+        self.assertListEqual(
+            [item.attrib['id'] for item in fixture_xml],
+            [
+                'user-groups',
+                'item-list:latte-index',
+                'item-list:big-mac-index',
+                'commtrack:products',
+                'commtrack:programs'
+            ]
+        )


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?257817
My refactor in https://github.com/dimagi/commcare-hq/pull/16904 was including all the global fixtures again if there were any user-specific fixtures. 

@esoergel @ctsims 

buddy: @snopoke 