### PR TITLE
removing resident filter from agg script

### DIFF
--- a/custom/icds_reports/migrations/sql_templates/create_functions.sql
+++ b/custom/icds_reports/migrations/sql_templates/create_functions.sql
@@ -1165,9 +1165,9 @@ BEGIN
                   ' AND (date_death IS NULL OR date_death >= ' || quote_literal(_end_date) || ')' ||
       ' THEN seeking_services ELSE 0 END) as cases_person_beneficiary, ' ||
 		'sum(CASE WHEN ' || quote_literal(_month_end_11yr) || ' > dob AND ' || quote_literal(_month_start_15yr) || ' <= dob' || ' AND sex = ' || quote_literal(_female) || ' THEN seeking_services ELSE 0 END) as cases_person_adolescent_girls_11_14, ' ||
-		'sum(CASE WHEN ' || quote_literal(_month_end_11yr) || ' > dob AND ' || quote_literal(_month_start_15yr) || ' <= dob' || ' AND sex = ' || quote_literal(_female) || ' AND resident = ' || quote_literal(_yes_text) || ' THEN 1 ELSE 0 END) as cases_person_adolescent_girls_11_14_all, ' ||
+		'sum(CASE WHEN ' || quote_literal(_month_end_11yr) || ' > dob AND ' || quote_literal(_month_start_15yr) || ' <= dob' || ' AND sex = ' || quote_literal(_female) || ' THEN 1 ELSE 0 END) as cases_person_adolescent_girls_11_14_all, ' ||
 		'sum(CASE WHEN ' || quote_literal(_month_end_15yr) || ' > dob AND ' || quote_literal(_month_start_18yr) || ' <= dob' || ' AND sex = ' || quote_literal(_female) || ' THEN seeking_services ELSE 0 END) as cases_person_adolescent_girls_15_18, ' ||
-		'sum(CASE WHEN ' || quote_literal(_month_end_15yr) || ' > dob AND ' || quote_literal(_month_start_18yr) || ' <= dob' || ' AND sex = ' || quote_literal(_female) || ' AND resident = ' || quote_literal(_yes_text) || ' THEN 1 ELSE 0 END) as cases_person_adolescent_girls_15_18_all ' ||
+		'sum(CASE WHEN ' || quote_literal(_month_end_15yr) || ' > dob AND ' || quote_literal(_month_start_18yr) || ' <= dob' || ' AND sex = ' || quote_literal(_female) || ' THEN 1 ELSE 0 END) as cases_person_adolescent_girls_15_18_all ' ||
 		'FROM ' || quote_ident(_person_tablename) || ' ' ||
 		'WHERE (opened_on <= ' || quote_literal(_end_date) || ' AND (closed_on IS NULL OR closed_on >= ' || quote_literal(_start_date) || ' )) ' ||
 		'GROUP BY awc_id) ut ' ||


### PR DESCRIPTION
@sheelio cc: @kaapstorm @emord 
http://manage.dimagi.com/default.asp?263566
The resident filter was being applied to the column representing all women but not those registered in ICDS which made the percent registered over 100% since there were registered women that were not residents. This fixes the data in the short term, since the percents will be more reasonable, while we correctly implement the filter that was intended (migration status).