### PR TITLE
Change styling for messages.warning

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1473,7 +1473,7 @@ MESSAGE_TAGS = {
     messages.INFO: 'alert-info',
     messages.DEBUG: '',
     messages.SUCCESS: 'alert-success',
-    messages.WARNING: 'alert-error alert-danger',
+    messages.WARNING: 'alert-error alert-warning',
     messages.ERROR: 'alert-error alert-danger',
 }
 


### PR DESCRIPTION
Noticed while looking at https://manage.dimagi.com/default.asp?263971 that we don't visually differentiate between errors and warnings. This'll change warnings to use yellow styling instead of the red/pink "danger" styling.

@sravfeyn / @biyeun 