### PR TITLE
Formplayer clear user data

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -473,6 +473,12 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
     });
 });
 
+/**
+ * clearUserData
+ *
+ * Sends a request to formplayer to wipe out all application and user dbs for the
+ * current user. Returns the ajax promise.
+ */
 FormplayerFrontend.reqres.setHandler('clearUserData', function() {
     var user = FormplayerFrontend.request('currentUser'),
         formplayer_url = user.formplayer_url,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -12,6 +12,7 @@ var showSuccess = hqImport('cloudcare/js/util.js').showSuccess;
 var tfLoading = hqImport('cloudcare/js/util.js').tfLoading;
 var tfLoadingComplete = hqImport('cloudcare/js/util.js').tfLoadingComplete;
 var tfSyncComplete = hqImport('cloudcare/js/util.js').tfSyncComplete;
+var clearUserDataComplete = hqImport('cloudcare/js/util.js').clearUserDataComplete;
 
 FormplayerFrontend.on("before:start", function () {
     var RegionContainer = Marionette.LayoutView.extend({
@@ -470,6 +471,29 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
         $("#cloudcare-notifications").empty();
         FormplayerFrontend.trigger('navigateHome');
     });
+});
+
+FormplayerFrontend.reqres.setHandler('clearUserData', function() {
+    var user = FormplayerFrontend.request('currentUser'),
+        formplayer_url = user.formplayer_url,
+        resp,
+        options = {
+            url: formplayer_url + "/clear_user_data",
+            data: JSON.stringify({
+                domain: user.domain,
+                username: user.username,
+                restoreAs: user.restoreAs,
+            }),
+        };
+    Util.setCrossDomainAjaxOptions(options);
+    tfLoading();
+    resp = $.ajax(options);
+    resp.fail(function () {
+        tfLoadingComplete(true);
+    }).done(function(response) {
+        clearUserDataComplete(response.hasOwnProperty('exception'));
+    });
+    return resp;
 });
 
 FormplayerFrontend.on('navigateHome', function() {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -476,7 +476,7 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
 /**
  * clearUserData
  *
- * Sends a request to formplayer to wipe out all application and user dbs for the
+ * Sends a request to formplayer to wipe out all application and user db for the
  * current user. Returns the ajax promise.
  */
 FormplayerFrontend.reqres.setHandler('clearUserData', function() {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -32,14 +32,24 @@ FormplayerFrontend.module("Apps", function(Apps, FormplayerFrontend, Backbone, M
             FormplayerFrontend.regions.main.show(landingPageAppView);
         },
         listSettings: function() {
-            var collection = new Backbone.Collection([
-                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_LANG }),
-                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_DISPLAY }),
-                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.CLEAR_USER_DATA }),
-            ]);
-            var settingsView = new FormplayerFrontend.Layout.Views.SettingsView({
+            var currentUser = FormplayerFrontend.request('currentUser'),
+                settings = [],
+                collection,
+                settingsView;
+            if (currentUser.environment === FormplayerFrontend.Constants.PREVIEW_APP_ENVIRONMENT) {
+                settings = settings.concat([
+                    new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_LANG }),
+                    new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_DISPLAY }),
+                ]);
+            }
+            settings.push(
+                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.CLEAR_USER_DATA })
+            );
+            collection = new Backbone.Collection(settings);
+            settingsView = new FormplayerFrontend.Layout.Views.SettingsView({
                 collection: collection,
             });
+
             FormplayerFrontend.regions.main.show(settingsView);
         },
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -32,7 +32,13 @@ FormplayerFrontend.module("Apps", function(Apps, FormplayerFrontend, Backbone, M
             FormplayerFrontend.regions.main.show(landingPageAppView);
         },
         listSettings: function() {
-            var settingsView = new FormplayerFrontend.Layout.Views.SettingsView();
+            var collection = new Backbone.Collection([
+                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_LANG }),
+                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_DISPLAY }),
+            ]);
+            var settingsView = new FormplayerFrontend.Layout.Views.SettingsView({
+                collection: collection,
+            });
             FormplayerFrontend.regions.main.show(settingsView);
         },
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -35,6 +35,7 @@ FormplayerFrontend.module("Apps", function(Apps, FormplayerFrontend, Backbone, M
             var collection = new Backbone.Collection([
                 new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_LANG }),
                 new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_DISPLAY }),
+                new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.CLEAR_USER_DATA }),
             ]);
             var settingsView = new FormplayerFrontend.Layout.Views.SettingsView({
                 collection: collection,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -58,6 +58,24 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         },
     });
 
