### PR TITLE
Rename Expand To/From fields

### DIFF
--- a/corehq/apps/locations/const.py
+++ b/corehq/apps/locations/const.py
@@ -21,6 +21,6 @@ LOCATION_TYPE_SHEET_HEADERS = {
     'do_delete': 'Delete(Y/N)',
     'shares_cases': 'Shares Cases Y/N',
     'view_descendants': 'View Child Cases (Y/N)',
-    'expand_from': 'Expand From',
-    'expand_to': 'Expand To',
+    'expand_from': 'ExpandFrom',
+    'expand_to': 'ExpandTo',
 }


### PR DESCRIPTION
The issue here is that the `WorksheetJSONReader` via `IteratorJSONReader` util takes columns whose name consists of two space-separated words and conslidates them into a list of values. So the values for "Expand To" and "Expand From" in the location uploader were being conslidated into a list for the key "Expand" in the JSON.

This was causing the uploader to think that the Expand From / To values were changing when they were not, and not letting us take advantage of delaying MPTT updates as a result.

I started to make the complex column logic optional with https://github.com/dimagi/commcare-hq/compare/gc/fix-expand-columns, but then realized that the locations importer actually relies on the dictionary consolidation of column values for custom location metadata, which is also handled in the `IteratorJSONReader`.

So to keep this simple, this just renames these columns to be one word so it won't consolidate them into a list of values.

@esoergel @calellowitz 