### PR TITLE
Add file extension when downloading CommCareMultimedia

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -183,6 +183,12 @@ class CommCareMultimedia(BlobMixin, SafeSaveDocument):
                 return data
         return None
 
+    def get_file_extension(self):
+        extension = ''
+        if self.aux_media:
+            extension = '.{}'.format(self.aux_media[-1]['uploaded_filename'].split(".")[-1])
+        return extension
+
     def get_media_info(self, path, is_updated=False, original_path=None):
         return {
             "path": path,

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -652,7 +652,12 @@ class ViewMultimediaFile(View):
         data, content_type = self.multimedia.get_display_file()
         if self.thumb:
             data = CommCareImage.get_thumbnail_data(data, self.thumb)
-        return HttpResponse(data, content_type=content_type)
+        extension = ''
+        if self.multimedia.aux_media:
+            extension = self.multimedia.aux_media[-1]['uploaded_filename'].split(".")[-1]
+        response = HttpResponse(data, content_type=content_type)
+        response['Content-Disposition'] = 'filename="download.{}"'.format(extension)
+        return response
 
 
 def iter_index_files(app, build_profile_id=None):

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -652,11 +652,8 @@ class ViewMultimediaFile(View):
         data, content_type = self.multimedia.get_display_file()
         if self.thumb:
             data = CommCareImage.get_thumbnail_data(data, self.thumb)
-        extension = ''
-        if self.multimedia.aux_media:
-            extension = self.multimedia.aux_media[-1]['uploaded_filename'].split(".")[-1]
         response = HttpResponse(data, content_type=content_type)
-        response['Content-Disposition'] = 'filename="download.{}"'.format(extension)
+        response['Content-Disposition'] = 'filename="download{}"'.format(self.multimedia.get_file_extension())
         return response
 
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?260475

@biyeun / @millerdev know of any better way to do this? So far as I can tell, the filename is stored outside of `CommCareMultimedia`, someplace like `app.multimedia_map` so there isn't a clean, generic way to go from multimedia back to filename.

code buddy @gcapalbo 