### PR TITLE
Kill underscore-mixins.js

### DIFF
--- a/corehq/apps/export/static/export/js/customize_export.js
+++ b/corehq/apps/export/static/export/js/customize_export.js
@@ -394,11 +394,10 @@ var CustomExportView = {
                 self.valid(newFormat !== "html");
             }
         });
-        
 
         self.save_no_preview = function() {
             var exportType = self.export_type();
-            exportType = _(exportType).capitalize();
+            exportType = hqImport('export/js/utils').capitalize(exportType);
             var action = "Regular";
             if (self.presave()) {
                 action = "Saved";

--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -1,3 +1,4 @@
+/* global analytics */
 (function (angular, undefined) {
     'use strict';
     // module: hq.download_export

--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -105,7 +105,7 @@
         self._getGroups();
 
         var exportType = $scope.exportList[0].export_type;
-        self.exportType = _(exportType).capitalize();
+        self.exportType = hqImport('export/js/utils').capitalize(exportType);
 
         self.sendAnalytics = function () {
             _.each($scope.formData.user_types, function (user_type) {
@@ -267,7 +267,8 @@
         });
 
         $scope.sendAnalytics = function () {
-            analytics.usage("Download Export", _(exportDownloadService.exportType).capitalize(), "Saved");
+            analytics.usage("Download Export",
+                            hqImport('export/js/utils').capitalize(exportDownloadService.exportType), "Saved");
             analytics.workflow("Clicked Download button");
         };
     };

--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -120,7 +120,7 @@
             })
                 .success(function (data) {
                     if (data.success) {
-                        var exportType = _(exp.exportType).capitalize();
+                        var exportType = hqImport('export/js/utils').capitalize(exp.exportType);
                         analytics.usage("Update Saved Export", exportType, "Saved");
                         component.updatingData = false;
                         component.updatedDataTriggered = true;

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -240,7 +240,7 @@ hqDefine('export/js/models', function () {
      */
     ExportInstance.prototype.recordSaveAnalytics = function(callback) {
         var analyticsAction = this.is_daily_saved_export() ? 'Saved' : 'Regular',
-            analyticsExportType = _.capitalize(this.type()),
+            analyticsExportType = utils.capitalize(this.type()),
             args,
             eventCategory;
 

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -31,6 +31,10 @@ hqDefine('export/js/utils', function() {
         }, 'slow', undefined, callback);
     };
 
+    var capitalize = function(string) {
+        return string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
+    };
+
     /**
      * readablePath
      *
@@ -77,6 +81,7 @@ hqDefine('export/js/utils', function() {
         getTagCSSClass: getTagCSSClass,
         redirect: redirect,
         animateToEl: animateToEl,
+        capitalize: capitalize,
         readablePath: readablePath,
         customPathToNodes: customPathToNodes,
     };

--- a/corehq/apps/export/templates/export/customize_export_old.html
+++ b/corehq/apps/export/templates/export/customize_export_old.html
@@ -4,6 +4,7 @@
 
 {% block js %}
     {{ block.super }}
+    <script src="{% static 'export/js/utils.js' %}"></script>
     <script src="{% static 'export/js/customize_export.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -37,6 +37,7 @@
 
 {% block js %}
 <script src="{% static 'reports/js/reports.util.js' %}"></script>
+<script src="{% static 'export/js/utils.js' %}"></script>
 <script src="{% static 'export/js/download_export.ng.js' %}"></script>
 <script src="{% static 'export/js/download_export.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -19,6 +19,7 @@
 {% block js %}
 <script src="{% static 'export/js/list_exports.ng.js' %}"></script>
 <script src="{% static 'app_manager/js/hq.app_data_drilldown.ng.js' %}"></script>
+<script src="{% static 'export/js/utils.js' %}"></script>
 <script src="{% static 'export/js/export_list.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/export/templates/export/spec/mocha.html
+++ b/corehq/apps/export/templates/export/spec/mocha.html
@@ -7,6 +7,7 @@
 {% endblock %}
 
 {% block dependencies %}
+<script src="{% static 'export/js/utils.js' %}"></script>
 <script src="{% static 'export/js/list_exports.ng.js' %}"></script>
 <script src="{% static 'reports/js/reports.util.js' %}"></script>
 <script src="{% static 'export/js/download_export.ng.js' %}"></script>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/underscore-mixins.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/underscore-mixins.js
@@ -1,5 +1,0 @@
-_.mixin({
-  capitalize: function(string) {
-    return string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
-  }
-});

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
@@ -1,7 +1,6 @@
 {% load hq_shared_tags %}
 <script src="{% static 'jquery-form/jquery.form.js' %}"></script>
 <script src="{% static 'underscore/underscore.js' %}"></script>
-<script src="{% static 'hqwebapp/js/underscore-mixins.js' %}"></script>
 <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
 <script src="{% static 'hqwebapp/js/hq_extensions.jquery.js' %}"></script>
 <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>


### PR DESCRIPTION
It's only one function, which is only used in exports.

@gcapalbo / @dannyroberts 