### PR TITLE
Fix ilsgateway base report template

### DIFF
--- a/custom/ilsgateway/templates/ilsgateway/base_template.html
+++ b/custom/ilsgateway/templates/ilsgateway/base_template.html
@@ -95,20 +95,5 @@
             standardReport: standardHQReport,
         });
         asyncHQReport.init();
-        var defaultConfig = {{ default_config|JSON }};
-        {% if report.has_datespan %}
-            defaultConfig.date_range = 'last7';
-        {% else %}
-            defaultConfig.date_range = null;
-        {% endif %}
-        defaultConfig.has_ucr_datespan = false;
-        defaultConfig.datespan_filters = [];
-        defaultConfig.datespan_slug = null;
-        $("#savedReports").reportConfigEditor({
-            filterForm: $("#reportFilters"),
-            items: {{ report_configs|JSON }},
-            defaultItem: defaultConfig,
-            saveUrl: '{% url "add_report_config" domain %}'
-        });
     </script>
 {% endblock %}


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/16918 broke the ilsgateway reports because `#savedReports` now has its knockout bindings applied in `base.js` so they don't need to be applied in `ilsgateway/base_template.html`.

<img width="1295" alt="screen shot 2017-07-17 at 6 08 56 pm" src="https://user-images.githubusercontent.com/1486591/28291978-1c855ecc-6b1b-11e7-8bec-556189f28c29.png">

@gcapalbo / @kaapstorm 