### PR TITLE
Translate message, and make it more appropriate

### DIFF
--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -25,7 +25,8 @@
     </button>
     {% else %}
     <div class="col-md-3 pull-right">
-        Data source too large to rebuild. Please contact a dev to run the async_rebuild_table  command to rebuild this data source
+        {% blocktrans %}This data source is too large to rebuild. Please contact Dimagi if you need to rebuild
+        this data source.{% endblocktrans %}
     </div>
     {% endif %}
     <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview data' %}</a>

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -25,7 +25,8 @@
     </button>
     {% else %}
     <div class="col-md-3 pull-right">
-        {% blocktrans %}This data source is too large to rebuild. Please contact Dimagi if you need to rebuild
+        {% blocktrans %}This data source is too large to rebuild. Please click the
+        <i class="fa fa-question-circle nav-main-icon"></i> above and Report an Issue if you need to rebuild
         this data source.{% endblocktrans %}
     </div>
     {% endif %}


### PR DESCRIPTION
While looking at [FB 263070](https://manage.dimagi.com/default.asp?263070) I noticed a user-facing message that seems to be addresses to Dimagi staff, and not end users. 

This change translates the message, and tries to make it more appropriate for non-Dimagi users.
