### PR TITLE
Don't specify form id

### DIFF
--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -241,7 +241,6 @@ class DashboardView(TemplateView):
                 domain=self.domain,
                 app_id=build_id,
                 module_id=0,
-                form_id=0
             )
         return super(DashboardView, self).get_context_data(**kwargs)
 


### PR DESCRIPTION
This doesn't specify the form id and it will take the user to the case select screen where they can select "report a new issue"

It looks like the web apps URL includes a `steps": [0, "action 0"]`. @dannyroberts or @wspride is that "action" a new addition to the URL. it's possible I missed that before, but I thought it was supposed to be [0, 0] ?

buddy @sravfeyn 