### PR TITLE
Start running enikshay_task again

### DIFF
--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -53,6 +53,7 @@ DoseStatus = namedtuple('DoseStatus', 'taken missed unknown source')
 CACHE_KEY = "enikshay-task-id-{}".format(datetime.date.today())
 cache = get_redis_client()
 
+
 @periodic_task(
     bind=True,
     run_every=crontab(hour=0, minute=0),  # every day at midnight

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -53,12 +53,11 @@ DoseStatus = namedtuple('DoseStatus', 'taken missed unknown source')
 CACHE_KEY = "enikshay-task-id-{}".format(datetime.date.today())
 cache = get_redis_client()
 
-# ToDo: Enable post migration
-# @periodic_task(
-#     bind=True,
-#     run_every=crontab(hour=0, minute=0),  # every day at midnight
-#     queue=getattr(settings, 'ENIKSHAY_QUEUE', 'celery')
-# )
+@periodic_task(
+    bind=True,
+    run_every=crontab(hour=0, minute=0),  # every day at midnight
+    queue=getattr(settings, 'ENIKSHAY_QUEUE', 'celery')
+)
 def enikshay_task(self):
     # runs adherence and voucher calculations for all domains that have
     # `toggles.UATBC_ADHERENCE_TASK` enabled

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -66,6 +66,10 @@ def enikshay_task(self):
 
     domains = toggles.UATBC_ADHERENCE_TASK.get_enabled_domains()
     for domain in domains:
+        if toggles.DATA_MIGRATION.enabled(domain):
+            # Don't run this on the india cluster anymore
+            continue
+
         try:
             updater = EpisodeUpdater(domain, task_id=task_id)
             updater.run()


### PR DESCRIPTION
@nickpell @esoergel @sravfeyn do any of you have context on this task? based on my notes from @proteusvacuum we can enable this on the new cluster as soon as the static-enikshay-adherence data source is rebuilt (which it now is), so i think this is good to start running again.

fyi @mkangia 