### PR TITLE
fix pillow timeout

### DIFF
--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -138,7 +138,7 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
         if self.max_checkpoint_delay:
             seconds_since_last_update = (datetime.utcnow() - self.last_update).total_seconds()
             time_hit = seconds_since_last_update >= self.max_checkpoint_delay
-        return context.do_set_checkpoint and (frequency_hit or time_hit)
+        return frequency_hit or time_hit
 
     def update_checkpoint(self, new_seq):
         self.checkpoint.update_to(new_seq)

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -114,21 +114,15 @@ class PillowCheckpoint(object):
 
 class PillowCheckpointEventHandler(ChangeEventHandler):
 
-    def __init__(self, checkpoint, checkpoint_frequency,
-                 max_checkpoint_delay=MAX_CHECKPOINT_DELAY, checkpoint_callback=None):
+    def __init__(self, checkpoint, checkpoint_frequency, checkpoint_callback=None):
         """
         :param checkpoint: PillowCheckpoint object
         :param checkpoint_frequency: Number of changes between checkpoint updates
-        :param max_checkpoint_delay: Max number of seconds between checkpoint updates
         """
         # check settings to make it easy to override in tests
-        override_delay = getattr(settings, 'PTOP_CHECKPOINT_DELAY_OVERRIDE', DELAY_SENTINEL)
-        if override_delay != DELAY_SENTINEL:
-            max_checkpoint_delay = override_delay
-
+        self.max_checkpoint_delay = getattr(settings, 'PTOP_CHECKPOINT_DELAY_OVERRIDE', MAX_CHECKPOINT_DELAY)
         self.checkpoint = checkpoint
         self.checkpoint_frequency = checkpoint_frequency
-        self.max_checkpoint_delay = max_checkpoint_delay
         self.last_update = datetime.utcnow()
         self.checkpoint_callback = checkpoint_callback
 

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -29,9 +29,8 @@ class PillowRuntimeContext(object):
     so that other functions can use it without maintaining global state on the class.
     """
 
-    def __init__(self, changes_seen=0, do_set_checkpoint=True):
+    def __init__(self, changes_seen=0):
         self.changes_seen = changes_seen
-        self.do_set_checkpoint = do_set_checkpoint
 
 
 class PillowBase(object):
@@ -99,7 +98,7 @@ class PillowBase(object):
         """
         Process changes from the changes stream.
         """
-        context = PillowRuntimeContext(changes_seen=0, do_set_checkpoint=True)
+        context = PillowRuntimeContext(changes_seen=0)
         try:
             for change in self.get_change_feed().iter_changes(since=since or None, forever=forever):
                 if change:


### PR DESCRIPTION
@nickpell This is why the checkpoint wasn't updating every 5 min.

@snopoke This is why ucr_slow log didn't work. https://github.com/dimagi/commcare-hq/commit/05ffd2fc04991fe0d1745857e728a3af802f57ea#commitcomment-23013635

Introduced https://github.com/dimagi/commcare-hq/pull/16549 

This passed in checkpoint_callback to max_checkpoint_delay. I removed a couple of different things here as they aren't used or were ever only one value

@biyeun @proteusvacuum 