### PR TITLE
Remove user signal

### DIFF
--- a/corehq/apps/users/signals.py
+++ b/corehq/apps/users/signals.py
@@ -31,15 +31,6 @@ def django_user_post_save_signal(sender, instance, created, raw=False, **kwargs)
     return CouchUser.django_user_post_save_signal(sender, instance, created)
 
 
-def update_user_in_es(sender, couch_user, **kwargs):
-    """
-    Automatically sync the user to elastic directly on save or delete
-    """
-    from corehq.pillows.user import transform_user_for_elasticsearch
-    send_to_elasticsearch("users", transform_user_for_elasticsearch(couch_user.to_json()),
-                          delete=couch_user.to_be_deleted())
-
-
 def sync_user_phone_numbers(sender, couch_user, **kwargs):
     from corehq.apps.sms.tasks import sync_user_phone_numbers as sms_sync_user_phone_numbers
     sms_sync_user_phone_numbers.delay(couch_user.get_id)
@@ -50,5 +41,4 @@ def connect_user_signals():
     from django.contrib.auth.models import User
     post_save.connect(django_user_post_save_signal, User,
                       dispatch_uid="django_user_post_save_signal")
-    couch_user_post_save.connect(update_user_in_es, dispatch_uid="update_user_in_es")
     couch_user_post_save.connect(sync_user_phone_numbers, dispatch_uid="sync_user_phone_numbers")


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/223708154/

@esoergel @snopoke When a device id changes we save the user in the restore. This signal causes restores to be dependent on ES responding, so if an ES node goes down it will cause restores to fail.

from https://github.com/dimagi/commcare-hq/pull/4393 it seems like the only reason to have this is to have changes show up when pillowtop is not running. I'm not aware of a time when pillows should not be running for a long time, so I'm assuming this was just because you wanted local changes to show up immediately? If that's the case then I think we should remove this and let pillows handle this.

buddy @sravfeyn 