### PR TITLE
add reserved words

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/case-reserved-words.json
+++ b/corehq/apps/app_manager/static/app_manager/json/case-reserved-words.json
@@ -9,6 +9,8 @@
     "closed_by",
     "closed_on",
     "commtrack",
+    "computed_",
+    "computed_modified_on_",
     "date",
     "date_modified",
     "date-opened",


### PR DESCRIPTION
@dannyroberts is this enough to trigger these fields to be disallowed in exports? bit of a shot in the dark.

see https://manage.dimagi.com/default.asp?264139 for context.

These fields are coming [from here](https://github.com/dimagi/commcare-hq/blob/0580ece3bb2f96ffc1d939fbcc5ae7ea2802e0f6/corehq/ex-submodules/dimagi/utils/indicators.py#L22-L23). I think this is a correct change regardless of exports since presumably you can also make bad apps right now (assuming this all still works how I remember...)?