### PR TITLE
one more attempt at fixing celery

### DIFF
--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -258,10 +258,12 @@ class LoadBasedLoader(DjangoLoader):
     def read_configuration(self):
         ret = super(LoadBasedLoader, self).read_configuration()
         ret['CELERYD_AUTOSCALER'] = 'corehq.util.celery_utils:LoadBasedAutoscaler'
+        ret['CELERYD_PREFETCH_MULTIPLIER'] = 1
+        ret['AUTOSCALE_KEEPALIVE'] = 120
         return ret
 
 
-class OffPeakLoadBasedLoader(DjangoLoader):
+class OffPeakLoadBasedLoader(LoadBasedLoader):
     def read_configuration(self):
         ret = super(OffPeakLoadBasedLoader, self).read_configuration()
         ret['CELERYD_AUTOSCALER'] = 'corehq.util.celery_utils:OffPeakLoadBasedAutoscaler'

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -201,8 +201,8 @@ class LoadBasedAutoscaler(Autoscaler):
         available_cpus = multiprocessing.cpu_count()
         try:
             load_avgs = os.getloadavg()
-            max_avg = max(load_avgs[0], load_avgs[1])
-            normalized_load = max_avg / available_cpus
+            one_min_avg = load_avgs[0]
+            normalized_load = one_min_avg / available_cpus
         except OSError:
             # if we can't get the load average, let's just use normal autoscaling
             load_avgs = None


### PR DESCRIPTION
I ended up looking through a lot of code in celery, billiard and kombu. I think that this will "fix" the loaders on ICDS.

The keepalive stops this from trying to scale too quickly. it'll only make changes once every 2 minutes.

The prefetch multiplier stops the queue from grabbing a lot of tasks at once. The default is 4 meaning that if there are 16 workers then it will grab 4 * 16 = 64 tasks for every queue. 

When we ask celery to scale down, it raises an error in billiard [0] which is somewhat ignored [1] (unsure if that's intentional) which decrements the prefetch eventually [2] (IME it's pretty quick). 

I think what happens is that some of those workers we asked to scale down get in a weird state, where it doesn't process new tasks even though there's a backlog of tasks that it's received. Once the tasks that have been received is less than the current number of workers we can finally turn off those workers for real, and that's when the queue starts to recover. This means that the celery queues would eventually recover, but it can take a long time to burn through 64 tasks. (5 min * 64 / however many workers are actually processing).

@gcapalbo @esoergel 

[0] https://github.com/celery/billiard/blob/v3.3.0.23/billiard/pool.py#L1204
[1] https://github.com/celery/celery/blob/v3.1.25/celery/worker/autoscale.py#L142-L148
[2] https://github.com/celery/kombu/blob/259ac2e2bfc174ecd6d6f9e7cd31269a6166d337/kombu/common.py#L387-L399