+    /**
+     * Force clear user data.
+     * Available for both Web Apps and App Preview
+     */
+    var ClearUserDataView = Marionette.ItemView.extend({
+        template: '#clear-user-data-setting-template',
+        tagName: 'tr',
+        ui: {
+            clearUserData: '.js-clear-user-data',
+        },
+        events: {
+            'click @ui.clearUserData': 'onClickClearUserData',
+        },
+        onClickClearUserData: function() {
+            console.log('clearing user data...');
+        },
+    });
+
     Views.SettingsView = Marionette.CompositeView.extend({
         ui: {
             done: '.js-done',
@@ -68,6 +86,8 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
                 return LangSettingView;
             } else if (item.get('slug') === Views.SettingSlugs.SET_DISPLAY) {
                 return DisplaySettingView;
+            } else if (item.get('slug') === Views.SettingSlugs.CLEAR_USER_DATA) {
+                return ClearUserDataView;
             }
         },
         events: {
@@ -82,6 +102,7 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
     Views.SettingSlugs = {
         SET_LANG: 'lang',
         SET_DISPLAY: 'display',
+        CLEAR_USER_DATA: 'clear-user-data',
     };
 
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -1,28 +1,50 @@
 /*global FormplayerFrontend, Util */
 
 FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, Backbone, Marionette) {
-    Views.SettingsView = Marionette.ItemView.extend({
-        ui: {
-            oneQuestionPerScreen: '.js-one-question-per-screen',
-            language: '.js-lang',
-            done: '.js-done',
-        },
-        events: {
-            'switchChange.bootstrapSwitch @ui.oneQuestionPerScreen': 'onChangeOneQuestionPerScreen',
-            'change @ui.language': 'onLanguageChange',
-            'click @ui.done': 'onClickDone',
-        },
-        template: '#settings-template',
+    /**
+     * Sets the application language. Should only be used for App Preview.
+     */
+    var LangSettingView = Marionette.ItemView.extend({
+        template: '#lang-setting-template',
+        tagName: 'tr',
         initialize: function() {
             this.currentUser = FormplayerFrontend.request('currentUser');
+        },
+        ui: {
+            language: '.js-lang',
+        },
+        events: {
+            'change @ui.language': 'onLanguageChange',
+        },
+        onLanguageChange: function(e) {
+            this.currentUser.displayOptions.language = $(e.currentTarget).val();
+            Util.saveDisplayOptions(this.currentUser.displayOptions);
         },
         templateHelpers: function() {
             var appId = FormplayerFrontend.request('getCurrentAppId');
             var currentApp = FormplayerFrontend.request("appselect:getApp", appId);
             return {
                 langs: currentApp.get('langs'),
-                displayOptions: this.currentUser.displayOptions,
+                currentLang: this.currentUser.displayOptions.language,
             };
+        },
+    });
+
+    /**
+     * Sets whether or not the application should use One Question Per Screen or not.
+     * Should only be used for App Preview.
+     */
+    var DisplaySettingView = Marionette.ItemView.extend({
+        template: '#display-setting-template',
+        tagName: 'tr',
+        initialize: function() {
+            this.currentUser = FormplayerFrontend.request('currentUser');
+        },
+        ui: {
+            oneQuestionPerScreen: '.js-one-question-per-screen',
+        },
+        events: {
+            'switchChange.bootstrapSwitch @ui.oneQuestionPerScreen': 'onChangeOneQuestionPerScreen',
         },
         onRender: function() {
             this.ui.oneQuestionPerScreen.bootstrapSwitch(
@@ -34,12 +56,33 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
             this.currentUser.displayOptions.oneQuestionPerScreen = switchValue;
             Util.saveDisplayOptions(this.currentUser.displayOptions);
         },
-        onLanguageChange: function(e) {
-            this.currentUser.displayOptions.language = $(e.currentTarget).val();
-            Util.saveDisplayOptions(this.currentUser.displayOptions);
+    });
+
+    Views.SettingsView = Marionette.CompositeView.extend({
+        ui: {
+            done: '.js-done',
+        },
+        childViewContainer: 'tbody',
+        getChildView: function(item) {
+            if (item.get('slug') === 'lang') {
+                return LangSettingView;
+            } else if (item.get('slug') === 'display') {
+                return DisplaySettingView;
+            }
+        },
+        events: {
+            'click @ui.done': 'onClickDone',
+        },
+        template: '#settings-template',
+        initialize: function() {
+            this.collection = new Backbone.Collection([
+                new Backbone.Model({ slug: 'lang' }),
+                new Backbone.Model({ slug: 'display' }),
+            ]);
         },
         onClickDone: function() {
             FormplayerFrontend.trigger('navigateHome');
         },
     });
+
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -64,9 +64,9 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         },
         childViewContainer: 'tbody',
         getChildView: function(item) {
-            if (item.get('slug') === 'lang') {
+            if (item.get('slug') === Views.SettingSlugs.SET_LANG) {
                 return LangSettingView;
-            } else if (item.get('slug') === 'display') {
+            } else if (item.get('slug') === Views.SettingSlugs.SET_DISPLAY) {
                 return DisplaySettingView;
             }
         },
@@ -74,15 +74,14 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
             'click @ui.done': 'onClickDone',
         },
         template: '#settings-template',
-        initialize: function() {
-            this.collection = new Backbone.Collection([
-                new Backbone.Model({ slug: 'lang' }),
-                new Backbone.Model({ slug: 'display' }),
-            ]);
-        },
         onClickDone: function() {
             FormplayerFrontend.trigger('navigateHome');
         },
     });
+
+    Views.SettingSlugs = {
+        SET_LANG: 'lang',
+        SET_DISPLAY: 'display',
+    };
 
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -71,8 +71,12 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         events: {
             'click @ui.clearUserData': 'onClickClearUserData',
         },
-        onClickClearUserData: function() {
-            console.log('clearing user data...');
+        onClickClearUserData: function(e) {
+            var promise = FormplayerFrontend.request('clearUserData');
+            $(e.currentTarget).prop('disabled', true);
+            promise.done(function() {
+                $(e.currentTarget).prop('disabled', false);
+            });
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -159,6 +159,18 @@ hqDefine('cloudcare/js/util.js', function () {
         }
     };
 
+    var clearUserDataComplete = function(isError) {
+        hideLoading();
+        if (isError) {
+            showError(
+                gettext('Could not clear user data. Please report an issue if this persists.'),
+                $('#cloudcare-notifications')
+            );
+        } else {
+            showSuccess(gettext('User data successfully cleared.'), $('#cloudcare-notifications'), 5000);
+        }
+    };
+
     var hideLoading = function (selector) {
         NProgress.done();
     };
@@ -181,6 +193,7 @@ hqDefine('cloudcare/js/util.js', function () {
         showHTMLError: showHTMLError,
         showSuccess: showSuccess,
         showLoading: showLoading,
+        clearUserDataComplete: clearUserDataComplete,
         tfLoading: tfLoading,
         tfLoadingComplete: tfLoadingComplete,
         tfSyncComplete: tfSyncComplete,

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -39,6 +39,14 @@
           </div>
         </div>
         {% endif %}
+        <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
+          <div class="js-settings appicon appicon-settings">
+            <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
+            <div class="appicon-title">
+              <h3>{% trans "Settings" %}</h3>
+            </div>
+          </div>
+        </div>
     </div>
 </script>
 

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -8,22 +8,6 @@
       </div>
       <table class="table module-table">
           <tbody>
-              <tr>
-                  <th>Use one question per screen</th>
-                  <td><input class="js-one-question-per-screen" type="checkbox" data-size="mini" /></td>
-              </tr>
-              <tr>
-                  <th>Set the application language</th>
-                  <td>
-                    <select class="form-control js-lang">
-                      <% _.each(langs, function(lang) { %>
-                      <option <% if (lang === displayOptions.language) { %>selected<% } %>>
-                        <%= lang %>
-                      </option>
-                      <% }) %>
-                    </select>
-                  </td>
-              </tr>
           </tbody>
       </table>
       <div class="page-footer">
@@ -32,4 +16,20 @@
           </button>
       </div>
   </div>
+</script>
+<script type="text/template" id="display-setting-template">
+    <th>Use one question per screen</th>
+    <td><input class="js-one-question-per-screen" type="checkbox" data-size="mini" /></td>
+</script>
+<script type="text/template" id="lang-setting-template">
+    <th>Set the application language</th>
+    <td>
+      <select class="form-control js-lang">
+        <% _.each(langs, function(lang) { %>
+        <option <% if (lang === currentLang) { %>selected<% } %>>
+          <%= lang %>
+        </option>
+        <% }) %>
+      </select>
+    </td>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -2,13 +2,10 @@
 {% load i18n %}
 
 <script type="text/template" id="settings-template">
-  <div class="breadcrumb-form-container">
-    <ol class="breadcrumb breadcrumb-form">
-      <li class="js-home breadcrumb-text"><i class="fa fa-home"></i></li>
-      <li class="breadcrumb-text">{% trans "Settings" %}</li>
-    </ol>
-  </div>
   <div class="module-menu-container module-menu-bar-offset">
+      <div class="page-header menu-header">
+          <h1 class="page-title">Settings</h1>
+      </div>
       <table class="table module-table">
           <tbody>
               <tr>

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -33,3 +33,7 @@
       </select>
     </td>
 </script>
+<script type="text/template" id="clear-user-data-setting-template">
+    <th>Clear user data</th>
+    <td><button class="js-clear-user-data btn btn-sm btn-warning">Clear</button></td>
+</script>


### PR DESCRIPTION
@ctsims @wpride this is the front end to wipe the the user db / application db. refactored the settings so it's easier to add settings in the future. If you're user is `brudolph@dimagi.com` and you're logged in as `ben`, then it will wipe everything in the dir: `<domain>/brudolph@dimagi.com_ben` which is where the user db for `ben` lives as well as all the apps. it will not wipe the user db for `brudolph@dimagi.com` or other dbs of logged in as users (`brudolph@dimagi.com_test` for example). in order to do that, you need to login as that user.

<img width="509" alt="screen shot 2017-07-24 at 1 37 31 pm" src="https://user-images.githubusercontent.com/918514/28536468-b283be8c-7075-11e7-99be-b5e3c8ffec94.png">
<img width="1792" alt="screen shot 2017-07-24 at 1 37 27 pm" src="https://user-images.githubusercontent.com/918514/28536469-b289f8f6-7075-11e7-95d2-f5bf0688a824.png">

broken down by commit, but can probably review all at once

needs: https://github.com/dimagi/formplayer/pull/440

cc: @proteusvacuum 