### PR TITLE
Refactor xpath debugger ko

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -212,7 +212,7 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
                 },
                 success: function () {
                     return this.status === 'accepted';
-                }
+                },
             };
         };
         self.xPathQuery = ko.observable(null);
@@ -391,7 +391,7 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
 
     ko.bindingHandlers.codeMirror = {
         /* copied and edited from https://stackoverflow.com/a/33966345/240553 */
-        init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        init: function(element, valueAccessor) {
             var options = {
                 mode: 'xml',
                 viewportMargin: Infinity,
@@ -402,12 +402,12 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
             editor.setSize(null, 200);  // hard-coded right now;
             element.editor = editor;
         },
-        update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        update: function(element, valueAccessor) {
             var observedValue = ko.unwrap(valueAccessor());
             if (element.editor) {
                 element.editor.setValue(observedValue);
             }
-        }
+        },
     };
 
     return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -200,11 +200,13 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
                 status: data.status,
                 output: data.output,
                 xpath: data.xpath,
-                formattedResult: function () {
-                    var result;
+                successResult: function () {
                     if (this.success()) {
                         return self.formatResult(data.output);
-                    } else {
+                    }
+                },
+                errorResult: function () {
+                    if (!this.success()) {
                         return data.output || gettext('Error evaluating expression.');
                     }
                 },
@@ -213,7 +215,7 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
                 }
             };
         };
-        self.xPathQuery = ko.observable(self.newXPathQuery({}));
+        self.xPathQuery = ko.observable(null);
         self.recentXPathQueries = ko.observableArray();
         self.setRecentXPathQueries = function (rawQueries) {
             self.recentXPathQueries(_.map(rawQueries, self.newXPathQuery));

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -200,18 +200,16 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
                 status: data.status,
                 output: data.output,
                 xpath: data.xpath,
-                result: function () {
+                formattedResult: function () {
+                    var result;
                     if (this.success()) {
-                        return data.output;
+                        return self.formatResult(data.output);
                     } else {
                         return data.output || gettext('Error evaluating expression.');
                     }
                 },
-                formattedResult: function () {
-                    return self.formatResult(this.result());
-                },
                 success: function () {
-                    return self.isSuccess(this);
+                    return this.status === 'accepted';
                 }
             };
         };
@@ -277,10 +275,6 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
                 );
             });
             window.analytics.workflow('[app-preview] User evaluated XPath');
-        };
-
-        self.isSuccess = function(query) {
-            return query.status === 'accepted';
         };
 
         self.onMouseUp = function() {

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -222,7 +222,7 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
         };
 
         var resultRegex = new RegExp(
-            '^<[?]xml version="1.0" encoding="UTF-8"[?]>\\s*<result>([\\s\\S]*?)\\s*</result>\\s*|' +
+            '^<[?]xml version="1.0" encoding="UTF-8"[?]>\\s*<result>\n*([\\s\\S]*?)\\s*</result>\\s*|' +
             '^<[?]xml version="1.0" encoding="UTF-8"[?]>\\s*<result/>()\\s*$');
 
         self.formatResult = function (output) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -389,26 +389,28 @@ hqDefine('cloudcare/js/debugger/debugger.js', function () {
         },
     };
 
-    ko.bindingHandlers.codeMirror = {
-        /* copied and edited from https://stackoverflow.com/a/33966345/240553 */
-        init: function(element, valueAccessor) {
-            var options = {
-                mode: 'xml',
-                viewportMargin: Infinity,
-                readOnly: true,
-            };
-            options.value = ko.unwrap(valueAccessor());
-            var editor = CodeMirror.fromTextArea(element, options);
-            editor.setSize(null, 200);  // hard-coded right now;
-            element.editor = editor;
-        },
-        update: function(element, valueAccessor) {
-            var observedValue = ko.unwrap(valueAccessor());
-            if (element.editor) {
-                element.editor.setValue(observedValue);
-            }
-        },
-    };
+    _.delay(function  () {
+        ko.bindingHandlers.codeMirror = {
+            /* copied and edited from https://stackoverflow.com/a/33966345/240553 */
+            init: function(element, valueAccessor) {
+                var options = {
+                    mode: 'xml',
+                    viewportMargin: Infinity,
+                    readOnly: true,
+                };
+                options.value = ko.unwrap(valueAccessor());
+                var editor = CodeMirror.fromTextArea(element, options);
+                editor.setSize(null, 200);  // hard-coded right now;
+                element.editor = editor;
+            },
+            update: function(element, valueAccessor) {
+                var observedValue = ko.unwrap(valueAccessor());
+                if (element.editor) {
+                    element.editor.setValue(observedValue);
+                }
+            },
+        };
+    });
 
     return {
         CloudCareDebuggerFormEntry: CloudCareDebuggerFormEntry,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/debugger_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/debugger_spec.js
@@ -62,5 +62,26 @@ describe('Debugger', function() {
         });
 
     });
