### PR TITLE
Let a user search for exact matches by name and locations under specific location

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -344,10 +344,7 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         """
         Takes a set of location ids and returns a django queryset of their children.
         """
-        return self.get_queryset_descendants(
-            self.filter(location_id__in=location_ids),
-            include_self=False
-        ).location_ids()
+        return self.get_children(location_ids).location_ids()
 
     def get_locations_and_children_ids(self, location_ids):
         return list(self.get_locations_and_children(location_ids).location_ids())

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -303,7 +303,7 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         except self.model.DoesNotExist:
             return self.get(domain=domain, name__iexact=user_input)
 
-    def filter_path_by_user_input(self, domain, user_input, from_location_ids=None):
+    def filter_path_by_user_input(self, domain, user_input):
         """
         Returns a queryset including all locations matching the user input
         and their children. This means "Middlesex" will match:
@@ -313,8 +313,6 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         It matches by name or site-code
         """
         direct_matches = self.filter_by_user_input(domain, user_input)
-        if from_location_ids is not None:
-            direct_matches = direct_matches.filter(location_id__in=from_location_ids)
         return self.get_queryset_descendants(direct_matches, include_self=True)
 
     def get_locations(self, location_ids):
@@ -325,20 +323,10 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         Takes a set of location ids and returns a django queryset of those
         locations and their children.
         """
-        return self.get_descendants(location_ids, include_self=True)
-
-    def get_descendants(self, location_ids, include_self=False):
-        """
-        Takes a set of location ids and returns a django queryset of their descendants.
-        :param include_self: include the locations with location_ids in the final queryset as well
-        """
         return self.get_queryset_descendants(
             self.filter(location_id__in=location_ids),
-            include_self=include_self
+            include_self=True
         )
-
-    def get_descendants_ids(self, location_ids):
-        return list(self.get_descendants(location_ids).location_ids())
 
     def get_locations_and_children_ids(self, location_ids):
         return list(self.get_locations_and_children(location_ids).location_ids())

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -330,7 +330,7 @@ class LocationManager(LocationQueriesMixin, TreeManager):
             include_self=True
         )
 
-    def get_children(self, location_ids):
+    def get_descendants(self, location_ids):
         """
         Takes a set of location ids and returns a django queryset of their children.
         """
@@ -339,11 +339,11 @@ class LocationManager(LocationQueriesMixin, TreeManager):
             include_self=False
         )
 
-    def get_children_ids(self, location_ids):
+    def get_descendants_ids(self, location_ids):
         """
         Takes a set of location ids and returns a django queryset of their children.
         """
-        return self.get_children(location_ids).location_ids()
+        return self.get_descendants(location_ids).location_ids()
 
     def get_locations_and_children_ids(self, location_ids):
         return list(self.get_locations_and_children(location_ids).location_ids())

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -295,16 +295,13 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         except self.model.DoesNotExist:
             return self.get(domain=domain, name__iexact=user_input)
 
-    def filter_by_user_input(self, domain, user_input, from_location_ids=None):
+    def filter_by_user_input(self, domain, user_input):
         """
         Accepts partial matches, matches against name and site_code.
         """
-        locations = (self.filter(domain=domain)
-                     .filter(models.Q(name__icontains=user_input) |
-                             models.Q(site_code__icontains=user_input)))
-        if from_location_ids is not None:
-            locations = locations.filter(location_id__in=from_location_ids)
-        return locations
+        return (self.filter(domain=domain)
+                    .filter(models.Q(name__icontains=user_input) |
+                            models.Q(site_code__icontains=user_input)))
 
     def filter_path_by_user_input(self, domain, user_input, from_location_ids=None):
         """
@@ -315,7 +312,9 @@ class LocationManager(LocationQueriesMixin, TreeManager):
             Massachusetts/Middlesex/Cambridge
         It matches by name or site-code
         """
-        direct_matches = self.filter_by_user_input(domain, user_input, from_location_ids)
+        direct_matches = self.filter_by_user_input(domain, user_input)
+        if from_location_ids is not None:
+            direct_matches = direct_matches.filter(location_id__in=from_location_ids)
         return self.get_queryset_descendants(direct_matches, include_self=True)
 
     def get_locations(self, location_ids):

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -325,18 +325,16 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         Takes a set of location ids and returns a django queryset of those
         locations and their children.
         """
