### PR TITLE
'Menu' not 'Module' when creating form export

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -160,8 +160,8 @@ class ApplicationDataRMIHelper(object):
     APP_TYPE_NONE = 'no_app'
     APP_TYPE_UNKNOWN = 'unknown'
 
-    def __init__(self, domain, user, as_dict=True, form_labels=None,
-                 form_placeholders=None, case_placeholders=None):
+    def __init__(self, domain, user, as_dict=True, form_placeholders=None,
+                 case_placeholders=None, form_labels=None):
         self.domain = domain
         self.user = user
         self.as_dict = as_dict

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -19,7 +19,7 @@ ApplicationDataSource = collections.namedtuple('ApplicationDataSource', ['applic
 RMIDataChoice = collections.namedtuple('RMIDataChoice', ['id', 'text', 'data'])
 AppFormRMIResponse = collections.namedtuple('AppFormRMIResponse', [
     'app_types', 'apps_by_type', 'modules_by_app',
-    'forms_by_app_by_module', 'placeholders'
+    'forms_by_app_by_module', 'labels', 'placeholders'
 ])
 AppFormRMIPlaceholder = collections.namedtuple('AppFormRMIPlaceholder', [
     'application', 'module', 'form'
@@ -160,10 +160,16 @@ class ApplicationDataRMIHelper(object):
     APP_TYPE_NONE = 'no_app'
     APP_TYPE_UNKNOWN = 'unknown'
 
-    def __init__(self, domain, user, as_dict=True, form_placeholders=None, case_placeholders=None):
+    def __init__(self, domain, user, as_dict=True, form_labels=None, form_placeholders=None, case_placeholders=None):
         self.domain = domain
         self.user = user
         self.as_dict = as_dict
+        default_form_labels = AppFormRMIPlaceholder(
+            application=_("Application"),
+            module=_("Menu"),
+            form=_("Form"),
+        )
+        self.form_labels = form_labels or default_form_labels
         default_form_placeholder = AppFormRMIPlaceholder(
             application=_("Select Application"),
             module=_("Select Menu"),
@@ -176,6 +182,7 @@ class ApplicationDataRMIHelper(object):
         )
         self.case_placeholders = case_placeholders or default_case_placeholder
         if self.as_dict:
+            self.form_labels = self.form_labels._asdict()
             self.form_placeholders = self.form_placeholders._asdict()
             self.case_placeholders = self.case_placeholders._asdict()
 
@@ -470,6 +477,7 @@ class ApplicationDataRMIHelper(object):
             apps_by_type=self._get_applications_by_type(self.as_dict),
             modules_by_app=modules_by_app,
             forms_by_app_by_module=forms_by_app_by_module,
+            labels=self.form_labels,
             placeholders=self.form_placeholders,
         )
         if self.as_dict:

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -160,7 +160,8 @@ class ApplicationDataRMIHelper(object):
     APP_TYPE_NONE = 'no_app'
     APP_TYPE_UNKNOWN = 'unknown'
 
-    def __init__(self, domain, user, as_dict=True, form_labels=None, form_placeholders=None, case_placeholders=None):
+    def __init__(self, domain, user, as_dict=True, form_labels=None,
+                 form_placeholders=None, case_placeholders=None):
         self.domain = domain
         self.user = user
         self.as_dict = as_dict

--- a/corehq/apps/app_manager/static/app_manager/js/hq.app_data_drilldown.ng.js
+++ b/corehq/apps/app_manager/static/app_manager/js/hq.app_data_drilldown.ng.js
@@ -64,6 +64,7 @@
             $scope.formData['model_type'] = modelType;
         }
 
+        self._labels = {};
         self._placeholders = {};
         self._app_types = [];
         self._apps_by_type = {};
@@ -73,6 +74,10 @@
 
         self._select2Test = {};
 
+        var _formElemContainer = function(fieldSlug) {
+            return $('#div_id_' + fieldSlug);
+        };
+
         var _formElemGetter = function(fieldSlug) {
             return $('#id_' + fieldSlug);
         };
@@ -81,6 +86,7 @@
             return function (field_data) {
                 if (fieldSlug) {
                     $scope.formData[fieldSlug] = '';
+                    _formElemContainer(fieldSlug).find("label").text(self._labels[fieldSlug]);
                     var $formElem = _formElemGetter(fieldSlug);
                     if ($formElem.length > 0) {
                         $formElem.select2({
@@ -160,6 +166,7 @@
                     if (data.success) {
                         $scope.showNoAppsError = data.app_types.length === 1 && data.apps_by_type.all.length === 0;
                         if (!$scope.showNoAppsError) {
+                            self._labels = data.labels || {};
                             self._placeholders = data.placeholders || {};
                             self._app_types = data.app_types || [];
                             $scope.hasSpecialAppTypes = data.app_types.length > 1;


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?261542

Was expecting this to be a one-line change [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/export/forms.py#L181), but that had no effect. This is verbose but works.

@gcapalbo / @dannyroberts 