### PR TITLE
Use FileWrapper for both kinds of blobs

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1578,10 +1578,7 @@ class DataFileDownloadDetail(BaseProjectDataView):
         try:
             data_file = DataFile.objects.filter(domain=self.domain).get(pk=kwargs['pk'])
             blob = data_file.get_blob()
-            response = StreamingHttpResponse(
-                blob if hasattr(blob, '__iter__') else FileWrapper(blob),
-                content_type=data_file.content_type
-            )
+            response = StreamingHttpResponse(FileWrapper(blob), content_type=data_file.content_type)
         except (DataFile.DoesNotExist, NotFound):
             raise Http404
         response['Content-Disposition'] = 'attachment; filename="' + data_file.filename + '"'


### PR DESCRIPTION
Although `blob` has an `__iter__` method, it doesn't guarantee it can iterate. :expressionless: In the case of S3 blobs, `blob.__iter__()` calls `iter(self._obj)`, which fails when `self._obj` isn't iterable. 

For simplicity, just use `FileWrapper` for both S3 and file system blobs.

Context: [FB 2158588](http://manage.dimagi.com/default.asp?258588)

@biyeun 
