### PR TITLE
Mobile UCR v2 caching

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3981,7 +3981,7 @@ class ReportAppConfig(DocumentSchema):
 
     filters = SchemaDictProperty(ReportAppFilter)
     uuid = StringProperty(required=True)
-    sync_delay = DecimalProperty(default=0.0)
+    sync_delay = DecimalProperty(default=0.0)  # in hours
 
     _report = None
 

--- a/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
@@ -194,7 +194,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
 
     function ReportConfig(report_id, display,
                           localizedDescription, xpathDescription, useXpathDescription,
-                          showDataTable, uuid, availableReportIds,
+                          showDataTable, syncDelay, uuid, availableReportIds,
                           reportCharts, graph_configs, columnXpathTemplate, dataPathPlaceholders,
                           filterValues, reportFilters,
                           language, languages, changeSaveButton) {
@@ -211,6 +211,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
         this.xpathDescription = ko.observable(xpathDescription);
         this.useXpathDescription = ko.observable(useXpathDescription);
         this.showDataTable = ko.observable(showDataTable);
+        this.syncDelay = ko.observable(syncDelay);
 
         this.reportId.subscribe(changeSaveButton);
         this.display.subscribe(changeSaveButton);
@@ -218,6 +219,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
         this.xpathDescription.subscribe(changeSaveButton);
         this.useXpathDescription.subscribe(changeSaveButton);
         this.showDataTable.subscribe(changeSaveButton);
+        this.syncDelay.subscribe(changeSaveButton);
 
         self.graphConfig = new GraphConfig(this.reportId, this.display(), availableReportIds, reportCharts,
                                            graph_configs, columnXpathTemplate, dataPathPlaceholders,
@@ -239,6 +241,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
                 xpath_description: self.xpathDescription(),
                 use_xpath_description: self.useXpathDescription(),
                 show_data_table: self.showDataTable(),
+                sync_delay: self.syncDelay(),
                 uuid: self.uuid,
             };
         };
@@ -259,6 +262,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
         var currentReports = options.currentReports || [];
         var availableReports = options.availableReports || [];
         var saveURL = options.saveURL;
+        self.supportSyncDelay = options.supportSyncDelay;
         self.staticFilterData = options.staticFilterData;
         self.languages = options.languages;
         self.lang = options.lang;
@@ -349,6 +353,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
                 options.xpath_description,
                 options.use_xpath_description,
                 options.show_data_table,
+                options.sync_delay,
                 options.uuid,
                 self.availableReportIds,
                 self.reportCharts,

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
@@ -39,6 +39,7 @@
                         <th>{% trans "Report" %}</th>
                         <th>{% trans "Display Text" %}</th>
                         <th>{% trans "Description" %}</th>
+                        <th data-bind="visible: $root.supportSyncDelay">{% trans "Sync Delay (in hours)" %}</th>
                         <th>
                             {% trans "Data Table" %}
                             <span class="hq-help-template"
@@ -87,6 +88,9 @@
                                     {% trans "Not localizable." %}
                                 </p>
                             </div>
+                        </td>
+                        <td>
+                            <input type="number" class="form-control" data-bind="value: syncDelay, visible: $root.supportSyncDelay">
                         </td>
                         <td>
                             <label>

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -54,7 +54,8 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             report_id=report_id,
             filters={'computed_owner_name_40cc88a0_1': StaticChoiceListFilter()}
         )
-        user = Mock(user_id='mock-user-id')
+        restore_user = Mock(user_id='mock-user-id')
+        restore_state = Mock(overwrite_cache=False, restore_user=restore_user)
 
         with mock_report_configuration_get({report_id: MAKE_REPORT_CONFIG('test_domain', report_id)}), \
                 patch('corehq.apps.app_manager.fixtures.mobile_ucr.ReportFactory') as report_factory_patch, \
@@ -62,7 +63,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
 
             report_factory_patch.from_spec.return_value = self.get_data_source_mock()
             utcnow_patch.return_value = datetime(2017, 9, 11, 6, 35, 20)
-            fixtures = provider.report_config_to_v2_fixture(report_app_config, user)
+            fixtures = provider.report_config_to_v2_fixture(report_app_config, restore_state)
             report = E.restore()
             report.extend(fixtures)
             self.assertXMLEqual(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -24,6 +24,7 @@ from corehq.apps.app_manager.views.utils import back_to_main, bail, get_langs, h
 from corehq import toggles
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.app_manager.const import (
+    MOBILE_UCR_VERSION_1,
     USERCASE_TYPE,
     CLAIM_DEFAULT_RELEVANT_CONDITION,
 )
@@ -229,7 +230,7 @@ def _get_report_module_context(app, module):
         {'slug': f.slug, 'description': f.short_description} for f in get_auto_filter_configurations()
 
     ]
-    from corehq.apps.app_manager.suite_xml.features.mobile_ucr import COLUMN_XPATH_CLIENT_TEMPLATE, get_data_path
+    from corehq.apps.app_manager.suite_xml.features.mobile_ucr import get_column_xpath_client_template, get_data_path
     data_path_placeholders = {}
     for r in module.report_configs:
         data_path_placeholders[r.report_id] = {}
@@ -242,9 +243,10 @@ def _get_report_module_context(app, module):
             'moduleFilter': module.module_filter,
             'availableReports': [_report_to_config(r) for r in all_reports],  # structure for all reports
             'currentReports': [r.to_json() for r in module.report_configs],  # config data for app reports
-            'columnXpathTemplate': COLUMN_XPATH_CLIENT_TEMPLATE,
+            'columnXpathTemplate': get_column_xpath_client_template(app.mobile_ucr_restore_version),
             'dataPathPlaceholders': data_path_placeholders,
             'languages': app.langs,
+            'supportSyncDelay': app.mobile_ucr_restore_version != MOBILE_UCR_VERSION_1,
         },
         'static_data_options': {
             'filterChoices': filter_choices,


### PR DESCRIPTION
This will allow UCRs to be cached independently of each other. It'll be specified on the reports module when ucr v2 is configured

![image](https://user-images.githubusercontent.com/1471773/32192267-13fde424-bd8a-11e7-9b91-a16091e8be73.png)

This is going into my other branch. Will move this back to master once that's merged
buddy @mkangia 