### PR TITLE
Reference form ID in close extensions

### DIFF
--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -192,9 +192,8 @@ class SubmissionPost(object):
                     else:
                         instance.initial_processing_complete = True
                         self.save_processed_models(xforms, case_stock_result)
-                        device_id = instance.metadata.deviceID if instance.metadata else ""
                         case_stock_result.case_result.close_extensions(case_db,
-                            "SubmissionPost-close_extensions-%s" % device_id)
+                            "SubmissionPost-%s-close_extensions" % instance.form_id)
                         cases = case_stock_result.case_models
                         ledgers = case_stock_result.stock_result.models_to_save
                 elif instance.is_error:


### PR DESCRIPTION
PR feedback from #17640. Once I thought about it I realized it's possible to lookup the device ID with the referenced form ID, so I think it makes sense to just use the form ID here.

@snopoke 