### PR TITLE
ICDS: Exclude migrated cases

### DIFF
--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -1464,6 +1464,15 @@
             },
             {
               "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "type": "named",
+                "name": "not_migrated"
+              },
+              "property_value": "yes"
+            },
+            {
+              "type": "boolean_expression",
               "operator": "gt",
               "property_value": 0,
               "expression": {
@@ -1901,6 +1910,36 @@
           "type": "constant",
           "constant": "no"
         }
+      },
+      "not_migrated": {
+        "type": "conditional",
+        "test": {
+          "type": "not",
+          "filter": {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "doc_id_expression": {
+                "type": "icds_parent_id"
+              },
+              "related_doc_type": "CommCareCase",
+              "type": "related_doc",
+              "value_expression": {
+                "property_name": "migration_status",
+                "type": "property_name"
+              }
+            },
+            "property_value": "migrated"
+          }
+        },
+        "expression_if_true": {
+          "type": "constant",
+          "constant": "yes"
+        },
+        "expression_if_false": {
+          "type": "constant",
+          "constant": "no"
+        }
       }
     },
     "named_filters": {
@@ -1939,6 +1978,15 @@
               "name": "seeking_services"
             },
             "property_value": "yes"
+          },
+          {
+            "type": "boolean_expression",
+            "operator": "eq",
+            "expression": {
+              "type": "named",
+              "name": "not_migrated"
+            },
+            "property_value": "yes"
           }
         ]
       },
@@ -1967,6 +2015,15 @@
             "expression": {
               "type": "named",
               "name": "seeking_services"
+            },
+            "property_value": "yes"
+          },
+          {
+            "type": "boolean_expression",
+            "operator": "eq",
+            "expression": {
+              "type": "named",
+              "name": "not_migrated"
             },
             "property_value": "yes"
           }
@@ -2095,6 +2152,15 @@
             "expression": {
               "type": "named",
               "name": "seeking_services"
+            },
+            "property_value": "yes"
+          },
+          {
+            "type": "boolean_expression",
+            "operator": "eq",
+            "expression": {
+              "type": "named",
+              "name": "not_migrated"
             },
             "property_value": "yes"
           }
@@ -2343,6 +2409,15 @@
             "expression": {
               "type": "named",
               "name": "seeking_services"
+            },
+            "property_value": "yes"
+          },
+          {
+            "type": "boolean_expression",
+            "operator": "eq",
+            "expression": {
+              "type": "named",
+              "name": "not_migrated"
             },
             "property_value": "yes"
           },

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -2974,6 +2974,36 @@
           "constant": "no"
         }
       },
+      "not_migrated": {
+        "type": "conditional",
+        "test": {
+          "type": "not",
+          "filter": {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "doc_id_expression": {
+                "type": "icds_parent_id"
+              },
+              "related_doc_type": "CommCareCase",
+              "type": "related_doc",
+              "value_expression": {
+                "property_name": "migration_status",
+                "type": "property_name"
+              }
+            },
+            "property_value": "migrated"
+          }
+        },
+        "expression_if_true": {
+          "type": "constant",
+          "constant": "yes"
+        },
+        "expression_if_false": {
+          "type": "constant",
+          "constant": "no"
+        }
+      },
       "valid_in_month": {
         "type": "conditional",
         "test": {
@@ -3002,6 +3032,15 @@
               "expression": {
                 "type": "named",
                 "name": "seeking_services"
+              }
+            },
+            {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "property_value": "yes",
+              "expression": {
+                "type": "named",
+                "name": "not_migrated"
               }
             },
             {
@@ -3377,6 +3416,15 @@
             "expression": {
               "type": "named",
               "name": "seeking_services"
+            }
+          },
+          {
+            "type": "boolean_expression",
+            "operator": "eq",
+            "property_value": "yes",
+            "expression": {
+              "type": "named",
+              "name": "not_migrated"
             }
           },
           {

--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2188,22 +2188,43 @@
         "column_id": "disabled_speaking_count"
       },
       {
+        "comment": "This filters on both registered status and migration status",
         "column_id": "seeking_services",
         "type": "boolean",
         "filter": {
-          "type": "not",
-          "filter": {
-            "operator": "eq",
-            "type": "boolean_expression",
-            "expression": {
-              "type": "root_doc",
-              "expression": {
-                "property_name": "registered_status",
-                "type": "property_name"
+          "type": "and",
+          "filters": [
+            {
+              "type": "not",
+              "filter": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                  "type": "root_doc",
+                  "expression": {
+                    "property_name": "registered_status",
+                    "type": "property_name"
+                  }
+                },
+                "property_value": "not_registered"
               }
             },
-            "property_value": "not_registered"
-          }
+            {
+              "type": "not",
+              "filter": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                  "type": "root_doc",
+                  "expression": {
+                    "property_name": "migration_status",
+                    "type": "property_name"
+                  }
+                },
+                "property_value": "migrated"
+              }
+            }
+          ]
         }
       },
       {
@@ -2671,9 +2692,24 @@
       "number_of_shards": 8
     },
     "sql_column_indexes": [
-      {"column_ids": ["supervisor_id", "dob"]},
-      {"column_ids": ["awc_id", "dob"]},
-      {"column_ids": ["awc_id", "opened_on"]}
+      {
+        "column_ids": [
+          "supervisor_id",
+          "dob"
+        ]
+      },
+      {
+        "column_ids": [
+          "awc_id",
+          "dob"
+        ]
+      },
+      {
+        "column_ids": [
+          "awc_id",
+          "opened_on"
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
This updates the UCRs to exclude migrated cases (moving forward, doesn't need to be recalculated for existing data).  

@emord 