### PR TITLE
Tag system initiated case transacitons

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -44,13 +44,16 @@ class DomainLite(namedtuple('DomainLite', 'name default_timezone cc_case_type us
 
 class _UserCaseHelper(object):
 
+    CASE_SOURCE_ID = __name__ + "._UserCaseHelper."
+
     def __init__(self, domain, owner_id):
         self.domain = domain
         self.owner_id = owner_id
 
-    def _submit_case_block(self, caseblock):
+    def _submit_case_block(self, caseblock, source):
+        device_id = self.CASE_SOURCE_ID + source
         casexml = ElementTree.tostring(caseblock.as_xml())
-        submit_case_blocks(casexml, self.domain.name)
+        submit_case_blocks(casexml, self.domain.name, device_id=device_id)
 
     @staticmethod
     def re_open_case(case):
@@ -69,7 +72,7 @@ class _UserCaseHelper(object):
             case_name=fields.pop('name', None),
             update=fields
         )
-        self._submit_case_block(caseblock)
+        self._submit_case_block(caseblock, "create_user_case")
         self._user_case_changed(fields)
 
     def update_user_case(self, case, case_type, fields):
@@ -82,7 +85,7 @@ class _UserCaseHelper(object):
             close=False,
             update=fields
         )
-        self._submit_case_block(caseblock)
+        self._submit_case_block(caseblock, "update_user_case")
         self._user_case_changed(fields)
 
     def close_user_case(self, case, case_type):
@@ -93,7 +96,7 @@ class _UserCaseHelper(object):
             case_type=case_type,
             close=True,
         )
-        self._submit_case_block(caseblock)
+        self._submit_case_block(caseblock, "close_user_case")
 
     def _user_case_changed(self, fields):
         field_names = fields.keys()

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -84,6 +84,7 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
                     domain,
                     username,
                     user_id,
+                    device_id=__name__ + ".do_import",
                 )
 
                 if form.is_error:

--- a/corehq/apps/commtrack/helpers.py
+++ b/corehq/apps/commtrack/helpers.py
@@ -39,7 +39,7 @@ def make_supply_point(domain, location):
         },
         **kwargs
     )
-    _submit_commtrack_caseblock(domain, caseblock)
+    _submit_commtrack_caseblock(domain, caseblock, "make_supply_point")
     return SupplyInterface(domain).get_supply_point(case_id)
 
 
@@ -65,17 +65,18 @@ def update_supply_point_from_location(supply_point, location):
             },
             **kwargs
         )
-        _submit_commtrack_caseblock(domain, caseblock)
+        _submit_commtrack_caseblock(domain, caseblock, "update_supply_point_from_location")
         return SupplyInterface(domain).get_supply_point(supply_point.case_id)
     else:
         return supply_point
 
 
-def _submit_commtrack_caseblock(domain, caseblock):
+def _submit_commtrack_caseblock(domain, caseblock, source):
     submit_case_blocks(
         caseblock.as_string(),
         domain,
         const.COMMTRACK_USERNAME,
         const.get_commtrack_user_id(domain),
-        xmlns=const.COMMTRACK_SUPPLY_POINT_XMLNS
+        xmlns=const.COMMTRACK_SUPPLY_POINT_XMLNS,
+        device_id=__name__ + "." + source,
     )

--- a/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
+++ b/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
@@ -36,10 +36,11 @@ def get_cases(domain):
 
 
 def update_supply_points(domain):
+    device_id = __name__ + ".update_supply_points"
     case_blocks = (case_block(c) for c in get_cases(domain) if needs_update(c))
     if case_blocks:
         for chunk in chunked(case_blocks, 100):
-            submit_case_blocks(chunk, domain)
+            submit_case_blocks(chunk, domain, device_id=device_id)
             print("updated {} cases on domain {}".format(len(chunk), domain))
 
 

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -407,7 +407,12 @@ class StockExportColumn(ComplexExportColumn):
 def close_supply_point_case(location):
     supply_point_id = location.supply_point_id
     if supply_point_id:
