### PR TITLE
add migration_comment case property for public sector migrated cases

### DIFF
--- a/custom/enikshay/nikshay_datamigration/factory.py
+++ b/custom/enikshay/nikshay_datamigration/factory.py
@@ -51,8 +51,9 @@ class EnikshayCaseFactory(object):
     domain = None
     patient_detail = None
 
-    def __init__(self, domain, patient_detail, nikshay_codes_to_location, test_phi=None):
+    def __init__(self, domain, migration_comment, patient_detail, nikshay_codes_to_location, test_phi=None):
         self.domain = domain
+        self.migration_comment = migration_comment
         self.patient_detail = patient_detail
         self.case_accessor = CaseAccessors(domain)
         self.nikshay_codes_to_location = nikshay_codes_to_location
@@ -172,6 +173,7 @@ class EnikshayCaseFactory(object):
                     'secondary_contact_phone_number': validate_phone_number(self.patient_detail.cmob),
                     'sex': self.patient_detail.sex,
 
+                    'migration_comment': self.migration_comment,
                     'migration_created_case': 'true',
                     'migration_created_from_record': self.patient_detail.PregId,
                 },
@@ -229,6 +231,7 @@ class EnikshayCaseFactory(object):
                     'occurrence_episode_count': 1,
                     'occurrence_id': get_human_friendly_id(),
 
+                    'migration_comment': self.migration_comment,
                     'migration_created_case': 'true',
                     'migration_created_from_record': self.patient_detail.PregId,
                 },
@@ -299,6 +302,7 @@ class EnikshayCaseFactory(object):
                     'treatment_supporter_last_name': self.patient_detail.treatment_supporter_last_name,
                     'treatment_supporter_mobile_number': validate_phone_number(self.patient_detail.dotmob),
 
+                    'migration_comment': self.migration_comment,
                     'migration_created_case': 'true',
                     'migration_created_from_record': self.patient_detail.PregId,
                 },
@@ -337,6 +341,7 @@ class EnikshayCaseFactory(object):
                 'update': {
                     'name': self.patient_detail.pname,
 
+                    'migration_comment': self.migration_comment,
                     'migration_created_case': 'true',
                     'migration_created_from_record': self.patient_detail.PregId,
                 }
@@ -372,6 +377,7 @@ class EnikshayCaseFactory(object):
                     'result_recorded': 'yes',
                     'testing_facility_id': followup.DMC,
 
+                    'migration_comment': self.migration_comment,
                     'migration_created_case': 'true',
                     'migration_created_from_id': followup.id,
                     'migration_created_from_record': self.patient_detail.PregId,

--- a/custom/enikshay/nikshay_datamigration/management/commands/create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/management/commands/create_enikshay_cases.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
+        parser.add_argument('migration_comment')
         parser.add_argument(
             '--start',
             dest='start',
@@ -66,7 +67,7 @@ class Command(BaseCommand):
         )
 
     @mock_ownership_cleanliness_checks()
-    def handle(self, domain, **options):
+    def handle(self, domain, migration_comment, **options):
         if not settings.UNIT_TESTING:
             raise CommandError('must migrate case data from phone_number to contact_phone_number before running')
 
@@ -116,7 +117,7 @@ class Command(BaseCommand):
             counter += 1
             try:
                 case_factory = EnikshayCaseFactory(
-                    domain, patient_detail, nikshay_codes_to_location, test_phi
+                    domain, migration_comment, patient_detail, nikshay_codes_to_location, test_phi
                 )
                 case_structures.extend(case_factory.get_case_structures_to_create())
             except MatchingNikshayIdCaseNotMigrated:

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -22,7 +22,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
     @patch('custom.enikshay.nikshay_datamigration.factory.datetime')
     def test_case_creation(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2016, 9, 8, 1, 2, 3, 4123)
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         self.assertEqual(1, len(person_case_ids))
@@ -44,6 +44,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
                 ('hiv_status', 'non_reactive'),
                 ('is_active', 'yes'),
                 ('last_name', 'C'),
