### PR TITLE
don't truncate password on invite

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1185,13 +1185,6 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         )
 
 
-########################################################################################################
-
-min_pwd = 4
-max_pwd = 20
-pwd_pattern = re.compile( r"([-\w]){"  + str(min_pwd) + ',' + str(max_pwd) + '}' )
-
-
 def clean_password(txt):
     if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
         strength = legacy_get_password_strength(txt)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _, ugettext
 from corehq.apps.programs.models import Program
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.forms import RoleForm, SupplyPointSelectWidget
-from corehq.apps.domain.forms import clean_password, max_pwd, NoAutocompleteMixin
+from corehq.apps.domain.forms import clean_password, NoAutocompleteMixin
 from corehq.apps.domain.models import Domain
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.hqwebapp.utils import decode_password
@@ -253,7 +253,6 @@ class WebUserInvitationForm(NoAutocompleteMixin, DomainRegistrationForm):
                              help_text=_('You will use this email to log in.'),
                              widget=forms.TextInput(attrs={'class': 'form-control'}))
     password = forms.CharField(label=_('Create Password'),
-                               max_length=max_pwd,
                                widget=forms.PasswordInput(render_value=False,
                                                           attrs={
                                                             'data-bind': "value: password, valueUpdate: 'input'",


### PR DESCRIPTION
This has been here since before I joined Dimagi...

When accepting an invitation to a domain and creating the new user in that form, the chosen password has always been silently truncated to 20 characters. Now it will allow any length, just like all the other interfaces for setting a password.