### PR TITLE
New data source for CC Outbound report

### DIFF
--- a/custom/enikshay/ucr/data_sources/episode_for_cc_outbound.json
+++ b/custom/enikshay/ucr/data_sources/episode_for_cc_outbound.json
@@ -1,0 +1,370 @@
+{
+    "domains": [
+        "enikshay",
+        "enikshay-performance-test"
+    ],
+    "server_environment": [
+        "enikshay"
+    ],
+    "config": {
+        "referenced_doc_type": "CommCareCase",
+        "asynchronous": true,
+        "engine_id": "ucr",
+        "description": "",
+        "base_item_expression": {
+        },
+        "table_id": "episode_for_cc_outbound",
+        "display_name": "Episode for CC Outbound",
+        "configured_filter": {
+            "type": "and",
+            "filters": [
+                {
+                    "operator": "eq",
+                    "expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "type"
+                    },
+                    "type": "boolean_expression",
+                    "property_value": "episode"
+                }
+            ]
+        },
+        "configured_indicators": [
+            {
+                "display_name": "person/name",
+                "datatype": "string",
+                "type": "expression",
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "name"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "column_id": "person_name"
+            },
+            {
+                "display_name": "person/person_id",
+                "datatype": "string",
+                "type": "expression",
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "person_id"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "column_id": "person_id_property"
+            },
+            {
+                "display_name": "priority",
+                "column_id": "priority",
+                "datatype": "string",
+                "type": "expression",
+                "expression":{
+                    "type": "property_name",
+                    "property_name": "priority"
+                }
+            },
+            {
+                "display_name": "date_last_refilled",
+                "column_id": "date_last_refilled",
+                "datatype": "date",
+                "type": "expression",
+                "expression":{
+                    "type": "property_name",
+                    "property_name": "date_last_refilled"
+                }
+            },
+            {
+                "display_name": "one_week_adherence_score",
+                "column_id": "one_week_adherence_score",
+                "datatype": "string",
+                "type": "expression",
+                "expression":{
+                    "type": "property_name",
+                    "property_name": "one_week_adherence_score"
+                }
+            },
+            {
+                "display_name": "month_adherence_score",
+                "column_id": "month_adherence_score",
+                "datatype": "string",
+                "type": "expression",
+                "expression":{
+                    "type": "property_name",
+                    "property_name": "month_adherence_score"
+                }
+            },
+            {
+                "display_name": "person/mobile_number",
+                "datatype": "string",
+                "type": "expression",
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "phone_number"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "column_id": "mobile_number"
+            },
+            {
+                "display_name": "adherence_tracking_mechanism",
+                "column_id": "adherence_tracking_mechanism",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "adherence_tracking_mechanism"
+                }
+            },
+            {
+                "display_name": "episode_info_freetext",
+                "column_id": "episode_info_freetext",
+                "datatype": "string",
+                "type": "expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "episode_info_freetext"
+                }
+            },
+            {
+                "display_name": "person/sex",
+                "datatype": "string",
+                "type": "expression",
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "sex"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "column_id": "sex"
+            },
+            {
+                "display_name": "person/age",
+                "datatype": "integer",
+                "type": "expression",
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "type": "named",
+                    "name": "age"
+                },
+                "column_id": "age"
+            },
+            {
+                "display_name": "person/current_address",
+                "datatype": "string",
+                "type": "expression",
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "value_expression": {
+                        "datatype": "string",
+                        "type": "property_name",
+                        "property_name": "current_address"
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "column_id": "current_address"
+            },
+            {
+                "display_name": "person/owner_id",
+                "datatype": "string",
+                "type": "expression",
+                "create_index": true,
+                "is_primary_key": false,
+                "transform": {
+                },
+                "is_nullable": true,
+                "expression": {
+                    "value_expression": {
+                        "type": "conditional",
+                        "test": {
+                            "operator": "eq",
+                            "expression": {
+                                "type": "property_name",
+                                "property_name": "owner_id"
+                            },
+                            "type": "boolean_expression",
+                            "property_value": "_archive_"
+                        },
+                        "expression_if_true": {
+                            "type": "property_name",
+                            "property_name": "last_owner"
+                        },
+                        "expression_if_false": {
+                            "type": "property_name",
+                            "property_name": "owner_id"
+                        }
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "datatype": null,
+                        "type": "named",
+                        "name": "person_id"
+                    }
+                },
+                "column_id": "person_owner_id"
+            }
+        ],
+        "named_filters": {},
+        "named_expressions": {
+            "person_id": {
+                "value_expression": {
+                    "type": "nested",
+                    "value_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "referenced_id"
+                    },
+                    "argument_expression": {
+                        "type": "array_index",
+                        "array_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "indices"
+                        },
+                        "index_expression": {
+                            "type": "constant",
+                            "constant": 0
+                        }
+                    }
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                    "value_expression": {
+                        "datatype": null,
+                        "type": "property_name",
+                        "property_name": "referenced_id"
+                    },
+                    "type": "nested",
+                    "argument_expression": {
+                        "type": "array_index",
+                        "array_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "indices"
+                        },
+                        "index_expression": {
+                            "type": "constant",
+                            "constant": 0
+                        }
+                    }
+                }
+            },
+            "age": {
+                "value_expression": {
+                    "datatype": "integer",
+                    "type": "property_name",
+                    "property_name": "age"
+                },
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                    "value_expression": {
+                        "type": "nested",
+                        "value_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "referenced_id"
+                        },
+                        "argument_expression": {
+                            "type": "array_index",
+                            "array_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "indices"
+                            },
+                            "index_expression": {
+                                "type": "constant",
+                                "constant": 0
+                            }
+                        }
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareCase",
+                    "doc_id_expression": {
+                        "value_expression": {
+                            "datatype": null,
+                            "type": "property_name",
+                            "property_name": "referenced_id"
+                        },
+                        "type": "nested",
+                        "argument_expression": {
+                            "type": "array_index",
+                            "array_expression": {
+                                "datatype": null,
+                                "type": "property_name",
+                                "property_name": "indices"
+                            },
+                            "index_expression": {
+                                "type": "constant",
+                                "constant": 0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom/enikshay/ucr/data_sources/episode_for_cc_outbound.json
+++ b/custom/enikshay/ucr/data_sources/episode_for_cc_outbound.json
@@ -16,19 +16,14 @@
         "table_id": "episode_for_cc_outbound",
         "display_name": "Episode for CC Outbound",
         "configured_filter": {
-            "type": "and",
-            "filters": [
-                {
-                    "operator": "eq",
-                    "expression": {
-                        "datatype": null,
-                        "type": "property_name",
-                        "property_name": "type"
-                    },
-                    "type": "boolean_expression",
-                    "property_value": "episode"
-                }
-            ]
+            "operator": "eq",
+            "expression": {
+                "datatype": null,
+                "type": "property_name",
+                "property_name": "type"
+            },
+            "type": "boolean_expression",
+            "property_value": "episode"
         },
         "configured_indicators": [
             {
@@ -279,7 +274,7 @@
                     "argument_expression": {
                         "type": "array_index",
                         "array_expression": {
-                            "datatype": null,
+                            "datatype": "array",
                             "type": "property_name",
                             "property_name": "indices"
                         },
@@ -301,7 +296,7 @@
                     "argument_expression": {
                         "type": "array_index",
                         "array_expression": {
-                            "datatype": null,
+                            "datatype": "array",
                             "type": "property_name",
                             "property_name": "indices"
                         },
@@ -331,7 +326,7 @@
                         "argument_expression": {
                             "type": "array_index",
                             "array_expression": {
-                                "datatype": null,
+                                "datatype": "array",
                                 "type": "property_name",
                                 "property_name": "indices"
                             },
@@ -353,7 +348,7 @@
                         "argument_expression": {
                             "type": "array_index",
                             "array_expression": {
-                                "datatype": null,
+                                "datatype": "array",
                                 "type": "property_name",
                                 "property_name": "indices"
                             },

--- a/settings.py
+++ b/settings.py
@@ -1951,6 +1951,7 @@ STATIC_DATA_SOURCES = [
 
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'adherence.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode.json'),
+    os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_for_cc_outbound.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_v2.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_2b.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_2b_v2.json'),


### PR DESCRIPTION
CC outbound originally uses episode data source for 1.0 app which is really huge. I think there is no point to copy whole old episode data source, I only copied fields that are needed in the report.

@calellowitz 