### PR TITLE
don't close already closed extension cases

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -207,13 +207,18 @@ class AutoCloseExtensionsTest(TestCase):
             attrs={'close': True}
         ))
         cases = {
-            case.case_id: case.closed
+            case.case_id: case
             for case in CaseAccessors(self.domain).get_cases([self.host_id] + self.extension_ids)
         }
-        self.assertTrue(cases[self.host_id])
-        self.assertTrue(cases[self.extension_ids[0]])
-        self.assertTrue(cases[self.extension_ids[1]])
-        self.assertTrue(cases[self.extension_ids[2]])
+        self.assertTrue(cases[self.host_id].closed)
+        self.assertTrue(cases[self.extension_ids[0]].closed)
+        self.assertTrue(cases[self.extension_ids[1]].closed)
+        self.assertTrue(cases[self.extension_ids[2]].closed)
+
+        self.assertEqual(1, len(cases[self.host_id].get_closing_transactions()))
+        self.assertEqual(1, len(cases[self.extension_ids[0]].get_closing_transactions()))
+        self.assertEqual(1, len(cases[self.extension_ids[1]].get_closing_transactions()))
+        self.assertEqual(1, len(cases[self.extension_ids[2]].get_closing_transactions()))
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
     def test_close_cases_child(self):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -143,16 +143,15 @@ class AutoCloseExtensionsTest(TestCase):
         no_cases = get_extensions_to_close(created_cases[-1], self.domain)
         self.assertEqual(set(), no_cases)
 
-        created_cases[-1] = self.factory.create_or_update_case(CaseStructure(
-            case_id=self.host_id,
-            attrs={'close': True}
-        ))[0]
+        # don't actually close the cases otherwise they will get excluded
+        created_cases[-1].closed = True
 
         # host closed, should get full chain
         full_chain = get_extensions_to_close(created_cases[-1], self.domain)
         self.assertEqual(set(self.extension_ids), full_chain)
 
         # extension (not a host), should be empty
+        created_cases[2].closed = True
         no_cases = get_extensions_to_close(created_cases[2], self.domain)
         self.assertEqual(set(), no_cases)
 
@@ -165,18 +164,13 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertEqual(set(), no_cases)
 
         # close parent, shouldn't get extensions
-        created_cases[-1] = self.factory.create_or_update_case(CaseStructure(
-            case_id=self.parent_id,
-            attrs={'close': True}
-        ))[0]
+        # don't actually close the cases otherwise they will get excluded
+        created_cases[-1].closed = True
         no_cases = get_extensions_to_close(created_cases[-1], self.domain)
         self.assertEqual(set(), no_cases)
 
         # close host that is also a child
-        created_cases[-2] = self.factory.create_or_update_case(CaseStructure(
-            case_id=self.host_id,
-            attrs={'close': True}
-        ))[0]
+        created_cases[-2].closed = True
         full_chain = get_extensions_to_close(created_cases[-2], self.domain)
         self.assertEqual(set(self.extension_ids[0:2]), full_chain)
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -146,14 +146,14 @@ class AutoCloseExtensionsTest(TestCase):
         # don't actually close the cases otherwise they will get excluded
         created_cases[-1].closed = True
 
-        # host closed, should get full chain
+        # top level host closed, should get full chain
         full_chain = get_extensions_to_close(created_cases[-1], self.domain)
         self.assertEqual(set(self.extension_ids), full_chain)
 
-        # extension (not a host), should be empty
+        # extension (also a host), should get it's chain
         created_cases[2].closed = True
         no_cases = get_extensions_to_close(created_cases[2], self.domain)
-        self.assertEqual(set(), no_cases)
+        self.assertEqual(set(self.extension_ids[1:3]), no_cases)
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
     def test_get_extension_to_close_child_host(self):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -302,7 +302,7 @@ def get_all_extensions_to_close(domain, case_updates):
 
 def get_extensions_to_close(case, domain):
     if case.closed and EXTENSION_CASES_SYNC_ENABLED.enabled(domain):
