### PR TITLE
Skip where owner is - but case is yet no closed

### DIFF
--- a/custom/enikshay/ucr/data_sources/test_tasklist_v2.json
+++ b/custom/enikshay/ucr/data_sources/test_tasklist_v2.json
@@ -66,7 +66,8 @@
             "comment": null,
             "property_value": [
               null,
-              ""
+              "",
+              "-"
             ]
           },
           "comment": null,

--- a/custom/enikshay/ucr/data_sources/test_tasklist_v3.json
+++ b/custom/enikshay/ucr/data_sources/test_tasklist_v3.json
@@ -61,7 +61,8 @@
                       "operator": "in",
                       "property_value": [
                           null,
-                          ""
+                          "",
+                          "-"
                       ],
                       "type": "boolean_expression"
                   },


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/311047779/

Possibly the change needed for that error.
v2 is not used anywhere now but looks like the failing indicators are just retrying and failing but still adding that change in v2 as well. 

Note: This would also need a rebuild. Added label for the same

cc: Buddy @esoergel 