### PR TITLE
Update restore caching tests to be more consistent with real usage

### DIFF
--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -70,8 +70,7 @@ class StockProcessingResult(object):
         """
         # if cases were changed we should purge the sync token cache
         # this ensures that ledger updates will sync back down
-        if self.relevant_cases and self.xform.get_sync_token():
-            self.xform.get_sync_token().invalidate_cached_payloads()
+        pass
 
 
 LedgerValues = namedtuple('LedgerValues', ['balance', 'delta'])

--- a/corehq/apps/commtrack/tests/data/balances.py
+++ b/corehq/apps/commtrack/tests/data/balances.py
@@ -19,7 +19,7 @@ def balance_ota_block(sp, section_id, soh_reports, datestring):
 
 
 def submission_wrap(instance_id, products, user, sp_id, sp2_id, insides, timestamp=None,
-                    date_formatter=json_format_datetime):
+                    date_formatter=json_format_datetime, device_id=None):
     timestamp = timestamp or datetime.utcnow()
     date_string = date_formatter(timestamp)
     insides = insides() if callable(insides) else insides
@@ -27,7 +27,7 @@ def submission_wrap(instance_id, products, user, sp_id, sp2_id, insides, timesta
         <data uiVersion="1" version="33" name="New Form" xmlns="http://commtrack.org/test_form_submission">
             <products>{product0} {product1} {product2}</products>
             <meta>
-                <deviceID>351746051189879</deviceID>
+                <deviceID>{device_id}</deviceID>
                 <timeStart>2013-12-10T17:08:46.215-05</timeStart>
                 <timeEnd>2013-12-10T17:08:57.887-05</timeEnd>
                 <username>{username}</username>
@@ -49,6 +49,7 @@ def submission_wrap(instance_id, products, user, sp_id, sp2_id, insides, timesta
         instance_id=instance_id,
         username=user.username,
         long_date=date_string,
+        device_id=device_id if device_id is not None else '',
     )
 
 

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -221,7 +221,8 @@ class CommTrackSubmissionTest(XMLTest):
 
     @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
     @process_pillow_changes('LedgerToElasticsearchPillow')
-    def submit_xml_form(self, xml_method, timestamp=None, date_formatter=json_format_datetime, **submit_extras):
+    def submit_xml_form(self, xml_method, timestamp=None, date_formatter=json_format_datetime,
+                        device_id='351746051189879', **submit_extras):
         instance_id = uuid.uuid4().hex
         instance = submission_wrap(
             instance_id,
@@ -232,6 +233,7 @@ class CommTrackSubmissionTest(XMLTest):
             xml_method,
             timestamp=timestamp,
             date_formatter=date_formatter,
+            device_id=device_id,
         )
         submit_form_locally(
             instance=instance,
@@ -584,7 +586,8 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
 
         # submit with token
         amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
-        self.submit_xml_form(balance_submission(amounts), last_sync_token=self.sync_log_id)
+        self.submit_xml_form(balance_submission(amounts), last_sync_token=self.sync_log_id,
+                             device_id=None)
         # now restore should have the case
         check_user_has_case(self, self.restore_user, self.sp_block, should_have=True,
                             restore_id=self.sync_log_id, version=V2, line_by_line=False)

--- a/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
+++ b/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' ?>
 <system version="1" uiVersion="1" xmlns="{{ xmlns }}" xmlns:orx="http://openrosa.org/jr/xforms">
     <orx:meta xmlns:cc="http://commcarehq.org/xforms">
-        <orx:deviceID />
+        {% if not device_id %}<orx:deviceID />{% else %}<orx:deviceID>{{ device_id }}</orx:deviceID>{% endif %}
         <orx:timeStart>{{ time }}</orx:timeStart>
         <orx:timeEnd>{{ time }}</orx:timeEnd>
         <orx:username>{{ username }}</orx:username>

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -25,7 +25,7 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 ]
 
 
-def submit_case_blocks(case_blocks, domain, username="system", user_id="",
+def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
                        xmlns=SYSTEM_FORM_XMLNS, attachments=None,
                        form_id=None, form_extras=None, case_db=None):
     """
