### PR TITLE
Move analytics document onready logic into main.js

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -261,7 +261,14 @@ hqDefine("hqwebapp/js/main", function() {
         'use strict';
         $(window).on('beforeunload', beforeUnloadCallback);
         initBlock($("body"));
+
         $('#modalTrial30Day').modal('show');
+
+        $(document).on('click', '.track-usage-link', function(e) {
+            var $link = $(e.currentTarget),
+                data = $link.data();
+            window.analytics.trackUsageLink($link, data.category, data.action, data.label, data.value);
+        });
     });
 
     return {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/analytics_all.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/analytics_all.html
@@ -141,13 +141,5 @@
         analytics.identify({'hq_instance': '{{ANALYTICS_CONFIG.HQ_INSTANCE}}'});
     {% endif %}
 
-    $(function() {
-        $(document).on('click', '.track-usage-link', function(e) {
-            var $link = $(e.currentTarget),
-                data = $link.data();
-            window.analytics.trackUsageLink($link, data.category, data.action, data.label, data.value);
-        });
-    });
-
 </script>
 {% endaddtoblock %}


### PR DESCRIPTION
Bandaid to allow RequireJS to work without modularizing all of the analytics code right now.

Verified that prelogin and formplayer, though they include `analytics_all.html`, don't use `.track-usage-link`.

@millerdev / @proteusvacuum 