### PR TITLE
Refactor test_sync_mode to use MockDevice

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -105,20 +105,24 @@ def check_xml_line_by_line(test_case, expected, actual):
 
 
 def assert_user_has_case(testcase, user, case_id, **kwargs):
+    """DEPRECATED use assertIn(case_id, <MockDevice>.sync().cases)"""
     return assert_user_has_cases(testcase, user, [case_id], return_single=True, **kwargs)
 
 
 def assert_user_has_cases(testcase, user, case_ids, **kwargs):
+    """DEPRECATED use assertTrue(set(case_ids) <= set(<MockDevice>.sync().cases))"""
     case_blocks = [CaseBlock(case_id=case_id).as_xml() for case_id in case_ids]
     return check_user_has_case(testcase, user, case_blocks,
                                should_have=True, line_by_line=False, **kwargs)
 
 
 def assert_user_doesnt_have_case(testcase, user, case_id, **kwargs):
+    """DEPRECATED use assertNotIn(case_id, <MockDevice>.sync().cases)"""
     return assert_user_doesnt_have_cases(testcase, user, [case_id], return_single=True, **kwargs)
 
 
 def assert_user_doesnt_have_cases(testcase, user, case_ids, **kwargs):
+    """DEPRECATED use assertFalse(set(case_ids) & set(<MockDevice>.sync().cases))"""
     case_blocks = [CaseBlock(case_id=case_id).as_xml() for case_id in case_ids]
     return check_user_has_case(testcase, user, case_blocks,
                                should_have=False, **kwargs)
@@ -137,6 +141,7 @@ def extract_caseblocks_from_xml(payload_string, version=V2):
 @contextmanager
 def cached_restore(testcase, user, restore_id="", version=V2,
                    purge_restore_cache=False):
+    """DEPRECATED use <MockDevice>.sync().cases"""
     assert not hasattr(testcase, 'restore_config'), testcase
     assert not hasattr(testcase, 'payload_string'), testcase
 
