### PR TITLE
Upgrade psycopg2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -29,7 +29,7 @@ mock==0.8.0
 openpyxl==2.2.5
 Pillow==2.7.0
 phonenumberslite==7.1.0
-psycopg2==2.7.3
+psycopg2==2.7.3.1
 psycogreen==1.0
 pycrypto==2.6.1
 py-KISSmetrics==1.0.1


### PR DESCRIPTION
the old version breaks on new versions of glibc. they removed the dependency in the new release

@sravfeyn 