### PR TITLE
Add indexes to v2 tables.

### DIFF
--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
@@ -238,8 +238,7 @@
         "transform": {},
         "is_nullable": false,
         "type": "expression",
-        "column_id": "awc_id",
-        "create_index": true
+        "column_id": "awc_id"
       },
       {
         "display_name": null,
@@ -259,8 +258,7 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id",
-        "create_index": true
+        "column_id": "supervisor_id"
       },
       {
         "display_name": null,
@@ -2586,6 +2584,14 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": ["awc_id", "month"]
+      },
+      {
+        "column_ids": ["supervisor_id", "month"]
+      }
+    ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
@@ -155,8 +155,7 @@
             "property_name": "owner_id"
           }
         },
-        "column_id": "awc_id",
-        "create_index": true
+        "column_id": "awc_id"
       },
       {
         "display_name": null,
@@ -176,8 +175,7 @@
         "transform": {},
         "is_nullable": true,
         "type": "expression",
-        "column_id": "supervisor_id",
-        "create_index": true
+        "column_id": "supervisor_id"
       },
       {
         "display_name": null,
@@ -3200,6 +3198,17 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": ["awc_id", "month"]
+      },
+      {
+        "column_ids": ["district_id", "month"]
+      },
+      {
+        "column_ids": ["supervisor_id", "month"]
+      }
+    ]
   }
 }


### PR DESCRIPTION
These were added to the v1. adding these to v2 so we don't fall over in a week. need to run these asynchronously first:

```
CREATE INDEX CONCURRENTLY "ix_config_report_icds-cas_static-child_cases_month_ce820" ON "config_report_icds-cas_static-child_cases_monthly_v2_198ccc06" (supervisor_id, month) 
CREATE INDEX CONCURRENTLY "ix_config_report_icds-cas_static-child_cases_month_87e5a" ON "config_report_icds-cas_static-child_cases_monthly_v2_198ccc06" (awc_id, month) 
CREATE INDEX CONCURRENTLY "ix_config_report_icds-cas_static-child_cases_month_e2f5d" ON "config_report_icds-cas_static-child_cases_monthly_v2_198ccc06" (district_id, month)

CREATE INDEX CONCURRENTLY "ix_config_report_icds-cas_static-ccs_record_cases__7bfb0" ON "config_report_icds-cas_static-ccs_record_cases_monthly_e9f777f7" (supervisor_id, month)
CREATE INDEX CONCURRENTLY "ix_config_report_icds-cas_static-ccs_record_cases__fb5bc" ON "config_report_icds-cas_static-ccs_record_cases_monthly_e9f777f7" (awc_id, month)

```

@nickpell 