### PR TITLE
stop doing local imports

### DIFF
--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 from corehq.apps.domain_migration_flags.exceptions import DomainMigrationProgressError
 from corehq.toggles import DATA_MIGRATION
 from corehq.util.quickcache import quickcache
-from models import DomainMigrationProgress, MigrationStatus
+from .models import DomainMigrationProgress, MigrationStatus
 
 
 def set_migration_started(domain, slug):

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from StringIO import StringIO
 import datetime
 import re
@@ -36,7 +37,7 @@ from dimagi.utils.web import json_request, json_response
 from dimagi.utils.parsing import string_to_boolean
 from corehq.apps.reports.cache import request_cache
 from django.utils.translation import ugettext
-from export import get_writer
+from .export import get_writer
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from copy import copy
 from datetime import datetime, timedelta, date
 import itertools
@@ -756,7 +757,7 @@ class AddSavedReportConfigView(View):
 @datespan_default
 def email_report(request, domain, report_slug, report_type=ProjectReportDispatcher.prefix, once=False):
     from corehq.apps.hqwebapp.tasks import send_html_email_async
-    from forms import EmailReportForm
+    from .forms import EmailReportForm
     user_id = request.couch_user._id
 
     form = EmailReportForm(request.GET)

--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 import random
 import string
@@ -572,7 +573,7 @@ def process_incoming(msg):
             handled = load_and_call(settings.CUSTOM_SMS_HANDLERS, v, msg.text, msg)
 
             if not handled and v and v.pending_verification:
-                import verify
+                from . import verify
                 handled = verify.process_verification(v, msg,
                     create_subevent_for_inbound=not has_domain_two_way_scope)
 

--- a/corehq/ex-submodules/auditcare/decorators/__init__.py
+++ b/corehq/ex-submodules/auditcare/decorators/__init__.py
@@ -1,3 +1,4 @@
-from login import watch_login
-from login import watch_logout
+from __future__ import absolute_import
+from .login import watch_login
+from .login import watch_logout
 

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import datetime
 from django.urls import reverse
 from corehq import privileges
@@ -40,7 +41,7 @@ from corehq.apps.fixtures.interface import FixtureViewInterface, FixtureEditInte
 import hashlib
 from dimagi.utils.modules import to_function
 import logging
-import toggles
+from . import toggles
 from django.utils.translation import ugettext_noop as _, ugettext_lazy
 from corehq.apps.indicators.admin import document_indicators, couch_indicators, dynamic_indicators
 from corehq.apps.data_interfaces.interfaces import CaseReassignmentInterface, BulkFormManagementInterface

--- a/corehq/util/global_request/__init__.py
+++ b/corehq/util/global_request/__init__.py
@@ -1,1 +1,2 @@
-from api import get_request, get_request_domain
+from __future__ import absolute_import
+from .api import get_request, get_request_domain

--- a/custom/_legacy/hsph/tests.py
+++ b/custom/_legacy/hsph/tests.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 import re
 from django.test import SimpleTestCase
 from mock import Mock
-import tasks
+from . import tasks
 
 
 def iter_cases_to_modify():

--- a/custom/apps/gsid/reports/__init__.py
+++ b/custom/apps/gsid/reports/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.reports.dont_use.fields import ReportSelectField
 from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter
@@ -11,7 +12,7 @@ from custom.apps.gsid.reports.sql_reports import (
     GSIDSQLTestLotsReport,
     PatientMapReport,
 )
-from util import get_unique_combinations
+from .util import get_unique_combinations
 
 
 class AsyncClinicField(MultiLocationFilter):

--- a/custom/apps/gsid/reports/sql_reports.py
+++ b/custom/apps/gsid/reports/sql_reports.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import functools
 from sqlagg.columns import *
 from sqlagg.base import AliasColumn
@@ -15,7 +16,7 @@ from corehq.const import USER_MONTH_FORMAT
 from corehq.util.dates import iso_string_to_date
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_date
-from util import get_unique_combinations,  capitalize_fn
+from .util import get_unique_combinations,  capitalize_fn
 
 from datetime import timedelta
 

