### PR TITLE
update scripts/subtree-merge for more recent versions of git

### DIFF
--- a/scripts/subtree-merge
+++ b/scripts/subtree-merge
@@ -12,7 +12,7 @@ function subtree-merge() {
   new_path=$4
 
   git remote add -f $module_name $module_uri
-  git merge -s ours --no-commit $module_name/master
+  git merge -s ours --no-commit $module_name/master --allow-unrelated-histories
   git read-tree --prefix=$new_path -u $module_name/master:$old_path
   git commit -m "subtree merge $module_name:$old_path into $new_path"
 }


### PR DESCRIPTION
merge now fails on unrelated histories unless you use --allow-unrelated-histories