### PR TITLE
ICDS: Fix launched AWCs bug

### DIFF
--- a/custom/icds_reports/sql_templates/create_functions.sql
+++ b/custom/icds_reports/sql_templates/create_functions.sql
@@ -1242,11 +1242,11 @@ BEGIN
 
 	-- Update num launched AWCs based on previous month as well
 	EXECUTE 'UPDATE ' || quote_ident(_tablename5) || ' agg_awc SET ' ||
-	   'is_launched = ut.is_launched, ' ||
-	   'num_launched_awcs = ut.num_launched_awcs ' ||
-    'FROM (SELECT is_launched, num_launched_awcs, awc_id ' ||
+	   'is_launched = ' || quote_literal(_yes_text) || ', ' ||
+	   'num_launched_awcs = 1 ' ||
+    'FROM (SELECT DISTINCT(awc_id) ' ||
        'FROM agg_awc ' ||
-	'WHERE month = ' || quote_literal(_previous_month_date) || ' AND is_launched = ' || quote_literal(_yes_text) || ' AND awc_id <> ' || quote_literal(_all_text) || ') ut ' ||
+	'WHERE month <= ' || quote_literal(_previous_month_date) || ' AND usage_num_hh_reg > 0 AND awc_id <> ' || quote_literal(_all_text) || ') ut ' ||
 	'WHERE ut.awc_id = agg_awc.awc_id';
 
 	-- Update training status based on the previous month as well


### PR DESCRIPTION
It looks like the is_launched value isn't being correctly set for prior months (i.e. more than 3 months ago). This removes the reliance on that value so we can correctly calculate the number of launched AWCs.

@emord 

(We can consider switching back to the other method once this runs for at least a month).  