### PR TITLE
Soft limit time for async UCR

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -230,7 +230,9 @@ def delete_data_source_task(domain, config_id):
     delete_data_source_shared(domain, config_id)
 
 
-@periodic_task(run_every=crontab(minute="*/5"), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(
+    run_every=settings.ASYNC_INDICATOR_QUEUE_CRONTAB, queue=settings.CELERY_PERIODIC_QUEUE
+)
 def run_queue_async_indicators_task():
     queue_async_indicators.delay()
 

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -1,17 +1,12 @@
 from __future__ import print_function
-import multiprocessing
-import os
-
-import kombu.five
-from celery import Celery
-from celery import current_app
-from celery.backends.base import DisabledBackend
-from celery.task import task
-from celery.worker.autoscale import Autoscaler
-from django.conf import settings
-from djcelery.loaders import DjangoLoader
 from datetime import datetime
 from time import sleep, time
+
+from celery import Celery, current_app
+from celery.backends.base import DisabledBackend
+from celery.task import task
+from django.conf import settings
+import kombu.five
 
 
 def no_result_task(*args, **kwargs):
@@ -191,80 +186,3 @@ def get_running_workers(timeout=10):
         worker_names.extend(worker_info.keys())
 
     return worker_names
-
-
-class LoadBasedAutoscaler(Autoscaler):
-    def _maybe_scale(self, req=None):
-        procs = self.processes
-        cur = min(self.qty, self.max_concurrency)
-
-        available_cpus = multiprocessing.cpu_count()
-        try:
-            load_avgs = os.getloadavg()
-            one_min_avg = load_avgs[0]
-            normalized_load = one_min_avg / available_cpus
-        except OSError:
-            # if we can't get the load average, let's just use normal autoscaling
-            load_avgs = None
-            normalized_load = 0
-
-        if cur > procs and normalized_load < 0.90:
-            self.scale_up(cur - procs)
-            return True
-        elif procs > self.min_concurrency:
-            if cur < procs:
-                self.scale_down(min(procs - cur, procs - self.min_concurrency))
-                return True
-            elif normalized_load > 0.90:
-                # if load is too high trying scaling down 1 worker at a time.
-                # if we're already at minimum concurrency let's just ride it out
-                self.scale_down(1)
-                return True
-
-
-class OffPeakLoadBasedAutoscaler(LoadBasedAutoscaler):
-    def _is_off_peak(self):
-        now = datetime.utcnow().time()
-        if settings.OFF_PEAK_TIME:
-            time_begin = settings.OFF_PEAK_TIME[0]
-            time_end = settings.OFF_PEAK_TIME[1]
-            if time_begin < time_end:  # off peak is middle of day
-                if time_begin < now < time_end:
-                    return True
-            else:  # off peak is overnight
-                if time_begin < now or now < time_end:
-                    return True
-
-        # if this setting isn't set consider us always during peak time
-        return False
-
-    def _during_peak_time(self):
-        return not self._is_off_peak()
-
-    def _maybe_scale(self, req=None):
-        procs = self.processes
-
-        if self._during_peak_time():
-            if procs > self.min_concurrency:
-                self.scale_down(1)
-                return True
-            elif procs == self.min_concurrency:
-                return False
-
-        return super(OffPeakLoadBasedAutoscaler, self)._maybe_scale(req)
-
-
-class LoadBasedLoader(DjangoLoader):
-    def read_configuration(self):
-        ret = super(LoadBasedLoader, self).read_configuration()
-        ret['CELERYD_AUTOSCALER'] = 'corehq.util.celery_utils:LoadBasedAutoscaler'
-        ret['CELERYD_PREFETCH_MULTIPLIER'] = 1
-        ret['AUTOSCALE_KEEPALIVE'] = 120
-        return ret
-
-
-class OffPeakLoadBasedLoader(LoadBasedLoader):
-    def read_configuration(self):
-        ret = super(OffPeakLoadBasedLoader, self).read_configuration()
-        ret['CELERYD_AUTOSCALER'] = 'corehq.util.celery_utils:OffPeakLoadBasedAutoscaler'
-        return ret

--- a/settings.py
+++ b/settings.py
@@ -591,9 +591,6 @@ ENIKSHAY_QUEUE = CELERY_MAIN_QUEUE
 # time limit is exceeded.
 CELERYD_TASK_SOFT_TIME_LIMIT = 86400 * 2  # 2 days in seconds
 
-# tuple of (time_start, time_end) of off peak times for async processing queues to use
-OFF_PEAK_TIME = None
-
 # websockets config
 WEBSOCKET_URL = '/ws/'
 WS4REDIS_PREFIX = 'ws'

--- a/settings.py
+++ b/settings.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import
 import importlib
 from collections import defaultdict
-
 import os
-from six.moves.urllib.parse import urlencode
+
+from celery.schedules import crontab
 from django.contrib import messages
 import settingshelper as helper
 
@@ -916,6 +916,7 @@ ENIKSHAY_PRIVATE_API_PASSWORD = None
 # number of docs for UCR to queue asynchronously at once
 # ideally # of documents it takes to process in ~30 min
 ASYNC_INDICATORS_TO_QUEUE = 10000
+ASYNC_INDICATOR_QUEUE_CRONTAB = crontab(minute="*/5")
 DAYS_TO_KEEP_DEVICE_LOGS = 60
 
 MAX_RULE_UPDATES_IN_ONE_RUN = 10000


### PR DESCRIPTION
@gcapalbo I think you said you were going to look into this, but I realized we could do this.

This will just stop queueing tasks based on a cron schedule, so the workers will stay up but should scale down during the day

buddy @sravfeyn 