### PR TITLE
Documented an incorrectly calculated indicator.

### DIFF
--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -1198,6 +1198,7 @@
         }
       },
       {
+        "comment": "NOTE: This is not correct. To fix we must get the task cases",
         "display_name": null,
         "transform": {},
         "datatype": "date",


### PR DESCRIPTION
Working around this incorrect calculation https://github.com/dimagi/commcare-hq/pull/17892

We don't need this for any mobile reports or the dashboard at the moment, so I have left this comment and also a comment in the dashboard specifications about how to fix this and have opted not to fix it for now because it would slow down the processing of these documents for no immediate gain.

Also opting to leave it in the database, because removing a column is a blocking operation that we do not have support for in UCR

fyi @sheelio 

buddy @sravfeyn 