### PR TITLE
Decrease blob db access on restore

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -510,7 +510,7 @@ class RestoreConfig(object):
             case_sync=case_sync,
         )
 
-        self.force_cache = self.cache_settings.force_cache or self.async
+        self.force_cache = self.cache_settings.force_cache
         self.cache_timeout = self.cache_settings.cache_timeout
         self.overwrite_cache = self.cache_settings.overwrite_cache
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -9,14 +9,13 @@ from cStringIO import StringIO
 from uuid import uuid4
 from distutils.version import LooseVersion
 from datetime import datetime, timedelta
-from wsgiref.util import FileWrapper
 from xml.etree import cElementTree as ElementTree
 
 import six
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
 from couchdbkit import ResourceNotFound
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse, FileResponse
 from django.conf import settings
 
 from casexml.apps.phone.data_providers import get_element_providers, get_async_providers
@@ -68,8 +67,8 @@ DEFAULT_CASE_SYNC = CLEAN_OWNERS
 
 def stream_response(payload, headers=None, status=200):
     try:
-        response = StreamingHttpResponse(
-            FileWrapper(payload),
+        response = FileResponse(
+            payload,
             content_type="text/xml; charset=utf-8",
             status=status
         )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -167,6 +167,7 @@ class RestoreResponse(object):
     def as_string(self):
         """Get content as utf8-encoded bytes
 
+        NOTE: This method is only used in tests.
         Cannot be called more than once, and `self.as_file()` will
         return a closed file after this is called.
         """

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -19,7 +19,7 @@ from casexml.apps.phone.restore import (
     RestoreParams,
     RestoreCacheSettings,
     AsyncRestoreResponse,
-    FileRestoreResponse,
+    RestoreResponse,
 )
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.tests.utils import create_restore_user
@@ -120,8 +120,8 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
 
         # Second sync, don't timeout (can't use AsyncResult in tests, so mock
         # the return value).
-        file_restore_response = mock.MagicMock(return_value=FileRestoreResponse())
-        with mock.patch.object(AsyncResult, 'get', file_restore_response) as get_result:
+        restore_response = mock.MagicMock(return_value=RestoreResponse(None))
+        with mock.patch.object(AsyncResult, 'get', restore_response) as get_result:
             with mock.patch.object(AsyncResult, 'status', ASYNC_RESTORE_SENT):
                 subsequent_restore = self._restore_config(async=True)
                 self.assertIsNotNone(async_restore_task_id_cache.get_value())
@@ -173,7 +173,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
 
     @mock.patch.object(RestorePayloadPathCache, 'invalidate')
     @mock.patch.object(RestorePayloadPathCache, 'get_value')
-    @mock.patch.object(FileRestoreResponse, 'get_payload')
+    @mock.patch.object(RestoreResponse, 'as_file')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
     def test_clears_cache(self, task, response, get_value, invalidate):
         delay = mock.MagicMock()
@@ -257,7 +257,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
 
     @mock.patch.object(RestorePayloadPathCache, 'invalidate')
     @mock.patch.object(RestorePayloadPathCache, 'get_value')
-    @mock.patch.object(FileRestoreResponse, 'get_payload')
+    @mock.patch.object(RestoreResponse, 'as_file')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
     def test_clears_cache(self, task, response, get_value, invalidate):
         delay = mock.MagicMock()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -156,10 +156,6 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         self.assertTrue(restore_config.timing_context.is_finished())
         self.assertIsNotNone(restore_config.restore_state.current_sync_log)
 
-    def test_force_cache_on_async(self):
-        restore_config = self._restore_config(async=True)
-        self.assertTrue(restore_config.force_cache)
-
     @flag_enabled('ASYNC_RESTORE')
     def test_submit_form_no_userid(self):
         form = """

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore_v3.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore_v3.py
@@ -8,7 +8,7 @@ from casexml.apps.case.tests.util import (
     delete_all_sync_logs,
 )
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.phone.restore import FileRestoreResponse
+from casexml.apps.phone.restore import RestoreContent
 from casexml.apps.phone.tests.utils import create_restore_user, MockDevice
 
 
@@ -42,7 +42,7 @@ class OtaV3RestoreTest(TestCase):
         self.assertIn(case_id, device.sync().cases)
 
 
-class TestRestoreResponse(SimpleTestCase):
+class TestRestoreContent(SimpleTestCase):
 
     def _expected(self, username, body, items=None):
         items_text = (b' items="%s"' % items) if items is not None else b''
@@ -61,14 +61,16 @@ class TestRestoreResponse(SimpleTestCase):
         user = u'user1'
         body = b'<elem>data0</elem>'
         expected = self._expected(user, body, items=None)
-        with FileRestoreResponse(user, False) as response:
+        with RestoreContent(user, False) as response:
             response.append(body)
-        self.assertEqual(expected, str(response))
+            with response.get_fileobj() as fileobj:
+                self.assertEqual(expected, fileobj.read())
 
     def test_items(self):
         user = u'user1'
         body = b'<elem>data0</elem>'
         expected = self._expected(user, body, items=2)
-        with FileRestoreResponse(user, True) as response:
+        with RestoreContent(user, True) as response:
             response.append(body)
-        self.assertEqual(expected, str(response))
+            with response.get_fileobj() as fileobj:
+                self.assertEqual(expected, fileobj.read())

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -11,7 +11,6 @@ from casexml.apps.phone.restore_caching import RestorePayloadPathCache
 from casexml.apps.case.mock import CaseBlock, CaseStructure, CaseIndex
 from casexml.apps.phone.tests.utils import (
     create_restore_user,
-    delete_cached_response,
     get_restore_config,
     MockDevice,
 )
@@ -20,6 +19,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.blobs import get_blob_db
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
@@ -1274,24 +1274,31 @@ class SyncTokenCachingTest(BaseSyncTest):
 
     def testCacheInvalidationAfterFileDelete(self):
         # first request should populate the cache
-        original_payload = RestoreConfig(
+        config = RestoreConfig(
             project=self.project,
             restore_user=self.user,
             cache_settings=RestoreCacheSettings(force_cache=True),
             **self.restore_options
-        ).get_payload()
+        )
+        original_payload = config.get_payload()
         self.assertNotIsInstance(original_payload, CachedResponse)
 
-        delete_cached_response(original_payload)
+        original_name = config.restore_payload_path_cache.get_value()
+        self.assertTrue(original_name)
+        get_blob_db().delete(original_name)
 
         # resyncing should recreate the cache
-        next_file = RestoreConfig(
+        next_config = RestoreConfig(
             project=self.project,
             restore_user=self.user,
+            cache_settings=RestoreCacheSettings(force_cache=True),
             **self.restore_options
-        ).get_payload()
+        )
+        next_file = next_config.get_payload()
+        next_name = next_config.restore_payload_path_cache.get_value()
         self.assertNotIsInstance(next_file, CachedResponse)
-        self.assertNotEqual(original_payload.name, next_file.name)
+        self.assertTrue(next_name)
+        self.assertNotEqual(original_name, next_name)
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -12,7 +12,6 @@ from casexml.apps.phone.models import (
     OTARestoreCommCareUser,
 )
 from casexml.apps.phone.restore import (
-    BlobRestoreResponse,
     RestoreCacheSettings,
     RestoreConfig,
     RestoreParams,
@@ -21,7 +20,6 @@ from casexml.apps.phone.tests.dbaccessors import get_all_sync_logs_docs
 from casexml.apps.phone.xml import SYNC_XMLNS
 
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.blobs import get_blob_db
 
 
 def create_restore_user(
@@ -282,10 +280,3 @@ class SyncResult(object):
             sync_log_id=self.restore_id,
             device_id=self.device.id,
         ).get_value())
-
-
-def delete_cached_response(response):
-    if isinstance(response, BlobRestoreResponse):
-        get_blob_db().delete(response.name)
-    else:
-        raise NotImplementedError(type(response).__name__)


### PR DESCRIPTION
Accumulating response content in a temporary file is now managed by a separate class than serving that content in the response. Response content is no longer stored in the blob db if the content is not cached. This results in less blob db access.

Same as before:
- accumulate response elements in a temp file.
- put elements in second temp file wrapped in OpenRosaResponse element and delete first temp file.

Before:
- send content to blob db.
- delete second temp file.
- stream content from blob db (response).

After:
- if caching: send content to blob db.
- serve content (response).
- delete second temp file.

Best reviewed by commit 🐠 

@snopoke @proteusvacuum 