### PR TITLE
add static task list data sources

### DIFF
--- a/custom/enikshay/ucr/data_sources/episode_tasklist.json
+++ b/custom/enikshay/ucr/data_sources/episode_tasklist.json
@@ -1,0 +1,1832 @@
+{
+    "domains": [
+        "enikshay",
+        "sheel-enikshay",
+        "enikshay-reports-qa"
+    ],
+    "server_environment": [
+        "enikshay",
+        "softlayer"
+    ],
+    "config": {
+      "referenced_doc_type": "CommCareCase",
+      "asynchronous": true,
+      "engine_id": "ucr",
+      "description": "",
+      "base_item_expression": {
+      },
+      "table_id": "episode_tasklist",
+      "display_name": "episode (task list)",
+      "configured_filter": {
+        "type": "and",
+        "filters": [
+          {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "type"
+            },
+            "comment": null,
+            "property_value": "episode"
+          },
+          {
+            "operator": "not_eq",
+            "type": "boolean_expression",
+            "expression": {
+              "datatype": "string",
+              "type": "named",
+              "name": "owner_id"
+            },
+            "comment": null,
+            "property_value": "_archive_"
+          },
+          {
+            "operator": "not_eq",
+            "type": "boolean_expression",
+            "expression": {
+              "datatype": "string",
+              "type": "named",
+              "name": "owner_id"
+            },
+            "comment": null,
+            "property_value": null
+          }
+        ]
+      },
+      "configured_indicators": [
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "owner id",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": "string",
+            "type": "named",
+            "name": "owner_id"
+          },
+          "column_id": "owner_id"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "owner name",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": false,
+          "expression": {
+            "value_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "name"
+            },
+            "type": "related_doc",
+            "related_doc_type": "Location",
+            "doc_id_expression": {
+              "type": "named",
+              "name": "owner_id"
+            }
+          },
+          "column_id": "owner_name"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "owned location level",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": false,
+          "expression": {
+            "location_id_expression": {
+              "type": "named",
+              "name": "owner_id"
+            },
+            "type": "location_type_name"
+          },
+          "column_id": "location_type"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "TU ID",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "location_id_expression": {
+              "type": "named",
+              "name": "owner_id"
+            },
+            "type": "location_parent_id"
+          },
+          "column_id": "tu_id"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "DTO ID",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "location_id_expression": {
+              "location_id_expression": {
+                "type": "named",
+                "name": "owner_id"
+              },
+              "type": "location_parent_id"
+            },
+            "type": "location_parent_id"
+          },
+          "column_id": "dto_id"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "person/name",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "value_expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "name"
+            },
+            "type": "related_doc",
+            "related_doc_type": "CommCareCase",
+            "doc_id_expression": {
+              "datatype": null,
+              "type": "named",
+              "name": "person_id"
+            }
+          },
+          "column_id": "person_name"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "date opened",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "opened_on"
+          },
+          "column_id": "date_opened"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "patient_type",
+          "datatype": "string",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "patient_type_choice"
+          },
+          "transform": {},
+          "is_nullable": true,
+          "is_primary_key": false,
+          "column_id": "patient_type",
+          "type": "expression"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": null,
+          "datatype": "string",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "episode_type"
+          },
+          "is_primary_key": false,
+          "transform": {},
+          "is_nullable": true,
+          "type": "expression",
+          "column_id": "episode_type"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": null,
+          "datatype": "string",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "is_active"
+          },
+          "transform": {},
+          "is_nullable": true,
+          "is_primary_key": false,
+          "column_id": "is_active",
+          "type": "expression"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "awaiting claim?",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "has_open_referral"
+          },
+          "column_id": "awaiting_claim"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "date_of_diagnosis",
+          "datatype": "date",
+          "expression": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "date_of_diagnosis"
+          },
+          "transform": {},
+          "is_nullable": true,
+          "is_primary_key": false,
+          "column_id": "date_of_diagnosis",
+          "type": "expression"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "confirmed tb?",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "is_confirmed"
+          },
+          "column_id": "is_confirmed"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "pending registration?",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "is_pending"
+          },
+          "column_id": "is_pending"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "treatment not initiated",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "evaluator",
+            "context_variables": {
+              "has_open_referral": {
+                "type": "named",
+                "name": "has_open_referral"
+              },
+              "is_pending": {
+                "type": "named",
+                "name": "is_pending"
+              },
+              "is_confirmed": {
+                "type": "named",
+                "name": "is_confirmed"
+              }
+            },
+            "statement": "is_pending and is_confirmed and has_open_referral == 0"
+          },
+          "column_id": "treatment_not_initiated"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "hiv_status",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "value_expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "hiv_status"
+            },
+            "type": "related_doc",
+            "related_doc_type": "CommCareCase",
+            "doc_id_expression": {
+              "datatype": null,
+              "type": "named",
+              "name": "person_id"
+            }
+          },
+          "column_id": "hiv_status"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "hiv_status_unknown",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "value_expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "hiv_status"
+            },
+            "type": "related_doc",
+            "related_doc_type": "CommCareCase",
+            "doc_id_expression": {
+              "datatype": null,
+              "type": "named",
+              "name": "person_id"
+            }
+          },
+          "column_id": "hiv_status_unknown"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "hiv_not_updated",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "test": {
+              "operator": "eq",
+              "type": "boolean_expression",
+              "expression": {
+                "value_expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "hiv_status"
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                  "datatype": null,
+                  "type": "named",
+                  "name": "person_id"
+                }
+              },
+              "comment": null,
+              "property_value": "unknown"
+            },
+            "expression_if_true": {
+              "test": {
+                "operator": "eq",
+                "expression": {
+                  "type": "named",
+                  "name": "has_open_referral"
+                },
+                "type": "boolean_expression",
+                "comment": null,
+                "property_value": 0
+              },
+              "expression_if_true": 1,
+              "type": "conditional",
+              "expression_if_false": 0
+            },
+            "type": "conditional",
+            "expression_if_false": 0
+          },
+          "column_id": "hiv_not_updated"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "diabetes_not_updated",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "test": {
+              "operator": "eq",
+              "type": "boolean_expression",
+              "expression": {
+                "value_expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "diabetes_status"
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                  "datatype": null,
+                  "type": "named",
+                  "name": "person_id"
+                }
+              },
+              "comment": null,
+              "property_value": "unknown"
+            },
+            "expression_if_true": {
+              "test": {
+                "operator": "eq",
+                "expression": {
+                  "type": "named",
+                  "name": "has_open_referral"
+                },
+                "type": "boolean_expression",
+                "comment": null,
+                "property_value": 0
+              },
+              "expression_if_true": 1,
+              "type": "conditional",
+              "expression_if_false": 0
+            },
+            "type": "conditional",
+            "expression_if_false": 0
+          },
+          "column_id": "diabetes_not_updated"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "result_recorded",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_nullable": true,
+          "is_primary_key": false,
+          "column_id": "result_recorded",
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "result_recorded"
+          }
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "test results awaited",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "evaluator",
+            "context_variables": {
+              "has_open_referral": {
+                "type": "named",
+                "name": "has_open_referral"
+              },
+              "test_requested": {
+                "type": "named",
+                "name": "test_requested"
+              },
+              "result_recorded": {
+                "type": "named",
+                "name": "result_recorded"
+              }
+            },
+            "statement": "test_requested and result_recorded and has_open_referral == 0"
+          },
+          "column_id": "test_results_awaited"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "test requested date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "test_requested_date"
+          },
+          "column_id": "test_requested_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "adherence information missing",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "test": {
+              "operator": "eq",
+              "type": "boolean_expression",
+              "expression": {
+                "type": "named",
+                "name": "has_open_referral"
+              },
+              "comment": null,
+              "property_value": 0
+            },
+            "expression_if_true": 1,
+            "type": "conditional",
+            "expression_if_false": 0
+          },
+          "column_id": "adherence_information_missing"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "last adherence date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": "date",
+            "type": "named",
+            "name": "last_adherence_date"
+          },
+          "column_id": "last_adherence_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "treatment initiation date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "treatment_initiation_date"
+          },
+          "column_id": "treatment_initiation_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "last good adherence date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "test": {
+              "operator": "eq",
+              "expression": {
+                "type": "named",
+                "name": "last_adherence_date"
+              },
+              "type": "boolean_expression",
+              "comment": null,
+              "property_value": null
+            },
+            "expression_if_true": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "treatment_initiation_date"
+            },
+            "type": "conditional",
+            "expression_if_false": {
+              "type": "named",
+              "name": "last_adherence_date"
+            }
+          },
+          "column_id": "last_good_adherence_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "cp test count",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "cp_test_count"
+          },
+          "column_id": "cp_test_count"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "cp or ip test count",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "cp_or_ip_test_count"
+          },
+          "column_id": "cp_or_ip_test_count"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "date cp/ip threshold crossed",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": "date",
+            "type": "named",
+            "name": "follow_up_due_anchor_date"
+          },
+          "column_id": "follow_up_due_anchor_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "follow up due",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "evaluator",
+            "context_variables": {
+              "has_open_referral": {
+                "type": "named",
+                "name": "has_open_referral"
+              },
+              "ip_threshold_crossed": {
+                "datatype": "integer",
+                "type": "named",
+                "name": "ip_threshold_crossed"
+              },
+              "cp_threshold_crossed": {
+                "datatype": "integer",
+                "type": "named",
+                "name": "cp_threshold_crossed"
+              },
+              "cp_or_ip_test_count": {
+                "datatype": "integer",
+                "type": "named",
+                "name": "cp_or_ip_test_count"
+              },
+              "cp_test_count": {
+                "datatype": "integer",
+                "type": "named",
+                "name": "cp_test_count"
+              }
+            },
+            "statement": "((cp_threshold_crossed and cp_test_count == 0) or (ip_threshold_crossed and cp_or_ip_test_count == 0)) and has_open_referral == 0"
+          },
+          "column_id": "follow_up_due"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "home visit pending",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "home_visit_pending"
+          },
+          "column_id": "home_visit_pending"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "is pulmonary",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "is_pulmonary"
+          },
+          "column_id": "is_pulmonary"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "date reported",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "date_reported"
+          },
+          "column_id": "date_reported"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "household visit anchor date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "household_visit_anchor_date"
+          },
+          "column_id": "household_visit_anchor_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "household visit anchor date non null",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "household_visit_anchor_date_non_null"
+          },
+          "column_id": "household_visit_anchor_date_non_null"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "new patient household visit",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "evaluator",
+            "context_variables": {
+              "has_open_referral": {
+                "type": "named",
+                "name": "has_open_referral"
+              },
+              "household_visit_anchor_date_non_null": {
+                "datatype": "date",
+                "type": "named",
+                "name": "household_visit_anchor_date_non_null"
+              },
+              "home_visit_pending": {
+                "datatype": "date",
+                "type": "named",
+                "name": "home_visit_pending"
+              }
+            },
+            "statement": "household_visit_anchor_date_non_null and home_visit_pending and has_open_referral == 0"
+          },
+          "column_id": "new_patient_household_visit"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "drug_formulations contains fdc",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "fdc_drug_formulations"
+          },
+          "column_id": "fdc_drug_formulations"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "refill_next_date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "test": {
+              "operator": "in",
+              "expression": {
+                "datatype": null,
+                "type": "property_name",
+                "property_name": "refill_next_date"
+              },
+              "type": "boolean_expression",
+              "comment": null,
+              "property_value": [
+                null,
+                ""
+              ]
+            },
+            "expression_if_true": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "treatment_initiation_date"
+            },
+            "type": "conditional",
+            "expression_if_false": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "refill_next_date"
+            }
+          },
+          "column_id": "refill_next_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "fdc_task_list",
+          "datatype": "integer",
+          "expression": {
+            "type": "named",
+            "name": "fdc_task_list"
+          },
+          "is_primary_key": false,
+          "transform": {},
+          "is_nullable": true,
+          "type": "expression",
+          "column_id": "fdc_task_list"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "outcome_due_date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "outcome_due_date"
+          },
+          "column_id": "outcome_due_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "outcome_due",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "outcome_due"
+          },
+          "column_id": "outcome_due"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "treatment_outcome",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "treatment_outcome"
+          },
+          "column_id": "treatment_outcome"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "treatment_initiated",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "treatment_initiated"
+          },
+          "column_id": "treatment_initiated"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "referred_outcome_due",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "referred_outcome_due"
+          },
+          "column_id": "referred_outcome_due"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "open_referral",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "has_open_referral"
+          },
+          "column_id": "open_referral"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "date of referral",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "type": "named",
+            "name": "date_of_referral"
+          },
+          "column_id": "date_of_referral"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "treatment_card_completed_date",
+          "datatype": "date",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "treatment_card_completed_date"
+          },
+          "column_id": "treatment_card_completed_date"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "closed",
+          "datatype": "integer",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": true,
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "closed"
+          },
+          "column_id": "closed"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": "treatment outcome happened",
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": false,
+          "expression": {
+            "datatype": "integer",
+            "type": "named",
+            "name": "treatment_outcome_happened"
+          },
+          "column_id": "treatment_outcome_happened"
+        },
+        {
+          "comment": null,
+          "create_index": false,
+          "display_name": null,
+          "datatype": "string",
+          "type": "expression",
+          "transform": {},
+          "is_primary_key": false,
+          "is_nullable": false,
+          "expression": {
+            "datatype": "string",
+            "type": "named",
+            "name": "adherence_schedule_type"
+          },
+          "column_id": "adherence_schedule_type"
+        }
+      ],
+      "named_expressions": {
+        "test_requested": {
+          "test": {
+            "operator": "eq",
+            "expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "test_requested_date"
+            },
+            "type": "boolean_expression",
+            "property_value": ""
+          },
+          "expression_if_true": 0,
+          "type": "conditional",
+          "expression_if_false": 1
+        },
+        "date_of_referral": {
+          "value_expression": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "date_of_referral"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "named",
+            "name": "open_referral_id"
+          }
+        },
+        "referral_case": {
+          "aggregation_fn": "last_item",
+          "type": "reduce_items",
+          "items_expression": {
+            "sort_expression": {
+              "type": "property_name",
+              "property_name": "opened_on"
+            },
+            "type": "sort_items",
+            "items_expression": {
+              "filter_expression": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                  "type": "property_name",
+                  "property_name": "type"
+                },
+                "property_value": "referral"
+              },
+              "type": "filter_items",
+              "items_expression": {
+                "type": "get_subcases",
+                "case_id_expression": {
+                  "value_expression": {
+                    "value_expression": {
+                      "datatype": null,
+                      "type": "property_name",
+                      "property_name": "referenced_id"
+                    },
+                    "type": "nested",
+                    "argument_expression": {
+                      "type": "array_index",
+                      "array_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "indices"
+                      },
+                      "index_expression": {
+                        "type": "constant",
+                        "constant": 0
+                      }
+                    }
+                  },
+                  "type": "related_doc",
+                  "related_doc_type": "CommCareCase",
+                  "doc_id_expression": {
+                    "value_expression": {
+                      "datatype": null,
+                      "type": "property_name",
+                      "property_name": "referenced_id"
+                    },
+                    "type": "nested",
+                    "argument_expression": {
+                      "type": "array_index",
+                      "array_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "indices"
+                      },
+                      "index_expression": {
+                        "type": "constant",
+                        "constant": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "adherence_date_outcome_due": {
+          "datatype": "date",
+          "type": "property_name",
+          "property_name": "adherence_date_outcome_due"
+        },
+        "referred_outcome_due": {
+          "test": {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "type": "named",
+              "name": "outcome_due"
+            },
+            "property_value": 1
+          },
+          "expression_if_true": {
+            "type": "named",
+            "name": "has_open_referral"
+          },
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "outcome_due_date": {
+          "test": {
+            "operator": "in",
+            "expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "treatment_initiation_date"
+            },
+            "type": "boolean_expression",
+            "property_value": [
+              "",
+              null
+            ]
+          },
+          "expression_if_true": {
+            "type": "constant",
+            "constant": null
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "test": {
+              "operator": "in",
+              "expression": {
+                "type": "named",
+                "name": "adherence_date_outcome_due"
+              },
+              "type": "boolean_expression",
+              "property_value": [
+                "",
+                null
+              ]
+            },
+            "expression_if_true": {
+              "type": "named",
+              "name": "15_months_after_treatment_initiation"
+            },
+            "type": "conditional",
+            "expression_if_false": {
+              "type": "named",
+              "name": "outcome_due_date_min"
+            }
+          }
+        },
+        "is_confirmed": {
+          "test": {
+            "type": "or",
+            "filters": [
+              {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "episode_type"
+                },
+                "type": "boolean_expression",
+                "property_value": "confirmed_tb"
+              },
+              {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "episode_type"
+                },
+                "type": "boolean_expression",
+                "property_value": "confirmed_drtb"
+              }
+            ]
+          },
+          "expression_if_true": 1,
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "cp_threshold_crossed": {
+          "test": {
+            "operator": "in",
+            "type": "boolean_expression",
+            "expression": {
+              "datatype": "date",
+              "type": "property_name",
+              "property_name": "adherence_cp_date_threshold_crossed"
+            },
+            "property_value": [
+              null,
+              ""
+            ]
+          },
+          "expression_if_true": {
+            "constant": 0,
+            "type": "constant"
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "constant": 1,
+            "type": "constant"
+          }
+        },
+        "is_pulmonary": {
+          "test": {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "value_expression": {
+                "type": "property_name",
+                "property_name": "disease_classification"
+              },
+              "type": "related_doc",
+              "related_doc_type": "CommCareCase",
+              "doc_id_expression": {
+                "type": "named",
+                "name": "occurrence_id"
+              }
+            },
+            "property_value": "pulmonary"
+          },
+          "expression_if_true": 1,
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "person_case_version": {
+          "value_expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "case_version"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "named",
+            "name": "person_id"
+          }
+        },
+        "treatment_outcome_happened": {
+          "test": {
+            "operator": "in",
+            "expression": {
+              "type": "property_name",
+              "property_name": "treatment_outcome"
+            },
+            "type": "boolean_expression",
+            "property_value": [
+              "not_evaluated",
+              "",
+              null
+            ]
+          },
+          "expression_if_true": {
+            "type": "constant",
+            "constant": 0
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "type": "constant",
+            "constant": 1
+          }
+        },
+        "person_id": {
+          "value_expression": {
+            "value_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "referenced_id"
+            },
+            "type": "nested",
+            "argument_expression": {
+              "type": "array_index",
+              "array_expression": {
+                "datatype": null,
+                "type": "property_name",
+                "property_name": "indices"
+              },
+              "index_expression": {
+                "type": "constant",
+                "constant": 0
+              }
+            }
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "named",
+            "name": "occurrence_id"
+          }
+        },
+        "owner_id": {
+          "value_expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "named",
+            "name": "person_id"
+          }
+        },
+        "cp_test_count": {
+          "aggregation_fn": "count",
+          "type": "reduce_items",
+          "items_expression": {
+            "filter_expression": {
+              "operator": "eq",
+              "expression": {
+                "type": "identity"
+              },
+              "type": "boolean_expression",
+              "property_value": "end_of_cp"
+            },
+            "type": "filter_items",
+            "items_expression": {
+              "type": "named",
+              "name": "all_test_reasons"
+            }
+          }
+        },
+        "home_visit_pending": {
+          "test": {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "value_expression": {
+                "type": "property_name",
+                "property_name": "initial_home_visit_status"
+              },
+              "type": "related_doc",
+              "related_doc_type": "CommCareCase",
+              "doc_id_expression": {
+                "type": "named",
+                "name": "occurrence_id"
+              }
+            },
+            "property_value": "pending"
+          },
+          "expression_if_true": 1,
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "adherence_schedule_type": {
+          "default": {
+            "type": "constant",
+            "constant": "no_adherence_schedule"
+          },
+          "cases": {
+            "schedule_mwf": {
+              "type": "constant",
+              "constant": "intermittent"
+            },
+            "schedule_trs": {
+              "type": "constant",
+              "constant": "intermittent"
+            },
+            "schedule_daily": {
+              "type": "constant",
+              "constant": "daily"
+            }
+          },
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "adherence_schedule_id"
+          }
+        },
+        "all_test_reasons": {
+          "map_expression": {
+            "type": "coalesce",
+            "expression": {
+              "type": "property_name",
+              "property_name": "rft_dstb_followup"
+            },
+            "default_expression": {
+              "type": "property_name",
+              "property_name": "follow_up_test_reason"
+            }
+          },
+          "type": "map_items",
+          "items_expression": {
+            "filter_expression": {
+              "operator": "eq",
+              "expression": {
+                "datatype": null,
+                "type": "property_name",
+                "property_name": "type"
+              },
+              "type": "boolean_expression",
+              "property_value": "test"
+            },
+            "type": "filter_items",
+            "items_expression": {
+              "type": "get_subcases",
+              "case_id_expression": {
+                "type": "named",
+                "name": "occurrence_id"
+              }
+            }
+          }
+        },
+        "outcome_due_date_min": {
+          "aggregation_fn": "min",
+          "type": "reduce_items",
+          "items_expression": {
+            "expressions": [
+              {
+                "datatype": "date",
+                "type": "property_name",
+                "property_name": "adherence_date_outcome_due"
+              },
+              {
+                "date_expression": {
+                  "datatype": "date",
+                  "type": "property_name",
+                  "property_name": "treatment_initiation_date"
+                },
+                "type": "add_days",
+                "count_expression": 450
+              }
+            ],
+            "type": "iterator"
+          }
+        },
+        "occurrence_id": {
+          "value_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "referenced_id"
+          },
+          "type": "nested",
+          "argument_expression": {
+            "type": "array_index",
+            "array_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "indices"
+            },
+            "index_expression": {
+              "type": "constant",
+              "constant": 0
+            }
+          }
+        },
+        "fdc_drug_formulations": {
+          "test": {
+            "operator": "in_multi",
+            "type": "boolean_expression",
+            "expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "drug_formulations"
+            },
+            "property_value": "fdc"
+          },
+          "expression_if_true": 1,
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "follow_up_due_anchor_date": {
+          "test": {
+            "operator": "gt",
+            "expression": {
+              "datatype": "integer",
+              "type": "named",
+              "name": "cp_or_ip_test_count"
+            },
+            "type": "boolean_expression",
+            "property_value": 0
+          },
+          "expression_if_true": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "adherence_cp_date_threshold_crossed"
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "adherence_ip_date_threshold_crossed"
+          }
+        },
+        "last_adherence_date": {
+          "aggregation_fn": "last_item",
+          "type": "reduce_items",
+          "items_expression": {
+            "map_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "adherence_date"
+            },
+            "type": "map_items",
+            "items_expression": {
+              "filter_expression": {
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": {
+                  "datatype": null,
+                  "type": "property_name",
+                  "property_name": "type"
+                },
+                "property_value": "adherence"
+              },
+              "type": "filter_items",
+              "items_expression": {
+                "type": "get_subcases",
+                "case_id_expression": {
+                  "datatype": null,
+                  "type": "property_name",
+                  "property_name": "_id"
+                }
+              }
+            }
+          }
+        },
+        "outcome_due": {
+          "test": {
+            "operator": "in",
+            "expression": {
+              "type": "property_name",
+              "property_name": "treatment_initiated"
+            },
+            "type": "boolean_expression",
+            "property_value": [
+              "yes_phi",
+              "yes_private"
+            ]
+          },
+          "expression_if_true": {
+            "type": "named",
+            "name": "treatment_outcome_happened"
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "type": "constant",
+            "constant": 0
+          }
+        },
+        "ip_threshold_crossed": {
+          "test": {
+            "operator": "in",
+            "type": "boolean_expression",
+            "expression": {
+              "datatype": "date",
+              "type": "property_name",
+              "property_name": "adherence_ip_date_threshold_crossed"
+            },
+            "property_value": [
+              null,
+              ""
+            ]
+          },
+          "expression_if_true": {
+            "constant": 0,
+            "type": "constant"
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "constant": 1,
+            "type": "constant"
+          }
+        },
+        "15_months_after_treatment_initiation": {
+          "date_expression": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "treatment_initiation_date"
+          },
+          "type": "add_days",
+          "count_expression": 450
+        },
+        "open_referral_id": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "case_id"
+          },
+          "type": "nested",
+          "argument_expression": {
+            "aggregation_fn": "first_item",
+            "type": "reduce_items",
+            "items_expression": {
+              "filter_expression": {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "closed"
+                },
+                "type": "boolean_expression",
+                "property_value": "false"
+              },
+              "type": "filter_items",
+              "items_expression": {
+                "type": "get_subcases",
+                "case_id_expression": {
+                  "type": "named",
+                  "name": "occurrence_id"
+                }
+              }
+            }
+          }
+        },
+        "cp_or_ip_test_count": {
+          "aggregation_fn": "count",
+          "type": "reduce_items",
+          "items_expression": {
+            "filter_expression": {
+              "operator": "in",
+              "expression": {
+                "type": "identity"
+              },
+              "type": "boolean_expression",
+              "property_value": [
+                "end_of_cp",
+                "end_of_ip"
+              ]
+            },
+            "type": "filter_items",
+            "items_expression": {
+              "type": "named",
+              "name": "all_test_reasons"
+            }
+          }
+        },
+        "has_open_referral": {
+          "test": {
+            "operator": "eq",
+            "type": "boolean_expression",
+            "expression": {
+              "value_expression": {
+                "type": "property_name",
+                "property_name": "closed"
+              },
+              "type": "nested",
+              "argument_expression": {
+                "type": "named",
+                "name": "referral_case"
+              }
+            },
+            "property_value": "true"
+          },
+          "expression_if_true": {
+            "type": "constant",
+            "constant": 1
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "type": "constant",
+            "constant": 0
+          }
+        },
+        "household_visit_anchor_date_non_null": {
+          "test": {
+            "operator": "eq",
+            "expression": {
+              "type": "named",
+              "name": "household_visit_anchor_date"
+            },
+            "type": "boolean_expression",
+            "property_value": null
+          },
+          "expression_if_true": {
+            "type": "constant",
+            "constant": 0
+          },
+          "type": "conditional",
+          "expression_if_false": {
+            "type": "constant",
+            "constant": 1
+          }
+        },
+        "fdc_task_list": {
+          "datatype": "integer",
+          "type": "evaluator",
+          "context_variables": {
+            "treatment_initiation_date": {
+              "datatype": "date",
+              "type": "property_name",
+              "property_name": "treatment_initiation_date"
+            },
+            "treatment_outcome_happened": {
+              "type": "named",
+              "name": "treatment_outcome_happened"
+            },
+            "fdc_drug_formulations": {
+              "type": "named",
+              "name": "fdc_drug_formulations"
+            }
+          },
+          "statement": "treatment_initiation_date and fdc_drug_formulations and not treatment_outcome_happened"
+        },
+        "result_recorded": {
+          "test": {
+            "operator": "eq",
+            "expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "result_recorded"
+            },
+            "type": "boolean_expression",
+            "property_value": "yes"
+          },
+          "expression_if_true": 1,
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "is_pending": {
+          "test": {
+            "operator": "eq",
+            "expression": {
+              "datatype": "string",
+              "type": "property_name",
+              "property_name": "episode_pending_registration"
+            },
+            "type": "boolean_expression",
+            "property_value": "yes"
+          },
+          "expression_if_true": 1,
+          "type": "conditional",
+          "expression_if_false": 0
+        },
+        "household_visit_anchor_date": {
+          "type": "evaluator",
+          "context_variables": {
+            "a": {
+              "datatype": "date",
+              "type": "property_name",
+              "property_name": "date_of_diagnosis"
+            },
+            "b": {
+              "datatype": "date",
+              "type": "property_name",
+              "property_name": "date_reported"
+            }
+          },
+          "statement": "a if (a != None and ((b != None and a <= b) or b == None)) else b"
+        }
+      },
+      "named_filters": {}
+    }
+}

