### PR TITLE
Hide all info in email from report

### DIFF
--- a/custom/enikshay/reports/repeaters.py
+++ b/custom/enikshay/reports/repeaters.py
@@ -71,7 +71,6 @@ class ENikshayForwarderReport(DomainForwardingRepeatRecords):
                 DataTablesColumn(_('URL')),
                 DataTablesColumn(_('Last sent date')),
                 DataTablesColumn(_('Attempts')),
-                DataTablesColumn(_('Payload')),
             ]
         return DataTablesHeader(*columns)
 
@@ -81,10 +80,6 @@ class ENikshayForwarderReport(DomainForwardingRepeatRecords):
                 date=self._format_date(attempt.datetime),
                 message=attempt.message))
             for attempt in record.attempts]
-        try:
-            payload = record.get_payload()
-        except Exception as error:
-            payload = u"Error: {}".format(error)
 
         row = [
             record._id,
@@ -93,7 +88,6 @@ class ENikshayForwarderReport(DomainForwardingRepeatRecords):
             record.url if record.url else _(u'Unable to generate url for record'),
             self._format_date(record.last_checked) if record.last_checked else '---',
             ",<br />".join(attempt_messages),
-            payload,
         ]
         return row
 


### PR DESCRIPTION
Email body was including all the data. Which in some cases was making the email to large to send.
We just want the excel export anyway.
@mkangia 
cc @gcapalbo 