### PR TITLE
Fix ICDS web apps link

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -47,6 +47,21 @@ def get_latest_released_app(domain, app_id):
     return None
 
 
+def get_latest_released_build_id(domain, app_id):
+    """Get the latest starred build id for an application"""
+    from .models import Application
+    key = ['^ReleasedApplications', domain, app_id]
+    app = Application.get_db().view(
+        'app_manager/applications',
+        startkey=key + [{}],
+        endkey=key,
+        descending=True,
+        include_docs=False,
+        limit=1,
+    ).first()
+    return app['id'] if app else None
+
+
 def _get_latest_build_view(domain, app_id, include_docs):
     from .models import Application
     return Application.get_db().view(

--- a/custom/icds_reports/const.py
+++ b/custom/icds_reports/const.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-APP_ID = '361a135293a84427afc947beee1acdfe'
+APP_ID = '48cc1709b7f62ffea24cc6634a005734'
 
 
 TABLEAU_TICKET_URL = settings.TABLEAU_URL_ROOT + "trusted/"

--- a/custom/icds_reports/utils.py
+++ b/custom/icds_reports/utils.py
@@ -7,12 +7,14 @@ import operator
 
 from django.template.loader import render_to_string
 
+from corehq.apps.app_manager.dbaccessors import get_latest_released_build_id
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.reports.datatables import DataTablesColumn
 from corehq.apps.reports_core.filters import Choice
 from corehq.apps.userreports.models import StaticReportConfiguration
 from corehq.apps.userreports.reports.factory import ReportFactory
-from custom.icds_reports.const import LocationTypes
+from corehq.util.quickcache import quickcache
+from custom.icds_reports.const import LocationTypes, APP_ID
 from custom.icds_reports.queries import get_test_state_locations_id
 from dimagi.utils.dates import DateSpan
 
@@ -283,3 +285,8 @@ def get_location_filter(location, domain, config):
         except SQLLocation.DoesNotExist:
             pass
     return loc_level
+
+
+@quickcache([])
+def get_latest_issue_tracker_build_id():
+    return get_latest_released_build_id('icds-cas', APP_ID)

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -20,7 +20,7 @@ from corehq.apps.locations.permissions import location_safe, user_can_access_loc
 from corehq.apps.locations.util import location_hierarchy_config
 from corehq.apps.hqwebapp.decorators import use_daterangepicker
 from corehq.apps.users.models import Permissions, UserRole
-from custom.icds_reports.const import LocationTypes, APP_ID, BHD_ROLE
+from custom.icds_reports.const import LocationTypes, BHD_ROLE
 from custom.icds_reports.filters import CasteFilter, MinorityFilter, DisabledFilter, \
     ResidentFilter, MaternalStatusFilter, ChildAgeFilter, THRBeneficiaryType, ICDSMonthFilter, \
     TableauLocationFilter, ICDSYearFilter
@@ -79,7 +79,8 @@ from custom.icds_reports.reports.registered_household import get_registered_hous
 from custom.icds_reports.sqldata import ChildrenExport, ProgressReport, PregnantWomenExport, \
     DemographicsExport, SystemUsageExport, AWCInfrastructureExport, BeneficiaryExport
 from custom.icds_reports.tasks import move_ucr_data_into_aggregation_tables
-from custom.icds_reports.utils import get_age_filter, get_location_filter
+from custom.icds_reports.utils import get_age_filter, get_location_filter, \
+    get_latest_issue_tracker_build_id
 from dimagi.utils.dates import force_to_date
 from . import const
 from .exceptions import TableauTokenException
@@ -235,7 +236,10 @@ class DashboardView(TemplateView):
         )
 
         if is_commcare_user or is_web_user_with_edit_data_permissions:
-            kwargs['report_an_issue_url'] = webapps_url(domain=self.domain, app_id=APP_ID, module_id=0, form_id=0)
+            build_id = get_latest_issue_tracker_build_id()
+            kwargs['report_an_issue_url'] = webapps_url(
+                domain=self.domain, app_id=build_id, module_id=0, form_id=0
+            )
         return super(DashboardView, self).get_context_data(**kwargs)
 
 


### PR DESCRIPTION
The dashboard is supposed to link to web apps. Before we were using an old build id which broke when upgrading that app.

This will get the latest released build id for the issue tracker app.

buddies @gcapalbo @calellowitz 