### PR TITLE
Fix main menu tab analytics

### DIFF
--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -87,9 +87,11 @@ class MainMenuNode(template.Node):
         # set the context variable in the highest scope so it can be used in
         # other blocks
         context.dicts[0]['active_tab'] = active_tab
-        return mark_safe(render_to_string('tabs/menu_main.html', {
+        flat = context.flatten()
+        flat.update({
             'tabs': visible_tabs,
-        }))
+        })
+        return mark_safe(render_to_string('tabs/menu_main.html', flat))
 
 
 @register.tag(name="format_main_menu")


### PR DESCRIPTION
`GOOGLE_ANALYTICS_API_ID` wasn't getting passed in the context, so [menu_main_js.html](https://github.com/dimagi/commcare-hq/blob/master/corehq/tabs/templates/tabs/menu_main_js.html) wasn't doing anything.

@proteusvacuum 

fyi @krsdimagi Google analytics for the menu tabs seem to have been broken for at least the last 18 months. It would be good for us to think about doing some kind of sanity checking infrastructure for analytics (eventually - don't expect it to be a priority anytime soon).