### PR TITLE
Refactored ICDS aggregation script for smaller transactions.

### DIFF
--- a/custom/icds_reports/sql_templates/update_monthly_aggregate_tables.sql
+++ b/custom/icds_reports/sql_templates/update_monthly_aggregate_tables.sql
@@ -3,26 +3,41 @@
 BEGIN;
 	-- Update Months Table
 	SELECT update_months_table((%(date)s)::date);
+COMMIT;
 
-	-- Setup Monthly Tables
-	-- Could turn this into a script with variable for date (or for individual tables)
-	SELECT create_new_aggregate_table_for_month('agg_awc', (%(date)s)::date);
-	SELECT create_new_aggregate_table_for_month('agg_ccs_record', (%(date)s)::date);
-	SELECT create_new_aggregate_table_for_month('agg_child_health', (%(date)s)::date);
-	SELECT create_new_table_for_month('ccs_record_monthly', (%(date)s)::date);
+BEGIN;
 	SELECT create_new_table_for_month('child_health_monthly', (%(date)s)::date);
-	SELECT create_new_aggregate_table_for_month('agg_thr_data', (%(date)s)::date);
-	SELECT create_new_table_for_month('daily_attendance', (%(date)s)::date);
-
-	-- Copy Data Into Monthly Tables
 	SELECT insert_into_child_health_monthly((%(date)s)::date);
-	SELECT insert_into_ccs_record_monthly((%(date)s)::date);
-	SELECT insert_into_daily_attendance((%(date)s)::date);
+COMMIT;
 
-	-- Aggregate data into monthly tables
+BEGIN;
+	SELECT create_new_table_for_month('ccs_record_monthly', (%(date)s)::date);
+	SELECT insert_into_ccs_record_monthly((%(date)s)::date);
+COMMIT;
+
+BEGIN;
+	SELECT create_new_table_for_month('daily_attendance', (%(date)s)::date);
+	SELECT insert_into_daily_attendance((%(date)s)::date);
+COMMIT;
+
+
+BEGIN;
+	SELECT create_new_aggregate_table_for_month('agg_child_health', (%(date)s)::date);
 	SELECT aggregate_child_health((%(date)s)::date);
+COMMIT;
+
+BEGIN;
+	SELECT create_new_aggregate_table_for_month('agg_ccs_record', (%(date)s)::date);
 	SELECT aggregate_ccs_record((%(date)s)::date);
+COMMIT;
+
+BEGIN;
+	SELECT create_new_aggregate_table_for_month('agg_thr_data', (%(date)s)::date);
 	SELECT aggregate_thr_data((%(date)s)::date);
+COMMIT;
+
+BEGIN;
+	SELECT create_new_aggregate_table_for_month('agg_awc', (%(date)s)::date);
 	SELECT aggregate_awc_data((%(date)s)::date);
 
 COMMIT;


### PR DESCRIPTION
@sheelio This keeps the aggregation steps in the same order, but separates them out into different transactions. This should allow for much less lockingof the database when the aggregation is happening (currently it's pretty much useless overnight because so many tables are dropped/created. Eventually it would be good to break these out into separate tasks and have some of them work in parallel (like inserting from UCR tables)

buddy @mkangia