### PR TITLE
don't use iterator alongside transaction pooling

### DIFF
--- a/custom/ilsgateway/tanzania/warehouse/updater.py
+++ b/custom/ilsgateway/tanzania/warehouse/updater.py
@@ -279,7 +279,7 @@ def process_facility_warehouse_data(facility, start_date, end_date, runner=None)
         location_id=facility.location_id,
         status_date__gte=start_date,
         status_date__lt=end_date
-    ).order_by('status_date').iterator()
+    ).order_by('status_date')
     process_facility_statuses(location_id, new_statuses)
 
     new_reports = StockReport.objects.filter(
@@ -287,7 +287,7 @@ def process_facility_warehouse_data(facility, start_date, end_date, runner=None)
         date__gte=start_date,
         date__lt=end_date,
         stocktransaction__type='stockonhand'
-    ).distinct().order_by('date').iterator()
+    ).distinct().order_by('date')
     process_facility_product_reports(location_id, new_reports)
 
     new_trans = get_latest_transaction_from_each_month(supply_point_id, start_date, end_date)


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/391634638/

https://docs.djangoproject.com/en/1.11/ref/models/querysets/
https://docs.djangoproject.com/en/1.11/ref/databases/#transaction-pooling-server-side-cursors

Neither of these querysets return big enough amounts of data for memory to be a concern.