### PR TITLE
Set DISABLE_SERVER_SIDE_CURSORS if it isn't already set

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -978,6 +978,12 @@ try:
 except NameError:
     COUCH_DATABASES = _determine_couch_databases(None)
 
+if DATABASES['default'].get('DISABLE_SERVER_SIDE_CURSORS') is None:
+    # Unless DISABLE_SERVER_SIDE_CURSORS has explicitly been set, default to True because Django >= 1.11.1 and
+    # our hosting environments use pgBouncer with transaction pooling. More info:
+    # https://docs.djangoproject.com/en/1.11/releases/1.11.1/#allowed-disabling-server-side-cursors-on-postgresql
+    DATABASES['default']['DISABLE_SERVER_SIDE_CURSORS'] = True
+
 
 _location = lambda x: os.path.join(FILEPATH, x)
 


### PR DESCRIPTION
We use queryset iterators to dump cases. This prevents that from breaking, and allows us to use iterators elsewhere too if we want.

We went with defaulting it to `True` globally because we use pgBouncer in all environments except dev environments.

@snopoke @nickpell 
