### PR TITLE
get the new associated case if available

### DIFF
--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -125,10 +125,16 @@ def get_open_occurrence_case_from_person(domain, person_case_id):
 def get_associated_episode_case_for_test(test_case, occurrence_case_id):
     """
     get associated episode case set on the test case for new structure
-    fallback to finding the open episode case for old submissions
+    if has a new_episode_id (for diagnostic -> confirmed_tb or dstb -> drtb episode transition)
+        return that episode which should be a confirmed_tb/confirmed_drtb case
+    elif has a episode_case_id (for follow up test cases)
+        return the associated episode case only
+        which should be a confirmed_tb/confirmed_drtb case
+    else
+        fallback to finding the open confirmed tb episode case
     """
     test_case_properties = test_case.dynamic_case_properties()
-    test_case_episode_id = test_case_properties.get('episode_case_id')
+    test_case_episode_id = test_case_properties.get('new_episode_case_id') or test_case_properties.get('episode_case_id')
     if test_case_episode_id:
         accessor = CaseAccessors(test_case.domain)
         try:

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -134,7 +134,10 @@ def get_associated_episode_case_for_test(test_case, occurrence_case_id):
         fallback to finding the open confirmed tb episode case
     """
     test_case_properties = test_case.dynamic_case_properties()
-    test_case_episode_id = test_case_properties.get('new_episode_case_id') or test_case_properties.get('episode_case_id')
+    test_case_episode_id = (
+        test_case_properties.get('new_episode_case_id')
+        or test_case_properties.get('episode_case_id')
+    )
     if test_case_episode_id:
         accessor = CaseAccessors(test_case.domain)
         try:

--- a/custom/enikshay/integrations/nikshay/repeater_generator.py
+++ b/custom/enikshay/integrations/nikshay/repeater_generator.py
@@ -96,11 +96,9 @@ class BaseNikshayPayloadGenerator(BasePayloadGenerator):
             "IP_FROM": server_ip,
         }
 
-    def use_2b_app_structure(self, person_case, episode_case):
-        return (
-            episode_case.dynamic_case_properties().get('episode_type') == DSTB_EPISODE_TYPE and
-            person_case.dynamic_case_properties().get('case_version') == PERSON_CASE_2B_VERSION
-        )
+    @staticmethod
+    def use_2b_app_structure(person_case):
+        return person_case.dynamic_case_properties().get('case_version') == PERSON_CASE_2B_VERSION
 
 
 class NikshayRegisterPatientPayloadGenerator(BaseNikshayPayloadGenerator):
@@ -114,7 +112,7 @@ class NikshayRegisterPatientPayloadGenerator(BaseNikshayPayloadGenerator):
         episode_case_properties = episode_case.dynamic_case_properties()
         person_case_properties = person_case.dynamic_case_properties()
         occurence_case = None
-        use_2b_app_structure = self.use_2b_app_structure(person_case, episode_case)
+        use_2b_app_structure = self.use_2b_app_structure(person_case)
         if use_2b_app_structure:
             occurence_case = get_occurrence_case_from_episode(episode_case.domain, episode_case.get_id)
         properties_dict = self._base_properties(repeat_record)
@@ -264,7 +262,7 @@ class NikshayFollowupPayloadGenerator(BaseNikshayPayloadGenerator):
 
         test_case_properties = test_case.dynamic_case_properties()
         episode_case_properties = episode_case.dynamic_case_properties()
-        use_2b_app_structure = self.use_2b_app_structure(person_case, episode_case)
+        use_2b_app_structure = self.use_2b_app_structure(person_case)
 
         interval_id, lab_serial_number, result_grade, dmc_code = self._get_mandatory_fields(
             test_case, test_case_properties, occurence_case,


### PR DESCRIPTION
So the app keeps two episode cases on it
1. Current episode case
2. New confirmed episode case that is added because the test is positive.

Making this change for follow up repeater where we notify nikshay about the diagnostic test done for the episode. So considering that all diagnostic episode cases will have a new episode case id set when it would result in a confirmed tb. For all other test cases which are follow up tests should be associated with current test case only.

Also sneaking in a fix for checking if to use 2b structure. For some reason it was checking for episode type as well but that should not be needed.

Note: Retrigger all failed notifications with error 
`Value missing for intervalID, purpose_of_testing: None, follow_up_test_reason: None`