### PR TITLE
Add owner_id, server_modifed_on index to partitioned dbs.

### DIFF
--- a/corehq/form_processor/migrations/0066_auto_20170818_2020.py
+++ b/corehq/form_processor/migrations/0066_auto_20170818_2020.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.sql_db.operations import HqRunSQL
+
+
+TABLE_NAME = 'form_processor_commcarecasesql'
+INDEX_NAME = 'form_processor_commcarecasesql_owner_id_3a402c4e_idx'
+COLUMNS = ['owner_id', 'server_modified_on']
+
+
+CREATE_INDEX_SQL = "CREATE INDEX CONCURRENTLY {} ON {} ({})".format(
+    INDEX_NAME, TABLE_NAME, ','.join(COLUMNS))
+DROP_INDEX_SQL = "DROP INDEX CONCURRENTLY {}".format(INDEX_NAME)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ('form_processor', '0065_auto_20170725_1339'),
+    ]
+
+    operations = [
+        HqRunSQL(
+            sql=CREATE_INDEX_SQL,
+            reverse_sql=DROP_INDEX_SQL,
+            state_operations=[
+                migrations.AlterIndexTogether(
+                    name='commcarecasesql',
+                    index_together=set([
+                        ('owner_id', 'server_modified_on'),
+                        ('domain', 'owner_id', 'closed'),
+                        ('domain', 'external_id', 'type')
+                    ]),
+                ),
+            ]
+        ),
+    ]

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -892,6 +892,7 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
 
     class Meta:
         index_together = [
+            ["owner_id", "server_modified_on"],
             ["domain", "owner_id", "closed"],
             ["domain", "external_id", "type"],
         ]


### PR DESCRIPTION
This adds the most needed index according to PGHero. This should help with a query that has taken 881 min of server time since I turned on stat collection. it has an average of 250 ms and was called a few hundred thousand times.

I needed to do something a little different here. I used `atomic = False` so that this index runs outside of a transaction because I want to do this concurrently.

@dimagi/scale-team 