### PR TITLE
Detect repeat contexts for groups inside of repeats

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -951,7 +951,6 @@ class XForm(WrappedNode):
         control_nodes = self.get_control_nodes()
         leaf_data_nodes = self.get_leaf_data_nodes()
 
-        import re
         for cnode in control_nodes:
             node = cnode.node
             path = cnode.path
@@ -1004,8 +1003,6 @@ class XForm(WrappedNode):
         repeat_contexts = sorted(repeat_contexts, reverse=True)
 
         for path, data_node in leaf_data_nodes.iteritems():
-            if re.search(r'fp_reporting.reports', path):
-               import pdb; pdb.set_trace()
             if path not in excluded_paths:
                 bind = self.get_bind(path)
                 try:

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -951,19 +951,21 @@ class XForm(WrappedNode):
         control_nodes = self.get_control_nodes()
         leaf_data_nodes = self.get_leaf_data_nodes()
 
+        import re
         for cnode in control_nodes:
             node = cnode.node
             path = cnode.path
             excluded_paths.add(path)
+
+            repeat = cnode.repeat
+            if repeat is not None:
+                repeat_contexts.add(repeat)
+
             if not cnode.is_leaf and not include_groups:
                 continue
 
             if node.tag_name == 'trigger' and not include_triggers:
                 continue
-
-            repeat = cnode.repeat
-            if repeat is not None:
-                repeat_contexts.add(repeat)
 
             question = {
                 "label": self.get_label_text(node, langs),
@@ -1002,6 +1004,8 @@ class XForm(WrappedNode):
         repeat_contexts = sorted(repeat_contexts, reverse=True)
 
         for path, data_node in leaf_data_nodes.iteritems():
+            if re.search(r'fp_reporting.reports', path):
+               import pdb; pdb.set_trace()
             if path not in excluded_paths:
                 bind = self.get_bind(path)
                 try:


### PR DESCRIPTION
More work on https://manage.dimagi.com/default.asp?262193, it doesn't look like https://github.com/dimagi/commcare-hq/pull/17905 was the only problem.

L10K's app has a group as a the only non-hidden child of a repeat group:

<img width="245" alt="screen shot 2017-09-21 at 2 44 03 pm" src="https://user-images.githubusercontent.com/1486591/30712841-5f8687b6-9edb-11e7-8f26-ce2c200efe70.png">

The form doesn't think it has any repeat contexts, because as `get_questions` cycles through control nodes looking for repeat contexts, when it examines the group, it returns before adding the repeat context.

@snopoke / @nickpell 