### PR TITLE
Ignore icds-ucr-standby

### DIFF
--- a/corehq/sql_db/management/commands/migrate_multi.py
+++ b/corehq/sql_db/management/commands/migrate_multi.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
         if migration_name is not None:
             args.append(migration_name)
         for db_alias in settings.DATABASES.keys():
+            if db_alias == 'icds-ucr-standby':
+                continue
             print('\n======================= Migrating DB: {} ======================='.format(db_alias))
             call_options = copy(options)
             call_options['database'] = db_alias


### PR DESCRIPTION
https://github.com/dimagi/commcarehq-ansible/pull/899/files#diff-2a475a69e9f47422e69d6e420532df87R146

https://sentry.io/dimagi/commcarehq/issues/338428936/?referrer=slack

@snopoke This change caused icds to try to run the migrations on icds-ucr-standby, and it failed. I deployed using this change to unblock deploy, but it will fail on the next deploy.

I think the proper fix to this will be adding some flag to the databases in local settings, but is it actually necessary to have the standby in the databases?