### PR TITLE
Report Builder: Allow for Chart / Summary with no Grouping Column

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1433,7 +1433,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
             if self.cleaned_data['chart'] == "bar":
                 return [{
                     "type": "multibar",
-                    "x_axis_column": get_agged_columns()[0] if get_agged_columns() else '',
+                    "x_axis_column": get_agged_columns()[0]['column_id'] if get_agged_columns() else '',
                     # TODO: Possibly use more columns?
                     "y_axis_columns": [
                         {"column_id": c["column_id"], "display": c["display"]} for c in get_non_agged_columns()

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1440,7 +1440,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
                     ],
                 }]
                 if get_agged_columns():
-                    spec['x_axis_column'] = get_agged_columns()[0]
+                    spec[0]['x_axis_column'] = get_agged_columns()[0]
                 return spec
             elif self.cleaned_data['chart'] == "pie":
                 return [{

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1376,7 +1376,8 @@ class ConfigureTableReportForm(ConfigureListReportForm):
         u'of that property.  For example, if you add a column for a yes or no question, the report will show a '
         u'column for "yes" and a column for "no."'
     )
-    group_by = forms.MultipleChoiceField(label=_("Show one row for each"))
+    group_by = forms.MultipleChoiceField(label=_("Show one row for each"),
+                                         required=False)
     chart = forms.CharField(widget=forms.HiddenInput)
 
     def __init__(self, report_name, app_id, source_type, report_source_id, existing_report=None, *args, **kwargs):
@@ -1430,6 +1431,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
             if self.cleaned_data['chart'] == "bar":
                 spec = [{
                     "type": "multibar",
+                    'x_axis_column': "",
                     # TODO: Possibly use more columns?
                     "y_axis_columns": [
                         {"column_id": c["column_id"], "display": c["display"]} for c in get_non_agged_columns()

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1424,16 +1424,20 @@ class ConfigureTableReportForm(ConfigureListReportForm):
 
         def get_non_agged_columns():
             return [c for c in self._report_columns if c['aggregation'] != "simple"]
+        def get_agged_columns():
+            return [c for c in self._report_columns if c['aggregation'] == "simple"]
         if get_non_agged_columns():
             if self.cleaned_data['chart'] == "bar":
-                return [{
+                spec = [{
                     "type": "multibar",
-                    "x_axis_column": "column_agg_0",
                     # TODO: Possibly use more columns?
                     "y_axis_columns": [
                         {"column_id": c["column_id"], "display": c["display"]} for c in get_non_agged_columns()
                     ],
                 }]
+                if get_agged_columns():
+                    spec['x_axis_column'] = get_agged_columns()[0]
+                return spec
             elif self.cleaned_data['chart'] == "pie":
                 return [{
                     "type": "pie",

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1428,7 +1428,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
 
         def get_agged_columns():
             return [c for c in self._report_columns if c['aggregation'] == "simple"]
-        
+
         if get_non_agged_columns():
             if self.cleaned_data['chart'] == "bar":
                 spec = [{

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1425,8 +1425,10 @@ class ConfigureTableReportForm(ConfigureListReportForm):
 
         def get_non_agged_columns():
             return [c for c in self._report_columns if c['aggregation'] != "simple"]
+
         def get_agged_columns():
             return [c for c in self._report_columns if c['aggregation'] == "simple"]
+        
         if get_non_agged_columns():
             if self.cleaned_data['chart'] == "bar":
                 spec = [{

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1431,7 +1431,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
             if self.cleaned_data['chart'] == "bar":
                 spec = [{
                     "type": "multibar",
-                    'x_axis_column': "",
+                    "x_axis_column": "",
                     # TODO: Possibly use more columns?
                     "y_axis_columns": [
                         {"column_id": c["column_id"], "display": c["display"]} for c in get_non_agged_columns()

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1431,17 +1431,14 @@ class ConfigureTableReportForm(ConfigureListReportForm):
 
         if get_non_agged_columns():
             if self.cleaned_data['chart'] == "bar":
-                spec = [{
+                return [{
                     "type": "multibar",
-                    "x_axis_column": "",
+                    "x_axis_column": get_agged_columns()[0] if get_agged_columns() else '',
                     # TODO: Possibly use more columns?
                     "y_axis_columns": [
                         {"column_id": c["column_id"], "display": c["display"]} for c in get_non_agged_columns()
                     ],
                 }]
-                if get_agged_columns():
-                    spec[0]['x_axis_column'] = get_agged_columns()[0]
-                return spec
             elif self.cleaned_data['chart'] == "pie":
                 return [{
                     "type": "pie",

--- a/corehq/apps/userreports/static/userreports/js/constants.js
+++ b/corehq/apps/userreports/static/userreports/js/constants.js
@@ -12,5 +12,9 @@ hqDefine('userreports/js/constants', function () {
 
         REPORT_TYPE_LIST: "list",
         REPORT_TYPE_TABLE: "table",
+
+        CHART_TYPE_BAR: "bar",
+        CHART_TYPE_PIE: "pie",
+        CHART_TYPE_NONE: "none",
     };
 });

--- a/corehq/apps/userreports/static/userreports/js/constants.js
+++ b/corehq/apps/userreports/static/userreports/js/constants.js
@@ -12,9 +12,5 @@ hqDefine('userreports/js/constants', function () {
 
         REPORT_TYPE_LIST: "list",
         REPORT_TYPE_TABLE: "table",
-
-        CHART_TYPE_BAR: "bar",
-        CHART_TYPE_PIE: "pie",
-        CHART_TYPE_NONE: "none",
     };
 });

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -120,9 +120,9 @@ var reportBuilder = function () {  // eslint-disable-line
             self.saveButton.fire('change');
         });
 
-        self.isAggregationEnabled = ko.observable(self.reportType() === 'none');
+        self.isAggregationEnabled = ko.observable(self.reportType() === constants.REPORT_TYPE_TABLE);
 
-        self.selectedChart = ko.observable(constants.CHART_TYPE_NONE);
+        self.selectedChart = ko.observable('none');
         self.selectedChart.subscribe(function (newValue) {
             if (newValue === "none") {
                 self.previewChart(false);

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -212,15 +212,6 @@ var reportBuilder = function () {  // eslint-disable-line
             self.saveButton.fire('change');
         });
 
-        var _isMissingAggColumn = function() {
-            return (self.reportType() === constants.REPORT_TYPE_TABLE) && (
-                ! _.some(self.columnList.columns(), function (c) {
-                    return c.calculation() === constants.GROUP_BY;
-                })
-            );
-        };
-        self.missingAggColumn = ko.computed(_isMissingAggColumn, this);
-
         self.filterList = new PropertyList({
             hasFormatCol: self._sourceType === "case",
             hasCalculationCol: false,
@@ -263,8 +254,7 @@ var reportBuilder = function () {  // eslint-disable-line
                 $('#preview').hide();
 
                 // Check if a preview should be requested from the server
-                // Note: We can't use self.missingAggColumn() because it gets updated after this function is called.
-                if (serializedColumns === "[]" || _isMissingAggColumn()) {
+                if (serializedColumns === "[]") {
                     return;  // Nothing to do.
                 }
                 $.ajax({
@@ -343,9 +333,6 @@ var reportBuilder = function () {  // eslint-disable-line
 
         self.validate = function () {
             var isValid = true;
-            if (self.missingAggColumn()) {
-                isValid = false;
-            }
             if (!self.columnList.validate()) {
                 isValid = false;
                 $("#report-config-columns").collapse('show');

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -105,7 +105,7 @@ var reportBuilder = function () {  // eslint-disable-line
             self._suspendPreviewRefresh = true;
             var wasAggregationEnabled = self.isAggregationEnabled();
             self.isAggregationEnabled(newValue === constants.REPORT_TYPE_TABLE);
-            self.previewChart(newValue === constants.REPORT_TYPE_TABLE && self.selectedChart() !== constants.CHART_TYPE_NONE);
+            self.previewChart(newValue === constants.REPORT_TYPE_TABLE && self.selectedChart() !== "none");
             if (self.isAggregationEnabled() && !wasAggregationEnabled) {
                 self.columnList.columns().forEach(function(val, index) {
                     if (index === 0) {
@@ -120,11 +120,11 @@ var reportBuilder = function () {  // eslint-disable-line
             self.saveButton.fire('change');
         });
 
-        self.isAggregationEnabled = ko.observable(self.reportType() === constants.REPORT_TYPE_TABLE);
+        self.isAggregationEnabled = ko.observable(self.reportType() === 'none');
 
         self.selectedChart = ko.observable(constants.CHART_TYPE_NONE);
         self.selectedChart.subscribe(function (newValue) {
-            if (newValue === constants.CHART_TYPE_NONE) {
+            if (newValue === "none") {
                 self.previewChart(false);
             } else {
                 self.previewChart(true);

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -105,7 +105,7 @@ var reportBuilder = function () {  // eslint-disable-line
             self._suspendPreviewRefresh = true;
             var wasAggregationEnabled = self.isAggregationEnabled();
             self.isAggregationEnabled(newValue === constants.REPORT_TYPE_TABLE);
-            self.previewChart(newValue === constants.REPORT_TYPE_TABLE && self.selectedChart() !== "none");
+            self.previewChart(newValue === constants.REPORT_TYPE_TABLE && self.selectedChart() !== constants.CHART_TYPE_NONE);
             if (self.isAggregationEnabled() && !wasAggregationEnabled) {
                 self.columnList.columns().forEach(function(val, index) {
                     if (index === 0) {
@@ -122,9 +122,9 @@ var reportBuilder = function () {  // eslint-disable-line
 
         self.isAggregationEnabled = ko.observable(self.reportType() === constants.REPORT_TYPE_TABLE);
 
-        self.selectedChart = ko.observable('none');
+        self.selectedChart = ko.observable(constants.CHART_TYPE_NONE);
         self.selectedChart.subscribe(function (newValue) {
-            if (newValue === "none") {
+            if (newValue === constants.CHART_TYPE_NONE) {
                 self.previewChart(false);
             } else {
                 self.previewChart(true);

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -291,11 +291,6 @@
                   If the issue persists, please report an issue.
                 {% endblocktrans %}
               </p>
-              <p data-bind="visible: missingAggColumn()" class="alert alert-warning">
-                  {% blocktrans %}
-                      Summary reports require at least one column with the "Group By" format.
-                  {% endblocktrans %}
-              </p>
               <table id="preview" class="table"></table>
             </div>
           </div>


### PR DESCRIPTION
@biyeun 
Feedback from FMs after testing out report builder

Product Note:  Allows creating a summary report that does not have a grouping column.  This is useful for cascade style reports.