### PR TITLE
fixing "click here to install" for app profiles

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4907,14 +4907,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     def odk_media_profile_url(self):
         return reverse('download_odk_media_profile', args=[self.domain, self._id])
 
-    @property
-    def odk_profile_display_url(self):
-        return self.short_odk_url or self.odk_profile_url
-
-    @property
-    def odk_media_profile_display_url(self):
-        return self.short_odk_media_url or self.odk_media_profile_url
-
     def get_odk_qr_code(self, with_media=False, build_profile_id=None):
         """Returns a QR code, as a PNG to install on CC-ODK"""
         try:

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -301,7 +301,7 @@ def odk_install(request, domain, app_id, with_media=False):
     app = get_app(domain, app_id)
     qr_code_view = "odk_qr_code" if not with_media else "odk_media_qr_code"
     build_profile_id = request.GET.get('profile')
-    profile_url = app.odk_profile_display_url if not with_media else app.odk_media_profile_display_url
+    profile_url = app.odk_profile_url if not with_media else app.odk_media_profile_url
     if build_profile_id is not None:
         profile_url += '?profile={profile}'.format(profile=build_profile_id)
     context = {


### PR DESCRIPTION
@orangejenny 
https://manage.dimagi.com/default.asp?257773
I am relatively certain this is the only place that url is used (the app code part gets the bitly url through another mechanism i believe) so now it only uses the full url as its not user visible anyway.