--- a/custom/apps/gsid/reports/sql_reports.py
+++ b/custom/apps/gsid/reports/sql_reports.py
@@ -16,7 +16,7 @@ from corehq.const import USER_MONTH_FORMAT
 from corehq.util.dates import iso_string_to_date
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_date
-from .util import get_unique_combinations,  capitalize_fn
+from .util import get_unique_combinations, capitalize_fn
 
 from datetime import timedelta
 

--- a/custom/ewsghana/tests/test_input_stock_view.py
+++ b/custom/ewsghana/tests/test_input_stock_view.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from decimal import Decimal
 from django.urls import reverse
 from django.test import TestCase
@@ -16,7 +17,7 @@ from django.test.client import Client
 from custom.ewsghana.models import EWSExtension
 from custom.ewsghana.reports.specific_reports.stock_status_report import StockStatus
 from custom.ewsghana.utils import make_url
-import test_utils
+from . import test_utils
 from dimagi.utils.couch.database import get_db
 
 TEST_DOMAIN = 'ewsghana-test-input-stock'

--- a/custom/m4change/utils.py
+++ b/custom/m4change/utils.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.decorators.memoized import memoized
 from corehq.apps.users.models import CommCareUser
-from constants import EMPTY_FIELD
+from .constants import EMPTY_FIELD
 from custom.m4change.models import McctStatus
 
 

--- a/scripts/check-all-merges.py
+++ b/scripts/check-all-merges.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import argparse
 import sh
 import yaml
-from gitutils import get_git, git_submodules, OriginalBranch
-from rebuildstaging import BranchConfig, check_merges
+from .gitutils import get_git, git_submodules, OriginalBranch
+from .rebuildstaging import BranchConfig, check_merges
 
 
 def get_unmerged_remote_branches(git=None):

--- a/scripts/couchdb/add_replica_node.py
+++ b/scripts/couchdb/add_replica_node.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import sys
 
-from utils import (
+from .utils import (
     do_couch_request,
     get_arg_parser,
     node_details_from_args,

--- a/scripts/couchdb/copy_db_to_new_cluster.py
+++ b/scripts/couchdb/copy_db_to_new_cluster.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 import argparse
 import getpass
 import sys
 
 from requests.exceptions import HTTPError
 
-from utils import (
+from .utils import (
     do_couch_request,
     check_connection,
     confirm,

--- a/scripts/couchdb/remove_node.py
+++ b/scripts/couchdb/remove_node.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import sys
 
-from utils import (
+from .utils import (
     do_couch_request,
     get_arg_parser,
     node_details_from_args,

--- a/scripts/couchdb/replicate_db_to_new_node.py
+++ b/scripts/couchdb/replicate_db_to_new_node.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import sys
 
-from utils import (
+from .utils import (
     do_couch_request,
     get_arg_parser,
     node_details_from_args,

--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import re
 import sh
-from sh_verbose import ShVerbose
+from .sh_verbose import ShVerbose
 
 
 def get_git(path=None):

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -24,6 +24,7 @@ Where staging.yaml looks as follows:
 When not specified, a submodule's trunk and name inherit from the parent
 """
 from __future__ import print_function
+from __future__ import absolute_import
 
 from gevent import monkey
 monkey.patch_all(time=False, select=False)
@@ -36,8 +37,8 @@ import contextlib
 import gevent
 
 from fabric.colors import red
-from sh_verbose import ShVerbose
-from gitutils import (
+from .sh_verbose import ShVerbose
+from .gitutils import (
     OriginalBranch,
     get_git,
     has_merge_conflict,


### PR DESCRIPTION
Ran ```futurize . -w -f libfuturize.fixes.fix_absolute_import```

Seems like a good prelude to running ```python-modernize -w -f libmodernize.fixes.fix_import``` since the first command seems slightly riskier than the second (which adds ```from __future__ import absolute_import``` to all files).

@dimagi/py3 