### PR TITLE
better handling for async indicators with multiple data sources

### DIFF
--- a/corehq/apps/userreports/admin.py
+++ b/corehq/apps/userreports/admin.py
@@ -12,8 +12,9 @@ class AsyncIndicatorAdmin(admin.ModelAdmin):
         'indicator_config_ids',
         'date_created',
         'date_queued',
+        'unsuccessful_attempts'
     ]
-    list_filter = ('doc_type', 'domain')
+    list_filter = ('doc_type', 'domain', 'unsuccessful_attempts')
     search_fields = ('doc_id',)
 
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -814,7 +814,7 @@ class AsyncIndicator(models.Model):
     def update_failure(self, to_remove):
         self.refresh_from_db(fields=['indicator_config_ids'])
         new_indicators = set(self.indicator_config_ids) - set(to_remove)
-        self.indicator_config_ids = new_indicators
+        self.indicator_config_ids = sorted(list(new_indicators))
         self.unsuccessful_attempts += 1
 
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -806,9 +806,16 @@ class AsyncIndicator(models.Model):
                 if config_ids - current_config_ids:
                     new_config_ids = sorted(list(current_config_ids.union(config_ids)))
                     indicator.indicator_config_ids = new_config_ids
+                    indicator.unsuccessful_attempts = 0
                     indicator.save()
 
         return indicator
+
+    def update_failure(self, to_remove):
+        self.refresh_from_db(fields=['indicator_config_ids'])
+        new_indicators = set(self.indicator_config_ids) - set(to_remove)
+        self.indicator_config_ids = new_indicators
+        self.unsuccessful_attempts += 1
 
 
 def get_datasource_config(config_id, domain):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -10,6 +10,7 @@ from celery.task import task, periodic_task
 from couchdbkit import ResourceConflict, ResourceNotFound
 from django.conf import settings
 from django.db import InternalError, DatabaseError
+from django.db import transaction
 from django.db.models import Count, F, Min
 from django.utils.translation import ugettext as _
 from elasticsearch.exceptions import ConnectionTimeout
@@ -309,16 +310,17 @@ def save_document(doc_ids):
         with timer:
             for doc in doc_store.iter_documents(doc_ids):
                 indicator = indicator_by_doc_id[doc['_id']]
-                successfully_processed = _save_document_helper(indicator, doc)
+                successfully_processed, to_remove = _save_document_helper(indicator, doc)
                 if successfully_processed:
                     processed_indicators.append(indicator.pk)
                 else:
-                    failed_indicators.append(indicator.pk)
+                    failed_indicators.append((indicator.pk, to_remove))
 
         AsyncIndicator.objects.filter(pk__in=processed_indicators).delete()
-        AsyncIndicator.objects.filter(pk__in=failed_indicators).update(
-            date_queued=None, unsuccessful_attempts=F('unsuccessful_attempts') + 1
-        )
+        with transaction.atomic():
+            for indicator, to_remove in failed_indicators:
+                indicator.update_failure(to_remove)
+                indicator.save()
 
     datadog_histogram(
         'commcare.async_indicator.processing_time', timer.duration,
@@ -331,6 +333,7 @@ def save_document(doc_ids):
 def _save_document_helper(indicator, doc):
     eval_context = EvaluationContext(doc)
     something_failed = False
+    configs_to_remove = []
     for config_id in indicator.indicator_config_ids:
         adapter = None
         try:
@@ -341,7 +344,7 @@ def _save_document_helper(indicator, doc):
         except ESError:
             celery_task_logger.info("ES errored when trying to retrieve config")
             something_failed = True
-            return
+            continue
         try:
             adapter = get_indicator_adapter(config, can_handle_laboratory=True)
             adapter.save(doc, eval_context)
@@ -351,15 +354,15 @@ def _save_document_helper(indicator, doc):
             # a database had an issue so log it and go on to the next document
             celery_task_logger.info("DB error when saving config: {}".format(config_id))
             something_failed = True
-            return
         except Exception as e:
             # getting the config could fail before the adapter is set
             if adapter:
                 adapter.handle_exception(doc, e)
             something_failed = True
-            return
+        else:
+            configs_to_remove.append(config_id)
 
-    return not something_failed
+    return (not something_failed, configs_to_remove)
 
 
 @periodic_task(

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -314,7 +314,7 @@ def save_document(doc_ids):
                 if successfully_processed:
                     processed_indicators.append(indicator.pk)
                 else:
-                    failed_indicators.append((indicator.pk, to_remove))
+                    failed_indicators.append((indicator, to_remove))
 
         AsyncIndicator.objects.filter(pk__in=processed_indicators).delete()
         with transaction.atomic():


### PR DESCRIPTION
@kaapstorm @emord 
enikshay ran into an issue where the failure on one data source was preventing the others from being tried (and eventually stopped that case id from being queued at all, as max retries was exceeded). This tries all data sources for each doc instead of failing fast, and just removes the successful ones from the list of data sources requiring insertion.