### PR TITLE
Use is distinct from instead of not equal

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -137,11 +137,18 @@ class QuarterFilterValue(FilterValue):
         }
 
 
+class IsDistinctFromFilter(BasicFilter):
+
+    def build_expression(self, table):
+        return get_column(table, self.column_name).is_distinct_from(self.parameter)
+
+
 class NumericFilterValue(FilterValue):
     DBSpecificFilter = namedtuple('DBSpecificFilter', ['sql', 'es'])
     operators_to_filters = {
         '=': DBSpecificFilter(EQFilter, filters.term),
         '!=': DBSpecificFilter(NOTEQFilter, filters.not_term),
+        'distinct from': DBSpecificFilter(IsDistinctFromFilter, filters.not_term),
         '>=': DBSpecificFilter(GTEFilter, lambda field, val: filters.range_filter(field, gte=val)),
         '>': DBSpecificFilter(GTFilter, lambda field, val: filters.range_filter(field, gt=val)),
         '<=': DBSpecificFilter(LTEFilter, lambda field, val: filters.range_filter(field, lte=val)),


### PR DESCRIPTION
@calellowitz @emord 
I ran into an issue when I tried to add the following filter:

```json
  {
    "pre_value": "_invalid_", 
    "datatype": "string", 
    "pre_operator": "!=", 
    "display": null, 
    "field": "person_owner_id", 
    "type": "pre", 
    "slug": "owner_id"
  }
```
This correctly filters out all records with ```person_owner_id = _invalid_``` but as a side effect it also filters out all records with ```person_owner_id = NULL```. It turned out it's correct database behavior for nullable columns.

Postgres doc says:
https://www.postgresql.org/docs/9.4/static/functions-comparison.html
> Ordinary comparison operators yield null (signifying "unknown"), not true or false, when either input is null. For example, 7 = NULL yields null, as does 7 <> NULL. When this behavior is not suitable, use the IS [ NOT ] DISTINCT FROM constructs:

Although it's correct from the DB perspective, it doesn't seem to me like a correct behavior for the end user so my proposition is to change this to IS DISTINCT FROM.

It's pretty urgent for the Enikshay project since we need to add a bunch of filters like this.
