### PR TITLE
Abt report: Fix custom UCR expression for malformed submissions (again)

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -104,7 +104,7 @@ class AbtSupervisorExpressionSpec(JsonObject):
         """
         Return the language in which this row should be rendered.
         """
-        if item.get("domain", None) == "airsmadagascar":
+        if item.get("domain", None) in ("airsmadagascar", "abtmali"):
             return "fra"
         country = cls._get_val(item, ["location_data", "country"])
         if country in ["Senegal", u'S\xe9n\xe9gal', "Benin", "Mali", "Madagascar"]:


### PR DESCRIPTION
Same as https://github.com/dimagi/commcare-hq/pull/17160

This is a change to a custom UCR expression used by an abt report.
Some form submissions are missing an expected hidden value used to determine language, but we can use the domain in this case instead.

buddy @biyeun 