### PR TITLE
Fix django template comment

### DIFF
--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -376,10 +376,10 @@
         {% block modals %}{% endblock modals %}
 
         {% block additional_initial_page_data %}
-            {#
+            {% comment %}
                 fallback place to put initial page data for templates where it's
                 awkward or impossible to include it in another block
-            #}
+            {% endcomment %}
         {% endblock %}
         <div class="initial-page-data" class="hide">
         {% block initial_page_data %}


### PR DESCRIPTION
Today I learned that `{# ... #}` is only for single-line comments.

<img width="1331" alt="screen shot 2017-07-17 at 5 47 27 pm" src="https://user-images.githubusercontent.com/1486591/28291379-2f69970e-6b18-11e7-9956-dedafe0625f0.png">

@gcapalbo / @kaapstorm 