-});
 
+    describe('Format Result', function () {
+        var evalXPath = new EvaluateXPath();
+        it('Should handle single values correctly', function () {
+            assert.equal(
+                evalXPath.formatResult("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result>fun</result>\n"),
+                'fun'
+            );
+        });
+        it('Should handle the empty string value correctly', function () {
+            assert.equal(
+                evalXPath.formatResult("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result/>\n"),
+                ''
+            );
+        });
+        it('Should handle nested xml correctly', function () {
+            assert.equal(
+                evalXPath.formatResult("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result>\n  <session>\n    <data/>\n    <context>\n      <deviceid>Formplayer</deviceid>\n      <appversion>Formplayer Version: 2.36</appversion>\n      <username>droberts@dimagi.com</username>\n      <userid>9393007a6921eecd4a9f20eefb5c7a8e</userid>\n    </context>\n    <user>\n      <data>\n        <commcare_first_name/>\n        <commcare_phone_number/>\n        <commcare_last_name/>\n        <commcare_project>openmrs-test</commcare_project>\n        <user_type>standard</user_type>\n      </data>\n    </user>\n  </session>\n</result>\n"),
+                '  <session>\n    <data/>\n    <context>\n      <deviceid>Formplayer</deviceid>\n      <appversion>Formplayer Version: 2.36</appversion>\n      <username>droberts@dimagi.com</username>\n      <userid>9393007a6921eecd4a9f20eefb5c7a8e</userid>\n    </context>\n    <user>\n      <data>\n        <commcare_first_name/>\n        <commcare_phone_number/>\n        <commcare_last_name/>\n        <commcare_project>openmrs-test</commcare_project>\n        <user_type>standard</user_type>\n      </data>\n    </user>\n  </session>'
+            );
+        });
+    });
+});

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -84,78 +84,78 @@
 
 <script type="text/html" id="debugger-evaluate-template">
 <!--ko with: evalXPath-->
-      <form class="form-horizontal" data-bind="submit: onSubmitXPath">
-          <div class="col-sm-12">
-          <div class="form-group">
-              <textarea
-                  id="xpath"
-                  class="form-control debugger-code at-who-input"
-                  name="xpath"
-                  placeholder="XPath Expression"
-                  autocomplete="off"
-                  spellcheck=false
-                  data-bind="value: xpath, event: { mouseup: onMouseUp }" ></textarea>
-          </div>
-          </div>
-          <div class="col-sm-12">
-          <div class="form-group">
+    <form class="form-horizontal" data-bind="submit: onSubmitXPath">
+        <div class="col-sm-12">
+            <div class="form-group">
+                <textarea
+                    id="xpath"
+                    class="form-control debugger-code at-who-input"
+                    name="xpath"
+                    placeholder="XPath Expression"
+                    autocomplete="off"
+                    spellcheck=false
+                    data-bind="value: xpath, event: { mouseup: onMouseUp }" ></textarea>
+            </div>
+        </div>
+        <div class="col-sm-12">
+            <div class="form-group">
                 <input class="btn btn-success" id="evaluate-button" value="Evaluate" type="submit"/>
                 <input
                     class="btn btn-default"
                     value="Evaluate Selection"
                     type="button"
                     data-bind="css: { disabled: !selectedXPath() }, click: onClickSelectedXPath"/>
