### PR TITLE
use cache as session

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -154,7 +154,7 @@ MIDDLEWARE = [
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
 ]
 
-SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 # time in minutes before forced logout due to inactivity
 INACTIVITY_TIMEOUT = 60 * 24 * 14


### PR DESCRIPTION
buddy @orangejenny 

As a side effect we also need to provide formplayer with a way to do auth based on the session key. This PR also adds an admin view for getting the internal user ID from a session key.