### PR TITLE
Diagnosis Test Migration: Include yes_private and filter private patients

### DIFF
--- a/custom/enikshay/management/commands/run_diagnosis_test_migration.py
+++ b/custom/enikshay/management/commands/run_diagnosis_test_migration.py
@@ -7,7 +7,8 @@ from django.core.management import BaseCommand
 
 from casexml.apps.case.mock import CaseFactory
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from custom.enikshay.case_utils import get_occurrence_case_from_episode
+from custom.enikshay.case_utils import get_occurrence_case_from_episode, get_person_case_from_episode
+from custom.enikshay.const import ENROLLED_IN_PRIVATE
 from custom.enikshay.exceptions import ENikshayCaseNotFound, NikshayLocationNotFound
 
 
@@ -55,7 +56,7 @@ class Command(BaseCommand):
                     episode_case = accessor.get_case(episode_case_id)
                     case_properties = episode_case.dynamic_case_properties()
 
-                    if self.should_migrate_case(case_properties):
+                    if self.should_migrate_case(episode_case_id, case_properties, domain):
                         test = self.get_relevant_test_case(domain, episode_case, error_logger)
 
                         if test is not None:
@@ -76,13 +77,22 @@ class Command(BaseCommand):
         print('Migration complete at {}'.format(datetime.datetime.utcnow()))
 
     @staticmethod
-    def should_migrate_case(case_properties):
-        return (
+    def should_migrate_case(case_id, case_properties, domain):
+        if (
             case_properties.get('datamigration_diagnosis_test_information') != 'yes'
             and case_properties.get('episode_type') == 'confirmed_tb'
-            and case_properties.get('treatment_initiated') == 'yes_phi'
             and case_properties.get('diagnosis_test_result_date', '') == ''
-        )
+            and (case_properties.get('treatment_initiated') == 'yes_phi' or
+                 case_properties.get('treatment_initiated') == 'yes_private')
+        ):
+            # Filter and skip private cases
+            try:
+                person = get_person_case_from_episode(domain, case_id)
+            except ENikshayCaseNotFound:
+                return False
+            if person.get_case_property(ENROLLED_IN_PRIVATE) != 'true':
+                return True
+        return False
 
     @staticmethod
     def get_relevant_test_case(domain, episode_case, error_logger):


### PR DESCRIPTION
@nickpell 

Based on feedback from Jordan, this updates the diagnosis test information for patients initiated in private (who were registered in public sector). 