### PR TITLE
Removed person cases UCR from async queue.

### DIFF
--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2664,7 +2664,6 @@
         "property_value": null
       }
     },
-    "asynchronous": true,
     "engine_id": "icds-ucr",
     "backend_id": "LABORATORY",
     "es_index_settings": {


### PR DESCRIPTION
This will make all future person case changes be updated by the pillow instead of the async queue. It was only in the async queue to get through the backlog, which it has now completed.

buddy @nickpell 