### PR TITLE
MOTECH toggle unused

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -38,7 +38,7 @@ from corehq.motech.openmrs.views import OpenmrsImporterView
 from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
 from corehq.tabs.uitab import UITab
 from corehq.tabs.utils import dropdown_dict, sidebar_to_dropdown, regroup_sidebar_items
-from corehq.toggles import PUBLISH_CUSTOM_REPORTS, MOTECH
+from corehq.toggles import PUBLISH_CUSTOM_REPORTS
 from custom.world_vision import WORLD_VISION_DOMAINS
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.utils import has_privilege


### PR DESCRIPTION
MOTECH toggle can be deleted from `corehq/toggles.py` once #18239 has been merged.

@sheelio 