### PR TITLE
revert fixture cache PRs

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -1,12 +1,8 @@
 from collections import defaultdict
 from xml.etree import ElementTree
-from StringIO import StringIO
-
-from corehq.blobs import get_blob_db
-from corehq.blobs.exceptions import NotFound
 
 from casexml.apps.phone.fixtures import FixtureProvider
-from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType, FIXTURE_BUCKET
+from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.products.fixtures import product_fixture_generator_json
 from corehq.apps.programs.fixtures import program_fixture_generator_json
 
@@ -47,59 +43,37 @@ class ItemListsProvider(FixtureProvider):
 
     def __call__(self, restore_state):
         restore_user = restore_state.restore_user
-        domain = restore_user.domain
-        db = get_blob_db()
 
-        all_types = {t._id: t for t in FixtureDataType.by_domain(domain)}
+        all_types = {t._id: t for t in FixtureDataType.by_domain(restore_user.domain)}
         global_types = {id: t for id, t in all_types.items() if t.is_global}
 
-        if restore_state.overwrite_cache:
-            db.delete(domain, FIXTURE_BUCKET)
-
-        # get global types from the db
-        try:
-            global_items = [db.get(domain, FIXTURE_BUCKET).read()]
-        except NotFound:
-            global_items = self.get_global_items(restore_user, global_types)
-            cached_element = [ElementTree.tostring(element, encoding='utf-8') for element in global_items]
-            db.put(StringIO("".join(cached_element)), domain, FIXTURE_BUCKET)
-
-        user_items = self.get_user_items(restore_user, all_types, global_types)
-        return global_items + user_items
-
-    def _set_cached_type(self, item, data_type):
-        # set the cached version used by the object so that it doesn't
-        # have to do another db trip later
-        item._data_type = data_type
-
-    def get_global_items(self, restore_user, global_types):
-        types_sorted_by_tag = sorted(global_types.iteritems(), key=lambda (id_, type_): type_.tag)
         items_by_type = defaultdict(list)
+
+        def _set_cached_type(item, data_type):
+            # set the cached version used by the object so that it doesn't
+            # have to do another db trip later
+            item._data_type = data_type
+
         items = FixtureDataItem.by_data_types(restore_user.domain, global_types)
         for item in items:
-            self._set_cached_type(item, global_types[item.data_type_id])
+            _set_cached_type(item, global_types[item.data_type_id])
             items_by_type[item.data_type_id].append(item)
-        return self._generate_fixture_from_type(restore_user, items_by_type, types_sorted_by_tag)
 
-    def get_user_items(self, restore_user, all_types, global_types):
         if set(all_types) - set(global_types):
             # only query ownership models if there are non-global types
-            types_sorted_by_tag = sorted(all_types.iteritems(), key=lambda (id_, type_): type_.tag)
+            other_items = restore_user.get_fixture_data_items()
 
-            items_by_type = defaultdict(list)
-            for item in restore_user.get_fixture_data_items():
+            for item in other_items:
                 if item.data_type_id in global_types:
                     continue  # was part of the global type so no need to add here
                 try:
-                    self._set_cached_type(item, all_types[item.data_type_id])
+                    _set_cached_type(item, all_types[item.data_type_id])
                 except (AttributeError, KeyError):
                     continue
                 items_by_type[item.data_type_id].append(item)
-            return self._generate_fixture_from_type(restore_user, items_by_type, types_sorted_by_tag)
-        return []
 
-    def _generate_fixture_from_type(self, restore_user, items_by_type, types_sorted_by_tag):
         fixtures = []
+        types_sorted_by_tag = sorted(all_types.iteritems(), key=lambda (id_, type_): type_.tag)
         for data_type_id, data_type in types_sorted_by_tag:
             if data_type.is_indexed:
                 fixtures.append(self._get_schema_element(data_type))
@@ -119,7 +93,7 @@ class ItemListsProvider(FixtureProvider):
         fixture_element.append(item_list_element)
         for item in items:
             item_list_element.append(item.to_xml())
