### PR TITLE
Remove unused javascript in reports/async/default.html

### DIFF
--- a/corehq/apps/reports/templates/reports/async/default.html
+++ b/corehq/apps/reports/templates/reports/async/default.html
@@ -1,6 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
-{% if show_time_notice %}{% include "style/partials/time_notice.html"%}{% endif %}
+{% if show_time_notice %}{% include "style/partials/time_notice.html" with hide=1 %}{% endif %}
 
 {% block reportcontent %}
     {% if report.slug %}

--- a/corehq/apps/reports/templates/reports/async/default.html
+++ b/corehq/apps/reports/templates/reports/async/default.html
@@ -3,41 +3,17 @@
 {% if show_time_notice %}{% include "style/partials/time_notice.html"%}{% endif %}
 
 {% block reportcontent %}
-    {% if report.show %}
-        {% if report.slug %}
-            <div class="report-loading-container">
-                <div class="report-loading">
-                    <h4>{% trans "Loading Report" %}</h4>
-                    <i class="fa fa-spin fa-spinner js-loading-spinner"></i>
-                    <h6>{% trans report.title %}</h6>
-                </div>
+    {% if report.slug %}
+        <div class="report-loading-container">
+            <div class="report-loading">
+                <h4>{% trans "Loading Report" %}</h4>
+                <i class="fa fa-spin fa-spinner js-loading-spinner"></i>
+                <h6>{% trans report.title %}</h6>
             </div>
-        {% else %}
-            <h6 style="text-align: center; margin-top: 200px;">{{ report.title }}</h6>
-        {% endif %}
+        </div>
     {% else %}
-        <h6>
-            <i class="fa fa-info-circle" id="no-viewable-reports"></i>
-            {% trans 'You are not registered to see reports' %}
-        </h6>
-        <script>
-            $(function () {
-                $('.sidebar').hide();
-                $('.hq-double-col').css({background: 'white'});
-                $('#no-viewable-reports').popover({
-                    placement: 'top',
-                    title: "{% trans "We're serious about security" %}",
-                    content: "{% trans "Your project may contain sensitive personal and medical information, so we don't show this data to just anyone. If you think you should have access to your project's reports please contact your project lead." %}"
-                });
-            });
-        </script>
+        <h6 style="text-align: center; margin-top: 200px;">{{ report.title }}</h6>
     {% endif %}
-    <script>
-        $(function() {
-            $('.hq-report-time-notice').addClass('hide');
-            $('.hq-loading').fadeIn();
-        });
-    </script>
 {% endblock %}
 
 {% block js %}

--- a/corehq/apps/style/templates/style/partials/time_notice.html
+++ b/corehq/apps/style/templates/style/partials/time_notice.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="alert alert-info alert-full hq-report-time-notice">
+<div class="alert alert-info alert-full hq-report-time-notice{% if hide %} hide{% endif %}">
     <strong>
         {% trans "The current date and time is" %}
         {% if timezone %}{{ timezone_now }} {{ timezone }}{% else %}{{ now }} GMT{% endif %}.


### PR DESCRIPTION
The warning for users without permissions doesn't seem to get triggered anymore; reports that the user doesn't have access to now 404.

Also moved the time notice logic to django, and removed the `.hq-loading` logic which looks outdated, verified that the WAR still loads as expected.

@snopoke / @millerdev 