### PR TITLE
Use treatment initiating facility id which filled the Start treatment Card

### DIFF
--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -347,7 +347,7 @@ def update_case(domain, case_id, updated_properties, external_id=None,
 
 def get_person_locations(person_case, episode_case=None):
     """
-    picks episode case's diagnosing_facility_id if passed else falls back to person's owner id for
+    picks episode case's treatment_initiating_facility_id if passed else falls back to person's owner id for
     fetching the base location to get the hierarchy
     public locations hierarchy
     sto -> cto -> dto -> tu -> phi
@@ -366,8 +366,8 @@ def _get_public_locations(person_case, episode_case):
     try:
         phi_location_id = None
         if episode_case:
-            phi_location_id = episode_case.dynamic_case_properties().get('diagnosing_facility_id')
-        # fallback to person_case.owner_id in case diagnosing_facility_id not set on episode
+            phi_location_id = episode_case.dynamic_case_properties().get('treatment_initiating_facility_id')
+        # fallback to person_case.owner_id in case treatment_initiating_facility_id not set on episode
         # or if no episode case was passed
         if not phi_location_id:
             phi_location_id = person_case.owner_id

--- a/custom/enikshay/tests/test_case_utils.py
+++ b/custom/enikshay/tests/test_case_utils.py
@@ -202,7 +202,7 @@ class TestGetPersonLocations(ENikshayCaseStructureMixin, ENikshayLocationStructu
         self.assertEqual(expected_locations, get_person_locations(person_case)._asdict())
 
         update_case(self.domain, self.episode_id, {
-            "diagnosing_facility_id": person_case.owner_id
+            "treatment_initiating_facility_id": person_case.owner_id
         })
         person_case.owner_id = ARCHIVED_CASE_OWNER_ID
         person_case.save()


### PR DESCRIPTION
From kriti,
> treatment_initiating_facility_id will be the id of the facility that owned the person at the time the Start Treatment Card form was filled out. 