-        return self.get_queryset_descendants(
-            self.filter(location_id__in=location_ids),
-            include_self=True
-        )
+        return self.get_descendants(location_ids, include_self=True)
 
-    def get_descendants(self, location_ids):
+    def get_descendants(self, location_ids, include_self=False):
         """
-        Takes a set of location ids and returns a django queryset of their children.
+        Takes a set of location ids and returns a django queryset of their descendants.
+        :param include_self: include the locations with location_ids in the final queryset as well
         """
         return self.get_queryset_descendants(
             self.filter(location_id__in=location_ids),
-            include_self=False
+            include_self=include_self
         )
 
     def get_descendants_ids(self, location_ids):

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -265,6 +265,14 @@ class LocationQueriesMixin(object):
             publish_location_saved(domain, location_id, is_deletion=True)
         return super(LocationQueriesMixin, self).delete(*args, **kwargs)
 
+    def filter_by_user_input(self, domain, user_input):
+        """
+        Accepts partial matches, matches against name and site_code.
+        """
+        return (self.filter(domain=domain)
+                    .filter(models.Q(name__icontains=user_input) |
+                            models.Q(site_code__icontains=user_input)))
+
 
 class LocationQuerySet(LocationQueriesMixin, models.query.QuerySet):
     pass
@@ -294,14 +302,6 @@ class LocationManager(LocationQueriesMixin, TreeManager):
             return self.get(domain=domain, site_code=user_input)
         except self.model.DoesNotExist:
             return self.get(domain=domain, name__iexact=user_input)
-
-    def filter_by_user_input(self, domain, user_input):
-        """
-        Accepts partial matches, matches against name and site_code.
-        """
-        return (self.filter(domain=domain)
-                    .filter(models.Q(name__icontains=user_input) |
-                            models.Q(site_code__icontains=user_input)))
 
     def filter_path_by_user_input(self, domain, user_input, from_location_ids=None):
         """

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -338,10 +338,7 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         )
 
     def get_descendants_ids(self, location_ids):
-        """
-        Takes a set of location ids and returns a django queryset of their children.
-        """
-        return self.get_descendants(location_ids).location_ids()
+        return list(self.get_descendants(location_ids).location_ids())
 
     def get_locations_and_children_ids(self, location_ids):
         return list(self.get_locations_and_children(location_ids).location_ids())

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -157,17 +157,17 @@ class LocationRestrictedEmwfOptionsMixin(object):
     def custom_locations_search(self):
         """
         When the query is specifically searching for just locations and not any other entity like user, group.
-        For ex: enter "/Bihar/patn" would match child locations under locations named Bihar, having name like
+        For ex: enter "Bihar/patn" would match child locations under locations named Bihar, having name like
         patn.
         """
-        return self.q.startswith('/')
+        return '/' in self.q
 
     @staticmethod
     def _get_location_specific_custom_filters(query):
         query_sections = query.split("/")
-        parent_name = query_sections[1]
+        parent_name = query_sections[0]
         try:
-            search_query = query_sections[2]
+            search_query = query_sections[1]
         except IndexError:
             search_query = ""
         return parent_name, search_query

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -175,7 +175,7 @@ class LocationRestrictedEmwfOptionsMixin(object):
     def get_locations_query(self, query):
         if self.custom_locations_search():
             parent_name, search_query = self._get_location_specific_custom_filters(query)
-            parents = SQLLocation.active_objects.filter(name=parent_name)
+            parents = SQLLocation.active_objects.filter(name=parent_name, domain=self.domain)
             if parent_name and parents.count():
                 descendants = SQLLocation.active_objects.get_queryset_descendants(parents, include_self=True)
                 locations = descendants.filter_by_user_input(self.domain, search_query)

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -175,7 +175,7 @@ class LocationRestrictedEmwfOptionsMixin(object):
     def get_locations_query(self, query):
         if self.custom_locations_search():
             parent_name, search_query = self._get_location_specific_custom_filters(query)
-            parents = SQLLocation.active_objects.filter(name=parent_name, domain=self.domain)
+            parents = SQLLocation.active_objects.filter(name__iexact=parent_name, domain=self.domain)
             if parent_name and parents.count():
                 descendants = SQLLocation.active_objects.get_queryset_descendants(parents, include_self=True)
                 locations = descendants.filter_by_user_input(self.domain, search_query)

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -157,17 +157,17 @@ class LocationRestrictedEmwfOptionsMixin(object):
     def custom_locations_search(self):
         """
         When the query is specifically searching for just locations and not any other entity like user, group.
