### PR TITLE
Add nullable columns to UCR without rebuild

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -24,9 +24,9 @@ from corehq.util.datadog.gauges import datadog_histogram
 from corehq.util.soft_assert import soft_assert
 from corehq.util.timer import TimingContext
 from fluff.signals import (
-    apply_index_changes,
+    migrate_tables,
     get_migration_context,
-    get_tables_with_index_changes,
+    get_tables_to_migrate,
     get_tables_to_rebuild,
     reformat_alembic_diffs
 )
@@ -180,9 +180,9 @@ class ConfigurableReportTableManagerMixin(object):
                 else:
                     self.rebuild_table(sql_adapter)
 
-            tables_with_index_changes = get_tables_with_index_changes(diffs, table_names)
-            tables_with_index_changes -= tables_to_rebuild
-            apply_index_changes(engine, raw_diffs, tables_with_index_changes)
+            tables_to_migrate = get_tables_to_migrate(diffs, table_names)
+            tables_to_migrate -= tables_to_rebuild
+            migrate_tables(engine, raw_diffs, tables_to_migrate)
 
     def _rebuild_es_tables(self, adapters):
         # note unlike sql rebuilds this doesn't rebuild the indicators

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -576,6 +576,10 @@ def _save_sql_case(doc):
 
 
 class RebuildTableTest(TestCase):
+    """This test is pretty fragile because in UCRs we have a global metadata
+    object that sqlalchemy uses to keep track of tables and indexes. I've attempted
+    to work around it here, but it feels a little nasty
+    """
 
     def tearDown(self):
         self.adapter.drop_table()
@@ -604,6 +608,7 @@ class RebuildTableTest(TestCase):
 
         # add the index to the config
         config = self._get_config('add_index')
+        self.addCleanup(config.delete)
         config.configured_indicators[0]['create_index'] = True
         config.save()
         adapter = get_indicator_adapter(config)
@@ -629,6 +634,7 @@ class RebuildTableTest(TestCase):
 
         # add the column to the config
         config = self._get_config('add_non_nullable_col')
+        self.addCleanup(config.delete)
         config.configured_indicators.append({
             "column_id": "new_date",
             "type": "raw",
@@ -672,6 +678,7 @@ class RebuildTableTest(TestCase):
 
         # add the column to the config
         config = self._get_config('add_nullable_col')
+        self.addCleanup(config.delete)
         config.configured_indicators.append({
             "column_id": "new_date",
             "type": "raw",

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -578,7 +578,7 @@ def _save_sql_case(doc):
 
 class RebuildTableTest(TestCase):
 
-    def teardown(self):
+    def tearDown(self):
         # we need to get the config multiple times in the test for it to properly
         # recalculate the schema, so we can't have a class wide config variable
         config = get_sample_data_source()

--- a/corehq/ex-submodules/fluff/signals.py
+++ b/corehq/ex-submodules/fluff/signals.py
@@ -5,6 +5,7 @@ import logging
 
 from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 from django.dispatch import Signal
@@ -228,6 +229,15 @@ def add_columns(engine, raw_diffs, table_names):
             op.add_column(table_name, col)
 
 
+def get_tables_to_migrate(diffs, table_names):
+    tables_with_indexes = get_tables_with_index_changes(diffs, table_names)
+    tables_with_added_columns = get_tables_with_added_nullable_columns(diffs, table_names)
+    return tables_with_indexes | tables_with_added_columns
+
+
+def migrate_tables(engine, raw_diffs, table_names):
+    apply_index_changes(engine, raw_diffs, table_names)
+    add_columns(engine, raw_diffs, table_names)
 
 
 def rebuild_table(engine, pillow, indicator_doc):


### PR DESCRIPTION
@NoahCarnahan 

These tests are going to fail because the metadata is a global variable. I haven't figured it out yet.

Doesn't do anything smart with the rebuild

buddy @biyeun 