### PR TITLE
Update expected_doses_taken to be inclusive

### DIFF
--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -283,10 +283,10 @@ class EpisodeAdherenceUpdate(object):
         self.domain = domain
         self.episode = episode_case
         self.adherence_data_store = get_datastore(self.domain)
-        # set purge_date to 30 days back
+        self.date_today_in_india = datetime.datetime.now(pytz.timezone(ENIKSHAY_TIMEZONE)).date()
         self.purge_date = datetime.datetime.now(
             pytz.timezone(ENIKSHAY_TIMEZONE)).date() - datetime.timedelta(days=30)
-        self.date_today_in_india = datetime.datetime.now(pytz.timezone(ENIKSHAY_TIMEZONE)).date()
+
 
         self._cache_dose_taken_by_date = False
 
@@ -463,6 +463,9 @@ class EpisodeAdherenceUpdate(object):
         date, prior to which adherence cases are closed. The "purged" cases are
         not sent down to the phone.
 
+        Adherence cases are closed 30 days after the adherence_date property.
+        If today is Jan 31, then all cases on or before Jan 1 will have been "purged"
+
         """
 
         if (adherence_schedule_date_start > self.purge_date) or not latest_adherence_date:
@@ -491,9 +494,13 @@ class EpisodeAdherenceUpdate(object):
         )
 
         doses_per_week = self.get_doses_per_week()
-        update['expected_doses_taken'] = int(((
-            (update['aggregated_score_date_calculated'] - adherence_schedule_date_start)).days / 7.0
-        ) * doses_per_week)
+
+        # the expected number of doses taken between the time the adherence
+        # schedule started and the last valid date of the score
+        # (i.e. the earlier of (30 days ago, latest_adherence_date))
+        # this property should actually have been called "aggregated_score_count_expected"
+        num_days = (update['aggregated_score_date_calculated'] - adherence_schedule_date_start).days + 1
+        update['expected_doses_taken'] = int(doses_per_week * num_days / 7.0)
 
         update['total_expected_doses_taken'] = self.get_total_expected_doses_taken(adherence_schedule_date_start)
         return update

--- a/custom/enikshay/tests/test_adherence_updates.py
+++ b/custom/enikshay/tests/test_adherence_updates.py
@@ -298,15 +298,22 @@ class TestAdherenceUpdater(TestCase):
         )
 
     def test_adherence_date_less_than_purge_date(self):
+        purge_date = datetime.date(2016, 1, 20)
+        adherence_schedule_start_date = datetime.date(2016, 1, 10)
+        latest_adherence_date = datetime.date(2016, 1, 15)
+        expected_doses_taken = 6
+
         self.assert_update(
-            datetime.date(2016, 1, 20), datetime.date(2016, 1, 10), 'schedule1',
+            purge_date,
+            adherence_schedule_start_date,
+            'schedule1',
             # if adherence_date less than purge_date
-            [(datetime.date(2016, 1, 15), DTIndicators[0])],
+            [(latest_adherence_date, DTIndicators[0])],
             output={
                 # set to latest adherence_date
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 15),
                 # co-efficient (aggregated_score_date_calculated - adherence_schedule_date_start)
-                'expected_doses_taken': int((5.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': expected_doses_taken,
                 'aggregated_score_count_taken': 1,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 15),
                 'adherence_total_doses_taken': 1
@@ -314,21 +321,23 @@ class TestAdherenceUpdater(TestCase):
         )
 
     def test_adherence_date_greater_than_purge_date(self):
+        purge_date = datetime.date(2016, 1, 31)
+        adherence_schedule_start_date = datetime.date(2016, 1, 1)
+        expected_doses_taken = 31
+
         self.assert_update(
-            datetime.date(2016, 1, 20),
-            datetime.date(2016, 1, 10), 'schedule1',
-            # if adherence_date is less than adherence_schedule_date_start
-            [(datetime.date(2016, 1, 22), DTIndicators[0])],
+            purge_date,
+            adherence_schedule_start_date,
+            'schedule1',
+            # if adherence_date is later than adherence_schedule_date_start
+            [(datetime.date(2016, 2, 22), DTIndicators[0])],
             output={
-                # should be purge_date
-                'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
-                # co-efficient (aggregated_score_date_calculated - adherence_schedule_date_start)
-                'expected_doses_taken': int((10.0 / 7) * int(self.fixture_data['schedule1'])),
-                # no doses taken before aggregated_score_date_calculated
+                'aggregated_score_date_calculated': purge_date,
+                'expected_doses_taken': expected_doses_taken,
+                # no doses taken before purge_date
                 'aggregated_score_count_taken': 0,
                 # latest adherence taken date
-                'adherence_latest_date_recorded': datetime.date(2016, 1, 22),
-                # no doses taken before aggregated_score_date_calculated
+                'adherence_latest_date_recorded': datetime.date(2016, 2, 22),
                 'adherence_total_doses_taken': 1
             }
         )
@@ -347,7 +356,7 @@ class TestAdherenceUpdater(TestCase):
             output={   # should be purge_date
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
                 # co-efficient (aggregated_score_date_calculated - adherence_schedule_date_start)
-                'expected_doses_taken': int((10.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data['schedule1'])),
                 # no dose taken before aggregated_score_date_calculated
                 'aggregated_score_count_taken': 0,
                 # latest recorded
@@ -370,7 +379,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={   # set to latest adherence_date, exclude 14th because its unknown
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 12),
-                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((3.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 2,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 12),
                 'adherence_total_doses_taken': 2
@@ -389,7 +398,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 12),
-                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((3.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 2,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 12),
                 'adherence_total_doses_taken': 2
@@ -408,7 +417,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
-                'expected_doses_taken': int((10.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 2,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 21),
                 'adherence_total_doses_taken': 2
@@ -426,7 +435,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 11),
-                'expected_doses_taken': int((1.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 1,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 11),
                 'adherence_total_doses_taken': 1
@@ -443,7 +452,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 11),
-                'expected_doses_taken': int((1.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 1,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 11),
                 'adherence_total_doses_taken': 1
@@ -475,7 +484,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 11),
-                'expected_doses_taken': int((1.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 0,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 11),
                 'adherence_total_doses_taken': 0
@@ -507,7 +516,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
-                'expected_doses_taken': int((10.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data['schedule1'])),
                 'aggregated_score_count_taken': 0,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 22),
                 'adherence_total_doses_taken': 0


### PR DESCRIPTION
Code buddy: @orangejenny

@ctsims @sravfeyn : this was a bug with the adherence task before. Does my logic below make sense? 

https://github.com/dimagi/commcare-hq/pull/17932#discussion_r140597462
https://trello.com/c/CpN3oKlT/228-adherence-task-date-issues

FYI @gcapalbo 

This `expected_doses_taken` property is a count of all of the doses that should
have been taken up until the date that cases are automatically closed (i.e. the
"purge date"), or the date of the last adherence case, whichever is later. We
don't want to count cases that remain open, as this would ruin the calculations
on the phone.

**aggregated_score_date_calculated = purge date**
- Today is `2017-01-31`. The purge_date is then `2017-01-01`
- Cases get closed at midnight of the 30th day after their `adherence_date` property here: https://enikshay.in/a/enikshay/data/edit/automatic_updates/edit/152/
    - If today is `2017-01-31`, then all cases where the adherence_date property is `2017-01-01` and earlier will be closed. i.e. all cases where `adherence_date` = `purge_date` are closed.
- If the `adherence_schedule_date_start` is `2016-01-01`, then we want to count the number of days between `[2016-01-01, 2017-01-01]` = 366 (since 2016 was a leap year).
- i.e. This should be inclusive.

**aggregate_score_date_calculated = latest_adherence_date**
- Today is `2017-01-31`.
- The latest adherence case we received is `2016-12-31`
- The `adherence_schedule_date_start` is `2016-01-01`
- We want to count all the cases within the window [2016-01-01, 2016-12-31]. i.e. we also count the cases that occur on the `latest_adherence_date`. i.e. 31 days.
- Conclusion: this should also be inclusive.