### PR TITLE
Remove app id requirement

### DIFF
--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -11,10 +11,11 @@ from corehq.toggles import EXPORT_NO_SORT
 def get_form_export_base_query(domain, app_id, xmlns, include_errors):
     query = (FormES(es_instance_alias=ES_EXPORT_INSTANCE)
             .domain(domain)
-            .app(app_id)
             .xmlns(xmlns)
             .remove_default_filter('has_user'))
 
+    if app_id:
+        query = query.app(app_id)
     if not EXPORT_NO_SORT.enabled(domain):
         query = query.sort("received_on")
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1554,7 +1554,7 @@ class FormExportDataSchema(ExportDataSchema):
     @classmethod
     def _get_current_app_ids_for_domain(cls, domain, app_id):
         if not app_id:
-            raise BadExportConfiguration('Must include app id for form data schemas')
+            return []
         return [app_id]
 
     @staticmethod

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -355,7 +355,7 @@ def _create_user_defined_column(old_column, column_path, transform):
 def _app_id_from_xmlns(domain, xmlns):
     apps = get_apps_in_domain(domain)
     for app in apps:
-        if xmlns in app.get_xmlns_map():
+        if hasattr(app, 'get_xmlns_map') and xmlns in app.get_xmlns_map():
             return app._id
     return None
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -90,8 +90,6 @@ def convert_saved_export_to_export_instance(
         else:
             app_id = saved_export.app_id
 
-        assert app_id, 'Form exports require an app id'
-
         instance_cls = FormExportInstance
         schema = FormExportDataSchema.generate_schema_from_builds(
             domain,


### PR DESCRIPTION
@NoahCarnahan this remove the `app_id` constraint from the form export. Makes me sad, but this is the only way we'll be able to move forward with the migrations. I think once this is in, we'll at last be able to finish the export migration

cc: @proteusvacuum 