### PR TITLE
add SKIP_REMOVE_INDICES

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -9,6 +9,8 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from couchdbkit import ResourceConflict, BulkSaveError
 from casexml.apps.case.mock import CaseBlock
+
+from corehq import toggles
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import UserArchivedRebuild
 from corehq.util.log import SensitiveErrorMail
@@ -147,6 +149,9 @@ def tag_system_forms_as_deleted(domain, deleted_forms, deleted_cases, deletion_i
 
 @task(queue='background_queue', ignore_result=True, acks_late=True)
 def _remove_indices_from_deleted_cases_task(domain, case_ids):
+    if toggles.SKIP_REMOVE_INDICES.enabled(domain):
+        return
+
     # todo: we may need to add retry logic here but will wait to see
     # what errors we should be catching
     try:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1266,3 +1266,10 @@ PHONE_HEARTBEAT = StaticToggle(
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN]
 )
+
+SKIP_REMOVE_INDICES = StaticToggle(
+    'skip_remove_indices',
+    'Make _remove_indices_from_deleted_cases_task into a no-op.',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
Alternative to revoking celery tasks, without affecting other domains.

@proteusvacuum @emord @calellowitz @ctsims 