### PR TITLE
Add column width and font styling support to UCR

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datatables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datatables.less
@@ -7,7 +7,8 @@
   padding-right: 5px;
 }
 
-.datatable thead th {
+.datatable thead th,
+.dataTable thead th {
   background-color: desaturate(@cc-brand-low, 50%);
   color: #ffffff;
   &:nth-child(odd) {
@@ -16,13 +17,16 @@
 }
 
 .datatable tfoot td,
-.datatable tfoot th {
+.datatable tfoot th,
+.dataTable tfoot td,
+.dataTable tfoot th{
   background-color: lighten(desaturate(@cc-brand-low, 60%), 10%);
   color: #ffffff;
   padding: 8px;
 }
 
-.datatable .header {
+.datatable .header,
+.dataTable .header {
   &.headerSortUp {
     .dt-sort-icon:before {
       content: "\f077";
@@ -39,7 +43,8 @@
   }
 }
 
-.datatable .sorting_1 {
+.datatable .sorting_1,
+.dataTable .sorting_1 {
   background-color: @cc-bg;
 }
 
@@ -56,4 +61,32 @@
       }
     }
   }
+}
+
+.dataTable td.text-xs {
+  font-size: .8em;
+}
+
+.dataTable td.text-sm {
+  font-size: .9em;
+}
+
+.dataTable td.text-lg {
+  font-size: 1.1em;
+}
+
+.dataTable td.text-xl {
+  font-size: 1.2em;
+}
+
+.dataTable td.text-bold {
+  font-weight: bold;
+}
+
+.dataTable td.text-red {
+  color: @cc-att-neg-mid;
+}
+
+.dataTable td.text-green {
+  color: @cc-att-pos-mid;
 }

--- a/corehq/apps/reports/datatables/__init__.py
+++ b/corehq/apps/reports/datatables/__init__.py
@@ -8,7 +8,7 @@ class DataTablesColumn(object):
     def __init__(self, name, span=0, sort_type=None, sort_direction=None,
                  help_text=None, sortable=True, rotate=False,
                  expected=None, prop_name=None, visible=True, data_slug=None,
-                 alt_prop_name=None):
+                 alt_prop_name=None, width=None, css_class=None):
         self.html = name
         self.css_span = span
         self.sort_type = sort_type
@@ -23,6 +23,8 @@ class DataTablesColumn(object):
         self.expected = expected
         self.data_slug = data_slug
         self.alt_prop_name = alt_prop_name
+        self.width = width
+        self.css_class = css_class
 
     @property
     def render_html(self):
@@ -33,7 +35,8 @@ class DataTablesColumn(object):
             css="span%d" % self.css_span if self.css_span > 0 else '',
             rowspan=self.rowspan,
             help_text=self.help_text,
-            expected=self.expected
+            expected=self.expected,
+            width=self.width
         )
         return render_to_string("reports/datatables/column.html", dict(
             col=column_params
@@ -55,6 +58,8 @@ class DataTablesColumn(object):
             aoColumns["bVisible"] = self.visible
         if self.data_slug:
             aoColumns['mDataProp'] = self.data_slug
+        if self.css_class:
+            aoColumns['sClass'] = self.css_class
         return aoColumns
 
 

--- a/corehq/apps/reports/templates/reports/datatables/column.html
+++ b/corehq/apps/reports/templates/reports/datatables/column.html
@@ -1,9 +1,11 @@
 <th{% if col.rowspan %} rowspan="{{ col.rowspan }}"{% endif %}{% if col.css %} class="{{ col.css }}"{% endif %}>
     <div {% if col.help_text %}
         class="header-popover"
-        style="cursor:pointer;"
+        style="cursor:pointer;{% if col.width %} width: {{ col.width }};{% endif %}"
         data-title="{{ col.title }}"
         data-content="{{ col.help_text }}"
+        {% elif col.width %}
+          style="width: {{ col.width }};"
         {% endif %}>
     {% if col.sort %}<i class="icon-white fa dt-sort-icon"></i>{% endif %}
     {% if col.rotate %}<div class="sideways">{% endif %}

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -148,6 +148,8 @@ class FieldColumn(ReportColumn):
         'percent_of_total',
     ])
     sortable = BooleanProperty(default=False)
+    width = StringProperty(default=None, required=False)
+    css_class = StringProperty(default=None, required=False)
 
     @classmethod
     def wrap(cls, obj):
@@ -181,7 +183,9 @@ class FieldColumn(ReportColumn):
                 data_slug=self.column_id,
                 format_fn=self.get_format_fn(),
                 help_text=self.description,
-                visible=self.visible
+                visible=self.visible,
+                width=self.width,
+                css_class=self.css_class,
             )
         ])
 


### PR DESCRIPTION
![screen shot 2017-10-11 at 2 46 09 am](https://user-images.githubusercontent.com/716573/31425747-86b3ff0a-ae2e-11e7-97ea-c4dcbc0035bd.png)

```
            {
                "sortable": false,
                "description": "this is a test help text description",
                "format": "default",
                "transform": {},
                "aggregation": "simple",
                "field": "current_address",
                "calculate_total": false,
                "type": "field",
                "display": "Complete Address",
                "width": "300px",
                "css_class": "text-xs text-red text-bold"
            },
```

New fields added to the UCR column config spec:
- `width`: a string specifying a width in `px`, `%`, `em`....use `px` for best results.
- `css_class`: you can specify a class specific to the data in that column. Available classes are:  `text-xs` (two sizes smaller), `text-sm` (one size smaller), `text-lg` (one size larger), `text-xl` (two sizes larger), `text-bold`, `text-red`, `text-green`

Also, the hover-over description already exists but want to keep as a note in this PR. Enable it by filling in `description`

@calellowitz cc @dannyroberts 

