### PR TITLE
Don't allow cloudcare views to throw a 500 if the user is not logged in

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -116,6 +116,9 @@ class FormplayerMain(View):
         the eventual response
         """
 
+        if not hasattr(request, 'couch_user'):
+            raise Http404()
+
         def set_cookie(response):  # set_coookie is a noop by default
             return response
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?260002

@kaapstorm 
cc @nickpell 