### PR TITLE
Remove deploy links from applications dashboard tile

### DIFF
--- a/corehq/apps/dashboard/models.py
+++ b/corehq/apps/dashboard/models.py
@@ -295,9 +295,7 @@ class BasePaginatedTileContextProcessor(BaseTileContextProcessor):
     def _fmt_item(name,
                   url,
                   description=None,
-                  full_name=None,
-                  secondary_url=None,
-                  secondary_url_icon=None):
+                  full_name=None):
         """This is the format that the paginator expects items to be in
         so that the template can be fully rendered.
         :param name: string
@@ -306,8 +304,6 @@ class BasePaginatedTileContextProcessor(BaseTileContextProcessor):
         If present, a popover will appear to the left of the list item.
         :param full_name: string. optional.
         If present, set the popover title.
-        :param secondary_url: string. optional.
-        :param secondary_url_icon: string. optional.
         If these two values are present, display an icon that link to a secondary url when the line is hovered.
         :return:
         """
@@ -317,8 +313,6 @@ class BasePaginatedTileContextProcessor(BaseTileContextProcessor):
             'name': name,
             'description': description,
             'url': url,
-            'secondary_url': secondary_url,
-            'secondary_url_icon': secondary_url_icon
         }
 
     @property
@@ -376,8 +370,6 @@ class AppsPaginatedContext(BasePaginatedTileContextProcessor):
     """Generates the Paginated context for the Applications Tile.
     """
 
-    secondary_url_icon = "fa fa-download"
-
     @property
     def total(self):
         # todo: optimize this at some point. unfortunately applications_brief
@@ -407,11 +399,7 @@ class AppsPaginatedContext(BasePaginatedTileContextProcessor):
         apps = self.applications[self.skip:self.skip + self.limit]
 
         return [self._fmt_item(a.name,
-                               _get_app_url(a),
-                               None,  # description
-                               None,  # full_name
-                               _get_release_manager_url(a),
-                               self.secondary_url_icon) for a in apps]
+                               _get_app_url(a)) for a in apps]
 
 
 class DataPaginatedContext(BasePaginatedTileContextProcessor, ExportsPermissionsMixin):

--- a/corehq/apps/dashboard/static/dashboard/ng_partials/paginated_tile.html
+++ b/corehq/apps/dashboard/static/dashboard/ng_partials/paginated_tile.html
@@ -23,11 +23,6 @@
                          track-analytics=""
                          title="">
                         <a href="{{ item.url }}">{{ item.name }}</a>
-                        <a class="list-group-item-icon"
-                           data-ng-if="item.secondary_url"
-                           href="{{ item.secondary_url }}">
-                            <i class="{{ item.secondary_url_icon }}"></i>
-                        </a>
                     </div>
             </div>
             <pagination direction-links="true"


### PR DESCRIPTION
Remove the secondary deploy icons, now that the application name links to the releases page.

<img width="299" alt="screen shot 2017-08-21 at 3 53 37 pm" src="https://user-images.githubusercontent.com/1486591/29535723-ef823506-8688-11e7-8ba9-8cb3b742d1b9.png">

@millerdev / @biyeun 