### PR TITLE
Mobile UCR: handle columns manually added or deleted in JSON

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -152,6 +152,13 @@ def _get_summary_details(config, domain, module):
                 graph_config = config.complete_graph_configs.get(chart_config.chart_id, GraphConfiguration(
                     series=[GraphSeries() for c in chart_config.y_axis_columns],
                 ))
+
+                # Reconcile graph_config.series with any additions/deletions in chart_config.y_axis_columns
+                while len(chart_config.y_axis_columns) > len(graph_config.series):
+                    graph_config.series.append(GraphSeries())
+                if len(chart_config.y_axis_columns) < len(graph_config.series):
+                    graph_config.series = graph_config.series[:len(chart_config.y_axis_columns)]
+
                 for index, column in enumerate(chart_config.y_axis_columns):
                     graph_config.series[index].data_path = (
                         graph_config.series[index].data_path or


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?259385

It's still possible for a user to reorder the JSON columns and get into trouble, but there isn't a bulletproof way to match the JSON's y axis columns with the graph config's series, so I'm going to leave that alone until it becomes an issue.

@snopoke / @nickpell 