### PR TITLE
Data files: Allow users to navigate the UI

### DIFF
--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -16,7 +16,7 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import static
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.dbaccessors import user_ids_at_accessible_locations
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.users.permissions import can_view_form_exports, can_view_case_exports
+from corehq.apps.users.permissions import can_view_form_exports, can_view_case_exports, can_download_data_files
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.util.workbook_json.excel import JSONReaderError, WorkbookJSONReader, \
     InvalidExcelFileException
@@ -67,9 +67,13 @@ def default(request, domain):
 
 def default_data_view_url(request, domain):
     from corehq.apps.export.views import (
-        FormExportListView, CaseExportListView,
-        DeIdFormExportListView, user_can_view_deid_exports
+        CaseExportListView,
+        DataFileDownloadList,
+        DeIdFormExportListView,
+        FormExportListView,
+        user_can_view_deid_exports,
     )
+
     if can_view_form_exports(request.couch_user, domain):
         return reverse(FormExportListView.urlname, args=[domain])
     elif can_view_case_exports(request.couch_user, domain):
@@ -77,6 +81,9 @@ def default_data_view_url(request, domain):
 
     if user_can_view_deid_exports(domain, request.couch_user):
         return reverse(DeIdFormExportListView.urlname, args=[domain])
+
+    if can_download_data_files(domain):
+        return reverse(DataFileDownloadList.urlname, args=[domain])
 
     raise Http404()
 

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from corehq import privileges
+from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 
 FORM_EXPORT_PERMISSION = 'corehq.apps.reports.standard.export.ExcelExportReport'
@@ -25,6 +25,10 @@ def get_extra_permissions():
         CASE_EXPORT_PERMISSION, CaseExportListView.page_title, lambda domain: True)
     yield ReportPermission(
         SMS_EXPORT_PERMISSION, DownloadNewSmsExportView.page_title, lambda domain: True)
+
+
+def can_download_data_files(domain):
+    return toggles.DATA_FILE_DOWNLOAD.enabled(domain)
 
 
 def can_view_form_exports(couch_user, domain):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -27,7 +27,12 @@ from corehq.apps.reports.models import ReportConfig, ReportsSidebarOrdering
 from corehq.apps.smsbillables.dispatcher import SMSAdminInterfaceDispatcher
 from corehq.apps.userreports.util import has_report_builder_access
 from corehq.apps.users.models import AnonymousCouchUser
-from corehq.apps.users.permissions import can_view_form_exports, can_view_case_exports, can_view_sms_exports
+from corehq.apps.users.permissions import (
+    can_view_form_exports,
+    can_view_case_exports,
+    can_view_sms_exports,
+    can_download_data_files,
+)
 from corehq.form_processor.utils import use_new_exports
 from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
 from corehq.tabs.uitab import UITab
@@ -483,7 +488,9 @@ class ProjectDataTab(UITab):
 
     @property
     def _is_viewable(self):
-        return self.domain and (self.can_edit_commcare_data or self.can_export_data)
+        return self.domain and (
+            self.can_edit_commcare_data or self.can_export_data or can_download_data_files(self.domain)
+        )
 
     @property
     def sidebar_items(self):
@@ -702,7 +709,7 @@ class ProjectDataTab(UITab):
                     'subpages': []
                 })
 
-        if toggles.DATA_FILE_DOWNLOAD.enabled(self.domain):
+        if can_download_data_files(self.domain):
             from corehq.apps.export.views import DataFileDownloadList
 
             export_data_views.append({
@@ -750,11 +757,17 @@ class ProjectDataTab(UITab):
 
     @property
     def dropdown_items(self):
-        if self.can_only_see_deid_exports or not self.can_export_data:
+        if (
+            self.can_only_see_deid_exports or (
+                not self.can_export_data and not can_download_data_files(self.domain)
+            )
+        ):
             return []
+
         from corehq.apps.export.views import (
             FormExportListView, CaseExportListView, DownloadNewSmsExportView,
         )
+
         items = []
         if self.can_view_form_exports:
             items.append(dropdown_dict(
@@ -772,10 +785,9 @@ class ProjectDataTab(UITab):
                 url=reverse(DownloadNewSmsExportView.urlname, args=(self.domain,))
             ))
 
-        items += [
-            dropdown_dict(None, is_divider=True),
-            dropdown_dict(_("View All"), url=self.url),
-        ]
+        if items:
+            items += [dropdown_dict(None, is_divider=True)]
+        items += [dropdown_dict(_("View All"), url=self.url)]
         return items
 
 


### PR DESCRIPTION
If users can download data files, allow them to navigate the UI (using the Data menu or breadcrumbs) to the "Download Data Files" page.

Context: [FB 258588](http://manage.dimagi.com/default.asp?258588)

(This PR only resolves the issue relating to navigation. A separate PR for download issue to follow.)

@biyeun 