### PR TITLE
improve Data Preview Evaluate XPath formatting

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -198,7 +198,15 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
         self.$xpath = null;
         self.codeMirrorResult = null;
         self.result = ko.observable('');
-        self.success = ko.observable(true);
+        self.success = ko.observable();
+        var resultRegex = new RegExp(
+            '^<[?]xml version="1.0" encoding="UTF-8"[?]>\\s*<result>([\\s\\S]*?)\\s*</result>\\s*|' +
+            '^<[?]xml version="1.0" encoding="UTF-8"[?]>\\s*<result/>()\\s*$');
+
+        self.formatResult = function (output) {
+            return output.replace(resultRegex, "$1");
+        };
+
         self.onSubmitXPath = function() {
             self.evaluate(self.xpath());
         };
@@ -264,7 +272,7 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
         };
 
         self.result.subscribe(function(newResult) {
-            self.codeMirrorResult.setValue(newResult);
+            self.codeMirrorResult.setValue(self.formatResult(newResult));
         });
 
         self.isSuccess = function(query) {

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -100,6 +100,7 @@
                   name="xpath"
                   placeholder="XPath Expression"
                   autocomplete="off"
+                  spellcheck=false
                   data-bind="value: xpath, event: { mouseup: onMouseUp }" ></textarea>
           </div>
           </div>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -114,6 +114,9 @@
           </div>
           </div>
           <div class="col-sm-12">
+              <!--ko if: success() && formatResult(result()) === ''-->
+              <div><i>{% trans "Empty String" %}</i></div>
+              <!--/ko-->
               <textarea
                   id="evaluate-result"
                   type="text"
@@ -146,7 +149,10 @@
                 <span data-bind="text: xpath"></span>
               </td>
               <td class="col-sm-3">
-                <span data-bind="text: output"></span>
+                <!--ko if: $parent.isSuccess($data) && $parent.formatResult(output) === ''-->
+                <div><i>{% trans "Empty String" %}</i></div>
+                <!--/ko-->
+                <span data-bind="text: $parent.formatResult(output)"></span>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
- remove always-same XML heading and <result/> wrapping tag in display
- display "Empty String" (not monospaced) for an empty string

Here's how it looks now:

XML node:
<img width="426" alt="screen shot 2017-07-31 at 12 31 27 pm" src="https://user-images.githubusercontent.com/137212/28788081-f33bcdf8-75ec-11e7-9f14-0a7962a6a286.png">
Single value:
<img width="412" alt="screen shot 2017-07-31 at 12 31 40 pm" src="https://user-images.githubusercontent.com/137212/28788086-f9d7dc60-75ec-11e7-9a17-a9aada8b7775.png">
Empty string:
<img width="333" alt="screen shot 2017-07-31 at 12 31 50 pm" src="https://user-images.githubusercontent.com/137212/28788093-fd663c96-75ec-11e7-9132-b34bafea3aac.png">

And in the history:
<img width="1424" alt="screen shot 2017-07-31 at 12 31 56 pm" src="https://user-images.githubusercontent.com/137212/28788097-0162f8f2-75ed-11e7-8bfd-60fc79650dbb.png">
