### PR TITLE
Add index schema to products fixture

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -6,6 +6,8 @@ from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.products.fixtures import product_fixture_generator_json
 from corehq.apps.programs.fixtures import program_fixture_generator_json
 
+from .utils import get_index_schema_node
+
 
 def item_lists_by_domain(domain):
     ret = list()
@@ -96,16 +98,9 @@ class ItemListsProvider(FixtureProvider):
         return fixture_element
 
     def _get_schema_element(self, data_type):
-        schema_element = ElementTree.Element(
-            'schema',
-            attrib={'id': ':'.join((self.id, data_type.tag))}
-        )
-        indices_element = ElementTree.SubElement(schema_element, 'indices')
-        for field in data_type.fields:
-            if field.is_indexed:
-                index_element = ElementTree.SubElement(indices_element, 'index')
-                index_element.text = field.field_name
-        return schema_element
+        attrs_to_index = [field.field_name for field in data_type.fields if field.is_indexed]
+        fixture_id = ':'.join((self.id, data_type.tag))
+        return get_index_schema_node(fixture_id, attrs_to_index)
 
 
 item_lists = ItemListsProvider()

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -39,3 +39,17 @@ def get_fields_without_attributes(fields):
     for fixture_field in fields:
         fields_without_attributes.append(fixture_field.field_name)
     return fields_without_attributes
+
+
+def get_index_schema_node(fixture_id, attrs_to_index):
+    """
+    Assemble a schema node to tell mobile how to index a fixture.
+    """
+    indices_node = ElementTree.Element('indices')
+    for index_attr in sorted(attrs_to_index):  # sorted only for tests
+        element = ElementTree.Element('index')
+        element.text = index_attr
+        indices_node.append(element)
+    node = ElementTree.Element('schema', {'id': fixture_id})
+    node.append(indices_node)
+    return node

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -17,7 +17,7 @@ from casexml.apps.case.fixtures import CaseDBFixture
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.xml import V2
 from corehq import toggles, privileges
-from corehq.const import OPENROSA_VERSION_MAP, OPENROSA_DEFAULT_VERSION
+from corehq.const import OPENROSA_VERSION_MAP
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.case_search.models import QueryMergeException
@@ -199,7 +199,7 @@ def get_restore_params(request):
         openrosa_headers = getattr(request, 'openrosa_headers', {})
         openrosa_version = openrosa_headers[OPENROSA_VERSION_HEADER]
     except KeyError:
-        openrosa_version = request.GET.get('openrosa_version', OPENROSA_DEFAULT_VERSION)
+        openrosa_version = request.GET.get('openrosa_version', None)
 
     return {
         'since': request.GET.get('since'),
@@ -220,7 +220,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
                          cache_timeout=None, overwrite_cache=False,
                          force_restore_mode=None,
                          as_user=None, device_id=None, user_id=None,
-                         openrosa_version=OPENROSA_DEFAULT_VERSION,
+                         openrosa_version=None,
                          case_sync=None):
 
     if user_id and user_id != couch_user.user_id:
@@ -260,8 +260,9 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     project = Domain.get_by_name(domain)
     app = get_app(domain, app_id) if app_id else None
     async_restore_enabled = (
-        toggles.ASYNC_RESTORE.enabled(domain) and
-        LooseVersion(openrosa_version) >= LooseVersion(OPENROSA_VERSION_MAP['ASYNC_RESTORE'])
+        toggles.ASYNC_RESTORE.enabled(domain)
+        and openrosa_version
+        and LooseVersion(openrosa_version) >= LooseVersion(OPENROSA_VERSION_MAP['ASYNC_RESTORE'])
     )
     restore_config = RestoreConfig(
         project=project,
@@ -273,6 +274,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
             include_item_count=items,
             app=app,
             device_id=device_id,
+            openrosa_version=openrosa_version,
         ),
         cache_settings=RestoreCacheSettings(
             force_cache=force_cache or async_restore_enabled,

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -1,6 +1,7 @@
 from casexml.apps.phone.fixtures import FixtureProvider
 from corehq.apps.products.models import Product
 from corehq.apps.commtrack.fixtures import simple_fixture_generator
+from corehq.apps.fixtures.utils import get_index_schema_node
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.custom_data_fields.dbaccessors import get_by_domain_and_type
 
@@ -52,8 +53,14 @@ class ProductFixturesProvider(FixtureProvider):
                 key=lambda product: product.code
             )
 