-        close_case(supply_point_id, location.domain, const.COMMTRACK_USERNAME)
+        close_case(
+            supply_point_id,
+            location.domain,
+            const.COMMTRACK_USERNAME,
+            __name__ + ".close_supply_point_case",
+        )
 
 
 def _reopen_or_create_supply_point(location):

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -174,10 +174,9 @@ def submit_mapping_case_block(user, index):
         )
 
     submit_case_blocks(
-        ElementTree.tostring(
-            caseblock.as_xml()
-        ),
+        ElementTree.tostring(caseblock.as_xml()),
         user.domain,
+        device_id=__name__ + ".submit_mapping_case_block"
     )
 
 

--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -40,7 +40,7 @@ def explode_cases(user_id, domain, factor, task=None):
             new_case_id = uuid.uuid4().hex
             # add new parent ids to the old to new id mapping
             old_to_new[case.case_id].append(new_case_id)
-            submit_case(case, new_case_id, domain)
+            submit_case(case, new_case_id, domain, "explode_cases[copy parents]")
             count += 1
             if task:
                 DownloadBase.set_progress(explode_case_task, count, 0)
@@ -76,7 +76,7 @@ def explode_cases(user_id, domain, factor, task=None):
             parents = {k: v[i] for k, v in parent_ids.items()}
             new_case_id = uuid.uuid4().hex
             old_to_new[case.case_id].append(new_case_id)
-            submit_case(case, new_case_id, domain, parents)
+            submit_case(case, new_case_id, domain, "explode_cases", parents)
             count += 1
             if task:
                 DownloadBase.set_progress(explode_case_task, count, 0)
@@ -86,6 +86,7 @@ def explode_cases(user_id, domain, factor, task=None):
     return {'messages': messages}
 
 
-def submit_case(case, new_case_id, domain, new_parent_ids=dict()):
+def submit_case(case, new_case_id, domain, source, new_parent_ids=dict()):
+    device_id = __name__ + "." + source
     case_block, attachments = make_creating_casexml(domain, case, new_case_id, new_parent_ids)
-    submit_case_blocks(case_block, domain, attachments=attachments)
+    submit_case_blocks(case_block, domain, attachments=attachments, device_id=device_id)

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -254,7 +254,7 @@ def update_case(domain, case_id, case_properties=None, close=False,
     )
 
 
-def bulk_update_cases(domain, case_changes, device_id=None):
+def bulk_update_cases(domain, case_changes, device_id):
     """
     Updates or closes a list of cases (or both) by submitting a form.
     domain - the cases' domain

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -26,8 +26,8 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
-                       xmlns=SYSTEM_FORM_XMLNS, attachments=None,
-                       form_id=None, form_extras=None, case_db=None, device_id=None):
+                       xmlns=None, attachments=None, form_id=None,
+                       form_extras=None, case_db=None, device_id=None):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -51,7 +51,7 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
         case_blocks = ''.join(case_blocks)
     form_id = form_id or uuid.uuid4().hex
     form_xml = render_to_string('hqcase/xml/case_block.xml', {
-        'xmlns': xmlns,
+        'xmlns': xmlns or SYSTEM_FORM_XMLNS,
         'case_block': case_blocks,
         'time': now,
         'uid': form_id,
@@ -204,17 +204,20 @@ def _process_case_block(domain, case_block, attachments, old_case_id):
     return ET.tostring(root), ret_attachments
 
 
-def submit_case_block_from_template(domain, template, context, xmlns=None, user_id=None):
+def submit_case_block_from_template(domain, template, context, xmlns=None,
+        user_id=None, device_id=None):
     case_block = render_to_string(template, context)
     # Ensure the XML is formatted properly
     # An exception is raised if not
     case_block = ElementTree.tostring(ElementTree.XML(case_block))
 
-    user_id = user_id or SYSTEM_USER_ID
-    kwargs = {}
-    if xmlns:
-        kwargs['xmlns'] = xmlns
-    return submit_case_blocks(case_block, domain, user_id=user_id, **kwargs)
+    return submit_case_blocks(
+        case_block,
+        domain,
+        user_id=user_id or SYSTEM_USER_ID,
+        xmlns=xmlns,
+        device_id=device_id,
+    )
 
 
 def _get_update_or_close_case_block(case_id, case_properties=None, close=False):
@@ -229,7 +232,8 @@ def _get_update_or_close_case_block(case_id, case_properties=None, close=False):
     return CaseBlock(case_id, **kwargs)
 
 
-def update_case(domain, case_id, case_properties=None, close=False, xmlns=None):
+def update_case(domain, case_id, case_properties=None, close=False,
+                xmlns=None, device_id=None):
     """
     Updates or closes a case (or both) by submitting a form.
     domain - the case's domain
