### PR TITLE
use product_type__isnull

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2698,7 +2698,7 @@ class CreditLine(ValidateModelMixin, models.Model):
     @classmethod
     def get_non_general_credits_by_subscription(cls, subscription):
         return cls.objects.filter(subscription=subscription).filter(
-            Q(product_type=SoftwareProductType.ANY) |
+            Q(product_type__isnull=False) |
             Q(feature_type__in=[f[0] for f in FeatureType.CHOICES])
         ).all()
 


### PR DESCRIPTION
One step forwards eliminating all usages of ```SoftwareProductType```

@emord 