### PR TITLE
set expires to 60s for latest queries

### DIFF
--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -61,7 +61,9 @@ def safe_cached_download(f):
         try:
             request.app = get_app(domain, app_id, latest=latest, target=target)
             response = f(request, *args, **kwargs)
-            if not latest and request.app.copy_of is not None and request.app.is_released:
+            if request.app.copy_of is not None and request.app.is_released:
+                if latest:
+                    response._cache_max_age = 60
                 response._always_allow_browser_caching = True
                 response._remember_domain = False
             return response

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -154,8 +154,9 @@ class NoCacheMiddleware(MiddlewareMixin):
             response['Expires'] = "Thu, 01 Dec 1994 16:00:00 GMT"
             response['Pragma'] = "no-cache"
         else:
+            max_age = getattr(response, '_cache_max_age', "31536000")
             content_type, _ = mimetypes.guess_type(request.path)
-            response['Cache-Control'] = "max-age=31536000"
+            response['Cache-Control'] = "max-age={}".format(max_age)
             del response['Vary']
             del response['Set-Cookie']
             response['Content-Type'] = content_type


### PR DESCRIPTION
looking at the logs we were still getting nailed by queries for `media_profile.ccpr?latest=true`

Allowing that to be cached for 60s. I've patched this to NIC for now and it's working well. Might not be OK for general use though.... will have to think it through some more.