### PR TITLE
Search All Cases: Match exact and then fuzzy

### DIFF
--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -120,6 +120,28 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
                                                     "match": {
                                                         "case_properties.value": {
                                                             "query": "polly",
+                                                            "fuzziness": "0"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "case_properties",
+                                        "query": {
+                                            "filtered": {
+                                                "filter": {
+                                                    "term": {
+                                                        "case_properties.key": "parrot_name"
+                                                    }
+                                                },
+                                                "query": {
+                                                    "match": {
+                                                        "case_properties.value": {
+                                                            "query": "polly",
                                                             "fuzziness": "AUTO"
                                                         }
                                                     }

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -103,6 +103,28 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
                                             }
                                         }
                                     }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "case_properties",
+                                        "query": {
+                                            "filtered": {
+                                                "filter": {
+                                                    "term": {
+                                                        "case_properties.key": "parrot_name"
+                                                    }
+                                                },
+                                                "query": {
+                                                    "match": {
+                                                        "case_properties.value": {
+                                                            "query": "polly",
+                                                            "fuzziness": "AUTO"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             ],
                             "should": [
@@ -121,28 +143,6 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
                                                         "case_properties.value": {
                                                             "query": "polly",
                                                             "fuzziness": "0"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "nested": {
-                                        "path": "case_properties",
-                                        "query": {
-                                            "filtered": {
-                                                "filter": {
-                                                    "term": {
-                                                        "case_properties.key": "parrot_name"
-                                                    }
-                                                },
-                                                "query": {
-                                                    "match": {
-                                                        "case_properties.value": {
-                                                            "query": "polly",
-                                                            "fuzziness": "AUTO"
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
Context: [FB 261367](https://manage.dimagi.com/default.asp?261367)

Preserves current behaviour for non-fuzzy searches. For fuzzy searches, uses a "should" clause instead of a "must" clause, and searches for exact matches before fuzzy matches.

You can see the new query for fuzzy searches in the [Update test](1523a0b) commit.

**DISCLAIMER**: I did NOT repro the original issue. I am relying on unit tests to prove that this change does what it is meant to do. Feel free to tell me to go back and do more homework. :grimacing: 

@proteusvacuum @esoergel cc @dannyroberts 