### PR TITLE
Fixed return value for off peak scaler.

### DIFF
--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -251,7 +251,7 @@ class OffPeakLoadBasedAutoscaler(LoadBasedAutoscaler):
             elif procs == self.min_concurrency:
                 return False
 
-        super(OffPeakLoadBasedAutoscaler, self)._maybe_scale(req)
+        return super(OffPeakLoadBasedAutoscaler, self)._maybe_scale(req)
 
 
 class LoadBasedLoader(DjangoLoader):


### PR DESCRIPTION
I fixed this https://github.com/dimagi/commcare-hq/pull/16994/files  but didn't realize the ramifications of the bug

https://github.com/celery/celery/blob/a87ef75884e59c78da21b1482bb66cf649fbb7d3/celery/worker/autoscale.py#L96 uses the return value to maintaint the pool. this means that the workers can scale up/down during off peak, but htey only scale down when hitting high load, to never scale up again

@gcapalbo @esoergel 