### PR TITLE
Catch error and send to emord

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -13,7 +13,9 @@ from corehq.apps.userreports.const import (
     KAFKA_TOPICS, UCR_ES_BACKEND, UCR_SQL_BACKEND, UCR_LABORATORY_BACKEND, UCR_ES_PRIMARY
 )
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider
-from corehq.apps.userreports.exceptions import TableRebuildError, StaleRebuildError, UserReportsWarning
+from corehq.apps.userreports.exceptions import (
+    BadSpecError, TableRebuildError, StaleRebuildError, UserReportsWarning
+)
 from corehq.apps.userreports.models import AsyncIndicator
 from corehq.apps.userreports.specs import EvaluationContext
 from corehq.apps.userreports.sql import metadata
@@ -156,7 +158,11 @@ class ConfigurableReportTableManagerMixin(object):
         tables_by_engine = defaultdict(dict)
         for adapter in adapters:
             sql_adapter = get_indicator_adapter(adapter.config)
-            tables_by_engine[sql_adapter.engine_id][sql_adapter.get_table().name] = sql_adapter
+            try:
+                tables_by_engine[sql_adapter.engine_id][sql_adapter.get_table().name] = sql_adapter
+            except BadSpecError:
+                _soft_assert = soft_assert(to='{}@{}'.format('jemord', 'dimagi.com'))
+                _soft_assert(False, "Broken data source {}".format(adapter.config.get_id)
 
         _assert = soft_assert(notify_admins=True)
         _notify_rebuild = lambda msg, obj: _assert(False, msg, obj)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -162,7 +162,7 @@ class ConfigurableReportTableManagerMixin(object):
                 tables_by_engine[sql_adapter.engine_id][sql_adapter.get_table().name] = sql_adapter
             except BadSpecError:
                 _soft_assert = soft_assert(to='{}@{}'.format('jemord', 'dimagi.com'))
-                _soft_assert(False, "Broken data source {}".format(adapter.config.get_id)
+                _soft_assert(False, "Broken data source {}".format(adapter.config.get_id))
 
         _assert = soft_assert(notify_admins=True)
         _notify_rebuild = lambda msg, obj: _assert(False, msg, obj)


### PR DESCRIPTION
This error is coming up because https://github.com/dimagi/commcare-hq/pull/17900/files removed some custom expressions that non static icds reports were using on softlayer. 

This should notify me and I can remove them from the server

@dannyroberts this is why kafka-ucr-main was so slow yesterday

@millerdev 