### PR TITLE
convert value to string before passing to UI

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -220,6 +220,8 @@ def get_settings_values(app):
     hq_settings['build_spec'] = app.build_spec.to_string()
     # the admin_password hash shouldn't be sent to the client
     hq_settings.pop('admin_password', None)
+    # convert int to string
+    hq_settings['mobile_ucr_sync_interval'] = str(hq_settings.get('mobile_ucr_sync_interval', 'none'))
 
     domain = Domain.get_by_name(app.domain)
     return {


### PR DESCRIPTION
The values specified in the settings config are strings and it would
be some effort to make the JS support ints. The other option
is to store the value in the app as a string.

https://manage.dimagi.com/default.asp?257982