### PR TITLE
Fr/retrigger nikshay

### DIFF
--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -216,7 +216,7 @@ class NikshayRegisterPrivatePatientRepeater(SOAPRepeaterMixin, BaseNikshayRepeat
 
         episode_case_properties = episode_case.dynamic_case_properties()
         return (
-            episode_case_properties.get('nikshay_registered', 'false') == 'false' and
+            episode_case_properties.get('private_nikshay_registered', 'false') == 'false' and
             not episode_case_properties.get('nikshay_id') and
             case_properties_changed(episode_case, [PRIVATE_PATIENT_EPISODE_PENDING_REGISTRATION]) and
             episode_case_properties.get(PRIVATE_PATIENT_EPISODE_PENDING_REGISTRATION, 'yes') == 'no' and

--- a/custom/enikshay/management/commands/retrigger_private_nikshay_records.py
+++ b/custom/enikshay/management/commands/retrigger_private_nikshay_records.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from corehq.util.log import with_progress_bar
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.exceptions import CaseNotFound
+from corehq.motech.repeaters.models import Repeater, RepeatRecord
+from corehq.motech.repeaters.dbaccessors import iter_repeat_records_by_domain, get_repeat_record_count
+from custom.enikshay.integrations.utils import is_valid_episode_submission
+
+domain = 'enikshay'
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('old_repeater_id')
+        parser.add_argument('new_repeater_id')
+
+    def handle(self, old_repeater_id, new_repeater_id, **options):
+        new_repeater = Repeater.get(new_repeater_id)
+
+        records = iter_repeat_records_by_domain(domain, repeater_id=old_repeater_id)
+        record_count = get_repeat_record_count(domain, repeater_id=old_repeater_id)
+        accessor = CaseAccessors(domain)
+
+        for record in with_progress_bar(records, length=record_count):
+
+            try:
+                episode = accessor.get_case(record.payload_id)
+            except CaseNotFound:
+                continue
+
+            episode_case_properties = episode.dynamic_case_properties()
+            if(episode_case_properties.get('nikshay_registered', 'false') == 'false'
+               and not episode_case_properties.get('nikshay_id')
+               and episode_case_properties.get('episode_type') == 'confirmed_tb'
+               and is_valid_episode_submission(episode)):
+
+                new_record = RepeatRecord(
+                    domain=domain,
+                    next_check=datetime.utcnow(),
+                    repeater_id=new_repeater_id,
+                    repeater_type=new_repeater.doc_type,
+                    payload_id=record.payload_id,
+                )
+                new_record.save()

--- a/custom/enikshay/management/commands/retrigger_private_nikshay_records.py
+++ b/custom/enikshay/management/commands/retrigger_private_nikshay_records.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
                 continue
 
             episode_case_properties = episode.dynamic_case_properties()
-            if(episode_case_properties.get('nikshay_registered', 'false') == 'false'
+            if(episode_case_properties.get('private_nikshay_registered', 'false') == 'false'
                and not episode_case_properties.get('nikshay_id')
                and episode_case_properties.get('episode_type') == 'confirmed_tb'
                and is_valid_episode_submission(episode)):

--- a/custom/enikshay/management/commands/retrigger_private_nikshay_records.py
+++ b/custom/enikshay/management/commands/retrigger_private_nikshay_records.py
@@ -31,7 +31,8 @@ class Command(BaseCommand):
                 continue
 
             episode_case_properties = episode.dynamic_case_properties()
-            if(episode_case_properties.get('private_nikshay_registered', 'false') == 'false'
+            if(episode_case_properties.get('nikshay_registered', 'false') == 'false'
+               and episode_case_properties.get('private_nikshay_registered', 'false') == 'false'
                and not episode_case_properties.get('nikshay_id')
                and episode_case_properties.get('episode_type') == 'confirmed_tb'
                and is_valid_episode_submission(episode)):


### PR DESCRIPTION
@esoergel @mkangia 

This will take all the current repeat records in the private sector Nikshay repeater and create new records for them in a _new_ repeater of the same type (that will be made before running this command)

The reason for this:
- We triggered a lot of the migrated cases accidentally, so we have like 100,000 records that shouldn't be there
- All of the cases failed their initial sending to Nikshay because we didn't have the TU ids

cc @benrudolph 