### PR TITLE
Faster UCR case rebuilding

### DIFF
--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -143,7 +143,6 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
             is_deactivated=False,
             referenced_doc_type="XFormInstance",
             table_id="foo",
-
         )
         other_data_source = DataSourceConfiguration(
             domain=self.project.name,

--- a/corehq/apps/userreports/document_stores.py
+++ b/corehq/apps/userreports/document_stores.py
@@ -6,12 +6,12 @@ from corehq.util.couch import get_db_by_doc_type
 from pillowtop.dao.couch import CouchDocumentStore
 
 
-def get_document_store(domain, doc_type):
+def get_document_store(domain, doc_type, case_type_or_xmlns=None):
     use_sql = should_use_sql_backend(domain)
     if use_sql and doc_type == 'XFormInstance':
-        return ReadonlyFormDocumentStore(domain)
+        return ReadonlyFormDocumentStore(domain, xmlns=case_type_or_xmlns)
     elif use_sql and doc_type == 'CommCareCase':
-        return ReadonlyCaseDocumentStore(domain)
+        return ReadonlyCaseDocumentStore(domain, case_type=case_type_or_xmlns)
     elif doc_type == LOCATION_DOC_TYPE:
         return ReadonlyLocationDocumentStore(domain)
     else:

--- a/corehq/apps/userreports/document_stores.py
+++ b/corehq/apps/userreports/document_stores.py
@@ -10,7 +10,7 @@ def get_document_store(domain, doc_type, case_type_or_xmlns=None):
     use_sql = should_use_sql_backend(domain)
     if use_sql and doc_type == 'XFormInstance':
         return ReadonlyFormDocumentStore(domain, xmlns=case_type_or_xmlns)
-    elif use_sql and doc_type == 'CommCareCase':
+    elif doc_type == 'CommCareCase':
         return ReadonlyCaseDocumentStore(domain, case_type=case_type_or_xmlns)
     elif doc_type == LOCATION_DOC_TYPE:
         return ReadonlyLocationDocumentStore(domain)

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -350,6 +350,27 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         es_index_settings.pop('doc_type')
         return {"settings": es_index_settings}
 
+    def get_case_type_or_xmlns_filter(self):
+        def _get_property_value(config_filter, prop_name):
+            if (config_filter['type'] != 'boolean_expression'
+                    or config_filter['operator'] != 'eq'):
+                return None
+            expression = config_filter['expression']
+            if expression['type'] == 'property_name' and expression['property_name'] == prop_name:
+                return config_filter['property_value']
+            return None
+
+        if self.referenced_doc_type == 'CommCareCase':
+            prop_value = _get_property_value(self.configured_filter, 'type')
+            if prop_value:
+                return prop_value
+        elif self.referenced_doc_type == 'XFormInstance':
+            prop_value = _get_property_value(self.configured_filter, 'xmlns')
+            if prop_value:
+                return prop_value
+
+        return None
+
 
 class ReportMeta(DocumentSchema):
     # `True` if this report was initially constructed by the report builder.

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -352,7 +352,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
 
     def get_case_type_or_xmlns_filter(self):
         def _get_property_value(config_filter, prop_name):
-            if (config_filter['type'] != 'boolean_expression'
+            if (config_filter.get('type') != 'boolean_expression'
                     or config_filter['operator'] != 'eq'):
                 return None
             expression = config_filter['expression']

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -133,9 +133,12 @@ def _iteratively_build_table(config, last_id=None, resume_helper=None,
                              in_place=False, doc_id_provider=None, limit=-1):
     resume_helper = resume_helper or DataSourceResumeHelper(config)
     indicator_config_id = config._id
+    case_type_or_xmlns = config.get_case_type_or_xmlns_filter()
 
     relevant_ids = []
-    document_store = get_document_store(config.domain, config.referenced_doc_type)
+    document_store = get_document_store(
+        config.domain, config.referenced_doc_type, case_type_or_xmlns=case_type_or_xmlns
+    )
 
     if not doc_id_provider:
         doc_id_provider = document_store.iter_document_ids(last_id)

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -13,9 +13,10 @@ from pillowtop.dao.interface import ReadOnlyDocumentStore
 
 class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
 
-    def __init__(self, domain):
+    def __init__(self, domain, xmlns=None):
         self.domain = domain
         self.form_accessors = FormAccessors(domain=domain)
+        self.xmlns = xmlns
 
     def get_document(self, doc_id):
         try:
@@ -25,6 +26,7 @@ class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
 
     def iter_document_ids(self, last_id=None):
         # todo: support last_id
+        # todo: add migration for function that filters by xmlns
         return iter(self.form_accessors.get_all_form_ids_in_domain())
 
     def iter_documents(self, ids):
@@ -34,9 +36,10 @@ class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
 
 class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
 
-    def __init__(self, domain):
+    def __init__(self, domain, case_type=None):
         self.domain = domain
         self.case_accessors = CaseAccessors(domain=domain)
+        self.case_type = case_type
 
     def get_document(self, doc_id):
         try:
@@ -46,7 +49,7 @@ class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
 
     def iter_document_ids(self, last_id=None):
         # todo: support last_id
-        return iter(self.case_accessors.get_case_ids_in_domain())
+        return iter(self.case_accessors.get_case_ids_in_domain(type=self.case_type))
 
     def iter_documents(self, ids):
         for wrapped_case in self.case_accessors.iter_cases(ids):


### PR DESCRIPTION
The only thing missing here is a SQL function to filter by XMLNS, but this should be mergeable now and mostly better than what we have for cases.

@calellowitz likely useful for eniskahy rebuilds

buddy @sravfeyn 