### PR TITLE
Externalize js: global notifications

### DIFF
--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -133,7 +133,7 @@ hqDefine('notifications/js/notifications_service', function () {
         $(document).on('click', '.notification-link', function() {
             ga_track_event('Notification', 'Opened Message', this.href);
         });
-        window.analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
+        window.analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon');
     });
 
     return module;

--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -129,6 +129,11 @@ hqDefine('notifications/js/notifications_service', function () {
         notifications.setRMI(hqImport('hqwebapp/js/initial_page_data').reverse('notifications_service'), csrfToken);
         notifications.initService('#js-settingsmenu-notifications');
         notifications.initUINotify('.alert-ui-notify');
+
+        $(document).on('click', '.notification-link', function() {
+            ga_track_event('Notification', 'Opened Message', this.href);
+        });
+        window.analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
     });
 
     return module;

--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -1,12 +1,4 @@
 {% load i18n %}
-<script>
-    $(function() {
-        $('#notification-link').click(function() {
-            ga_track_event('Notification', 'Opened Message', this.href);
-        });
-        window.analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
-    });
-</script>
 <li id="js-settingsmenu-notifications" class="dropdown">
     <a href="#" data-bind="click: bellClickHandler" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown" id="notification-icon">
         <i class="icon-bell-alt fa fa-bell nav-main-icon"
@@ -24,7 +16,7 @@
                 'notifications-info': isInfo(),
                 'notifications-unread': !isRead()
             }">
-            <a data-bind="attr: {href: url}, click: markAsRead" class="clearfix" target="_blank" id="notification-link">
+            <a data-bind="attr: {href: url}, click: markAsRead" class="clearfix notification-link" target="_blank">
                 <span class="notifications-icon">
                     <i class="notifications-type fa"
                        data-bind="css: {


### PR DESCRIPTION
This doesn't fire on all links if there are multiple; `$("#notification-link")` will only return one element. It also attaches the event to the empty template version of `#notification-link` - at least some of the time, might depend on what order ready handlers load in - and never fire.

@calellowitz / @nickpell 