### PR TITLE
Don't apply owner transform in ASR report

### DIFF
--- a/custom/icds_reports/utils.py
+++ b/custom/icds_reports/utils.py
@@ -56,10 +56,18 @@ class ICDSData(object):
 
     def __init__(self, domain, filters, report_id):
         report_config = ReportFactory.from_spec(
-            StaticReportConfiguration.by_id(report_id.format(domain=domain))
+            self._get_static_report_configuration_without_owner_transform(report_id.format(domain=domain))
         )
         report_config.set_filter_values(filters)
         self.report_config = report_config
+
+    def _get_static_report_configuration_without_owner_transform(self, report_id):
+        static_report_configuration = StaticReportConfiguration.by_id(report_id)
+        for report_column in static_report_configuration.report_columns:
+            transform = report_column.transform
+            if transform.get('type') == 'custom' and transform.get('custom_type') == 'owner_display':
+                report_column.transform = {}
+        return static_report_configuration
 
     def data(self):
         return self.report_config.get_data()


### PR DESCRIPTION
@emord 
https://manage.dimagi.com/default.asp?255223
I find this as a bottleneck since it needed to hit a database a lot of times to transform owner_id to owner name. Currently, we don't need this in ASR report so I'm removing all this transform before fetching the data.