### PR TITLE
don't change blank to '---' in case display

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -109,7 +109,7 @@ def _to_html(val, key=None, level=0, timeago=False):
         ret = mark_safe("<time %s title='%s' datetime='%s'>%s</time>" % (
             "class='timeago'" if timeago else "", iso, iso, safe_strftime(val, fmt)))
     else:
-        if val is None or val == '':
+        if val is None:
             val = '---'
 
         ret = escape(val)


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?258726

Make case display more consistent with exports by showing blank case properties (set to '') as blank on the case display page instead of as '---' which signifies the property was never set at all.