### PR TITLE
Decouple change feed metrics from the pillows running.

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -176,26 +176,6 @@ class PillowBase(object):
             ])
 
     def _record_change_in_datadog(self, change, timer):
-        from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
-        change_feed = self.get_change_feed()
-        current_seq = self._normalize_sequence(change_feed.get_processed_offsets())
-        current_offsets = change_feed.get_latest_offsets()
-
-        tags = [
-            'pillow_name:{}'.format(self.get_name()),
-            'feed_type:{}'.format('kafka' if isinstance(change_feed, KafkaChangeFeed) else 'couch')
-        ]
-        for topic, value in current_seq.iteritems():
-            tags_with_topic = tags + [_topic_for_ddog(topic), ]
-            datadog_gauge('commcare.change_feed.processed_offsets', value, tags=tags_with_topic)
-            if topic in current_offsets:
-                needs_processing = current_offsets[topic] - value
-                datadog_gauge('commcare.change_feed.need_processing', needs_processing, tags=tags_with_topic)
-
-        for topic, offset in current_offsets.iteritems():
-            tags_with_topic = tags + [_topic_for_ddog(topic), ]
-            datadog_gauge('commcare.change_feed.current_offsets', offset, tags=tags_with_topic)
-
         self.__record_change_metric_in_datadog('commcare.change_feed.changes.count', change, timer)
 
     def _record_change_success_in_datadog(self, change):

--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -2,7 +2,7 @@ from celery.schedules import crontab
 from celery.task import periodic_task
 from django.conf import settings
 
-from corehq.util.datadog.gauges import datadog_counter, datadog_gauge, datadog_histogram
+from corehq.util.datadog.gauges import datadog_gauge
 from corehq.util.decorators import serial_task
 from pillowtop.utils import get_all_pillows_json
 
@@ -34,8 +34,8 @@ def pillow_datadog_metrics():
                 processed_offset = pillow['seq']
             else:
                 assert isinstance(pillow['seq'], dict)
-                if len(pillow['seq']) == 0:
-                    # this pillow has never been initialized. 
+                if not pillow['seq']:
+                    # this pillow has never been initialized.
                     # (custom pillows on most environments)
                     continue
                 assert len(pillow['offsets']) == len(pillow['seq'])

--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -1,0 +1,63 @@
+from celery.schedules import crontab
+from celery.task import periodic_task
+from django.conf import settings
+
+from corehq.util.datadog.gauges import datadog_counter, datadog_gauge, datadog_histogram
+from corehq.util.decorators import serial_task
+from pillowtop.utils import get_all_pillows_json
+
+
+@periodic_task(run_every=crontab(minute="*/5"), queue=settings.CELERY_PERIODIC_QUEUE)
+def run_pillow_datadog_metrics():
+    pillow_datadog_metrics.delay()
+
+
+@serial_task('pillow-datadog-metrics', timeout=30 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
+def pillow_datadog_metrics():
+    def _is_couch(pillow):
+        # text is couch, json is kafka
+        return pillow['seq_format'] == 'text'
+
+    pillow_meta = get_all_pillows_json()
+
+    for pillow in pillow_meta:
+        tags = [
+            'pillow_name:{}'.format(pillow['name']),
+            'feed_type:{}'.format('couch' if _is_couch(pillow) else 'kafka')
+        ]
+
+        for topic_name, offset in pillow['offsets'].items():
+            if _is_couch(pillow):
+                assert isinstance(pillow['seq'], int)
+                assert len(pillow['offsets']) == 1
+                tags_with_topic = tags + ['topic:{}'.format(topic_name)]
+                processed_offset = pillow['seq']
+            else:
+                assert isinstance(pillow['seq'], dict)
+                if len(pillow['seq']) == 0:
+                    # this pillow has never been initialized. 
+                    # (custom pillows on most environments)
+                    continue
+                assert len(pillow['offsets']) == len(pillow['seq'])
+                topic, partition = topic_name.split(',')
+                tags_with_topic = tags + ['topic:{}-{}'.format(topic, partition)]
+                processed_offset = pillow['seq'][topic_name]
+
+            if processed_offset == 0:
+                # assume if nothing has been processed that this pillow is not
+                # supposed to be running
+                continue
+
+            datadog_gauge(
+                'commcare.change_feed.current_offsets',
+                offset, tags=tags_with_topic
+            )
+            datadog_gauge(
+                'commcare.change_feed.processed_offsets',
+                processed_offset, tags=tags_with_topic
+            )
+            needs_processing = offset - processed_offset
+            datadog_gauge(
+                'commcare.change_feed.need_processing',
+                needs_processing, tags=tags_with_topic
+            )


### PR DESCRIPTION
If a pillow isn't running then these won't get reported. this moves the datadog reporting to the periodic celery queue, so that they give accurate numbers even when a pillow is down. Noticed it on icds this morning:

![image](https://user-images.githubusercontent.com/1471773/29636296-178c2bc4-881e-11e7-9560-d17f04133659.png)

@biyeun @proteusvacuum 