### PR TITLE
dont use cached object

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -22,7 +22,6 @@ import stripe
 
 from dimagi.ext.couchdbkit import DateTimeProperty, StringProperty, SafeSaveDocument, BooleanProperty
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.django.cached_object import CachedObject
 from dimagi.utils.web import get_site_domain
 
 from corehq.apps.accounting.emails import send_subscription_change_alert
@@ -2497,16 +2496,7 @@ class InvoicePdf(SafeSaveDocument):
         }
 
     def get_data(self, invoice):
-        obj = CachedObject('%s:InvoicePdf' % self._id)
-        if not obj.is_cached():
-            data = self.fetch_attachment(self.get_filename(invoice), True).read()
-            metadata = {'content_type': 'application/pdf'}
-            buff = StringIO(data)
-            obj.cache_put(buff, metadata, timeout=None)
-        else:
-            buff = obj.get()[1]
-            data = buff.getvalue()
-        return data
+        return self.fetch_attachment(self.get_filename(invoice), True).read()
 
 
 class LineItemManager(models.Manager):

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -42,7 +42,6 @@ from corehq.apps.hqmedia.tasks import process_bulk_upload_zip, build_application
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.django.cached_object import CachedObject
 from soil.util import expose_cached_download
 from django.utils.translation import ugettext as _
 from django_prbac.decorators import requires_privilege_raise404

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -21,10 +21,6 @@ from corehq.apps.sms.mixin import MessagingCaseContactMixin
 from corehq.blobs.mixin import DeferredBlobMixin
 from corehq.form_processor.abstract_models import AbstractCommCareCase, DEFAULT_PARENT_IDENTIFIER
 from dimagi.ext.couchdbkit import *
-from dimagi.utils.django.cached_object import (
-    CachedObject, OBJECT_ORIGINAL, OBJECT_SIZE_MAP, CachedImage, IMAGE_SIZE_ORDERING
-)
-from casexml.apps.phone.xml import get_case_element
 from casexml.apps.case.signals import case_post_save
 from casexml.apps.case import const
 from dimagi.utils.modules import to_function

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1253,10 +1253,3 @@ PREVENT_MOBILE_UCR_SYNC = StaticToggle(
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN]
 )
-
-NO_CACHE_APP_FILES = StaticToggle(
-    'no_cache_app_files',
-    'Serve app files from blobdb and not from cache',
-    TAG_ONE_OFF,
-    [NAMESPACE_DOMAIN]
-)


### PR DESCRIPTION
Follow up on the other PRs. CachedObject comes from a time when we had to pull attachments from couch instead of riak. We had some issues with redis growing a lot and it may have been putting binary attachments into redis as a cache. This removes CachedObject except for case attachments because that uses a CachedIMage class that caches thumbnails

@dimagi/scale-team @nickpell 