### PR TITLE
Don't cache get_cases

### DIFF
--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -275,43 +275,6 @@ class CaseAPIMiscTests(TestCase):
         json = res_unsanitized.case_json
         self.assertEqual(json['properties']['case_type'], None)
 
-    def testGetCasesCaching(self):
-        _create_case(self.user, 'case_type_A', close=False, domain=self.domain)
-
-        self.client.login(username=self.user.username, password=self.password)
-        result = self.client.get(reverse('cloudcare_get_cases', args=[self.domain]), {
-            'ids_only': 'true',
-            'use_cache': 'true',
-        })
-        cases = json.loads(result.content)
-        self.assertEqual(result.status_code, 200)
-        self.assertEqual(len(cases), 1)
-
-        _create_case(self.user, 'case_type_A', close=False, domain=self.domain)
-
-        result = self.client.get(reverse('cloudcare_get_cases', args=[self.domain]), {
-            'ids_only': 'true',
-            'use_cache': 'true',
-        })
-        cases_cached = json.loads(result.content)
-        self.assertEqual(len(cases_cached), 1)
-
-        # Shouldn't cache when use_cache=false
-        result = self.client.get(reverse('cloudcare_get_cases', args=[self.domain]), {
-            'ids_only': 'true',
-            'use_cache': 'false',
-        })
-        cases_not_cached = json.loads(result.content)
-        self.assertEqual(len(cases_not_cached), 2)
-
-        # shouldn't cache when requesting full cases
-        full_result = self.client.get(reverse('cloudcare_get_cases', args=[self.domain]), {
-            'ids_only': 'false',
-            'use_cache': 'true',
-        })
-        full_cases = json.loads(full_result.content)
-        self.assertEqual(len(full_cases), 2)
-
 
 def _child_case_type(type):
     return "%s-child" % type

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -394,37 +394,7 @@ def form_context(request, domain, app_id, module_id, form_id):
 cloudcare_api = login_or_digest_ex(allow_cc_users=True)
 
 
-def get_cases_vary_on(request, domain):
-    request_params = request.GET
-
-    return [
-        request.couch_user.get_id
-        if request.couch_user.is_commcare_user() else request_params.get('user_id', ''),
-        request_params.get('ids_only', 'false'),
-        request_params.get('case_id', ''),
-        request_params.get('footprint', 'false'),
-        request_params.get('closed', 'false'),
-        json.dumps(get_filters_from_request_params(request_params)),
-        domain,
-    ]
-
-
-def get_cases_skip_arg(request, domain):
-    """
-    When this function returns True, quickcache will not go to the cache for the result. By default,
-    if neither of these params are passed into the function, nothing will be cached. Cache will always be
-    skipped if ids_only is false.
-
-    The caching is mainly a hack for touchforms to respond more quickly. Touchforms makes repeated requests to
-    get the list of case_ids associated with a user.
-    """
-    request_params = request.GET
-    return (not string_to_boolean(request_params.get('use_cache', 'false')) or
-        not string_to_boolean(request_params.get('ids_only', 'false')))
-
-
 @cloudcare_api
-@quickcache(get_cases_vary_on, get_cases_skip_arg, timeout=240 * 60)
 def get_cases(request, domain):
     request_params = request.GET
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?258790

The caching was causing an issue where newly-created cases were not showing up until the cache expired, making the sms surveys for those cases fail. Since I think this endpoint is not being used by formplayer anymore (@benrudolph correct me if I'm wrong), and since touchforms only calls out to hq once at the beginning of an smsforms session, I think we can just remove the caching all together.

cc @dannyroberts @millerdev 