### PR TITLE
Don't trigger if id_device_number or id_device_body has changed

### DIFF
--- a/custom/enikshay/integrations/bets/repeaters.py
+++ b/custom/enikshay/integrations/bets/repeaters.py
@@ -415,6 +415,10 @@ class BETSUserRepeater(BETSRepeaterMixin, UserRepeater):
             try:
                 previous_payload_json = json.loads(previous_payload)
                 current_payload = get_bets_user_json(user.domain, user)
+                del previous_payload_json['user_data']['id_device_number']
+                del previous_payload_json['user_data']['id_device_body']
+                del current_payload['user_data']['id_device_number']
+                del current_payload['user_data']['id_device_body']
                 if current_payload == previous_payload_json:
                     return False
             except (TypeError, ValueError):

--- a/custom/enikshay/integrations/bets/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/bets/tests/test_repeaters.py
@@ -771,6 +771,16 @@ class UserRepeaterTest(TestCase):
         user.save()
         self.assertEqual(2, len(self.repeat_records().all()))
 
+        record = list(self.repeat_records())[-1]
+        _mock_fire_record(record)
+
+        # updating the id_device_number or id_device_body shouldn't trigger
+        user = CommCareUser.get(user.user_id)
+        user.user_data['id_device_body'] = "AA"
+        user.user_data['id_device_number'] = 1
+        user.save()
+        self.assertEqual(1, len(self.repeat_records().all()))
+
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class LocationRepeaterTest(ENikshayLocationStructureMixin, TestCase):


### PR DESCRIPTION
@esoergel : these change every time someone syncs. I doubt BETS cares about this information, so we can just not trigger if these change. 

cc @biyeun 