-        For ex: enter "Bihar/patn" would match child locations under locations named Bihar, having name like
+        For ex: enter "/Bihar/patn" would match child locations under locations named Bihar, having name like
         patn.
         """
-        return '/' in self.q
+        return self.q.startswith('/')
 
     @staticmethod
     def _get_location_specific_custom_filters(query):
         query_sections = query.split("/")
-        parent_name = query_sections[0]
+        parent_name = query_sections[1]
         try:
-            search_query = query_sections[1]
+            search_query = query_sections[2]
         except IndexError:
             search_query = ""
         return parent_name, search_query

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -61,8 +61,36 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
             'total': 0,
         })
 
+    def custom_locations_search(self):
+        """
+        When the query is specifically searching for just locations and not any other entity like user, group.
+        For ex: enter "/Bihar/patn" would match child locations under locations named Bihar, having name like
+        patn.
+        """
+        return self.q.startswith('/')
+
+    @staticmethod
+    def _get_location_specific_custom_filters(query):
+        query_sections = query.split("/")
+        parent_name = query_sections[1]
+        try:
+            search_query = query_sections[2]
+        except IndexError:
+            search_query = ""
+        return parent_name, search_query
+
     def get_locations_query(self, query):
-        return SQLLocation.active_objects.filter_path_by_user_input(self.domain, query)
+        if self.custom_locations_search():
+            parent_name, search_query = self._get_location_specific_custom_filters(query)
+            parents = SQLLocation.active_objects.filter(name__iexact=parent_name, domain=self.domain)
+            if parent_name and parents.count():
+                descendants = SQLLocation.active_objects.get_queryset_descendants(parents, include_self=True)
+                locations = descendants.filter_by_user_input(self.domain, search_query)
+            else:
+                return SQLLocation.active_objects.none()
+        else:
+            locations = SQLLocation.active_objects.filter_path_by_user_input(self.domain, query)
+        return locations
 
     def get_locations(self, query, start, size):
         """
@@ -77,6 +105,10 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
 
     @property
     def data_sources(self):
