### PR TITLE
lock cases during rebuild

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -235,7 +235,7 @@ class CouchSqlDomainMigrator(object):
         from corehq.apps.tzmigration.timezonemigration import json_diff
 
         rebuilt_case = FormProcessorCouch.hard_rebuild_case(
-            self.domain, couch_case['_id'], None, save=False
+            self.domain, couch_case['_id'], None, save=False, lock=False
         )
         rebuilt_case_json = rebuilt_case.to_json()
         diffs = json_diff(rebuilt_case_json, sql_case_json, track_list_indices=False)

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -150,7 +150,7 @@ class FormProcessorCouch(object):
     def hard_rebuild_case(domain, case_id, detail, save=True, lock=True):
         case, lock_obj = FormProcessorCouch.get_case_with_lock(case_id, lock=lock)
         found = bool(case)
-        if found:
+        if not found:
             case = CommCareCase()
             case.case_id = case_id
             case.domain = domain
@@ -159,7 +159,8 @@ class FormProcessorCouch(object):
 
         assert case.domain == domain
         try:
-            if lock_obj:
+            if not found and lock_obj:
+                # the lock was only aquired if we found a case
                 acquire_lock(lock_obj, degrade_gracefully=False)
             forms = FormProcessorCouch.get_case_forms(case_id)
             filtered_forms = [f for f in forms if f.is_normal]

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -157,8 +157,8 @@ class FormProcessorCouch(object):
             if lock:
                 lock_obj = CommCareCase.get_obj_lock_by_id(case_id)
 
-        assert case.domain == domain
         try:
+            assert case.domain == domain, (case.domain, domain)
             if not found and lock_obj:
                 # the lock was only aquired if we found a case
                 acquire_lock(lock_obj, degrade_gracefully=False)

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -150,7 +150,7 @@ class FormProcessorCouch(object):
     def hard_rebuild_case(domain, case_id, detail, save=True, lock=True):
         case, lock_obj = FormProcessorCouch.get_case_with_lock(case_id, lock=lock)
         found = bool(case)
-        if not case:
+        if found:
             case = CommCareCase()
             case.case_id = case_id
             case.domain = domain

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -154,7 +154,7 @@ class FormProcessorCouch(object):
             case = CommCareCase()
             case.case_id = case_id
             case.domain = domain
-            if lock_obj:
+            if lock:
                 lock_obj = CommCareCase.get_obj_lock_by_id(case_id)
 
         try:

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -148,18 +148,18 @@ class FormProcessorCouch(object):
 
     @staticmethod
     def hard_rebuild_case(domain, case_id, detail, save=True, lock=True):
-        case, lock = FormProcessorCouch.get_case_with_lock(case_id, lock=lock)
+        case, lock_obj = FormProcessorCouch.get_case_with_lock(case_id, lock=lock)
         found = bool(case)
         if not case:
             case = CommCareCase()
             case.case_id = case_id
             case.domain = domain
-            if lock:
-                lock = CommCareCase.get_obj_lock_by_id(case_id)
+            if lock_obj:
+                lock_obj = CommCareCase.get_obj_lock_by_id(case_id)
 
         try:
-            if lock:
-                acquire_lock(lock, degrade_gracefully=False)
+            if lock_obj:
+                acquire_lock(lock_obj, degrade_gracefully=False)
             assert case.domain == domain
             forms = FormProcessorCouch.get_case_forms(case_id)
             filtered_forms = [f for f in forms if f.is_normal]
@@ -184,7 +184,7 @@ class FormProcessorCouch(object):
                 case.save()
             return case
         finally:
-            release_lock(lock, degrade_gracefully=True)
+            release_lock(lock_obj, degrade_gracefully=True)
 
     @staticmethod
     def get_case_forms(case_id):

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -156,12 +156,10 @@ class FormProcessorCouch(object):
             case.domain = domain
             if lock:
                 lock_obj = CommCareCase.get_obj_lock_by_id(case_id)
+                acquire_lock(lock_obj, degrade_gracefully=False)
 
         try:
             assert case.domain == domain, (case.domain, domain)