-        return CaseAccessors(domain).get_extension_chain([case.case_id])
+        return CaseAccessors(domain).get_extension_chain([case.case_id], include_closed=False)
     else:
         return set()
 

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -56,9 +56,9 @@ class CaseProcessingResult(object):
 
     def close_extensions(self, case_db):
         from casexml.apps.case.cleanup import close_cases
-        extensions_to_close = list(self.extensions_to_close)
+        extensions_to_close = case_db.filter_closed_extensions(list(self.extensions_to_close))
         if extensions_to_close:
-            return close_cases(list(self.extensions_to_close), self.domain, SYSTEM_USER_ID, case_db)
+            return close_cases(extensions_to_close, self.domain, SYSTEM_USER_ID, case_db)
 
     def commit_dirtiness_flags(self):
         """

--- a/corehq/form_processor/backends/couch/casedb.py
+++ b/corehq/form_processor/backends/couch/casedb.py
@@ -8,6 +8,7 @@ from casexml.apps.case.util import iter_cases
 from corehq.form_processor.backends.couch.update_strategy import CouchCaseUpdateStrategy
 from corehq.form_processor.casedb_base import AbstractCaseDbCache
 from corehq.form_processor.exceptions import CouchSaveAborted
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 class CaseDbCacheCouch(AbstractCaseDbCache):
@@ -68,3 +69,19 @@ class CaseDbCacheCouch(AbstractCaseDbCache):
 
     def get_reverse_indexed_cases(self, case_ids):
         return get_reverse_indexed_cases(self.domain, case_ids)
+
+    def filter_closed_extensions(self, extensions_to_close):
+        # filter out cases that are closed which we already have cached
+        extensions_to_close = [
+            case_id for case_id in extensions_to_close
+            if case_id not in self.cache or not self.cache[case_id].closed
+        ]
+        if extensions_to_close:
+            # filter out any other cases that are already closed (or deleted)
+            closed_deleted = [
+                case_id for case_id, _, _ in
+                CaseAccessors(self.domain).get_closed_and_deleted_ids(extensions_to_close)
+            ]
+            extensions_to_close = [case_id for case_id in extensions_to_close if case_id not in closed_deleted]
+
+        return extensions_to_close

--- a/corehq/form_processor/backends/couch/casedb.py
+++ b/corehq/form_processor/backends/couch/casedb.py
@@ -5,10 +5,10 @@ from casexml.apps.case.dbaccessors.related import get_reverse_indexed_cases
 from casexml.apps.case.exceptions import IllegalCaseId
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import iter_cases
+from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
 from corehq.form_processor.backends.couch.update_strategy import CouchCaseUpdateStrategy
 from corehq.form_processor.casedb_base import AbstractCaseDbCache
 from corehq.form_processor.exceptions import CouchSaveAborted
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 class CaseDbCacheCouch(AbstractCaseDbCache):
@@ -80,7 +80,7 @@ class CaseDbCacheCouch(AbstractCaseDbCache):
             # filter out any other cases that are already closed (or deleted)
             closed_deleted = [
                 case_id for case_id, _, _ in
-                CaseAccessors(self.domain).get_closed_and_deleted_ids(extensions_to_close)
+                CaseAccessorCouch.get_closed_and_deleted_ids(self.domain, extensions_to_close)
             ]
             extensions_to_close = [case_id for case_id in extensions_to_close if case_id not in closed_deleted]
 

--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -194,7 +194,8 @@ class CaseAccessorCouch(AbstractCaseAccessor):
         return get_case_ids_modified_with_owner_since(domain, owner_id, reference_date)
 
     @staticmethod
-    def get_extension_case_ids(domain, case_ids):
+    def get_extension_case_ids(domain, case_ids, include_closed=True):
+        # include_closed ignored for couch
         return get_extension_case_ids(domain, case_ids)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/casedb.py
+++ b/corehq/form_processor/backends/sql/casedb.py
@@ -44,3 +44,7 @@ class CaseDbCacheSQL(AbstractCaseDbCache):
 
     def get_reverse_indexed_cases(self, case_ids):
         return CaseAccessorSQL.get_reverse_indexed_cases(self.domain, case_ids)
+
+    def filter_closed_extensions(self, extensions_to_close):
+        # noop for SQL since the filtering already happened when we fetched the IDs
+        return extensions_to_close

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -941,14 +941,14 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             [domain, case_ids, list(exclude_indices)]))
 
     @staticmethod
-    def get_closed_and_deleted_ids(accessor, case_ids):
+    def get_closed_and_deleted_ids(domain, case_ids):
         assert isinstance(case_ids, list), case_ids
         if not case_ids:
             return []
         with get_cursor(CommCareCaseSQL) as cursor:
             cursor.execute(
                 'SELECT case_id, closed, deleted FROM get_closed_and_deleted_ids(%s, %s)',
-                [accessor.domain, case_ids]
+                [domain, case_ids]
             )
             return list(fetchall_as_namedtuple(cursor))
 

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -187,5 +187,6 @@ class AbstractCaseDbCache(six.with_metaclass(ABCMeta)):
         # This is only used by ledger actions currently
         self.case_update_strategy(case).apply_action_intents(primary_intent, deprecation_intent)
 
+    @abstractmethod
     def filter_closed_extensions(self, extensions_to_close):
-        return extensions_to_close
+        pass

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -186,3 +186,6 @@ class AbstractCaseDbCache(six.with_metaclass(ABCMeta)):
         """
         # This is only used by ledger actions currently
         self.case_update_strategy(case).apply_action_intents(primary_intent, deprecation_intent)