+        # data sources for options for selection in filter
+        # when searcing for custom locations search limit to just locations
+        if self.custom_locations_search():
+            return [(self.get_locations_size, self.get_locations)]
         return [
             (self.get_static_options_size, self.get_static_options),
             (self.get_groups_size, self.get_groups),
@@ -154,35 +186,8 @@ class LocationRestrictedEmwfOptionsMixin(object):
         # extra data sources to be included for filtering
         raise NotImplementedError('Not implemented yet')
 
-    def custom_locations_search(self):
-        """
-        When the query is specifically searching for just locations and not any other entity like user, group.
-        For ex: enter "/Bihar/patn" would match child locations under locations named Bihar, having name like
-        patn.
-        """
-        return self.q.startswith('/')
-
-    @staticmethod
-    def _get_location_specific_custom_filters(query):
-        query_sections = query.split("/")
-        parent_name = query_sections[1]
-        try:
-            search_query = query_sections[2]
-        except IndexError:
-            search_query = ""
-        return parent_name, search_query
-
     def get_locations_query(self, query):
-        if self.custom_locations_search():
-            parent_name, search_query = self._get_location_specific_custom_filters(query)
-            parents = SQLLocation.active_objects.filter(name__iexact=parent_name, domain=self.domain)
-            if parent_name and parents.count():
-                descendants = SQLLocation.active_objects.get_queryset_descendants(parents, include_self=True)
-                locations = descendants.filter_by_user_input(self.domain, search_query)
-            else:
-                return SQLLocation.active_objects.none()
-        else:
-            locations = SQLLocation.active_objects.filter_path_by_user_input(self.domain, query)
+        locations = super(LocationRestrictedEmwfOptionsMixin, self).get_locations_query(query)
         return locations.accessible_to_user(self.request.domain, self.request.couch_user)
 
     def get_users(self, query, start, size):
@@ -203,6 +208,7 @@ class LocationRestrictedEmwfOptionsMixin(object):
     @property
     def data_sources(self):
         # data sources for options for selection in filter
+        # when searcing for custom locations search limit to just locations
         if self.custom_locations_search():
             return [(self.get_locations_size, self.get_locations)]
         sources = []

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -177,7 +177,7 @@ class LocationRestrictedEmwfOptionsMixin(object):
             parent_name, search_query = self._get_location_specific_custom_filters(query)
             parents = SQLLocation.active_objects.filter(name=parent_name)
             if parent_name and parents.count():
-                descendants = SQLLocation.active_objects.get_queryset_descendants(parents)
+                descendants = SQLLocation.active_objects.get_queryset_descendants(parents, include_self=True)
                 locations = descendants.filter_by_user_input(self.domain, search_query)
             else:
                 return SQLLocation.active_objects.none()

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -154,9 +154,41 @@ class LocationRestrictedEmwfOptionsMixin(object):
         # extra data sources to be included for filtering
         raise NotImplementedError('Not implemented yet')
 
+    def custom_locations_search(self):
+        """
+        When the query is specifically for just locations and not any other entity like user, group
+        For ex: enter "/Bihar/patn" would match locations Under locations names Bihar with name like
+        patn.
+        :return:
+        """
+        return self.q.startswith('/')
+
+    @staticmethod
+    def _get_location_specific_custom_filters(query):
+        query_sections = query.split("/")
+        parent_name = query_sections[1]
+        from_location_ids = None
+        try:
+            search_query = query_sections[2]
+        except IndexError:
+            search_query = ""
+        if parent_name:
+            parent_ids = SQLLocation.active_objects.filter(name=parent_name).location_ids()
+            if search_query:
+                from_location_ids = SQLLocation.active_objects.get_children_ids(parent_ids)
+            else:
+                from_location_ids = SQLLocation.active_objects.get_locations_and_children_ids(parent_ids)
+        return from_location_ids, parent_name, search_query
+
     def get_locations_query(self, query):
+        from_location_ids = None
+        if self.custom_locations_search():
+            from_location_ids, parent_name, search_query = self._get_location_specific_custom_filters(query)
+            if not from_location_ids:
+                return SQLLocation.active_objects.none()
+            query = search_query
         return (SQLLocation.active_objects
-                .filter_path_by_user_input(self.domain, query)
+                .filter_path_by_user_input(self.domain, query, from_location_ids)
                 .accessible_to_user(self.request.domain, self.request.couch_user))
 
     def get_users(self, query, start, size):
@@ -177,6 +209,8 @@ class LocationRestrictedEmwfOptionsMixin(object):
     @property
     def data_sources(self):
         # data sources for options for selection in filter
+        if self.custom_locations_search():
+            return [(self.get_locations_size, self.get_locations)]
         sources = []
         if self.request.can_access_all_locations:
             sources.append((self.get_static_options_size, self.get_static_options))

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -174,7 +174,7 @@ class LocationRestrictedEmwfOptionsMixin(object):
         if parent_name:
             parent_ids = SQLLocation.active_objects.filter(name=parent_name).location_ids()
             if search_query:
-                from_location_ids = SQLLocation.active_objects.get_children_ids(parent_ids)
+                from_location_ids = SQLLocation.active_objects.get_descendants_ids(parent_ids)
             else:
                 from_location_ids = SQLLocation.active_objects.get_locations_and_children_ids(parent_ids)
         return from_location_ids, parent_name, search_query

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -64,17 +64,19 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
     def custom_locations_search(self):
         """
         When the query is specifically searching for just locations and not any other entity like user, group.
-        For ex: enter "/Bihar/patn" would match child locations under locations named Bihar, having name like
+        For ex: enter "Bihar"/patn would match child locations under locations named Bihar, having name like
         patn.
         """
-        return self.q.startswith('/')
+        return self.q.startswith('"')
 
     @staticmethod
     def _get_location_specific_custom_filters(query):
         query_sections = query.split("/")
-        parent_name = query_sections[1]
+        # first section would be u'"parent' or u'"parent_name"', so split with " to get
+        # ['', 'parent'] or ['', 'parent_name', '']
+        parent_name = query_sections[0].split('"')[1]
         try:
-            search_query = query_sections[2]
+            search_query = query_sections[1]
         except IndexError:
             search_query = None
         return parent_name, search_query

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -74,11 +74,14 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
         query_sections = query.split("/")
         # first section would be u'"parent' or u'"parent_name"', so split with " to get
         # ['', 'parent'] or ['', 'parent_name', '']
-        parent_name = query_sections[0].split('"')[1]
+        parent_name_section_splits = query_sections[0].split('"')
+        parent_name = parent_name_section_splits[1]
         try:
             search_query = query_sections[1]
         except IndexError:
-            search_query = None
+            # when user has entered u'"parent_name"' without trailing "/"
+            # consider it same as u'"parent_name"/'
+            search_query = "" if len(parent_name_section_splits) == 3 else None
         return parent_name, search_query
 
     def get_locations_query(self, query):

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -175,10 +175,12 @@ class LocationRestrictedEmwfOptionsMixin(object):
     def get_locations_query(self, query):
         if self.custom_locations_search():
             parent_name, search_query = self._get_location_specific_custom_filters(query)
-            query = search_query
             parents = SQLLocation.active_objects.filter(name=parent_name)
-            descendants = SQLLocation.active_objects.get_queryset_descendants(parents)
-            locations = descendants.filter_by_user_input(self.domain, query)
+            if parent_name and parents.count():
+                descendants = SQLLocation.active_objects.get_queryset_descendants(parents)
+                locations = descendants.filter_by_user_input(self.domain, search_query)
+            else:
+                return SQLLocation.active_objects.none()
         else:
             locations = SQLLocation.active_objects.filter_path_by_user_input(self.domain, query)
         return locations.accessible_to_user(self.request.domain, self.request.couch_user)

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -156,10 +156,9 @@ class LocationRestrictedEmwfOptionsMixin(object):
 
     def custom_locations_search(self):
         """
-        When the query is specifically for just locations and not any other entity like user, group
-        For ex: enter "/Bihar/patn" would match locations Under locations names Bihar with name like
+        When the query is specifically searching for just locations and not any other entity like user, group.
+        For ex: enter "/Bihar/patn" would match child locations under locations named Bihar, having name like
         patn.
-        :return:
         """
         return self.q.startswith('/')
 

--- a/corehq/apps/reports/filters/location.py
+++ b/corehq/apps/reports/filters/location.py
@@ -52,6 +52,10 @@ class LocationGroupFilterOptions(EmwfOptionsView):
 
     @property
     def data_sources(self):
+        # data sources for options for selection in filter
+        # when searcing for custom locations search limit to just locations
+        if self.custom_locations_search():
+            return [(self.get_locations_size, self.get_locations)]
         return [
             (self.get_groups_size, self.get_groups),
             (self.get_locations_size, self.get_locations),

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -220,7 +220,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         "Specify groups and users to include in the report")
     is_cacheable = False
     options_url = 'emwf_options'
-    search_help_inline = mark_safe("Quick search a location by using location1/location2 for case insensitive search "
+    search_help_inline = mark_safe("Quick search a location by using /location1/location2 for case insensitive search "
                                    "on parent and fuzzy search on descendants")
 
     @property

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -220,8 +220,12 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         "Specify groups and users to include in the report")
     is_cacheable = False
     options_url = 'emwf_options'
-    search_help_inline = mark_safe("Quick search a location by using /location1/location2 for case insensitive "
-                                   "search on parent and fuzzy search on descendants")
+    search_help_inline = mark_safe(ugettext_lazy(
+        'To quick search for a location, write your query as /parent/descendant. '
+        'For more info, see the '
+        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Location" '
+        'target="_blank">Location Search</a> help page.'
+    ))
 
     @property
     @memoized
@@ -315,7 +319,9 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     def filter_context(self):
         context = super(ExpandedMobileWorkerFilter, self).filter_context
         url = reverse(self.options_url, args=[self.domain])
-        context.update({'endpoint': url, 'search_help_inline': self.search_help_inline})
+        context.update({'endpoint': url})
+        if self.request.project.uses_locations:
+            context.update({'search_help_inline': self.search_help_inline})
         return context
 
     @classmethod

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -223,7 +223,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     search_help_inline = mark_safe(ugettext_lazy(
         'To quick search for a location, write your query as "parent"/descendant. '
         'For more info, see the '
-        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Location" '
+        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" '
         'target="_blank">Location Search</a> help page.'
     ))
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -220,8 +220,8 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         "Specify groups and users to include in the report")
     is_cacheable = False
     options_url = 'emwf_options'
