### PR TITLE
Added more indexes to ICDS UCRs.

### DIFF
--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -1755,7 +1755,8 @@
       "number_of_shards": 5
     },
     "sql_column_indexes": [
-      {"column_ids": ["supervisor_id", "edd"]}
+      {"column_ids": ["supervisor_id", "edd"]},
+      {"column_ids": ["awc_id", "owner_id"]}
     ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
@@ -3460,7 +3460,10 @@
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "month"]},
       {"column_ids": ["district_id", "month"]},
-      {"column_ids": ["supervisor_id", "month"]}
+      {"column_ids": ["supervisor_id", "month"]},
+      {"column_ids": ["block_id", "age_in_months"]},
+      {"column_ids": ["supervisor_id", "age_in_months"]},
+      {"column_ids": ["awc_id", "age_in_months"]}
     ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
@@ -3208,6 +3208,15 @@
       },
       {
         "column_ids": ["supervisor_id", "month"]
+      },
+      {
+        "column_ids": ["block_id", "age_in_months"]
+      },
+      {
+        "column_ids": ["supervisor_id", "age_in_months"]
+      },
+      {
+        "column_ids": ["awc_id", "age_in_months"]
       }
     ]
   }

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -180,6 +180,20 @@
     "backend_id": "LABORATORY",
     "es_index_settings": {
       "number_of_shards": 5
-    }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "owner_id"
+        ]
+      },
+      {
+        "column_ids": [
+          "awc_id",
+          "owner_id"
+        ]
+      }
+    ]
   }
 }

--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2699,8 +2699,20 @@
       },
       {
         "column_ids": [
+          "supervisor_id",
+          "owner_id"
+        ]
+      },
+      {
+        "column_ids": [
           "awc_id",
           "dob"
+        ]
+      },
+      {
+        "column_ids": [
+          "awc_id",
+          "owner_id"
         ]
       },
       {


### PR DESCRIPTION
@dimagi/scale-team indexes suggested from pghero. I plan on writing up a guide on how i've been using that in the next week.

Will need to add these concurrent:

```
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-child_cases_monthly_318ac2e9 (block_id, age_in_months)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-person_cases_v2_b4b5d57a (supervisor_id, owner_id)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-person_cases_v2_b4b5d57a (awc_id, owner_id)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-child_cases_monthly_318ac2e9 (supervisor_id, age_in_months)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-child_health_cases_a46c129f (date_death)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-household_cases_eadc276d (supervisor_id, owner_id)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-household_cases_eadc276d (awc_id, owner_id)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-ccs_record_cases_cedcca39 (awc_id, owner_id)
CREATE INDEX CONCURRENTLY ON config_report_icds-cas_static-child_cases_monthly_318ac2e9 (awc_id, age_in_months)
```

buddy @nickpell 