-          </div>
-          </div>
-          <div class="col-sm-12">
-              <!--ko if: success() && formatResult(result()) === ''-->
-              <div><i>{% trans "Empty String" %}</i></div>
-              <!--/ko-->
-              <textarea id="evaluate-result" type="text" data-bind="
-                  codeMirror: formatResult(result())
-              "></textarea>
-          </div>
-      </form>
-      <div class="row">
-        <div class="col-sm-12">
-          <h4>{% trans "Recent Queries" %}</h4>
+            </div>
         </div>
-      </div>
-      <!-- ko if: recentXPathQueries().length -->
-      <div class="table-responsive">
+        <div class="col-sm-12">
+            <!--ko if: success() && formatResult(result()) === ''-->
+            <div><i>{% trans "Empty String" %}</i></div>
+            <!--/ko-->
+            <textarea id="evaluate-result" type="text" data-bind="
+                codeMirror: formatResult(result())
+            "></textarea>
+        </div>
+    </form>
+    <div class="row">
+        <div class="col-sm-12">
+            <h4>{% trans "Recent Queries" %}</h4>
+        </div>
+    </div>
+    <!-- ko if: recentXPathQueries().length -->
+    <div class="table-responsive">
         <table class="table table-striped table-hover">
-          <tbody data-bind="foreach: recentXPathQueries">
-            <tr class="query-container" data-bind="click: $parent.onClickSavedQuery">
-              <td class="col-sm-1 query-status">
-                <span><i class="fa" data-bind="
-                    css: {
-                      'fa-check': $parent.isSuccess($data),
-                      'fa-times': !$parent.isSuccess($data),
-                      'text-success': $parent.isSuccess($data),
-                      'text-danger': !$parent.isSuccess($data)
-                    }
-                    "></i></span>
-              </td>
-              <td class="col-sm-8 debugger-code">
-                <span data-bind="text: xpath"></span>
-              </td>
-              <td class="col-sm-3">
-                <!--ko if: $parent.isSuccess($data) && $parent.formatResult(output) === ''-->
-                <div><i>{% trans "Empty String" %}</i></div>
-                <!--/ko-->
-                <span data-bind="text: $parent.formatResult(output)"></span>
-              </td>
-            </tr>
-          </tbody>
+            <tbody data-bind="foreach: recentXPathQueries">
+                <tr class="query-container" data-bind="click: $parent.onClickSavedQuery">
+                    <td class="col-sm-1 query-status">
+                        <span><i class="fa" data-bind="
+                            css: {
+                                'fa-check': $parent.isSuccess($data),
+                                'fa-times': !$parent.isSuccess($data),
+                                'text-success': $parent.isSuccess($data),
+                                'text-danger': !$parent.isSuccess($data)
+                            }
+                        "></i></span>
+                    </td>
+                    <td class="col-sm-8 debugger-code">
+                        <span data-bind="text: xpath"></span>
+                    </td>
+                    <td class="col-sm-3">
+                        <!--ko if: $parent.isSuccess($data) && $parent.formatResult(output) === ''-->
+                        <div><i>{% trans "Empty String" %}</i></div>
+                        <!--/ko-->
+                        <span data-bind="text: $parent.formatResult(output)"></span>
+                    </td>
+                </tr>
+            </tbody>
         </table>
-      </div>
-      <!-- /ko -->
-      <!-- ko ifnot: recentXPathQueries().length -->
-      <div class="row">
+    </div>
+    <!-- /ko -->
+    <!-- ko ifnot: recentXPathQueries().length -->
+    <div class="row">
         <div class="col-sm-12">
-          <i>{% trans "No recent queries" %}</i>
+            <i>{% trans "No recent queries" %}</i>
         </div>
-      </div>
-      <!-- /ko -->
+    </div>
+    <!-- /ko -->
 <!--/ko-->
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -83,14 +83,7 @@
 </script>
 
 <script type="text/html" id="debugger-evaluate-template">
-    <div data-bind="template: {
-        name: 'debugger-eval-ko-template',
-        afterRender: evalXPath.afterRender,
-        data: evalXPath
-    }"></div>
-</script>
-
-<script type="text/html" id="debugger-eval-ko-template">
+<!--ko with: evalXPath-->
       <form class="form-horizontal" data-bind="submit: onSubmitXPath">
           <div class="col-sm-12">
           <div class="form-group">