@@ -44,7 +44,7 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id="",
         'time': now,
         'uid': form_id,
         'username': username,
-        'user_id': user_id,
+        'user_id': user_id or "",
     })
     form_extras = form_extras or {}
 

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -27,7 +27,7 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
                        xmlns=SYSTEM_FORM_XMLNS, attachments=None,
-                       form_id=None, form_extras=None, case_db=None):
+                       form_id=None, form_extras=None, case_db=None, device_id=None):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -45,6 +45,7 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
         'uid': form_id,
         'username': username,
         'user_id': user_id or "",
+        'device_id': device_id,
     })
     form_extras = form_extras or {}
 

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -79,7 +79,7 @@ class CaseFactory(object):
             **kwargs
         ).as_xml()
 
-    def post_case_blocks(self, caseblocks, form_extras=None, user_id=None):
+    def post_case_blocks(self, caseblocks, form_extras=None, user_id=None, device_id=None):
         submit_form_extras = copy.copy(self.form_extras)
         if form_extras is not None:
             submit_form_extras.update(form_extras)
@@ -88,6 +88,7 @@ class CaseFactory(object):
             form_extras=submit_form_extras,
             domain=self.domain,
             user_id=user_id,
+            device_id=device_id,
         )
 
     def create_case(self, **kwargs):
@@ -113,7 +114,7 @@ class CaseFactory(object):
     def create_or_update_case(self, case_structure, form_extras=None, user_id=None):
         return self.create_or_update_cases([case_structure], form_extras, user_id=user_id)
 
-    def create_or_update_cases(self, case_structures, form_extras=None, user_id=None):
+    def create_or_update_cases(self, case_structures, form_extras=None, user_id=None, device_id=None):
         from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
         def _get_case_block(substructure):
@@ -132,6 +133,7 @@ class CaseFactory(object):
             [block for structure in case_structures for block in _get_case_blocks(structure)],
             form_extras,
             user_id=user_id,
+            device_id=device_id,
         )
 
         case_ids = [id for structure in case_structures for id in structure.walk_ids()]

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -79,7 +79,7 @@ class CaseFactory(object):
             **kwargs
         ).as_xml()
 
-    def post_case_blocks(self, caseblocks, form_extras=None):
+    def post_case_blocks(self, caseblocks, form_extras=None, user_id=None):
         submit_form_extras = copy.copy(self.form_extras)
         if form_extras is not None:
             submit_form_extras.update(form_extras)
@@ -87,6 +87,7 @@ class CaseFactory(object):
             caseblocks,
             form_extras=submit_form_extras,
             domain=self.domain,
+            user_id=user_id,
         )
 
     def create_case(self, **kwargs):
@@ -109,10 +110,10 @@ class CaseFactory(object):
         """
         return self.create_or_update_case(CaseStructure(case_id=case_id, attrs={'close': True}))[0]
 
-    def create_or_update_case(self, case_structure, form_extras=None):
-        return self.create_or_update_cases([case_structure], form_extras)
+    def create_or_update_case(self, case_structure, form_extras=None, user_id=None):
+        return self.create_or_update_cases([case_structure], form_extras, user_id=user_id)
 
-    def create_or_update_cases(self, case_structures, form_extras=None):
+    def create_or_update_cases(self, case_structures, form_extras=None, user_id=None):
         from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
         def _get_case_block(substructure):
@@ -130,6 +131,7 @@ class CaseFactory(object):
         self.post_case_blocks(
             [block for structure in case_structures for block in _get_case_blocks(structure)],
             form_extras,
+            user_id=user_id,
         )
 
         case_ids = [id for structure in case_structures for id in structure.walk_ids()]

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -7,6 +7,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.util.test_utils import unit_testing_only
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 
 from dimagi.utils.dates import utcnow_sans_milliseconds
 from lxml import etree
@@ -14,7 +15,8 @@ from lxml import etree
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V1, V2, NS_VERSION_MAP
 from casexml.apps.phone.models import SyncLog
-from casexml.apps.phone.restore import RestoreConfig, RestoreParams
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams, \
+    restore_payload_path_cache_key
 
 
 TEST_DOMAIN_NAME = 'test-domain'
@@ -141,7 +143,12 @@ def cached_restore(testcase, user, restore_id="", version=V2,
     assert not hasattr(testcase, 'payload_string'), testcase
 
     if restore_id and purge_restore_cache:
-        SyncLog.get(restore_id).invalidate_cached_payloads()
+        get_redis_default_cache().delete(restore_payload_path_cache_key(
+            domain=user.domain,
+            user_id=user.user_id,
+            sync_log_id=restore_id,
+            device_id=None,
+        ))
 
     testcase.restore_config = RestoreConfig(
         project=user.project,

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -41,7 +41,7 @@ def validate_phone_datetime(datetime_string, none_ok=False, form_id=None):
         raise PhoneDateValueError('{!r}'.format(datetime_string))
 
 
-def post_case_blocks(case_blocks, form_extras=None, domain=None):
+def post_case_blocks(case_blocks, form_extras=None, domain=None, user_id=None):
     """
     Post case blocks.
 
