### PR TITLE
improve handling of server errors

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -592,7 +592,7 @@ Formplayer.Errors = {
         "Please make sure you are connected to the " +
         "Internet in order to submit your form.",
     LOCK_TIMEOUT_ERROR: gettext('Another process prevented us from servicing your request. ' +
-        'Please try again later.')
+        'Please try again later.'),
 };
 
 Formplayer.Utils.touchformsError = function(message) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -420,11 +420,12 @@ function Question(json, parent) {
     };
     self.afterRender = function() { self.entry.afterRender(); };
 
-    self.onchange = _.throttle(function() {
+    self.triggerAnswer = function() {
         $.publish('formplayer.dirty');
         self.pendingAnswer(_.clone(self.answer()));
         $.publish('formplayer.' + Formplayer.Const.ANSWER, self);
-    }, self.throttle);
+    };
+    self.onchange = _.throttle(self.triggerAnswer, self.throttle);
 
     self.mediaSrc = function(resourceType) {
         if (!resourceType || !_.isFunction(Formplayer.resourceMap)) { return ''; }
@@ -589,7 +590,9 @@ Formplayer.Errors = {
         "Technical Details: ",
     TIMEOUT_ERROR: "CommCareHQ has detected a possible network connectivity problem. " +
         "Please make sure you are connected to the " +
-        "Internet in order to submit your form."
+        "Internet in order to submit your form.",
+    LOCK_TIMEOUT_ERROR: gettext('Another process prevented us from servicing your request. ' +
+        'Please try again later.')
 };
 
 Formplayer.Utils.touchformsError = function(message) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
@@ -157,7 +157,7 @@ describe('WebForm', function() {
             // First blocking request
             $.publish('formplayer.' + Formplayer.Const.ANSWER, { answer: sinon.spy() });
 
-            assert.isUndefined(sess.blockingRequestInProgress);
+            assert.isFalse(sess.blockingRequestInProgress);
 
             // Attempt another request
             $.publish('formplayer.' + Formplayer.Const.ANSWER, { answer: sinon.spy() });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -329,8 +329,7 @@ WebFormSession.prototype.answerQuestion = function(q) {
             }
         }, false, function () {
             q.serverError(
-                gettext("An issue on the server prevented this answer from being saved. " +
-                    "To retry later, click on the error symbol."));
+                gettext("We were unable to save this answer. Please try again later."));
             q.pendingAnswer(Formplayer.Const.NO_PENDING_ANSWER);
         });
 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -152,7 +152,7 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
     if (this.blockingRequestInProgress) {
         return;
     }
-    this.blockingRequestInProgress = blocking;
+    this.blockingRequestInProgress = blocking || false;
     $.publish('session.block', blocking);
 
     this.numPendingRequests++;
@@ -227,8 +227,8 @@ WebFormSession.prototype.handleFailure = function(resp, action, textStatus, fail
         human_readable_message: errorMessage
     });
     this.onLoadingComplete();
-    $.publish('session.block', false);
-    this.blockingRequestInProgress = false;
+//    $.publish('session.block', false);
+//    this.blockingRequestInProgress = false;
 };
 
 /*

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -137,7 +137,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.formplayerEnabled = true;
     data.displayOptions = $.extend(true, {}, user.displayOptions);
     data.onerror = function (resp) {
-        showError(resp.exception, $("#cloudcare-notifications"));
+        showError(resp.human_readable_message || resp.exception, $("#cloudcare-notifications"));
     };
     data.onsubmit = function (resp) {
         if (resp.status === "success") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -1,4 +1,4 @@
-/*global FormplayerFrontend, Util */
+/*global FormplayerFrontend, Util, Formplayer */
 
 /**
  * Backbone model for listing and selecting CommCare menus (modules, forms, and cases)
@@ -39,7 +39,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                     }
                 },
                 error: function (_, response) {
-                    if (response.status == 423) {
+                    if (response.status === 423) {
                         FormplayerFrontend.trigger(
                             'showError',
                             Formplayer.Errors.LOCK_TIMEOUT_ERROR

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -38,12 +38,19 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                         }
                     }
                 },
-                error: function () {
-                    FormplayerFrontend.trigger(
-                        'showError',
-                        gettext('Unable to connect to form playing service. ' +
-                                'Please report an issue if you continue to see this message.')
-                    );
+                error: function (_, response) {
+                    if (response.status == 423) {
+                        FormplayerFrontend.trigger(
+                            'showError',
+                            Formplayer.Errors.LOCK_TIMEOUT_ERROR
+                        );
+                    } else {
+                        FormplayerFrontend.trigger(
+                            'showError',
+                            gettext('Unable to connect to form playing service. ' +
+                                    'Please report an issue if you continue to see this message.')
+                        );
+                    }
                     defer.reject();
                 },
             };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -1,4 +1,4 @@
-/*global FormplayerFrontend, Util, Formplayer */
+/*global FormplayerFrontend, Formplayer */
 
 /**
  * Backbone model for listing and selecting CommCare menus (modules, forms, and cases)

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -40,7 +40,8 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
 
                 Menus.Controller.showMenu(menuResponse);
             }).fail(function() {
-                FormplayerFrontend.trigger('navigateHome');
+                // if it didn't go through, then it displayed an error message.
+                // the right thing to do is then to just stay in the same place.
             });
         },
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -130,7 +130,7 @@
             <div class="loading">
                 <i class="fa fa-check text-success" data-bind="visible: clean "></i>
                 <i class="fa fa-spin fa-refresh" data-bind="visible: dirty"></i>
-                <i class="fa fa-remove text-danger" data-bind="visible: hasError"></i>
+                <i class="fa fa-remove text-danger clickable" data-bind="visible: hasError, click: triggerAnswer"></i>
             </div>
             <div class="widget" data-bind="
                 template: { name: entryTemplate, data: entry, afterRender: afterRender },


### PR DESCRIPTION
generally, say something went wrong and stay in the same place
so the user can retry later.

This is in preparation for drastically lowering the lock timeout in formplayer: https://github.com/dimagi/formplayer/pull/461.

Here's what it looks like when it errors during answering a question in the form, a case I payed special attention to:

<img width="1191" alt="screen shot 2017-08-29 at 5 59 10 pm" src="https://user-images.githubusercontent.com/137212/29846263-0d75d70a-8ce4-11e7-83f0-0d0704f6612d.png">
