### PR TITLE
Mk update follow up test and Hiv Test forwarders

### DIFF
--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -122,6 +122,24 @@ def get_open_occurrence_case_from_person(domain, person_case_id):
     return open_occurrence_cases[0]
 
 
+def get_associated_episode_case_for_test(test_case, occurrence_case_id):
+    """
+    get associated episode case set on the test case for new structure
+    fallback to finding the open episode case for old submissions
+    """
+    test_case_properties = test_case.dynamic_case_properties()
+    test_case_episode_id = test_case_properties.get('episode_case_id')
+    if test_case_episode_id:
+        accessor = CaseAccessors(test_case.domain)
+        try:
+            return accessor.get_case(test_case_episode_id)
+        except CaseNotFound:
+            raise ENikshayCaseNotFound("Could not find episode case %s associated with test %s" %
+                                       (test_case_episode_id, test_case.get_id))
+
+    return get_open_episode_case_from_occurrence(test_case.domain, occurrence_case_id)
+
+
 def get_open_episode_case_from_occurrence(domain, occurrence_case_id):
     """
     Gets the first open 'episode' case for the occurrence

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -245,7 +245,7 @@ def get_occurrence_case_from_test(domain, test_case_id):
     """
         Gets the first open occurrence case for a test
         """
-    return get_parent_of_case(domain, test_case_id, CASE_TYPE_OCCURRENCE)
+    return get_first_parent_of_case(domain, test_case_id, CASE_TYPE_OCCURRENCE)
 
 
 @hqnottest

--- a/custom/enikshay/integrations/nikshay/repeater_generator.py
+++ b/custom/enikshay/integrations/nikshay/repeater_generator.py
@@ -25,7 +25,7 @@ from custom.enikshay.case_utils import (
     get_person_locations,
     get_open_episode_case_from_person,
     get_occurrence_case_from_test,
-    get_open_episode_case_from_occurrence,
+    get_associated_episode_case_for_test,
     get_person_case_from_occurrence,
     get_lab_referral_from_test,
     get_occurrence_case_from_episode,
@@ -259,7 +259,7 @@ class NikshayFollowupPayloadGenerator(BaseNikshayPayloadGenerator):
 
     def get_payload(self, repeat_record, test_case):
         occurence_case = get_occurrence_case_from_test(test_case.domain, test_case.get_id)
-        episode_case = get_open_episode_case_from_occurrence(test_case.domain, occurence_case.get_id)
+        episode_case = get_associated_episode_case_for_test(test_case, occurence_case.get_id)
         person_case = get_person_case_from_occurrence(test_case.domain, occurence_case.get_id)
 
         test_case_properties = test_case.dynamic_case_properties()

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -184,20 +184,10 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
         # and episode.nikshay_registered is true
         allowed_case_types_and_users = self._allowed_case_type(test_case) and self._allowed_user(test_case)
         if allowed_case_types_and_users:
-            try:
-                occurence_case = get_occurrence_case_from_test(test_case.domain, test_case.get_id)
-                episode_case = get_open_episode_case_from_occurrence(test_case.domain, occurence_case.get_id)
-            except ENikshayCaseNotFound:
-                return False
             test_case_properties = test_case.dynamic_case_properties()
-            episode_case_properties = episode_case.dynamic_case_properties()
             return (
                 test_case_properties.get('nikshay_registered', 'false') == 'false' and
                 test_case_properties.get('test_type_value', '') in ['microscopy-zn', 'microscopy-fluorescent'] and
-                (  # has a nikshay id already or is a valid submission probably waiting notification
-                    episode_case_properties.get('nikshay_id') or
-                    valid_nikshay_patient_registration(episode_case_properties)
-                ) and
                 (
                     test_case_properties.get('purpose_of_testing') == 'diagnostic' or
                     test_case_properties.get('follow_up_test_reason') in self.followup_for_tests or

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -111,17 +111,7 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
         # InitiatedDate/Art Initiated date changes
         allowed_case_types_and_users = self._allowed_case_type(person_case) and self._allowed_user(person_case)
         if allowed_case_types_and_users:
-            try:
-                episode_case = get_open_episode_case_from_person(person_case.domain, person_case.get_id)
-            except ENikshayCaseNotFound:
-                return False
-            episode_case_properties = episode_case.dynamic_case_properties()
-
             return (
-                (   # has a nikshay id already or is a valid submission probably waiting notification
-                    episode_case_properties.get('nikshay_id') or
-                    valid_nikshay_patient_registration(episode_case_properties)
-                ) and
                 (
                     related_dates_changed(person_case) or
                     person_hiv_status_changed(person_case)

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -799,18 +799,6 @@ class TestNikshayFollowupRepeater(ENikshayLocationStructureMixin, NikshayRepeate
 
         self.factory.create_or_update_cases([self.lab_referral, self.episode])
 
-        # skip if episode case not nikshay registered
-        update_case(self.domain, self.test_id, {"date_reported": datetime.now()})
-        self.assertFalse(check_repeat_record_added())
-
-        update_case(self.domain, self.episode_id, {"nikshay_registered": 'true'})
-
-        # skip if episode case has no nikshay_id
-        update_case(self.domain, self.test_id, {"date_reported": datetime.now()})
-        self.assertFalse(check_repeat_record_added())
-
-        update_case(self.domain, self.episode_id, {"nikshay_id": DUMMY_NIKSHAY_ID})
-
         update_case(self.domain, self.test_id, {"date_reported": datetime.now()})
         self.assertTrue(check_repeat_record_added())
 


### PR DESCRIPTION
1. Skip associated episode related checks when checking for forwarding to avoid silently failing
2. Use associated episode case for tests if available
3. Dont check for open occurrence case for test since its not needed and blocks notifications in case the occurrence has been closed with the same form as submitted for test update, [example case](https://enikshay.in/a/enikshay/reports/case_data/39381ac3-f5fc-4813-8050-0cc93c63937a/#!history?form_id=23242cd1-608b-48ef-8132-d00b8fc8d300)

cc: buddy @esoergel 

best review 🐟 / 🐟 