### PR TITLE
more indexes for ICDS

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -12,9 +12,9 @@ from corehq.apps.userreports.sql.columns import column_to_sql
 from corehq.apps.userreports.sql.connection import get_engine_id
 from corehq.apps.userreports.util import get_table_name
 from corehq.sql_db.connections import connection_manager
+from corehq.util.soft_assert import soft_assert
 from corehq.util.test_utils import unit_testing_only
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.logging import notify_exception
 
 
 metadata = sqlalchemy.MetaData()
@@ -148,13 +148,18 @@ class ErrorRaisingIndicatorSqlAdapter(IndicatorSqlAdapter):
 def get_indicator_table(indicator_config, custom_metadata=None):
     sql_columns = [column_to_sql(col) for col in indicator_config.get_columns()]
     table_name = get_table_name(indicator_config.domain, indicator_config.table_id)
-    extra_indices = [
-        Index(
-            _custom_index_name(table_name, index.column_ids),
-            *index.column_ids
-        )
-        for index in indicator_config.sql_column_indexes
-    ]
+    columns_by_col_id = {col.database_column_name for col in indicator_config.get_columns()}
+    extra_indices = []
+    for index in indicator_config.sql_column_indexes:
+        if set(index.column_ids).issubset(columns_by_col_id):
+            extra_indices.append(Index(
+                _custom_index_name(table_name, index.column_ids),
+                *index.column_ids
+            ))
+        else:
+            _assert = soft_assert('{}@{}'.format('jemord', 'dimagi.com'))
+            _assert(False, "Invalid index specified on {}".format(table_name))
+            break
     columns_and_indices = sql_columns + extra_indices
     # todo: needed to add extend_existing=True to support multiple calls to this function for the same table.
     # is that valid?

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -79,7 +79,6 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
-        "create_index": true,
         "expression": {
           "location_id_expression": {
             "expression": {
@@ -1754,6 +1753,9 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {"column_ids": ["supervisor_id", "edd"]}
+    ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
@@ -178,8 +178,7 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id",
-        "create_index": true
+        "column_id": "supervisor_id"
       },
       {
         "display_name": null,
@@ -3460,7 +3459,8 @@
     },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "month"]},
-      {"column_ids": ["district_id", "month"]}
+      {"column_ids": ["district_id", "month"]},
+      {"column_ids": ["supervisor_id", "month"]}
     ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -181,8 +181,7 @@
           },
           "type": "location_parent_id"
         },
-        "column_id": "supervisor_id",
-        "create_index": true
+        "column_id": "supervisor_id"
       },
       {
         "display_name": null,
@@ -1500,7 +1499,9 @@
       "number_of_shards": 5
     },
     "sql_column_indexes": [
-      {"column_ids": ["awc_id", "date_death"]}
+      {"column_ids": ["awc_id", "date_death"]},
+      {"column_ids": ["awc_id", "dob"]},
+      {"column_ids": ["supervisor_id", "dob"]}
     ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -56,7 +56,6 @@
         },
         "is_primary_key": false,
         "is_nullable": true,
-        "create_index": true,
         "column_id": "awc_id",
         "type": "expression"
       },
@@ -1045,6 +1044,9 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {"column_ids": ["awc_id", "submitted_on"]}
+    ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -93,8 +93,7 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id",
-        "create_index": true
+        "column_id": "supervisor_id"
       },
       {
         "display_name": "Block ID",
@@ -639,7 +638,8 @@
       "number_of_shards": 5
     },
     "sql_column_indexes": [
-      {"column_ids": ["awc_id", "last_date_gmp"]}
+      {"column_ids": ["awc_id", "last_date_gmp"]},
+      {"column_ids": ["supervisor_id", "last_date_gmp"]}
     ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/home_visit_forms.json
+++ b/custom/icds_reports/ucr/data_sources/home_visit_forms.json
@@ -73,7 +73,6 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
-        "create_index": true,
         "expression": {
           "location_id_expression": {
             "value_expression": {
@@ -182,6 +181,9 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {"column_ids": ["supervisor_id", "submitted_on"]}
+    ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms.json
@@ -67,7 +67,6 @@
         "is_nullable": true,
         "is_primary_key": false,
         "column_id": "supervisor_id",
-        "create_index": true,
         "expression": {
           "location_id_expression": {
             "value_expression": {
@@ -126,6 +125,9 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {"column_ids": ["supervisor_id", "submitted_on"]}
+    ]
   }
 }


### PR DESCRIPTION
Things to do:

- [x] add these concurrently to the database
- [ ] merge and deploy this branch
- [ ] remove indexes removed here
- [ ] once we have more stat gathering on pg0 we should re-evaluate these indexes. for instance some of these are indexed on month, but it's possible that (supervisor_id, age_in_months) would be a better index than (supervisor_id, months)

I also need to add columns to the new v2 indexes, but have been too busy adding them to v1 so far.

@dimagi/scale-team buddy @esoergel 