### PR TITLE
filtering last syncs by app

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -147,6 +147,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         if self.selected_app_id:
             user_query = user_query.filter(
                 filters.term('reporting_metadata.last_submissions.app_id', self.selected_app_id)
+            ).filter(
+                filters.term('reporting_metadata.last_syncs.app_id', self.selected_app_id)
             )
         return user_query
 


### PR DESCRIPTION
@orangejenny 
Sorting was occurring without limiting it to the relevant app, but then the correct sync was displayed, so it appeared to sort incorrectly.
https://manage.dimagi.com/default.asp?260748#1387128