### PR TITLE
Abt report: Fix custom UCR expression for malformed submissions

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -104,6 +104,8 @@ class AbtSupervisorExpressionSpec(JsonObject):
         """
         Return the language in which this row should be rendered.
         """
+        if item.get("domain", None) == "airsmadagascar":
+            return "fra"
         country = cls._get_val(item, ["location_data", "country"])
         if country in ["Senegal", u'S\xe9n\xe9gal', "Benin", "Mali", "Madagascar"]:
             return "fra"


### PR DESCRIPTION
This is a change to a custom UCR expression used by an abt report.

Some form submissions are missing an expected hidden value used to determine language, but we can use the domain in this case instead.