+
+    def filter_closed_extensions(self, extensions_to_close):
+        return extensions_to_close

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -222,7 +222,7 @@ class AbstractCaseAccessor(six.with_metaclass(ABCMeta)):
         raise NotImplementedError
 
     @abstractmethod
-    def get_extension_case_ids(domain, case_ids):
+    def get_extension_case_ids(domain, case_ids, include_closed):
         raise NotImplementedError
 
     @abstractmethod
@@ -392,16 +392,16 @@ class CaseAccessors(object):
     def get_deleted_case_ids_by_owner(self, owner_id):
         return self.db_accessor.get_deleted_case_ids_by_owner(self.domain, owner_id)
 
-    def get_extension_chain(self, case_ids):
+    def get_extension_chain(self, case_ids, include_closed=True):
         assert isinstance(case_ids, list)
         get_extension_case_ids = self.db_accessor.get_extension_case_ids
 
-        incoming_extensions = set(get_extension_case_ids(self.domain, case_ids))
+        incoming_extensions = set(get_extension_case_ids(self.domain, case_ids, include_closed))
         all_extension_ids = set(incoming_extensions)
         new_extensions = set(incoming_extensions)
         while new_extensions:
             new_extensions = (
-                set(get_extension_case_ids(self.domain, list(new_extensions))) -
+                set(get_extension_case_ids(self.domain, list(new_extensions), include_closed)) -
                 all_extension_ids
             )
             all_extension_ids = all_extension_ids | new_extensions

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -345,7 +345,7 @@ class CaseAccessors(object):
 
         :returns: List of three-tuples: `(case_id, closed, deleted)`
         """
-        return self.db_accessor.get_closed_and_deleted_ids(self, case_ids)
+        return self.db_accessor.get_closed_and_deleted_ids(self.domain, case_ids)
 
     def get_modified_case_ids(self, case_ids, sync_log):
         """Get the subset of given list of case ids that have been modified


### PR DESCRIPTION
Currently when a host case gets closed we recursively close the full extension chain. This means that cases further down in the chain get closed multiple times.

review by commit :fish: 

note: killing the build until this is resolved: https://github.com/dimagi/commcare-hq/commit/18fdb656b29c0ea2564dec436a82ed26c2a5e4bc#commitcomment-23185981

buddy @orangejenny 