### PR TITLE
Atomic save processed models

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -99,3 +99,4 @@ quickcache==0.0.1
 zeep==1.6.0
 ethiopian_date==0.1.1
 architect==0.5.6
+contextlib2=0.5.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -99,4 +99,4 @@ quickcache==0.0.1
 zeep==1.6.0
 ethiopian_date==0.1.1
 architect==0.5.6
-contextlib2=0.5.4
+contextlib2==0.5.4


### PR DESCRIPTION
@snopoke @calellowitz quick POC for atomic saves. i think we should remove the other atomic calls in the `saves`. i don't really know how this will affect the load, but it certainly should cut down on only half of the cases being submitted. thoughts?

cc: @proteusvacuum 