### PR TITLE
SyncLog Pruning Fixes

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/dbaccessors/sync_logs_by_user.py
@@ -1,5 +1,7 @@
 from datetime import date
+from casexml.apps.phone.exceptions import CouldNotRetrieveSyncLogIds
 from casexml.apps.phone.models import SyncLog, properly_wrap_sync_log
+from restkit.errors import RequestFailed
 
 
 def get_last_synclog_for_user(user_id):
@@ -32,13 +34,20 @@ def get_synclogs_for_user(user_id, limit=10):
     return result
 
 
-def get_synclog_ids_before_date(before_date, limit=1000):
+def get_synclog_ids_before_date(before_date, limit=1000, num_tries=10):
     if isinstance(before_date, date):
         before_date = before_date.strftime("%Y-%m-%d")
-    return [r['id'] for r in SyncLog.view(
-        "sync_logs_by_date/view",
-        endkey=[before_date],
-        limit=limit,
-        reduce=False,
-        include_docs=False
-    )]
+
+    for i in range(num_tries):
+        try:
+            return [r['id'] for r in SyncLog.view(
+                "sync_logs_by_date/view",
+                endkey=[before_date],
+                limit=limit,
+                reduce=False,
+                include_docs=False
+            )]
+        except RequestFailed:
+            pass
+
+    raise CouldNotRetrieveSyncLogIds()

--- a/corehq/ex-submodules/casexml/apps/phone/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/exceptions.py
@@ -86,3 +86,7 @@ class InvalidOwnerIdError(OwnershipCleanlinessError):
 
 class SyncLogCachingError(Exception):
     pass
+
+
+class CouldNotRetrieveSyncLogIds(Exception):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -68,7 +68,7 @@ def update_celery_state(sender=None, body=None, **kwargs):
 
 
 @periodic_task(
-    run_every=crontab(hour="23", minute="0"),
+    run_every=crontab(hour="1", minute="0"),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery')
 )
 def prune_synclogs():

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -4,4 +4,4 @@ def delete_sync_logs(before_date, limit=1000):
     from casexml.apps.phone.models import SyncLog
     from dimagi.utils.couch.database import iter_bulk_delete_with_doc_type_verification
     sync_log_ids = get_synclog_ids_before_date(before_date, limit)
-    return iter_bulk_delete_with_doc_type_verification(SyncLog.get_db(), sync_log_ids, 'SyncLog', chunksize=5)
+    return iter_bulk_delete_with_doc_type_verification(SyncLog.get_db(), sync_log_ids, 'SyncLog', chunksize=25)


### PR DESCRIPTION
SyncLogs haven't been pruned in ICDS because the task is failing each night on getting the SyncLog ids. To fix this, the changes made here are to:

- run the prune sync log task 1 hour after the preindexing task starts running to help avoid view timeouts
- catch and retry on RequestFailed errors when getting the ids
- bump the bulk delete from 5 at a time to 25 at a time (this doesn't have to do with this fix but reduces deleting 1000 sync logs to about 1 minute on ICDS vs several minutes)

@dimagi/scale-team 