-        return ElementTree.tostring(fixture_element, encoding="utf-8")
+        return fixture_element
 
     def _get_schema_element(self, data_type):
         schema_element = ElementTree.Element(

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -82,11 +82,9 @@ class ItemListsProvider(FixtureProvider):
         return self._generate_fixture_from_type(restore_user, items_by_type, types_sorted_by_tag)
 
     def get_user_items(self, restore_user, all_types, global_types):
-        user_type_ids = set(all_types) - set(global_types)
-        if user_type_ids:
+        if set(all_types) - set(global_types):
             # only query ownership models if there are non-global types
-            user_types = {user_type_id: all_types[user_type_id] for user_type_id in user_type_ids}
-            types_sorted_by_tag = sorted(user_types.iteritems(), key=lambda (id_, type_): type_.tag)
+            types_sorted_by_tag = sorted(all_types.iteritems(), key=lambda (id_, type_): type_.tag)
 
             items_by_type = defaultdict(list)
             for item in restore_user.get_fixture_data_items():

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -119,14 +119,7 @@ class ItemListsProvider(FixtureProvider):
         fixture_element.append(item_list_element)
         for item in items:
             item_list_element.append(item.to_xml())
-        if len(fixture_element) == 0:
-            # There is a bug on mobile versions prior to 2.27 where
-            # a parsing error will cause mobile to ignore the element
-            # after this one if this element is empty.
-            # So we have to add a dummy empty_element child to prevent
-            # this element from being empty.
-            ElementTree.SubElement(fixture_element, 'empty_element')
-        return fixture_element
+        return ElementTree.tostring(fixture_element, encoding="utf-8")
 
     def _get_schema_element(self, data_type):
         schema_element = ElementTree.Element(

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from xml.etree import ElementTree
 from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 from django.db import models
-from corehq.blobs import get_blob_db
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.fixtures.dbaccessors import (
     get_owner_ids_by_type,
@@ -22,23 +21,13 @@ from dimagi.utils.decorators.memoized import memoized
 from corehq.apps.locations.models import SQLLocation
 
 
-FIXTURE_BUCKET = 'domain-fixtures'
-
-
-class FixtureBlobInvalidationMixin(object):
-    def save(self):
-        super(FixtureBlobInvalidationMixin, self).save()
-        db = get_blob_db()
-        db.delete(self.domain, FIXTURE_BUCKET)
-
-
 class FixtureTypeField(DocumentSchema):
     field_name = StringProperty()
     properties = StringListProperty()
     is_indexed = BooleanProperty(default=False)
 
 
-class FixtureDataType(QuickCachedDocumentMixin, FixtureBlobInvalidationMixin, Document):
+class FixtureDataType(QuickCachedDocumentMixin, Document):
     domain = StringProperty()
     is_global = BooleanProperty(default=False)
     tag = StringProperty()
@@ -135,7 +124,7 @@ class FieldList(DocumentSchema):
         return value
 
 
-class FixtureDataItem(FixtureBlobInvalidationMixin, Document):
+class FixtureDataItem(Document):
     """
     Example old Item:
         domain = "hq-domain"
@@ -478,7 +467,7 @@ def _id_from_doc(doc_or_doc_id):
     return doc_id
 
 
-class FixtureOwnership(FixtureBlobInvalidationMixin, Document):
+class FixtureOwnership(Document):
     domain = StringProperty()
     data_item_id = StringProperty()
     owner_id = StringProperty()

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -1,6 +1,5 @@
 from xml.etree import ElementTree
 from django.test import TestCase
-from corehq.blobs import get_blob_db
 from casexml.apps.case.tests.util import check_xml_line_by_line
 from casexml.apps.phone.tests.utils import call_fixture_generator
 from corehq.apps.fixtures import fixturegenerators
@@ -8,7 +7,7 @@ from corehq.apps.fixtures.dbaccessors import delete_all_fixture_data_types, \
     get_fixture_data_types_in_domain
 from corehq.apps.fixtures.exceptions import FixtureVersionError
 from corehq.apps.fixtures.models import FixtureDataType, FixtureTypeField, \
-    FixtureDataItem, FieldList, FixtureItemField, FixtureOwnership, FIXTURE_BUCKET
+    FixtureDataItem, FieldList, FixtureItemField, FixtureOwnership
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser
 
@@ -100,7 +99,6 @@ class FixtureDataTest(TestCase):
         delete_all_users()
         delete_all_fixture_data_types()
         get_fixture_data_types_in_domain.clear(self.domain)
-        get_blob_db().delete(self.domain, FIXTURE_BUCKET)
         super(FixtureDataTest, self).tearDown()
 
     def test_xml(self):

--- a/corehq/apps/fixtures/tests/test_location_ownership.py
+++ b/corehq/apps/fixtures/tests/test_location_ownership.py
@@ -1,4 +1,3 @@
-from casexml.apps.phone.fixtures import generator
 from corehq.apps.fixtures.dbaccessors import get_fixture_data_types_in_domain
 from corehq.apps.fixtures.models import FixtureDataType, FixtureTypeField, \
     FixtureDataItem, FieldList, FixtureItemField, FixtureOwnership
@@ -30,7 +29,6 @@ class TestLocationOwnership(LocationHierarchyTestCase):
         data_type = FixtureDataType(
             domain=cls.domain,
             tag=cls.tag,
-            is_global=False,
             name="Big Mac Index",
             fields=[
                 FixtureTypeField(field_name="cost", properties=[]),
@@ -104,51 +102,3 @@ class TestLocationOwnership(LocationHierarchyTestCase):
     def test_has_no_assigned_fixture(self):
         fixture_items = FixtureDataItem.by_user(self.middlesex_user)
         self.assertEqual(len(fixture_items), 0)
-
-    def test_fixture_generation(self):
-        latte_type = FixtureDataType(
-            domain=self.domain,
-            tag="latte-index",
-            is_global=True,
-            name="Tall Latte index",
-            fields=[
-                FixtureTypeField(field_name="cost", properties=[]),
-                FixtureTypeField(field_name="region", properties=[]),
-            ],
-            item_attributes=[],
-        )
-        latte_type.save()
-
-        latte_item = FixtureDataItem(
-                domain=self.domain,
-                data_type_id=latte_type.get_id,
-                fields={
-                    "cost": FieldList(
-                        field_list=[FixtureItemField(
-                            field_value='5.75',
-                            properties={},
-                        )]
-                    ),
-                    "location_name": FieldList(
-                        field_list=[FixtureItemField(
-                            field_value="Boston",
-                            properties={},
-                        )]
-                    ),
-                },
-                item_attributes={},
-            )
-        latte_item.save()
-
-        fixture_xml = list(generator.get_fixtures(self.boston_user.to_ota_restore_user()))
-        # make sure each fixture is there, and only once
-        self.assertListEqual(
-            [item.attrib['id'] for item in fixture_xml],
-            [
-                'user-groups',
-                'item-list:latte-index',
-                'item-list:big-mac-index',
-                'commtrack:products',
-                'commtrack:programs'
-            ]
-        )

--- a/corehq/apps/fixtures/tests/test_location_ownership.py
+++ b/corehq/apps/fixtures/tests/test_location_ownership.py
@@ -120,24 +120,24 @@ class TestLocationOwnership(LocationHierarchyTestCase):
         latte_type.save()
 
         latte_item = FixtureDataItem(
-            domain=self.domain,
-            data_type_id=latte_type.get_id,
-            fields={
-                "cost": FieldList(
-                    field_list=[FixtureItemField(
-                        field_value='5.75',
-                        properties={},
-                    )]
-                ),
-                "location_name": FieldList(
-                    field_list=[FixtureItemField(
-                        field_value="Boston",
-                        properties={},
-                    )]
-                ),
-            },
-            item_attributes={},
-        )
+                domain=self.domain,
+                data_type_id=latte_type.get_id,
+                fields={
+                    "cost": FieldList(
+                        field_list=[FixtureItemField(
+                            field_value='5.75',
+                            properties={},
+                        )]
+                    ),
+                    "location_name": FieldList(
+                        field_list=[FixtureItemField(
+                            field_value="Boston",
+                            properties={},
+                        )]
+                    ),
+                },
+                item_attributes={},
+            )
         latte_item.save()
 
         fixture_xml = list(generator.get_fixtures(self.boston_user.to_ota_restore_user()))

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -1,10 +1,9 @@
 from couchdbkit import ResourceNotFound
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
-from corehq.blobs import get_blob_db
 
 from corehq.apps.fixtures.models import FixtureDataType, FieldList, FixtureItemField, \
-    FixtureDataItem, FIXTURE_BUCKET
+    FixtureDataItem
 from corehq.apps.fixtures.upload.const import DELETE_HEADER
 from corehq.apps.fixtures.upload.definitions import FixtureUploadResult
 from corehq.apps.fixtures.upload.location_cache import get_memoized_location_getter
@@ -192,18 +191,7 @@ def _run_fixture_upload(domain, workbook, replace=False, task=None):
                                                    transaction=transaction)
 
     clear_fixture_quickcache(data_types)
-    clear_fixture_blob(domain, data_types)
     return return_val
-
-
-def clear_fixture_blob(domain, data_types):
-    """Clear global fixture cache for the domain f any of the data_types uploaded
-    are global
-
-    """
-    if any([data_type.is_global for data_type in data_types]):
-        db = get_blob_db()
-        db.delete(domain, FIXTURE_BUCKET)
 
 
 def clear_fixture_quickcache(data_types):

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -197,8 +197,13 @@ def _run_fixture_upload(domain, workbook, replace=False, task=None):
 
 
 def clear_fixture_blob(domain, data_types):
-    db = get_blob_db()
-    db.delete(domain, FIXTURE_BUCKET)
+    """Clear global fixture cache for the domain f any of the data_types uploaded
+    are global
+
+    """
+    if any([data_type.is_global for data_type in data_types]):
+        db = get_blob_db()
+        db.delete(domain, FIXTURE_BUCKET)
 
 
 def clear_fixture_quickcache(data_types):

--- a/corehq/ex-submodules/casexml/apps/phone/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/fixtures.py
@@ -93,7 +93,6 @@ class FixtureGenerator(object):
         fixtures = self._get_fixtures(restore_user, fixture_id)
         for fixture in fixtures:
             if isinstance(fixture, basestring):
-                # could be a string if it's coming from cache
                 cached_fixtures = ElementTree.fromstring(
                     "<cached-fixture>{}</cached-fixture>".format(fixture)
                 )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -756,6 +756,13 @@ class RestoreConfig(object):
             for provider in element_providers:
                 with self.timing_context(provider.__class__.__name__):
                     for element in provider.get_elements(self.restore_state):
+                        if element.tag == 'fixture' and len(element) == 0:
+                            # There is a bug on mobile versions prior to 2.27 where
+                            # a parsing error will cause mobile to ignore the element
+                            # after this one if this element is empty.
+                            # So we have to add a dummy empty_element child to prevent
+                            # this element from being empty.
+                            ElementTree.SubElement(element, 'empty_element')
                         response.append(element)
 
             full_response_providers = get_full_response_providers(self.timing_context, async_task)


### PR DESCRIPTION
We're getting weird bugs with fixtures that we can't repro, e.g.
https://sentry.io/dimagi/formplayer/issues/278668711/events/6250443091/

This is a combination of reverting (couldn't revert 2 PRs at a time)
https://github.com/dimagi/commcare-hq/pull/16904/
and https://github.com/dimagi/commcare-hq/pull/16951/

I really don't understand why this would only happen on specific users for global fixtures as the cache is domain wide, and should just get sent down with every sync and restore. 

Will look into it further, but for now, we should revert so that we can figure out if it was this change that is causing these errors.

@snopoke @sheelio 
