### PR TITLE
A new permission for MOTECH

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2428,7 +2428,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
     page_title = ugettext_lazy("Data Forwarding")
     template_name = 'domain/admin/domain_forwarding.html'
 
-    @method_decorator(domain_admin_required)
+    @method_decorator(require_permission(Permissions.edit_motech))
     def dispatch(self, request, *args, **kwargs):
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 
@@ -2458,7 +2458,7 @@ class AddRepeaterView(BaseAdminProjectSettingsView):
     template_name = 'domain/admin/add_form_repeater.html'
     repeater_form_class = GenericRepeaterForm
 
-    @method_decorator(domain_admin_required)
+    @method_decorator(require_permission(Permissions.edit_motech))
     def dispatch(self, request, *args, **kwargs):
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -85,6 +85,7 @@ class Permissions(DocumentSchema):
     edit_web_users = BooleanProperty(default=False)
     edit_commcare_users = BooleanProperty(default=False)
     edit_locations = BooleanProperty(default=False)
+    edit_motech = BooleanProperty(default=False)
     edit_data = BooleanProperty(default=False)
     edit_apps = BooleanProperty(default=False)
     access_all_locations = BooleanProperty(default=True)
@@ -175,6 +176,7 @@ class Permissions(DocumentSchema):
             edit_web_users=True,
             edit_commcare_users=True,
             edit_locations=True,
+            edit_motech=True,
             edit_data=True,
             edit_apps=True,
             view_reports=True,

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -312,6 +312,12 @@
                                 data-content="{% trans "Create, update, and delete Locations in the Organization Hierarchy." %}"></span>
                         </th>
                         <th>
+                          {% trans "Edit MOTECH Configuration" %}
+                          <span class="hq-help-template"
+                                data-title="{% trans 'Edit MOTECH Configuration' %}"
+                                data-content="{% trans 'Manage integration with other systems.' %}"></span>
+                        </th>
+                        <th>
                           {% trans "Edit Data" %}
                           <span class="hq-help-template"
                                 data-title="{% trans "Edit Data" %}"
@@ -347,6 +353,7 @@
                         <td><i data-bind="staticChecked: permissions.edit_web_users"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_commcare_users"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_locations"></i></td>
+                        <td><i data-bind="staticChecked: permissions.edit_motech"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_data"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_apps"></i></td>
                         <td>
@@ -471,6 +478,20 @@
                                                     <input type="checkbox"
                                                            data-bind="checked: permissions.edit_locations" />
                                                     {% trans "Allow role to edit Locations." %}
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="col-sm-4 control-label">
+                                            {% trans "Edit MOTECH Configuration" %}
+                                        </label>
+                                        <div class="col-sm-8 controls">
+                                            <div class="checkbox">
+                                                <label>
+                                                    <input type="checkbox"
+                                                           data-bind="checked: permissions.edit_motech" />
+                                                    {% trans "Allow role to manage integration with other systems." %}
                                                 </label>
                                             </div>
                                         </div>

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -311,12 +311,14 @@
                                 data-title="{% trans "Edit Locations"%}"
                                 data-content="{% trans "Create, update, and delete Locations in the Organization Hierarchy." %}"></span>
                         </th>
+                        {% if show_integration %}
                         <th>
-                          {% trans "Edit MOTECH Configuration" %}
+                          {% trans "Edit Integration" %}
                           <span class="hq-help-template"
-                                data-title="{% trans 'Edit MOTECH Configuration' %}"
+                                data-title="{% trans 'Edit Integration' %}"
                                 data-content="{% trans 'Manage integration with other systems.' %}"></span>
                         </th>
+                        {% endif %}
                         <th>
                           {% trans "Edit Data" %}
                           <span class="hq-help-template"
@@ -353,7 +355,9 @@
                         <td><i data-bind="staticChecked: permissions.edit_web_users"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_commcare_users"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_locations"></i></td>
+                        {% if show_integration %}
                         <td><i data-bind="staticChecked: permissions.edit_motech"></i></td>
+                        {% endif %}
                         <td><i data-bind="staticChecked: permissions.edit_data"></i></td>
                         <td><i data-bind="staticChecked: permissions.edit_apps"></i></td>
                         <td>
@@ -482,9 +486,10 @@
                                             </div>
                                         </div>
                                     </div>
+                                    {% if show_integration %}
                                     <div class="form-group">
                                         <label class="col-sm-4 control-label">
-                                            {% trans "Edit MOTECH Configuration" %}
+                                            {% trans "Edit Integration" %}
                                         </label>
                                         <div class="col-sm-8 controls">
                                             <div class="checkbox">
@@ -496,6 +501,7 @@
                                             </div>
                                         </div>
                                     </div>
