### PR TITLE
change session backed to just cache

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -140,7 +140,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django_otp.middleware.OTPMiddleware',

--- a/settings.py
+++ b/settings.py
@@ -157,7 +157,7 @@ MIDDLEWARE = [
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
 ]
 
-SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 # time in minutes before forced logout due to inactivity
 INACTIVITY_TIMEOUT = 60 * 24 * 14


### PR DESCRIPTION
pulled this out of https://github.com/dimagi/commcare-hq/pull/16992

This will force logout everyone who's logged in when it get's deployed. Added 'open for review' flag until we can check if we need to do comms.