### PR TITLE
Resize image to be parent dimensions

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -125,11 +125,13 @@
     <% _.each(data, function(datum, index) { %>
     <div class="<%= prefix %>-grid-style-<%= index %> box">
         <% if (styles[index].displayFormat === 'Image') {
-        if(resolveUri(datum)) { %>
-        <img class="module-icon" style="max-width:100%; max-height:100%;" src="<%= resolveUri(datum) %>"/>
-        <% } %>
+            if(resolveUri(datum)) { %>
+                <img class="module-icon" style="max-width:100%; max-height:100%;" src="<%= resolveUri(datum) %>"/>
+            <% } %>
+        <% } else if(styles[index].widthHint === 0) { %>
+            <div style="display:none;"><%= datum %></div>
         <% } else { %>
-        <div><%= datum %></div>
+            <div><%= datum %></div>
         <% } %>
     </div>
     <% }); %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -126,7 +126,7 @@
     <div class="<%= prefix %>-grid-style-<%= index %> box">
         <% if (styles[index].displayFormat === 'Image') {
         if(resolveUri(datum)) { %>
-        <img class="module-icon" style="max-width:100%; height: auto;" src="<%= resolveUri(datum) %>"/>
+        <img class="module-icon" style="max-width:100%; max-height:100%;" src="<%= resolveUri(datum) %>"/>
         <% } %>
         <% } else { %>
         <div><%= datum %></div>


### PR DESCRIPTION
fix for corehq/apps/cloudcare/templates/formplayer/case_list.html

Maybe @orangejenny or @biyeun can weigh in - essentially I want the image to fill (but not overflow) the parent `div` while maintaining the aspect ratio. 

Before:
<img width="501" alt="screen shot 2017-10-05 at 4 56 20 pm" src="https://user-images.githubusercontent.com/2293064/31252113-291333b4-a9ee-11e7-99f3-fb53c654df43.png">
After:
<img width="549" alt="screen shot 2017-10-05 at 4 55 52 pm" src="https://user-images.githubusercontent.com/2293064/31252117-2cb792b2-a9ee-11e7-8303-5f16ef43d2b8.png">
