### PR TITLE
make domain subscription pages ignore product_type

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -334,7 +334,7 @@ class CreditStripePaymentHandler(BaseStripePaymentHandler):
         )
 
     def _humanized_features(self):
-        return [{'type': get_feature_name(feature['type'], SoftwareProductType.COMMCARE),
+        return [{'type': get_feature_name(feature['type']),
                  'amount': fmt_dollar_amount(feature['amount'])}
                 for feature in self.features]
 

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -3,7 +3,6 @@ from django.utils.translation import ugettext_lazy as _
 from corehq.apps.accounting.models import (
     FeatureType,
     SoftwarePlanEdition as Edition,
-    SoftwareProductType as Product,
 )
 
 DESC_BY_EDITION = {
@@ -46,14 +45,7 @@ FEATURE_TYPE_TO_NAME = {
 }
 
 
-# This exists here specifically so that text can be translated
-def ensure_product(product):
-    if product not in [s[0] for s in Product.CHOICES]:
-        raise ValueError("Unsupported Product")
-
-
-def get_feature_name(feature_type, product):
-    ensure_product(product)
+def get_feature_name(feature_type):
     if feature_type not in [f[0] for f in FeatureType.CHOICES]:
         raise ValueError("Unsupported Feature")
     return {

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -57,11 +57,7 @@ def get_feature_name(feature_type, product):
     if feature_type not in [f[0] for f in FeatureType.CHOICES]:
         raise ValueError("Unsupported Feature")
     return {
-        FeatureType.USER: {
-            Product.COMMCARE: _("Mobile Users"),
-            Product.COMMCONNECT: _("Mobile Users"),
-            Product.COMMTRACK: _("Facilities"),
-        }[product],
+        FeatureType.USER: _("Mobile Users"),
         FeatureType.SMS: _("SMS"),
     }[feature_type]
 

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -2,38 +2,38 @@ from __future__ import absolute_import
 from django.utils.translation import ugettext_lazy as _
 from corehq.apps.accounting.models import (
     FeatureType,
-    SoftwarePlanEdition as Edition,
+    SoftwarePlanEdition
 )
 
 DESC_BY_EDITION = {
-    Edition.COMMUNITY: {
+    SoftwarePlanEdition.COMMUNITY: {
         'name': _("Community"),
         'description': _("For projects in a pilot phase with a small group (up to %d) of "
                          "mobile users that only need very basic CommCare features."),
     },
-    Edition.STANDARD: {
+    SoftwarePlanEdition.STANDARD: {
         'name': _("Standard"),
         'description': _("For projects with a medium set (up to %d) of mobile users that want to "
                          "build in limited SMS workflows and have increased data security needs."),
     },
-    Edition.PRO: {
+    SoftwarePlanEdition.PRO: {
         'name': _("Pro"),
         'description': _("For projects with a large group (up to %d) of mobile users that want to "
                          "build in comprehensive SMS workflows and have increased reporting needs."),
     },
-    Edition.ADVANCED: {
+    SoftwarePlanEdition.ADVANCED: {
         'name': _("Advanced"),
         'description': _("For projects scaling to an even larger group (up to %d) of mobile users "
                          "that want the full CommCare feature set and dedicated support from Dimagi "
                          "staff.")
     },
-    Edition.ENTERPRISE: {
+    SoftwarePlanEdition.ENTERPRISE: {
         'name': _("Enterprise"),
         'description': _("For projects scaling regionally or country wide (1,001+ people) that require "
                          "the full CommCare feature set. Your organization will receive discounted "
                          "pricing and dedicated enterprise-level support from Dimagi.")
     },
-    Edition.RESELLER: {
+    SoftwarePlanEdition.RESELLER: {
         'name': _("Reseller"),
         'description': _("Reseller")
     },

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -642,10 +642,6 @@ class DomainAccountingSettings(BaseProjectSettingsView):
         return super(DomainAccountingSettings, self).dispatch(request, *args, **kwargs)
 
     @property
-    def product(self):
-        return SoftwareProductType.COMMCARE
-
-    @property
     @memoized
     def account(self):
         return BillingAccount.get_account_by_domain(self.domain)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -92,7 +92,7 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan, SoftwarePlanEdition, BillingAccount,
     BillingAccountType,
     Invoice, BillingRecord, InvoicePdf, PaymentMethodType,
-    EntryPoint, WireInvoice, FeatureType,
+    EntryPoint, WireInvoice,
     StripePaymentMethod, LastPayment,
     UNLIMITED_FEATURE_USAGE,
 )
@@ -1156,24 +1156,13 @@ class CreditsWireInvoiceView(DomainAccountingSettings):
 
     @staticmethod
     def _get_items(request):
-        features = [{'type': get_feature_name(feature_type[0]),
-                     'amount': Decimal(request.POST.get(feature_type[0], 0))}
-                    for feature_type in FeatureType.CHOICES
-                    if Decimal(request.POST.get(feature_type[0], 0)) > 0]
-        products = [{'type': pt[0],
-                     'amount': Decimal(request.POST.get(pt[0], 0))}
-                    for pt in SoftwareProductType.CHOICES
-                    if Decimal(request.POST.get(pt[0], 0)) > 0]
-
-        items = products + features
-
         if Decimal(request.POST.get('general_credit', 0)) > 0:
-            items.append({
+            return [{
                 'type': 'General Credits',
                 'amount': Decimal(request.POST.get('general_credit', 0))
-            })
+            }]
 
-        return items
+        return []
 
 
 class InvoiceStripePaymentView(BaseStripePaymentView):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -788,7 +788,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 if remaining < 0:
                     remaining = _("%d over limit") % (-1 * remaining)
             return {
-                'name': get_feature_name(feature_type, self.product),
+                'name': get_feature_name(feature_type),
                 'usage': usage,
                 'limit': limit,
                 'remaining': remaining,
@@ -1162,7 +1162,7 @@ class CreditsWireInvoiceView(DomainAccountingSettings):
 
     @staticmethod
     def _get_items(request):
-        features = [{'type': get_feature_name(feature_type[0], SoftwareProductType.COMMCARE),
+        features = [{'type': get_feature_name(feature_type[0]),
                      'amount': Decimal(request.POST.get(feature_type[0], 0))}
                     for feature_type in FeatureType.CHOICES
                     if Decimal(request.POST.get(feature_type[0], 0)) > 0]

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 import logging
 import json
 import cStringIO
-import sys
 
 import pytz
 from couchdbkit import ResourceNotFound
@@ -13,7 +12,6 @@ from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.core.validators import validate_email
-from django.template import RequestContext
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_GET
 from django.views.generic import View
@@ -25,9 +23,9 @@ from django.utils.http import urlsafe_base64_decode
 from django.utils.safestring import mark_safe
 from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse, Http404
-from django.shortcuts import redirect, render, render_to_response
+from django.shortcuts import redirect, render
 from django.contrib import messages
-from django.contrib.auth.views import password_reset_confirm, password_reset
+from django.contrib.auth.views import password_reset_confirm
 from django.views.decorators.http import require_POST
 from PIL import Image
 from django.utils.translation import ugettext as _, ugettext_lazy


### PR DESCRIPTION
```product_type``` is deprecated, so let's remove dependencies on it

@biyeun cc: @kaapstorm 