### PR TITLE
Add count to case search admin view

### DIFF
--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -8,6 +8,7 @@ hqDefine('case_search/js/case_search.js', function(){
         self.owner_id = ko.observable();
         self.customQueryAddition = ko.observable();
         self.results = ko.observableArray();
+        self.count = ko.observable();
         self.case_data_url = case_data_url;
         self.parameters = ko.observableArray([{
             key: "",
@@ -42,6 +43,7 @@ hqDefine('case_search/js/case_search.js', function(){
                 )},
                 success: function(data){
                     self.results(data.values);
+                    self.count(data.count);
                 },
             });
         };

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -108,7 +108,7 @@
 
         <div class="row">
             <div class="col-sm-12">
-                <h3>{% trans "Results" %}</h3>
+                <h3>{% trans "Results" %} <small data-bind="text: count"></small></h3>
             </div>
             <div class="col-sm-12">
                 <table class="table table-striped">

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -61,4 +61,4 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             new_query = merge_queries(search.get_query(), addition.query_addition)
             search = search.set_query(new_query)
         search_results = search.run().raw_hits
-        return json_response({'values': search_results})
+        return json_response({'values': search_results, 'count': search.count()})

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -43,7 +43,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         search_params = query.get('parameters', [])
         query_addition = query.get("customQueryAddition", None)
         search = CaseSearchES()
-        search = search.domain(self.domain).is_closed(False)
+        search = search.domain(self.domain).is_closed(False).size(CASE_SEARCH_MAX_RESULTS)
         if case_type:
             search = search.case_type(case_type)
         if owner_id:
@@ -60,5 +60,5 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
             new_query = merge_queries(search.get_query(), addition.query_addition)
             search = search.set_query(new_query)
-        search_results = search.size(CASE_SEARCH_MAX_RESULTS).run().raw_hits
-        return json_response({'values': search_results, 'count': search.count()})
+        search_results = search.run()
+        return json_response({'values': search_results.raw_hits, 'count': search_results.total})

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -43,7 +43,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         search_params = query.get('parameters', [])
         query_addition = query.get("customQueryAddition", None)
         search = CaseSearchES()
-        search = search.domain(self.domain).is_closed(False).size(CASE_SEARCH_MAX_RESULTS)
+        search = search.domain(self.domain).is_closed(False)
         if case_type:
             search = search.case_type(case_type)
         if owner_id:
@@ -60,5 +60,5 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
             new_query = merge_queries(search.get_query(), addition.query_addition)
             search = search.set_query(new_query)
-        search_results = search.run().raw_hits
+        search_results = search.size(CASE_SEARCH_MAX_RESULTS).run().raw_hits
         return json_response({'values': search_results, 'count': search.count()})


### PR DESCRIPTION
Adds the total number of results to the case search admin view. 
Useful for seeing for e.g. how many cases have a specific case property set to a particular value