--- a/custom/enikshay/ucr/data_sources/referral_tasklist.json
+++ b/custom/enikshay/ucr/data_sources/referral_tasklist.json
@@ -1,0 +1,278 @@
+{
+  "domains": [
+    "enikshay",
+    "sheel-enikshay",
+    "enikshay-reports-qa"
+  ],
+  "server_environment": [
+    "enikshay",
+    "softlayer"
+  ],
+  "config": {
+    "referenced_doc_type": "CommCareCase",
+    "asynchronous": true,
+    "engine_id": "ucr",
+    "description": "",
+    "base_item_expression": {
+    },
+    "table_id": "referral_tasklist",
+    "display_name": "referral (task list)",
+    "configured_filter": {
+      "operator": "eq",
+      "expression": {
+        "datatype": "string",
+        "type": "property_name",
+        "property_name": "type"
+      },
+      "type": "boolean_expression",
+      "comment": null,
+      "property_value": "referral"
+    },
+    "configured_indicators": [
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "date opened",
+        "datatype": "date",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "opened_on"
+        },
+        "column_id": "date_opened"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "date of referral",
+        "datatype": "date",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "type": "coalesce",
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "referral_initiated_date"
+          },
+          "default_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "date_of_referral"
+          }
+        },
+        "column_id": "date_of_referral"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "closed",
+        "datatype": "integer",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "closed"
+        },
+        "column_id": "closed"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "person_name",
+        "datatype": "string",
+        "type": "expression",
+        "transform": {},
+        "is_nullable": true,
+        "is_primary_key": false,
+        "column_id": "person_name",
+        "expression": {
+          "datatype": null,
+          "type": "named",
+          "name": "person_name"
+        }
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "owner_id",
+        "datatype": "string",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "type": "named",
+          "name": "owner_id"
+        },
+        "column_id": "owner_id"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "TU ID",
+        "datatype": "string",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "type": "named",
+          "name": "tu_id"
+        },
+        "column_id": "tu_id"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "DTO ID",
+        "datatype": "string",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "type": "named",
+          "name": "dto_id"
+        },
+        "column_id": "dto_id"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "awating_claim",
+        "datatype": "string",
+        "type": "expression",
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "awaiting_claim"
+        },
+        "column_id": "awaiting_claim"
+      }
+    ],
+    "named_expressions": {
+      "host_host_id": {
+        "value_expression": {
+          "value_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "referenced_id"
+          },
+          "type": "nested",
+          "argument_expression": {
+            "type": "array_index",
+            "array_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "indices"
+            },
+            "index_expression": {
+              "type": "constant",
+              "constant": 0
+            }
+          }
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "named",
+          "name": "host_id"
+        }
+      },
+      "person_name": {
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "name"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "named",
+          "name": "person_id"
+        }
+      },
+      "dto_id": {
+        "location_id_expression": {
+          "type": "named",
+          "name": "tu_id"
+        },
+        "type": "location_parent_id"
+      },
+      "tu_id": {
+        "location_id_expression": {
+          "type": "named",
+          "name": "owner_id"
+        },
+        "type": "location_parent_id"
+      },
+      "person_id": {
+        "test": {
+          "operator": "eq",
+          "type": "boolean_expression",
+          "expression": {
+            "value_expression": {
+              "type": "property_name",
+              "property_name": "type"
+            },
+            "type": "related_doc",
+            "related_doc_type": "CommCareCase",
+            "doc_id_expression": {
+              "type": "named",
+              "name": "host_id"
+            }
+          },
+          "property_value": "person"
+        },
+        "expression_if_true": {
+          "type": "named",
+          "name": "host_id"
+        },
+        "type": "conditional",
+        "expression_if_false": {
+          "type": "named",
+          "name": "host_host_id"
+        }
+      },
+      "host_id": {
+        "value_expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "referenced_id"
+        },
+        "type": "nested",
+        "argument_expression": {
+          "type": "array_index",
+          "array_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "indices"
+          },
+          "index_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
+      },
+      "owner_id": {
+        "type": "property_name",
+        "property_name": "owner_id"
+      }
+    },
+    "named_filters": {}
+  }
+}
+
+

