### PR TITLE
Move remote request dependence back to 2.40

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -155,4 +155,4 @@ class CommCareFeatureSupportMixin(object):
         """
         Enable Remote Request question type in the form builder.
         """
-        return self._require_minimum_version('2.41')
+        return self._require_minimum_version('2.40')


### PR DESCRIPTION
Small change. Undoes some bad guidance I gave for what minimum app version is required for the remote request feature here: https://github.com/dimagi/commcare-hq/pull/18194#discussion_r145196733

This should actually be 2.40, which is the minimum version where it won't interfere with the mobile code.