### PR TITLE
Handle javascript translations on transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -11,3 +11,14 @@ trans.hi = locale/hin/LC_MESSAGES/django.po
 trans.pt = locale/por/LC_MESSAGES/django.po
 trans.sw = locale/sw/LC_MESSAGES/django.po
 type = PO
+
+[commcare-hq.djangojspo]
+file_filter = locale/<lang>/LC_MESSAGES/djangojs.po
+source_file = locale/en/LC_MESSAGES/djangojs.po
+source_lang = en
+trans.fr = locale/fra/LC_MESSAGES/djangojs.po
+trans.es = locale/es/LC_MESSAGES/djangojs.po
+trans.hi = locale/hin/LC_MESSAGES/djangojs.po
+trans.pt = locale/por/LC_MESSAGES/djangojs.po
+trans.sw = locale/sw/LC_MESSAGES/djangojs.po
+type = PO

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -37,7 +37,7 @@ echo "Gathering all translation strings.  Note that this will probably take a wh
 ./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules'
 
 echo "Gathering javascript translation strings.  This will also probably take a while"
-./manage.py makemessages -d djangojs --all
+./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'bower_components'
 
 set +e   # Temporarily disable strict mode so we can respond any failure
 echo "Compiling translation files."

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -34,10 +34,10 @@ echo "Pulling translations from transifex"
 tx pull -f
 
 echo "Gathering all translation strings.  Note that this will probably take a while"
-./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules'
+./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'bower_components'
 
 echo "Gathering javascript translation strings.  This will also probably take a while"
-./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'bower_components'
+./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'bower_components' --ignore 'docs'
 
 set +e   # Temporarily disable strict mode so we can respond any failure
 echo "Compiling translation files."


### PR DESCRIPTION
We haven't been sending these to transifex, so none of the strings were translated.  I thought for a bit that something else was broken too, 'cause I still wasn't seeing things locally, but it turns out I'd just forgotten to run:
```$ ./manage.py compilejsi18n```

@kaapstorm @orangejenny @biyeun