+                ('migration_comment', 'test_migration'),
                 ('migration_created_case', 'true'),
                 ('migration_created_from_record', 'MH-ABD-05-16-0001'),
                 ('person_id', 'NIK-MH-ABD-05-16-0001'),
@@ -71,6 +72,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
                 ('current_episode_type', 'confirmed_tb'),
                 ('ihv_date', '2016-12-25'),
                 ('initial_home_visit_status', 'completed'),
+                ('migration_comment', 'test_migration'),
                 ('migration_created_case', 'true'),
                 ('migration_created_from_record', 'MH-ABD-05-16-0001'),
                 ('occurrence_episode_count', '1'),
@@ -108,6 +110,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
                 ('episode_id', '20160908010203004'),
                 ('episode_pending_registration', 'no'),
                 ('episode_type', 'confirmed_tb'),
+                ('migration_comment', 'test_migration'),
                 ('migration_created_case', 'true'),
                 ('migration_created_from_record', 'MH-ABD-05-16-0001'),
                 ('nikshay_id', 'MH-ABD-05-16-0001'),
@@ -165,6 +168,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.assertEqual(self.drtb_hiv.location_id, drtb_hiv_referral_case.owner_id)
         self.assertEqual(
             OrderedDict([
+                ('migration_comment', 'test_migration'),
                 ('migration_created_case', 'true'),
                 ('migration_created_from_record', 'MH-ABD-05-16-0001'),
             ]),
@@ -350,6 +354,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
             ('diagnostic_test_reason', 'presumptive_tb'),
             ('episode_type_at_request', 'presumptive_tb'),
             ('lab_serial_number', '2073'),
+            ('migration_comment', 'test_migration'),
             ('migration_created_case', 'true'),
             ('migration_created_from_id', str(followup.id)),
             ('migration_created_from_record', self.patient_detail.PregId),
@@ -397,6 +402,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
             ('episode_type_at_request', 'confirmed_tb'),
             ('follow_up_test_reason', 'end_of_ip'),
             ('lab_serial_number', '2073'),
+            ('migration_comment', 'test_migration'),
             ('migration_created_case', 'true'),
             ('migration_created_from_id', str(followup.id)),
             ('migration_created_from_record', self.patient_detail.PregId),
@@ -444,6 +450,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
             ('episode_type_at_request', 'confirmed_tb'),
             ('follow_up_test_reason', 'end_of_cp'),
             ('lab_serial_number', '2073'),
+            ('migration_comment', 'test_migration'),
             ('migration_created_case', 'true'),
             ('migration_created_from_id', str(followup.id)),
             ('migration_created_from_record', self.patient_detail.PregId),

--- a/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_create_enikshay_cases.py
@@ -152,7 +152,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
     def test_drtb_hiv_referral(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         self.assertEqual(1, len(person_case_ids))
@@ -178,7 +178,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
     def test_case_update(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         new_addhaar_number = 867386000001
         new_pname = 'Bubbles'
@@ -190,7 +190,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.outcome.HIVStatus = 'Pos'
         self.outcome.save()
 
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         self.assertEqual(1, len(person_case_ids))
@@ -215,17 +215,17 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.assertEqual(drtb_hiv_referral_case.name, new_pname)
 
     def test_matching_case_not_migrated(self):
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
         episode_case_ids = self.case_accessor.get_case_ids_in_domain(type='episode')
         CaseFactory(self.domain).update_case(episode_case_ids[0], update={'migration_created_case': ''})
         with self.assertRaises(MatchingNikshayIdCaseNotMigrated):
             EnikshayCaseFactory(
-                self.domain, self.patient_detail, {}, 'test_phi'
+                self.domain, 'test_migration', self.patient_detail, {}, 'test_phi'
             ).get_case_structures_to_create()
 
     def test_location_not_found(self):
         self.phi.delete()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 0)
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='occurrence')), 0)
@@ -237,7 +237,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.outcome.Outcome = '1'
         self.outcome.OutcomeDate = '2/01/2017'
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         self.assertEqual(1, len(person_case_ids))
@@ -266,7 +266,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.outcome.Outcome = '3'
         self.outcome.OutcomeDate = '2-01-2017'
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         self.assertEqual(1, len(person_case_ids))
@@ -291,7 +291,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.assertEqual(0, len(drtb_hiv_referral_case_ids))
 
     def test_nikshay_case_from_enikshay_not_duplicated(self):
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         assert len(person_case_ids) == 1
         person_case = self.case_accessor.get_case(person_case_ids[0])
