### PR TITLE
Fix restore cache invalidation

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -162,7 +162,6 @@ def get_restore_params(request):
 def get_restore_response(domain, couch_user, app_id=None, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,
-                         force_restore_mode=None,
                          as_user=None, device_id=None, user_id=None,
                          openrosa_version=None,
                          case_sync=None):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -342,8 +342,8 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
     def _cache_key(self, version):
         from casexml.apps.phone.restore import restore_payload_path_cache_key
         return restore_payload_path_cache_key(
-            self.domain,
-            self.user_id,
+            domain=self.domain,
+            user_id=self.user_id,
             version=version,
             sync_log_id=self._id,
         )

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -19,7 +19,6 @@ from dimagi.utils.couch import LooselyEqualDocumentSchema
 from dimagi.utils.couch.database import get_db
 from casexml.apps.case import const
 from casexml.apps.case.xml import V1, V2
-from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.case.sharedmodels import CommCareCaseIndex, IndexHoldingMixIn
 from casexml.apps.phone.checksum import Checksum, CaseStateHash
 from casexml.apps.phone.utils import get_restore_response_class
@@ -341,11 +340,9 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
         return self._previous_log_ref
 
     def _cache_key(self, version):
-        from casexml.apps.phone.restore import restore_cache_key
-
-        return restore_cache_key(
+        from casexml.apps.phone.restore import restore_payload_path_cache_key
+        return restore_payload_path_cache_key(
             self.domain,
-            RESTORE_CACHE_KEY_PREFIX,
             self.user_id,
             version=version,
             sync_log_id=self._id,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -698,8 +698,8 @@ class RestoreConfig(object):
     @property
     def _restore_cache_key(self):
         return restore_payload_path_cache_key(
-            self.domain,
-            self.restore_user.user_id,
+            domain=self.domain,
+            user_id=self.restore_user.user_id,
             version=self.version,
             sync_log_id=self.sync_log._id if self.sync_log else '',
             device_id=self.params.device_id,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_CASE_SYNC = CLEAN_OWNERS
 
 
-def _restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None, device_id=None):
+def _restore_cache_key(domain, prefix, user_id, version, sync_log_id, device_id):
     response_class = get_restore_response_class(domain)
     hashable_key = '{response_class}-{prefix}-{user}-{version}-{sync_log_id}-{device_id}'.format(
         response_class=response_class.__name__,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -81,6 +81,28 @@ def restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None, d
     return hashlib.md5(hashable_key).hexdigest()
 
 
+def restore_payload_path_cache_key(domain, user_id, version=None, sync_log_id=None, device_id=None):
+    return restore_cache_key(
+        domain=domain,
+        prefix=RESTORE_CACHE_KEY_PREFIX,
+        user_id=user_id,
+        version=version,
+        sync_log_id=sync_log_id,
+        device_id=device_id,
+    )
+
+
+def async_restore_task_id_cache_key(domain, user_id, version=None, sync_log_id=None, device_id=None):
+    return restore_cache_key(
+        domain=domain,
+        prefix=ASYNC_RESTORE_CACHE_KEY_PREFIX,
+        user_id=user_id,
+        version=version,
+        sync_log_id=sync_log_id,
+        device_id=device_id,
+    )
+
+
 def stream_response(payload, headers=None, status=200):
     try:
         response = StreamingHttpResponse(

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_CASE_SYNC = CLEAN_OWNERS
 
 
-def restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None, device_id=None):
+def _restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None, device_id=None):
     response_class = get_restore_response_class(domain)
     hashable_key = '{response_class}-{prefix}-{user}-{version}-{sync_log_id}-{device_id}'.format(
         response_class=response_class.__name__,
@@ -82,7 +82,7 @@ def restore_cache_key(domain, prefix, user_id, version=None, sync_log_id=None, d
 
 
 def restore_payload_path_cache_key(domain, user_id, version=None, sync_log_id=None, device_id=None):
-    return restore_cache_key(
+    return _restore_cache_key(
         domain=domain,
         prefix=RESTORE_CACHE_KEY_PREFIX,
         user_id=user_id,
@@ -93,7 +93,7 @@ def restore_payload_path_cache_key(domain, user_id, version=None, sync_log_id=No
 
 
 def async_restore_task_id_cache_key(domain, user_id, version=None, sync_log_id=None, device_id=None):
-    return restore_cache_key(
+    return _restore_cache_key(
         domain=domain,
         prefix=ASYNC_RESTORE_CACHE_KEY_PREFIX,
         user_id=user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -92,12 +92,12 @@ def restore_payload_path_cache_key(domain, user_id, version=None, sync_log_id=No
     )
 
 
-def async_restore_task_id_cache_key(domain, user_id, version=None, sync_log_id=None, device_id=None):
+def async_restore_task_id_cache_key(domain, user_id, sync_log_id=None, device_id=None):
     return _restore_cache_key(
         domain=domain,
         prefix=ASYNC_RESTORE_CACHE_KEY_PREFIX,
         user_id=user_id,
-        version=version,
+        version=None,
         sync_log_id=sync_log_id,
         device_id=device_id,
     )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -92,7 +92,7 @@ def restore_payload_path_cache_key(domain, user_id, version=None, sync_log_id=No
     )
 
 
-def async_restore_task_id_cache_key(domain, user_id, sync_log_id=None, device_id=None):
+def async_restore_task_id_cache_key(domain, user_id, sync_log_id, device_id):
     return _restore_cache_key(
         domain=domain,
         prefix=ASYNC_RESTORE_CACHE_KEY_PREFIX,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -689,8 +689,8 @@ class RestoreConfig(object):
     @property
     def async_cache_key(self):
         return async_restore_task_id_cache_key(
-            self.domain,
-            self.restore_user.user_id,
+            domain=self.domain,
+            user_id=self.restore_user.user_id,
             sync_log_id=self.sync_log._id if self.sync_log else '',
             device_id=self.params.device_id,
         )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -698,9 +698,8 @@ class RestoreConfig(object):
 
     @property
     def _restore_cache_key(self):
-        return restore_cache_key(
+        return restore_payload_path_cache_key(
             self.domain,
-            RESTORE_CACHE_KEY_PREFIX,
             self.restore_user.user_id,
             version=self.version,
             sync_log_id=self.sync_log._id if self.sync_log else '',

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -688,9 +688,8 @@ class RestoreConfig(object):
 
     @property
     def async_cache_key(self):
-        return restore_cache_key(
+        return async_restore_task_id_cache_key(
             self.domain,
-            ASYNC_RESTORE_CACHE_KEY_PREFIX,
             self.restore_user.user_id,
             sync_log_id=self.sync_log._id if self.sync_log else '',
             device_id=self.params.device_id,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -99,7 +99,12 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
 
     def test_subsequent_syncs_when_job_complete(self):
         # First sync, return a timout. Ensure that the async_task_id gets set
-        cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
+        cache_id = async_restore_task_id_cache_key(
+            domain=self.domain,
+            user_id=self.user.user_id,
+            sync_log_id=None,
+            device_id=None,
+        )
         with mock.patch('casexml.apps.phone.restore.get_async_restore_payload') as task:
             delay = mock.MagicMock()
             delay.id = 'random_task_id'
@@ -129,7 +134,12 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
                 get_result.assert_called_with(timeout=1)
 
     def test_completed_task_deletes_cache(self):
-        cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
+        cache_id = async_restore_task_id_cache_key(
+            domain=self.domain,
+            user_id=self.user.user_id,
+            sync_log_id=None,
+            device_id=None,
+        )
         restore_config = self._restore_config(async=True)
         restore_config.cache.set(cache_id, 'im going to be deleted by the next command')
         restore_config.timing_context.start()
@@ -184,7 +194,12 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
     def test_restore_in_progress_form_submitted_kills_old_jobs(self):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
-        task_cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
+        task_cache_id = async_restore_task_id_cache_key(
+            domain=self.domain,
+            user_id=self.user.user_id,
+            sync_log_id=None,
+            device_id=None,
+        )
         initial_sync_cache_id = restore_payload_path_cache_key(
             domain=self.domain,
             user_id=self.user.user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -20,8 +20,8 @@ from casexml.apps.phone.restore import (
     AsyncRestoreResponse,
     FileRestoreResponse,
     restore_cache_key,
-)
-from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX, RESTORE_CACHE_KEY_PREFIX
+    restore_payload_path_cache_key)
+from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
@@ -185,9 +185,8 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
         task_cache_id = restore_cache_key(self.domain, ASYNC_RESTORE_CACHE_KEY_PREFIX, self.user.user_id)
-        initial_sync_cache_id = restore_cache_key(
+        initial_sync_cache_id = restore_payload_path_cache_key(
             self.domain,
-            RESTORE_CACHE_KEY_PREFIX,
             self.user.user_id,
             version='2.0'
         )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -186,8 +186,8 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         """
         task_cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
         initial_sync_cache_id = restore_payload_path_cache_key(
-            self.domain,
-            self.user.user_id,
+            domain=self.domain,
+            user_id=self.user.user_id,
             version='2.0'
         )
         fake_cached_thing = 'fake-cached-thing'

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -99,7 +99,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
 
     def test_subsequent_syncs_when_job_complete(self):
         # First sync, return a timout. Ensure that the async_task_id gets set
-        cache_id = async_restore_task_id_cache_key(self.domain, self.user.user_id)
+        cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
         with mock.patch('casexml.apps.phone.restore.get_async_restore_payload') as task:
             delay = mock.MagicMock()
             delay.id = 'random_task_id'
@@ -129,7 +129,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
                 get_result.assert_called_with(timeout=1)
 
     def test_completed_task_deletes_cache(self):
-        cache_id = async_restore_task_id_cache_key(self.domain, self.user.user_id)
+        cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
         restore_config = self._restore_config(async=True)
         restore_config.cache.set(cache_id, 'im going to be deleted by the next command')
         restore_config.timing_context.start()
@@ -184,7 +184,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
     def test_restore_in_progress_form_submitted_kills_old_jobs(self):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
-        task_cache_id = async_restore_task_id_cache_key(self.domain, self.user.user_id)
+        task_cache_id = async_restore_task_id_cache_key(domain=self.domain, user_id=self.user.user_id)
         initial_sync_cache_id = restore_payload_path_cache_key(
             self.domain,
             self.user.user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -86,9 +86,9 @@ class SimpleCachingResponseTest(SimpleTestCase):
         BlobRestoreResponse that we don't use the old FileRestoreResponse
         cache
         '''
-        key1 = restore_payload_path_cache_key('domain', 'user_id')
+        key1 = restore_payload_path_cache_key(domain='domain', user_id='user_id')
         with flag_enabled('BLOBDB_RESTORE'):
-            key2 = restore_payload_path_cache_key('domain', 'user_id')
+            key2 = restore_payload_path_cache_key(domain='domain', user_id='user_id')
         self.assertNotEqual(key1, key2)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -3,7 +3,7 @@ from django.test import TestCase, SimpleTestCase
 from casexml.apps.case.xml import V1, V2
 from casexml.apps.phone.models import SyncLog, CaseState
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
-from casexml.apps.phone.restore import RestoreParams, RestoreConfig, restore_cache_key
+from casexml.apps.phone.restore import RestoreParams, RestoreConfig, restore_payload_path_cache_key
 from casexml.apps.phone.tests.utils import create_restore_user, generate_restore_payload
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
@@ -86,9 +86,9 @@ class SimpleCachingResponseTest(SimpleTestCase):
         BlobRestoreResponse that we don't use the old FileRestoreResponse
         cache
         '''
-        key1 = restore_cache_key('domain', 'prefix', 'user_id')
+        key1 = restore_payload_path_cache_key('domain', 'user_id')
         with flag_enabled('BLOBDB_RESTORE'):
-            key2 = restore_cache_key('domain', 'prefix', 'user_id')
+            key2 = restore_payload_path_cache_key('domain', 'user_id')
         self.assertNotEqual(key1, key2)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -9,10 +9,10 @@ from casexml.apps.phone.models import (
     OTARestoreWebUser,
     OTARestoreCommCareUser,
 )
-from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings, restore_cache_key
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings, \
+    restore_payload_path_cache_key
 from casexml.apps.phone.tests.dbaccessors import get_all_sync_logs_docs
 from casexml.apps.phone.xml import SYNC_XMLNS
-from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX
 
 from corehq.apps.users.models import CommCareUser, WebUser
 
@@ -124,10 +124,9 @@ def generate_restore_response(project, user, restore_id="", version=V1, state_ha
     return config.get_response()
 
 
-def has_cached_payload(sync_log, version, prefix=RESTORE_CACHE_KEY_PREFIX):
-    return bool(get_redis_default_cache().get(restore_cache_key(
+def has_cached_payload(sync_log, version):
+    return bool(get_redis_default_cache().get(restore_payload_path_cache_key(
         sync_log.domain,
-        prefix,
         sync_log.user_id,
         version=version,
         sync_log_id=sync_log._id,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -126,8 +126,8 @@ def generate_restore_response(project, user, restore_id="", version=V1, state_ha
 
 def has_cached_payload(sync_log, version):
     return bool(get_redis_default_cache().get(restore_payload_path_cache_key(
-        sync_log.domain,
-        sync_log.user_id,
+        domain=sync_log.domain,
+        user_id=sync_log.user_id,
         version=version,
         sync_log_id=sync_log._id,
     )))

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -25,7 +25,7 @@ from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.form import process_xform_xml
 from corehq.form_processor.utils.metadata import scrub_meta
-from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX, RESTORE_CACHE_KEY_PREFIX
+from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX
 from couchforms.const import BadRequest, DEVICE_LOG_XMLNS
 from couchforms.models import DefaultAuthContext, UnfinishedSubmissionStub
 from couchforms.signals import successful_form_received
@@ -214,10 +214,10 @@ class SubmissionPost(object):
         return restore_cache_key
 
     def _invalidate_caches(self, user_id):
+        from casexml.apps.phone.restore import restore_payload_path_cache_key
         """invalidate cached initial restores"""
-        initial_restore_cache_key = self._restore_cache_key(
+        initial_restore_cache_key = restore_payload_path_cache_key(
             self.domain,
-            RESTORE_CACHE_KEY_PREFIX,
             user_id,
             version=V2
         )

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -222,7 +222,7 @@ class SubmissionPost(object):
 
     def _invalidate_async_caches(self, user_id):
         from casexml.apps.phone.restore import async_restore_task_id_cache_key
-        cache_key = async_restore_task_id_cache_key(self.domain, user_id)
+        cache_key = async_restore_task_id_cache_key(domain=self.domain, user_id=user_id)
         task_id = self._cache.get(cache_key)
 
         if task_id is not None:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -211,8 +211,8 @@ class SubmissionPost(object):
         from casexml.apps.phone.restore import restore_payload_path_cache_key
         """invalidate cached initial restores"""
         initial_restore_cache_key = restore_payload_path_cache_key(
-            self.domain,
-            user_id,
+            domain=self.domain,
+            user_id=user_id,
             version=V2
         )
         self._cache.delete(initial_restore_cache_key)

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -11,8 +11,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import check_user_has_case
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.tests.utils import create_restore_user
-from casexml.apps.phone.restore import restore_cache_key
-from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX
+from casexml.apps.phone.restore import restore_payload_path_cache_key
 from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
@@ -304,7 +303,7 @@ class FundamentalCaseTests(TestCase):
 
     def test_restore_caches_cleared(self):
         cache = get_redis_default_cache()
-        cache_key = restore_cache_key(DOMAIN, RESTORE_CACHE_KEY_PREFIX, 'user_id', version="2.0")
+        cache_key = restore_payload_path_cache_key(DOMAIN, 'user_id', version="2.0")
         cache.set(cache_key, 'test-thing')
         self.assertEqual(cache.get(cache_key), 'test-thing')
         form = """

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -303,7 +303,7 @@ class FundamentalCaseTests(TestCase):
 
     def test_restore_caches_cleared(self):
         cache = get_redis_default_cache()
-        cache_key = restore_payload_path_cache_key(DOMAIN, 'user_id', version="2.0")
+        cache_key = restore_payload_path_cache_key(domain=DOMAIN, user_id='user_id', version="2.0")
         cache.set(cache_key, 'test-thing')
         self.assertEqual(cache.get(cache_key), 'test-thing')
         form = """


### PR DESCRIPTION
Should fix https://manage.dimagi.com/default.asp?260109

Most commits are to
* make it more obvious what the code is doing, splitting `restore_cache_key` into one function per `prefix`, making arguments explicit, etc.

This commit https://github.com/dimagi/commcare-hq/pull/17499/commits/402e87c7f647b618dbc2a8ba473b706185f52193 is the only one that makes a change, to
* invalidate the async task id cache using the same key that's used to fetch it