### PR TITLE
Map answer concepts, support form questions

### DIFF
--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -1,7 +1,13 @@
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.openmrs_config import IdMatcher
-from corehq.motech.openmrs.repeater_helpers import CaseTriggerInfo, get_patient_by_id, \
-    update_person_attribute, create_person_attribute, create_visit, set_person_properties
+from corehq.motech.openmrs.repeater_helpers import (
+    CaseTriggerInfo,
+    get_patient_by_id,
+    update_person_attribute,
+    create_person_attribute,
+    create_visit,
+    set_person_properties,
+)
 from dimagi.utils.parsing import string_to_utc_datetime
 
 

--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -5,7 +5,7 @@ from corehq.motech.openmrs.repeater_helpers import CaseTriggerInfo, get_patient_
 from dimagi.utils.parsing import string_to_utc_datetime
 
 
-def send_openmrs_data(requests, form_json, case_trigger_infos, openmrs_config):
+def send_openmrs_data(requests, form_json, openmrs_config, case_trigger_infos, form_question_values):
     problem_log = []
     person_uuids = []
     logger.debug(case_trigger_infos)
@@ -20,6 +20,7 @@ def send_openmrs_data(requests, form_json, case_trigger_infos, openmrs_config):
     if len(person_uuids) == 1 and all(person_uuid for person_uuid in person_uuids):
         person_uuid, = person_uuids
         info, = case_trigger_infos
+        info.form_question_values.update(form_question_values)
         for form_config in openmrs_config.form_configs:
             logger.debug('send_openmrs_visit?', form_config, form_json)
             if form_config.xmlns == form_json['form']['@xmlns']:

--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -67,7 +67,8 @@ def sync_openmrs_patient(requests, info, openmrs_config, problem_log):
         for person_property, value_source in openmrs_config.case_config.person_properties.items()
         if value_source.get_value(info)
     }
