### PR TITLE
Don't show new app builder modal in v1

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/v1/managed_app.html
@@ -12,7 +12,6 @@
     <script src="{% static 'hqwebapp/js/lib/history-1.7.1.js' %}"></script>
     <script src="{% static 'hqwebapp/js/lib/bootstrap-tab-history-custom.js' %}"></script>
     <script src="{% static 'app_manager/js/managed_app.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -90,16 +89,10 @@
             {% endif %}
         </li>
         {% endif %}
-        <li class="rollout-toggle-label">
+        <li>
             <a href="{% url "app_summary" domain app.id %}">
                 <i class="fa fa-list"></i>
                 {% trans "App Summary" %}
-            </a>
-        </li>
-        <li>
-            <a href="#" data-toggle="modal" data-target="#rollout-modal">
-                <i class="fa fa-bell-o"></i>
-                {% trans "New App Builder" %}
             </a>
         </li>
         <li class="divider"></li>
@@ -309,8 +302,4 @@
     {% initial_page_data 'app_subset' app_subset %}
     {% initial_page_data 'formdesigner' formdesigner %}
     {% block form-view %}{% endblock %}
-{% endblock %}
-
-{% block modals %}{{ block.super }}
-    {% include "hqwebapp/rollout_modal.html" %}
 {% endblock %}

--- a/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
+++ b/corehq/apps/app_manager/tests/data/v2_diffs/templates/managed_app.html.diff.txt
@@ -6,7 +6,7 @@
  {% load xforms_extras %}
  {% load url_extras %}
  {% load hq_shared_tags %}
-@@ -8,11 +8,14 @@
+@@ -8,10 +8,14 @@
  
  {% block js %}
      {{ block.super }}
@@ -16,12 +16,12 @@
      <script src="{% static 'hqwebapp/js/lib/history-1.7.1.js' %}"></script>
      <script src="{% static 'hqwebapp/js/lib/bootstrap-tab-history-custom.js' %}"></script>
      <script src="{% static 'app_manager/js/managed_app.js' %}"></script>
-     <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
++    <script src="{% static 'hqwebapp/js/rollout_modal.js' %}"></script>
 +    <script src="{% static 'app_manager/js/section_changer.js' %}"></script>
  {% endblock %}
  
  {% block breadcrumbs %}
-@@ -26,291 +29,170 @@
+@@ -25,281 +29,170 @@
  {% endblock %}
  
  {% block page_navigation %}
@@ -128,16 +128,10 @@
 -            {% endif %}
 -        </li>
 -        {% endif %}
--        <li class="rollout-toggle-label">
+-        <li>
 -            <a href="{% url "app_summary" domain app.id %}">
 -                <i class="fa fa-list"></i>
 -                {% trans "App Summary" %}
--            </a>
--        </li>
--        <li>
--            <a href="#" data-toggle="modal" data-target="#rollout-modal">
--                <i class="fa fa-bell-o"></i>
--                {% trans "New App Builder" %}
 -            </a>
 -        </li>
 -        <li class="divider"></li>
@@ -457,8 +451,7 @@
 +      </div>
 +    </script>
  {% endblock %}
- 
- {% block modals %}{{ block.super }}
--    {% include "hqwebapp/rollout_modal.html" %}
++
++{% block modals %}{{ block.super }}
 +    {% include "hqwebapp/rollout_revert_modal.html" %}
- {% endblock %}
++{% endblock %}


### PR DESCRIPTION
Minor followup for https://github.com/dimagi/commcare-hq/pull/17156 : if you've gone back to old app builder, don't show the modal that pushes you to turn on new app builder.

@snopoke / @biyeun 