### PR TITLE
Address API endpoint is "address" not "name"

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -208,7 +208,7 @@ def update_person_address(requests, info, openmrs_config, person_uuid, address_u
     }
     if properties:
         requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/name/{address_uuid}'.format(
+            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
                 person_uuid=person_uuid,
                 address_uuid=address_uuid,
             ),


### PR DESCRIPTION
Doh. When updating an address, post to the "address" URI, not the "name" URI.

@dannyroberts @calellowitz 