### PR TITLE
re-fetch the user so we don't get a document update conflict

### DIFF
--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -545,6 +545,8 @@ class BETSUserPayloadGenerator(UserPayloadGenerator):
         return json.dumps(user_json, cls=DjangoJSONEncoder)
 
     def handle_success(self, response, user, repeat_record):
+        # re-fetch the user so we don't get a document update conflict
+        user = CommCareUser.get(user._id)
         existing_ids = user.user_data.get('BETS_user_repeat_record_ids')
         if existing_ids:
             user.user_data['BETS_user_repeat_record_ids'] = "{} {}".format(

--- a/custom/enikshay/integrations/bets/repeater_generators.py
+++ b/custom/enikshay/integrations/bets/repeater_generators.py
@@ -564,6 +564,7 @@ class BETSLocationPayloadGenerator(LocationPayloadGenerator):
         return json.dumps(get_bets_location_json(location))
 
     def handle_success(self, response, location, repeat_record):
+        location.refresh_from_db()
         existing_ids = location.metadata.get('BETS_location_repeat_record_ids')
         if existing_ids:
             location.metadata['BETS_location_repeat_record_ids'] = "{} {}".format(


### PR DESCRIPTION
This is a pretty blunt approach, but there is already a request to the BETS
server between when this user is pulled and when it's saved, so it's not
unreasonable to anticipate race conditions.
@proteusvacuum