@@ -118,11 +111,8 @@
               <!--ko if: success() && formatResult(result()) === ''-->
               <div><i>{% trans "Empty String" %}</i></div>
               <!--/ko-->
-              <textarea
-                  id="evaluate-result"
-                  type="text"
-                  data-bind="
-                      css: { 'text-danger': !success() }
+              <textarea id="evaluate-result" type="text" data-bind="
+                  codeMirror: formatResult(result())
               "></textarea>
           </div>
       </form>
@@ -167,4 +157,5 @@
         </div>
       </div>
       <!-- /ko -->
+<!--/ko-->
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -82,6 +82,15 @@
     <div id="xml-viewer-pretty"></div>
 </script>
 
+<script type="text/html" id="debugger-evaluate-result-template">
+    <!--ko if: success() && formattedResult() === ''-->
+    <div><i>{% trans "Empty String" %}</i></div>
+    <!--/ko-->
+    <textarea type="text" data-bind="
+        codeMirror: formattedResult()
+    "></textarea>
+</script>
+
 <script type="text/html" id="debugger-evaluate-template">
 <!--ko with: evalXPath-->
     <form class="form-horizontal" data-bind="submit: onSubmitXPath">
@@ -107,13 +116,10 @@
                     data-bind="css: { disabled: !selectedXPath() }, click: onClickSelectedXPath"/>
             </div>
         </div>
-        <div class="col-sm-12">
-            <!--ko if: success() && formatResult(result()) === ''-->
-            <div><i>{% trans "Empty String" %}</i></div>
-            <!--/ko-->
-            <textarea type="text" data-bind="
-                codeMirror: formatResult(result())
-            "></textarea>
+        <div class="col-sm-12" data-bind="template: {
+            name: 'debugger-evaluate-result-template',
+            data: xPathQuery()
+        }">
         </div>
     </form>
     <div class="row">
@@ -129,10 +135,10 @@
                     <td class="col-sm-1 query-status">
                         <span><i class="fa" data-bind="
                             css: {
-                                'fa-check': $parent.isSuccess($data),
-                                'fa-times': !$parent.isSuccess($data),
-                                'text-success': $parent.isSuccess($data),
-                                'text-danger': !$parent.isSuccess($data)
+                                'fa-check': success(),
+                                'fa-times': !success(),
+                                'text-success': success(),
+                                'text-danger': !success()
                             }
                         "></i></span>
                     </td>
@@ -140,10 +146,10 @@
                         <span data-bind="text: xpath"></span>
                     </td>
                     <td class="col-sm-3">
-                        <!--ko if: $parent.isSuccess($data) && $parent.formatResult(output) === ''-->
+                        <!--ko if: success() && formattedResult() === ''-->
                         <div><i>{% trans "Empty String" %}</i></div>
                         <!--/ko-->
-                        <span data-bind="text: $parent.formatResult(output)"></span>
+                        <span data-bind="text: formattedResult()"></span>
                     </td>
                 </tr>
             </tbody>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -111,7 +111,7 @@
             <!--ko if: success() && formatResult(result()) === ''-->
             <div><i>{% trans "Empty String" %}</i></div>
             <!--/ko-->
-            <textarea id="evaluate-result" type="text" data-bind="
+            <textarea type="text" data-bind="
                 codeMirror: formatResult(result())
             "></textarea>
         </div>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -83,16 +83,19 @@
 </script>
 
 <script type="text/html" id="debugger-evaluate-result-template">
-    <!--ko if: xPathQuery.success() && xPathQuery.formattedResult() === ''-->
+    <!--ko if: xPathQuery.successResult() === ''-->
     <div><i>{% trans "Empty String" %}</i></div>
     <!--/ko-->
-    <!--ko if: options.useCodeMirror-->
+    <!--ko if: xPathQuery.errorResult()-->
+    <div data-bind="text: xPathQuery.errorResult(), css: 'text-danger'"></div>
+    <!--/ko-->
+    <!--ko if: options.useCodeMirror && xPathQuery.successResult()-->
     <textarea type="text" data-bind="
-        codeMirror: xPathQuery.formattedResult()
+        codeMirror: xPathQuery.successResult()
     "></textarea>
     <!--/ko-->
