### PR TITLE
 upgrade Stripe API to latest version

### DIFF
--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -220,7 +220,7 @@ def get_customer_cards(username, domain):
             method_type=PaymentMethodType.STRIPE
         )
         stripe_customer = payment_method.customer
-        return stripe_customer.cards
+        return dict(stripe_customer.cards)
     except StripePaymentMethod.DoesNotExist:
         pass
     except stripe.error.AuthenticationError:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -61,7 +61,7 @@ redis==2.10.5
 twilio==6.5.1
 django-countries==4.6
 reportlab==3.0
-stripe==1.12.2
+stripe==1.67.0
 django-compressor==2.1
 django-angular==0.7.16
 Pycco==0.5.1


### PR DESCRIPTION
Requires one code change - ```ListObject``` is a subclass of ```dict``` but now has to be cast explicitly for HQ's custom django tag ```JSON``` to work.