### PR TITLE
Change repeat record attempt from a <pre/> to a <div/>

### DIFF
--- a/corehq/apps/domain/templates/domain/repeat_record_report.html
+++ b/corehq/apps/domain/templates/domain/repeat_record_report.html
@@ -17,8 +17,8 @@
 {% block js-inline %}{{ block.super }}
 <script>
     $(function() {
-        $('#report-content').on('click', '.toggle-next-pre', function (e) {
-            $(this).nextAll('pre').toggle();
+        $('#report-content').on('click', '.toggle-next-attempt', function (e) {
+            $(this).nextAll('.record-attempt').toggle();
             e.preventDefault();
         });
         var codeMirror = null;

--- a/corehq/apps/domain/templates/domain/repeaters/partials/attempt_history.html
+++ b/corehq/apps/domain/templates/domain/repeaters/partials/attempt_history.html
@@ -5,12 +5,16 @@
     <li><strong>Attempt #{{ attempt_number }}</strong>
     {% if attempt.succeeded %}
         <br/><i class="fa fa-check"></i> {% trans "Success" %}
-        <a href="#" class="toggle-next-pre">…</a>
-        <pre style="display: none">{{ attempt.success_response }}</pre>
+        <a href="#" class="toggle-next-attempt">…</a>
+        <div class="well record-attempt" style="display: none; font-family: monospace;">
+            {{ attempt.success_response }}
+        </div>
     {% elif attempt.failure_reason %}
         <br/><i class="fa fa-exclamation-triangle"></i> {% trans "Failed" %}
-        <a href="#" class="toggle-next-pre">…</a>
-        <pre style="display: none">{{ attempt.failure_reason }}</pre>
+        <a href="#" class="toggle-next-attempt">…</a>
+        <div class="well record-attempt" style="display: none; font-family: monospace;">
+            {{ attempt.failure_reason }}
+        </div>
     {% endif %}
     {% if attempt.cancelled %}
         <br/><i class="fa fa-remove"></i> {% trans "Cancelled" %}


### PR DESCRIPTION
When the response from the server doesn't contain newlines, you have to scroll
all the way over to read the error message and it's kinda annoying.  This keeps
it visually separated, but will break lines.