### PR TITLE
Update Facility Ids if either property is not set

### DIFF
--- a/custom/enikshay/tests/test_episode_facility_migration.py
+++ b/custom/enikshay/tests/test_episode_facility_migration.py
@@ -68,10 +68,7 @@ class TestEpisodeFacilityIDMigration(ENikshayCaseStructureMixin, TestCase):
     def test_get_json(self):
         self._create_cases(episode_type='presumptive_tb')
         self.assertDictEqual(
-            self.updater.update_json(),
-            {
-                'facility_id_migration_complete': 'true',
-            }
+            self.updater.update_json(), {}
         )
 
         self._update_person({'owner_id': "new_owner"})
@@ -86,7 +83,7 @@ class TestEpisodeFacilityIDMigration(ENikshayCaseStructureMixin, TestCase):
             {
                 'diagnosing_facility_id': 'newer_owner',
                 'treatment_initiating_facility_id': 'new_owner',
-                'facility_id_migration_complete': 'true',
+                'facility_id_migration_v2_complete': 'true',
             }
         )
 
@@ -99,8 +96,14 @@ class TestEpisodeFacilityIDMigration(ENikshayCaseStructureMixin, TestCase):
         self.assertTrue(self.updater.should_update)
 
         self._update_episode({'treatment_initiating_facility_id': "abc"})
+        self._update_episode({'diagnosing_facility_id': "-"})
+        self.assertTrue(self.updater.should_update)
+
+        self._update_episode({'treatment_initiating_facility_id': "abc"})
+        self._update_episode({'diagnosing_facility_id': "abc"})
         self.assertFalse(self.updater.should_update)
 
         self._update_episode({'treatment_initiating_facility_id': ""})
-        self._update_episode({'facility_id_migration_complete': "true"})
+        self._update_episode({'diagnosing_facility_id': ""})
+        self._update_episode({'facility_id_migration_v2_complete': "true"})
         self.assertFalse(self.updater.should_update)


### PR DESCRIPTION
Original spec was incorrect. 
Also, there was a bug in the app which was setting these properties to `-` incorrectly. 

New spec:
```
For all episodes with 'episode_type' = 'confirmed_tb':
    set: treatment initiating facility id if this is not yet set, and can be set
    set: diagnosing facility id if this is not yet set, and can be set
If both treatment initiating facility id and diagnosing facility id are set, we'll ignore the case in future runs of the task.
```
@snopoke 