-    set_person_properties(requests, person_uuid, properties)
+    if properties:
+        set_person_properties(requests, person_uuid, properties)
 
     # update attributes
 

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -1,4 +1,5 @@
 from dimagi.ext.couchdbkit import (
+    DictProperty,
     DocumentSchema,
     ListProperty,
     SchemaDictProperty,
@@ -6,6 +7,13 @@ from dimagi.ext.couchdbkit import (
     SchemaProperty,
     StringProperty,
 )
+
+
+def recurse_subclasses(cls):
+    return (
+        cls.__subclasses__() +
+        [subsub for sub in cls.__subclasses__() for subsub in recurse_subclasses(sub)]
+    )
 
 
 class IdMatcher(DocumentSchema):
@@ -18,7 +26,7 @@ class ValueSource(DocumentSchema):
     def wrap(cls, data):
         if cls is ValueSource:
             return {
-                sub._doc_type: sub for sub in cls.__subclasses__()
+                sub._doc_type: sub for sub in recurse_subclasses(cls)
             }[data['doc_type']].wrap(data)
         else:
             return super(ValueSource, cls).wrap(data)
@@ -39,6 +47,22 @@ class ConstantString(ValueSource):
 
     def get_value(self, case_trigger_info):
         return self.value
+
+
+class CasePropertyConcept(CaseProperty):
+    """
+    Maps case property values to OpenMRS concepts
+    """
+    value_concepts = DictProperty()
+
+    def get_value(self, case_trigger_info):
+        value = super(CasePropertyConcept, self).get_value(case_trigger_info)
+        try:
+            return self.value_concepts[value]
+        except KeyError:
+            # We don't care if some CommCare answers are not mapped to OpenMRS concepts, e.g. when only the "yes"
+            # value of a yes-no question in CommCare is mapped to a concept in OpenMRS.
+            return None
 
 
 class OpenmrsCaseConfig(DocumentSchema):

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -42,6 +42,13 @@ class CaseProperty(ValueSource):
         return case_trigger_info.updates.get(self.case_property)
 
 
+class FormQuestion(ValueSource):
+    form_question = StringProperty()  # e.g. "/data/foo/bar"
+
+    def get_value(self, case_trigger_info):
+        return case_trigger_info.form_question_values.get(self.form_question)
+
+
 class ConstantString(ValueSource):
     value = StringProperty()
 
@@ -62,6 +69,20 @@ class CasePropertyConcept(CaseProperty):
         except KeyError:
             # We don't care if some CommCare answers are not mapped to OpenMRS concepts, e.g. when only the "yes"
             # value of a yes-no question in CommCare is mapped to a concept in OpenMRS.
+            return None
+
+
+class FormQuestionConcept(FormQuestion):
+    """
+    Maps form question values to OpenMRS concepts
+    """
+    value_concepts = DictProperty()
+
+    def get_value(self, case_trigger_info):
+        value = super(FormQuestionConcept, self).get_value(case_trigger_info)
+        try:
+            return self.value_concepts[value]
+        except KeyError:
             return None
 
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -172,7 +172,7 @@ CaseTriggerInfo = namedtuple('CaseTriggerInfo',
 def get_form_question_values(form_json):
     """
     Returns question-value pairs to result where questions are given as "/data/foo/bar"
-    
+
     >>> get_form_question_values({'form': {'foo': {'bar': 'baz'}}})
     {'/data/foo/bar': 'baz'}
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -176,7 +176,7 @@ def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extr
         [case_block['@case_id'] for case_block in case_blocks], ordered=True)
     for case, case_block in zip(cases, case_blocks):
         assert case_block['@case_id'] == case.case_id
-        if case.type in case_types:
+        if not case_types or case.type in case_types:
             result.append(CaseTriggerInfo(
                 case_id=case_block['@case_id'],
                 updates=dict(

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -166,7 +166,42 @@ class PatientSearchParser(object):
 
 
 CaseTriggerInfo = namedtuple('CaseTriggerInfo',
-                             ['case_id', 'updates', 'created', 'closed', 'extra_fields'])
+                             ['case_id', 'updates', 'created', 'closed', 'extra_fields', 'form_question_values'])
+
+
+def get_form_question_values(form_json):
+    """
+    Returns question-value pairs to result where questions are given as "/data/foo/bar"
+    
+    >>> get_form_question_values({'form': {'foo': {'bar': 'baz'}}})
+    {'/data/foo/bar': 'baz'}
+
+    """
+    _reserved_keys = ('@uiVersion', '@xmlns', '@name', '#type', 'case', 'meta', '@version')
+
+    def _recurse_form_questions(form_dict, path, result_):
+        for key, value in form_dict.items():
+            if key in _reserved_keys:
+                continue
+            new_path = path + [key]
+            if isinstance(value, list):
+                # Repeat group
+                for v in value:
+                    assert isinstance(v, dict)
+                    _recurse_form_questions(v, new_path, result_)
+            elif isinstance(value, dict):
+                # Group
+                _recurse_form_questions(value, new_path, result_)
+            else:
+                # key is a question and value is its answer
+                question = '/'.join(new_path)
+                result_[question] = value
+
+    result = {}
+    _recurse_form_questions(form_json['form'], ['/data'], result)  # "/data" is just convention, hopefully familiar
+    # from form builder. The form's data will usually be immediately under "form_json['form']" but not necessarily.
+    # If this causes problems we may need a more reliable way to get to it.
+    return result
 
 
 def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extra_fields):
@@ -185,7 +220,8 @@ def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extr
                 ),
                 created='create' in case_block,
                 closed='close' in case_block,
-                extra_fields={field: case.get_case_property(field) for field in extra_fields}
+                extra_fields={field: case.get_case_property(field) for field in extra_fields},
+                form_question_values={}
             ))
     return result
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -16,7 +16,7 @@ class Requests(object):
         self.password = password
 
     def _url(self, uri):
-        return '{}{}'.format(self.base_url, uri)
+        return '/'.join((self.base_url.rstrip('/'), uri.lstrip('/')))
 
     def get(self, uri, *args, **kwargs):
         return self.requests.get(self._url(uri), *args,

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -12,8 +12,11 @@ from corehq.motech.repeaters.signals import create_repeat_records
 from couchforms.signals import successful_form_received
 from corehq.motech.openmrs.openmrs_config import OpenmrsConfig
 from corehq.motech.openmrs.handler import send_openmrs_data
-from corehq.motech.openmrs.repeater_helpers import get_relevant_case_updates_from_form_json, \
-    Requests
+from corehq.motech.openmrs.repeater_helpers import (
+    Requests,
+    get_form_question_values,
+    get_relevant_case_updates_from_form_json,
+)
 from dimagi.utils.decorators.memoized import memoized
 
 
@@ -48,13 +51,14 @@ class OpenmrsRepeater(CaseRepeater):
     def fire_for_record(self, repeat_record):
         form_json = json.loads(self.get_payload(repeat_record))
 
-        trigger_case_infos = get_relevant_case_updates_from_form_json(
+        case_trigger_infos = get_relevant_case_updates_from_form_json(
             self.domain, form_json, case_types=self.white_listed_case_types,
             extra_fields=[id_matcher.case_property
                           for id_matcher in self.openmrs_config.case_config.id_matchers])
+        form_question_values = get_form_question_values(form_json)
 
-        send_openmrs_data(Requests(self.url, self.username, self.password), form_json,
-                          trigger_case_infos, self.openmrs_config)
+        send_openmrs_data(Requests(self.url, self.username, self.password), form_json, self.openmrs_config,
+                          case_trigger_infos, form_question_values)
 
         return repeat_record.handle_success(None)
 

--- a/corehq/motech/openmrs/templates/openmrs/edit_config.html
+++ b/corehq/motech/openmrs/templates/openmrs/edit_config.html
@@ -2,6 +2,7 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {# todo: this was just copied from userreports/userreports_base.html #}
+{% block title %}Edit Config : OpenMRS :: {% endblock %}
 {% block js %}{{ block.super }}
     <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
     <script src="{% static 'codemirror/mode/javascript/javascript.js' %}"></script>

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -1,9 +1,11 @@
+import doctest
 import os
 from django.test import SimpleTestCase
 import mock
 from casexml.apps.case.models import CommCareCase
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.test_utils import TestFileMixin
+import corehq.motech.openmrs.repeater_helpers
 from corehq.motech.openmrs.repeater_helpers import \
     get_relevant_case_updates_from_form_json, CaseTriggerInfo
 
@@ -33,6 +35,7 @@ class OpenmrsRepeaterTest(SimpleTestCase, TestFileMixin):
                     created=True,
                     closed=False,
                     extra_fields={},
+                    form_question_values={},
                 )
             ]
         )
@@ -51,6 +54,14 @@ class OpenmrsRepeaterTest(SimpleTestCase, TestFileMixin):
                     created=False,
                     closed=False,
                     extra_fields={},
+                    form_question_values={},
                 )
             ]
         )
+
+
+class DocTests(SimpleTestCase):
+
+    def test_doctests(self):
+        results = doctest.testmod(corehq.motech.openmrs.repeater_helpers)
+        self.assertEqual(results.failed, 0)


### PR DESCRIPTION
This change allows MOTECH to map multiple choice answers in CommCare to concepts in OpenMRS, and to forward form questions that are not case properties. 

(`send_openmrs_data` still assumes that it has been able to identify a patient.)

Might be easier to :tropical_fish: 

@dannyroberts cc @snopoke buddy @biyeun 