-    <!--ko if: !options.useCodeMirror && xPathQuery.formattedResult()-->
-        <pre data-bind="text: xPathQuery.formattedResult()"></pre>
+    <!--ko if: !options.useCodeMirror && xPathQuery.successResult()-->
+        <pre data-bind="text: xPathQuery.successResult()"></pre>
     <!--/ko-->
 </script>
 
@@ -123,7 +126,8 @@
         </div>
         <div class="col-sm-12" data-bind="template: {
             name: 'debugger-evaluate-result-template',
-            data: {xPathQuery: xPathQuery(), options: {useCodeMirror: true}}
+            data: {xPathQuery: xPathQuery(), options: {useCodeMirror: true}},
+            if: xPathQuery()
         }">
         </div>
     </form>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -83,12 +83,17 @@
 </script>
 
 <script type="text/html" id="debugger-evaluate-result-template">
-    <!--ko if: success() && formattedResult() === ''-->
+    <!--ko if: xPathQuery.success() && xPathQuery.formattedResult() === ''-->
     <div><i>{% trans "Empty String" %}</i></div>
     <!--/ko-->
+    <!--ko if: options.useCodeMirror-->
     <textarea type="text" data-bind="
-        codeMirror: formattedResult()
+        codeMirror: xPathQuery.formattedResult()
     "></textarea>
+    <!--/ko-->
+    <!--ko if: !options.useCodeMirror && xPathQuery.formattedResult()-->
+        <pre data-bind="text: xPathQuery.formattedResult()"></pre>
+    <!--/ko-->
 </script>
 
 <script type="text/html" id="debugger-evaluate-template">
@@ -118,7 +123,7 @@
         </div>
         <div class="col-sm-12" data-bind="template: {
             name: 'debugger-evaluate-result-template',
-            data: xPathQuery()
+            data: {xPathQuery: xPathQuery(), options: {useCodeMirror: true}}
         }">
         </div>
     </form>
@@ -145,14 +150,10 @@
                     <td class="col-sm-8 debugger-code">
                         <span data-bind="text: xpath"></span>
                     </td>
-                    <td class="col-sm-3">
-                        <!--ko if: success() && formattedResult() === ''-->
-                        <div><i>{% trans "Empty String" %}</i></div>
-                        <!--/ko-->
-                        <!--ko if: formattedResult()-->
-                        <pre data-bind="text: formattedResult()"></pre>
-                        <!--/ko-->
-                    </td>
+                    <td class="col-sm-3" data-bind="template: {
+                        name: 'debugger-evaluate-result-template',
+                        data: {xPathQuery: $data, options: {useCodeMirror: false}}
+                    }"></td>
                 </tr>
             </tbody>
         </table>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -149,7 +149,9 @@
                         <!--ko if: success() && formattedResult() === ''-->
                         <div><i>{% trans "Empty String" %}</i></div>
                         <!--/ko-->
-                        <span data-bind="text: formattedResult()"></span>
+                        <!--ko if: formattedResult()-->
+                        <pre data-bind="text: formattedResult()"></pre>
+                        <!--/ko-->
                     </td>
                 </tr>
             </tbody>

--- a/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
+++ b/corehq/apps/style/static/cloudcare/less/debugger/debugger.less
@@ -71,7 +71,3 @@
 .debugger .query-container:hover {
   cursor: pointer;
 }
-
-#evaluate-result {
-  min-height: 20px;
-}


### PR DESCRIPTION
Followup to https://github.com/dimagi/commcare-hq/pull/17280.

This refactor unifies the very similar display logic for the evaluate xpath result in the current and historical views. It also has the following (hopefully nice) changes:

- in historical view, the eval result now shows up in a monospaced code style that preserves spaces and newlines (but is simpler/lighter weight than CodeMirror—just a `<pre>`)
- XPath errors now show up as red text rather than in a code box
- Until/unless there's something in the code mirror box, there isn't the 200px gap between the eval box and the eval history

It's about 20 lines longer (not counting tests) than previously, but I think they're much nicer lines, with better encapsulation of the xpath query result as a common object, and allows much more freedom to make changes that will be reflected in both current and historical view without keeping two things in sync.