### PR TITLE
move SessionDetailsView out of hqadmin

### DIFF
--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -1,20 +1,8 @@
-import base64
-import hashlib
-import hmac
-import json
-
-from django.conf import settings
 from django.http import HttpResponse
 from django.test import SimpleTestCase
-from django.test import TestCase
-from django.test.client import Client
-from django.test.utils import override_settings
-from django.urls.base import reverse
 from mock import patch, Mock
 
 from corehq.apps.hqadmin.views import AdminRestoreView
-from corehq.apps.users.models import CommCareUser
-from corehq.util.test_utils import softer_assert
 
 
 class AdminRestoreViewTests(SimpleTestCase):
@@ -44,69 +32,3 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'num_cases': 0,
                 'num_locations': 0,
             })
-
-
-class SessionDetailsViewTest(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(SessionDetailsViewTest, cls).setUpClass()
-        cls.couch_user = CommCareUser.create('toyland', 'bunkey', '123')
-        cls.sql_user = cls.couch_user.get_django_user()
-
-        client = Client()
-        client.login(username='bunkey', password='123')
-
-        session = client.session
-        session.save()
-        cls.session_key = session.session_key
-
-        cls.url = reverse('session_details')
-
-        cls.expected_response = {
-            u'username': cls.sql_user.username,
-            u'djangoUserId': cls.sql_user.pk,
-            u'superUser': cls.sql_user.is_superuser,
-            u'authToken': None,
-            u'domains': [u'toyland'],
-            u'anonymous': False
-        }
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.couch_user.delete()
-        super(SessionDetailsViewTest, cls).tearDownClass()
-
-    @override_settings(DEBUG=True)
-    @softer_assert()
-    def test_session_details_view(self):
-        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
-        response = Client().post(self.url, data, content_type="application/json")
-        self.assertEqual(200, response.status_code)
-        self.assertJSONEqual(response.content, self.expected_response)
-
-    @override_settings(FORMPLAYER_INTERNAL_AUTH_KEY='123abc', DEBUG=False)
-    def test_with_hmac_signing(self):
-        assert not settings.DEBUG
-        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
-        header_value = base64.b64encode(hmac.new('123abc', data, hashlib.sha256).digest())
-        response = Client().post(
-            self.url,
-            data,
-            content_type="application/json",
-            HTTP_X_MAC_DIGEST=header_value
-        )
-        self.assertEqual(200, response.status_code)
-        self.assertJSONEqual(response.content, self.expected_response)
-
-    @override_settings(FORMPLAYER_INTERNAL_AUTH_KEY='123abc', DEBUG=False)
-    def test_with_hmac_signing_fail(self):
-        assert not settings.DEBUG
-        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
-
-        response = Client().post(
-            self.url,
-            data,
-            content_type="application/json",
-            HTTP_X_MAC_DIGEST='bad signature'
-        )
-        self.assertEqual(401, response.status_code)

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -28,8 +28,8 @@ from corehq.apps.hqadmin.views import (
     system_ajax,
     pillow_operation_api,
     web_user_lookup,
-    top_five_projects_by_country,
-    SessionDetailsView)
+    top_five_projects_by_country)
+
 from corehq.apps.reports.dispatcher import AdminReportDispatcher
 
 from corehq.apps.api.urls import admin_urlpatterns as admin_api_urlpatterns
@@ -73,6 +73,5 @@ urlpatterns = [
         name=ReprocessMessagingCaseUpdatesView.urlname),
     url(r'^top_five_projects_by_country/$', top_five_projects_by_country, name='top_five_projects_by_country'),
     url(r'^web_user_data', WebUserDataView.as_view(), name=WebUserDataView.urlname),
-    url(r'^session_details/', SessionDetailsView.as_view(), name=SessionDetailsView.urlname),
     AdminReportDispatcher.url_pattern(),
 ]

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -25,12 +25,10 @@ from django.http.response import Http404
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_lazy
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import FormView, TemplateView, View
 from lxml import etree
 from lxml.builder import E
-from rest_framework.authtoken.models import Token
 from restkit import Resource
 from restkit.errors import Unauthorized
 
@@ -66,10 +64,9 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import XFormInstanceSQL, CommCareCaseSQL
 from corehq.form_processor.serializers import XFormInstanceSQLRawDocSerializer, \
     CommCareCaseSQLRawDocSerializer
-from corehq.toggles import any_toggle_enabled, SUPPORT, ANONYMOUS_WEB_APPS_USAGE
+from corehq.toggles import any_toggle_enabled, SUPPORT
 from corehq.util import reverse
 from corehq.util.couchdb_management import couch_config
