### PR TITLE
Use correct field person_id instead of external_id [skip ci]

### DIFF
--- a/custom/enikshay/ucr/reports/cc_outbound_call_list.json
+++ b/custom/enikshay/ucr/reports/cc_outbound_call_list.json
@@ -55,7 +55,7 @@
             {
                 "display": "eNikshay ID",
                 "type": "field",
-                "field": "external_id",
+                "field": "person_id",
                 "aggregation": "simple",
                 "sortable": false,
                 "description": null,


### PR DESCRIPTION
Fixes for https://manage.dimagi.com/default.asp?260027

In progress:
1. Correct use of person id instead of external id for enikshay id. 