### PR TITLE
Revert "set couch auth for docker"

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -36,7 +36,7 @@ postgres:
 
 couch:
   image: klaemo/couchdb:2.0-dev
-  command: ["--with-haproxy", "--admin=commcarehq:commcarehq", "-n", "1"]
+  command: ["--with-haproxy", "--with-admin-party-please", "-n", "1"]
   expose:
     - "5984"
   volumes:

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -75,8 +75,8 @@ COUCH_DATABASES = {
         # for production this ought to be set to true on your configured couch instance
         'COUCH_HTTPS': False,
         'COUCH_SERVER_ROOT': 'couch:5984',  # 6984 for https couch
-        'COUCH_USERNAME': 'commcarehq',
-        'COUCH_PASSWORD': 'commcarehq',
+        'COUCH_USERNAME': '',
+        'COUCH_PASSWORD': '',
         'COUCH_DATABASE_NAME': 'commcarehq'
     }
 }


### PR DESCRIPTION
Reverts dimagi/commcare-hq#16929

@dimagi/team-commcare-hq Going to revert this for now because it's causing a lot of test failures which will get/is getting pretty annoying to get PRs tested.