@@ -158,6 +163,7 @@ def cached_restore(testcase, user, restore_id="", version=V2,
 def check_user_has_case(testcase, user, case_blocks, should_have=True,
                         line_by_line=True, restore_id="", version=V2,
                         purge_restore_cache=False, return_single=False):
+    """DEPRECATED use <MockDevice>.sync().cases"""
 
     try:
         restore_config = testcase.restore_config
@@ -167,7 +173,7 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
             restore_config = testcase.restore_config
             payload_string = testcase.payload_string
 
-    return check_payload_has_cases(
+    return _check_payload_has_cases(
         testcase=testcase,
         payload_string=payload_string,
         username=user.username,
@@ -180,13 +186,9 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
     )
 
 
-def check_payload_has_case_ids(testcase, payload_string, username, case_ids):
-    case_blocks = [CaseBlock(case_id=case_id).as_xml() for case_id in case_ids]
-    return check_payload_has_cases(testcase, payload_string, username, case_blocks, line_by_line=False)
-
-
-def check_payload_has_cases(testcase, payload_string, username, case_blocks, should_have=True,
+def _check_payload_has_cases(testcase, payload_string, username, case_blocks, should_have=True,
                             line_by_line=True, version=V2, return_single=False, restore_config=None):
+    """DEPRECATED use <MockDevice>.sync().cases"""
 
     if not isinstance(case_blocks, list):
         case_blocks = [case_blocks]

--- a/corehq/ex-submodules/casexml/apps/phone/tests/performance_tests.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/performance_tests.py
@@ -1,5 +1,5 @@
 from unittest import skip
-from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.mock import CaseBlock, CaseStructure
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest, PARENT_TYPE
 from casexml.apps.phone.tests.utils import (
     synclog_from_restore_payload,
@@ -28,6 +28,14 @@ class SyncPerformanceTest(SyncBaseTest):
     """
     Tests the interaction of two users in sync mode doing various things
     """
+
+    def _createCaseStubs(self, id_list, **kwargs):
+        # TODO remove this when these tests use MockDevice
+        case_attrs = {'create': True}
+        case_attrs.update(kwargs)
+        return self.factory.create_or_update_cases(
+            [CaseStructure(case_id=case_id, attrs=case_attrs) for case_id in id_list],
+        )
 
     def setUp(self):
         super(SyncPerformanceTest, self).setUp()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/performance_tests.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/performance_tests.py
@@ -37,6 +37,14 @@ class SyncPerformanceTest(SyncBaseTest):
             [CaseStructure(case_id=case_id, attrs=case_attrs) for case_id in id_list],
         )
 
+    def _postFakeWithSyncToken(self, caseblocks, token_id):
+        # TODO remove this when these tests use MockDevice
+        if not isinstance(caseblocks, list):
+            # can't use list(caseblocks) since that returns children of the node
+            # http://lxml.de/tutorial.html#elements-are-lists
+            caseblocks = [caseblocks]
+        return self.factory.post_case_blocks(caseblocks, form_extras={"last_sync_token": token_id})
+
     def setUp(self):
         super(SyncPerformanceTest, self).setUp()
         # the other user is an "owner" of the original users cases as well,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -167,6 +167,7 @@ class TestLiveQuery(TestCase):
 
     def test_clean_owners_after_livequery(self):
         device = MockDevice(self.project, self.user, {"case_sync": LIVEQUERY})
+        device.sync()
         with self.assertRaises(RestoreException):
             device.sync(case_sync=CLEAN_OWNERS)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1,9 +1,9 @@
+import os
 import uuid
+from datetime import datetime
 from xml.etree import ElementTree
-from couchdbkit import ResourceNotFound
 from django.test.utils import override_settings
 from django.test import TestCase
-import os
 
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.exceptions import RestoreException
@@ -21,18 +21,14 @@ from corehq.form_processor.tests.utils import (
     use_sql_backend,
 )
 from corehq.util.test_utils import flag_enabled
-from casexml.apps.case.tests.util import (
-    check_user_has_case, assert_user_doesnt_have_case,
-    assert_user_has_case, TEST_DOMAIN_NAME, assert_user_has_cases,
-    check_payload_has_case_ids, assert_user_doesnt_have_cases)
-from casexml.apps.phone.tests.utils import create_restore_user, has_cached_payload
+from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
+from casexml.apps.phone.tests.utils import create_restore_user
 from casexml.apps.phone.models import (
     AbstractSyncLog,
     get_properly_wrapped_sync_log,
     LOG_FORMAT_LIVEQUERY,
     LOG_FORMAT_SIMPLIFIED,
     SimplifiedSyncLog,
-    SyncLog,
 )
 from casexml.apps.phone.restore import (
     CachedResponse,
@@ -44,7 +40,6 @@ from casexml.apps.phone.restore import (
 )
 from casexml.apps.case.xml import V2, V1
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
-from datetime import datetime
 
 USERNAME = "syncguy"
 OTHER_USERNAME = "ferrel"

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -7,13 +7,9 @@ import os
 
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.exceptions import RestoreException
-from casexml.apps.phone.tests.utils import (
-    get_next_sync_log,
-    generate_restore_payload,
-    MockDevice,
-)
-from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure, CaseIndex
-from casexml.apps.phone.tests.utils import synclog_from_restore_payload, get_restore_config
+from casexml.apps.phone.tests.utils import MockDevice
+from casexml.apps.case.mock import CaseBlock, CaseStructure, CaseIndex
+from casexml.apps.phone.tests.utils import get_restore_config
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
@@ -174,13 +170,6 @@ class SyncBaseTest(TestCase):
             migrated_sync_log = SimplifiedSyncLog.from_other_format(sync_log)
             self.assertEqual(sync_log.get_state_hash(), migrated_sync_log.get_state_hash())
             self._testUpdate(migrated_sync_log, case_id_map, dependent_case_id_map)
-
-    def get_next_sync_log(self, **kw):
-        assert not set(self.restore_options) & set(kw), kw
-        kw.update(self.restore_options)
-        kw.setdefault('project', self.project)
-        kw.setdefault('user', self.user)
-        return get_next_sync_log(**kw)
 
 
 class SyncTokenUpdateTest(SyncBaseTest):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -846,8 +846,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         """
         case_type = 'case'
         index_identifier = 'idx'
-        host = CaseStructure(case_id='host',
-                             attrs={'create': True})
+        host = CaseStructure(case_id='host', attrs={'create': True})
         extension = CaseStructure(
             case_id='extension',
             attrs={'create': True, 'owner_id': '-'},
@@ -859,8 +858,8 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
             )],
         )
 
-        self.factory.create_or_update_cases([extension])
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes(extension)
+        sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.index_tree.indices, {})
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {index_identifier: host.case_id}})
@@ -871,8 +870,7 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
         """creating multiple indices should add to the right tree
         """
         case_type = 'case'
-        host = CaseStructure(case_id='host',
-                             attrs={'create': True})
+        host = CaseStructure(case_id='host', attrs={'create': True})
         extension = CaseStructure(
             case_id='extension',
             attrs={'create': True, 'owner_id': '-'},
@@ -888,9 +886,8 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
                 related_type=case_type,
             )],
         )
-
-        self.factory.create_or_update_cases([extension])
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes(extension)
+        sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.index_tree.indices,
                              {extension.case_id: {'child': host.case_id}})
         self.assertDictEqual(sync_log.extension_index_tree.indices,
@@ -922,9 +919,8 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
                 related_type=case_type,
             )]
         )
-
-        self.factory.create_or_update_cases([extension_extension])
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes(extension_extension)
+        sync_log = self.device.last_sync.get_log()
         expected_extension_tree = {extension.case_id: {'host': host.case_id},
                                    extension_extension.case_id: {'host_2': extension.case_id}}
         self.assertDictEqual(sync_log.index_tree.indices, {})
@@ -946,13 +942,12 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
                 related_type=case_type,
             )],
         )
-        self.factory.create_or_update_case(extension)
-
         delegated_extension = CaseStructure(case_id=extension.case_id, attrs={'owner_id': 'me'})
-        self.factory.create_or_update_case(delegated_extension)
+        self.device.post_changes(extension)
+        self.device.post_changes(delegated_extension)
 
         expected_extension_tree = {extension.case_id: {'host': host.case_id}}
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([extension.case_id]))
         self.assertEqual(sync_log.case_ids_on_phone, set([extension.case_id, host.case_id]))
@@ -971,10 +966,10 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
                 related_type=case_type,
             )],
         )
-        self.factory.create_or_update_case(extension)
+        self.device.post_changes(extension)
 
         expected_extension_tree = {extension.case_id: {'host': host.case_id}}
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.extension_index_tree.indices, expected_extension_tree)
         self.assertEqual(sync_log.case_ids_on_phone, set([host.case_id, extension.case_id]))
 
@@ -995,15 +990,14 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
                 related_type=case_type,
             )],
         )
-
-        self.factory.create_or_update_cases([extension])
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes(extension)
+        sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {index_identifier: host.case_id}})
 
         closed_host = CaseStructure(case_id=host.case_id, attrs={'close': True})
-        self.factory.create_or_update_case(closed_host)
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes(closed_host)
+        sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.extension_index_tree.indices, {})
         self.assertEqual(sync_log.dependent_case_ids_on_phone, set([]))
         self.assertEqual(sync_log.case_ids_on_phone, set([]))
@@ -1060,8 +1054,8 @@ class ExtensionCasesSyncTokenUpdates(SyncBaseTest):
                 related_type=case_type,
             )]
         )
-        self.factory.create_or_update_cases([O, E2])
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes([O, E2])
+        sync_log = self.device.last_sync.get_log()
 
         expected_dependent_ids = set([C.case_id, E1.case_id, E2.case_id])
         self.assertEqual(sync_log.dependent_case_ids_on_phone, expected_dependent_ids)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1977,8 +1977,8 @@ class MultiUserSyncTest(SyncBaseTest):
         p2, o2, e2 = create_case_graph(2)
 
         # Alice and Bob sync
-        alice = self.get_device()
-        bob = self.get_device(user=self.other_user)
+        alice = self.get_device(sync=True)
+        bob = self.get_device(user=self.other_user, sync=True)
         all_cases = {case.case_id for case in [p1, o1, e1, p2, o2, e2]}
         self.assertEqual(set(alice.last_sync.log.case_ids_on_phone), all_cases)
         self.assertEqual(set(bob.last_sync.log.case_ids_on_phone), all_cases)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -84,12 +84,7 @@ class SyncBaseTest(TestCase):
         FormProcessorTestUtils.delete_all_xforms()
         FormProcessorTestUtils.delete_all_sync_logs()
 
-        self.device = MockDevice(
-            self.project,
-            self.user,
-            self.restore_options,
-            default_case_type=PARENT_TYPE,
-        )
+        self.device = self.get_device()
         self.sync_log = self.device.sync(overwrite_cache=True, version=V1).log
         self.factory = self.device.case_factory
         # HACK remove once all tests are converted to use self.device
@@ -126,6 +121,13 @@ class SyncBaseTest(TestCase):
         with open(file_path, "rb") as f:
             xml_data = f.read()
         return submit_form_locally(xml_data, 'test-domain', last_sync_token=token_id).xform
+
+    def get_device(self, **kw):
+        kw.setdefault("project", self.project)
+        kw.setdefault("user", self.user)
+        kw.setdefault("restore_options", self.restore_options)
+        kw.setdefault("default_case_type", PARENT_TYPE)
+        return MockDevice(**kw)
 
     def _postFakeWithSyncToken(self, caseblocks, token_id):
         if not isinstance(caseblocks, list):
@@ -1975,8 +1977,8 @@ class MultiUserSyncTest(SyncBaseTest):
         p2, o2, e2 = create_case_graph(2)
 
         # Alice and Bob sync
-        alice = MockDevice(self.project, self.user, self.restore_options)
-        bob = MockDevice(self.project, self.other_user, self.restore_options)
+        alice = self.get_device()
+        bob = self.get_device(user=self.other_user)
         all_cases = {case.case_id for case in [p1, o1, e1, p2, o2, e2]}
         self.assertEqual(set(alice.last_sync.log.case_ids_on_phone), all_cases)
         self.assertEqual(set(bob.last_sync.log.case_ids_on_phone), all_cases)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -111,13 +111,6 @@ class SyncBaseTest(TestCase):
         kw.setdefault("default_case_type", PARENT_TYPE)
         return MockDevice(**kw)
 
-    def _postFakeWithSyncToken(self, caseblocks, token_id):
-        if not isinstance(caseblocks, list):
-            # can't use list(caseblocks) since that returns children of the node
-            # http://lxml.de/tutorial.html#elements-are-lists
-            caseblocks = [caseblocks]
-        return self.factory.post_case_blocks(caseblocks, form_extras={"last_sync_token": token_id})
-
     def _checkLists(self, l1, l2, msg=None):
         self.assertEqual(set(l1), set(l2), msg)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1088,9 +1088,7 @@ class ExtensionCasesFirstSync(SyncBaseTest):
 
     def setUp(self):
         super(ExtensionCasesFirstSync, self).setUp()
-        self.restore_config = RestoreConfig(
-            project=self.project, restore_user=self.user, **self.restore_options)
-        self.restore_state = self.restore_config.restore_state
+        self.restore_state = self.device.last_sync.config.restore_state
 
     def test_is_first_extension_sync(self):
         """Before any syncs, this should return true when the toggle is enabled, otherwise false"""
@@ -1101,16 +1099,17 @@ class ExtensionCasesFirstSync(SyncBaseTest):
 
     def test_is_first_extension_sync_after_sync(self):
         """After a sync with the extension code in place, this should be false"""
-        self.factory.create_case()
+        self.device.post_changes(create=True, case_id='first')
+        sync0 = self.device.last_sync
         with flag_enabled('EXTENSION_CASES_SYNC_ENABLED'):
             config = get_restore_config(self.project, self.user,
-                restore_id=self.sync_log._id, **self.restore_options)
-            self.assertTrue(get_properly_wrapped_sync_log(self.sync_log._id).extensions_checked)
+                restore_id=sync0.log._id, **self.restore_options)
+            self.assertTrue(sync0.get_log().extensions_checked)
             self.assertFalse(config.restore_state.is_first_extension_sync)
 
         config = get_restore_config(self.project, self.user,
-            restore_id=self.sync_log._id, **self.restore_options)
-        self.assertTrue(get_properly_wrapped_sync_log(self.sync_log._id).extensions_checked)
+            restore_id=sync0.log._id, **self.restore_options)
+        self.assertTrue(sync0.get_log().extensions_checked)
         self.assertFalse(config.restore_state.is_first_extension_sync)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2172,92 +2172,27 @@ class SyncTokenReprocessingTest(SyncBaseTest):
     Tests sync token logic for fixing itself when it gets into a bad state.
     """
 
-    def testUpdateNonExisting(self):
-        case_id = 'non_existent'
-        caseblock = CaseBlock(
-            create=False,
-            case_id=case_id,
-            user_id=self.user_id,
-            owner_id=self.user_id,
-            case_type=PARENT_TYPE,
-        ).as_xml()
-        try:
-            self._postFakeWithSyncToken(caseblock, self.sync_log.get_id)
-            self.fail('posting an update to a non-existant case should fail')
-        except AssertionError:
-            # this should fail because it's a true error
-            pass
-
     def testShouldHaveCase(self):
         case_id = "should_have"
-        self._createCaseStubs([case_id])
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.device.post_changes(case_id=case_id, create=True)
+        sync_log = self.device.last_sync.get_log()
         cases_on_phone = sync_log.tests_only_get_cases_on_phone()
-        self.assertEqual(1, len(cases_on_phone))
-        self.assertEqual(case_id, cases_on_phone[0].case_id)
+        self.assertEqual({case_id}, {c.case_id for c in cases_on_phone})
 
         # manually delete it and then try to update
         sync_log.test_only_clear_cases_on_phone()
         sync_log.save()
 
-        update = CaseBlock(
-            create=False,
+        self.device.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.user_id,
             owner_id=self.user_id,
             case_type=PARENT_TYPE,
             update={'something': "changed"},
-        ).as_xml()
-
+        ))
         # this should work because it should magically fix itself
-        self._postFakeWithSyncToken(update, self.sync_log.get_id)
-        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        sync_log = self.device.last_sync.get_log()
         self.assertFalse(getattr(sync_log, 'has_assert_errors', False))
-
-    def testCodependencies(self):
-
-        case_id1 = 'bad1'
-        case_id2 = 'bad2'
-        initial_caseblocks = [CaseBlock(
-            create=True,
-            case_id=case_id,
-            user_id='not_me',
-            owner_id='not_me',
-            case_type=PARENT_TYPE,
-        ).as_xml() for case_id in [case_id1, case_id2]]
-
-        post_case_blocks(
-            initial_caseblocks,
-        )
-
-        def _get_bad_caseblocks(ids):
-            return [CaseBlock(
-                create=False,
-                case_id=id,
-                user_id=self.user_id,
-                owner_id=self.user_id,
-                case_type=PARENT_TYPE,
-            ).as_xml() for id in ids]
-
-        try:
-            post_case_blocks(
-                _get_bad_caseblocks([case_id1, case_id2]),
-                form_extras={ "last_sync_token": self.sync_log._id }
-            )
-            self.fail('posting an update to non-existant cases should fail')
-        except AssertionError:
-            # this should fail because it's a true error
-            pass
-
-        try:
-            post_case_blocks(
-                _get_bad_caseblocks([case_id2, case_id1]),
-                form_extras={ "last_sync_token": self.sync_log._id }
-            )
-            self.fail('posting an update to non-existant cases should fail')
-        except AssertionError:
-            # this should fail because it's a true error
-            pass
 
 
 @use_sql_backend
@@ -2277,24 +2212,17 @@ class LiveQuerySyncTokenReprocessingTestSQL(LiveQuerySyncTokenReprocessingTest):
 class LooseSyncTokenValidationTest(SyncBaseTest):
 
     def test_submission_with_bad_log_toggle_enabled(self):
-        domain = 'submission-domain-with-toggle'
-
-        def _test():
-            post_case_blocks(
-                [CaseBlock(create=True, case_id='bad-log-toggle-enabled').as_xml()],
-                form_extras={"last_sync_token": 'not-a-valid-synclog-id'},
-                domain=domain,
-            )
-
         # this is just asserting that an exception is not raised when there's no synclog
-        _test()
+        post_case_blocks(
+            [CaseBlock(create=True, case_id='bad-log-toggle-enabled').as_xml()],
+            form_extras={"last_sync_token": 'not-a-valid-synclog-id'},
+            domain='submission-domain-with-toggle',
+        )
 
     def test_restore_with_bad_log_toggle_enabled(self):
-        domain = 'restore-domain-with-toggle'
-
-        def _test():
+        with self.assertRaises(RestoreException):
             RestoreConfig(
-                project=Domain(name=domain),
+                project=Domain(name='restore-domain-with-toggle'),
                 restore_user=self.user,
                 params=RestoreParams(
                     version=V2,
@@ -2302,9 +2230,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
                 ),
                 **self.restore_options
             ).get_payload()
-
-        with self.assertRaises(RestoreException):
-            _test()
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -108,13 +108,6 @@ class SyncBaseTest(TestCase):
         delete_all_users()
         super(SyncBaseTest, cls).tearDownClass()
 
-    def _createCaseStubs(self, id_list, **kwargs):
-        case_attrs = {'create': True}
-        case_attrs.update(kwargs)
-        return self.factory.create_or_update_cases(
-            [CaseStructure(case_id=case_id, attrs=case_attrs) for case_id in id_list],
-        )
-
     def get_device(self, **kw):
         kw.setdefault("project", self.project)
         kw.setdefault("user", self.user)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2329,7 +2329,7 @@ class IndexSyncTest(SyncBaseTest):
         other_parent_id = "sky"
         branch_index = 'stem_index'
         wave_index = 'wave_index'
-        self.factory.create_or_update_case(CaseStructure(
+        self.device.change_cases(CaseStructure(
             case_id=child_id,
             attrs={'create': True},
             indices=[CaseIndex(
@@ -2347,16 +2347,10 @@ class IndexSyncTest(SyncBaseTest):
                 identifier=wave_index,
             )],
         ))
-        payload = generate_restore_payload(
-            self.project, self.user, version=V2, **self.restore_options)
-        check_payload_has_case_ids(
-            self,
-            payload_string=payload,
-            username=self.user.username,
-            case_ids=[child_id, parent_id, other_parent_id]
-        )
-        self.assertIn(branch_index, payload)  # HACK
-        self.assertIn(wave_index, payload)  # HACK
+        sync = self.device.sync(restore_id='')
+        self.assertEqual(sync.case_ids, {child_id, parent_id, other_parent_id})
+        self.assertIn(branch_index, sync.cases[child_id].index)
+        self.assertIn(wave_index, sync.cases[child_id].index)
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2011,11 +2011,11 @@ class MultiUserSyncTest(SyncBaseTest):
 
         sync2 = alice.sync()
         self.assertEqual(set(sync2.log.case_ids_on_phone), alice_cases)
-        self.assertEqual(sync2.case_ids, {e1.case_id, e3.case_id})
+        self.assertEqual(set(sync2.cases), {e1.case_id, e3.case_id})
 
         sync3 = alice.sync()
         self.assertEqual(set(sync3.log.case_ids_on_phone), alice_cases)
-        self.assertEqual(sync3.case_ids, set())
+        self.assertEqual(set(sync3.cases), set())
 
 
 @use_sql_backend
@@ -2348,7 +2348,7 @@ class IndexSyncTest(SyncBaseTest):
             )],
         ))
         sync = self.device.sync(restore_id='')