@@ -61,7 +61,8 @@ def post_case_blocks(case_blocks, form_extras=None, domain=None):
     return submit_case_blocks(
         [ElementTree.tostring(case_block) for case_block in case_blocks],
         domain=domain,
-        form_extras=form_extras
+        form_extras=form_extras,
+        user_id=user_id,
     )
 
 

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -41,7 +41,7 @@ def validate_phone_datetime(datetime_string, none_ok=False, form_id=None):
         raise PhoneDateValueError('{!r}'.format(datetime_string))
 
 
-def post_case_blocks(case_blocks, form_extras=None, domain=None, user_id=None):
+def post_case_blocks(case_blocks, form_extras=None, domain=None, user_id=None, device_id=None):
     """
     Post case blocks.
 
@@ -63,6 +63,7 @@ def post_case_blocks(case_blocks, form_extras=None, domain=None, user_id=None):
         domain=domain,
         form_extras=form_extras,
         user_id=user_id,
+        device_id=device_id,
     )
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -2,7 +2,6 @@ from collections import defaultdict, namedtuple
 from copy import copy
 from datetime import datetime
 import json
-import itertools
 from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from casexml.apps.phone.exceptions import IncompatibleSyncLogType
 from corehq.toggles import LEGACY_SYNC_SUPPORT
@@ -11,14 +10,11 @@ from corehq.util.soft_assert import soft_assert
 from corehq.toggles import ENABLE_LOADTEST_USERS
 from corehq.apps.domain.models import Domain
 from dimagi.ext.couchdbkit import *
-from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from django.db import models
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.mixins import UnicodeMixIn
 from dimagi.utils.couch import LooselyEqualDocumentSchema
-from dimagi.utils.couch.database import get_db
 from casexml.apps.case import const
-from casexml.apps.case.xml import V1, V2
 from casexml.apps.case.sharedmodels import CommCareCaseIndex, IndexHoldingMixIn
 from casexml.apps.phone.checksum import Checksum, CaseStateHash
 from casexml.apps.phone.utils import get_restore_response_class
@@ -339,21 +335,6 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
                 self._previous_log_ref = None
         return self._previous_log_ref
 
-    def _cache_key(self, version):
-        from casexml.apps.phone.restore import restore_payload_path_cache_key
-        return restore_payload_path_cache_key(
-            domain=self.domain,
-            user_id=self.user_id,
-            version=version,
-            sync_log_id=self._id,
-        )
-
-    def invalidate_cached_payloads(self):
-        keys = [self._cache_key(version) for version in [V1, V2]]
-
-        for key in keys:
-            get_redis_default_cache().delete(key)
-
     @classmethod
     def from_other_format(cls, other_sync_log):
         """
@@ -567,7 +548,6 @@ class SyncLog(AbstractSyncLog):
         if case_list:
             try:
                 self.save()
