### PR TITLE
by_id returns None

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1103,8 +1103,10 @@ def quick_find(request):
             else:
                 doc = django_model.objects.get(pk=query)
         except django_model.DoesNotExist:
-            pass
+            continue
         else:
+            if doc is None:
+                continue
             domain = doc.domain
             return deal_with_doc(doc, domain, get_object_info)
 


### PR DESCRIPTION
@benrudolph https://github.com/dimagi/commcare-hq/pull/17189

by_id catches doesnotexist and returns none

@nickpell 