### PR TITLE
Use new URL parameters for view_form

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -134,7 +134,7 @@ def copy_form(request, domain, app_id, form_unique_id):
 
     if new_form:
         return back_to_main(request, domain, app_id=app_id, form_unique_id=new_form.unique_id)
-    return HttpResponseRedirect(reverse('view_form', args=[domain, app._id, module.id, form.id]))
+    return HttpResponseRedirect(reverse('view_form', args=(domain, app._id, form.unique_id)))
 
 
 @no_conflict_require_POST


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?264290
It looks like this was using the parameters provided to "view_form_legacy", so
the `reverse` call was failing.
@orangejenny @proteusvacuum @calellowitz