### PR TITLE
remove es_scroll metrics

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -288,10 +288,6 @@ def scan(client, query=None, scroll='5m', **kwargs):
 
             start = int(time.time() * 1000)
             resp = client.scroll(scroll_id, scroll=scroll)
-            datadog_histogram('commcare.es_scroll', (time.time() * 1000) - start, tags=[
-                u'iteration:{}'.format(iteration),
-            ])
-
             for hit in resp['hits']['hits']:
                 yield hit
 


### PR DESCRIPTION
I don't think this is being used and it's generating a lot of metrics:

![image](https://user-images.githubusercontent.com/249606/30956777-9cf983b6-a438-11e7-9f84-ce9c2a681155.png)
