### PR TITLE
Add lag by data source config metric

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -347,16 +347,14 @@ def _save_document_helper(indicator, doc):
     queue=settings.CELERY_PERIODIC_QUEUE,
 )
 def async_indicators_metrics():
-    for config_id, metrics in _indicators_by_count().iteritems():
+    for config_id, metrics in _indicator_metrics().iteritems():
         tags = ["config_id:{}".format(config_id)]
         datadog_gauge('commcare.async_indicator.indicator_count', metrics['count'], tags=tags)
         datadog_gauge('commcare.async_indicator.lag', metrics['lag'], tags=tags)
 
 
-def _indicators_by_count(date_created=None):
+def _indicator_metrics(date_created=None):
     """
-    Number of docs in the queue that have a specific indicator config ids
-
     returns {
         "config_id": {
             "count": number of indicators with that config,
@@ -394,7 +392,7 @@ def _indicators_by_count(date_created=None):
     queue=settings.CELERY_PERIODIC_QUEUE,
 )
 def icds_async_indicators_metrics():
-    indicator_count_until_28 = _indicators_by_count(datetime(2017, 6, 28))
+    indicator_count_until_28 = _indicator_metrics(datetime(2017, 6, 28))
 
     for config_id, metrics in indicator_count_until_28.iteritems():
         tags = ["config_id:{}".format(config_id)]

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -10,7 +10,7 @@ from celery.task import task, periodic_task
 from couchdbkit import ResourceConflict, ResourceNotFound
 from django.conf import settings
 from django.db import InternalError, DatabaseError
-from django.db.models import Count, F
+from django.db.models import Count, F, Min
 from django.utils.translation import ugettext as _
 from elasticsearch.exceptions import ConnectionTimeout
 from restkit import RequestError
@@ -347,8 +347,10 @@ def _save_document_helper(indicator, doc):
     queue=settings.CELERY_PERIODIC_QUEUE,
 )
 def async_indicators_metrics():
-    for config_id, count in _indicators_by_count().iteritems():
-        datadog_gauge('commcare.async_indicator.indicator_count', count, tags=["config_id:{}".format(config_id)])
+    for config_id, metrics in _indicators_by_count().iteritems():
+        tags = ["config_id:{}".format(config_id)]
+        datadog_gauge('commcare.async_indicator.indicator_count', metrics['count'], tags=tags)
+        datadog_gauge('commcare.async_indicator.lag', metrics['lag'], tags=tags)
 
 
 def _indicators_by_count(date_created=None):
@@ -356,21 +358,33 @@ def _indicators_by_count(date_created=None):
     Number of docs in the queue that have a specific indicator config ids
 
     returns {
-        "config_id": "number of indicators with that config"
+        "config_id": {
+            "count": number of indicators with that config,
+            "lag": earliest created record
+        }
     }
     """
-    ret = defaultdict(lambda: 0)
-    indicators_by_count = (
+    ret = {}
+    indicator_metrics = (
         AsyncIndicator.objects
         .values('indicator_config_ids')
-        .annotate(Count('indicator_config_ids'))
+        .annotate(Count('indicator_config_ids'), Min('date_created'))
         .order_by()  # needed to get rid of implict ordering by date_created
     )
     if date_created:
-        indicators_by_count = indicators_by_count.filter(date_created__lt=date_created)
-    for ind in indicators_by_count:
+        indicator_metrics = indicator_metrics.filter(date_created__lt=date_created)
+    for ind in indicator_metrics:
+        count = ind['indicator_config_ids__count']
+        lag = ind['date_created__min']
         for config_id in ind['indicator_config_ids']:
-            ret[config_id] += ind['indicator_config_ids__count']
+            if ret.get(config_id):
+                ret[config_id]['count'] += ind['indicator_config_ids__count']
+                ret[config_id]['lag'] = min(lag, ret['config_id']['lag'])
+            else:
+                ret[config_id] = {
+                    "count": count,
+                    "lag": lag
+                }
 
     return ret
 
@@ -382,5 +396,6 @@ def _indicators_by_count(date_created=None):
 def icds_async_indicators_metrics():
     indicator_count_until_28 = _indicators_by_count(datetime(2017, 6, 28))
 
-    for config_id, count in indicator_count_until_28.iteritems():
-        datadog_gauge('commcare.async_indicator.icds_rebuild', count, tags=["config_id:{}".format(config_id)])
+    for config_id, metrics in indicator_count_until_28.iteritems():
+        tags = ["config_id:{}".format(config_id)]
+        datadog_gauge('commcare.async_indicator.icds_rebuild', metrics['count'], tags=tags)


### PR DESCRIPTION
@nickpell 

Adds a metric that reports the lag for each data source in async indicators