### PR TITLE
json payload in case of soap hash payload

### DIFF
--- a/corehq/motech/repeaters/views.py
+++ b/corehq/motech/repeaters/views.py
@@ -77,6 +77,8 @@ class RepeatRecordView(LoginAndDomainMixin, View):
             payload = indent_xml(payload)
         elif content_type == 'application/json':
             payload = json.dumps(json.loads(payload), indent=4)
+        elif content_type == 'application/soap+xml':
+            payload = json.dump(payload, indent=4)
 
         return json_response({
             'payload': payload,


### PR DESCRIPTION
From #16448
Missed this change in that PR. We added a different content type but the view still needs to sent it as JSON
