### PR TITLE
Revert "filtering last syncs by app"

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -147,8 +147,6 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         if self.selected_app_id:
             user_query = user_query.filter(
                 filters.term('reporting_metadata.last_submissions.app_id', self.selected_app_id)
-            ).filter(
-                filters.term('reporting_metadata.last_syncs.app_id', self.selected_app_id)
             )
         return user_query
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#17701
@dannyroberts @millerdev cc: @orangejenny 
This fix is not working as expected and I think it may have unintended consequences for webapps only users, so I am going to revert.