### PR TITLE
Use month_end instead of month_start in alive_in_month

### DIFF
--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -2247,7 +2247,7 @@
               "expression": {
                 "from_date_expression": {
                   "type": "named",
-                  "name": "month_start"
+                  "name": "month_end"
                 },
                 "type": "diff_days",
                 "to_date_expression": {


### PR DESCRIPTION
@sheelio Spec says this should use the month end for alive_in_month. https://manage.dimagi.com/default.asp?263652#1411633

Will need to do a partial rebuild. I think it should be sufficient to rebuild any indicators that have alive_in_month "no" for any month so that the previous months are calculated.

@mkangia 