### PR TITLE
V2 Privilege Generation Code

### DIFF
--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -440,16 +440,27 @@ class EnableMobilePrivilegesView(BaseMyAccountView):
 
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
-        message = json.dumps([
+        message_v1 = json.dumps([
             {'username': request.user.username},
             {'flag': MULTIPLE_APPS_UNLIMITED.slug}
         ]).replace(' ', '')
+
+        message_v2 = json.dumps([
+            {'username': request.user.username},
+            {'flags': [MULTIPLE_APPS_UNLIMITED.slug,ADVANCED_SETTINGS_ACCESS.slug]}
+        ]).replace(' ', '')
+
         qrcode_data = json.dumps({
             'username': request.user.username,
+            'version': 2,
             'flag': MULTIPLE_APPS_UNLIMITED.slug,
-            'signature': b64encode(sign(message))
+            'flags': [MULTIPLE_APPS_UNLIMITED.slug,ADVANCED_SETTINGS_ACCESS.slug],
+            'signature': b64encode(sign(message_v1)),
+            'multiple_flags_signature': b64encode(sign(message_v2))
         })
+        
         qrcode = get_qrcode(qrcode_data)
+        
         context = self.get_context_data(**kwargs)
         context['qrcode_64'] = b64encode(qrcode)
         return self.render_to_response(context)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -447,20 +447,20 @@ class EnableMobilePrivilegesView(BaseMyAccountView):
 
         message_v2 = json.dumps([
             {'username': request.user.username},
-            {'flags': [MULTIPLE_APPS_UNLIMITED.slug,ADVANCED_SETTINGS_ACCESS.slug]}
+            {'flags': [MULTIPLE_APPS_UNLIMITED.slug, ADVANCED_SETTINGS_ACCESS.slug]}
         ]).replace(' ', '')
 
         qrcode_data = json.dumps({
             'username': request.user.username,
             'version': 2,
             'flag': MULTIPLE_APPS_UNLIMITED.slug,
-            'flags': [MULTIPLE_APPS_UNLIMITED.slug,ADVANCED_SETTINGS_ACCESS.slug],
+            'flags': [MULTIPLE_APPS_UNLIMITED.slug, ADVANCED_SETTINGS_ACCESS.slug],
             'signature': b64encode(sign(message_v1)),
             'multiple_flags_signature': b64encode(sign(message_v2))
         })
-        
+
         qrcode = get_qrcode(qrcode_data)
-        
+
         context = self.get_context_data(**kwargs)
         context['qrcode_64'] = b64encode(qrcode)
         return self.render_to_response(context)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -17,6 +17,7 @@ from django.contrib import messages
 from django.http import Http404
 from django.views.decorators.http import require_POST
 from corehq.mobile_flags import MULTIPLE_APPS_UNLIMITED
+from corehq.mobile_flags import ADVANCED_SETTINGS_ACCESS
 import langcodes
 
 from django.http import HttpResponseRedirect, HttpResponse

--- a/corehq/mobile_flags.py
+++ b/corehq/mobile_flags.py
@@ -8,3 +8,8 @@ MULTIPLE_APPS_UNLIMITED = MobileFlag(
     'multiple_apps_unlimited',
     'Enable unlimited multiple apps'
 )
+
+ADVANCED_SETTINGS_ACCESS = MobileFlag(
+    'advanced_settings_access',
+    'Enable access to advanced settings'
+)


### PR DESCRIPTION
Update to the mobile privilege code, allows splitting out privileges.

For now just replicates the previous capabilities (turning on all features)
Spec:
https://docs.google.com/document/d/1VKkAjD6-HRoHM7eql3rwy9_vMnsPaobfeNmrz7zx4lw/edit

Mobile PR and Tests are here:
https://github.com/dimagi/commcare-android/pull/1784

Tested to work on both an old phone (with the old processing code) and the new PR processor