### PR TITLE
Remove dependency on es to retrieve case ids

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -236,7 +236,7 @@ class AutomaticUpdateRule(models.Model):
                  .case_type(case_type)
                  .is_closed(closed=False)
                  .exclude_source()
-                 .size(chunk_size))
+                 .size(100))
 
         if boundary_date:
             query = query.server_modified_range(lte=boundary_date)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -130,25 +130,24 @@ def run_case_update_rules_for_domain(domain, now=None):
 
     for case_type, rules in rules_by_case_type.iteritems():
         boundary_date = AutomaticUpdateRule.get_boundary_date(rules, now)
-        case_id_chunks = AutomaticUpdateRule.get_case_ids(domain, case_type, boundary_date)
+        case_ids = list(AutomaticUpdateRule.get_case_ids(domain, case_type, boundary_date))
 
-        for case_ids in case_id_chunks:
-            for case in CaseAccessors(domain).iter_cases(case_ids):
-                migration_in_progress, last_migration_check_time = check_data_migration_in_progress(domain,
-                    last_migration_check_time)
+        for case in CaseAccessors(domain).iter_cases(case_ids):
+            migration_in_progress, last_migration_check_time = check_data_migration_in_progress(domain,
+                last_migration_check_time)
 
-                time_elapsed = datetime.utcnow() - start_run
-                if (
-                    time_elapsed.seconds > HALT_AFTER or
-                    case_update_result.total_updates >= settings.MAX_RULE_UPDATES_IN_ONE_RUN or
-                    migration_in_progress
-                ):
-                    run_record.done(DomainCaseRuleRun.STATUS_HALTED, cases_checked, case_update_result)
-                    notify_error("Halting rule run for domain %s." % domain)
-                    return
+            time_elapsed = datetime.utcnow() - start_run
+            if (
+                time_elapsed.seconds > HALT_AFTER or
+                case_update_result.total_updates >= settings.MAX_RULE_UPDATES_IN_ONE_RUN or
+                migration_in_progress
+            ):
+                run_record.done(DomainCaseRuleRun.STATUS_HALTED, cases_checked, case_update_result)
+                notify_error("Halting rule run for domain %s." % domain)
+                return
 
-                case_update_result.add_result(run_rules_for_case(case, rules, now))
-                cases_checked += 1
+            case_update_result.add_result(run_rules_for_case(case, rules, now))
+            cases_checked += 1
 
         for rule in rules:
             rule.last_run = now

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -168,9 +168,6 @@ class AutomaticCaseUpdateTest(TestCase):
         FormProcessorTestUtils.delete_all_cases(self.domain)
         super(AutomaticCaseUpdateTest, self).tearDown()
 
-    def _get_case_ids(self, *args, **kwargs):
-        return [[self.case_id]]
-
     def _get_case(self):
         return self.case_db.get_case(self.case_id)
 
@@ -186,7 +183,9 @@ class AutomaticCaseUpdateTest(TestCase):
     @run_with_all_backends
     def test_rule(self):
         now = datetime(2015, 10, 22, 0, 0)
-        with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.get_case_ids', new=self._get_case_ids):
+        with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.get_case_ids') as case_ids_patch:
+            case_ids_patch.return_value = [self.case_id]
+
             # No update: both dates are 27 days away
             last_modified = datetime(2015, 9, 25, 12, 0)
             _update_case(self.domain, self.case_id, last_modified, date(2015, 9, 25))
@@ -1516,7 +1515,7 @@ class CaseRuleEndToEndTests(BaseCaseRuleTest):
 
         with _with_case(self.domain, 'person', datetime.utcnow()) as case:
             with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.get_case_ids') as case_ids_patch:
-                case_ids_patch.return_value = [[case.case_id]]
+                case_ids_patch.return_value = [case.case_id]
                 self.assertRuleRunCount(0)
 
                 # Case does not match, nothing to update


### PR DESCRIPTION
Uses postgres to get the case ids instead of es. Can review with `w=1`

@orangejenny 