@@ -238,21 +242,19 @@ def update_case(domain, case_id, case_properties=None, close=False, xmlns=None):
                       to ignore case updates, leave this argument out
     close - True to close the case, False otherwise
     xmlns - pass in an xmlns to use it instead of the default
+    device_id - see submit_case_blocks device_id docs
     """
-    kwargs = {}
-    if xmlns:
-        kwargs['xmlns'] = xmlns
-
     caseblock = _get_update_or_close_case_block(case_id, case_properties, close)
     return submit_case_blocks(
         ElementTree.tostring(caseblock.as_xml()),
         domain,
         user_id=SYSTEM_USER_ID,
-        **kwargs
+        xmlns=xmlns,
+        device_id=device_id,
     )
 
 
-def bulk_update_cases(domain, case_changes):
+def bulk_update_cases(domain, case_changes, device_id=None):
     """
     Updates or closes a list of cases (or both) by submitting a form.
     domain - the cases' domain
@@ -261,6 +263,7 @@ def bulk_update_cases(domain, case_changes):
         case_properties - to update the case, pass in a dictionary of {name1: value1, ...}
                           to ignore case updates, leave this argument out
         close - True to close the case, False otherwise
+    device_id - see submit_case_blocks device_id docs
     """
     case_blocks = []
     for case_id, case_properties, close in case_changes:
@@ -269,4 +272,4 @@ def bulk_update_cases(domain, case_changes):
         # An exception is raised if not
         case_block = ElementTree.tostring(case_block.as_xml())
         case_blocks.append(case_block)
-    return submit_case_blocks(case_blocks, domain)
+    return submit_case_blocks(case_blocks, domain, device_id=device_id)

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -31,6 +31,18 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
+    :param xmlns: Form XMLNS. Format: IRI or URN. Historically this was
+    used in some places to uniquely identify the subsystem that posted
+    the cases; `device_id` is now recommended for that purpose. Going
+    forward, it is recommended to use the default value along with
+    `device_id`, which indicates that the cases were submitted by an
+    internal system process.
+    :param device_id: Identifier for the source of posted cases. Ideally
+    this should uniquely identify the subsystem that is posting cases to
+    make it easier to trace the source. All new code should use this
+    argument. A human recognizable value is recommended outside of test
+    code. Example: "auto-close-rule-<GUID>"
+
     returns the UID of the resulting form.
     """
     attachments = attachments or {}

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -7,7 +7,6 @@ from bulk_update.helper import bulk_update as bulk_update_helper
 from dimagi.utils.decorators.memoized import memoized
 from django.db import models, transaction
 import jsonfield
-from casexml.apps.case.cleanup import close_case
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.apps.commtrack.const import COMMTRACK_USERNAME

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -127,7 +127,9 @@ def claim(request, domain):
                                 status=409)
 
         claim_case(domain, restore_user.user_id, case_id,
-                   host_type=request.POST.get('case_type'), host_name=request.POST.get('case_name'))
+                   host_type=request.POST.get('case_type'),
+                   host_name=request.POST.get('case_name'),
+                   device_id=__name__ + ".claim")
     except CaseNotFound:
         return HttpResponse('The case "{}" you are trying to claim was not found'.format(case_id),
                             status=410)

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1404,7 +1404,8 @@ def close_case_view(request, domain, case_id):
     if case.closed:
         messages.info(request, u'Case {} is already closed.'.format(case.name))
     else:
