### PR TITLE
Set expected doses taken even if before purge date

### DIFF
--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -494,8 +494,8 @@ class EpisodeAdherenceUpdate(object):
         adherence_schedule_id = self.episode.get_case_property('adherence_schedule_id') or DAILY_SCHEDULE_ID
         doses_per_week = dose_data.get(adherence_schedule_id)
         if not doses_per_week:
-            soft_assert(notify_admins=True)(
-                True,
+            soft_assert('{}@{}'.format('frener', 'dimagi.com'))(
+                False,
                 "No fixture item found with schedule_id {}".format(adherence_schedule_id)
             )
             return 0

--- a/custom/enikshay/tests/test_adherence_updates.py
+++ b/custom/enikshay/tests/test_adherence_updates.py
@@ -242,6 +242,28 @@ class TestAdherenceUpdater(TestCase):
                        for episode in self.case_updater._get_open_episode_cases(case_ids)]
         self.assertEqual(episode_ids, [self.episode_id])
 
+    def test_total_expected_doses_taken(self):
+
+        # adherence_schedule_start after purge
+        self.assert_update(
+            datetime.date(2016, 1, 15), datetime.date(2016, 1, 17), 'schedule1',
+            adherence_cases=[],
+            output={
+                'total_expected_doses_taken': 31,
+            },
+            date_today_in_india=datetime.date(2016, 2, 17),
+        )
+
+        # adherence_schedule_start before purge
+        self.assert_update(
+            datetime.date(2015, 1, 15), datetime.date(2016, 2, 15), 'schedule1',
+            adherence_cases=[],
+            output={
+                'total_expected_doses_taken': 2,
+            },
+            date_today_in_india=datetime.date(2016, 2, 17),
+        )
+
     def test_adherence_schedule_date_start_late(self):
         self.assert_update(
             datetime.date(2016, 1, 15), datetime.date(2016, 1, 17), 'schedule1',


### PR DESCRIPTION
@calellowitz 
I hadn't written this in the spec, but this property needed to be set always, not just when the purge date was passed. 
Also this was using the wrong date (`date.today()` instead of the date in India which led to inconsistencies in the data)

cc: @biyeun 