### PR TITLE
ICDS: Fix tetanus complete expression

### DIFF
--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -1982,19 +1982,34 @@
                 }
               },
               "filter_expression": {
-                "type": "not",
-                "filter": {
-                  "operator": "in",
-                  "type": "boolean_expression",
-                  "expression": {
-                    "type": "property_name",
-                    "property_name": "tt_complete_date"
+                "type": "and",
+                "filters": [
+                  {
+                    "operator": "eq",
+                    "type": "boolean_expression",
+                    "expression": {
+                      "datatype": null,
+                      "type": "property_name",
+                      "property_name": "type"
+                    },
+                    "property_value": "tasks"
                   },
-                  "property_value": [
-                    "",
-                    null
-                  ]
-                }
+                  {
+                    "type": "not",
+                    "filter": {
+                      "operator": "in",
+                      "type": "boolean_expression",
+                      "expression": {
+                        "type": "property_name",
+                        "property_name": "tt_complete_date"
+                      },
+                      "property_value": [
+                        "",
+                        null
+                      ]
+                    }
+                  }
+                ]
               }
             }
           },

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -603,12 +603,8 @@
                 "operator": "in",
                 "type": "boolean_expression",
                 "expression": {
-                  "type": "root_doc",
-                  "expression": {
-                    "datatype": "date",
-                    "type": "property_name",
-                    "property_name": "tt_complete_date"
-                  }
+                  "type": "named",
+                  "name": "tetanus_complete_date"
                 },
                 "property_value": [
                   "",
@@ -623,12 +619,8 @@
               "expression": {
                 "type": "diff_days",
                 "from_date_expression": {
-                  "type": "root_doc",
-                  "expression": {
-                    "type": "property_name",
-                    "property_name": "tt_complete_date",
-                    "datatype": "date"
-                  }
+                  "type": "named",
+                  "name": "tetanus_complete_date"
                 },
                 "to_date_expression": {
                   "type": "named",
@@ -1940,6 +1932,77 @@
         "expression_if_false": {
           "type": "constant",
           "constant": "no"
+        }
+      },
+      "tetanus_complete_date": {
+        "comment": "TT Complete date is currently stored on the task case.  Ideally should be stored on the ccs_record case",
+        "type": "conditional",
+        "test": {
+          "type": "not",
+          "filter": {
+            "operator": "in",
+            "type": "boolean_expression",
+            "expression": {
+              "type": "root_doc",
+              "expression": {
+                "datatype": "date",
+                "type": "property_name",
+                "property_name": "tt_complete_date"
+              }
+            },
+            "property_value": [
+              "",
+              null
+            ]
+          }
+        },
+        "expression_if_true": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "tt_complete_date"
+          }
+        },
+        "expression_if_false": {
+          "type": "nested",
+          "argument_expression": {
+            "type": "reduce_items",
+            "aggregation_fn": "first_item",
+            "items_expression": {
+              "type": "filter_items",
+              "items_expression": {
+                "type": "get_subcases",
+                "case_id_expression": {
+                  "type": "root_doc",
+                  "expression": {
+                    "type": "property_name",
+                    "property_name": "_id"
+                  }
+                }
+              },
+              "filter_expression": {
+                "type": "not",
+                "filter": {
+                  "operator": "in",
+                  "type": "boolean_expression",
+                  "expression": {
+                    "type": "property_name",
+                    "property_name": "tt_complete_date"
+                  },
+                  "property_value": [
+                    "",
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "value_expression": {
+            "datatype": "date",
+            "type": "property_name",
+            "property_name": "tt_complete_date"
+          }
         }
       }
     },


### PR DESCRIPTION
@emord 

The application unfortunately stores tetanus complete on the tasks case instead of the ccs record case.  I'm going to ask the app team to change, but in the meantime we have to check the task subcases to get the information. 

(This may need a rebuild of the ccs record data source after its merged - we should probably time that rebuild with reducing the number of iterations)