### PR TITLE
fix edit form with attachments

### DIFF
--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -33,6 +33,18 @@ class FormProcessorCouch(object):
             )
 
     @classmethod
+    def copy_attachments(cls, from_form, to_form):
+        for name, meta in from_form.blobs.items():
+            if name != 'form.xml':
+                with from_form.fetch_attachment(name, stream=True) as content:
+                    to_form.deferred_put_attachment(
+                        content,
+                        name=name,
+                        content_type=meta.content_type,
+                        content_length=meta.content_length,
+                    )
+
+    @classmethod
     def new_xform(cls, form_data):
         _id = extract_meta_instance_id(form_data) or uuid.uuid4().hex
         assert _id

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -47,6 +47,21 @@ class FormProcessorSQL(object):
         xform.unsaved_attachments = xform_attachments
 
     @classmethod
+    def copy_attachments(cls, from_form, to_form):
+        to_form.unsaved_attachments = to_form.unsaved_attachments or []
+        for att in from_form.get_attachments():
+            if att.name != 'form.xml':
+                to_form.unsaved_attachments.append(XFormAttachmentSQL(
+                    name=att.name,
+                    attachment_id=uuid.uuid4(),
+                    content_type=att.content_type,
+                    properties=att.properties,
+                    blob_id=att.blob_id,
+                    blob_bucket=att.blob_bucket,
+                    md5=att.md5,
+                ))
+
+    @classmethod
     def new_xform(cls, form_data):
         form_id = extract_meta_instance_id(form_data) or unicode(uuid.uuid4())
 

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -102,6 +102,10 @@ class FormProcessorInterface(object):
         """
         return self.processor.store_attachments(xform, attachments)
 
+    def copy_attachments(self, from_form, to_form):
+        """Copy attachments from one for to another (exlucding form.xml)"""
+        self.processor.copy_attachments(from_form, to_form)
+
     def is_duplicate(self, xform_id, domain=None):
         """
         Check if there is already a form with the given ID. If domain is specified only check for

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -215,15 +215,6 @@ def apply_deprecation(existing_xform, new_xform, interface=None):
 
     interface = interface or FormProcessorInterface(existing_xform.domain)
     interface.copy_attachments(existing_xform, new_xform)
-    if existing_xform.persistent_blobs:
-        for name, meta in existing_xform.persistent_blobs.items():
-            with existing_xform.fetch_attachment(name, stream=True) as content:
-                existing_xform.deferred_put_attachment(
-                    content,
-                    name=name,
-                    content_type=meta.content_type,
-                    content_length=meta.content_length,
-                )
     new_xform.form_id = existing_xform.form_id
     existing_xform = interface.assign_new_id(existing_xform)
     existing_xform.orig_id = new_xform.form_id

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -214,7 +214,7 @@ def apply_deprecation(existing_xform, new_xform, interface=None):
     #  - Save the new instance to the previous document to preserve the ID
 
     interface = interface or FormProcessorInterface(existing_xform.domain)
-
+    interface.copy_attachments(existing_xform, new_xform)
     if existing_xform.persistent_blobs:
         for name, meta in existing_xform.persistent_blobs.items():
             with existing_xform.fetch_attachment(name, stream=True) as content:


### PR DESCRIPTION
If a form has attachments e.g. images then when the form is edited the attachments don't get copied over to the new form.

buddy @orangejenny 
