### PR TITLE
Retry partitioned_get on InterfaceError

### DIFF
--- a/corehq/sql_db/models.py
+++ b/corehq/sql_db/models.py
@@ -1,5 +1,8 @@
+from corehq.sql_db.util import close_db_connection
 from corehq.util.exceptions import AccessRestricted
 from django.db import models
+from django.db.utils import InterfaceError as DjangoInterfaceError
+from psycopg2._psycopg import InterfaceError as Psycopg2InterfaceError
 
 
 def raise_access_restricted():
@@ -69,7 +72,12 @@ class RequireDBManager(models.Manager):
             kwargs = {
                 self.model.partition_attr: partition_value
             }
-        return self.using(self.get_db(partition_value)).get(**kwargs)
+
+        try:
+            return self.using(self.get_db(partition_value)).get(**kwargs)
+        except (Psycopg2InterfaceError, DjangoInterfaceError):
+            close_db_connection(self.get_db(partition_value))
+            return self.using(self.get_db(partition_value)).get(**kwargs)
 
     def partitioned_query(self, partition_value):
         """Shortcut to get a queryset for a partitioned database.

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -104,7 +104,7 @@ def handle_connection_failure(get_db_aliases=get_default_db_aliases):
                 # force closing the connection to prevent Django from trying to reuse it.
                 # http://www.tryolabs.com/Blog/2014/02/12/long-time-running-process-and-django-orm/
                 for db_name in get_db_aliases():
-                    db.connections[db_name].close()
+                    close_db_connection(db_name)
 
                 # re raise the exception for additional error handling
                 raise
@@ -112,3 +112,7 @@ def handle_connection_failure(get_db_aliases=get_default_db_aliases):
         return _inner
 
     return _inner2
+
+
+def close_db_connection(db_alias):
+    db.connections[db_alias].close()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?259922

@snopoke this was the reason for the pillow retry queue getting so behind, the pillows were generating lots of the errors in the ticket. seems like this started happening with the new partitioned_get when the db has issues, since the persistent pillow processes don't ever close the connections.

hold off on merge for now, going to see if there's a cleaner way to do this tomorrow. for now the remedy was to just restart the pillows, and i temporarily boosted the concurrency on the pillow retry queue so it processes a little faster.