-        form_id = close_case(case_id, domain, request.couch_user)
+        device_id = __name__ + ".close_case_view"
+        form_id = close_case(case_id, domain, request.couch_user, device_id)
         msg = _(u'''Case {name} has been closed.
             <a href="javascript:document.getElementById('{html_form_id}').submit();">Undo</a>.
             You can also reopen the case in the future by archiving the last form in the case history.

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1967,7 +1967,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             from corehq.apps.commtrack.util import submit_mapping_case_block
             submit_mapping_case_block(self, self.supply_point_index_mapping(sp))
 
-    def submit_location_block(self, caseblock):
+    def submit_location_block(self, caseblock, source):
         from corehq.apps.hqcase.utils import submit_case_blocks
 
         submit_case_blocks(
@@ -1975,6 +1975,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 caseblock.as_xml()
             ),
             self.domain,
+            device_id=__name__ + ".CommCareUser." + source,
         )
 
     def remove_location_delegate(self, location):
@@ -1994,7 +1995,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                     index=self.supply_point_index_mapping(sp, True)
                 )
 
-                self.submit_location_block(caseblock)
+                self.submit_location_block(caseblock, "remove_location_delegate")
 
     def clear_location_delegates(self):
         """
@@ -2030,7 +2031,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             index=index
         )
 
-        self.submit_location_block(caseblock)
+        self.submit_location_block(caseblock, "create_location_delegates")
 
     def get_location_map_case(self):
         """

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -179,7 +179,8 @@ def remove_indices_from_deleted_cases(domain, case_ids):
         for index_info in indexes_referencing_deleted_cases
         if index_info.case_id not in deleted_ids
     ]
-    submit_case_blocks(case_updates, domain)
+    device_id = __name__ + ".remove_indices_from_deleted_cases"
+    submit_case_blocks(case_updates, domain, device_id=device_id)
 
 
 @task(bind=True, queue='background_queue', ignore_result=True,

--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -16,15 +16,17 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 
 
-def close_cases(case_ids, domain, user, case_db=None):
+def close_cases(case_ids, domain, user, device_id, case_db=None):
     """
     Close cases by submitting a close forms.
 
     Accepts submitting user as a user object or a fake system user string.
 
+    See `device_id` parameter documentation at
+    `corehq.apps.hqcase.utils.submit_case_blocks`.
+
     Returns the form id of the closing form.
     """
-
     if hasattr(user, '_id'):
         user_id = user._id
         username = user.username
@@ -38,11 +40,18 @@ def close_cases(case_ids, domain, user, case_db=None):
         close=True,
     ).as_xml()) for case_id in case_ids]
 
-    return submit_case_blocks(case_blocks, domain, username, user_id, case_db=case_db)[0].form_id
+    return submit_case_blocks(
+        case_blocks,
+        domain,
+        username,
+        user_id,
+        device_id=device_id,
+        case_db=case_db,
+    )[0].form_id
 
 
-def close_case(case_id, domain, user):
-    return close_cases([case_id], domain, user)
+def close_case(case_id, domain, user, device_id):
+    return close_cases([case_id], domain, user, device_id)
 
 
 def rebuild_case_from_actions(case, actions):

--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -107,7 +107,7 @@ def safe_hard_delete(case):
     interface.hard_delete_case_and_forms(case, forms)
 
 
-def claim_case(domain, owner_id, host_id, host_type=None, host_name=None):
+def claim_case(domain, owner_id, host_id, host_type=None, host_name=None, device_id=None):
     """
     Claim a case identified by host_id for claimant identified by owner_id.
 
@@ -133,7 +133,7 @@ def claim_case(domain, owner_id, host_id, host_type=None, host_name=None):
             )
         }
     ).as_xml()
-    post_case_blocks([claim_case_block], {'domain': domain})
+    post_case_blocks([claim_case_block], {'domain': domain}, device_id=device_id)
     return claim_id
 
 

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -47,6 +47,9 @@ def post_case_blocks(case_blocks, form_extras=None, domain=None, user_id=None, d
 
     Extras is used to add runtime attributes to the form before
     sending it off to the case (current use case is sync-token pairing)
+
+    See `device_id` parameter documentation at
+    `corehq.apps.hqcase.utils.submit_case_blocks`.
     """
     from corehq.apps.hqcase.utils import submit_case_blocks
 

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -54,11 +54,17 @@ class CaseProcessingResult(object):
     def get_flags_to_save(self):
         return {f.owner_id: f.case_id for f in self.dirtiness_flags}
 
-    def close_extensions(self, case_db):
+    def close_extensions(self, case_db, device_id):
         from casexml.apps.case.cleanup import close_cases
         extensions_to_close = case_db.filter_closed_extensions(list(self.extensions_to_close))
         if extensions_to_close:
-            return close_cases(extensions_to_close, self.domain, SYSTEM_USER_ID, case_db)
+            return close_cases(
+                extensions_to_close,
+                self.domain,
+                SYSTEM_USER_ID,
+                device_id,
+                case_db,
+            )
 
     def commit_dirtiness_flags(self):
         """

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -192,7 +192,9 @@ class SubmissionPost(object):
                     else:
                         instance.initial_processing_complete = True
                         self.save_processed_models(xforms, case_stock_result)
-                        case_stock_result.case_result.close_extensions(case_db)
+                        device_id = instance.metadata.deviceID if instance.metadata else ""
+                        case_stock_result.case_result.close_extensions(case_db,
+                            "SubmissionPost-close_extensions-%s" % device_id)
                         cases = case_stock_result.case_models
                         ledgers = case_stock_result.stock_result.models_to_save
                 elif instance.is_error:

--- a/custom/_legacy/hsph/tasks.py
+++ b/custom/_legacy/hsph/tasks.py
@@ -99,7 +99,11 @@ def new_update_case_properties():
         }
         if case.get('owner_id', None):
             kwargs['owner_id'] = case['owner_id']
-        submit_case_blocks([ElementTree.tostring(CaseBlock(**kwargs).as_xml())], domain)
+        submit_case_blocks(
+            [ElementTree.tostring(CaseBlock(**kwargs).as_xml())],
+            domain,
+            device_id=__name__ + ".new_update_case_properties",
+        )
 
 
 def iter_cases_to_modify():

--- a/custom/_legacy/pact/tasks.py
+++ b/custom/_legacy/pact/tasks.py
@@ -107,4 +107,8 @@ def set_schedule_case_properties(pact_case):
                 case_id=pact_case._id,
                 update=to_change,
             ).as_xml()
-            submit_case_blocks([ElementTree.tostring(case_block)], 'pact')
+            submit_case_blocks(
+                [ElementTree.tostring(case_block)],
+                'pact',
+                device_id=__name__ + ".set_schedule_case_properties",
+            )

--- a/custom/bihar/utils.py
+++ b/custom/bihar/utils.py
@@ -114,8 +114,9 @@ def assign_cases(caselist, owner_id, acting_user=None, update=None):
             ).as_xml()) for c in filtered_cases
         ]
         # todo: this should check whether the submit_case_blocks call actually succeeds
+        device_id = __name__ + ".assign_cases"
         submit_case_blocks(caseblocks, domain, username=username,
-                           user_id=user_id)
+                           user_id=user_id, device_id=device_id)
 
     return [c._id for c in filtered_cases]
 

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -282,17 +282,19 @@ def get_adherence_cases_between_dates(domain, person_case_id, start_date, end_da
     return open_pertinent_adherence_cases
 
 
-def update_case(domain, case_id, updated_properties, external_id=None):
+def update_case(domain, case_id, updated_properties, external_id=None,
+                device_id=__name__ + ".update_case"):
     kwargs = {
         'case_id': case_id,
         'update': updated_properties,
     }
     if external_id is not None:
-        kwargs.update({'external_id': external_id})
+        kwargs['external_id'] = external_id
 
     post_case_blocks(
         [CaseBlock(**kwargs).as_xml()],
-        {'domain': domain}
+        {'domain': domain},
+        device_id=device_id,
     )
 
 

--- a/custom/enikshay/integrations/bets/views.py
+++ b/custom/enikshay/integrations/bets/views.py
@@ -184,9 +184,8 @@ def payment_confirmation(request, domain):
         return json_response({"error": e.message}, status_code=e.status_code)
 
     bulk_update_cases(domain, [
-        (update.case_id, update.properties, False)
-        for update in updates
-    ])
+        (update.case_id, update.properties, False) for update in updates
+    ], __name__ + ".payment_confirmation")
     return json_response({'status': SUCCESS})
 
 

--- a/custom/enikshay/management/commands/base.py
+++ b/custom/enikshay/management/commands/base.py
@@ -35,11 +35,11 @@ class ENikshayBatchCaseUpdaterCommand(BaseCommand):
             if update_json:
                 updates.append((episode.case_id, update_json, False))
             if len(updates) >= batch_size:
-                bulk_update_cases(domain, updates)
+                bulk_update_cases(domain, updates, self.__module__)
                 updates = []
 
         if len(updates) > 0:
-            bulk_update_cases(domain, updates)
+            bulk_update_cases(domain, updates, self.__module__)
 
         self.write_errors(errors)
 

--- a/custom/enikshay/management/commands/import_voucher_confirmations.py
+++ b/custom/enikshay/management/commands/import_voucher_confirmations.py
@@ -179,7 +179,7 @@ class Command(BaseCommand):
                 for update in chunk
             ]
             if self.commit:
-                bulk_update_cases(self.domain, updates)
+                bulk_update_cases(self.domain, updates, self.__module__)
 
     def reconcile_repeat_records(self, voucher_updates):
         """

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -124,6 +124,7 @@ class EpisodeUpdater(object):
 
     def run(self):
         # iterate over all open 'episode' cases and set 'adherence' properties
+        device_id = "%s.%s" % (__name__, type(self).__name__)
         update_count = 0
         noupdate_count = 0
         error_count = 0
@@ -160,14 +161,14 @@ class EpisodeUpdater(object):
                 else:
                     noupdate_count += 1
                 if len(updates) >= batch_size:
-                    bulk_update_cases(self.domain, updates)
+                    bulk_update_cases(self.domain, updates, device_id)
                     updates = []
                     batches_processed += 1
 
                 self.update_status(t, success_count, error_count, total_count, batches_processed, errors)
 
             if len(updates) > 0:
-                bulk_update_cases(self.domain, updates)
+                bulk_update_cases(self.domain, updates, device_id)
 
         summary = (
             "Summary of enikshay_task: domain: {domain}, duration (sec): {duration} "

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -204,7 +204,8 @@ class EpisodeUpdater(object):
         assert episode_case.domain == self.domain
         update_json = EpisodeAdherenceUpdate(self.domain, episode_case).update_json()
         if update_json:
-            update_case(self.domain, episode_case.case_id, update_json)
+            update_case(self.domain, episode_case.case_id, update_json,
+                        device_id="%s.%s" % (__name__, type(self).__name__))
 
     def _get_case_ids(self):
         case_accessor = CaseAccessors(self.domain)

--- a/custom/hki/management/commands/hki_case_migration.py
+++ b/custom/hki/management/commands/hki_case_migration.py
@@ -34,7 +34,8 @@ class Command(BaseCommand):
             for cases in chunked(with_progress_bar(self._get_cases_to_process(), total_cases), 100):
                 cases_to_update = self._process_cases(cases, failed_updates, loc_mapping)
                 try:
-                    xform, cases = bulk_update_cases(self.domain, cases_to_update)
+                    xform, cases = bulk_update_cases(
+                        self.domain, cases_to_update, self.__module__)
                     fh.write(xform.form_id)
                 except LocalSubmissionError as e:
                     print unicode(e)

--- a/custom/icds/management/commands/cleanup_orphan_migration.py
+++ b/custom/icds/management/commands/cleanup_orphan_migration.py
@@ -34,7 +34,8 @@ class Command(BaseCommand):
                 print('Currently on chunk {}'.format(chunk_num))
                 case_tupes = [(case_id, {}, True) for case_id in orphan_case_chunk]
                 try:
-                    xform, cases = bulk_update_cases(self.domain, case_tupes)
+                    xform, cases = bulk_update_cases(
+                        self.domain, case_tupes, self.__module__)
                     fh.write(xform.form_id + '\n')
                 except LocalSubmissionError as e:
                     print('submission error')

--- a/custom/icds/management/commands/close_orphaned_cases.py
+++ b/custom/icds/management/commands/close_orphaned_cases.py
@@ -34,7 +34,8 @@ class Command(BaseCommand):
                 related_cases = self._get_related_cases(cases)
                 case_tupes = [(case_id, {}, True) for case_id in related_cases]
                 try:
-                    xform, cases = bulk_update_cases(domain, case_tupes)
+                    xform, cases = bulk_update_cases(
+                        domain, case_tupes, self.__module__)
                     fh.write(xform.form_id + '\n')
                 except LocalSubmissionError as e:
                     print('submission error')

--- a/custom/icds/management/commands/update_icds_case_property.py
+++ b/custom/icds/management/commands/update_icds_case_property.py
@@ -27,7 +27,8 @@ class Command(BaseCommand):
             for rows in chunked(reader, 100):
                 updates = [(case_id, {case_prop_name: prop}, False) for case_id, prop in rows]
                 try:
-                    xform, cases = bulk_update_cases(self.domain, updates)
+                    xform, cases = bulk_update_cases(
+                        self.domain, updates, self.__module__)
                     log.write(xform.form_id + '\n')
                 except Exception as e:
                     print('error')

--- a/custom/icds/rules/custom_actions.py
+++ b/custom/icds/rules/custom_actions.py
@@ -26,6 +26,7 @@ def _create_tech_issue_delegate_for_escalation(tech_issue, owner_id):
         tech_issue.domain,
         user_id=SYSTEM_USER_ID,
         xmlns=AUTO_UPDATE_XMLNS,
+        device_id=__name__ + "._create_tech_issue_delegate_for_escalation",
     )
 
 
@@ -41,6 +42,7 @@ def _update_existing_tech_issue_delegate(tech_issue_delegate):
         case_properties={'change_in_level': change_in_level},
         close=False,
         xmlns=AUTO_UPDATE_XMLNS,
+        device_id=__name__ + "._update_existing_tech_issue_delegate",
     )
 
 
@@ -57,6 +59,7 @@ def _update_tech_issue_for_escalation(case, escalated_ticket_level):
         },
         close=False,
         xmlns=AUTO_UPDATE_XMLNS,
+        device_id=__name__ + "._update_tech_issue_for_escalation",
     )
 
 


### PR DESCRIPTION
Update docstrings and usages of internal case transaction utility functions, making it easier to trace the source of case operations. I chose to use `device_id` as the primary means of providing source information rather than `xmlns`. The default `xmlns` (`SYSTEM_FORM_XMLNS`) tags the operation as a system initiated transaction, and `device_id` is intended to provide the name of the subsystem in HQ from whence it was initiated. The current convention is to pass the dotted function/method/class/module path as `device_id`.

Best reviewed by commit 🐠 

@proteusvacuum @dannyroberts cc @snopoke @ctsims 