### PR TITLE
Make url registration available to ICDS dashboard

### DIFF
--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -207,6 +207,12 @@
     </div>
 </div>
 
+<div class="commcarehq-urls" class="hide">
+{% block registered_urls %}
+    {# do not override this block, use registerurl template tag to populate #}
+{% endblock %}
+</div>
+
 {% block js-inline %}{% endblock js-inline %}
 <script>
     angular.module('icdsApp').constant('locationHierarchy', {{ location_hierarchy | JSON }});


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/17431#issuecomment-322340709

Happening because the ICDS dashboard doesn't inherit from `style/base.html`.

@millerdev / @emord 