### PR TITLE
Remove laboratory from ICDS reports.

### DIFF
--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -1750,10 +1750,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["supervisor_id", "edd"]},
       {"column_ids": ["awc_id", "owner_id"]}

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly.json
@@ -2986,10 +2986,6 @@
     },
     "asynchronous": true,
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "month"]},
       {"column_ids": ["supervisor_id", "month"]}

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau.json
@@ -2033,10 +2033,6 @@
       }
     },
     "asynchronous": true,
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -2441,10 +2441,6 @@
       }
     },
     "asynchronous": true,
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 4
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
@@ -2581,10 +2581,6 @@
     },
     "asynchronous": true,
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {
         "column_ids": ["awc_id", "month"]

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly.json
@@ -3453,10 +3453,6 @@
     },
     "asynchronous": true,
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "month"]},
       {"column_ids": ["district_id", "month"]},

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
@@ -3195,10 +3195,6 @@
     },
     "asynchronous": true,
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {
         "column_ids": ["awc_id", "month"]

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -1495,10 +1495,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "date_death"]},
       {"column_ids": ["awc_id", "dob"]},

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau.json
@@ -2750,10 +2750,6 @@
       }
     },
     "asynchronous": true,
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -3654,10 +3654,6 @@
       }
     },
     "asynchronous": true,
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 4
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -1041,10 +1041,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "submitted_on"]}
     ]

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -633,10 +633,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "last_date_gmp"]},
       {"column_ids": ["supervisor_id", "last_date_gmp"]}

--- a/custom/icds_reports/ucr/data_sources/home_visit_forms.json
+++ b/custom/icds_reports/ucr/data_sources/home_visit_forms.json
@@ -178,10 +178,6 @@
     "named_expressions": {},
     "named_filters": {},
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["supervisor_id", "submitted_on"]}
     ]

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -177,10 +177,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {
         "column_ids": [

--- a/custom/icds_reports/ucr/data_sources/person_cases.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases.json
@@ -2549,10 +2549,6 @@
       }
     },
     "asynchronous": true,
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }

--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2686,10 +2686,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 8
-    },
     "sql_column_indexes": [
       {
         "column_ids": [

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -333,10 +333,6 @@
       }
     },
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["awc_id", "date_turns_one_yr"]},
       {"column_ids": ["supervisor_id", "dob"]}

--- a/custom/icds_reports/ucr/data_sources/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms.json
@@ -122,10 +122,6 @@
     "named_expressions": {},
     "named_filters": {},
     "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    },
     "sql_column_indexes": [
       {"column_ids": ["supervisor_id", "submitted_on"]}
     ]

--- a/custom/icds_reports/ucr/data_sources/usage_forms.json
+++ b/custom/icds_reports/ucr/data_sources/usage_forms.json
@@ -919,10 +919,6 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr",
-    "backend_id": "LABORATORY",
-    "es_index_settings": {
-      "number_of_shards": 5
-    }
+    "engine_id": "icds-ucr"
   }
 }


### PR DESCRIPTION
@dimagi/scale-team This would remove the laboratory backend from the ICDS reports. I think we might not be close to having a stable ES cluster, so it might be worth taking this off. Thoughts?