### PR TITLE
Fix existing_role property

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -182,9 +182,15 @@ class BaseEditUserView(BaseUserSettingsView):
     @property
     def existing_role(self):
         try:
-            return self.editable_user.get_role(self.domain).get_qualified_id() or ''
+            role = self.editable_user.get_role(self.domain)
         except DomainMembershipError:
             raise Http404()
+
+        if role is None:
+            role = "none"
+        else:
+            role = role.get_qualified_id()
+        return role
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -187,6 +187,8 @@ class BaseEditUserView(BaseUserSettingsView):
             raise Http404()
 
         if role is None:
+            if isinstance(self.editable_user, WebUser):
+                raise ValueError("WebUser is always expected to have a role")
             return None
         else:
             return role.get_qualified_id()

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -187,10 +187,9 @@ class BaseEditUserView(BaseUserSettingsView):
             raise Http404()
 
         if role is None:
-            role = "none"
+            return None
         else:
-            role = role.get_qualified_id()
-        return role
+            return role.get_qualified_id()
 
     @property
     @memoized

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -239,15 +239,6 @@ class EditCommCareUserView(BaseEditUserView):
         return [('none', _('(none)'))] + self.editable_role_choices
 
     @property
-    def existing_role(self):
-        role = self.editable_user.get_role(self.domain)
-        if role is None:
-            role = "none"
-        else:
-            role = role.get_qualified_id()
-        return role
-
-    @property
     @memoized
     def form_user_update(self):
         if self.request.method == "POST" and self.request.POST['form_type'] == "update-user":


### PR DESCRIPTION
`existing_role` was returning 'none' for mobile workers with no role, which was preventing their role from being edited by non-admins.

@esoergel 