### PR TITLE
app builder v2 intro hasn't been showing for usability tests

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -146,12 +146,12 @@ def get_releases_context(request, domain, app_id):
                     'ab_test': ab.context,
                     'show_video': ab.version == ab_tests.APP_BUILDER_VIDEO_ON,
                 })
-                if toggles.APP_MANAGER_V2_TEMPLATE_APPS.enabled(domain):
-                    if app.version <= 2:
-                        context.update({'intro_only': True})
-                else:
-                    if len(app.modules) == 0:
-                        context.update({'intro_only': True})
+            if toggles.APP_MANAGER_V2_TEMPLATE_APPS.enabled(domain):
+                if app.version <= 2:
+                    context.update({'intro_only': True})
+            else:
+                if len(app.modules) == 0:
+                    context.update({'intro_only': True})
         # Multimedia is not supported for remote applications at this time.
         try:
             multimedia_state = app.check_media_state()


### PR DESCRIPTION
Bug in https://github.com/dimagi/commcare-hq/pull/17547 resulted in usability tests not getting the new help bubbles on new apps.

@gcapalbo / @biyeun 