### PR TITLE
Ensure case property changed for pertinent case only

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -162,6 +162,25 @@ class TestUpdatePatientRepeater(ENikshayLocationStructureMixin, ENikshayRepeater
         self._update_case(self.person_id, {PRIMARY_PHONE_NUMBER: '999999999', })
         self.assertEqual(1, len(self.repeat_records().all()))
 
+        # update a pertinent case with something that shouldn't trigger,
+        # and a non-pertinent case with a property that is in the list of triggers
+        self.factory.create_or_update_cases([
+            CaseStructure(
+                case_id=self.person_id,
+                attrs={
+                    "update": {'name': 'Elrond', },
+                }
+            ),
+            CaseStructure(
+                case_id=self.occurrence_id,
+                attrs={
+                    "update": {PRIMARY_PHONE_NUMBER: '999999999', },
+                }
+            ),
+
+        ])
+        self.assertEqual(1, len(self.repeat_records().all()))
+
         self._update_case(self.episode_id, {TREATMENT_SUPPORTER_PHONE: '999999999', })
         self.assertEqual(2, len(self.repeat_records().all()))
 

--- a/custom/enikshay/integrations/utils.py
+++ b/custom/enikshay/integrations/utils.py
@@ -85,7 +85,10 @@ def case_properties_changed(case, case_properties):
     if last_case_action.is_case_create:
         return False
 
-    update_actions = [update.get_update_action() for update in get_case_updates(last_case_action.form)]
+    update_actions = [
+        update.get_update_action() for update in get_case_updates(last_case_action.form)
+        if update.id == case.case_id
+    ]
     property_changed = any(
         action for action in update_actions
         if isinstance(action, CaseUpdateAction)


### PR DESCRIPTION
@snopoke 
We were triggering some repeaters whenever there was a form submission that was updating case properties on different cases that we didn't care about when the same form submission had a pertinent case. 