--- a/custom/enikshay/ucr/data_sources/test_tasklist.json
+++ b/custom/enikshay/ucr/data_sources/test_tasklist.json
@@ -1,0 +1,785 @@
+{
+  "domains": [
+    "enikshay",
+    "sheel-enikshay",
+    "enikshay-reports-qa"
+  ],
+  "server_environment": [
+    "enikshay",
+    "softlayer"
+  ],
+  "config": {
+    "referenced_doc_type": "CommCareCase",
+    "asynchronous": true,
+    "engine_id": "ucr",
+    "description": "",
+    "base_item_expression": {
+    },
+    "table_id": "test_tasklist",
+    "display_name": "test (task list)",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "operator": "eq",
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "type"
+          },
+          "type": "boolean_expression",
+          "comment": null,
+          "property_value": "test"
+        },
+        {
+          "operator": "not_eq",
+          "expression": {
+            "datatype": "string",
+            "type": "named",
+            "name": "owner_id"
+          },
+          "type": "boolean_expression",
+          "comment": null,
+          "property_value": "_archive_"
+        },
+        {
+          "operator": "not_eq",
+          "expression": {
+            "datatype": "string",
+            "type": "named",
+            "name": "owner_id"
+          },
+          "type": "boolean_expression",
+          "comment": null,
+          "property_value": "_invalid_"
+        },
+        {
+          "operator": "eq",
+          "expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "closed"
+          },
+          "type": "boolean_expression",
+          "comment": null,
+          "property_value": false
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "owner id",
+        "datatype": "string",
+        "expression": {
+          "datatype": "string",
+          "type": "named",
+          "name": "owner_id"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": false,
+        "type": "expression",
+        "column_id": "owner_id"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "name"
+          },
+          "type": "related_doc",
+          "related_doc_type": "Location",
+          "doc_id_expression": {
+            "type": "named",
+            "name": "owner_id"
+          }
+        },
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": false,
+        "type": "expression",
+        "column_id": "owner_name"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "owner_id"
+          },
+          "type": "location_type_name"
+        },
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": false,
+        "type": "expression",
+        "column_id": "location_type"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "TU ID",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "owner_id"
+          },
+          "type": "location_parent_id"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": false,
+        "type": "expression",
+        "column_id": "tu_id"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "DTO ID",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "location_id_expression": {
+              "type": "named",
+              "name": "owner_id"
+            },
+            "type": "location_parent_id"
+          },
+          "type": "location_parent_id"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": false,
+        "type": "expression",
+        "column_id": "dto_id"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "person/name",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "name"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "datatype": null,
+            "type": "named",
+            "name": "person_id"
+          }
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "person_name"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "date opened",
+        "datatype": "date",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "opened_on"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "date_opened"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "awaiting claim?",
+        "datatype": "integer",
+        "expression": {
+          "type": "named",
+          "name": "awaiting_claim_bool"
+        },
+        "transform": {},
+        "is_nullable": true,
+        "is_primary_key": false,
+        "column_id": "awaiting_claim",
+        "type": "expression"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "MDR suspects",
+        "datatype": "integer",
+        "expression": {
+          "datatype": null,
+          "type": "evaluator",
+          "statement": "key_populations or hiv_status or episode_type_at_request or follow_up_test_reason and test_type_value",
+          "context_variables": {
+            "key_populations": {
+              "type": "named",
+              "name": "key_populations"
+            },
+            "hiv_status": {
+              "type": "named",
+              "name": "hiv_status"
+            },
+            "follow_up_test_reason": {
+              "type": "named",
+              "name": "follow_up_test_reason"
+            },
+            "test_type_value": {
+              "type": "named",
+              "name": "test_type_value"
+            },
+            "episode_type_at_request": {
+              "type": "named",
+              "name": "episode_type_at_request"
+            }
+          }
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "mdr_suspects"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "result_recorded",
+        "datatype": "string",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "result_recorded"
+        },
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "result_recorded"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "result_recorded_bool",
+        "datatype": "integer",
+        "expression": {
+          "type": "named",
+          "name": "result_recorded"
+        },
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "result_recorded_bool"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "integer",
+        "expression": {
+          "type": "named",
+          "name": "not_direct_test_entry"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "not_direct_test_entry"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "string",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "sample_status"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "sample_status"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "string",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "test_facility_referred_to"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "test_facility_referred_to"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "test_requested",
+        "datatype": "integer",
+        "expression": {
+          "type": "named",
+          "name": "test_requested"
+        },
+        "is_primary_key": false,
+        "transform": {},
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "test_requested"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "test results awaited",
+        "datatype": "integer",
+        "expression": {
+          "datatype": "integer",
+          "type": "evaluator",
+          "statement": "test_requested and test_result_awaited_test_type and (1 - result_recorded) and (1 - awaiting_claim_bool)",
+          "context_variables": {
+            "test_result_awaited_test_type": {
+              "type": "named",
+              "name": "test_result_awaited_test_type"
+            },
+            "test_requested": {
+              "type": "named",
+              "name": "test_requested"
+            },
+            "awaiting_claim_bool": {
+              "type": "named",
+              "name": "awaiting_claim_bool"
+            },
+            "result_recorded": {
+              "type": "named",
+              "name": "result_recorded"
+            }
+          }
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "test_results_awaited"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": "test requested date",
+        "datatype": "date",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "test_requested_date"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "test_requested_date"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "string",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "test_type_label"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "test_type_label"
+      },
+      {
+        "comment": null,
+        "create_index": false,
+        "display_name": null,
+        "datatype": "string",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "test_type_value"
+        },
+        "transform": {},
+        "is_primary_key": false,
+        "is_nullable": true,
+        "type": "expression",
+        "column_id": "test_type_value"
+      }
+    ],
+    "named_expressions": {
+      "test_result_awaited_test_type": {
+        "test": {
+          "type": "and",
+          "filters": [
+            {
+              "filter": {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "test_type_value"
+                },
+                "type": "boolean_expression",
+                "property_value": "dst"
+              },
+              "type": "not"
+            },
+            {
+              "filter": {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "test_type_value"
+                },
+                "type": "boolean_expression",
+                "property_value": "culture"
+              },
+              "type": "not"
+            },
+            {
+              "filter": {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "test_type_value"
+                },
+                "type": "boolean_expression",
+                "property_value": "fl_line_probe_assay"
+              },
+              "type": "not"
+            },
+            {
+              "filter": {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "test_type_value"
+                },
+                "type": "boolean_expression",
+                "property_value": "sl_line_probe_assay"
+              },
+              "type": "not"
+            },
+            {
+              "filter": {
+                "operator": "eq",
+                "expression": {
+                  "datatype": "string",
+                  "type": "property_name",
+                  "property_name": "test_type_value"
+                },
+                "type": "boolean_expression",
+                "property_value": "line_probe_assay"
+              },
+              "type": "not"
+            }
+          ]
+        },
+        "expression_if_true": {
+          "type": "constant",
+          "constant": 1
+        },
+        "type": "conditional",
+        "expression_if_false": {
+          "type": "constant",
+          "constant": 0
+        }
+      },
+      "not_direct_test_entry": {
+        "test": {
+          "operator": "not_eq",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "is_direct_test_entry"
+          },
+          "type": "boolean_expression",
+          "property_value": "yes"
+        },
+        "expression_if_true": 1,
+        "type": "conditional",
+        "expression_if_false": 0
+      },
+      "awaiting_claim_bool": {
+        "test": {
+          "operator": "eq",
+          "type": "boolean_expression",
+          "expression": {
+            "type": "named",
+            "name": "awaiting_claim"
+          },
+          "comment": null,
+          "property_value": "yes"
+        },
+        "expression_if_true": 1,
+        "type": "conditional",
+        "expression_if_false": 0
+      },
+      "test_type_value": {
+        "test": {
+          "type": "or",
+          "filters": [
+            {
+              "operator": "eq",
+              "expression": {
+                "datatype": "string",
+                "type": "property_name",
+                "property_name": "test_type_value"
+              },
+              "type": "boolean_expression",
+              "property_value": "dst"
+            },
+            {
+              "operator": "eq",
+              "expression": {
+                "datatype": "string",
+                "type": "property_name",
+                "property_name": "test_type_value"
+              },
+              "type": "boolean_expression",
+              "property_value": "culture"
+            }
+          ]
+        },
+        "expression_if_true": 0,
+        "type": "conditional",
+        "expression_if_false": 1
+      },
+      "rft_dstb_followup": {
+        "default": {
+          "type": "property_name",
+          "property_name": "follow_up_test_reason"
+        },
+        "cases": {
+          "20": {
+            "type": "property_name",
+            "property_name": "rft_dstb_followup"
+          }
+        },
+        "type": "switch",
+        "switch_on": {
+          "type": "named",
+          "name": "person_case_version"
+        }
+      },
+      "awaiting_claim": {
+        "value_expression": {
+          "datatype": "string",
+          "type": "property_name",
+          "property_name": "awaiting_claim"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "named",
+          "name": "person_id"
+        }
+      },
+      "episode_type_at_request": {
+        "test": {
+          "operator": "eq",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "episode_type_at_request"
+          },
+          "type": "boolean_expression",
+          "property_value": "confirmed_tb"
+        },
+        "expression_if_true": 1,
+        "type": "conditional",
+        "expression_if_false": 0
+      },
+      "person_case_version": {
+        "value_expression": {
+          "datatype": "string",
+          "type": "property_name",
+          "property_name": "case_version"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "named",
+          "name": "person_id"
+        }
+      },
+      "key_populations": {
+        "test": {
+          "operator": "eq",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "key_populations"
+          },
+          "type": "boolean_expression",
+          "property_value": "none"
+        },
+        "expression_if_true": 0,
+        "type": "conditional",
+        "expression_if_false": 1
+      },
+      "test_requested": {
+        "test": {
+          "operator": "eq",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "test_requested_date"
+          },
+          "type": "boolean_expression",
+          "property_value": ""
+        },
+        "expression_if_true": 0,
+        "type": "conditional",
+        "expression_if_false": 1
+      },
+      "follow_up_test_reason": {
+        "test": {
+          "type": "or",
+          "filters": [
+            {
+              "operator": "eq",
+              "expression": {
+                "type": "named",
+                "name": "rft_dstb_followup"
+              },
+              "type": "boolean_expression",
+              "property_value": "end_of_ip"
+            },
+            {
+              "operator": "eq",
+              "expression": {
+                "type": "named",
+                "name": "rft_dstb_followup"
+              },
+              "type": "boolean_expression",
+              "property_value": "end_of_cp"
+            }
+          ]
+        },
+        "expression_if_true": 1,
+        "type": "conditional",
+        "expression_if_false": 0
+      },
+      "person_id": {
+        "value_expression": {
+          "value_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "referenced_id"
+          },
+          "type": "nested",
+          "argument_expression": {
+            "type": "array_index",
+            "array_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "indices"
+            },
+            "index_expression": {
+              "type": "constant",
+              "constant": 0
+            }
+          }
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "value_expression": {
+            "datatype": null,
+            "type": "property_name",
+            "property_name": "referenced_id"
+          },
+          "type": "nested",
+          "argument_expression": {
+            "type": "array_index",
+            "array_expression": {
+              "datatype": null,
+              "type": "property_name",
+              "property_name": "indices"
+            },
+            "index_expression": {
+              "type": "constant",
+              "constant": 0
+            }
+          }
+        }
+      },
+      "hiv_status": {
+        "test": {
+          "operator": "eq",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "hiv_status"
+          },
+          "type": "boolean_expression",
+          "property_value": "reactive"
+        },
+        "expression_if_true": 1,
+        "type": "conditional",
+        "expression_if_false": 0
+      },
+      "result_recorded": {
+        "test": {
+          "operator": "eq",
+          "expression": {
+            "datatype": "string",
+            "type": "property_name",
+            "property_name": "result_recorded"
+          },
+          "type": "boolean_expression",
+          "property_value": "yes"
+        },
+        "expression_if_true": 1,
+        "type": "conditional",
+        "expression_if_false": 0
+      },
+      "owner_id": {
+        "value_expression": {
+          "datatype": "string",
+          "type": "property_name",
+          "property_name": "owner_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "named",
+          "name": "person_id"
+        }
+      }
+    },
+    "named_filters": {}
+  }
+}

--- a/settings.py
+++ b/settings.py
@@ -1948,9 +1948,12 @@ STATIC_DATA_SOURCES = [
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_2b.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_drtb.json'),
+    os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_tasklist.json'),
+    os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'referral_tasklist.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'test.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'test_2b.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'test_drtb.json'),
+    os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'test_tasklist.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'voucher.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'person_for_referral_report.json'),
 


### PR DESCRIPTION
This is so nobody modifies the task list data sources without going through version control.  We recently had a modification kick off a rebuild from scratch, which means task lists will be incomplete until the rebuild finishes.