### PR TITLE
Remove cleanup permission from restore as

### DIFF
--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -89,7 +89,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.commcare_user,
             None,
-            False,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -99,7 +98,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             'wrong-domain',
             self.commcare_user,
             None,
-            False,
         )
         self.assertFalse(is_permitted)
         self.assertRegexpMatches(message, 'was not in the domain')
@@ -109,7 +107,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_user,
             None,
-            False,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -119,26 +116,14 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_user,
             self.commcare_user.username,
-            True,
         )
         self.assertTrue(is_permitted)
-
-    def test_web_user_as_user_bad_privilege(self):
-        is_permitted, message = is_permitted_to_restore(
-            self.domain,
-            self.web_user,
-            self.commcare_user.username,
-            False,
-        )
-        self.assertFalse(is_permitted)
-        self.assertRegexpMatches(message, 'does not have permissions')
 
     def test_web_user_as_user_bad_username(self):
         is_permitted, message = is_permitted_to_restore(
             self.domain,
             self.web_user,
             self.commcare_user.raw_username,  # Malformed, should include domain
-            True,
         )
         self.assertFalse(is_permitted)
         self.assertRegexpMatches(message, 'Invalid restore as user')
@@ -148,7 +133,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_user,
             u'{}@wrong-domain'.format(self.commcare_user.raw_username),
-            True,
         )
         self.assertFalse(is_permitted)
         self.assertRegexpMatches(message, 'Invalid restore as user')
@@ -158,7 +142,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_user,
             self.web_user.username,
-            True,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -168,7 +151,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.commcare_user,
             self.commcare_user.username,
-            True,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -178,7 +160,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_user,
             self.web_user.username,
-            True,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -191,7 +172,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.super_user,
             self.commcare_user.username,
-            False,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -201,7 +181,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.no_edit_commcare_user,
             self.location_user.username,
-            True,
         )
         self.assertFalse(is_permitted)
         self.assertRegexpMatches(message, 'does not have permission')
@@ -211,7 +190,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.commcare_user,
             self.location_user.username,
-            True,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -220,7 +198,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.commcare_user,
             self.wrong_location_user.username,
-            True,
         )
         self.assertFalse(is_permitted)
         self.assertRegexpMatches(message, 'not in allowed locations')
@@ -230,7 +207,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_location_user,
             self.location_user.username,
-            True,
         )
         self.assertTrue(is_permitted)
         self.assertIsNone(message)
@@ -239,7 +215,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
             self.domain,
             self.web_location_user,
             self.wrong_location_user.username,
-            True,
         )
         self.assertFalse(is_permitted)
         self.assertRegexpMatches(message, 'not in allowed locations')

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -101,7 +101,7 @@ def demo_restore_date_created(commcare_user):
             return restore.timestamp_created
 
 
-def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privilege):
+def is_permitted_to_restore(domain, couch_user, as_user):
     """
     This function determines if the couch_user is permitted to restore
     for the domain and/or as_user
@@ -120,7 +120,6 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privil
             if not as_user_obj:
                 raise RestorePermissionDenied(_(u'Invalid restore as user {}').format(as_user))
 
-            _ensure_cleanup_permission(domain, couch_user, as_user_obj, has_data_cleanup_privilege)
             _ensure_valid_restore_as_user(domain, couch_user, as_user_obj)
             _ensure_accessible_location(domain, couch_user, as_user_obj)
             _ensure_edit_data_permission(domain, couch_user)
@@ -138,14 +137,6 @@ def _restoring_as_yourself(couch_user, as_user):
 def _ensure_valid_domain(domain, couch_user):
     if not couch_user.is_member_of(domain):
         raise RestorePermissionDenied(_(u"{} was not in the domain {}").format(couch_user.username, domain))
-
-
-def _ensure_cleanup_permission(domain, couch_user, as_user, has_data_cleanup_privilege):
-    if not has_data_cleanup_privilege and not couch_user.is_superuser:
-        raise RestorePermissionDenied(_(u"{} does not have permissions to restore as {}").format(
-            couch_user.username,
-            as_user,
-        ))
 
 
 def _ensure_valid_restore_as_user(domain, couch_user, as_user_obj):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -207,7 +207,6 @@ def get_restore_params(request):
         'state': request.GET.get('state'),
         'items': request.GET.get('items') == 'true',
         'as_user': request.GET.get('as'),
-        'has_data_cleanup_privelege': has_privilege(request, privileges.DATA_CLEANUP),
         'overwrite_cache': request.GET.get('overwrite_cache') == 'true',
         'openrosa_version': openrosa_version,
         'device_id': request.GET.get('device_id'),
@@ -221,7 +220,6 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
                          cache_timeout=None, overwrite_cache=False,
                          force_restore_mode=None,
                          as_user=None, device_id=None, user_id=None,
-                         has_data_cleanup_privelege=False,
                          openrosa_version=OPENROSA_DEFAULT_VERSION,
                          case_sync=None):
 
@@ -241,7 +239,6 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
         domain,
         couch_user,
         as_user,
-        has_data_cleanup_privelege,
     )
     if not is_permitted:
         return HttpResponse(message, status=401), None


### PR DESCRIPTION
@proteusvacuum this drops the cleanup permission from restoring as another user. The impetus of this was that some plans that are on Standard plan don't have this permission, but the Standard plan allows for login as. This means now that any plan can use the restore as param, however app preview still only works / shows up for standard

@dimagi/product 