### PR TITLE
Enable ledgers for non-Supply projects

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -269,7 +269,8 @@ def _get_vellum_plugins(domain, form, module):
     privileges.
     """
     vellum_plugins = ["modeliteration", "itemset", "atwho"]
-    if toggles.COMMTRACK.enabled(domain):
+    if (toggles.COMMTRACK.enabled(domain)
+            or toggles.NON_COMMTRACK_LEDGERS.enabled(domain)):
         vellum_plugins.append("commtrack")
     if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):
         vellum_plugins.append("saveToCase")

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/stock.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/stock.py
@@ -1,16 +1,20 @@
 from collections import defaultdict
-from casexml.apps.stock.consumption import compute_default_monthly_consumption, \
-    ConsumptionConfiguration
+from datetime import datetime
+
+from corehq import toggles
 from corehq.form_processor.exceptions import LedgerValueNotFound
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_datetime
-from datetime import datetime
+
+from casexml.apps.stock.consumption import compute_default_monthly_consumption, \
+    ConsumptionConfiguration
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 
 
 def get_stock_payload(project, stock_settings, case_stub_list):
-    if project and not project.commtrack_enabled:
+    uses_ledgers = project.commtrack_enabled or toggles.NON_COMMTRACK_LEDGERS.enabled(project.name)
+    if project and not uses_ledgers:
         return
 
     generator = StockPayloadGenerator(project.name, stock_settings, case_stub_list)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -739,6 +739,13 @@ COMMTRACK = StaticToggle(
     save_fn=_commtrackify,
 )
 
+NON_COMMTRACK_LEDGERS = StaticToggle(
+    'non_commtrack_ledgers',
+    "Enable ledgers for projects which don't use Supply.",
+    TAG_EXPERIMENTAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 CUSTOM_INSTANCES = StaticToggle(
     'custom_instances',
     'Inject custom instance declarations',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -741,8 +741,12 @@ COMMTRACK = StaticToggle(
 
 NON_COMMTRACK_LEDGERS = StaticToggle(
     'non_commtrack_ledgers',
-    "Enable ledgers for projects which don't use Supply.",
+    "Enable ledgers for projects not using Supply.",
     TAG_EXPERIMENTAL,
+    description=(
+        'Turns on the ledger fixture and ledger transaction question types in '
+        'the form builder. ONLY WORKS ON SQL DOMAINS!'
+    ),
     namespaces=[NAMESPACE_DOMAIN],
 )
 


### PR DESCRIPTION
This allows you to add in transaction question types without turning on commtrack, and tells HQ to include ledgers in the restore.  Everything else seemed to just work.  I made an app locally using this and it went fine - I was able to add a transaction question, submit data against that, see the ledger data on the associated case, and reference it in subsequent forms.  Notably, HQ doesn't seem to care whether the specified entity id is a supply-point case (any old case works), nor whether the entry id is a product or just some arbitrary string.  I thought there were some checks against that sort of thing, but I couldn't find anything.  If anyone else has suggestions for things to test, lemme know.

@dannyroberts this is what I was talking about today
@mkangia code buddy
@snopoke can you think of anything else that could potentially go awry with this change?