### PR TITLE
Shadow forms: use parent's form validation cache

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3125,6 +3125,13 @@ class ShadowForm(AdvancedForm):
         return get_blank_form_xml("")
 
     @property
+    def validation_cache(self):
+        if not self.shadow_parent_form:
+            return None
+        else:
+            return self.shadow_parent_form.validation_cache
+
+    @property
     def xmlns(self):
         if not self.shadow_parent_form:
             return None


### PR DESCRIPTION
L10K is having an issue where the shadow form is displaying an old error from the parent form because the shadow form still has that error cached. Circumvent this by using the parent form's validation cache directly.

@sravfeyn / @emord / @dannyroberts 