-        return simple_fixture_generator(
+        fixture_nodes = simple_fixture_generator(
             restore_user, self.id, "product", PRODUCT_FIELDS, get_products, restore_state.last_sync_log
         )
+        if not fixture_nodes:
+            return []
+
+        schema_node = get_index_schema_node(self.id, ['@id', 'code', 'program_id', 'category'])
+        fixture_nodes[0].attrib['indexed'] = 'true'
+        return [schema_node] + fixture_nodes
 
 product_fixture_generator = ProductFixturesProvider()

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -1,4 +1,5 @@
 from casexml.apps.phone.fixtures import FixtureProvider
+from corehq.const import OPENROSA_VERSION_MAP
 from corehq.apps.products.models import Product
 from corehq.apps.commtrack.fixtures import simple_fixture_generator
 from corehq.apps.fixtures.utils import get_index_schema_node
@@ -59,7 +60,8 @@ class ProductFixturesProvider(FixtureProvider):
         if not fixture_nodes:
             return []
 
-        if restore_state.params.openrosa_version and restore_state.params.openrosa_version < '2.1':
+        if (restore_state.params.openrosa_version
+                and restore_state.params.openrosa_version < OPENROSA_VERSION_MAP['INDEXED_PRODUCTS_FIXTURE']):
             # Don't include index schema when openrosa version is specified and below 2.1
             return fixture_nodes
         else:

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -59,8 +59,13 @@ class ProductFixturesProvider(FixtureProvider):
         if not fixture_nodes:
             return []
 
-        schema_node = get_index_schema_node(self.id, ['@id', 'code', 'program_id', 'category'])
-        fixture_nodes[0].attrib['indexed'] = 'true'
-        return [schema_node] + fixture_nodes
+        if restore_state.params.openrosa_version and restore_state.params.openrosa_version < '2.1':
+            # Don't include index schema when openrosa version is specified and below 2.1
+            return fixture_nodes
+        else:
+            schema_node = get_index_schema_node(self.id, ['@id', 'code', 'program_id', 'category'])
+            fixture_nodes[0].attrib['indexed'] = 'true'
+            return [schema_node] + fixture_nodes
+
 
 product_fixture_generator = ProductFixturesProvider()

--- a/corehq/const.py
+++ b/corehq/const.py
@@ -14,9 +14,12 @@ MISSING_APP_ID = '_MISSING_APP_ID'
 
 OPENROSA_VERSION_1 = "1.0"
 OPENROSA_VERSION_2 = "2.0"
+OPENROSA_VERSION_2_1 = "2.1"
 OPENROSA_DEFAULT_VERSION = OPENROSA_VERSION_1
 OPENROSA_VERSION_MAP = {
     'ASYNC_RESTORE': OPENROSA_VERSION_2,
+    # Indexed fixture also applies when OR version not specified
+    'INDEXED_PRODUCTS_FIXTURE': OPENROSA_VERSION_2_1,
 }
 
 GOOGLE_PLAY_STORE_COMMCARE_URL = 'https://play.google.com/store/apps/details?id=org.commcare.dalvik&hl=en'

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -10,6 +10,7 @@ from cStringIO import StringIO
 from uuid import uuid4
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
+from distutils.version import LooseVersion
 
 from couchdbkit import ResourceNotFound
 from casexml.apps.phone.data_providers import get_element_providers, get_full_response_providers
@@ -410,13 +411,16 @@ class RestoreParams(object):
             state_hash='',
             include_item_count=False,
             device_id=None,
-            app=None):
+            app=None,
+            openrosa_version=None):
         self.sync_log_id = sync_log_id
         self.version = version
         self.state_hash = state_hash
         self.include_item_count = include_item_count
         self.app = app
         self.device_id = device_id
+        self.openrosa_version = (LooseVersion(openrosa_version)
+            if isinstance(openrosa_version, basestring) else openrosa_version)
 
     @property
     def app_id(self):


### PR DESCRIPTION
Add an index schema to the products fixture upon request from TDH Mali.  This should be a substantial speedup for any Supply projects with a large products list.

Here's a snapshot from a restore on my test domain with this change:

```xml
  <schema id="commtrack:products">
    <indices>
      <index>@id</index>
      <index>category</index>
      <index>code</index>
      <index>program_id</index>
    </indices>
  </schema>
  <fixture id="commtrack:products" indexed="true" user_id="858addfda49a77992d96ad64175733b8">
    <products>
      <product id="858addfda49a77992d96ad641775d2df">
        <name>milk</name>
        <unit/>
        <code>milk</code>
        <description/>
        <category/>
        <program_id>f92145f6b9a372f89599cb82a1bce97f</program_id>
        <cost/>
      </product>
    </products>
  </fixture>
```

@kaapstorm
@ctsims FYI