### PR TITLE
session bypassing for selected URLs

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -52,7 +52,9 @@ class CCHQPRBACMiddleware(MiddlewareMixin):
 class DomainHistoryMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
-        if hasattr(request, 'domain') and getattr(response, '_remember_domain', True):
+        if hasattr(request, 'domain') \
+                and hasattr(request, 'session') \
+                and getattr(response, '_remember_domain', True):
             self.remember_domain_visit(request, response)
         return response
 

--- a/settings.py
+++ b/settings.py
@@ -135,13 +135,12 @@ CSRF_SOFT_MODE = True
 
 MIDDLEWARE = [
     'corehq.middleware.NoCacheMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
+    'corehq.middleware.SessionBypassMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
+    'corehq.middleware.SessionlessAuthMiddleware',
+    'corehq.middleware.SessionlessMessageMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django_otp.middleware.OTPMiddleware',
     'corehq.middleware.OpenRosaMiddleware',
@@ -159,6 +158,16 @@ MIDDLEWARE = [
 ]
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
+SESSION_BYPASS_URLS = [
+    r'^/a/{domain}/receiver/',
+    r'^/a/{domain}/phone/restore/',
+    r'^/a/{domain}/phone/search/',
+    r'^/a/{domain}/phone/claim-case/',
+    r'^/a/{domain}/phone/heartbeat/',
+    r'^/a/{domain}/phone/keys/',
+    r'^/a/{domain}/phone/admin_keys/',
+]
 
 # time in minutes before forced logout due to inactivity
 INACTIVITY_TIMEOUT = 60 * 24 * 14


### PR DESCRIPTION
@dimagi/scale-team 

This PR also changes the session store to just be `cache` instead of `cache + DB`. There's no migration so deploying as is will effectively wipe everyone's session.

Having switched to cache I'm not sure it's really necessary to bypass at all. Also a bit concerned this might break web apps (@benrudolph don't they use session auth?)