### PR TITLE
Remove translations for deleted languages during bulk upload

### DIFF
--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -137,7 +137,7 @@ def process_bulk_app_translation_upload(app, f):
         if len(missing_cols) > 0:
             msgs.append((
                 messages.warning,
-                'Sheet "%s" has less columns than expected. '
+                'Sheet "%s" has fewer columns than expected. '
                 'Sheet will be processed but the following'
                 ' translations will be unchanged: %s'
                 % (sheet.worksheet.title, " ,".join(missing_cols))
@@ -465,6 +465,7 @@ def _process_modules_and_forms_sheet(rows, app):
 
 
 def _update_translation_dict(prefix, language_dict, row, langs):
+    # update translations as requested
     for lang in langs:
         key = '%s%s' % (prefix, lang)
         if key not in row:
@@ -473,6 +474,11 @@ def _update_translation_dict(prefix, language_dict, row, langs):
         if translation:
             language_dict[lang] = translation
         else:
+            language_dict.pop(lang, None)
+
+    # delete anything in language_dict that isn't in langs (anymore)
+    for lang in language_dict.keys():
+        if lang not in langs:
             language_dict.pop(lang, None)
 
 

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -258,14 +258,14 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
             self.upload_headers_bad_column,
             self.upload_data,
             expected_messages=[
-                u'Sheet "Modules_and_forms" has less columns than expected. Sheet '
+                u'Sheet "Modules_and_forms" has fewer columns than expected. Sheet '
                 u'will be processed but the following translations will be '
                 u'unchanged: default_fra',
 
                 u'Sheet "Modules_and_forms" has unrecognized columns. Sheet will '
                 u'be processed but ignoring the following columns: default-fra',
 
-                u'Sheet "module1" has less columns than expected. Sheet '
+                u'Sheet "module1" has fewer columns than expected. Sheet '
                 u'will be processed but the following translations will be '
                 u'unchanged: default_fra',
 
@@ -273,7 +273,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
                 u'be processed but ignoring the following columns: default-fra',
                 u"You must provide at least one translation of the case property 'name'",
 
-                u'Sheet "module1_form1" has less columns than expected. Sheet '
+                u'Sheet "module1_form1" has fewer columns than expected. Sheet '
                 u'will be processed but the following translations will be '
                 u'unchanged: default_fra',
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?264128

It's high LOE to remove translations when a language is deleted, because so many different properties are localizable. We'd effectively need to reproduce the logic in [_create_custom_app_strings](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/app_strings.py#L37) (and keep it up to date...).

However, it's straightforward to delete unknown languages when doing a bulk translation upload.

Form builder already does something similar (deletes unknown languages when the form is saved). Form builder warns you about this, and it'd be good to have a warning here, but again, we don't have a good way to find all of the properties that might include a value for an unknown language.

@sravfeyn / @emord / @snopoke 