### PR TITLE
fix for unicode in email ucrs

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -573,9 +573,9 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     def email_response(self):
         with closing(StringIO()) as temp:
             export_from_tables(self.export_table, temp, Format.HTML)
-            return self.render_json_response({
+            return HttpResponse(json.dumps({
                 'report': temp.getvalue(),
-            })
+            }), content_type='application/json')
 
     @property
     @memoized

--- a/corehq/apps/userreports/tests/test_report_rendering.py
+++ b/corehq/apps/userreports/tests/test_report_rendering.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+from django.test import SimpleTestCase
+from corehq.apps.userreports.reports.view import ConfigurableReport
+
+
+class VeryFakeReportView(ConfigurableReport):
+    # note: this is very coupled to what it tests below, but it beats bootstrapping a whole UCR thing
+
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def export_table(self):
+        return self._data
+
+
+class ReportRenderingTest(SimpleTestCase):
+
+    def test_email_response_unicode(self):
+        report = VeryFakeReportView(data=[
+            ['hello', u'हिन्दी']
+        ])
+        # this used to fail: https://manage.dimagi.com/default.asp?263803
+        report.email_response


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?263803

Introduced by https://github.com/dimagi/commcare-hq/pull/18022/

I believe all email UCRs involving unicode have been broken for 2+ weeks, but perhaps there aren't so many of those...