### PR TITLE
Add commands to deduplicate and send repeat records

### DIFF
--- a/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
@@ -1,0 +1,61 @@
+import csv
+import datetime
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+
+from corehq.util.couch import IterDB
+from corehq.motech.repeaters.const import RECORD_CANCELLED_STATE
+from corehq.motech.repeaters.models import RepeatRecord
+from corehq.motech.repeaters.dbaccessors import iter_repeat_records_by_domain
+
+
+class Command(BaseCommand):
+    help = """
+    If there are multiple cancelled repeat records for a given payload id, this
+    will delete all but one for each payload, reducing the number of requests
+    that must be made.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'domain',
+        )
+        parser.add_argument(
+            'repeater_id',
+        )
+
+    def handle(self, domain, repeater_id, *args, **options):
+        records_by_payload_id = defaultdict(list)
+        records = iter_repeat_records_by_domain(domain, repeater_id=repeater_id, state=RECORD_CANCELLED_STATE)
+        total_records = 0
+        for record in records:
+            records_by_payload_id[record.payload_id].append(record)
+            total_records += 1
+
+        unique_payloads = len(records_by_payload_id)
+        print ("There are {} total records and {} unique payload ids."
+               .format(total_records, unique_payloads))
+        print "Delete {} duplicate records?".format(total_records - unique_payloads)
+        if not raw_input("(y/n)") == 'y':
+            print "Aborting"
+            return
+
+        log = resolve_duplicates(records_by_payload_id)
+        filename = "cancelled_repeat_records-{}.csv".format(datetime.datetime.utcnow().isoformat())
+        print "Writing log of changes to {}".format(filename)
+        with open(filename, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerows(log)
+
+
+def resolve_duplicates(records_by_payload_id):
+    log = [('RepeatRecord ID', 'Payload ID', 'Deleted?')]
+    with IterDB(RepeatRecord.get_db()) as db:
+        for payload_id, records in records_by_payload_id.items():
+            log.append((records[0]._id, payload_id, records[0].failure_reason, 'No'))
+            if len(records) > 1:
+                for record in records[1:]:
+                    db.delete(record)
+                    log.append((record._id, payload_id, record.failure_reason, 'Yes'))
+    return log

--- a/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
@@ -51,11 +51,11 @@ class Command(BaseCommand):
 
 def resolve_duplicates(records_by_payload_id):
     log = [('RepeatRecord ID', 'Payload ID', 'Deleted?')]
-    with IterDB(RepeatRecord.get_db()) as db:
+    with IterDB(RepeatRecord.get_db()) as iter_db:
         for payload_id, records in records_by_payload_id.items():
             log.append((records[0]._id, payload_id, records[0].failure_reason, 'No'))
             if len(records) > 1:
                 for record in records[1:]:
-                    db.delete(record)
+                    iter_db.delete(record)
                     log.append((record._id, payload_id, record.failure_reason, 'Yes'))
     return log

--- a/corehq/motech/repeaters/management/commands/send_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/send_cancelled_records.py
@@ -1,0 +1,85 @@
+import csv
+import datetime
+import re
+import time
+
+from django.core.management.base import BaseCommand
+
+from corehq.motech.repeaters.const import RECORD_CANCELLED_STATE
+from corehq.motech.repeaters.dbaccessors import iter_repeat_records_by_domain
+
+
+class Command(BaseCommand):
+    help = """
+    Send cancelled repeat records. You may optionally specify a regex to
+    filter records using --include or --exclude, an a sleep time with --sleep
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('repeater_id')
+        parser.add_argument(
+            '--include',
+            dest='include_regex',
+            help=("Regex that will be applied to a record's 'failure_reason' to "
+                  "determine whether to include it."),
+        )
+        parser.add_argument(
+            '--exclude',
+            dest='exclude_regex',
+            help=("Regex that will be applied to a record's 'failure_reason' to "
+                  "determine whether to exclude it."),
+        )
+        parser.add_argument(
+            '--sleep',
+            dest='sleep_time',
+            help="Time in seconds to sleep between each request.",
+        )
+
+    def handle(self, domain, repeater_id, *args, **options):
+        sleep_time = options.get('sleep_time')
+        include_regex = options.get('include_regex')
+        exclude_regex = options.get('exclude_regex')
+        if include_regex and exclude_regex:
+            print "You may not specify both include and exclude"
+
+        def meets_filter(record):
+            if include_regex:
+                if not record.failure_reason:
+                    return False
+                return bool(re.search(include_regex, record.failure_reason))
+            elif exclude_regex:
+                if not record.failure_reason:
+                    return True
+                return not bool(re.search(exclude_regex, record.failure_reason))
+            return True  # No filter applied
+
+        records = filter(
+            meets_filter,
+            iter_repeat_records_by_domain(domain, repeater_id=repeater_id, state=RECORD_CANCELLED_STATE)
+        )
+
+        total_records = len(records)
+        print "Found {} matching records.  Requeue them?".format(total_records)
+        if not raw_input("(y/n)") == 'y':
+            print "Aborting"
+            return
+
+        log = [('record_id', 'payload_id', 'state', 'failure_reason')]
+        for i, record in enumerate(records):
+            try:
+                record.fire(force_send=True)
+            except Exception as e:
+                print "{}/{}: {} {}".format(i, total_records, 'EXCEPTION', repr(e))
+                log.append((record._id, record.payload_id, record.state, repr(e)))
+            else:
+                print "{}/{}: {}".format(i, total_records, record.state)
+                log.append((record._id, record.payload_id, record.state, record.failure_reason))
+            if sleep_time:
+                time.sleep(float(sleep_time))
+
+        filename = "sent_repeat_records-{}.csv".format(datetime.datetime.utcnow().isoformat())
+        print "Writing log of changes to {}".format(filename)
+        with open(filename, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerows(log)

--- a/corehq/motech/repeaters/management/commands/send_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/send_cancelled_records.py
@@ -65,24 +65,24 @@ class Command(BaseCommand):
             print "Aborting"
             return
 
-        log = [('record_id', 'payload_id', 'state', 'failure_reason')]
-        for i, record in enumerate(records):
-            try:
-                if record.next_check is None:
-                    record.next_check = datetime.datetime.utcnow()
-                record.fire(force_send=True)
-            except Exception as e:
-                print "{}/{}: {} {}".format(i, total_records, 'EXCEPTION', repr(e))
-                log.append((record._id, record.payload_id, record.state, repr(e)))
-            else:
-                print "{}/{}: {}".format(i, total_records, record.state)
-                log.append((record._id, record.payload_id, record.state, record.failure_reason))
-            if sleep_time:
-                time.sleep(float(sleep_time))
-
         filename = "sent_repeat_records-{}.csv".format(
             datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M.%S'))
-        print "Writing log of changes to {}".format(filename)
         with open(filename, 'w') as f:
             writer = csv.writer(f)
-            writer.writerows(log)
+            writer.writerow(('record_id', 'payload_id', 'state', 'failure_reason'))
+
+            for i, record in enumerate(records):
+                try:
+                    if record.next_check is None:
+                        record.next_check = datetime.datetime.utcnow()
+                    record.fire(force_send=True)
+                except Exception as e:
+                    print "{}/{}: {} {}".format(i, total_records, 'EXCEPTION', repr(e))
+                    writer.writerow((record._id, record.payload_id, record.state, repr(e)))
+                else:
+                    print "{}/{}: {}".format(i, total_records, record.state)
+                    writer.writerow((record._id, record.payload_id, record.state, record.failure_reason))
+                if sleep_time:
+                    time.sleep(float(sleep_time))
+
+        print "Wrote log of changes to {}".format(filename)

--- a/corehq/motech/repeaters/management/commands/send_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/send_cancelled_records.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         )
 
         total_records = len(records)
-        print "Found {} matching records.  Requeue them?".format(total_records)
+        print "Found {} matching records.  Send them?".format(total_records)
         if not raw_input("(y/n)") == 'y':
             print "Aborting"
             return
@@ -68,6 +68,8 @@ class Command(BaseCommand):
         log = [('record_id', 'payload_id', 'state', 'failure_reason')]
         for i, record in enumerate(records):
             try:
+                if record.next_check is None:
+                    record.next_check = datetime.datetime.utcnow()
                 record.fire(force_send=True)
             except Exception as e:
                 print "{}/{}: {} {}".format(i, total_records, 'EXCEPTION', repr(e))
@@ -78,7 +80,8 @@ class Command(BaseCommand):
             if sleep_time:
                 time.sleep(float(sleep_time))
 
-        filename = "sent_repeat_records-{}.csv".format(datetime.datetime.utcnow().isoformat())
+        filename = "sent_repeat_records-{}.csv".format(
+            datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M.%S'))
         print "Writing log of changes to {}".format(filename)
         with open(filename, 'w') as f:
             writer = csv.writer(f)


### PR DESCRIPTION
@proteusvacuum @dannyroberts
Thoughts on the general approach here?  I discussed the deduplication with Danny yesterday and we could also use an approach which doesn't delete any records of attempts, such as either save to another bucket that's not "CANCELLED", or to add those attempts to the repeat record that we'll be keeping.  I'm not sure either gives us much actual value, so I decided to keep it simple unless someone makes a case for keeping them.

buddy: @mkangia