### PR TITLE
How not to do it

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -104,6 +104,10 @@ def basicauth(realm=''):
             response = HttpResponse(status=401)
             response['WWW-Authenticate'] = 'Basic realm="%s"' % realm
             return response
+
+        if hasattr(view, 'is_location_safe'):
+            wrapper.is_location_safe = view.is_location_safe
+            # TODO: ^^^ Nice try. Not good enough. See corehq.apps.domain.decorators
         return wrapper
     return real_decorator
 

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -1,0 +1,47 @@
+from base64 import b64encode
+from django.http import HttpResponse
+from mock import Mock
+from corehq.apps.domain.decorators import basic_auth
+from corehq.apps.locations.permissions import location_safe
+from corehq.apps.users.models import WebUser
+from corehq.apps.locations.tests.util import LocationHierarchyTestCase
+
+
+USERNAME = 'polly'
+PASSWORD = 'the_fjords'
+
+
+@basic_auth
+@location_safe
+def some_view(request, domain):
+    return HttpResponse('Hello Polly!', content_type='text/plain')
+
+
+class BasicAuthTest(LocationHierarchyTestCase):
+    domain = 'petshop'
+    location_type_names = ['city']
+    location_structure = [
+        ('London', []),
+        ('Oslo', []),
+    ]
+
+    def setUp(self):
+        user = WebUser.create(self.domain, USERNAME, PASSWORD)
+        user.eula.signed = True
+        user.save()
+        user.set_location(self.domain, self.locations['London'])
+        self.restrict_user_to_assigned_locations(user)
+
+    def tearDown(self):
+        WebUser.get_by_username(USERNAME).delete()
+
+    def test_basic_auth(self):
+        request = Mock()
+        request.META = {
+            'HTTP_AUTHORIZATION': 'basic ' + b64encode(':'.join((USERNAME, PASSWORD)))
+        }
+        request.domain = self.domain
+        response = some_view(request, self.domain)
+        self.assertTrue(some_view.is_location_safe)
+        self.assertFalse(request.can_access_all_locations)
+        self.assertEqual(response.status_code, 200)

--- a/corehq/apps/locations/middleware.py
+++ b/corehq/apps/locations/middleware.py
@@ -42,6 +42,11 @@ class LocationAccessMiddleware(MiddlewareMixin):
         else:
             request.can_access_all_locations = False
             if not is_location_safe(view_fn, view_args, view_kwargs):
+                # is_location_safe() is returning False because the wrapped (wrapped, wrapped (wrapped?)) view_fn
+                # no longer has is_location_safe attribute set on it.
+                # TODO: Find where it's being dropped, and set it on the wrapper function from the wrapped function
+                #       ^^^ For *every* code path? See corehq.apps.domain.decorators. This doesn't seem like such
+                #       a good idea any more.
                 return location_restricted_response(request)
             elif not user.get_sql_location(domain):
                 return no_permissions(request, message=RESTRICTED_USER_UNASSIGNED_MSG)


### PR DESCRIPTION
Re: [FB 262139](http://manage.dimagi.com/default.asp?262139): "Potential Data Leakage Vulnerability (tt-patient-tracker)"

Figured I'd PR this for the sake of discussion. It seems that checking location safety after basic auth is going to be more painful than I thought, because the `is_location_safe` attribute on the view has been wrapped (and wrapped, and maybe wrapped again). It was late. Maybe I missed something obvious. But last night it seemed like following the code paths through corehq.apps.domain.decorators to find out where the original view function eventually pops out, and setting `is_location_safe` every step of the way, seemed like the wrong approach.

:blowfish: 
