### PR TITLE
Extend the right parent class

### DIFF
--- a/corehq/motech/dhis2/view.py
+++ b/corehq/motech/dhis2/view.py
@@ -12,14 +12,14 @@ from corehq.motech.dhis2.dbaccessors import get_dhis2_connection, get_dataset_ma
 from corehq.motech.dhis2.forms import Dhis2ConnectionForm
 from corehq.motech.dhis2.models import DataValueMap, DataSetMap, JsonApiLog
 from corehq.motech.dhis2.tasks import send_datasets
-from corehq.apps.domain.views import BaseAdminProjectSettingsView
+from corehq.apps.domain.views import BaseProjectSettingsView
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.web import json_response
 
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
 @method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
-class Dhis2ConnectionView(BaseAdminProjectSettingsView):
+class Dhis2ConnectionView(BaseProjectSettingsView):
     urlname = 'dhis2_connection_view'
     page_title = ugettext_lazy("DHIS2 Connection Settings")
     template_name = 'dhis2/connection_settings.html'
@@ -49,7 +49,7 @@ class Dhis2ConnectionView(BaseAdminProjectSettingsView):
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
 @method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
-class DataSetMapView(BaseAdminProjectSettingsView):
+class DataSetMapView(BaseProjectSettingsView):
     urlname = 'dataset_map_view'
     page_title = ugettext_lazy("DHIS2 DataSet Maps")
     template_name = 'dhis2/dataset_map.html'
@@ -96,7 +96,7 @@ class DataSetMapView(BaseAdminProjectSettingsView):
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
 @method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
-class Dhis2LogListView(BaseAdminProjectSettingsView, ListView):
+class Dhis2LogListView(BaseProjectSettingsView, ListView):
     urlname = 'dhis2_log_list_view'
     page_title = ugettext_lazy("DHIS2 Logs")
     template_name = 'dhis2/logs.html'
@@ -118,7 +118,7 @@ class Dhis2LogListView(BaseAdminProjectSettingsView, ListView):
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
 @method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
-class Dhis2LogDetailView(BaseAdminProjectSettingsView, DetailView):
+class Dhis2LogDetailView(BaseProjectSettingsView, DetailView):
     urlname = 'dhis2_log_detail_view'
     page_title = ugettext_lazy("DHIS2 Logs")
     template_name = 'dhis2/log_detail.html'

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_http_methods
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
-from corehq.apps.domain.views import BaseAdminProjectSettingsView
+from corehq.apps.domain.views import BaseProjectSettingsView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
@@ -134,7 +134,7 @@ def openmrs_import_now(request, domain):
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
 @method_decorator(toggles.OPENMRS_INTEGRATION.required_decorator(), name='dispatch')
-class OpenmrsImporterView(BaseAdminProjectSettingsView):
+class OpenmrsImporterView(BaseProjectSettingsView):
     urlname = 'openmrs_importer_view'
     page_title = ugettext_lazy("OpenMRS Importers")
     template_name = 'openmrs/importers.html'


### PR DESCRIPTION
The `dispatch` method of `BaseAdminProjectSettingsView` is limited to domain admins only. Extend `BaseProjectSettingsView` instead, so that we can allow users with `edit_motech` permission to get to the page.

@dannyroberts buddy @calellowitz 
