### PR TITLE
Drop table for device report logs.

### DIFF
--- a/corehq/ex-submodules/phonelog/tasks.py
+++ b/corehq/ex-submodules/phonelog/tasks.py
@@ -2,13 +2,17 @@ from datetime import datetime, timedelta
 from celery.schedules import crontab
 from celery.task import periodic_task
 from django.conf import settings
-from phonelog.models import DeviceReportEntry, UserErrorEntry, ForceCloseEntry, UserEntry
+from django.db import connection
+from phonelog.models import UserErrorEntry, ForceCloseEntry, UserEntry
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def purge_old_device_report_entries():
     max_age = datetime.utcnow() - timedelta(days=settings.DAYS_TO_KEEP_DEVICE_LOGS)
-    DeviceReportEntry.objects.filter(server_date__lt=max_age).delete()
+    with connection.cursor() as cursor:
+        partitoned_db_format = 'phonelog_daily_partitioned_devicereportentry_y%Yd%j'
+        table_to_drop = (max_age - timedelta(days=1)).strftime(partitoned_db_format)
+        cursor.execute("DROP TABLE {}".format(table_to_drop))
     UserErrorEntry.objects.filter(server_date__lt=max_age).delete()
     ForceCloseEntry.objects.filter(server_date__lt=max_age).delete()
     UserEntry.objects.filter(server_date__lt=max_age).delete()


### PR DESCRIPTION
@nickpell 

child tables are in a format of `tablename_yYYYY_dDDD` this drops that table instead of deleting all the rows which should be faster and clear up more space.