### PR TITLE
show proper error message on empty required select2

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/accounting.billing_info_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/accounting.billing_info_handler.js
@@ -106,6 +106,7 @@ hqDefine('accounting/js/accounting.billing_info_handler.js', function () {
             var handler = new EmailSelect2Handler($(input).attr("name"));
             handler.init();
         });
+        $(".ko-email-select2").removeAttr('required');
 
         _.each($(".ko-async-select2"), function(input) {
             var handler = new AsyncSelect2Handler($(input).attr("name"));


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?257804

This change avoids the JS error, and instead lets crispy forms acknowledge that the empty select2 needs a value.

@emord 