### PR TITLE
ICDS: Fix aadhar indicator

### DIFF
--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2241,13 +2241,19 @@
         "expression": {
           "type": "conditional",
           "test": {
-            "operator": "eq",
-            "type": "boolean_expression",
-            "expression": {
-              "type": "property_name",
-              "property_name": "has_aadhar"
-            },
-            "property_value": "yes"
+            "type": "not",
+            "filter": {
+              "operator": "in",
+              "type": "boolean_expression",
+              "expression": {
+                "type": "property_name",
+                "property_name": "aadhar_number"
+              },
+              "property_value": [
+                "",
+                null
+              ]
+            }
           },
           "expression_if_true": {
             "type": "conditional",
@@ -2286,16 +2292,22 @@
                     ]
                   },
                   "filter_expression": {
-                    "operator": "eq",
-                    "type": "boolean_expression",
-                    "expression": {
-                      "type": "property_path",
-                      "property_path": [
-                        "update",
-                        "has_aadhar"
+                    "type": "not",
+                    "filter": {
+                      "operator": "in",
+                      "type": "boolean_expression",
+                      "expression": {
+                        "type": "property_path",
+                        "property_path": [
+                          "update",
+                          "aadhar_number"
+                        ]
+                      },
+                      "property_value": [
+                        "",
+                        null
                       ]
-                    },
-                    "property_value": "yes"
+                    }
                   }
                 }
               },


### PR DESCRIPTION
@emord 

Apparently there is an app bug where the value has_aadhar is not getting correctly set in all situations.  This changes the way that indicator is calculated.

Still figuring out with the app team if we need to retrigger calculating this table for situations where aadhar_number is not null and has_aadhar != yes