### PR TITLE
Don't include hq.helpers twice in report builder

### DIFF
--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -17,7 +17,6 @@
     <script src="{% static 'userreports/js/builder_view_models.js' %}"></script>
     <script src="{% static 'userreports/js/report_config.js' %}"></script>
     <script src="{% static 'userreports/js/utils.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/hq.helpers.js' %}"></script>
 {% endblock %}
 
 {% block pre_page_content %}{% endblock %}{# Avoid the spacer #}


### PR DESCRIPTION
It's already included in base.html, and having it twice breaks RequireJS (see https://manage.dimagi.com/default.asp?264708). I think this was a bad merge somewhere around https://github.com/dimagi/commcare-hq/commit/82174eda04eed30f9822daf6307e2f07778589f6#diff-12ea744bd67dee33890f9e288e39d2b8

@sravfeyn / @biyeun 