### PR TITLE
configure reporting databases separately

### DIFF
--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -26,7 +26,7 @@ DATABASES = {
 
 @override_settings(DATABASES=DATABASES)
 class ConnectionManagerTests(SimpleTestCase):
-    @override_settings(UCR_DATABASE_URL='ucr-url', REPORTING_DATABASES=None)
+    @override_settings(UCR_DATABASE_URL='ucr-url', REPORTING_DATABASES=None, REPORTING_ENGINES=None)
     def test_legacy_settings(self):
         manager = ConnectionManager()
         self.assertEqual(manager.db_connection_map, {
@@ -34,7 +34,7 @@ class ConnectionManagerTests(SimpleTestCase):
             'ucr': 'ucr-url',
         })
 
-    @override_settings(REPORTING_DATABASES={})
+    @override_settings(REPORTING_DATABASES={}, REPORTING_ENGINES=None)
     def test_new_settings_empty(self):
         manager = ConnectionManager()
         self.assertEqual(manager.db_connection_map, {
@@ -42,14 +42,25 @@ class ConnectionManagerTests(SimpleTestCase):
             'ucr': 'postgresql+psycopg2://:@localhost:5432/default',
         })
 
-    @override_settings(REPORTING_DATABASES={'default': 'default', 'ucr': 'ucr', 'other': 'other'})
     def test_new_settings(self):
+        engine_conf = {'default': 'default', 'ucr': 'ucr', 'other': 'other'}
+        variations = [
+            {'REPORTING_DATABASES': engine_conf, 'REPORTING_ENGINES': None},
+            {'REPORTING_DATABASES': {}, 'REPORTING_ENGINES': engine_conf},
+            {'REPORTING_DATABASES': DATABASES, 'REPORTING_ENGINES': engine_conf},
+        ]
+        for settings_variation in variations:
+            with override_settings(**settings_variation):
+                self._check_connnection_map()
+
+    def _check_connnection_map(self):
         manager = ConnectionManager()
         self.assertEqual(manager.db_connection_map, {
             'default': 'postgresql+psycopg2://:@localhost:5432/default',
             'ucr': 'postgresql+psycopg2://:@localhost:5432/ucr',
             'other': 'postgresql+psycopg2://:@localhost:5432/other',
         })
+        return manager
 
     def test_read_load_balancing(self):
         reporting_dbs = {
@@ -58,13 +69,9 @@ class ConnectionManagerTests(SimpleTestCase):
                 'READ': [('ucr', 8), ('other', 1), ('default', 1)]
             },
         }
-        with override_settings(REPORTING_DATABASES=reporting_dbs):
-            manager = ConnectionManager()
-            self.assertEqual(manager.db_connection_map, {
-                'default': 'postgresql+psycopg2://:@localhost:5432/default',
-                'ucr': 'postgresql+psycopg2://:@localhost:5432/ucr',
-                'other': 'postgresql+psycopg2://:@localhost:5432/other',
-            })
+
+        def _test_load_balancing():
+            manager = self._check_connnection_map()
 
             # test that load balancing works with a 10% margin for randomness
             total_requests = 10000
@@ -78,7 +85,23 @@ class ConnectionManagerTests(SimpleTestCase):
             for db, requests in balanced.items():
                 self.assertAlmostEqual(requests, expected[db], delta=randomness_margin)
 
-        with override_settings(REPORTING_DATABASES={'default': 'default'}):
+        with override_settings(REPORTING_DATABASES=reporting_dbs, REPORTING_ENGINES=None):
+            _test_load_balancing()
+
+        with override_settings(REPORTING_DATABASES=DATABASES, REPORTING_ENGINES=reporting_dbs):
+            _test_load_balancing()
+
+        with override_settings(REPORTING_DATABASES={'default': 'default'}, REPORTING_ENGINES=None):
+            manager = ConnectionManager()
+            self.assertEqual(
+                ['default', 'default', 'default'],
+                [manager.get_load_balanced_read_engine_id('default') for i in range(3)]
+            )
+
+        with override_settings(
+                REPORTING_DATABASES={'default': _get_db_config('default')},
+                REPORTING_ENGINES={'default': 'default'}
+        ):
             manager = ConnectionManager()
             self.assertEqual(
                 ['default', 'default', 'default'],

--- a/settings.py
+++ b/settings.py
@@ -820,17 +820,29 @@ BANK_SWIFT_CODE = ''
 STRIPE_PUBLIC_KEY = ''
 STRIPE_PRIVATE_KEY = ''
 
-# mapping of report engine IDs to database configurations
-# values must be an alias of a DB in the Django DB configuration
-# or a dict of the following format:
-# {
-#     'WRITE': 'django_db_alias',
-#     'READ': [('django_db_alias', query_weighting_int), (...)]
+# Similar to DATABASES setting but not managed by Django.
+# If not specified or left blank then DATABASES will be used
+# REPORTING_DATABASES = {
+#     'reporting_db_alias': {
+#         'NAME': 'db_name',
+#         'USER': 'username',
+#         'PASSWORD': 'password',
+#         'HOST': 'localhost',
+#         'PORT': '5432',
+#     }
 # }
-REPORTING_DATABASES = {
-    'default': 'default',
-    'ucr': 'default'
-}
+
+# Mapping of report engine IDs to database configurations. If left
+# blank a 'default' and 'ucr' engine will be added both pointing to the
+# 'default' database.
+# Values must be an alias of a DB in the REPORTING_DATABASES configuration
+# or a dict of the following format:
+# REPORTING_ENGINES = {
+#     'engine_id': {
+#         'WRITE': 'reporting_db_alias',
+#         'READ': [('reporting_db_alias', query_weighting_int), (...)]
+#     }
+# }
 
 PL_PROXY_CLUSTER_NAME = 'commcarehq'
 


### PR DESCRIPTION
@emord I really do like making extra work for myself. Decided it's better to just have these settings completely separate (but with fallbacks to using Django settings).

I'll clean up the previous incantation once this is rolled out. I'll also remove the django migrations tables from the UCR DB's.