### PR TITLE
Remove split UCR pillows.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1690,22 +1690,6 @@ PILLOWTOPS = {
             }
         },
         {
-            'name': 'kafka-ucr-main-08',
-            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
-            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
-            'params': {
-                'ucr_division': '08'
-            }
-        },
-        {
-            'name': 'kafka-ucr-main-9f',
-            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
-            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
-            'params': {
-                'ucr_division': '9f'
-            }
-        },
-        {
             'name': 'kafka-ucr-static',
             'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
             'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -223,20 +223,6 @@
         "full_class_name": "corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow",
         "name": "kafka-ucr-main"
     },
-    "kafka-ucr-main-08": {
-        "advertised_name": "kafka-ucr-main-08",
-        "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "kafka-ucr-main-08",
-        "full_class_name": "corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow",
-        "name": "kafka-ucr-main-08"
-    },
-    "kafka-ucr-main-9f": {
-        "advertised_name": "kafka-ucr-main-9f",
-        "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "kafka-ucr-main-9f",
-        "full_class_name": "corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow",
-        "name": "kafka-ucr-main-9f"
-    },
     "kafka-ucr-static": {
         "advertised_name": "kafka-ucr-static",
         "change_feed_type": "KafkaChangeFeed",


### PR DESCRIPTION
@nickpell Removed these from prod today. Could also remove the code for this, but I think it may be useful in the future if we ever get really really behind (although now we have a decent amount of kafka partitions, so that shouldn't happen)