### PR TITLE
Show location name in page title

### DIFF
--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -4,6 +4,11 @@
 {% load hqstyle_tags %}
 {% load crispy_forms_tags %}
 
+{% block title %}
+    {% if not creates_new_location %}{{ location.name }} :{% endif %}
+    {{ block.super }}
+{% endblock title %}
+
 {% block js %}{{ block.super }}
     <script src="{% static 'locations/js/location_drilldown.async.js' %}"></script>
     <script src="{% static 'locations/js/location.js' %}"></script>


### PR DESCRIPTION
@sravfeyn
This should make it a little easier to tell locations apart from tabs or url bars.

I'm also thinking about doing the same for user pages.