@@ -319,7 +319,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         episode_case = self.case_accessor.get_case(episode_case_id)
         assert episode_case.dynamic_case_properties()['migration_created_case'] == 'false'
 
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         self.assertEqual(len(person_case_ids), 1)
@@ -331,7 +331,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
 
     def test_followup_diagnostic(self):
         followup = self._create_diagnostic_followup()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 1)
         occurrence_cases = self.case_accessor.get_case_ids_in_domain(type='occurrence')
@@ -379,7 +379,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         followup.IntervalId = 1
         followup.SmearResult = 1
         followup.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 1)
         occurrence_cases = self.case_accessor.get_case_ids_in_domain(type='occurrence')
@@ -427,7 +427,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         followup.IntervalId = 4
         followup.SmearResult = 98
         followup.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 1)
         occurrence_cases = self.case_accessor.get_case_ids_in_domain(type='occurrence')
@@ -474,7 +474,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
         self.outcome.HIVStatus = None
         self.outcome.save()
         self._create_diagnostic_followup()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 1)
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='occurrence')), 1)
@@ -485,7 +485,7 @@ class TestCreateEnikshayCases(NikshayMigrationMixin, TestCase):
     def test_multiple_followups(self):
         self._create_diagnostic_followup()
         self._create_diagnostic_followup()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
 
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='person')), 1)
         self.assertEqual(len(self.case_accessor.get_case_ids_in_domain(type='occurrence')), 1)

--- a/custom/enikshay/nikshay_datamigration/tests/test_delete_migrated_cases.py
+++ b/custom/enikshay/nikshay_datamigration/tests/test_delete_migrated_cases.py
@@ -11,7 +11,7 @@ class TestDeleteMigratedCases(ENikshayCaseStructureMixin, NikshayMigrationMixin,
     def test_deletion_open_cases(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
         assert len(self.case_accessor.get_case_ids_in_domain(type='person')) == 1
         assert len(self.case_accessor.get_case_ids_in_domain(type='occurrence')) == 1
         episode_case_ids = self.case_accessor.get_case_ids_in_domain(type='episode')
@@ -29,7 +29,7 @@ class TestDeleteMigratedCases(ENikshayCaseStructureMixin, NikshayMigrationMixin,
         self.outcome.Outcome = '1'
         self.outcome.OutcomeDate = '2/01/2017'
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
         assert len(self.case_accessor.get_case_ids_in_domain(type='person')) == 1
         assert len(self.case_accessor.get_case_ids_in_domain(type='occurrence')) == 1
         episode_case_ids = self.case_accessor.get_case_ids_in_domain(type='episode')
@@ -46,7 +46,7 @@ class TestDeleteMigratedCases(ENikshayCaseStructureMixin, NikshayMigrationMixin,
     def test_deletion_by_person_case_id(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
         person_case_ids = self.case_accessor.get_case_ids_in_domain(type='person')
         assert len(person_case_ids) == 1
         assert len(self.case_accessor.get_case_ids_in_domain(type='occurrence')) == 1
@@ -63,7 +63,7 @@ class TestDeleteMigratedCases(ENikshayCaseStructureMixin, NikshayMigrationMixin,
     def test_other_cases_not_deleted(self):
         self.outcome.HIVStatus = None
         self.outcome.save()
-        call_command('create_enikshay_cases', self.domain)
+        call_command('create_enikshay_cases', self.domain, 'test_migration')
         self.create_case_structure()
         assert len(self.case_accessor.get_case_ids_in_domain(type='person')) == 2
         assert len(self.case_accessor.get_case_ids_in_domain(type='occurrence')) == 2


### PR DESCRIPTION
Allows tagging cases by migration run

@emord 