### PR TITLE
Update Diagnosis and Notification to return proper date

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_property_changed_date.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_property_changed_date.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+import pytz
+
+from django.test import TestCase
+from casexml.apps.case.mock import CaseFactory, CaseStructure
+from casexml.apps.case.util import get_date_case_property_changed
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+
+
+class TestDateCasePropertyChanged(TestCase):
+    def setUp(self):
+        self.factory = CaseFactory('domain')
+        self.case = self.factory.create_case()
+
+    def test_date_case_property_changed(self):
+        updated_on = datetime(2015, 5, 3, 12, 11)
+        # submit 2 updates
+        self.factory.create_or_update_case(
+            CaseStructure(
+                self.case.case_id,
+                attrs={
+                    "update": {
+                        'abc': "updated"
+                    },
+                    "date_modified": updated_on
+                }),
+        )
+        self.factory.create_or_update_case(
+            CaseStructure(
+                self.case.case_id,
+                attrs={
+                    "update": {
+                        'bcd': "updated"
+                    },
+                }),
+        )
+        case = CaseAccessors('domain').get_case(self.case.case_id)
+
+        self.assertEqual(
+            updated_on.replace(tzinfo=pytz.UTC),
+            get_date_case_property_changed(case, "abc", "updated")
+        )

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_property_changed_date.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_property_changed_date.py
@@ -3,7 +3,7 @@ import pytz
 
 from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory, CaseStructure
-from casexml.apps.case.util import get_date_case_property_changed
+from casexml.apps.case.util import get_datetime_case_property_changed
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
@@ -38,5 +38,5 @@ class TestDateCasePropertyChanged(TestCase):
 
         self.assertEqual(
             updated_on.replace(tzinfo=pytz.UTC),
-            get_date_case_property_changed(case, "abc", "updated")
+            get_datetime_case_property_changed(case, "abc", "updated")
         )

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -179,8 +179,8 @@ def iter_cases(case_ids, strip_history=False, wrap=True):
             yield case
 
 