-        self.assertEqual(sync.case_ids, {child_id, parent_id, other_parent_id})
+        self.assertEqual(set(sync.cases), {child_id, parent_id, other_parent_id})
         self.assertIn(branch_index, sync.cases[child_id].index)
         self.assertIn(wave_index, sync.cases[child_id].index)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -90,7 +90,7 @@ class SyncBaseTest(TestCase):
             self.restore_options,
             default_case_type=PARENT_TYPE,
         )
-        self.sync_log = self.device.last_sync.log
+        self.sync_log = self.device.sync(overwrite_cache=True, version=V1).log
         self.factory = self.device.case_factory
         # HACK remove once all tests are converted to use self.device
         # NOTE self.device.sync() overrides last_sync_token with the

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -158,7 +158,7 @@ def call_fixture_generator(gen, restore_user, project=None, last_sync=None, app=
 class MockDevice(object):
 
     def __init__(self, project, user, restore_options,
-            sync=False, default_case_type="case"):
+            sync=False, default_case_type="case", default_owner_id=None):
         self.project = project
         self.user = user
         self.user_id = user.user_id
@@ -167,7 +167,7 @@ class MockDevice(object):
         self.case_factory = CaseFactory(
             case_defaults={
                 'user_id': self.user_id,
-                'owner_id': self.user_id,
+                'owner_id': default_owner_id or self.user_id,
                 'case_type': default_case_type,
             },
         )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -81,15 +81,6 @@ def generate_restore_payload(project, user, restore_id="", version=V1, state_has
     ).get_payload().as_string()
 
 
