### PR TITLE
Replace Nones with blank string

### DIFF
--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -259,10 +259,15 @@ class OnDiskExportWriter(ExportWriter):
 
     def _write_row(self, sheet_index, row):
 
-        def _encode_if_needed(val):
-            return val.encode("utf8") if isinstance(val, unicode) else val
-        row = map(_encode_if_needed, row)
+        def _transform(val):
+            if isinstance(val, unicode):
+                return val.encode("utf8")
+            elif val is None:
+                return ''
+            else:
+                return val
 
+        row = map(_transform, row)
         self.tables[sheet_index].write_row(row)
 
     def _close(self):


### PR DESCRIPTION
`None` was being rendered as `"None"` in emailed reports. Context: [FB 262316](https://manage.dimagi.com/default.asp?262316)

@gcapalbo cc @dannyroberts 