### PR TITLE
Fix toggle error

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -323,7 +323,7 @@ def toggle_values_by_name(username=None, domain=None):
 
     all toggles (including those not enabled) are included
     """
-    return {toggle_name: (toggle.enabled(username) or toggle.enabled(domain))
+    return {toggle_name: (toggle.enabled(username, NAMESPACE_USER) or toggle.enabled(domain, NAMESPACE_DOMAIN))
             for toggle_name, toggle in all_toggles_by_name().items()}
 
 


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/18082 - I've been getting this error locally:
```2017-10-09 14:23:49,886 ERROR Internal Server Error: /a/jennytraining/toggles.js
Traceback (most recent call last):
  File "/Users/jenniferschweers/.virtualenvs/hq/lib/python2.7/site-packages/django/core/handlers/exception.py", line 42, in inner
    response = get_response(request)
  File "/Users/jenniferschweers/.virtualenvs/hq/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/jenniferschweers/.virtualenvs/hq/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/jenniferschweers/Documents/commcare-hq/corehq/middleware.py", line 143, in inner
    response = fn(*args, **kwargs)
  File "/Users/jenniferschweers/Documents/commcare-hq/corehq/apps/domain/decorators.py", line 103, in _inner
    return view_func(req, domain_name, *args, **kwargs)
  File "/Users/jenniferschweers/Documents/commcare-hq/corehq/apps/hqwebapp/views.py", line 1223, in toggles_js
    'toggles_dict': toggles.toggle_values_by_name(username=request.user.username, domain=domain),
  File "/Users/jenniferschweers/Documents/commcare-hq/corehq/toggles.py", line 327, in toggle_values_by_name
    for toggle_name, toggle in all_toggles_by_name().items()}
  File "/Users/jenniferschweers/Documents/commcare-hq/corehq/toggles.py", line 327, in <dictcomp>
    for toggle_name, toggle in all_toggles_by_name().items()}
  File "/Users/jenniferschweers/Documents/commcare-hq/corehq/toggles.py", line 245, in enabled
    item=item,
ValueError: PredictablyRandomToggle.enabled() cannot be determined for toggle "icds_livequery" because it is not available for all namespaces and the namespace of "jschweers@dimagi.com" is not given.
2017-10-09 14:23:53,865 ERROR "GET /a/jennytraining/toggles.js?username=jschweers@dimagi.com&cachebuster=66e-64b-cb9-cef HTTP/1.1" 500 261365
```

@kaapstorm / @proteusvacuum 