### PR TITLE
Avoid irrelevant triggers

### DIFF
--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -29,7 +29,6 @@ CASE_TYPE_DRTB_HIV_REFERRAL = "drtb-hiv-referral"
 CASE_TYPE_TEST = "test"
 CASE_TYPE_PRESCRIPTION = "prescription"
 CASE_TYPE_VOUCHER = "voucher"
-CASE_TYPE_PRESCRIPTION = "prescription"
 CASE_TYPE_DRUG_RESISTANCE = "drug_resistance"
 CASE_TYPE_SECONDARY_OWNER = "secondary_owner"
 
@@ -104,6 +103,14 @@ def get_person_case_from_episode(domain, episode_case_id):
     )
 
 
+def get_all_occurrence_cases_from_person(domain, person_case_id):
+    case_accessor = CaseAccessors(domain)
+    all_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
+    occurrence_cases = [case for case in all_cases
+                        if case.type == CASE_TYPE_OCCURRENCE]
+    return occurrence_cases
+
+
 def get_open_occurrence_case_from_person(domain, person_case_id):
     """
     Gets the first open 'occurrence' case for the person
@@ -148,6 +155,18 @@ def get_associated_episode_case_for_test(test_case, occurrence_case_id):
                                        (test_case_episode_id, test_case.get_id))
 
     return get_open_episode_case_from_occurrence(test_case.domain, occurrence_case_id)
+
+
+def get_all_episode_cases_from_person(domain, person_case_id):
+    case_accessor = CaseAccessors(domain)
+    episode_cases = []
+    occurrence_cases = get_all_occurrence_cases_from_person(domain, person_case_id)
+    for occurrence_case in occurrence_cases:
+        all_cases = case_accessor.get_reverse_indexed_cases([occurrence_case.get_id])
+        episode_cases += [case for case in all_cases
+                          if case.type == CASE_TYPE_EPISODE and
+                          case.dynamic_case_properties().get('episode_type') == "confirmed_tb"]
+    return episode_cases
 
 
 def get_open_episode_case_from_occurrence(domain, occurrence_case_id):
@@ -561,3 +580,16 @@ def iter_all_active_person_episode_cases(domain, case_ids):
             continue
 
         yield person_case, episode_case
+
+
+def person_has_any_nikshay_notifiable_episode(person_case):
+    domain = person_case.domain
+    from custom.enikshay.integrations.utils import is_valid_person_submission
+    from custom.enikshay.integrations.nikshay.repeaters import valid_nikshay_patient_registration
+
+    if not is_valid_person_submission(person_case):
+        return False
+
+    episode_cases = get_all_episode_cases_from_person(domain, person_case.case_id)
+    return any(valid_nikshay_patient_registration(episode_case.dynamic_case_properties())
+               for episode_case in episode_cases)

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -19,7 +19,8 @@ from custom.enikshay.case_utils import (
     get_open_episode_case_from_person,
     get_occurrence_case_from_test,
     get_open_episode_case_from_occurrence,
-)
+    person_has_any_nikshay_notifiable_episode,
+    get_person_case_from_occurrence)
 from custom.enikshay.exceptions import ENikshayCaseNotFound
 from custom.enikshay.const import (
     TREATMENT_OUTCOME,
@@ -120,7 +121,8 @@ class NikshayHIVTestRepeater(BaseNikshayRepeater):
                     related_dates_changed(person_case) or
                     person_hiv_status_changed(person_case)
                 ) and
-                is_valid_person_submission(person_case)
+                is_valid_person_submission(person_case) and
+                person_has_any_nikshay_notifiable_episode(person_case)
             )
         else:
             return False
@@ -178,6 +180,8 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
         # test.test_type_value = microscopy-zn or test.test_type_value = microscopy-fluorescent
         # and episode.nikshay_registered is true
         allowed_case_types_and_users = self._allowed_case_type(test_case) and self._allowed_user(test_case)
+        occurrence_case = get_occurrence_case_from_test(test_case.domain, test_case.case_id)
+        person_case = get_person_case_from_occurrence(test_case.domain, occurrence_case.case_id)
         if allowed_case_types_and_users:
             test_case_properties = test_case.dynamic_case_properties()
             return (
@@ -191,7 +195,8 @@ class NikshayFollowupRepeater(BaseNikshayRepeater):
                     test_case_properties.get('rft_dstb_followup') in self.followup_for_tests
                 ) and
                 case_properties_changed(test_case, 'date_reported') and
-                not is_valid_test_submission(test_case)
+                not is_valid_test_submission(test_case) and
+                person_has_any_nikshay_notifiable_episode(person_case)
             )
         else:
             return False

--- a/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/nikshay/tests/test_repeaters.py
@@ -19,7 +19,7 @@ from custom.enikshay.const import (
     PRIVATE_PATIENT_EPISODE_PENDING_REGISTRATION,
     ENROLLED_IN_PRIVATE,
     PERSON_CASE_2B_VERSION,
-)
+    REAL_DATASET_PROPERTY_VALUE)
 from custom.enikshay.exceptions import NikshayLocationNotFound, NikshayRequiredValueMissing
 from custom.enikshay.integrations.nikshay.field_mappings import health_establishment_sector
 from custom.enikshay.integrations.nikshay.repeaters import (
@@ -28,7 +28,8 @@ from custom.enikshay.integrations.nikshay.repeaters import (
     NikshayTreatmentOutcomeRepeater,
     NikshayFollowupRepeater,
     NikshayRegisterPrivatePatientRepeater,
-    NikshayHealthEstablishmentRepeater)
+    NikshayHealthEstablishmentRepeater,
+)
 from custom.enikshay.tests.utils import (
     ENikshayCaseStructureMixin,
     ENikshayLocationStructureMixin,
@@ -165,6 +166,7 @@ class NikshayRepeaterTestBase(ENikshayCaseStructureMixin, TestCase):
     def set_up_to_use_2b_version(self):
         update_case(self.domain, self.person_id, {
             'case_version': PERSON_CASE_2B_VERSION,
+            'dataset': REAL_DATASET_PROPERTY_VALUE,
         })
 
         update_case(self.domain, self.occurrence_id, {
@@ -479,6 +481,10 @@ class TestNikshayHIVTestRepeater(ENikshayLocationStructureMixin, NikshayRepeater
     def test_trigger(self):
         # nikshay not enabled
         self.create_case(self.episode)
+        self._create_nikshay_enabled_case()
+        update_case(self.domain, self.person_id, {
+            "owner_id": self.phi.location_id,
+        })
         self._create_nikshay_registered_case()
         self.assertEqual(0, len(self.repeat_records().all()))
 
@@ -503,6 +509,7 @@ class TestNikshayHIVTestRepeater(ENikshayLocationStructureMixin, NikshayRepeater
         self.phi.metadata['is_test'] = 'yes'
         self.phi.save()
         self.create_case(self.episode)
+        self._create_nikshay_enabled_case()
         self._create_nikshay_registered_case()
         update_case(self.domain, self.person_id, {
             "hiv_status": "unknown",
@@ -526,6 +533,10 @@ class TestNikshayHIVTestRepeater(ENikshayLocationStructureMixin, NikshayRepeater
         self.phi.metadata['is_test'] = 'no'
         self.phi.save()
         self.create_case(self.episode)
+        self._create_nikshay_enabled_case()
+        update_case(self.domain, self.person_id, {
+            "owner_id": self.phi.location_id,
+        })
         self._create_nikshay_registered_case()
         update_case(self.domain, self.person_id, {
             "hiv_status": "unknown",
@@ -803,7 +814,10 @@ class TestNikshayFollowupRepeater(ENikshayLocationStructureMixin, NikshayRepeate
         self.assertEqual(0, len(self.repeat_records().all()))
 
         self.factory.create_or_update_cases([self.lab_referral, self.episode])
-
+        self._create_nikshay_enabled_case()
+        update_case(self.domain, self.person_id, {
+            "owner_id": self.phi.location_id,
+        })
         update_case(self.domain, self.test_id, {"date_reported": datetime.now()})
         self.assertTrue(check_repeat_record_added())
 
@@ -866,6 +880,10 @@ class TestNikshayFollowupRepeater(ENikshayLocationStructureMixin, NikshayRepeate
         self.dmc.metadata['is_test'] = 'yes'
         self.dmc.save()
         self.factory.create_or_update_cases([self.lab_referral, self.episode])
+        update_case(self.domain, self.person_id, {
+            "owner_id": self.phi.location_id,
+        })
+        self._create_nikshay_enabled_case()
         self._create_nikshay_registered_case()
         self.assertEqual(0, len(self.repeat_records().all()))
         update_case(self.domain, self.test_id, {
@@ -877,6 +895,10 @@ class TestNikshayFollowupRepeater(ENikshayLocationStructureMixin, NikshayRepeate
         self.dmc.metadata['is_test'] = 'no'
         self.dmc.save()
         self.factory.create_or_update_cases([self.lab_referral, self.episode])
+        update_case(self.domain, self.person_id, {
+            "owner_id": self.phi.location_id,
+        })
+        self._create_nikshay_enabled_case()
         self._create_nikshay_registered_case()
         self.assertEqual(0, len(self.repeat_records().all()))
         update_case(self.domain, self.test_id, {


### PR DESCRIPTION
For HIV tests avoid cases where HIV status is updated for a patient even before any episode is registered
For Follow Up tests avoid tests that are done for diagnosis even before starting treatment. A test where test would be positive should then start a new confirmed tb episode which would then get notified and use this test as diagnosis test

cc: @sravfeyn 