### PR TITLE
Support OpenMRS Person names and addresses

### DIFF
--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -1,11 +1,13 @@
 import logging
 from django import forms
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.userreports.ui.fields import JsonField
 from corehq.motech.openmrs.const import LOG_LEVEL_CHOICES, IMPORT_FREQUENCY_CHOICES
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.models import OpenmrsImporter, ColumnMapping
+from corehq.motech.openmrs.repeater_helpers import PERSON_PROPERTIES, NAME_PROPERTIES, ADDRESS_PROPERTIES
 from corehq.motech.utils import b64_aes_encrypt
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import StrictButton
@@ -21,6 +23,34 @@ class OpenmrsConfigForm(forms.Form):
         super(OpenmrsConfigForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.add_input(Submit('submit', _('Save Changes')))
+
+    def clean_case_config(self):
+
+        for key in self.cleaned_data['case_config']['person_properties']:
+            if key not in PERSON_PROPERTIES:
+                raise ValidationError(
+                    _('person property key "%(key)s" is not valid.'),
+                    code='invalid',
+                    params={'key': key}
+                )
+
+        for key in self.cleaned_data['case_config']['person_preferred_name']:
+            if key not in NAME_PROPERTIES:
+                raise ValidationError(
+                    _('person preferred name key "%(key)s" is not valid.'),
+                    code='invalid',
+                    params={'key': key}
+                )
+
+        for key in self.cleaned_data['case_config']['person_preferred_address']:
+            if key not in ADDRESS_PROPERTIES:
+                raise ValidationError(
+                    _('person preferred address key "%(key)s" is not valid.'),
+                    code='invalid',
+                    params={'key': key}
+                )
+
+        return self.cleaned_data['case_config']
 
 
 class OpenmrsImporterForm(forms.Form):

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -89,6 +89,8 @@ class FormQuestionConcept(FormQuestion):
 class OpenmrsCaseConfig(DocumentSchema):
     id_matchers = SchemaListProperty(IdMatcher)
     person_properties = SchemaDictProperty(ValueSource)
+    person_preferred_name = SchemaDictProperty(ValueSource)
+    person_preferred_address = SchemaDictProperty(ValueSource)
     person_attributes = SchemaDictProperty(ValueSource)
 
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -6,6 +6,44 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.logger import logger
 
 Should = namedtuple('Should', ['method', 'url', 'parser'])
+PERSON_PROPERTIES = (
+    'gender',
+    'age',
+    'birthdate',
+    'birthdateEstimated',
+    'dead',
+    'deathDate',
+    'deathdateEstimated',
+    'causeOfDeath',
+)
+PERSON_SUBRESOURCES = ('attribute', 'address', 'name')
+NAME_PROPERTIES = (
+    'givenName',
+    'familyName',
+    'middleName',
+    'familyName2',
+    'prefix',
+    'familyNamePrefix',
+    'familyNameSuffix',
+    'degree',
+)
+ADDRESS_PROPERTIES = (
+    'address1',
+    'address2',
+    'cityVillage',
+    'stateProvince',
+    'country',
+    'postalCode',
+    'latitude',
+    'longitude',
+    'countyDistrict',
+    'address3',
+    'address4',
+    'address5',
+    'address6',
+    'startDate',
+    'endDate',
+)
 
 
 class Requests(object):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -178,6 +178,59 @@ def get_patient_by_id(requests, patient_identifier_type, patient_identifier):
         patient_identifier_type, patient_identifier)
 
 
+def update_person_name(requests, info, openmrs_config, person_uuid, name_uuid):
+    properties = {
+        property_: value_source.get_value(info)
+        for property_, value_source in openmrs_config.case_config.person_preferred_name.items()
+        if property_ in NAME_PROPERTIES and value_source.get_value(info)
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
+                person_uuid=person_uuid,
+                name_uuid=name_uuid,
+            ),
+            json=properties,
+        )
+
+
+def create_person_address(requests, info, openmrs_config, person_uuid):
+    properties = {
+        property_: value_source.get_value(info)
+        for property_, value_source in openmrs_config.case_config.person_preferred_address.items()
+        if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/address/'.format(person_uuid=person_uuid),
+            json=properties,
+        )
+
+
+def update_person_address(requests, info, openmrs_config, person_uuid, address_uuid):
+    properties = {
+        property_: value_source.get_value(info)
+        for property_, value_source in openmrs_config.case_config.person_preferred_address.items()
+        if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/name/{address_uuid}'.format(
+                person_uuid=person_uuid,
+                address_uuid=address_uuid,
+            ),
+            json=properties,
+        )
+
+
+def get_subresource_instances(requests, person_uuid, subresource):
+    assert subresource in PERSON_SUBRESOURCES
+    return requests.get('/ws/rest/v1/person/{person_uuid}/{subresource}'.format(
+        person_uuid=person_uuid,
+        subresource=subresource,
+    )).json()['results']
+
+
 class PatientSearchParser(object):
     def __init__(self, response_json):
         self.response_json = response_json

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -27,6 +27,16 @@ class Requests(object):
         return self.requests.post(self.get_url(uri), *args,
                                   auth=(self.username, self.password), **kwargs)
 
