### PR TITLE
2.30 to 2.26 for practice user for ICDS

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -134,4 +134,4 @@ class CommCareFeatureSupportMixin(object):
         """
         Ability to configure practice mobile workers for apps
         """
-        return self._require_minimum_version('2.27')
+        return self._require_minimum_version('2.26')

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -134,4 +134,4 @@ class CommCareFeatureSupportMixin(object):
         """
         Ability to configure practice mobile workers for apps
         """
-        return self._require_minimum_version('2.30')
+        return self._require_minimum_version('2.27')

--- a/corehq/apps/app_manager/static/app_manager/json/v1/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/v1/commcare-app-settings.yaml
@@ -41,7 +41,7 @@
 - id: practice_mobile_worker_id
   name: 'Practice Mobile Worker'
   widget: select
-  since: '2.27'
+  since: '2.26'
   privilege: 'practice_mobile_workers'
   description: "Select the mobile worker to use as a practice user for this application"
 

--- a/corehq/apps/app_manager/static/app_manager/json/v1/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/v1/commcare-app-settings.yaml
@@ -41,7 +41,7 @@
 - id: practice_mobile_worker_id
   name: 'Practice Mobile Worker'
   widget: select
-  since: '2.30'
+  since: '2.27'
   privilege: 'practice_mobile_workers'
   description: "Select the mobile worker to use as a practice user for this application"
 

--- a/corehq/apps/app_manager/static/app_manager/json/v2/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/v2/commcare-app-settings.yaml
@@ -41,7 +41,7 @@
 - id: practice_mobile_worker_id
   name: 'Practice Mobile Worker'
   widget: select
-  since: '2.27'
+  since: '2.26'
   privilege: 'practice_mobile_workers'
   description: "Select the mobile worker to use as a practice user for this application"
 

--- a/corehq/apps/app_manager/static/app_manager/json/v2/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/v2/commcare-app-settings.yaml
@@ -41,7 +41,7 @@
 - id: practice_mobile_worker_id
   name: 'Practice Mobile Worker'
   widget: select
-  since: '2.30'
+  since: '2.27'
   privilege: 'practice_mobile_workers'
   description: "Select the mobile worker to use as a practice user for this application"
 


### PR DESCRIPTION
Changing the min version for practice user from 2.30 to 2.26 for ICDS. The feature is not really supported on 2.26 (when you enter practice mode on phones less than 2.26, it will crash), but ICDS is going to have this feature for users with more than 2.30, so it won't be an issue.

I will change this to be under feature flag latter so that other projects won't run into this.

@nickpell 