### PR TITLE
Je/fix queueing time

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -210,7 +210,7 @@ def run_queue_async_indicators_task():
     queue_async_indicators.delay()
 
 
-@serial_task('queue-async-indicators', timeout=10 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
+@serial_task('queue-async-indicators', timeout=30 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
 def queue_async_indicators():
     oldest_indicator = AsyncIndicator.objects.order_by('date_queued').first()
     if oldest_indicator and oldest_indicator.date_queued:

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -210,7 +210,7 @@ def compare_ucr_dbs(domain, report_config_id, filter_values, sort_column=None, s
 )
 def queue_async_indicators():
     start = datetime.utcnow()
-    cutoff = start + ASYNC_INDICATOR_QUEUE_TIME
+    cutoff = start + ASYNC_INDICATOR_QUEUE_TIME - timedelta(seconds=60)
     time_for_crit_section = ASYNC_INDICATOR_QUEUE_TIME.seconds - 10
 
     oldest_indicator = AsyncIndicator.objects.order_by('date_queued').first()

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -36,6 +36,7 @@ from corehq.apps.userreports.util import get_indicator_adapter, get_async_indica
 from corehq.elastic import ESError
 from corehq.util.context_managers import notify_someone
 from corehq.util.datadog.gauges import datadog_gauge, datadog_histogram
+from corehq.util.decorators import serial_task
 from corehq.util.quickcache import quickcache
 from corehq.util.timer import TimingContext
 from dimagi.utils.couch import CriticalSection
@@ -204,37 +205,31 @@ def compare_ucr_dbs(domain, report_config_id, filter_values, sort_column=None, s
     return objects
 
 
-@periodic_task(
-    run_every=crontab(minute="*/5"),
-    queue=settings.CELERY_PERIODIC_QUEUE,
-)
-def queue_async_indicators():
-    start = datetime.utcnow()
-    cutoff = start + ASYNC_INDICATOR_QUEUE_TIME - timedelta(seconds=60)
-    time_for_crit_section = ASYNC_INDICATOR_QUEUE_TIME.seconds - 10
+@periodic_task(run_every=crontab(minute="*/5"), queue=settings.CELERY_PERIODIC_QUEUE)
+def run_queue_async_indicators_task():
+    queue_async_indicators.delay()
 
+
+@serial_task('queue-async-indicators', timeout=10 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
+def queue_async_indicators():
     oldest_indicator = AsyncIndicator.objects.order_by('date_queued').first()
     if oldest_indicator and oldest_indicator.date_queued:
         lag = (datetime.utcnow() - oldest_indicator.date_queued).total_seconds()
         datadog_gauge('commcare.async_indicator.oldest_queued_indicator', lag)
 
-    with CriticalSection(['queue-async-indicators'], timeout=time_for_crit_section):
-        day_ago = datetime.utcnow() - timedelta(days=1)
-        indicators = AsyncIndicator.objects.all()[:settings.ASYNC_INDICATORS_TO_QUEUE]
-        if indicators:
-            lag = (datetime.utcnow() - indicators[0].date_created).total_seconds()
-            datadog_gauge('commcare.async_indicator.oldest_created_indicator', lag)
-        indicators_by_domain_doc_type = defaultdict(list)
-        for indicator in indicators:
-            # don't requeue anything htat's be queued in the past day
-            if not indicator.date_queued or indicator.date_queued < day_ago:
-                indicators_by_domain_doc_type[(indicator.domain, indicator.doc_type)].append(indicator)
+    day_ago = datetime.utcnow() - timedelta(days=1)
+    indicators = AsyncIndicator.objects.all()[:settings.ASYNC_INDICATORS_TO_QUEUE]
+    if indicators:
+        lag = (datetime.utcnow() - indicators[0].date_created).total_seconds()
+        datadog_gauge('commcare.async_indicator.oldest_created_indicator', lag)
+    indicators_by_domain_doc_type = defaultdict(list)
+    for indicator in indicators:
+        # don't requeue anything that's be queued in the past day
+        if not indicator.date_queued or indicator.date_queued < day_ago:
+            indicators_by_domain_doc_type[(indicator.domain, indicator.doc_type)].append(indicator)
 
-        for k, indicators in indicators_by_domain_doc_type.items():
-            now = datetime.utcnow()
-            if now > cutoff:
-                break
-            _queue_indicators(indicators)
+    for k, indicators in indicators_by_domain_doc_type.items():
+        _queue_indicators(indicators)
 
 
 def _queue_indicators(indicators):


### PR DESCRIPTION
The lock expires in 4 minutes and 50 seconds, but the cutoff has always been 5 minutes. That means there could be  10 seconds of overlap in the queueing which is why I think we've been getting errors like https://sentry.io/dimagi/commcarehq/issues/309028178/

@gcapalbo I changed this to using serial_task. I think that's the preferred way we use to not have tasks step on each other right?