### PR TITLE
Allow adding search engine for multiple environments

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -29,7 +29,7 @@
         <link type="application/opensearchdescription+xml"
               rel="search"
               href="{% url 'osdd' %}"
-              title="CommCare HQ" />
+              title="CommCare HQ{% if env %} - {{env}}{% endif %}" />
 
         {% if less_debug %}
             <link type="text/less"

--- a/corehq/apps/hqwebapp/templates/osdd.xml
+++ b/corehq/apps/hqwebapp/templates/osdd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-    <ShortName>CommCare HQ</ShortName>
+    <ShortName>CommCare HQ{% if env %} - {{env}}{% endif %}</ShortName>
     <Description>Enter any ID; a case ID or form ID, for example</Description>
     <Url type="text/html" method="get" template="{{ url_base }}/search/?q={searchTerms}"/>
 </OpenSearchDescription>

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -123,3 +123,14 @@ def format_angular_success(additional_data=None):
     if isinstance(additional_data, dict):
         resp.update(additional_data)
     return resp
+
+
+def get_environment_friendly_name():
+    try:
+        env = {
+            "production": "",
+            "softlayer": "India",
+        }[settings.SERVER_ENVIRONMENT]
+    except KeyError:
+        env = settings.SERVER_ENVIRONMENT
+    return env

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -63,6 +63,7 @@ from corehq.apps.hqadmin.management.commands.deploy_in_progress import DEPLOY_IN
 from corehq.apps.hqwebapp.doc_info import get_doc_info, get_object_info
 from corehq.apps.hqwebapp.encoders import LazyEncoder
 from corehq.apps.hqwebapp.forms import EmailAuthenticationForm, CloudCareAuthenticationForm
+from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.util import format_username
@@ -1114,7 +1115,10 @@ def quick_find(request):
 
 
 def osdd(request, template='osdd.xml'):
-    response = render(request, template, {'url_base': get_url_base()})
+    response = render(request, template, {
+        'url_base': get_url_base(),
+        'env': get_environment_friendly_name()
+    })
     response['Content-Type'] = 'application/xml'
     return response
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -4,6 +4,8 @@ from django.http import Http404
 from ws4redis.context_processors import default
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq import privileges
+from corehq.apps.hqwebapp.utils import get_environment_friendly_name
+
 
 COMMCARE = 'commcare'
 COMMTRACK = 'commtrack'
@@ -16,6 +18,7 @@ def base_template(request):
         'base_template': settings.BASE_TEMPLATE,
         'login_template': settings.LOGIN_TEMPLATE,
         'less_debug': settings.LESS_DEBUG,
+        'env': get_environment_friendly_name(),
     }
 
 


### PR DESCRIPTION
@orangejenny 

This allows you to add multiple custom search engines to your browser for the different commcare environments. Prior to this, if you'd added a search engine for prod, you weren't then able to add another custom search engine for india or enikshay. 