### PR TITLE
Don't consider UserDefinedExportColumns when inserting case name

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -856,14 +856,17 @@ class ExportInstance(BlobMixin, Document):
         """
         insert_fn = cls._get_insert_fn(table, top)
 
+        def consider(column):
+            return not isinstance(column, UserDefinedExportColumn)
+
         from corehq.apps.export.system_properties import get_case_name_column
         case_id_columns = {
             _path_nodes_to_string(column.item.path[:-1]): column
-            for column in table.columns if column.item.path[-1].name == '@case_id'
+            for column in table.columns if consider(column) and column.item.path[-1].name == '@case_id'
         }
         case_name_columns = {
             _path_nodes_to_string(column.item.path[:-2]): column
-            for column in table.columns if column.item.path[-1].name == 'case_name'
+            for column in table.columns if consider(column) and column.item.path[-1].name == 'case_name'
         }
         for path, column in case_id_columns.items():
             if path not in case_name_columns:


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?262270

It looks like this issue was introduced with https://github.com/dimagi/commcare-hq/pull/17619. Specifically, [this line](https://github.com/dimagi/commcare-hq/blob/0c8cdd5d5a887b78bb7566e5cfe21aa0f7955bb8/corehq/apps/export/models/new.py#L789) doesn't work with UserDefinedExportColumns, which use column.custom_path rather than the column.item.path.

Since UserDefinedExportColumns apply to remote apps, it seemed like they shouldn't be considered here. @esoergel @snopoke , looks like you added the original PR, is that right?