### PR TITLE
Web apps permissions + login as: prepwork

### DIFF
--- a/corehq/apps/cloudcare/dbaccessors.py
+++ b/corehq/apps/cloudcare/dbaccessors.py
@@ -1,7 +1,9 @@
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
 from corehq.apps.cloudcare.models import ApplicationAccess
+from corehq.util.quickcache import quickcache
 
 
+@quickcache(['domain'])
 def get_application_access_for_domain(domain):
     """
     there should only be one ApplicationAccess per domain,

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from django.conf import settings
 
 from corehq.apps.domain.dbaccessors import (
@@ -52,3 +53,19 @@ def refresh_group_views():
 def get_group_ids_by_domain(domain):
     from corehq.apps.groups.models import Group
     return get_doc_ids_in_domain_by_class(domain, Group)
+
+
+def get_groups_by_user(domain, user_ids):
+    """
+    given a list of user_ids, get all the groups they each belong to
+
+    returns a dict {user_id: set(group_ids)}
+    raises AssertionError if any of the groups invloved is not in `domain`
+
+    """
+    from corehq.apps.groups.models import Group
+    groups_by_user = defaultdict(set)
+    for row in Group.view('groups/by_user', keys=user_ids):
+        assert row['value'][0] == domain
+        groups_by_user[row['key']].add(row['id'])
+    return dict(groups_by_user)

--- a/corehq/apps/groups/tests/test_dbaccessors.py
+++ b/corehq/apps/groups/tests/test_dbaccessors.py
@@ -1,0 +1,56 @@
+from django.test import TestCase
+from corehq.apps.groups.dbaccessors import get_groups_by_user
+from corehq.apps.groups.models import Group
+from corehq.apps.users.models import CommCareUser
+
+
+class DbaccessorsTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = 'groups-dbaccessors-test'
+
+        cls.user_1 = CommCareUser.create(cls.domain, 'user1@example.com', '***')
+        cls.user_2 = CommCareUser.create(cls.domain, 'user2@example.com', '***')
+
+        cls.group_1 = Group(domain=cls.domain)
+        cls.group_1.add_user(cls.user_1, save=False)
+        cls.group_1.add_user(cls.user_2, save=False)
+        cls.group_1.save()
+
+        cls.group_2 = Group(domain=cls.domain)
+        cls.group_2.add_user(cls.user_2, save=False)
+        cls.group_2.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user_1.delete()
+        cls.user_2.delete()
+        cls.group_1.delete()
+        cls.group_2.delete()
+
+    def test_get_groups_by_user(self):
+        self.assertEqual(
+            get_groups_by_user(self.domain, [self.user_1.user_id]),
+            {
+                self.user_1.user_id: {self.group_1._id, }
+            }
+        )
+        self.assertEqual(
+            get_groups_by_user(self.domain, [self.user_2.user_id]),
+            {
+                self.user_2.user_id: {self.group_1._id, self.group_2._id}
+            }
+        )
+        self.assertEqual(
+            get_groups_by_user(self.domain, [self.user_1.user_id, self.user_2.user_id]),
+            {
+                self.user_2.user_id: {self.group_1._id, self.group_2._id},
+                self.user_1.user_id: {self.group_1._id},
+            }
+        )
+        self.assertEqual(
+            get_groups_by_user(self.domain, ['no-user']),
+            {}
+        )
+        with self.assertRaises(AssertionError):
+            get_groups_by_user('no-domain', [self.user_1.user_id]),


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?257563

@benrudolph this PR implements the backend for the approach of loading in app availability data per user along with the original list of users.

You can check for anything you might think is a performance issue, but I think this'll actually be really quick. Notably, we only load 10 users at a time, and the user/group relationships for those users is a single couch query.