### PR TITLE
fixing consumption download js

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/js/location_bulk_upload_file.js
+++ b/corehq/apps/commtrack/static/commtrack/js/location_bulk_upload_file.js
@@ -16,7 +16,6 @@ $(function () {
             return (
                 self.base_url + "?"
                 + (self.include_consumption() ? "include_consumption=true" : "")
-                + ((self.include_consumption() && self.include_ids()) ? "&" : "")
             );
         });
     }


### PR DESCRIPTION
@esoergel @sravfeyn cc: @gcapalbo 
http://manage.dimagi.com/default.asp?261079#1397638
looks like when we removed the checkbox to download location ids we didnt quite finish cleaning up the js