+                                    {% endif %}
                                     <div class="form-group">
                                         <label class="col-sm-4 control-label">
                                             {% trans "Edit Data" %}

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -538,6 +538,10 @@ class ListWebUsersView(HQJSONResponseMixin, BaseUserSettingsView):
             'uses_locations': self.domain_object.uses_locations,
             'can_restrict_access_by_location': self.can_restrict_access_by_location,
             'landing_page_choices': self.landing_page_choices,
+            'show_integration': (
+                toggles.OPENMRS_INTEGRATION.enabled(self.domain) or
+                toggles.DHIS2_INTEGRATION.enabled(self.domain)
+            ),
         }
 
 

--- a/corehq/motech/dhis2/view.py
+++ b/corehq/motech/dhis2/view.py
@@ -6,22 +6,24 @@ from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic import ListView, DetailView
 from corehq import toggles
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import Permissions
 from corehq.motech.dhis2.dbaccessors import get_dhis2_connection, get_dataset_maps
 from corehq.motech.dhis2.forms import Dhis2ConnectionForm
 from corehq.motech.dhis2.models import DataValueMap, DataSetMap, JsonApiLog
 from corehq.motech.dhis2.tasks import send_datasets
-from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views import BaseAdminProjectSettingsView
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.web import json_response
 
 
+@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
+@method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
 class Dhis2ConnectionView(BaseAdminProjectSettingsView):
     urlname = 'dhis2_connection_view'
     page_title = ugettext_lazy("DHIS2 Connection Settings")
     template_name = 'dhis2/connection_settings.html'
 
-    @method_decorator(domain_admin_required)
     def post(self, request, *args, **kwargs):
         form = self.dhis2_connection_form
         if form.is_valid():
@@ -30,12 +32,6 @@ class Dhis2ConnectionView(BaseAdminProjectSettingsView):
             return HttpResponseRedirect(self.page_url)
         context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
-
-    @method_decorator(domain_admin_required)
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.DHIS2_INTEGRATION.enabled(request.domain):
-            raise Http404()
-        return super(Dhis2ConnectionView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized
@@ -51,12 +47,13 @@ class Dhis2ConnectionView(BaseAdminProjectSettingsView):
         return {'dhis2_connection_form': self.dhis2_connection_form}
 
 
+@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
+@method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
 class DataSetMapView(BaseAdminProjectSettingsView):
     urlname = 'dataset_map_view'
     page_title = ugettext_lazy("DHIS2 DataSet Maps")
     template_name = 'dhis2/dataset_map.html'
 
-    @method_decorator(domain_admin_required)
     def post(self, request, *args, **kwargs):
 
         def update_dataset_map(instance, dict_):
@@ -88,12 +85,6 @@ class DataSetMapView(BaseAdminProjectSettingsView):
         except Exception as err:
             return json_response({'error': str(err)}, status_code=500)
 
-    @method_decorator(domain_admin_required)
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.DHIS2_INTEGRATION.enabled(request.domain):
-            raise Http404()
-        return super(DataSetMapView, self).dispatch(request, *args, **kwargs)
-
     @property
     def page_context(self):
         dataset_maps = [d.to_json() for d in get_dataset_maps(self.request.domain)]
@@ -103,6 +94,8 @@ class DataSetMapView(BaseAdminProjectSettingsView):
         }
 
 
+@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
+@method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
 class Dhis2LogListView(BaseAdminProjectSettingsView, ListView):
     urlname = 'dhis2_log_list_view'
     page_title = ugettext_lazy("DHIS2 Logs")
@@ -122,13 +115,9 @@ class Dhis2LogListView(BaseAdminProjectSettingsView, ListView):
     def object_list(self):
         return self.get_queryset()
 
-    @method_decorator(domain_admin_required)
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.DHIS2_INTEGRATION.enabled(request.domain):
-            raise Http404()
-        return super(Dhis2LogListView, self).dispatch(request, *args, **kwargs)
 
-
+@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
+@method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
 class Dhis2LogDetailView(BaseAdminProjectSettingsView, DetailView):
     urlname = 'dhis2_log_detail_view'
     page_title = ugettext_lazy("DHIS2 Logs")
@@ -142,12 +131,6 @@ class Dhis2LogDetailView(BaseAdminProjectSettingsView, DetailView):
     def object(self):
         return self.get_object()
 
-    @method_decorator(domain_admin_required)
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.DHIS2_INTEGRATION.enabled(request.domain):
-            raise Http404()
-        return super(Dhis2LogDetailView, self).dispatch(request, *args, **kwargs)
-
     @property
     @memoized
     def page_url(self):
@@ -156,7 +139,7 @@ class Dhis2LogDetailView(BaseAdminProjectSettingsView, DetailView):
 
 
 @require_POST
-@domain_admin_required
+@method_decorator(require_permission(Permissions.edit_motech))
 def send_dhis2_data(request, domain):
     send_datasets.delay(domain, send_now=True)
     return json_response({'success': _('Data is being sent to DHIS2.')}, status_code=202)

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -5,8 +5,10 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_http_methods
 from corehq import toggles
