### PR TITLE
Removed old way for off peak rebuilding.

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -205,7 +205,7 @@ def compare_ucr_dbs(domain, report_config_id, filter_values, sort_column=None, s
 
 
 @periodic_task(
-    run_every=crontab(minute="*/5", hour="0-8,18-23"),
+    run_every=crontab(minute="*/5"),
     queue=settings.CELERY_PERIODIC_QUEUE,
 )
 def queue_async_indicators():


### PR DESCRIPTION
This was the way I hackily implemented off peak rebuilding before we had the load balancer. No longer needed

@esoergel 