+    def post_with_raise(self, uri, *args, **kwargs):
+        response = self.post(uri, *args, **kwargs)
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            logger.debug('Request: ', self.get_url(uri), kwargs)
+            logger.debug('Response: ', response.json())
+            raise
+        return response
+
 
 def url(url_format_string, **kwargs):
     return url_format_string.format(**kwargs)
@@ -57,21 +67,10 @@ def set_person_properties(requests, person_uuid, properties):
     for p in properties:
         assert p in allowed_properties
 
-    response = requests.post(
+    return requests.post_with_raise(
         '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person_uuid),
         json=properties
-    )
-    try:
-        response.raise_for_status()
-    except HTTPError:
-        logger.debug(
-            'Request: ',
-            requests.get_url('/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person_uuid)),
-            properties
-        )
-        logger.debug('Response: ', response.json())
-        raise
-    return response.json()
+    ).json()
 
 
 def server_datetime_to_openmrs_timestamp(dt):
@@ -97,13 +96,7 @@ def create_visit(requests, person_uuid, visit_datetime, values_for_concept, enco
     }
     if location_uuid:
         visit['location'] = location_uuid
-    response = requests.post('/ws/rest/v1/visit', json=visit)
-    try:
-        response.raise_for_status()
-    except HTTPError:
-        logger.debug('Request: ', requests.get_url('/ws/rest/v1/visit'), visit)
-        logger.debug('Response: ', response.json())
-        raise
+    response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
     visit_uuid = response.json()['uuid']
 
     encounter = {
@@ -116,13 +109,7 @@ def create_visit(requests, person_uuid, visit_datetime, values_for_concept, enco
     }
     if location_uuid:
         encounter['location'] = location_uuid
-    response = requests.post('/ws/rest/v1/encounter', json=encounter)
-    try:
-        response.raise_for_status()
-    except HTTPError:
-        logger.debug('Request: ', requests.get_url('/ws/rest/v1/encounter'), encounter)
-        logger.debug('Response: ', response.json())
-        raise
+    response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
     encounter_uuid = response.json()['uuid']
 
     observation_uuids = []
@@ -137,13 +124,7 @@ def create_visit(requests, person_uuid, visit_datetime, values_for_concept, enco
             }
             if location_uuid:
                 observation['location'] = location_uuid
-            response = requests.post('/ws/rest/v1/obs', json=observation)
-            try:
-                response.raise_for_status()
-            except HTTPError:
-                logger.debug('Request: ', requests.get_url('/ws/rest/v1/obs'), observation)
-                logger.debug('Response: ', response.json())
-                raise
+            response = requests.post_with_raise('/ws/rest/v1/obs', json=observation)
             observation_uuids.append(response.json()['uuid'])
 
     logger.debug('Observations created: ', observation_uuids)

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -44,14 +44,15 @@ def openmrs_edit_config(request, domain, repeater_id):
             repeater.openmrs_config.form_configs = map(OpenmrsFormConfig.wrap, data['form_configs'])
             repeater.save()
 
-    form = OpenmrsConfigForm(
-        data={
-            'form_configs': json.dumps([
-                form_config.to_json()
-                for form_config in repeater.openmrs_config.form_configs]),
-            'case_config':  json.dumps(repeater.openmrs_config.case_config.to_json()),
-        }
-    )
+    else:
+        form = OpenmrsConfigForm(
+            data={
+                'form_configs': json.dumps([
+                    form_config.to_json()
+                    for form_config in repeater.openmrs_config.form_configs]),
+                'case_config':  json.dumps(repeater.openmrs_config.case_config.to_json()),
+            }
+        )
     return render(request, 'openmrs/edit_config.html', {
         'domain': domain,
         'repeater_id': repeater_id,

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -50,7 +50,7 @@ def openmrs_edit_config(request, domain, repeater_id):
                 'form_configs': json.dumps([
                     form_config.to_json()
                     for form_config in repeater.openmrs_config.form_configs]),
-                'case_config':  json.dumps(repeater.openmrs_config.case_config.to_json()),
+                'case_config': json.dumps(repeater.openmrs_config.case_config.to_json()),
             }
         )
     return render(request, 'openmrs/edit_config.html', {


### PR DESCRIPTION
Adds support for updating patient names and addresses in OpenMRS. Does not support multiple names and addresses per patient at this stage.

Probably easier to :blowfish: 

Labelling "hold off" pending more testing.

@dannyroberts cc @calellowitz 
