### PR TITLE
PredictablyRandomToggle should check namespace

### DIFF
--- a/corehq/apps/hqadmin/management/commands/clone_domain.py
+++ b/corehq/apps/hqadmin/management/commands/clone_domain.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster
 
         for toggle in all_toggles():
-            if toggle.enabled(self.existing_domain):
+            if toggle.enabled(self.existing_domain, NAMESPACE_DOMAIN):
                 self.stdout.write('Setting flag: {}'.format(toggle.slug))
                 if not self.no_commit:
                     toggle.set(self.new_domain, True, NAMESPACE_DOMAIN)

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -26,7 +26,7 @@ from casexml.apps.phone.exceptions import (
 )
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
-from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC, ICDS_LIVEQUERY
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC, ICDS_LIVEQUERY, NAMESPACE_USER
 from corehq.util.datadog.utils import bucket_value
 from corehq.util.timer import TimingContext
 from corehq.util.datadog.gauges import datadog_counter
@@ -388,7 +388,7 @@ class RestoreState(object):
             username = self.restore_user.username
             if LIVEQUERY_SYNC.enabled(self.domain):
                 case_sync = LIVEQUERY
-            elif self.domain == 'icds-cas' and ICDS_LIVEQUERY.enabled(username):
+            elif self.domain == 'icds-cas' and ICDS_LIVEQUERY.enabled(username, namespace=NAMESPACE_USER):
                 case_sync = LIVEQUERY
             else:
                 case_sync = DEFAULT_CASE_SYNC

--- a/corehq/ex-submodules/toggle/tests.py
+++ b/corehq/ex-submodules/toggle/tests.py
@@ -205,7 +205,7 @@ class PredictablyRandomToggleTests(TestCase):
     def setUpClass(cls):
         cls.user_toggle = Toggle(
             slug='user_toggle',
-            enabled_users=['arthur', 'diane'])
+            enabled_users=['arthur', 'diana'])
         cls.user_toggle.save()
         cls.domain_toggle = Toggle(
             slug='domain_toggle',
@@ -226,20 +226,22 @@ class PredictablyRandomToggleTests(TestCase):
 
     def test_user_namespace_disabled(self):
         toggle = PredictablyRandomToggle(
-            'test_toggle',
+            'user_toggle',
             'A toggle for testing',
             TAG_EXPERIMENTAL,
             [NAMESPACE_USER],
             randomness=0.01
         )
+        self.assertTrue(toggle.enabled('diana', namespace=NAMESPACE_USER))
         self.assertFalse(toggle.enabled('jessica', namespace=NAMESPACE_USER))
 
     def test_domain_namespace_disabled(self):
         toggle = PredictablyRandomToggle(
-            'test_toggle',
+            'domain_toggle',
             'A toggle for testing',
             TAG_EXPERIMENTAL,
             [NAMESPACE_DOMAIN],
             randomness=0.01
         )
+        self.assertTrue(toggle.enabled('dc', namespace=NAMESPACE_DOMAIN))
         self.assertFalse(toggle.enabled('marvel', namespace=NAMESPACE_DOMAIN))

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -294,8 +294,8 @@ def toggles_dict(username=None, domain=None):
 
     (only enabled toggles are included)
     """
-    return {t.slug: True for t in all_toggles() if (t.enabled(username) or
-                                                    t.enabled(domain))}
+    return {t.slug: True for t in all_toggles() if (t.enabled(username, NAMESPACE_USER) or
+                                                    t.enabled(domain, NAMESPACE_DOMAIN))}
 
 
 def toggle_values_by_name(username=None, domain=None):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from functools import wraps
 import hashlib
+import logging
 import math
 
 from django.contrib import messages
@@ -223,14 +224,18 @@ class PredictablyRandomToggle(StaticToggle):
     def _get_identifier(self, item):
         return '{}:{}:{}'.format(self.namespaces, self.slug, item)
 
-    def enabled(self, item, **kwargs):
+    def enabled(self, item, namespace=Ellipsis):
+        if namespace is Ellipsis:
+            logging.warning('PredictablyRandomToggle.enabled() may be invalid if namespace is not set')
         if settings.UNIT_TESTING:
             return False
         elif item in self.always_disabled:
             return False
+        elif namespace is not Ellipsis and namespace not in self.namespaces:
+            return False
         return (
             (item and deterministic_random(self._get_identifier(item)) < self.randomness)
-            or super(PredictablyRandomToggle, self).enabled(item, **kwargs)
+            or super(PredictablyRandomToggle, self).enabled(item, namespace)
         )
 
 # if no namespaces are specified the user namespace is assumed


### PR DESCRIPTION
Previously `PredictablyRandomToggle.enabled()` ignored namespaces, and they were only checked in the parent method if `deterministic_random(self._get_identifier(item)) < self.randomness`. This meant that a user-only toggle could be enabled for a domain.

More context: [FB 262625](https://manage.dimagi.com/default.asp?262625)

@millerdev, buddy @calellowitz 