### PR TITLE
Filter data sources server-side

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -58,7 +58,8 @@
                 url: '{% url "case_list_options" domain %}',
                 data: function (term, page) {
                     return {
-                        q: term
+                        q: term,
+                        ds: 'u|sg|l'
                     };
                 },
                 dataType: 'json',
@@ -66,12 +67,7 @@
                 results: function (data, page) {
                     return {
                         total: data.total,
-                        results: (data.results
-                            // white list groups and users
-                            .filter(function(o) {
-                                return o.id.startsWith('u__') || o.id.startsWith('sg__') || o.id.startsWith('l__');
-                            })
-                        )
+                        results: data.results
                     };
                 },
                 cache: true


### PR DESCRIPTION
Context: [FB 262457](https://manage.dimagi.com/default.asp?262457)

The user is looking for a case-sharing group. HQ is returning 10 results, but case-sharing group is (say) the 11th result. The data sources are being filtered client-side, so the case-sharing group the user is looking for is not returned.

If data sources are filtered server-side, what was result 11 will now appear in the top 10, and visible client-side.

@esoergel buddy @calellowitz 
