### PR TITLE
MockDevice.id

### DIFF
--- a/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
+++ b/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' ?>
 <system version="1" uiVersion="1" xmlns="{{ xmlns }}" xmlns:orx="http://openrosa.org/jr/xforms">
     <orx:meta xmlns:cc="http://commcarehq.org/xforms">
-        {% if not device_id %}<orx:deviceID />{% else %}<orx:deviceID>{{ device_id }}</orx:deviceID>{% endif %}
+        <orx:deviceID>{{ device_id }}</orx:deviceID>
         <orx:timeStart>{{ time }}</orx:timeStart>
         <orx:timeEnd>{{ time }}</orx:timeEnd>
         <orx:username>{{ username }}</orx:username>

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -45,7 +45,7 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
         'uid': form_id,
         'username': username,
         'user_id': user_id or "",
-        'device_id': device_id,
+        'device_id': device_id or "",
     })
     form_extras = form_extras or {}
 


### PR DESCRIPTION
Add `device_id` to forms posted by `MockDevice` as well as `MockDevice` restore requests.

Tangentially related: also added a test for a bug in `clean_owners` restore. This was only tangentially related because I wanted to verify that the bug still existed and had the same failure modes after adding `device_id` to `MockDevice` operations, which it does.

Best reviewed by commit 🐠 

@dannyroberts cc @ctsims 