### PR TITLE
Fix for not-clickable inline tiles 

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -31,6 +31,7 @@ FormplayerFrontend.module("Menus.Collections", function (Collections, Formplayer
             'maxHeight',
             'widthHints',
             'useUniformUnits',
+            'hasInlineTile',
         ],
 
         commandProperties: [

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -45,8 +45,10 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
         },
 
         selectDetail: function(caseId, detailIndex, isPersistent) {
-            var urlObject = Util.currentUrlToObject();
-            urlObject.addStep(caseId);
+            if (!isPersistent) {
+                var urlObject = Util.currentUrlToObject();
+                urlObject.addStep(caseId);
+            }
             var fetchingDetails = FormplayerFrontend.request("entity:get:details", urlObject, isPersistent);
             $.when(fetchingDetails).done(function (detailResponse) {
                 Menus.Controller.showDetail(detailResponse, detailIndex, caseId);
@@ -172,6 +174,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
             var numEntitiesPerRow = detailObject.numEntitiesPerRow || 1;
             var numRows = detailObject.maxHeight;
             var numColumns = detailObject.maxWidth;
+            var hasInlineTile = detailObject.hasInlineTile;
             var useUniformUnits = detailObject.useUniformUnits || false;
             var caseTileStyles = Menus.Views.buildCaseTileStyles(detailObject.tiles, numRows, numColumns,
                 numEntitiesPerRow, useUniformUnits, 'persistent');
@@ -186,6 +189,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 maxWidth: detailObject.maxWidth,
                 maxHeight: detailObject.maxHeight,
                 prefix: 'persistent',
+                hasInlineTile: detailObject.hasInlineTile,
             });
         },
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -174,7 +174,6 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
             var numEntitiesPerRow = detailObject.numEntitiesPerRow || 1;
             var numRows = detailObject.maxHeight;
             var numColumns = detailObject.maxWidth;
-            var hasInlineTile = detailObject.hasInlineTile;
             var useUniformUnits = detailObject.useUniformUnits || false;
             var caseTileStyles = Menus.Views.buildCaseTileStyles(detailObject.tiles, numRows, numColumns,
                 numEntitiesPerRow, useUniformUnits, 'persistent');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -45,8 +45,8 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
         },
 
         selectDetail: function(caseId, detailIndex, isPersistent) {
+            var urlObject = Util.currentUrlToObject();
             if (!isPersistent) {
-                var urlObject = Util.currentUrlToObject();
                 urlObject.addStep(caseId);
             }
             var fetchingDetails = FormplayerFrontend.request("entity:get:details", urlObject, isPersistent);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -251,7 +251,9 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
     Views.PersistentCaseTileView = Views.CaseTileView.extend({
         rowClick: function (e) {
             e.preventDefault();
-            FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, true);
+            if (this.options.hasInlineTile) {
+                FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, true);
+            }
         },
     });
 


### PR DESCRIPTION
Makes persistent case tiles without inline details un-clickable

Fixes a bug where inline case tile clicks could result in advancing the session

Held off on any UI changes, but @biyeun @orangejenny clickable case tiles should probably be differentiated from un-clickable ones somehow. Thoughts? (doesn't need to block)

fixes https://manage.dimagi.com/default.asp?259461

cross-request: https://github.com/dimagi/formplayer/pull/451