### PR TITLE
Fix Deploy Emails

### DIFF
--- a/corehq/apps/hqadmin/management/commands/record_deploy_success.py
+++ b/corehq/apps/hqadmin/management/commands/record_deploy_success.py
@@ -8,6 +8,7 @@ from django.core.management.base import BaseCommand
 from corehq.apps.hqadmin.models import HqDeploy
 from datetime import datetime, timedelta
 from django.conf import settings
+from corehq.util.log import send_HTML_email
 
 from dimagi.utils.parsing import json_format_datetime
 from pillow_retry.models import PillowError
@@ -133,6 +134,14 @@ class Command(BaseCommand):
                 environment=options['environment'], user=options['user'],
                 compare_url=compare_url)
             call_command('mail_admins', message_body, **{'subject': 'Deploy successful', 'html': True})
+            try:
+                recipient = settings.DAILY_DEPLOY_EMAIL
+                subject = '[%] Deploy Successful'.format(options['environment'])
+                send_HTML_email(subject=subject,
+                                recipient=recipient,
+                                html_content=message_body)
+            except Exception:
+                pass
 
         if settings.SENTRY_CONFIGURED and settings.SENTRY_API_KEY:
             create_update_sentry_release()

--- a/corehq/apps/hqadmin/management/commands/record_deploy_success.py
+++ b/corehq/apps/hqadmin/management/commands/record_deploy_success.py
@@ -136,7 +136,7 @@ class Command(BaseCommand):
             call_command('mail_admins', message_body, **{'subject': 'Deploy successful', 'html': True})
             try:
                 recipient = settings.DAILY_DEPLOY_EMAIL
-                subject = '[%] Deploy Successful'.format(options['environment'])
+                subject = '[{}] Deploy Successful'.format(options['environment'])
                 send_HTML_email(subject=subject,
                                 recipient=recipient,
                                 html_content=message_body)

--- a/corehq/apps/hqadmin/management/commands/record_deploy_success.py
+++ b/corehq/apps/hqadmin/management/commands/record_deploy_success.py
@@ -140,7 +140,7 @@ class Command(BaseCommand):
                 send_HTML_email(subject=subject,
                                 recipient=recipient,
                                 html_content=message_body)
-            except Exception:
+            except AttributeError:
                 pass
 
         if settings.SENTRY_CONFIGURED and settings.SENTRY_API_KEY:

--- a/corehq/apps/hqadmin/management/utils.py
+++ b/corehq/apps/hqadmin/management/utils.py
@@ -100,7 +100,7 @@ def _get_prs_by_label(pr_infos):
         for label in pr['labels']:
             if label['name'] in LABELS_TO_EXPAND:
                 prs_by_label[label['name']].append(pr)
-    return prs_by_label
+    return dict(prs_by_label)
 
 
 if __name__ == '__main__':

--- a/corehq/apps/hqadmin/templates/hqadmin/partials/project_snapshot.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/partials/project_snapshot.html
@@ -19,7 +19,7 @@
                     </span>
                 </span>
                 {% for label in pr.labels %}
-                <span class="text-label" style="color:{{ label.color }}">
+                <span class="text-label" style="color:#{{ label.color }}">
                     {{ label.name }}
                 </span>
                 {% endfor %}

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -99,6 +99,7 @@ EXCHANGE_NOTIFICATION_RECIPIENTS = ['commcarehq-dev+exchange@example.com']
 SERVER_EMAIL = 'commcarehq-noreply@example.com'  # the physical server emailing - differentiate if needed
 DEFAULT_FROM_EMAIL = 'commcarehq-noreply@example.com'
 SUPPORT_EMAIL = "commcarehq-support@example.com"
+DAILY_DEPLOY_EMAIL = "tech-announce-daily@example.com"
 EMAIL_SUBJECT_PREFIX = '[commcarehq] '
 SERVER_ENVIRONMENT = 'changeme' #Modify this value if you are deploying multiple environments of HQ to the same machine. Identify the target type of this running environment
 

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -99,7 +99,6 @@ EXCHANGE_NOTIFICATION_RECIPIENTS = ['commcarehq-dev+exchange@example.com']
 SERVER_EMAIL = 'commcarehq-noreply@example.com'  # the physical server emailing - differentiate if needed
 DEFAULT_FROM_EMAIL = 'commcarehq-noreply@example.com'
 SUPPORT_EMAIL = "commcarehq-support@example.com"
-DAILY_DEPLOY_EMAIL = "tech-announce-daily@example.com"
 EMAIL_SUBJECT_PREFIX = '[commcarehq] '
 SERVER_ENVIRONMENT = 'changeme' #Modify this value if you are deploying multiple environments of HQ to the same machine. Identify the target type of this running environment
 

--- a/settings.py
+++ b/settings.py
@@ -496,6 +496,7 @@ EULA_CHANGE_EMAIL = 'eula-notifications@dimagi.com'
 CONTACT_EMAIL = 'info@dimagi.com'
 BOOKKEEPER_CONTACT_EMAILS = []
 SOFT_ASSERT_EMAIL = 'commcarehq-ops+soft_asserts@dimagi.com'
+DAILY_DEPLOY_EMAIL = "tech-announce-daily@dimagi.com"
 EMAIL_SUBJECT_PREFIX = '[commcarehq] '
 
 SERVER_ENVIRONMENT = 'localdev'


### PR DESCRIPTION
@proteusvacuum 
This fixes the colour of the labels in the email, and properly displays PRs by label (django templates can't iterate a defaultdict).  

We also want to send out the email to something like daily-announce@dimagi.com.  Is that easy to do? From looking at the code, it looks like its sent to the site admins only?