### PR TITLE
Keep questionMap for repeat contexts updated when refreshing questions

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -98,13 +98,19 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             }
         });
 
-        var questionMap = {};
-        _(self.questions()).each(function (question) {
-            questionMap[question.value] = question;
-        });
+        self.questionMap = {};
+        var _buildQuestionMap = function() {
+            self.questionMap = {};
+            _(self.questions()).each(function (question) {
+                self.questionMap[question.value] = question;
+            });
+        };
+        _buildQuestionMap();
+        self.questions.subscribe(_buildQuestionMap);
+
         self.get_repeat_context = function(path) {
-            if (path && questionMap[path]) {
-                return questionMap[path].repeat;
+            if (path && self.questionMap[path]) {
+                return self.questionMap[path].repeat;
             } else {
                 return undefined;
             }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui_advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui_advanced.js
@@ -131,13 +131,19 @@ hqDefine('app_manager/js/forms/case_config_ui_advanced', function () {
             return modules;
         };
 
-        var questionMap = {};
-        _(self.questions()).each(function (question) {
-            questionMap[question.value] = question;
-        });
+        self.questionMap = {};
+        var _buildQuestionMap = function() {
+            self.questionMap = {};
+            _(self.questions()).each(function (question) {
+                self.questionMap[question.value] = question;
+            });
+        };
+        _buildQuestionMap();
+        self.questions.subscribe(_buildQuestionMap);
+
         self.get_repeat_context = function(path) {
-            if (path && questionMap[path]) {
-                return questionMap[path].repeat;
+            if (path && self.questionMap[path]) {
+                return self.questionMap[path].repeat;
             } else {
                 return undefined;
             }


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?262193 and https://manage.dimagi.com/default.asp?261963

`questionMap` wasn't being updated when `questions` changed, resulting in repeat context getting set incorrectly.

@proteusvacuum 
cc @nickpell 