### PR TITLE
Fix find_users_with_toggle_enabled

### DIFF
--- a/corehq/ex-submodules/toggle/shortcuts.py
+++ b/corehq/ex-submodules/toggle/shortcuts.py
@@ -72,23 +72,18 @@ def parse_toggle(entry):
     return namespace, entry
 
 
-def find_with_toggle_enabled(toggle, namespace):
-    from corehq.toggles import ALL_NAMESPACES
-
-    if namespace not in ALL_NAMESPACES:
-        raise ValueError('Unknown toggle namespace "{}"'.format(namespace))
+def find_users_with_toggle_enabled(toggle):
     try:
         doc = Toggle.get(toggle.slug)
     except ResourceNotFound:
         return []
-    return [user[len(namespace) + 1:] for user in doc.enabled_users if user.startswith(namespace)]
-
-
-def find_users_with_toggle_enabled(toggle):
-    from corehq.toggles import NAMESPACE_USER
-    return find_with_toggle_enabled(toggle, namespace=NAMESPACE_USER)
+    return filter(lambda user: ':' not in user, doc.enabled_users)
 
 
 def find_domains_with_toggle_enabled(toggle):
     from corehq.toggles import NAMESPACE_DOMAIN
-    return find_with_toggle_enabled(toggle, namespace=NAMESPACE_DOMAIN)
+    try:
+        doc = Toggle.get(toggle.slug)
+    except ResourceNotFound:
+        return []
+    return [user[len(NAMESPACE_DOMAIN) + 1:] for user in doc.enabled_users if user.startswith(NAMESPACE_DOMAIN)]

--- a/corehq/ex-submodules/toggle/shortcuts.py
+++ b/corehq/ex-submodules/toggle/shortcuts.py
@@ -73,11 +73,14 @@ def parse_toggle(entry):
 
 
 def find_users_with_toggle_enabled(toggle):
+    from corehq.toggles import ALL_NAMESPACES, NAMESPACE_USER
     try:
         doc = Toggle.get(toggle.slug)
     except ResourceNotFound:
         return []
-    return filter(lambda user: ':' not in user, doc.enabled_users)
+    prefixes = tuple(ns + ':' for ns in ALL_NAMESPACES if ns != NAMESPACE_USER)
+    # Users are not prefixed with NAMESPACE_USER, but exclude NAMESPACE_USER to keep `prefixes` short
+    return [u for u in doc.enabled_users if not u.startswith(prefixes)]
 
 
 def find_domains_with_toggle_enabled(toggle):
@@ -86,4 +89,5 @@ def find_domains_with_toggle_enabled(toggle):
         doc = Toggle.get(toggle.slug)
     except ResourceNotFound:
         return []
-    return [user[len(NAMESPACE_DOMAIN) + 1:] for user in doc.enabled_users if user.startswith(NAMESPACE_DOMAIN)]
+    prefix = NAMESPACE_DOMAIN + ':'
+    return [user[len(prefix):] for user in doc.enabled_users if user.startswith(prefix)]


### PR DESCRIPTION
So `find_users_with_toggle_enabled` couldn't work, because toggles' enabled users aren't namespaced. 

Good thing it isn't used anywhere. :upside_down_face: 

And YAGNI. ... But ... I decided I wouldn't kill it after all, because `find_domains_with_toggle_enabled` exists, and future developers would expect `find_users_with_toggle_enabled` to exist too.

Yep, more toggle stuff, @millerdev, @calellowitz 
