### PR TITLE
Small refactor

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -575,9 +575,11 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
         with os.fdopen(fd, 'wb') as temp:
             export_from_tables(self.export_table, temp, Format.HTML)
         with open(path) as f:
-            return HttpResponse(json.dumps({
-                'report': f.read(),
-            }))
+            html = f.read()
+        os.unlink(path)
+        return HttpResponse(json.dumps({
+            'report': html,
+        }))
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 from StringIO import StringIO
-from contextlib import contextmanager
+from contextlib import contextmanager, closing
 from datetime import datetime
 
 import pytz
@@ -571,15 +571,11 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def email_response(self):
-        fd, path = tempfile.mkstemp()
-        with os.fdopen(fd, 'wb') as temp:
+        with closing(StringIO()) as temp:
             export_from_tables(self.export_table, temp, Format.HTML)
-        with open(path) as f:
-            html = f.read()
-        os.unlink(path)
-        return HttpResponse(json.dumps({
-            'report': html,
-        }))
+            return self.render_json_response({
+                'report': temp.getvalue(),
+            })
 
     @property
     @memoized

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -259,10 +259,15 @@ class OnDiskExportWriter(ExportWriter):
 
     def _write_row(self, sheet_index, row):
 
-        def _encode_if_needed(val):
-            return val.encode("utf8") if isinstance(val, unicode) else val
-        row = map(_encode_if_needed, row)
+        def _transform(val):
+            if isinstance(val, unicode):
+                return val.encode("utf8")
+            elif val is None:
+                return ''
+            else:
+                return val
 
+        row = map(_transform, row)
         self.tables[sheet_index].write_row(row)
 
     def _close(self):


### PR DESCRIPTION
Small refactor to not use a temp file (considering we were reading it into memory anyway) and to set the content type to match the content. 

Builds on #18021 (only the last two commits are in this branch).

:blowfish: if you'd like to follow my thought process, although only the last commit is relevant.
