### PR TITLE
Fix disable-on-spinner for form builder edit name modal

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -154,6 +154,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
             $('.variable-form_name').text(name);
             hqImport('app_manager/js/app_manager').updatePageTitle(name);
             $('#edit-form-name-modal').modal('hide');
+            $('#edit-form-name-modal').find('.disable-on-submit').enableButton();
         });
         $('#edit-form-name-modal').koApplyBindings(editDetails);
     });

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -138,7 +138,7 @@
                   </div>
                   <div class="modal-footer">
                       <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
-                      <button type="submit disable-on-submit" class="btn btn-primary">{% trans "Save" %}</button>
+                      <button type="submit" class="btn btn-primary disable-on-submit">{% trans "Save" %}</button>
                   </div>
               </form>
           </div>


### PR DESCRIPTION
...and re-enable it when the form submission is complete.

@gcapalbo / @dannyroberts 
fyi @djmore9 