### PR TITLE
Increase maximum exportable ucr rows for enterprise environments

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -75,6 +75,7 @@ from no_exceptions.exceptions import Http403
 from corehq.apps.reports.datatables import DataTablesHeader
 
 UCR_EXPORT_TO_EXCEL_ROW_LIMIT = 5000
+ENTERPRISE_UCR_EXPORT_TO_EXCEL_ROW_LIMIT = 50000
 
 
 def get_filter_values(filters, request_dict, user=None):
@@ -563,11 +564,19 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
 
     @property
     @memoized
+    def excel_export_limit(self):
+        if settings.ENTERPRISE_MODE or self.domain == 'enikshay':
+            return ENTERPRISE_UCR_EXPORT_TO_EXCEL_ROW_LIMIT
+
+        return UCR_EXPORT_TO_EXCEL_ROW_LIMIT
+
+    @property
+    @memoized
     def export_too_large(self):
         data = self.data_source
         data.set_filter_values(self.filter_values)
         total_rows = data.get_total_records()
-        return total_rows > UCR_EXPORT_TO_EXCEL_ROW_LIMIT
+        return total_rows > self.excel_export_limit
 
     @property
     @memoized
@@ -589,7 +598,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
                     "Report export is limited to {number} rows. "
                     "Please filter the data in your report to "
                     "{number} or fewer rows before exporting"
-                ).format(number=UCR_EXPORT_TO_EXCEL_ROW_LIMIT),
+                ).format(number=self.excel_export_limit),
             })
         return self.render_json_response({
             "export_allowed": True,


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?258649

This is mainly to unblock enikshay. We can remove this for general enterprise environments if we think it's bad. I think this is all that's needed to accomplish this but pinging @NoahCarnahan since I think he originally implemented the limit.

@dimagi/scale-team 
cc @millerdev 