### PR TITLE
Don't include user testing domains in A/B test

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -140,17 +140,18 @@ def get_releases_context(request, domain, app_id):
             'enable_update_prompts': app.enable_update_prompts,
         })
         if not toggles.APP_MANAGER_V1.enabled(request.user.username):
-            ab = ab_tests.ABTest(ab_tests.APP_BUILDER_VIDEO, request)
-            context.update({
-                'ab_test': ab.context,
-                'show_video': ab.version == ab_tests.APP_BUILDER_VIDEO_ON,
-            })
-            if toggles.APP_MANAGER_V2_TEMPLATE_APPS.enabled(domain):
-                if app.version <= 2:
-                    context.update({'intro_only': True})
-            else:
-                if len(app.modules) == 0:
-                    context.update({'intro_only': True})
+            if not toggles.USER_TESTING_SIMPLIFY.enabled_for_request(request):
+                ab = ab_tests.ABTest(ab_tests.APP_BUILDER_VIDEO, request)
+                context.update({
+                    'ab_test': ab.context,
+                    'show_video': ab.version == ab_tests.APP_BUILDER_VIDEO_ON,
+                })
+                if toggles.APP_MANAGER_V2_TEMPLATE_APPS.enabled(domain):
+                    if app.version <= 2:
+                        context.update({'intro_only': True})
+                else:
+                    if len(app.modules) == 0:
+                        context.update({'intro_only': True})
         # Multimedia is not supported for remote applications at this time.
         try:
             multimedia_state = app.check_media_state()


### PR DESCRIPTION
Going to run some baseline tests on usertesting.com, don't want anyone in them to see the onboarding video.

@biyeun / @millerdev 

`w=1`