-            if not found and lock_obj:
-                # the lock was only aquired if we found a case
-                acquire_lock(lock_obj, degrade_gracefully=False)
             forms = FormProcessorCouch.get_case_forms(case_id)
             filtered_forms = [f for f in forms if f.is_normal]
             sorted_forms = sorted(filtered_forms, key=lambda f: f.received_on)

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -12,13 +12,13 @@ from casexml.apps.case.util import get_case_xform_ids
 from casexml.apps.case.xform import get_case_updates
 from corehq.blobs.mixin import bulk_atomic_blobs
 from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
-from corehq.form_processor.exceptions import CaseNotFound
-from couchforms.util import fetch_and_wrap_form
+from corehq.form_processor.utils import extract_meta_instance_id
 from couchforms.models import (
     XFormInstance, XFormDeprecated, XFormDuplicate,
     doc_types, XFormError, SubmissionErrorLog
 )
-from corehq.form_processor.utils import extract_meta_instance_id
+from couchforms.util import fetch_and_wrap_form
+from dimagi.utils.couch import acquire_lock, release_lock
 
 
 class FormProcessorCouch(object):
@@ -147,39 +147,44 @@ class FormProcessorCouch(object):
         return touched_cases
 
     @staticmethod
-    def hard_rebuild_case(domain, case_id, detail, save=True):
-        try:
-            case = CommCareCase.get(case_id)
-            assert case.domain == domain
-            found = True
-        except CaseNotFound:
+    def hard_rebuild_case(domain, case_id, detail, save=True, lock=True):
+        case, lock = FormProcessorCouch.get_case_with_lock(case_id, lock=lock)
+        found = bool(case)
+        if not case:
             case = CommCareCase()
             case.case_id = case_id
             case.domain = domain
-            found = False
+            if lock:
+                lock = CommCareCase.get_obj_lock_by_id(case_id)
 
-        forms = FormProcessorCouch.get_case_forms(case_id)
-        filtered_forms = [f for f in forms if f.is_normal]
-        sorted_forms = sorted(filtered_forms, key=lambda f: f.received_on)
+        try:
+            if lock:
+                acquire_lock(lock, degrade_gracefully=False)
+            assert case.domain == domain
+            forms = FormProcessorCouch.get_case_forms(case_id)
+            filtered_forms = [f for f in forms if f.is_normal]
+            sorted_forms = sorted(filtered_forms, key=lambda f: f.received_on)
 
-        actions = _get_actions_from_forms(domain, sorted_forms, case_id)
+            actions = _get_actions_from_forms(domain, sorted_forms, case_id)
 
-        if not found and case.domain is None:
-            case.domain = domain
+            if not found and case.domain is None:
+                case.domain = domain
 
-        rebuild_case_from_actions(case, actions)
-        # todo: should this move to case.rebuild?
-        if not case.xform_ids:
-            if not found:
-                return None
-            # there were no more forms. 'delete' the case
-            case.doc_type = 'CommCareCase-Deleted'
+            rebuild_case_from_actions(case, actions)
+            # todo: should this move to case.rebuild?
+            if not case.xform_ids:
+                if not found:
+                    return None
+                # there were no more forms. 'delete' the case
+                case.doc_type = 'CommCareCase-Deleted'
 
-        # add a "rebuild" action
-        case.actions.append(_rebuild_action())
-        if save:
-            case.save()
-        return case
+            # add a "rebuild" action
+            case.actions.append(_rebuild_action())
+            if save:
+                case.save()
+            return case
+        finally:
+            release_lock(lock, degrade_gracefully=True)
 
     @staticmethod
     def get_case_forms(case_id):

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -157,10 +157,10 @@ class FormProcessorCouch(object):
             if lock:
                 lock_obj = CommCareCase.get_obj_lock_by_id(case_id)
 
+        assert case.domain == domain
         try:
             if lock_obj:
                 acquire_lock(lock_obj, degrade_gracefully=False)
-            assert case.domain == domain
             forms = FormProcessorCouch.get_case_forms(case_id)
             filtered_forms = [f for f in forms if f.is_normal]
             sorted_forms = sorted(filtered_forms, key=lambda f: f.received_on)

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -251,12 +251,10 @@ class FormProcessorSQL(object):
             case = CommCareCaseSQL(case_id=case_id, domain=domain)
             if lock:
                 lock_obj = CommCareCaseSQL.get_obj_lock_by_id(case_id)
+                acquire_lock(lock_obj, degrade_gracefully=False)
 
         try:
             assert case.domain == domain, (case.domain, domain)
