### PR TITLE
Fix default media path for first form in module

### DIFF
--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -181,7 +181,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
     menu_host = form or module
     if menu_host:
         default_file_name = 'module%s' % module_id
-        if form_id:
+        if form:
             default_file_name = '%s_form%s' % (default_file_name, form_id)
 
         specific_media = [{


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?262419 and https://manage.dimagi.com/default.asp?262436

The module and its first form were being given the same file path. I looked a bit at recent PRs to see if some other change caused this (thought it might be https://github.com/dimagi/commcare-hq/pull/16962) but didn't find anything...seems that this bug has existed for 2+ years without notice, and then two different projects reported it this weekend. Fascinating.

@nickpell / @biyeun 