-def get_date_case_property_changed(case, case_property_name, value):
-    """Returns the date a particular case property was changed to a specific value
+def get_datetime_case_property_changed(case, case_property_name, value):
+    """Returns the datetime a particular case property was changed to a specific value
 
     Not performant!
     """

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 import uuid
 
 from xml.etree import ElementTree
 import datetime
 
 from django.conf import settings
+from django.utils.dateparse import parse_datetime
 from iso8601 import iso8601
 from restkit.errors import ResourceError
 
-from casexml.apps.case import const
 from casexml.apps.case.const import CASE_ACTION_UPDATE, CASE_ACTION_CREATE
 from casexml.apps.case.dbaccessors import get_indexed_case_ids
 from casexml.apps.case.exceptions import PhoneDateValueError
@@ -177,3 +177,35 @@ def iter_cases(case_ids, strip_history=False, wrap=True):
     else:
         for case in CommCareCase.bulk_get_lite(case_ids, wrap=wrap):
             yield case
+
+
+def get_date_case_property_changed(case, case_property_name, value):
+    """Returns the date a particular case property was changed to a specific value
+
+    Not performant!
+    """
+    from casexml.apps.case.xform import get_case_updates
+    PropertyChangedInfo = namedtuple("PropertyChangedInfo", 'new_value modified_on')
+
+    def property_changed_in_action(action, case_property_name):
+        update_actions = [
+            (update.modified_on_str, update.get_update_action())
+            for update in get_case_updates(action.form)
+        ]
+        for (modified_on, action) in update_actions:
+            if action:
+                property_changed = action.dynamic_properties.get(case_property_name)
+                if property_changed:
+                    return PropertyChangedInfo(property_changed, modified_on)
+        return False
+
+    date_of_change = None
+    actions = case.actions
+    for i, transactions in enumerate(actions):
+        property_changed_info = property_changed_in_action(transactions, case_property_name)
+        if property_changed_info and property_changed_info.new_value == value:
+            # get the date that case_property changed
+            date_of_change = parse_datetime(property_changed_info.modified_on)
+            break
+
+    return date_of_change

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.util.decorators import hqnottest
+from casexml.apps.case.const import ARCHIVED_CASE_OWNER_ID
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import post_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -488,3 +489,35 @@ def get_fulfilled_prescription_vouchers_from_episode(domain, episode_case_id):
 
 def get_prescription_from_voucher(domain, voucher_id):
     return get_parent_of_case(domain, voucher_id, CASE_TYPE_PRESCRIPTION)
+
+
+def get_all_episode_ids(domain):
+    case_accessor = CaseAccessors(domain)
+    case_ids = case_accessor.get_open_case_ids_in_domain_by_type(CASE_TYPE_EPISODE)
+    return case_ids
+
+
+def iter_all_active_person_episode_cases(domain, case_ids):
+    """From a list of case_ids, return all the active episodes and associate person case
+    """
+    case_accessor = CaseAccessors(domain)
+    episode_cases = case_accessor.iter_cases(case_ids)
+    for episode_case in episode_cases:
+        if episode_case.type != CASE_TYPE_EPISODE:
+            continue
+
+        if episode_case.closed:
+            continue
+
+        try:
+            person_case = get_person_case_from_episode(domain, episode_case.case_id)
+        except ENikshayCaseNotFound:
+            continue
+
+        if person_case.owner_id == ARCHIVED_CASE_OWNER_ID:
+            continue
+
+        if person_case.closed:
+            continue
+
+        yield person_case, episode_case

--- a/custom/enikshay/const.py
+++ b/custom/enikshay/const.py
@@ -47,6 +47,9 @@ PRIVATE_PATIENT_EPISODE_PENDING_REGISTRATION = "private_sector_episode_pending_r
 WEIGHT_BAND = 'weight_band'
 LAST_VOUCHER_CREATED_BY_ID = "bets_last_voucher_created_by_id"
 NOTIFYING_PROVIDER_USER_ID = "bets_notifying_provider_user_id"
+FIRST_PRESCRIPTION_VOUCHER_REDEEMED = 'bets_first_prescription_voucher_redeemed'
+FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE = 'bets_first_prescription_voucher_redeemed_date'
+
 
 CURRENT_ADDRESS = 'current_address'
 ENROLLED_IN_PRIVATE = "enrolled_in_private"

--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -26,6 +26,7 @@ from custom.enikshay.const import (
     NOTIFYING_PROVIDER_USER_ID,
     INVESTIGATION_TYPE,
     USERTYPE_DISPLAYS,
+    FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE,
 )
 from custom.enikshay.exceptions import NikshayLocationNotFound
 from .const import (
@@ -216,7 +217,7 @@ class IncentivePayload(BETSPayload):
 
         return cls(
             EventID=DIAGNOSIS_AND_NOTIFICATION_EVENT,
-            EventOccurDate=episode_case.get_case_property('bets_first_prescription_voucher_redeemed_date'),
+            EventOccurDate=episode_case.get_case_property(FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE),
             BeneficiaryUUID=episode_case.dynamic_case_properties().get(NOTIFYING_PROVIDER_USER_ID),
             BeneficiaryType=LOCATION_TYPE_MAP[location.location_type.code],
             EpisodeID=episode_case.case_id,

--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -216,7 +216,7 @@ class IncentivePayload(BETSPayload):
 
         return cls(
             EventID=DIAGNOSIS_AND_NOTIFICATION_EVENT,
-            EventOccurDate=cls._india_now(),
+            EventOccurDate=episode_case.get_case_property('bets_first_prescription_voucher_redeemed_date'),
             BeneficiaryUUID=episode_case.dynamic_case_properties().get(NOTIFYING_PROVIDER_USER_ID),
             BeneficiaryType=LOCATION_TYPE_MAP[location.location_type.code],
             EpisodeID=episode_case.case_id,

--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -198,12 +198,6 @@ class IncentivePayload(BETSPayload):
             EnikshayApprovalDate=None,
         )
 
-    @staticmethod
-    def _india_now():
-        utc_now = pytz.UTC.localize(datetime.utcnow())
-        india_now = utc_now.replace(tzinfo=timezone('Asia/Kolkata')).date()
-        return str(india_now)
-
     @classmethod
     def create_diagnosis_and_notification_payload(cls, episode_case):
         person_case = get_person_case_from_episode(episode_case.domain, episode_case.case_id)
@@ -248,7 +242,7 @@ class IncentivePayload(BETSPayload):
 
         return cls(
             EventID=AYUSH_REFERRAL_EVENT,
-            EventOccurDate=cls._india_now(),
+            EventOccurDate=episode_case.get_case_property(FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE),
             BeneficiaryUUID=location.user_id,
             BeneficiaryType='ayush_other',
             EpisodeID=episode_case.case_id,

--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -350,9 +350,9 @@ class BETSDiagnosisAndNotificationRepeater(BaseBETSRepeater):
         enrolled_in_private_sector = case_properties.get(ENROLLED_IN_PRIVATE) == 'true'
         return (
             case_properties.get("bets_first_prescription_voucher_redeemed") == 'true'
-            and case_properties_changed(episode_case, ['bets_first_prescription_voucher_redeemed'])
             and not_sent
             and enrolled_in_private_sector
+            and case_properties_changed(episode_case, ['bets_first_prescription_voucher_redeemed'])
             and is_valid_episode_submission(episode_case)
         )
 
@@ -377,10 +377,10 @@ class BETSAYUSHReferralRepeater(BaseBETSRepeater):
         enrolled_in_private_sector = case_properties.get(ENROLLED_IN_PRIVATE) == 'true'
         return (
             case_properties.get("bets_first_prescription_voucher_redeemed") == 'true'
-            and case_properties_changed(episode_case, ['bets_first_prescription_voucher_redeemed'])
             and case_properties.get("created_by_user_type") == "pac"
             and not_sent
             and enrolled_in_private_sector
+            and case_properties_changed(episode_case, ['bets_first_prescription_voucher_redeemed'])
             and is_valid_episode_submission(episode_case)
         )
 

--- a/custom/enikshay/integrations/bets/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/bets/tests/test_repeaters.py
@@ -390,13 +390,14 @@ class TestIncentivePayload(ENikshayLocationStructureMixin, ENikshayRepeaterTestB
         )
 
     def test_ayush_referral_payload(self):
+        date_today = u"2017-08-15"
         self.pac.user_id = self.user.user_id
         self.pac.save()
         self.episode.attrs['update']['registered_by'] = self.pac.location_id
+        self.episode.attrs['update'][FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE] = date_today
         cases = self.create_case_structure()
         self.assign_person_to_location(self.pcp.location_id)
         episode = cases[self.episode_id]
-        date_today = u"2017-08-15"
 
         expected_payload = {"incentive_details": [{
             u"EventID": unicode(AYUSH_REFERRAL_EVENT),
@@ -412,11 +413,10 @@ class TestIncentivePayload(ENikshayLocationStructureMixin, ENikshayRepeaterTestB
             u"EnikshayRole": None,
             u"EnikshayApprovalDate": None,
         }]}
-        with mock.patch.object(IncentivePayload, '_india_now', return_value=date_today):
-            self.assertDictEqual(
-                expected_payload,
-                json.loads(BETSAYUSHReferralPayloadGenerator(None).get_payload(None, episode))
-            )
+        self.assertDictEqual(
+            expected_payload,
+            json.loads(BETSAYUSHReferralPayloadGenerator(None).get_payload(None, episode))
+        )
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)

--- a/custom/enikshay/integrations/bets/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/bets/tests/test_repeaters.py
@@ -361,11 +361,12 @@ class TestIncentivePayload(ENikshayLocationStructureMixin, ENikshayRepeaterTestB
         )
 
     def test_diagnosis_and_notification_payload(self):
+        date_today = u"2017-08-15"
         self.episode.attrs['update'][NOTIFYING_PROVIDER_USER_ID] = self.user.user_id
+        self.episode.attrs['update']['bets_first_prescription_voucher_redeemed_date'] = date_today
         cases = self.create_case_structure()
         self.assign_person_to_location(self.pcp.location_id)
         episode = cases[self.episode_id]
-        date_today = u"2017-08-15"
 
         expected_payload = {"incentive_details": [{
             u"EventID": unicode(DIAGNOSIS_AND_NOTIFICATION_EVENT),
@@ -381,11 +382,10 @@ class TestIncentivePayload(ENikshayLocationStructureMixin, ENikshayRepeaterTestB
             u"EnikshayRole": None,
             u"EnikshayApprovalDate": None,
         }]}
-        with mock.patch.object(IncentivePayload, '_india_now', return_value=date_today):
-            self.assertDictEqual(
-                expected_payload,
-                json.loads(BETSDiagnosisAndNotificationPayloadGenerator(None).get_payload(None, episode))
-            )
+        self.assertDictEqual(
+            expected_payload,
+            json.loads(BETSDiagnosisAndNotificationPayloadGenerator(None).get_payload(None, episode))
+        )
 
     def test_ayush_referral_payload(self):
         self.pac.user_id = self.user.user_id

--- a/custom/enikshay/integrations/bets/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/bets/tests/test_repeaters.py
@@ -16,6 +16,8 @@ from custom.enikshay.const import (
     TREATMENT_OUTCOME_DATE,
     LAST_VOUCHER_CREATED_BY_ID,
     NOTIFYING_PROVIDER_USER_ID,
+    FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE,
+    FIRST_PRESCRIPTION_VOUCHER_REDEEMED,
 )
 from custom.enikshay.integrations.bets.const import (
     TREATMENT_180_EVENT,
@@ -363,7 +365,7 @@ class TestIncentivePayload(ENikshayLocationStructureMixin, ENikshayRepeaterTestB
     def test_diagnosis_and_notification_payload(self):
         date_today = u"2017-08-15"
         self.episode.attrs['update'][NOTIFYING_PROVIDER_USER_ID] = self.user.user_id
-        self.episode.attrs['update']['bets_first_prescription_voucher_redeemed_date'] = date_today
+        self.episode.attrs['update'][FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE] = date_today
         cases = self.create_case_structure()
         self.assign_person_to_location(self.pcp.location_id)
         episode = cases[self.episode_id]
@@ -596,7 +598,7 @@ class BETSDiagnosisAndNotificationRepeaterTest(ENikshayLocationStructureMixin, E
             self.domain,
             self.episode_id,
             {
-                'bets_first_prescription_voucher_redeemed': 'false',
+                FIRST_PRESCRIPTION_VOUCHER_REDEEMED: 'false',
                 ENROLLED_IN_PRIVATE: "true",
             },
         )
@@ -633,7 +635,7 @@ class BETSAYUSHReferralRepeaterTest(ENikshayLocationStructureMixin, ENikshayRepe
             self.domain,
             self.episode_id,
             {
-                'bets_first_prescription_voucher_redeemed': 'false',
+                FIRST_PRESCRIPTION_VOUCHER_REDEEMED: 'false',
                 'created_by_user_type': 'pac',
                 ENROLLED_IN_PRIVATE: "true",
             },

--- a/custom/enikshay/management/commands/base.py
+++ b/custom/enikshay/management/commands/base.py
@@ -1,0 +1,42 @@
+from django.core.management.base import BaseCommand
+
+from corehq.apps.hqcase.utils import bulk_update_cases
+from corehq.util.log import with_progress_bar
+
+from custom.enikshay.case_utils import get_all_episode_ids, iter_all_active_person_episode_cases
+
+
+class ENikshayBatchCaseUpdaterCommand(BaseCommand):
+
+    @property
+    def updater(self):
+        raise NotImplementedError("No updater class set")
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+
+    def handle(self, domain, **options):
+        batch_size = 100
+        updates = []
+        errors = []
+
+        case_ids = get_all_episode_ids(domain)
+        cases = iter_all_active_person_episode_cases(domain, case_ids)
+
+        for person, episode in with_progress_bar(cases, len(case_ids)):
+            update_json = {}
+            for updater in self.updaters:
+                try:
+                    update_json.update(updater(self.domain, episode).update_json())
+                except Exception as e:
+                    error = [episode.case_id, episode.domain, updater.__name__, e]
+                    errors.append(error)
+                    print "{}: {} - {}".format(*error)
+            if update_json:
+                updates.append((episode.case_id, update_json, False))
+            if len(updates) >= batch_size:
+                bulk_update_cases(domain, updates)
+                updates = []
+
+        if len(updates) > 0:
+            bulk_update_cases(domain, updates)

--- a/custom/enikshay/management/commands/set_redeemed_prescription_voucher_dates.py
+++ b/custom/enikshay/management/commands/set_redeemed_prescription_voucher_dates.py
@@ -1,0 +1,6 @@
+from custom.enikshay.management.commands.base import ENikshayBatchCaseUpdaterCommand
+from custom.enikshay.model_migration_sets.redeemed_prescription_vouchers import VoucherRedeemedDateSetter
+
+
+class Command(ENikshayBatchCaseUpdaterCommand):
+    updater = VoucherRedeemedDateSetter

--- a/custom/enikshay/model_migration_sets/redeemed_prescription_vouchers.py
+++ b/custom/enikshay/model_migration_sets/redeemed_prescription_vouchers.py
@@ -1,4 +1,10 @@
 from casexml.apps.case.util import get_datetime_case_property_changed
+from custom.enikshay.const import (
+    FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE,
+    FIRST_PRESCRIPTION_VOUCHER_REDEEMED,
+    ENROLLED_IN_PRIVATE,
+    REAL_DATASET_PROPERTY_VALUE,
+)
 
 
 class VoucherRedeemedDateSetter(object):
@@ -17,24 +23,24 @@ class VoucherRedeemedDateSetter(object):
             return {}
 
         redeemed_datetime = get_datetime_case_property_changed(
-            self.episode, 'bets_first_prescription_voucher_redeemed', 'true',
+            self.episode, FIRST_PRESCRIPTION_VOUCHER_REDEEMED, 'true',
         )
         if redeemed_datetime is not None:
             return {
-                'bets_first_prescription_voucher_redeemed_date': str(redeemed_datetime.date())
+                FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE: str(redeemed_datetime.date())
             }
         else:
             return {}
 
     @property
     def should_update(self):
-        if self.episode.get_case_property('bets_first_prescription_voucher_redeemed_date') is not None:
+        if self.episode.get_case_property(FIRST_PRESCRIPTION_VOUCHER_REDEEMED_DATE) is not None:
             return False
 
-        if self.episode.get_case_property('enrolled_in_private') != 'true':
+        if self.episode.get_case_property(ENROLLED_IN_PRIVATE) != 'true':
             return False
 
-        if self.person.get_case_property('dataset') != 'real':
+        if self.person.get_case_property('dataset') != REAL_DATASET_PROPERTY_VALUE:
             return False
 
         return True

--- a/custom/enikshay/model_migration_sets/redeemed_prescription_vouchers.py
+++ b/custom/enikshay/model_migration_sets/redeemed_prescription_vouchers.py
@@ -1,4 +1,4 @@
-from casexml.apps.case.util import get_date_case_property_changed
+from casexml.apps.case.util import get_datetime_case_property_changed
 
 
 class VoucherRedeemedDateSetter(object):
@@ -16,12 +16,12 @@ class VoucherRedeemedDateSetter(object):
         if not self.should_update:
             return {}
 
-        redeemed_date = get_date_case_property_changed(
+        redeemed_datetime = get_datetime_case_property_changed(
             self.episode, 'bets_first_prescription_voucher_redeemed', 'true',
         )
-        if redeemed_date is not None:
+        if redeemed_datetime is not None:
             return {
-                'bets_first_prescription_voucher_redeemed_date': redeemed_date
+                'bets_first_prescription_voucher_redeemed_date': str(redeemed_datetime.date())
             }
         else:
             return {}

--- a/custom/enikshay/model_migration_sets/redeemed_prescription_vouchers.py
+++ b/custom/enikshay/model_migration_sets/redeemed_prescription_vouchers.py
@@ -1,0 +1,40 @@
+from casexml.apps.case.util import get_date_case_property_changed
+
+
+class VoucherRedeemedDateSetter(object):
+    """Sets the bets_first_prescription_voucher_redeemed_date property for use by
+    the BETSDiagnosisAndNotificationRepeater
+
+    """
+
+    def __init__(self, domain, person, episode):
+        self.domain = domain
+        self.person = person
+        self.episode = episode
+
+    def update_json(self):
+        if not self.should_update:
+            return {}
+
+        redeemed_date = get_date_case_property_changed(
+            self.episode, 'bets_first_prescription_voucher_redeemed', 'true',
+        )
+        if redeemed_date is not None:
+            return {
+                'bets_first_prescription_voucher_redeemed_date': redeemed_date
+            }
+        else:
+            return {}
+
+    @property
+    def should_update(self):
+        if self.episode.get_case_property('bets_first_prescription_voucher_redeemed_date') is not None:
+            return False
+
+        if self.episode.get_case_property('enrolled_in_private') != 'true':
+            return False
+
+        if self.person.get_case_property('dataset') != 'real':
+            return False
+
+        return True


### PR DESCRIPTION
@esoergel 
This will fix the issue where all BETSDiagnosisAndNotificationRepeater EventDates are getting set to today's date.

🐟 

TODO:
- [x] Add this property to the app (once domain migration is complete)
- [ ] Run management command to update past cases

cc: @gcapalbo 