### PR TITLE
"livequery" sync log format

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -255,6 +255,7 @@ class SyncLogAssertionError(AssertionError):
 
 LOG_FORMAT_LEGACY = 'legacy'
 LOG_FORMAT_SIMPLIFIED = 'simplified'
+LOG_FORMAT_LIVEQUERY = 'livequery'
 
 
 class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
@@ -1160,6 +1161,10 @@ class SimplifiedSyncLog(AbstractSyncLog):
         """
         Migrate from the old SyncLog format to this one.
         """
+        if other_sync_log.log_format == LOG_FORMAT_LIVEQUERY:
+            raise IncompatibleSyncLogType('Unable to convert from {} to {}'.format(
+                other_sync_log.log_format, LOG_FORMAT_SIMPLIFIED
+            ))
         if isinstance(other_sync_log, SyncLog):
             previous_log_footprint = set(other_sync_log.get_footprint_of_cases_on_phone())
 
@@ -1233,6 +1238,7 @@ def get_sync_log_class_by_format(format):
     return {
         LOG_FORMAT_LEGACY: SyncLog,
         LOG_FORMAT_SIMPLIFIED: SimplifiedSyncLog,
+        LOG_FORMAT_LIVEQUERY: SimplifiedSyncLog,
     }.get(format, SyncLog)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -477,11 +477,15 @@ class RestoreState(object):
                 case_sync = DEFAULT_CASE_SYNC
         if case_sync not in [LIVEQUERY, CLEAN_OWNERS]:
             raise ValueError("unknown case sync algorithm: %s" % case_sync)
+        self._case_sync = case_sync
         self.is_livequery = case_sync == LIVEQUERY
 
     def validate_state(self):
         check_version(self.params.version)
         if self.last_sync_log:
+            if (self._case_sync == CLEAN_OWNERS and
+                    self.last_sync_log.log_format == LOG_FORMAT_LIVEQUERY):
+                raise RestoreException("clean_owners sync after livequery sync")
             if self.params.state_hash:
                 parsed_hash = CaseStateHash.parse(self.params.state_hash)
                 computed_hash = self.last_sync_log.get_state_hash()

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -24,10 +24,11 @@ from corehq.util.datadog.gauges import datadog_counter
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.phone.models import (
-    SyncLog,
     get_properly_wrapped_sync_log,
+    LOG_FORMAT_LIVEQUERY,
     OTARestoreUser,
     SimplifiedSyncLog,
+    SyncLog,
 )
 from dimagi.utils.couch.database import get_db
 from casexml.apps.phone import xml as xml_util
@@ -599,6 +600,8 @@ class RestoreState(object):
             previous_log_rev=previous_log_rev,
             extensions_checked=True,
         )
+        if self.is_livequery:
+            new_synclog.log_format = LOG_FORMAT_LIVEQUERY
         return new_synclog
 
     @property

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -5,8 +5,14 @@ from jsonobject import JsonObject
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.phone.exceptions import IncompatibleSyncLogType
-from casexml.apps.phone.models import SyncLog, SimplifiedSyncLog, LOG_FORMAT_SIMPLIFIED, LOG_FORMAT_LEGACY, \
-    CaseState
+from casexml.apps.phone.models import (
+    CaseState,
+    LOG_FORMAT_LEGACY,
+    LOG_FORMAT_LIVEQUERY,
+    LOG_FORMAT_SIMPLIFIED,
+    SimplifiedSyncLog,
+    SyncLog,
+)
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_from_restore_payload, create_restore_user
 from corehq.apps.domain.models import Domain
@@ -124,6 +130,16 @@ class TestSyncLogMigration(SimpleTestCase):
     def test_migrate_backwards(self):
         with self.assertRaises(IncompatibleSyncLogType):
             SyncLog.from_other_format(SimplifiedSyncLog())
+
+    def test_livequery_to_legacy(self):
+        sync_log = SimplifiedSyncLog(log_format=LOG_FORMAT_LIVEQUERY)
+        with self.assertRaises(IncompatibleSyncLogType):
+            SyncLog.from_other_format(sync_log)
+
+    def test_livequery_to_simplified(self):
+        sync_log = SimplifiedSyncLog(log_format=LOG_FORMAT_LIVEQUERY)
+        with self.assertRaises(IncompatibleSyncLogType):
+            SimplifiedSyncLog.from_other_format(sync_log)
 
 
 class TestNewSyncSpecifics(TestCase):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -31,8 +31,14 @@ from casexml.apps.case.tests.util import (
     assert_user_has_case, TEST_DOMAIN_NAME, assert_user_has_cases,
     check_payload_has_case_ids, assert_user_doesnt_have_cases)
 from casexml.apps.phone.tests.utils import create_restore_user, has_cached_payload
-from casexml.apps.phone.models import SyncLog, get_properly_wrapped_sync_log, SimplifiedSyncLog, \
-    AbstractSyncLog
+from casexml.apps.phone.models import (
+    AbstractSyncLog,
+    get_properly_wrapped_sync_log,
+    LOG_FORMAT_LIVEQUERY,
+    LOG_FORMAT_SIMPLIFIED,
+    SimplifiedSyncLog,
+    SyncLog,
+)
 from casexml.apps.phone.restore import (
     CachedResponse,
     CLEAN_OWNERS,
@@ -144,7 +150,10 @@ class SyncBaseTest(TestCase):
             all_ids.update(dependent_case_id_map)
             self.assertEqual(set(all_ids), sync_log.case_ids_on_phone)
             # livequery sync does not use or populate sync_log.index_tree
-            if self.restore_options['case_sync'] != LIVEQUERY:
+            if self.restore_options['case_sync'] == LIVEQUERY:
+                self.assertEqual(sync_log.log_format, LOG_FORMAT_LIVEQUERY)
+            else:
+                self.assertEqual(sync_log.log_format, LOG_FORMAT_SIMPLIFIED)
                 self.assertEqual(set(dependent_case_id_map.keys()), sync_log.dependent_case_ids_on_phone)
                 for case_id, indices in case_id_map.items():
                     if indices:


### PR DESCRIPTION
@ctsims: sets the sync log format to "livequery" when using that algorithm. Also 412 on clean_owners sync after livequery sync.

@proteusvacuum @dannyroberts cc @gcapalbo 