### PR TITLE
Changed logic of referring_facility_type column

### DIFF
--- a/custom/enikshay/ucr/data_sources/test_2b_v3.json
+++ b/custom/enikshay/ucr/data_sources/test_2b_v3.json
@@ -515,9 +515,16 @@
                 "display_name": null,
                 "datatype": "string",
                 "expression": {
-                    "datatype": null,
-                    "type": "property_name",
-                    "property_name": "referring_facility_type"
+                    "type": "related_doc",
+                    "related_doc_type": "Location",
+                    "doc_id_expression": {
+                        "type": "property_name",
+                        "property_name": "referring_facility_id"
+                    },
+                    "value_expression": {
+                        "type": "property_name",
+                        "property_name": "location_type"
+                    }
                 },
                 "transform": {},
                 "is_primary_key": false,


### PR DESCRIPTION
@proteusvacuum @calellowitz 
This data source isn't used in the live report so we can safely rebuild it.
Could you run rebuild once it's deployed?