### PR TITLE
Added load based autoscaler.

### DIFF
--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -211,14 +211,15 @@ class LoadBasedAutoscaler(Autoscaler):
         if cur > procs and normalized_load < 0.90:
             self.scale_up(cur - procs)
             return True
-        elif cur < procs:
-            self.scale_down((procs - cur) - self.min_concurrency)
-            return True
-        elif normalized_load > 0.90 and procs > self.min_concurrency:
-            # if load is too high trying scaling down 1 worker at a time.
-            # if we're already at minimum concurrency let's just ride it out
-            self.scale_down(1)
-            return True
+        elif procs > self.min_concurrency:
+            if cur < procs:
+                self.scale_down(min(procs - cur, procs - self.min_concurrency))
+                return True
+            elif normalized_load > 0.90:
+                # if load is too high trying scaling down 1 worker at a time.
+                # if we're already at minimum concurrency let's just ride it out
+                self.scale_down(1)
+                return True
 
 
 class OffPeakLoadBasedAutoscaler(LoadBasedAutoscaler):

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -9,6 +9,7 @@ from celery.backends.base import DisabledBackend
 from celery.task import task
 from celery.worker.autoscale import Autoscaler
 from django.conf import settings
+from djcelery.loaders import DjangoLoader
 from datetime import datetime
 from time import sleep, time
 
@@ -232,3 +233,17 @@ class OffPeakLoadBasedAutoscaler(LoadBasedAutoscaler):
             return True
 
         super(OffPeakLoadBasedAutoscaler, self)._maybe_scale(req)
+
+
+class LoadBasedLoader(DjangoLoader):
+    def read_configuration(self):
+        ret = super(LoadBasedLoader, self).read_configuration()
+        ret['CELERYD_AUTOSCALER'] = 'corehq.util.celery_utils:LoadBasedAutoscaler'
+        return ret
+
+
+class OffPeakLoadBasedLoader(DjangoLoader):
+    def read_configuration(self):
+        ret = super(LoadBasedLoader, self).read_configuration()
+        ret['CELERYD_AUTOSCALER'] = 'corehq.util.celery_utils:OffPeakLoadBasedAutoscaler'
+        return ret

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -202,10 +202,10 @@ class LoadBasedAutoscaler(Autoscaler):
         max_avg = max(load_avgs[0], load_avgs[1])
         normalized_load = max_avg / available_cpus
 
-        if cur > procs and normalized_load < 0.95:
+        if cur > procs and normalized_load < 0.90:
             self.scale_up(cur - procs)
             return True
-        elif cur < procs or normalized_load > 1.5:
+        elif cur < procs or normalized_load > 0.90:
             self.scale_down((procs - cur) - self.min_concurrency)
             return True
 

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -226,9 +226,16 @@ class OffPeakLoadBasedAutoscaler(LoadBasedAutoscaler):
     def _is_off_peak(self):
         now = datetime.utcnow().time()
         if settings.OFF_PEAK_TIME:
-            if settings.OFF_PEAK_TIME[0] < now < settings.OFF_PEAK_TIME[1]:
-                return True
+            time_begin = settings.OFF_PEAK_TIME[0]
+            time_end = settings.OFF_PEAK_TIME[1]
+            if time_begin < time_end:  # off peak is middle of day
+                if time_begin < now < time_end:
+                    return True
+            else:  # off peak is overnight
+                if time_begin > now or time_end < now:
+                    return True
 
+        # if this setting isn't set consider us always during peak time
         return False
 
     def _during_peak_time(self):

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -230,12 +230,18 @@ class OffPeakLoadBasedAutoscaler(LoadBasedAutoscaler):
 
         return False
 
+    def _during_peak_time(self):
+        return not self._is_off_peak()
+
     def _maybe_scale(self, req=None):
         procs = self.processes
 
-        if not self._is_off_peak() and procs > self.min_concurrency:
-            self.scale_down(1)
-            return True
+        if self._during_peak_time():
+            if procs > self.min_concurrency:
+                self.scale_down(1)
+                return True
+            elif procs == self.min_concurrency:
+                return False
 
         super(OffPeakLoadBasedAutoscaler, self)._maybe_scale(req)
 

--- a/settings.py
+++ b/settings.py
@@ -596,6 +596,9 @@ CELERY_REPEAT_RECORD_QUEUE = CELERY_MAIN_QUEUE
 # time limit is exceeded.
 CELERYD_TASK_SOFT_TIME_LIMIT = 86400 * 2  # 2 days in seconds
 
+# tuple of (time_start, time_end) of off peak times for async processing queues to use
+OFF_PEAK_TIME = None
+
 # websockets config
 WEBSOCKET_URL = '/ws/'
 WS4REDIS_PREFIX = 'ws'


### PR DESCRIPTION
@dimagi/scale-team Started work on autoscaling celery tasks based on load. I think we'll also want to have some time filters (like have if it's at night, we should allow higher load)

Currently the only way I see how to use this autoscaler is to specify `CELERYD_AUTOSCALER` in  settings.py, but that would cause all celery tasks to use this scaler. My first thought was it could be passed in an environment variable, but that seems messy. @gcapalbo do you know any way we could have this only apply to the ucr indicator queue?