### PR TITLE
Make BETS payment confirmations chunked and async

### DIFF
--- a/custom/enikshay/integrations/bets/tasks.py
+++ b/custom/enikshay/integrations/bets/tasks.py
@@ -1,0 +1,12 @@
+from celery.task import task
+from corehq.apps.hqcase.utils import bulk_update_cases
+from dimagi.utils.chunked import chunked
+
+
+@task(queue='background_queue', ignore_result=True)
+def process_payment_confirmations(domain, payment_confirmations):
+    for chunk in chunked(payment_confirmations, 100):
+        bulk_update_cases(domain, [
+            (update.case_id, update.properties, False)
+            for update in chunk
+        ], "custom.enikshay.integrations.bets.views.payment_confirmation")

--- a/custom/enikshay/integrations/bets/tasks.py
+++ b/custom/enikshay/integrations/bets/tasks.py
@@ -1,12 +1,27 @@
+import json
 from celery.task import task
 from corehq.apps.hqcase.utils import bulk_update_cases
 from dimagi.utils.chunked import chunked
+from dimagi.utils.logging import notify_exception
+
+PAYMENT_CONFIRMATION_FAILURE = """BETS_PAYMENT_CONFIRMATION_FAILURE:
+Updating payment confirmations failed. We need to manually reconcile failed
+records any time this happens. This error message should include the complete
+chunk of payment confirmations that were to be processed.
+"""
 
 
 @task(queue='background_queue', ignore_result=True)
 def process_payment_confirmations(domain, payment_confirmations):
     for chunk in chunked(payment_confirmations, 100):
-        bulk_update_cases(domain, [
-            (update.case_id, update.properties, False)
-            for update in chunk
-        ], "custom.enikshay.integrations.bets.views.payment_confirmation")
+        try:
+            bulk_update_cases(domain, [
+                (update.case_id, update.properties, False)
+                for update in chunk
+            ], "custom.enikshay.integrations.bets.views.payment_confirmation")
+        except Exception as e:
+            notify_exception(
+                request=None,
+                message=PAYMENT_CONFIRMATION_FAILURE,
+                details=json.dumps([update.to_json() for update in chunk]),
+            )

--- a/custom/enikshay/integrations/bets/views.py
+++ b/custom/enikshay/integrations/bets/views.py
@@ -20,7 +20,6 @@ from corehq.apps.locations.resources.v0_5 import LocationResource
 from corehq.motech.repeaters.views import AddCaseRepeaterView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
-
 from custom.enikshay.case_utils import CASE_TYPE_VOUCHER, CASE_TYPE_EPISODE
 from .const import BETS_EVENT_IDS
 from .tasks import process_payment_confirmations

--- a/custom/enikshay/integrations/bets/views.py
+++ b/custom/enikshay/integrations/bets/views.py
@@ -17,13 +17,13 @@ from jsonobject.exceptions import BadValueError
 from corehq import toggles
 from corehq.apps.domain.decorators import login_or_digest_or_basic_or_apikey
 from corehq.apps.locations.resources.v0_5 import LocationResource
-from corehq.apps.hqcase.utils import bulk_update_cases
 from corehq.motech.repeaters.views import AddCaseRepeaterView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 from custom.enikshay.case_utils import CASE_TYPE_VOUCHER, CASE_TYPE_EPISODE
 from .const import BETS_EVENT_IDS
+from .tasks import process_payment_confirmations
 from .utils import get_bets_location_json
 
 SUCCESS = "Success"
@@ -195,9 +195,7 @@ def payment_confirmation(request, domain):
             notify_exception(request, "BETS sent the eNikshay API a bad request.")
         return json_response({"error": e.message}, status_code=e.status_code)
 
-    bulk_update_cases(domain, [
-        (update.case_id, update.properties, False) for update in updates
-    ], __name__ + ".payment_confirmation")
+    process_payment_confirmations.delay(domain, updates)
     return json_response({'status': SUCCESS})
 
 


### PR DESCRIPTION
The partner is reporting mysterious errors with larger requests.  I'm not convinced this is the problem, but this certainly seems like something we should do anyways if this endpoint is to handle thousands of case updates at a time.
@proteusvacuum @gcapalbo