### PR TITLE
Use location_type_name expression instead of related doc

### DIFF
--- a/custom/enikshay/ucr/data_sources/test_2b_v3.json
+++ b/custom/enikshay/ucr/data_sources/test_2b_v3.json
@@ -619,15 +619,10 @@
                 "display_name": null,
                 "datatype": "string",
                 "expression": {
-                    "type": "related_doc",
-                    "related_doc_type": "Location",
-                    "doc_id_expression": {
+                    "type": "location_type_name",
+                    "location_id_expression": {
                         "type": "property_name",
                         "property_name": "referring_facility_id"
-                    },
-                    "value_expression": {
-                        "type": "property_name",
-                        "property_name": "location_type"
                     }
                 },
                 "transform": {},


### PR DESCRIPTION
@calellowitz 
Related doc doesn't pull archived locations. That's reason for that change
