### PR TITLE
don't show rebuild message after a data source is rebuilt asynchronously

### DIFF
--- a/corehq/apps/userreports/management/commands/async_rebuild_table.py
+++ b/corehq/apps/userreports/management/commands/async_rebuild_table.py
@@ -44,6 +44,12 @@ class Command(BaseCommand):
             change = FakeChange(case_id, fake_change_doc)
             AsyncIndicator.update_indicators(change, config_ids)
 
+        for config in configs:
+            if not config.is_static:
+                config.meta.build.rebuilt_asynchronously = True
+                config.save()
+
+
     def _get_case_ids_to_process(self):
         from corehq.sql_db.util import get_db_aliases_for_partitioned_query
         dbs = get_db_aliases_for_partitioned_query()

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -87,6 +87,7 @@ class DataSourceBuildInformation(DocumentSchema):
     # same as previous attributes but used for rebuilding tables in place
     finished_in_place = BooleanProperty(default=False)
     initiated_in_place = DateTimeProperty()
+    rebuilt_asynchronously = BooleanProperty(default=False)
 
 
 class DataSourceMeta(DocumentSchema):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -80,6 +80,7 @@ def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1):
             # able to see if the rebuild started a long time ago without finishing.
             config.meta.build.initiated = datetime.utcnow()
             config.meta.build.finished = False
+            config.meta.build.rebuilt_asynchronously = False
             config.save()
 
         adapter.rebuild_table()

--- a/corehq/apps/userreports/tests/data/report_builder_v2_diffs/views.py.diff.txt
+++ b/corehq/apps/userreports/tests/data/report_builder_v2_diffs/views.py.diff.txt
@@ -1651,7 +1651,7 @@
 +@login_and_domain_required
 +def data_source_status(request, domain, config_id):
 +    config, _ = get_datasource_config_or_404(config_id, domain)
-+    return json_response({'isBuilt': config.meta.build.finished})
++    return json_response({'isBuilt': config.meta.build.finished or config.meta.build.rebuilt_asynchronously})
 +
 +
 +def _get_report_filter(domain, report_id, filter_id):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1447,7 +1447,7 @@ def export_data_source(request, domain, config_id):
 @login_and_domain_required
 def data_source_status(request, domain, config_id):
     config, _ = get_datasource_config_or_404(config_id, domain)
-    return json_response({'isBuilt': config.meta.build.finished})
+    return json_response({'isBuilt': config.meta.build.finished or config.meta.build.rebuilt_asynchronously})
 
 
 def _get_report_filter(domain, report_id, filter_id):


### PR DESCRIPTION
A proposed solution to reports where the rebuild in progress notification appears after an asynchronous build has been kicked off: https://manage.dimagi.com/default.asp?260682#BugEvent.1389533

@emord 