### PR TITLE
Repeat Record report

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/repeater_row.html
+++ b/corehq/apps/domain/templates/domain/admin/repeater_row.html
@@ -1,10 +1,26 @@
 {% load i18n %}
 <tr>
     <td>{{ repeater.url }}</td>
-    <td>{{ repeater.get_pending_record_count }}</td>
-    <td>{{ repeater.get_failure_record_count }}</td>
-    <td>{{ repeater.get_cancelled_record_count }}</td>
-    <td>{{ repeater.get_success_record_count }}</td>
+    <td>
+        <a href="{% url 'domain_report_dispatcher' domain 'repeat_record_report' %}?repeater={{ repeater.get_id }}&record_state=PENDING">
+            {{ repeater.get_pending_record_count }}
+        </a>
+    </td>
+    <td>
+        <a href="{% url 'domain_report_dispatcher' domain 'repeat_record_report' %}?repeater={{ repeater.get_id }}&record_state=FAIL">
+            {{ repeater.get_failure_record_count }}
+        </a>
+    </td>
+    <td>
+        <a href="{% url 'domain_report_dispatcher' domain 'repeat_record_report' %}?repeater={{ repeater.get_id }}&record_state=CANCELLED">
+            {{ repeater.get_cancelled_record_count }}
+        </a>
+    </td>
+    <td>
+        <a href="{% url 'domain_report_dispatcher' domain 'repeat_record_report' %}?repeater={{ repeater.get_id }}&record_state=SUCCESS">
+            {{ repeater.get_success_record_count }}
+        </a>
+    </td>
     <td>
         <a
             class="btn btn-default"

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -130,6 +130,7 @@ from corehq.motech.repeaters.models import Repeater, RepeatRecord
 from corehq.motech.repeaters.dbaccessors import (
     get_paged_repeat_records,
     get_repeat_record_count,
+    get_repeat_records_by_payload_id,
 )
 from corehq.motech.repeaters.utils import get_all_repeater_types
 from corehq.motech.repeaters.const import (
@@ -2288,6 +2289,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
     fields = [
         'corehq.apps.reports.filters.select.RepeaterFilter',
         'corehq.apps.reports.filters.select.RepeatRecordStateFilter',
+        'corehq.apps.reports.filters.search.RepeaterPayloadIdFilter',
     ]
 
     def _make_cancel_payload_button(self, record_id):
@@ -2359,30 +2361,52 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
 
     @property
     def total_records(self):
-        return get_repeat_record_count(self.domain, self.repeater_id, self.state)
+        if self.payload_id:
+            return len(self._get_all_records_by_payload())
+        else:
+            return get_repeat_record_count(self.domain, self.repeater_id, self.state)
 
     @property
     def shared_pagination_GET_params(self):
         return [
             {'name': 'repeater', 'value': self.request.GET.get('repeater')},
             {'name': 'record_state', 'value': self.request.GET.get('record_state')},
+            {'name': 'payload_id', 'value': self.request.GET.get('payload_id')},
         ]
 
     def _format_date(self, date):
         tz_utc_aware_date = pytz.utc.localize(date)
         return tz_utc_aware_date.astimezone(self.timezone).strftime('%b %d, %Y %H:%M:%S %Z')
 
+    @memoized
+    def _get_all_records_by_payload(self):
+        # It is assumed that there are relatively few repeat records for a given payload,
+        # so this is just filtered in memory.  If that changes, we should filter in the db.
+        return [
+            r for r in get_repeat_records_by_payload_id(self.domain, self.payload_id)
+            if (not self.repeater_id or r.repeater_id == self.repeater_id)
+            and (not self.state or r.state == self.state)
+        ]
+
+    @property
+    def payload_id(self):
+        return self.request.GET.get('payload_id', None)
+
     @property
     def rows(self):
         self.repeater_id = self.request.GET.get('repeater', None)
         self.state = self.request.GET.get('record_state', None)
-        records = get_paged_repeat_records(
-            self.domain,
-            self.pagination.start,
-            self.pagination.count,
-            repeater_id=self.repeater_id,
-            state=self.state
-        )
+        if self.payload_id:
+            end = self.pagination.start + self.pagination.count
+            records = self._get_all_records_by_payload()[self.pagination.start:end]
+        else:
+            records = get_paged_repeat_records(
+                self.domain,
+                self.pagination.start,
+                self.pagination.count,
+                repeater_id=self.repeater_id,
+                state=self.state
+            )
         rows = [self._make_row(record) for record in records]
         return rows
 

--- a/corehq/apps/reports/filters/search.py
+++ b/corehq/apps/reports/filters/search.py
@@ -22,3 +22,8 @@ class SearchFilter(BaseReportFilter):
             'search_help_content': self.search_help_content,
             'search_help_inline': self.search_help_inline
         }
+
+
+class RepeaterPayloadIdFilter(SearchFilter):
+    slug = "payload_id"
+    label = ugettext_lazy("Payload ID")

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -106,7 +106,7 @@ def iter_repeat_records_by_domain(domain, repeater_id=None, state=None, since=No
         yield RepeatRecord.wrap(doc['doc'])
 
 
-def get_repeat_records_by_payload_id(domain, payload_id, chunk_size=1000):
+def get_repeat_records_by_payload_id(domain, payload_id):
     from .models import RepeatRecord
     results = RepeatRecord.get_db().view(
         'repeaters/repeat_records_by_payload_id',


### PR DESCRIPTION
First commit turns repeat record counts into links to the filtered report for that state.
Second commit adds the option to search by payload ID in the report.  That's to make it easier to track down whether a particular entity has been sent.
@gcapalbo
@dannyroberts @proteusvacuum FYI