-    search_help_inline = mark_safe("Quick search a location by using /location1/location2 for case insensitive search "
-                                   "on parent and fuzzy search on descendants")
+    search_help_inline = mark_safe("Quick search a location by using /location1/location2 for case insensitive "
+                                   "search on parent and fuzzy search on descendants")
 
     @property
     @memoized

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -221,7 +221,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     is_cacheable = False
     options_url = 'emwf_options'
     search_help_inline = mark_safe(ugettext_lazy(
-        'To quick search for a location, write your query as /parent/descendant. '
+        'To quick search for a location, write your query as "parent"/descendant. '
         'For more info, see the '
         '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Location" '
         'target="_blank">Location Search</a> help page.'

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from django.utils.translation import ugettext as _
 
@@ -219,6 +220,8 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         "Specify groups and users to include in the report")
     is_cacheable = False
     options_url = 'emwf_options'
+    search_help_inline = mark_safe("Quick search a location by using location1/location2 for case insensitive search "
+                                   "on parent and fuzzy search on descendants")
 
     @property
     @memoized
@@ -312,7 +315,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     def filter_context(self):
         context = super(ExpandedMobileWorkerFilter, self).filter_context
         url = reverse(self.options_url, args=[self.domain])
-        context.update({'endpoint': url})
+        context.update({'endpoint': url, 'search_help_inline': self.search_help_inline})
         return context
 
     @classmethod

--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -16,6 +16,12 @@
             placeholder="{{ select.placeholder }}"
             name="{{ slug }}" />
     {% endif %}
+    {% if search_help_inline %}
+        <span class="help-block">
+            <i class="fa fa-info-circle"></i>
+            {{ search_help_inline }}
+        </span>
+    {% endif %}
 {% endblock %}
 {% block filter_js %}
 <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>


### PR DESCRIPTION
Picking this up from conversation on [slack](https://dimagi.slack.com/archives/C0K5U3V2B/p1505979321000263) as a possible workaround for better location searching

In a tree of locations where it can get annoying searching for a location with a specific name,
This lets a user
1. Search for the location with exact match to the name and then also shows all locations under it. This can be done by using "/Massachusetts" or "/Massachusetts/"
2. Search for locations under a specific location with a fuzzy match. This can be useful when there is a long list of child locations "/Massachusetts/Bos" to look for Boston under Massachusetts

[Spec](https://docs.google.com/document/d/1Jh0wPCNk0N0noqrH5c_ZDDDEmmRcwIGNkKzVv0g4ZF4/edit#)