-from corehq.apps.domain.decorators import login_and_domain_required, domain_admin_required
+from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views import BaseAdminProjectSettingsView
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import Permissions
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.tasks import import_patients_to_domain
 from corehq.motech.repeaters.models import RepeatRecord
@@ -130,7 +132,7 @@ def openmrs_import_now(request, domain):
     return JsonResponse({'status': 'Accepted'}, status=202)
 
 
-@method_decorator(domain_admin_required, name='dispatch')
+@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
 @method_decorator(toggles.OPENMRS_INTEGRATION.required_decorator(), name='dispatch')
 class OpenmrsImporterView(BaseAdminProjectSettingsView):
     urlname = 'openmrs_importer_view'

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1393,8 +1393,11 @@ class ProjectSettingsTab(UITab):
         if user_is_admin:
             items.append((_('Project Administration'), _get_administration_section(self.domain)))
 
+        if self.couch_user.can_edit_motech:
+            items.append((_('Integration'), _get_integration_section(self.domain)))
+
         feature_flag_items = _get_feature_flag_items(self.domain)
-        if feature_flag_items:
+        if feature_flag_items and user_is_admin:
             items.append((_('Pre-release Features'), feature_flag_items))
 
         from corehq.apps.users.models import WebUser
@@ -1496,33 +1499,6 @@ def _get_administration_section(domain):
             }
         ])
 
-    def forward_name(repeater_type=None, **context):
-        if repeater_type == 'FormRepeater':
-            return _("Forward Forms")
-        elif repeater_type == 'ShortFormRepeater':
-            return _("Forward Form Stubs")
-        elif repeater_type == 'CaseRepeater':
-            return _("Forward Cases")
-
-    administration.extend([
-        {'title': _('Data Forwarding'),
-         'url': reverse('domain_forwarding', args=[domain]),
-         'subpages': [
-             {
-                 'title': forward_name,
-                 'urlname': 'add_repeater',
-             },
-             {
-                 'title': forward_name,
-                 'urlname': 'add_form_repeater',
-             },
-        ]},
-        {
-            'title': _('Data Forwarding Records'),
-            'url': reverse('domain_report_dispatcher', args=[domain, 'repeat_record_report'])
-        }
-    ])
-
     administration.append({
         'title': _(FeaturePreviewsView.page_title),
         'url': reverse(FeaturePreviewsView.urlname, args=[domain])
@@ -1534,8 +1510,42 @@ def _get_administration_section(domain):
             'url': reverse(TransferDomainView.urlname, args=[domain])
         })
 
+    return administration
+
+
+def _get_integration_section(domain):
+
+    def forward_name(repeater_type=None, **context):
+        if repeater_type == 'FormRepeater':
+            return _("Forward Forms")
+        elif repeater_type == 'ShortFormRepeater':
+            return _("Forward Form Stubs")
+        elif repeater_type == 'CaseRepeater':
+            return _("Forward Cases")
+
+    integration = [
+        {
+            'title': _('Data Forwarding'),
+            'url': reverse('domain_forwarding', args=[domain]),
+            'subpages': [
+                {
+                    'title': forward_name,
+                    'urlname': 'add_repeater',
+                },
+                {
+                    'title': forward_name,
+                    'urlname': 'add_form_repeater',
+                },
+            ]
+        },
+        {
+            'title': _('Data Forwarding Records'),
+            'url': reverse('domain_report_dispatcher', args=[domain, 'repeat_record_report'])
+        }
+    ]
+
     if toggles.DHIS2_INTEGRATION.enabled(domain):
-        administration.extend([{
+        integration.extend([{
             'title': _(Dhis2ConnectionView.page_title),
             'url': reverse(Dhis2ConnectionView.urlname, args=[domain])
         }, {
@@ -1547,12 +1557,12 @@ def _get_administration_section(domain):
         }])
 
     if toggles.OPENMRS_INTEGRATION.enabled(domain):
-        administration.append({
+        integration.append({
             'title': _(OpenmrsImporterView.page_title),
             'url': reverse(OpenmrsImporterView.urlname, args=[domain])
         })
 
-    return administration
+    return integration
 
 
 def _get_feature_flag_items(domain):


### PR DESCRIPTION
This change allows a web user to manage integration for a project space.

![new_permission](https://user-images.githubusercontent.com/708421/31151899-f0793c6a-a899-11e7-901a-1285b5415109.png)

**NOTE**: Resending and cancelling repeat records currently require the `edit_web_users` permission. This remains unchanged.

![new_project_settings_section](https://user-images.githubusercontent.com/708421/31152009-6874138e-a89a-11e7-998b-e168a691e151.png) ![project_settings_for_role](https://user-images.githubusercontent.com/708421/31152206-61468870-a89b-11e7-9c8a-05cdbd31e437.png)

Integration-related project settings are moved into their own section. Web users in the new role can only see "My Timezone" and Integration settings.

@dannyroberts cc @calellowitz 