### PR TITLE
log api access for the last 30 days

### DIFF
--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 from tastypie.authorization import ReadOnlyAuthorization
-from tastypie.throttle import CacheThrottle
+from tastypie.throttle import CacheDBThrottle
 
 from corehq.apps.api.resources.auth import LoginAndDomainAuthentication
 from corehq.apps.api.serializers import CustomXMLSerializer
 from corehq.toggles import API_THROTTLE_WHITELIST
 
 
-class HQThrottle(CacheThrottle):
+class HQThrottle(CacheDBThrottle):
 
     def should_be_throttled(self, identifier, **kwargs):
         if API_THROTTLE_WHITELIST.enabled(identifier):

--- a/corehq/apps/api/tasks.py
+++ b/corehq/apps/api/tasks.py
@@ -1,0 +1,10 @@
+import time
+from celery.schedules import crontab
+from celery.task.base import periodic_task
+from tastypie.models import ApiAccess
+
+
+@periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue')
+def clean_api_access():
+    accessed = int(time.time()) - 30 * 24 * 3600  # only keep last 30 days
+    ApiAccess.objects.filter(accessed__lt=accessed).delete()


### PR DESCRIPTION
With increased usage of our APIs I thought it could be useful to log access.