### PR TITLE
add db-level check on subscription dates

### DIFF
--- a/corehq/apps/accounting/migrations/0013_subscription_dates_check.py
+++ b/corehq/apps/accounting/migrations/0013_subscription_dates_check.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.sql_db.operations import HqRunSQL
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0012_replace__product_type__with__is_product'),
+    ]
+
+    operations = [
+        HqRunSQL(
+            """
+            ALTER TABLE accounting_subscription
+            ADD CONSTRAINT subscription_dates_check CHECK (date_start <= date_end);
+            """,
+            reverse_sql="""
+            ALTER TABLE accounting_subscription
+            DROP CONSTRAINT IF EXISTS subscription_dates_check;
+            """,
+        ),
+    ]


### PR DESCRIPTION
Subscription end dates aren't supposed to come before the start date.  Right now, this is enforced at the application layer, but if we could assume that this is always true then we could simplify a lot of queries.  I've cleaned up the few subscriptions that did not satisfy this constraint.

@snopoke 