### PR TITLE
Revert #16809

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -36,8 +36,7 @@ class CleanOwnerSyncPayload(object):
         self.extension_indices = defaultdict(set)
         self.all_dependencies_syncing = set()
         self.closed_cases = set()
-        self.potential_updates_to_sync = {}
-        self.potential_ids_to_sync = set()
+        self.potential_elements_to_sync = {}
 
         self.timing_context = timing_context
 
@@ -65,51 +64,52 @@ class CleanOwnerSyncPayload(object):
 
     def _get_next_case_batch(self):
         ids = pop_ids(self.case_ids_to_sync, chunk_size)
-        self.potential_ids_to_sync.update(ids)
         return [
             case for case in self.case_accessor.get_cases(ids)
             if not case.is_deleted and case_needs_to_sync(case, last_sync_log=self.restore_state.last_sync_log)
         ]
 
     def process_case_batch(self, case_batch):
-        new_updates = get_case_sync_updates(
+        updates = get_case_sync_updates(
             self.restore_state.domain, case_batch, self.restore_state.last_sync_log
         )
-        self.potential_updates_to_sync.update(new_updates)
 
-        for update in new_updates.itervalues():
-            self._process_case_update(update)
-            self._mark_case_as_checked(update.case)
+        for update in updates:
+            case = update.case
+            self.potential_elements_to_sync[case.case_id] = PotentialSyncElement(
+                case_stub=CaseStub(case.case_id, case.type),
+                sync_xml_items=get_xml_for_response(update, self.restore_state)
+            )
+            self._process_case_update(case)
+            self._mark_case_as_checked(case)
 
-    def _process_case_update(self, update):
-        if update.case_indices:
-            self._update_indices_in_new_synclog(update)
-            self._add_unchecked_indices_to_be_checked(update)
+    def _process_case_update(self, case):
+        if case.indices:
+            self._update_indices_in_new_synclog(case)
+            self._add_unchecked_indices_to_be_checked(case)
 
-        if not _is_live(update.case, self.restore_state):
-            self.all_dependencies_syncing.add(update.case_id)
-            if update.case.closed:
-                self.closed_cases.add(update.case_id)
+        if not _is_live(case, self.restore_state):
+            self.all_dependencies_syncing.add(case.case_id)
+            if case.closed:
+                self.closed_cases.add(case.case_id)
 
     def _mark_case_as_checked(self, case):
         self.checked_cases.add(case.case_id)
 
-    def _update_indices_in_new_synclog(self, update):
-        if update.is_extension:
-            self.extension_indices[update.case_id] = {
-                index.identifier: index.referenced_id
-                for index in update.case_indices
-                if index.relationship == CASE_INDEX_EXTENSION
-            }
-        if update.is_child:
-            self.child_indices[update.case_id] = {
-                index.identifier: index.referenced_id
-                for index in update.case_indices
-                if index.relationship == CASE_INDEX_CHILD
-            }
+    def _update_indices_in_new_synclog(self, case):
+        self.extension_indices[case.case_id] = {
+            index.identifier: index.referenced_id
+            for index in case.indices
+            if index.relationship == CASE_INDEX_EXTENSION
+        }
+        self.child_indices[case.case_id] = {
+            index.identifier: index.referenced_id
+            for index in case.indices
+            if index.relationship == CASE_INDEX_CHILD
+        }
 
-    def _add_unchecked_indices_to_be_checked(self, update):
-        for index in update.case_indices:
+    def _add_unchecked_indices_to_be_checked(self, case):
+        for index in case.indices:
             if index.referenced_id not in self.all_maybe_syncing:
                 self.case_ids_to_sync.add(index.referenced_id)
         self.all_maybe_syncing |= self.case_ids_to_sync
@@ -165,30 +165,30 @@ class CleanOwnerSyncPayload(object):
         return irrelevant_cases
 
     def compile_response(self, irrelevant_cases):
-        syncable_ids = set(self.potential_updates_to_sync.keys()) - irrelevant_cases
-        relevant_sync_updates = [
-            self.potential_updates_to_sync[syncable_id]
-            for syncable_id in syncable_ids
+        relevant_sync_elements = [
+            potential_sync_element
+            for syncable_case_id, potential_sync_element in self.potential_elements_to_sync.iteritems()
+            if syncable_case_id not in irrelevant_cases
         ]
 
         with self.timing_context('add_commtrack_elements_to_response'):
-            self._add_commtrack_elements_to_response(relevant_sync_updates)
+            self._add_commtrack_elements_to_response(relevant_sync_elements)
 
-        self._add_case_elements_to_response(relevant_sync_updates)
+        self._add_case_elements_to_response(relevant_sync_elements)
 
-    def _add_commtrack_elements_to_response(self, relevant_sync_updates):
+    def _add_commtrack_elements_to_response(self, relevant_sync_elements):
         commtrack_elements = get_stock_payload(
             self.restore_state.project, self.restore_state.stock_settings,
             [
-                potential_sync_element.case
-                for potential_sync_element in relevant_sync_updates
+                potential_sync_element.case_stub
+                for potential_sync_element in relevant_sync_elements
             ]
         )
         self.response.extend(commtrack_elements)
 
     def _add_case_elements_to_response(self, relevant_sync_elements):
         for relevant_case in relevant_sync_elements:
-            for xml_item in get_xml_for_response(relevant_case, self.restore_state):
+            for xml_item in relevant_case.sync_xml_items:
                 self.response.append(xml_item)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -307,7 +307,7 @@ def compile_response(timing_context, restore_state, batches, update_progress):
 
         with timing_context("get_xml_for_response (%s updates)" % len(updates)):
             response.extend(item
-                for update in updates.itervalues()
+                for update in updates
                 for item in get_xml_for_response(update, restore_state))
 
         done += len(cases)

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/utils.py
@@ -35,8 +35,8 @@ class CaseSyncUpdate(object):
 def get_case_sync_updates(domain, cases, last_sync_log):
     """
     Given a domain, list of cases, and sync log representing the last
-    sync, return a dict of CaseSyncUpdate objects (keyed by case_id)
-    that should be applied to the next sync.
+    sync, return a list of CaseSyncUpdate objects that should be applied
+    to the next sync.
     """
     case_updates_to_sync = []
 

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/utils.py
@@ -13,12 +13,6 @@ class CaseSyncUpdate(object):
 
     def __init__(self, case, sync_token, required_updates=None):
         self.case = case
-        self.case_id = case.case_id
-        self.case_indices = case.indices
-        self.is_extension = any([index for index in self.case_indices
-                                 if index.relationship == const.CASE_INDEX_EXTENSION])
-        self.is_child = any([index for index in self.case_indices
-                             if index.relationship == const.CASE_INDEX_CHILD])
         self.sync_token = sync_token
         # cache this property since computing it can be expensive
         self.required_updates = required_updates if required_updates is not None else self._get_required_updates()
@@ -44,7 +38,7 @@ def get_case_sync_updates(domain, cases, last_sync_log):
     sync, return a dict of CaseSyncUpdate objects (keyed by case_id)
     that should be applied to the next sync.
     """
-    case_updates_to_sync = {}
+    case_updates_to_sync = []
 
     def _approximate_domain_match(case):
         # if both objects have a domain then make sure they're the same, but if
@@ -54,6 +48,6 @@ def get_case_sync_updates(domain, cases, last_sync_log):
     for case in cases:
         sync_update = CaseSyncUpdate(case, last_sync_log)
         if sync_update.required_updates and _approximate_domain_match(case):
-            case_updates_to_sync[case.case_id] = sync_update
+            case_updates_to_sync.append(sync_update)
 
     return case_updates_to_sync


### PR DESCRIPTION
Revert #16809 to eliminate unnecessary work done by `CaseSyncUpdate` when using livequery. I believe most of the optimizations in #16809 were made irrelevant by #16939. One exception is prematurely generating XML for updates that are later excluded from the sync. We could add that back in if it seems important.

@proteusvacuum 