### PR TITLE
remote all-or-nothing param

### DIFF
--- a/corehq/apps/cachehq/mixins.py
+++ b/corehq/apps/cachehq/mixins.py
@@ -18,8 +18,8 @@ class _InvalidateCacheMixin(object):
             self.clear_caches()
 
     @classmethod
-    def save_docs(cls, docs, use_uuids=True, all_or_nothing=False):
-        super(_InvalidateCacheMixin, cls).save_docs(docs, use_uuids, all_or_nothing)
+    def save_docs(cls, docs, use_uuids=True):
+        super(_InvalidateCacheMixin, cls).save_docs(docs, use_uuids)
         for doc in docs:
             doc.clear_caches()
 
@@ -38,9 +38,9 @@ class _InvalidateCacheMixin(object):
         invalidate_document(self, deleted=True)
 
     @classmethod
-    def delete_docs(cls, docs, all_or_nothing=False, empty_on_delete=False):
+    def delete_docs(cls, docs, empty_on_delete=False):
         super(_InvalidateCacheMixin, cls).bulk_delete(
-            docs, all_or_nothing=all_or_nothing, empty_on_delete=empty_on_delete)
+            docs, empty_on_delete=empty_on_delete)
         for doc in docs:
             doc.clear_caches()
             invalidate_document(doc, deleted=True)

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -61,11 +61,11 @@ class Group(QuickCachedDocumentMixin, UndoableDocument):
         refresh_group_views()
 
     @classmethod
-    def save_docs(cls, docs, use_uuids=True, all_or_nothing=False):
+    def save_docs(cls, docs, use_uuids=True):
         utcnow = datetime.utcnow()
         for doc in docs:
             doc['last_modified'] = utcnow
-        super(Group, cls).save_docs(docs, use_uuids, all_or_nothing)
+        super(Group, cls).save_docs(docs, use_uuids)
         refresh_group_views()
 
     bulk_save = save_docs

--- a/corehq/apps/products/models.py
+++ b/corehq/apps/products/models.py
@@ -48,7 +48,7 @@ class Product(Document):
         return super(Product, cls).wrap(data)
 
     @classmethod
-    def save_docs(cls, docs, use_uuids=True, all_or_nothing=False, codes_by_domain=None):
+    def save_docs(cls, docs, use_uuids=True, codes_by_domain=None):
         from corehq.apps.commtrack.util import generate_code
 
         codes_by_domain = codes_by_domain or {}
@@ -67,7 +67,7 @@ class Product(Document):
                     get_codes(doc['domain'])
                 )
 
-        super(Product, cls).save_docs(docs, use_uuids, all_or_nothing)
+        super(Product, cls).save_docs(docs, use_uuids)
 
     bulk_save = save_docs
 

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -100,7 +100,7 @@ class TestLoggingDB(object):
         self.docs_saved = []
         self.num_writes = 0
 
-    def bulk_save(self, docs, use_uuids=True, all_or_nothing=False, new_edits=None, **params):
+    def bulk_save(self, docs, use_uuids=True, new_edits=None, **params):
         """Method signature matches coucdbkit.client.Database.bulk_save
         """
         self.docs_saved.extend(docs)


### PR DESCRIPTION
This isn't supported by CouchDB 2 or Cloudant

http://docs.couchdb.org/en/latest/whatsnew/2.0.html#upgrade-notes
https://stackoverflow.com/questions/29554887/why-there-is-no-all-or-nothing-support-in-cloudant#30047109