### PR TITLE
Analyze all case exports

### DIFF
--- a/corehq/apps/export/README.md
+++ b/corehq/apps/export/README.md
@@ -139,4 +139,3 @@ This is because when parsing the export 83b6fbfadc1fe0a43bc084fadb456a3f, it cou
 ### Caveats and edge cases
 
 - Unknown deleted questions: It is possible to have an export where there lists properties that do not have any data associated with them. This case can arise when adding a question, `q1`, to the current application (without making a build), opening an export (to kick off the processing of the current application), then deleting `q1` before making a build. `q1` will now always be in the schema but will be shown as deleted.
-- Case changes not immediately updated: When opening a case export, only the application that was chosen for the case type will be processed for the _current_ version. This means that if there exists another application that differs from the previous saved build and uses the same case type as another application, those updates will not show up until a build is made.

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1984,9 +1984,8 @@ class CreateNewCustomCaseExportView(BaseModifyNewCustomView):
 
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
-        app_id = request.GET.get('app_id')
 
-        schema = self.get_export_schema(self.domain, app_id, case_type)
+        schema = self.get_export_schema(self.domain, None, case_type)
         self.export_instance = self.create_new_export_instance(schema)
 
         return super(CreateNewCustomCaseExportView, self).get(request, *args, **kwargs)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?259213 - explanation in there, but in essence this ensures we analyze the latest app for every app in the domain instead of just the one selected. this was exports with the same case_type will be the same no matter which application you choose in the dropdown (means at some point we can remove the Application from the dropdown altogether, however that takes a bit more work)

@emord cc: @proteusvacuum 