-from corehq.util.hmac_request import validate_request_hmac
 from corehq.util.supervisord.api import (
     PillowtopSupervisorApi,
     SupervisorException,
@@ -97,7 +94,7 @@ from .forms import (
 from .history import get_recent_changes, download_changes
 from .models import HqDeploy
 from .reporting.reports import get_project_spaces, get_stats_data, HISTO_TYPE_TO_FUNC
-from .utils import get_celery_stats, get_django_user_from_session_key
+from .utils import get_celery_stats
 
 
 @require_superuser
@@ -1137,68 +1134,3 @@ class WebUserDataView(View):
             return JsonResponse(data)
         else:
             return HttpResponse('Only web users can access this endpoint', status=400)
-
-
-@method_decorator(csrf_exempt, name='dispatch')
-@method_decorator(validate_request_hmac('FORMPLAYER_INTERNAL_AUTH_KEY', ignore_if_debug=True), name='dispatch')
-class SessionDetailsView(View):
-    """
-    Internal API to allow formplayer to get the Django user ID
-    from the session key.
-
-    Authentication is done by HMAC signing of the request body:
-
-        secret = settings.FORMPLAYER_INTERNAL_AUTH_KEY
-        data = '{"session_id": "123"}'
-        digest = base64.b64encode(hmac.new(secret, data, hashlib.sha256).digest())
-        requests.post(url, data=data, headers={'X-MAC-DIGEST': digest})
-    """
-    urlname = 'session_details'
-    http_method_names = ['post']
-
-    def post(self, request, *args, **kwargs):
-        try:
-            data = json.loads(request.body)
-        except ValueError:
-            return HttpResponseBadRequest()
-
-        if not data or not isinstance(data, dict):
-            return HttpResponseBadRequest()
-
-        session_id = data.get('sessionId', None)
-        domain = data.get('domain', None)
-        if not session_id:
-            return HttpResponseBadRequest()
-
-        auth_token = None
-        anonymous = False
-        user = get_django_user_from_session_key(session_id)
-        if user:
-            couch_user = CouchUser.get_by_username(user.username)
-            if not couch_user:
-                raise Http404
-        elif domain and ANONYMOUS_WEB_APPS_USAGE.enabled(domain):
-            user, couch_user, auth_token = self._get_anonymous_user_details(domain)
-            anonymous = True
-        else:
-            raise Http404
-
-        return JsonResponse({
-            'username': user.username,
-            'djangoUserId': user.pk,
-            'superUser': user.is_superuser,
-            'authToken': auth_token,
-            'domains': couch_user.domains,
-            'anonymous': anonymous
-        })
-
-    def _get_anonymous_user_details(self, domain):
-        couch_user = CouchUser.get_anonymous_mobile_worker(domain)
-        if not couch_user:
-            raise Http404
-        user = couch_user.get_django_user()
-        try:
-            auth_token = user.auth_token.key
-        except Token.DoesNotExist:
-            raise Http404  # anonymous user must have an auth token
-        return user, couch_user, auth_token

--- a/corehq/apps/hqwebapp/session_details_endpoint/tests.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/tests.py
@@ -1,0 +1,75 @@
+import base64
+import hashlib
+import hmac
+import json
+from django.conf import settings
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
+from corehq.apps.users.models import CommCareUser
+from corehq.util.test_utils import softer_assert
+
+
+class SessionDetailsViewTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(SessionDetailsViewTest, cls).setUpClass()
+        cls.couch_user = CommCareUser.create('toyland', 'bunkey', '123')
+        cls.sql_user = cls.couch_user.get_django_user()
+
+        client = Client()
+        client.login(username='bunkey', password='123')
+
+        session = client.session
+        session.save()
+        cls.session_key = session.session_key
+
+        cls.url = reverse('session_details')
+
+        cls.expected_response = {
+            u'username': cls.sql_user.username,
+            u'djangoUserId': cls.sql_user.pk,
+            u'superUser': cls.sql_user.is_superuser,
+            u'authToken': None,
+            u'domains': [u'toyland'],
+            u'anonymous': False
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.couch_user.delete()
+        super(SessionDetailsViewTest, cls).tearDownClass()
+
+    @override_settings(DEBUG=True)
+    @softer_assert()
+    def test_session_details_view(self):
+        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
+        response = Client().post(self.url, data, content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        self.assertJSONEqual(response.content, self.expected_response)
+
+    @override_settings(FORMPLAYER_INTERNAL_AUTH_KEY='123abc', DEBUG=False)
+    def test_with_hmac_signing(self):
+        assert not settings.DEBUG
+        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
+        header_value = base64.b64encode(hmac.new('123abc', data, hashlib.sha256).digest())
+        response = Client().post(
+            self.url,
+            data,
+            content_type="application/json",
+            HTTP_X_MAC_DIGEST=header_value
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertJSONEqual(response.content, self.expected_response)
+
+    @override_settings(FORMPLAYER_INTERNAL_AUTH_KEY='123abc', DEBUG=False)
+    def test_with_hmac_signing_fail(self):
+        assert not settings.DEBUG
+        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
+
+        response = Client().post(
+            self.url,
+            data,
+            content_type="application/json",
+            HTTP_X_MAC_DIGEST='bad signature'
+        )
+        self.assertEqual(401, response.status_code)

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -1,0 +1,75 @@
+import json
+from django.http import HttpResponseBadRequest, Http404, JsonResponse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.authtoken.models import Token
+from corehq.apps.hqadmin.utils import get_django_user_from_session_key
+from corehq.apps.users.models import CouchUser
+from corehq.toggles import ANONYMOUS_WEB_APPS_USAGE
+from corehq.util.hmac_request import validate_request_hmac
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(validate_request_hmac('FORMPLAYER_INTERNAL_AUTH_KEY', ignore_if_debug=True), name='dispatch')
+class SessionDetailsView(View):
+    """
+    Internal API to allow formplayer to get the Django user ID
+    from the session key.
+
+    Authentication is done by HMAC signing of the request body:
+
+        secret = settings.FORMPLAYER_INTERNAL_AUTH_KEY
+        data = '{"session_id": "123"}'
+        digest = base64.b64encode(hmac.new(secret, data, hashlib.sha256).digest())
+        requests.post(url, data=data, headers={'X-MAC-DIGEST': digest})
+    """
+    urlname = 'session_details'
+    http_method_names = ['post']
+
+    def post(self, request, *args, **kwargs):
+        try:
+            data = json.loads(request.body)
+        except ValueError:
+            return HttpResponseBadRequest()
+
+        if not data or not isinstance(data, dict):
+            return HttpResponseBadRequest()
+
+        session_id = data.get('sessionId', None)
+        domain = data.get('domain', None)
+        if not session_id:
+            return HttpResponseBadRequest()
+
+        auth_token = None
+        anonymous = False
+        user = get_django_user_from_session_key(session_id)
+        if user:
+            couch_user = CouchUser.get_by_username(user.username)
+            if not couch_user:
+                raise Http404
+        elif domain and ANONYMOUS_WEB_APPS_USAGE.enabled(domain):
+            user, couch_user, auth_token = self._get_anonymous_user_details(domain)
+            anonymous = True
+        else:
+            raise Http404
+
+        return JsonResponse({
+            'username': user.username,
+            'djangoUserId': user.pk,
+            'superUser': user.is_superuser,
+            'authToken': auth_token,
+            'domains': couch_user.domains,
+            'anonymous': anonymous
+        })
+
+    def _get_anonymous_user_details(self, domain):
+        couch_user = CouchUser.get_anonymous_mobile_worker(domain)
+        if not couch_user:
+            raise Http404
+        user = couch_user.get_django_user()
+        try:
+            auth_token = user.auth_token.key
+        except Token.DoesNotExist:
+            raise Http404  # anonymous user must have an auth token
+        return user, couch_user, auth_token

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -12,6 +12,7 @@ from corehq.apps.hqwebapp.views import (
     yui_crossdomain, password_change, no_permissions, login, logout, bug_report, debug_notify,
     quick_find, osdd, create_alert, activate_alert, deactivate_alert, jserror, dropbox_upload, domain_login,
     retrieve_download, toggles_js, couch_doc_counts, server_up)
+from corehq.apps.hqwebapp.session_details_endpoint.views import SessionDetailsView
 
 urlpatterns = [
     url(r'^$', redirect_to_default),
@@ -44,7 +45,10 @@ urlpatterns = [
     url(r'^account/two_factor/disable/$', TwoFactorDisableView.as_view(), name=TwoFactorDisableView.urlname),
     url(r'^account/two_factor/backup/phone/register/$', TwoFactorPhoneSetupView.as_view(), name=TwoFactorPhoneSetupView.urlname),
     url(r'', include((tf_urls + tf_twilio_urls, 'two_factor'), namespace='two_factor')),
-    url(r'^account/two_factor/new_phone/$', NewPhoneView.as_view(), name=NewPhoneView.urlname)
+    url(r'^account/two_factor/new_phone/$', NewPhoneView.as_view(), name=NewPhoneView.urlname),
+    url(r'^hq/admin/session_details/$', SessionDetailsView.as_view(),
+        name=SessionDetailsView.urlname),
+
 ]
 
 domain_specific = [


### PR DESCRIPTION
All views inside hqadmin are audited by auditcare, so every auth request
from formplayer makes 2 couchdb saves. This change should take 80-200ms off of
every request to formplayer