-                self.invalidate_cached_payloads()
             except ResourceConflict:
                 logging.exception('doc update conflict saving sync log {id}'.format(
                     id=self._id,
@@ -1127,13 +1107,6 @@ class SimplifiedSyncLog(AbstractSyncLog):
                     self.last_submitted = datetime.utcnow()
                     self.rev_before_last_submitted = self._rev
                     self.save()
-                    if case_list:
-                        try:
-                            self.invalidate_cached_payloads()
-                        except ResourceConflict:
-                            # this operation is harmless so just blindly retry and don't
-                            # reraise if it goes through the second time
-                            SimplifiedSyncLog.get(self._id).invalidate_cached_payloads()
             except ResourceConflict:
                 logging.exception('doc update conflict saving sync log {id}'.format(
                     id=self._id,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -81,12 +81,12 @@ def _restore_cache_key(domain, prefix, user_id, version, sync_log_id, device_id)
     return hashlib.md5(hashable_key).hexdigest()
 
 
-def restore_payload_path_cache_key(domain, user_id, version, sync_log_id, device_id):
+def restore_payload_path_cache_key(domain, user_id, sync_log_id, device_id):
     return _restore_cache_key(
         domain=domain,
         prefix=RESTORE_CACHE_KEY_PREFIX,
         user_id=user_id,
-        version=version,
+        version='2.0',
         sync_log_id=sync_log_id,
         device_id=device_id,
     )
@@ -662,7 +662,6 @@ class RestoreConfig(object):
         self.cache_settings = cache_settings or RestoreCacheSettings()
         self.async = async
 
-        self.version = self.params.version
         self.restore_state = RestoreState(
             self.project,
             self.restore_user,
@@ -700,7 +699,6 @@ class RestoreConfig(object):
         return restore_payload_path_cache_key(
             domain=self.domain,
             user_id=self.restore_user.user_id,
-            version=self.version,
             sync_log_id=self.sync_log._id if self.sync_log else '',
             device_id=self.params.device_id,
         )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -81,7 +81,7 @@ def _restore_cache_key(domain, prefix, user_id, version, sync_log_id, device_id)
     return hashlib.md5(hashable_key).hexdigest()
 
 
-def restore_payload_path_cache_key(domain, user_id, version=None, sync_log_id=None, device_id=None):
+def restore_payload_path_cache_key(domain, user_id, version, sync_log_id, device_id):
     return _restore_cache_key(
         domain=domain,
         prefix=RESTORE_CACHE_KEY_PREFIX,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -205,7 +205,6 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         initial_sync_cache_id = restore_payload_path_cache_key(
             domain=self.domain,
             user_id=self.user.user_id,
-            version='2.0',
             device_id=device_id,
             sync_log_id=last_sync_token,
         )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -194,41 +194,53 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
     def test_restore_in_progress_form_submitted_kills_old_jobs(self):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
+        last_sync_token = '0a72d5a3c2ec53e85c1af27ee5717e0d'
+        device_id = 'RSMCHBA8PJNQIGMONN2JZT6E'
         task_cache_id = async_restore_task_id_cache_key(
             domain=self.domain,
             user_id=self.user.user_id,
-            sync_log_id=None,
-            device_id=None,
+            sync_log_id=last_sync_token,
+            device_id=device_id,
         )
         initial_sync_cache_id = restore_payload_path_cache_key(
             domain=self.domain,
             user_id=self.user.user_id,
-            version='2.0'
+            version='2.0',
+            device_id=device_id,
+            sync_log_id=last_sync_token,
         )
-        fake_cached_thing = 'fake-cached-thing'
+        async_restore_task_id = '0edecc20d89d6f4a09f2e992c0c24b5f'
+        initial_sync_path = 'path/to/payload'
         restore_config = self._restore_config(async=True)
         # pretend we have a task running
-        restore_config.cache.set(task_cache_id, fake_cached_thing)
-        restore_config.cache.set(initial_sync_cache_id, fake_cached_thing)
+        restore_config.cache.set(task_cache_id, async_restore_task_id)
+        restore_config.cache.set(initial_sync_cache_id, initial_sync_path)
 
-        form = """
-        <data xmlns="http://openrosa.org/formdesigner/blah">
-            <meta>
-                <userID>{user_id}</userID>
-            </meta>
-        </data>
-        """
+        def submit_form(user_id, device_id, last_sync_token):
+            form = """
+            <data xmlns="http://openrosa.org/formdesigner/blah">
+                <meta>
+                    <userID>{user_id}</userID>
+                    <deviceID>{device_id}</deviceID>
+                </meta>
+            </data>
+            """
+            submit_form_locally(
+                form.format(user_id=user_id, device_id=device_id),
+                self.domain,
+                last_sync_token=last_sync_token,
+            )
 
         with mock.patch('corehq.form_processor.submission_post.revoke_celery_task') as revoke:
             # with a different user in the same domain, task doesn't get killed
-            submit_form_locally(form.format(user_id="other_user"), self.domain)
+            submit_form(user_id="other_user", device_id='OTHERDEVICEID', last_sync_token='othersynctoken')
             self.assertFalse(revoke.called)
-            self.assertEqual(restore_config.cache.get(task_cache_id), fake_cached_thing)
-            self.assertEqual(restore_config.cache.get(initial_sync_cache_id), fake_cached_thing)
+            self.assertEqual(restore_config.cache.get(task_cache_id), async_restore_task_id)
+            self.assertEqual(restore_config.cache.get(initial_sync_cache_id), initial_sync_path)
 
             # task gets killed when the user submits a form
-            submit_form_locally(form.format(user_id=self.user.user_id), self.domain)
-            revoke.assert_called_with(fake_cached_thing)
+            submit_form(user_id=self.user.user_id, device_id=device_id, last_sync_token=last_sync_token)
+            revoke.assert_called_with(async_restore_task_id)
             self.assertIsNone(restore_config.cache.get(task_cache_id))
             self.assertIsNone(restore_config.cache.get(initial_sync_cache_id))
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -91,7 +91,6 @@ class SimpleCachingResponseTest(SimpleTestCase):
             return restore_payload_path_cache_key(
                 domain='domain',
                 user_id='user_id',
-                version='2.0',
                 sync_log_id='synclogid',
                 device_id='DEVICEID',
             )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_logs.py
@@ -86,9 +86,18 @@ class SimpleCachingResponseTest(SimpleTestCase):
         BlobRestoreResponse that we don't use the old FileRestoreResponse
         cache
         '''
-        key1 = restore_payload_path_cache_key(domain='domain', user_id='user_id')
+
+        def get_restore_payload_path_cache_key():
+            return restore_payload_path_cache_key(
+                domain='domain',
+                user_id='user_id',
+                version='2.0',
+                sync_log_id='synclogid',
+                device_id='DEVICEID',
+            )
+        key1 = get_restore_payload_path_cache_key()
         with flag_enabled('BLOBDB_RESTORE'):
-            key2 = restore_payload_path_cache_key(domain='domain', user_id='user_id')
+            key2 = get_restore_payload_path_cache_key()
         self.assertNotEqual(key1, key2)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -116,10 +116,12 @@ class SyncBaseTest(TestCase):
 
     def _createCaseStubs(self, id_list, **kwargs):
         case_attrs = {'create': True}
+        device_id = kwargs.pop('device_id', None)
         case_attrs.update(kwargs)
         return self.factory.create_or_update_cases(
             [CaseStructure(case_id=case_id, attrs=case_attrs) for case_id in id_list],
             user_id=kwargs.get('user_id') or self.user_id,
+            device_id=device_id,
         )
 
     def _postWithSyncToken(self, filename, token_id):
@@ -1243,6 +1245,7 @@ class SyncTokenCachingTest(SyncBaseTest):
             params=RestoreParams(
                 version=V2,
                 sync_log_id=self.sync_log._id,
+                device_id=device_id,
             ),
             **self.restore_options
         ).get_payload().as_string()
@@ -1294,7 +1297,7 @@ class SyncTokenCachingTest(SyncBaseTest):
 
         # posting a case associated with this sync token should invalidate the cache
         case_id = "cache_invalidation"
-        self._createCaseStubs([case_id])
+        self._createCaseStubs([case_id], device_id=device_id)
         self.sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
         self.assertFalse(has_cached_payload(SyncLog.get(self.sync_log._id), device_id))
 
@@ -1342,13 +1345,14 @@ class SyncTokenCachingTest(SyncBaseTest):
             user_id=self.user.user_id,
             owner_id=self.user.user_id,
             case_type=PARENT_TYPE,
-        ).as_xml()])
+        ).as_xml()], device_id=device_id, user_id=self.user_id)
         next_payload = RestoreConfig(
             project=self.project,
             restore_user=self.user,
             params=RestoreParams(
                 version=V2,
                 sync_log_id=self.sync_log._id,
+                device_id=device_id,
             ),
             **self.restore_options
         ).get_payload().as_string()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1219,7 +1219,7 @@ class SyncTokenCachingTest(SyncBaseTest):
 
     def testCaching(self):
         device_id = 'XYQR2HDOITHZQITPYN5DNEYL'
-        self.assertFalse(has_cached_payload(self.sync_log, V2, device_id))
+        self.assertFalse(has_cached_payload(self.sync_log, device_id))
         # first request should populate the cache
         original_payload = RestoreConfig(
             project=self.project,
@@ -1234,7 +1234,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         next_sync_log = synclog_from_restore_payload(original_payload)
 
         self.sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
-        self.assertTrue(has_cached_payload(self.sync_log, V2, device_id))
+        self.assertTrue(has_cached_payload(self.sync_log, device_id))
 
         # a second request with the same config should be exactly the same
         cached_payload = RestoreConfig(
@@ -1290,13 +1290,13 @@ class SyncTokenCachingTest(SyncBaseTest):
             **self.restore_options
         ).get_payload().as_string()
         self.sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
-        self.assertTrue(has_cached_payload(self.sync_log, V2, device_id))
+        self.assertTrue(has_cached_payload(self.sync_log, device_id))
 
         # posting a case associated with this sync token should invalidate the cache
         case_id = "cache_invalidation"
         self._createCaseStubs([case_id])
         self.sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
-        self.assertFalse(has_cached_payload(SyncLog.get(self.sync_log._id), V2, device_id))
+        self.assertFalse(has_cached_payload(SyncLog.get(self.sync_log._id), device_id))
 
         # resyncing should recreate the cache
         next_payload = RestoreConfig(
@@ -1310,7 +1310,7 @@ class SyncTokenCachingTest(SyncBaseTest):
             **self.restore_options
         ).get_payload().as_string()
         self.sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
-        self.assertTrue(has_cached_payload(self.sync_log, V2, device_id))
+        self.assertTrue(has_cached_payload(self.sync_log, device_id))
         self.assertNotEqual(original_payload, next_payload)
         self.assertFalse(case_id in original_payload)
         # since it was our own update, it shouldn't be in the new payload either
@@ -1331,7 +1331,7 @@ class SyncTokenCachingTest(SyncBaseTest):
             **self.restore_options
         ).get_payload().as_string()
         self.sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
-        self.assertTrue(has_cached_payload(self.sync_log, V2, device_id))
+        self.assertTrue(has_cached_payload(self.sync_log, device_id))
 
         # posting a case associated with this sync token should invalidate the cache
         # submitting a case not with the token will not touch the cache for that token

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -124,11 +124,10 @@ def generate_restore_response(project, user, restore_id="", version=V1, state_ha
     return config.get_response()
 
 
-def has_cached_payload(sync_log, version, device_id):
+def has_cached_payload(sync_log, device_id):
     return bool(get_redis_default_cache().get(restore_payload_path_cache_key(
         domain=sync_log.domain,
         user_id=sync_log.user_id,
-        version=version,
         sync_log_id=sync_log._id,
         device_id=device_id,
     )))

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -124,12 +124,13 @@ def generate_restore_response(project, user, restore_id="", version=V1, state_ha
     return config.get_response()
 
 
-def has_cached_payload(sync_log, version):
+def has_cached_payload(sync_log, version, device_id):
     return bool(get_redis_default_cache().get(restore_payload_path_cache_key(
         domain=sync_log.domain,
         user_id=sync_log.user_id,
         version=version,
         sync_log_id=sync_log._id,
+        device_id=device_id,
     )))
 
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -213,7 +213,9 @@ class SubmissionPost(object):
         initial_restore_cache_key = restore_payload_path_cache_key(
             domain=self.domain,
             user_id=xform.user_id,
-            version=V2
+            version=V2,
+            sync_log_id=xform.last_sync_token,
+            device_id=xform.metadata.deviceID if xform.metadata else None
         )
         self._cache.delete(initial_restore_cache_key)
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -213,7 +213,6 @@ class SubmissionPost(object):
         initial_restore_cache_key = restore_payload_path_cache_key(
             domain=self.domain,
             user_id=xform.user_id,
-            version=V2,
             sync_log_id=xform.last_sync_token,
             device_id=xform.metadata.deviceID if xform.metadata else None
         )

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -326,7 +326,6 @@ class FundamentalCaseTests(TestCase):
         cache_key = restore_payload_path_cache_key(
             domain=DOMAIN,
             user_id='user_id',
-            version="2.0",
             sync_log_id=sync_log_id,
             device_id=device_id,
         )

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -301,19 +301,43 @@ class FundamentalCaseTests(TestCase):
         case.date_opened = case.date_opened.date()
         check_user_has_case(self, user, case.as_xml())
 
-    def test_restore_caches_cleared(self):
-        cache = get_redis_default_cache()
-        cache_key = restore_payload_path_cache_key(domain=DOMAIN, user_id='user_id', version="2.0")
-        cache.set(cache_key, 'test-thing')
-        self.assertEqual(cache.get(cache_key), 'test-thing')
+    @staticmethod
+    def _submit_dummy_form(domain, user_id, device_id='', sync_log_id=None, form_id=None):
+        form_id = form_id or uuid.uuid4().hex
         form = """
             <data xmlns="http://openrosa.org/formdesigner/blah">
                 <meta>
                     <userID>{user_id}</userID>
+                    <deviceID>{device_id}</deviceID>
+                    <instanceID>{form_id}</instanceID>
                 </meta>
             </data>
         """
-        submit_form_locally(form.format(user_id='user_id'), DOMAIN)
+        return submit_form_locally(
+            form.format(user_id=user_id, device_id=device_id, form_id=form_id),
+            domain,
+            last_sync_token=sync_log_id,
+        )
+
+    def test_restore_caches_cleared(self):
+        sync_log_id = 'a8cac9222f42480764d6875c908040d5'
+        device_id = 'CBNMP7XCGTIIAPCIMNI2KRGY'
+        cache = get_redis_default_cache()
+        cache_key = restore_payload_path_cache_key(
+            domain=DOMAIN,
+            user_id='user_id',
+            version="2.0",
+            sync_log_id=sync_log_id,
+            device_id=device_id,
+        )
+        cache.set(cache_key, 'test-thing')
+        self.assertEqual(cache.get(cache_key), 'test-thing')
+        self._submit_dummy_form(
+            domain=DOMAIN,
+            user_id='user_id',
+            device_id=device_id,
+            sync_log_id=sync_log_id,
+        )
         self.assertIsNone(cache.get(cache_key))
 
     def test_update_case_without_creating_triggers_soft_assert(self):
@@ -342,22 +366,13 @@ class FundamentalCaseTests(TestCase):
 
     def test_globally_unique_form_id(self):
         form_id = uuid.uuid4().hex
-
-        form = """
-            <data xmlns="http://openrosa.org/formdesigner/blah">
-                <meta>
-                    <userID>123</userID>
-                    <instanceID>{form_id}</instanceID>
-                </meta>
-            </data>
-        """
         with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False):
-            xform = submit_form_locally(form.format(form_id=form_id), 'domain1').xform
+            xform = self._submit_dummy_form('domain1', user_id='123', form_id=form_id).xform
             self.assertEqual(form_id, xform.form_id)
 
         with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True):
             # form with duplicate ID submitted to different domain gets a new ID
-            xform = submit_form_locally(form.format(form_id=form_id), 'domain2').xform
+            xform = self._submit_dummy_form('domain2', user_id='123', form_id=form_id).xform
             self.assertNotEqual(form_id, xform.form_id)
 
     def test_globally_unique_case_id(self):


### PR DESCRIPTION
Much of this PR is changing tests to be more in line with actual usage, but there are a few important changes that go along with the test changes, and bring more consistency to the cache keys we use to fetch and invalidate restore payload caches.

Again, I can't say this will fix https://manage.dimagi.com/default.asp?260109, but any one of the small handful of bugs/inconsistencies fixed in this PR could plausibly be responsible for that problem.