-def get_next_sync_log(*args, **kw):
-    """Perform a sync and return the new sync log
-
-    Expects same arguments as `generate_restore_payload`
-    """
-    payload = generate_restore_payload(*args, **kw)
-    return synclog_from_restore_payload(payload)
-
-
 def get_restore_config(project, user, restore_id="", version=V1, state_hash="",
                        items=False, overwrite_cache=False, force_cache=False,
                        device_id=None, case_sync=None):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -235,13 +235,14 @@ class MockDevice(object):
             config['restore_id'] = self.last_sync.log._id
         restore_config = get_restore_config(self.project, self.user, **config)
         payload = restore_config.get_payload().as_string()
-        self.last_sync = SyncResult(payload)
+        self.last_sync = SyncResult(restore_config, payload)
         return self.last_sync
 
 
 class SyncResult(object):
 
-    def __init__(self, payload):
+    def __init__(self, config, payload):
+        self.config = config
         self.payload = payload
         self.xml = ElementTree.fromstring(payload)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -217,7 +217,7 @@ class MockDevice(object):
             self.change_cases(*args, **kw)
         if self.case_blocks:
             # post device case changes
-            token = self.last_sync.log._id
+            token = self.last_sync.log._id if self.last_sync else None
             self.case_factory.post_case_blocks(
                 self.case_blocks,
                 form_extras={"last_sync_token": token},

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -194,6 +194,8 @@ class MockDevice(object):
         if case_kwargs:
             assert cases is None, "pass one: cases or kwargs"
             if "case_id" not in case_kwargs:
+                if not case_kwargs.get('create'):
+                    raise ValueError("case_id is required for update")
                 case_kwargs["case_id"] = uuid4().hex
             self.case_blocks.append(factory.get_case_block(**case_kwargs))
             return

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -157,7 +157,8 @@ def call_fixture_generator(gen, restore_user, project=None, last_sync=None, app=
 
 class MockDevice(object):
 
-    def __init__(self, project, user, restore_options, default_case_type="case"):
+    def __init__(self, project, user, restore_options,
+            sync=False, default_case_type="case"):
         self.project = project
         self.user = user
         self.user_id = user.user_id
@@ -171,7 +172,8 @@ class MockDevice(object):
             },
         )
         self.last_sync = None
-        self.sync(overwrite_cache=True)
+        if sync:
+            self.sync()
 
     def change_cases(self, cases=None, **case_kwargs):
         """Enqueue case changes to be synced

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -236,8 +236,3 @@ class SyncResult(object):
     def cases(self):
         return {case.case_id: case for case in (CaseBlock.from_xml(node)
                 for node in self.xml.findall("{%s}case" % V2_NAMESPACE))}
-
-    @property
-    @memoized
-    def case_ids(self):
-        return set(self.cases)


### PR DESCRIPTION
Probably best reviewed by commit 🐠 Don't miss the collapsed `test_sync_mode.py` file, which is where the bulk of the work happened, if reviewing all changes at once.

To assist in this refactoring effort, I created utilities (not part of this PR) to verify that...
- the XML posted to HQ by `MockDevice` is equivalent to what was posted before when interacting directly with the `CaseFactory`.
- the restore config and payload generated by `MockDevice.sync()` are equivalent to what was restored before when using the various restore helper/assert functions.

While these utilities were not used to refactor every single test, they gave me a degree of confidence that the refactoring has not changed what is being tested.

@proteusvacuum @snopoke cc @orangejenny 