### PR TITLE
Increase repeater post timeout to 75 seconds

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -6,7 +6,7 @@ MIN_RETRY_WAIT = timedelta(minutes=60)
 CHECK_REPEATERS_INTERVAL = timedelta(minutes=5)
 CHECK_REPEATERS_KEY = 'check-repeaters-key'
 
-POST_TIMEOUT = 45  # seconds
+POST_TIMEOUT = 75  # seconds
 
 RECORD_PENDING_STATE = 'PENDING'
 RECORD_SUCCESS_STATE = 'SUCCESS'


### PR DESCRIPTION
99DOTS responses sometimes take ~60s to process, which leads us to mark those
records as failed

@gcapalbo 
FYI @mkangia @dannyroberts 