### PR TITLE
Add missing class less doc type for reference

### DIFF
--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -101,6 +101,8 @@ def get_classes_by_doc_type():
             if klass._doc_type not in classes_by_doc_type:
                 classes_by_doc_type[klass._doc_type] = klass
         queue.extend(klass.__subclasses__())
+    from corehq.motech.repeaters.models import RepeatRecord
+    classes_by_doc_type["RepeatRecord-Failed"] = RepeatRecord
     return classes_by_doc_type
 
 


### PR DESCRIPTION
The doc type RepeatRecord-Failed does not have a corresponding class and hence `CouchDataLoader` is unable to find the corresponding db for it.

I am not sure if this is the best fix but did work around for now.