-            if not found and lock_obj:
-                # the lock was only aquired if we found a case
-                acquire_lock(lock_obj, degrade_gracefully=False)
             case, rebuild_transaction = FormProcessorSQL._rebuild_case_from_transactions(case, detail)
             if case.is_deleted and not case.is_saved():
                 return None

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -248,7 +248,7 @@ class FormProcessorSQL(object):
         case, lock_obj = FormProcessorSQL.get_case_with_lock(case_id, lock=lock)
         if not case:
             case = CommCareCaseSQL(case_id=case_id, domain=domain)
-            if lock_obj:
+            if lock:
                 lock_obj = CommCareCaseSQL.get_obj_lock_by_id(case_id)
 
         try:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -252,8 +252,8 @@ class FormProcessorSQL(object):
             if lock:
                 lock_obj = CommCareCaseSQL.get_obj_lock_by_id(case_id)
 
-        assert case.domain == domain
         try:
+            assert case.domain == domain, (case.domain, domain)
             if not found and lock_obj:
                 # the lock was only aquired if we found a case
                 acquire_lock(lock_obj, degrade_gracefully=False)

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -245,15 +245,15 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def hard_rebuild_case(domain, case_id, detail, lock=True):
-        case, lock = FormProcessorSQL.get_case_with_lock(case_id, lock=lock)
+        case, lock_obj = FormProcessorSQL.get_case_with_lock(case_id, lock=lock)
         if not case:
             case = CommCareCaseSQL(case_id=case_id, domain=domain)
-            if lock:
-                lock = CommCareCaseSQL.get_obj_lock_by_id(case_id)
+            if lock_obj:
+                lock_obj = CommCareCaseSQL.get_obj_lock_by_id(case_id)
 
         try:
-            if lock:
-                acquire_lock(lock, degrade_gracefully=False)
+            if lock_obj:
+                acquire_lock(lock_obj, degrade_gracefully=False)
             assert case.domain == domain
             case, rebuild_transaction = FormProcessorSQL._rebuild_case_from_transactions(case, detail)
             if case.is_deleted and not case.is_saved():
@@ -264,7 +264,7 @@ class FormProcessorSQL(object):
             publish_case_saved(case)
             return case
         finally:
-            release_lock(lock, degrade_gracefully=True)
+            release_lock(lock_obj, degrade_gracefully=True)
 
     @staticmethod
     def _rebuild_case_from_transactions(case, detail, updated_xforms=None):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -251,10 +251,10 @@ class FormProcessorSQL(object):
             if lock:
                 lock_obj = CommCareCaseSQL.get_obj_lock_by_id(case_id)
 
+        assert case.domain == domain
         try:
             if lock_obj:
                 acquire_lock(lock_obj, degrade_gracefully=False)
-            assert case.domain == domain
             case, rebuild_transaction = FormProcessorSQL._rebuild_case_from_transactions(case, detail)
             if case.is_deleted and not case.is_saved():
                 return None

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -169,8 +169,8 @@ class FormProcessorInterface(object):
     def assign_new_id(self, xform):
         return self.processor.assign_new_id(xform)
 
-    def hard_rebuild_case(self, case_id, detail):
-        return self.processor.hard_rebuild_case(self.domain, case_id, detail)
+    def hard_rebuild_case(self, case_id, detail, lock=True):
+        return self.processor.hard_rebuild_case(self.domain, case_id, detail, lock=lock)
 
     def get_cases_from_forms(self, case_db, xforms):
         """

--- a/corehq/form_processor/reprocess.py
+++ b/corehq/form_processor/reprocess.py
@@ -143,7 +143,7 @@ def _reprocess_form(form, save=True):
                     if save:
                         # only rebuild cases that were updated
                         detail = FormReprocessRebuild(form_id=form.form_id)
-                        interface.hard_rebuild_case(case.case_id, detail)
+                        interface.hard_rebuild_case(case.case_id, detail, lock=False)
                 save and case_post_save.send(case.__class__, case=case)
 
             for ledger in ledgers:


### PR DESCRIPTION
This should prevent errors like this: https://sentry.io/dimagi/commcarehq/issues/246263032/events/6442823141/

I'm pretty sure what happened there is that a user triggered a rebuild and then a form submission came in during the rebuild.