### PR TITLE
Refactoring Analytics on HQ pt 1

### DIFF
--- a/corehq/apps/analytics/decorators.py
+++ b/corehq/apps/analytics/decorators.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from functools import wraps
 
 

--- a/corehq/apps/analytics/decorators.py
+++ b/corehq/apps/analytics/decorators.py
@@ -1,0 +1,18 @@
+from functools import wraps
+
+
+def use_new_analytics(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable the use of the new analytics library on that view.
+
+    Example:
+
+    @use_new_analytics
+    def dispatch(self, request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
+    """
+    @wraps(view_func)
+    def _wrapped(class_based_view, request, *args, **kwargs):
+        request.use_new_analytics = True
+        return view_func(class_based_view, request, *args, **kwargs)
+    return _wrapped

--- a/corehq/apps/analytics/decorators.py
+++ b/corehq/apps/analytics/decorators.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from functools import wraps
 
 

--- a/corehq/apps/analytics/static/analytics/js/deprecated.js
+++ b/corehq/apps/analytics/static/analytics/js/deprecated.js
@@ -69,7 +69,7 @@ hqDefine('analytics/js/deprecated', function () {
         return args;
     };
 
-    ga_track_event = _makeLegacyFn(_google, 'ga_track_event', _google.track.event, _addCallbackToArgs);
+    ga_track_event = _makeLegacyFn(_google, 'ga_track_event', _google.track.event, _addCallbackToArgs); // eslint-disable-line no-global-assign
 
     // Debug gtag's use of the ga function vs. the old usages
     var _oldGA = ga;
@@ -106,7 +106,7 @@ hqDefine('analytics/js/deprecated', function () {
                 userId = null;
             } else {
                 // uh-oh... can't tell what the first argument was intended to be.
-                throw "Unexpected argument types"
+                throw "Unexpected argument types";
             }
         }
         // Record identity

--- a/corehq/apps/analytics/static/analytics/js/deprecated.js
+++ b/corehq/apps/analytics/static/analytics/js/deprecated.js
@@ -1,11 +1,11 @@
 /* globals _, _kmq */
 
 // Deprecated analytics globals
-var ga_track_event,
-    trackLinkHelper,
-    gaTrackLink,
-    kmqPushSafe,
-    analytics;
+var ga_track_event, // eslint-disable-line no-unused-vars
+    trackLinkHelper, // eslint-disable-line no-unused-vars
+    gaTrackLink, // eslint-disable-line no-unused-vars
+    kmqPushSafe, // eslint-disable-line no-unused-vars
+    analytics; // eslint-disable-line no-unused-vars
 
 window.analytics = {};
 

--- a/corehq/apps/analytics/static/analytics/js/deprecated.js
+++ b/corehq/apps/analytics/static/analytics/js/deprecated.js
@@ -1,0 +1,133 @@
+/* globals _, _kmq */
+
+// Deprecated analytics globals
+var ga_track_event,
+    trackLinkHelper,
+    gaTrackLink,
+    kmqPushSafe,
+    analytics;
+
+window.analytics = {};
+
+// to support deprecated direct ga() calls
+var ga = window.ga || function () {
+    hqImport('analytics/js/google').logger.warning.log(arguments, 'no global ga function was defined');
+    if (arguments.length) {
+        var lastArg = arguments[arguments.length - 1];
+        if (lastArg) {
+            var callback = lastArg.hitCallback;
+            if (callback) {
+                callback();
+            }
+        }
+    }
+};
+
+/**
+ * This creates wrappers with warnings around legacy global functions to help with refactoring of HQ's analytics.
+ * Eventually this will be phased out and all the old globals replaced.
+ */
+hqDefine('analytics/js/deprecated', function () {
+    'use strict';
+    var _utils = hqImport('analytics/js/utils'),
+        _kissmetrics = hqImport('analytics/js/kissmetrics'),
+        _google = hqImport('analytics/js/google');
+
+    /**
+     * Helper function for wrapping the legacy functions.
+     * @param {object} api - the analytics api
+     * @param {string} fnName - Deprecated Function Name
+     * @param {function} fallbackFn - Function to fallback to.
+     * @param {function} formatArgs - (optional) Function that takes an array of arguments and reformats the arguments for fallback function.
+     * @returns {Function} A function that takes the same paramers as the legacy function, but processes it in the new world and warns of its usage.
+     * @private
+     */
+    var _makeLegacyFn = function(api, fnName, fallbackFn, formatArgs) {
+        return function () {
+            var args = Array.from(arguments);
+            api.logger.deprecated.log(arguments, fnName);
+            if (_.isFunction(formatArgs)) {
+                args = formatArgs(args);
+            }
+            return fallbackFn.apply(null, args);
+        };
+    };
+
+    /**
+     * Gets the callback frunction (from Google Analytics' hitCallback) from the last argument, if available,
+     * and re-adds to arguments
+     * @param args - Array of arguments
+     * @returns {array} - Array of arguments
+     * @private
+     */
+    var _addCallbackToArgs = function (args) {
+        var lastArg = _.last(args);
+        if (lastArg && _.isFunction(lastArg.hitCallback)) {
+            delete lastArg.hitCallback;
+            args = _.union(args, [lastArg.hitCallback]);
+        }
+        return args;
+    };
+
+    ga_track_event = _makeLegacyFn(_google, 'ga_track_event', _google.track.event, _addCallbackToArgs);
+
+    // Debug gtag's use of the ga function vs. the old usages
+    var _oldGA = ga;
+    ga = function () {
+        var args = Array.from(arguments);
+        if (args.length > 1 && args[0].startsWith('gtag')) {
+            _google.logger.debug.log(arguments, 'direct gtag > ga call');
+        } else if (args.length > 2 && args[1] === 'event') {
+            args = args.splice(2);
+            args = _addCallbackToArgs(args);
+            _google.logger.deprecated.log(arguments, 'ga');
+            return _google.track.event.apply(null, args);
+        } else {
+            _google.logger.debug.log(arguments, 'unknown ga call');
+        }
+        return _oldGA.apply(null, arguments);
+    };
+    trackLinkHelper = _makeLegacyFn(_google, 'trackLinkHelper', _utils.trackClickHelper);
+    gaTrackLink = _makeLegacyFn(_google, 'gaTrackLink', _google.track.click);
+    kmqPushSafe = _makeLegacyFn(_kissmetrics, 'kmqPushSafe', function (args, timeout) {
+        var lastArg = _.last(args);
+        args[args.length - 1] = _utils.createSafeCallback(lastArg, timeout);
+        _kmq.push(args);
+    });
+
+    window.analytics.usage = _makeLegacyFn(_google, 'window.analytics.usage', _google.track.event, _addCallbackToArgs);
+    window.analytics.trackUsageLink = _makeLegacyFn(_google, 'window.analytics.trackUsageLink', _google.track.click);
+
+    window.analytics.identify = _makeLegacyFn(_kissmetrics, 'window.analytics.identify', function (userId, traits) {
+        if (typeof userId === 'object'){
+            if (traits === undefined){
+                // the first and only argument passed was traits
+                traits = userId;
+                userId = null;
+            } else {
+                // uh-oh... can't tell what the first argument was intended to be.
+                throw "Unexpected argument types"
+            }
+        }
+        // Record identity
+        if (userId !== null) {
+            _kissmetrics.identify(userId);
+        }
+        if (traits !== undefined){
+            _kissmetrics.identifyTraits(traits);
+        }
+    });
+
+    window.analytics.workflow = _makeLegacyFn(_kissmetrics, 'window.analytics.workflow', _kissmetrics.track.event);
+    window.analytics.track = window.analytics.workflow;
+
+    window.analytics.trackWorkflowLink = _makeLegacyFn(_kissmetrics, ' window.analytics.trackWorkflowLink', function(element, event, properties) {
+        _utils.trackClickHelper(element, function (cb) {
+            _kissmetrics.track.event(event, properties, cb);
+        });
+    });
+
+    analytics = window.analytics;
+
+    return {};
+});

--- a/corehq/apps/analytics/static/analytics/js/google.js
+++ b/corehq/apps/analytics/static/analytics/js/google.js
@@ -27,7 +27,7 @@ hqDefine('analytics/js/google', function () {
 
     window.dataLayer = window.dataLayer || [];
     _gtag = function () {
-        dataLayer.push(arguments);
+        window.dataLayer.push(arguments);
         logger.verbose.log(arguments, 'gtag');
     };
     _gtag('js', new Date());
@@ -56,14 +56,6 @@ hqDefine('analytics/js/google', function () {
 
     // Configure Gtag with User Info
     _gtag('config', _init.apiId, _init.user);
-
-    var _fmtEvent = function (action, params) {
-        var messages = [];
-        messages.push({title: "Action", message: action, logGroup: true});
-        _.each(params, function (val, key) {
-            messages.push({title: key, message: val, logGroup: true});
-        });
-    };
 
     /**
      * Helper function for sending a Google Analytics Event.
@@ -126,9 +118,10 @@ hqDefine('analytics/js/google', function () {
              * @param {string} eventAction - The event action
              * @param {string} eventLabel - (optional) The event label
              * @param {string} eventValue - (optional) The event value
-             * @param {object} eventOptions - (optional) Options for the event call. Often used: hitCallback
+             * @param {object} eventParameters - (optional) Extra event parameters
+             * @param {function} eventCallback - (optional) Event callback fn
              */
-            event: function (eventAction, eventLabel, eventValue, eventOptions) {
+            event: function (eventAction, eventLabel, eventValue, eventParameters, eventCallback) {
                 trackEvent.apply(null, _.union([eventCategory], Array.from(arguments)));
             },
             /**
@@ -136,8 +129,9 @@ hqDefine('analytics/js/google', function () {
              * @param {string} eventAction - The event action
              * @param {string} eventLabel - (optional) The event label
              * @param {string} eventValue - (optional) The event value
+             * @param {object} eventParameters - (optional) Extra event parameters
              */
-            click: function (element, eventAction, eventLabel, eventValue) {
+            click: function (element, eventAction, eventLabel, eventValue, eventParameters) {
                 trackClick.apply(null, _.union([arguments[0], eventCategory], Array.from(arguments).splice(1)));
             },
         };

--- a/corehq/apps/analytics/static/analytics/js/google.js
+++ b/corehq/apps/analytics/static/analytics/js/google.js
@@ -1,0 +1,154 @@
+/* globals _, $, Array, window */
+/**
+ *  Handles communication with the google analytics API. gtag is the replacement
+ *  for Google's old analytics.js (ga).
+ */
+hqDefine('analytics/js/google', function () {
+    'use strict';
+    var _get = hqImport('analytics/js/initial').getFn('google'),
+        logger = hqImport('analytics/js/logging').getLoggerForApi('Google Analytics'),
+        _utils = hqImport('analytics/js/utils'),
+        _init = {},
+        _gtag;
+
+    logger.verbose.addCategory('data', 'DATA');
+
+    _init.apiId = _get('apiId');
+    logger.verbose.data(_init.apiId || "NOT SET", "API ID");
+
+    var _addGoogleScript = function (srcUrl) {
+        logger.verbose.log(srcUrl, "Added Script");
+        _utils.insertAsyncScript(srcUrl);
+    };
+
+    if (_init.apiId) {
+        _addGoogleScript('//www.googletagmanager.com/gtag/js?id=' + _init.apiId);
+    }
+
+    window.dataLayer = window.dataLayer || [];
+    _gtag = function () {
+        dataLayer.push(arguments);
+        logger.verbose.log(arguments, 'gtag');
+    };
+    _gtag('js', new Date());
+
+    _init.user = {
+        user_id: _get('userId', 'none'),
+        isDimagi: _get('userIsDimagi', 'no', 'yes'),
+        isCommCare: _get('userIsCommCare', 'no', 'yes'),
+        domain: _get('domain', 'none'),
+        hasBuiltApp: _get('userHasBuiltApp', 'no', 'yes'),
+    };
+    // Update User Data & Legacy "Dimensions"
+    _init.dimLabels = ['isDimagi', 'user_id', 'isCommCare', 'domain', 'hasBuiltApp'];
+    if (_init.user.user_id !== 'none') {
+        _init.user.daysOld = _get('userDaysSinceCreated');
+        _init.user.isFirstDay = _init.user.daysOld < 1 ? 'yes' : 'no';
+        _init.dimLabels.push('isFirstDay');
+        _init.user.isFirstWeek = _init.user.daysOld >= 1 && _init.user.daysOld < 7 ? 'yes' : 'no';
+        _init.dimLabels.push('isFirstWeek');
+    }
+    // Legacy Dimensions
+    _init.user.custom_map = {};
+    _.each(_init.dimLabels, function (val, ind) {
+        _init.user.custom_map['dimension' + ind] = _init.user[val];
+    });
+
+    // Configure Gtag with User Info
+    _gtag('config', _init.apiId, _init.user);
+
+    var _fmtEvent = function (action, params) {
+        var messages = [];
+        messages.push({title: "Action", message: action, logGroup: true});
+        _.each(params, function (val, key) {
+            messages.push({title: key, message: val, logGroup: true});
+        });
+    };
+
+    /**
+     * Helper function for sending a Google Analytics Event.
+     *
+     * @param {string} eventCategory - The event category
+     * @param {string} eventAction - The event action
+     * @param {string} eventLabel - (optional) The event label
+     * @param {string} eventValue - (optional) The event value
+     * @param {object} eventParameters - (optional) Extra event parameters
+     * @param {function} eventCallback - (optional) Event callback fn
+     */
+    var trackEvent = function (eventCategory, eventAction, eventLabel, eventValue, eventParameters, eventCallback) {
+        var params = {
+            event_category: eventCategory,
+            event_label: eventLabel,
+            event_value: eventValue,
+            event_callback: eventCallback,
+            event_action: eventAction,
+        };
+        if (_.isObject(eventParameters)) {
+            params = _.extend(params, eventParameters);
+        }
+        logger.debug.log(logger.fmt.labelArgs(["Category", "Action", "Label", "Value", "Parameters", "Callback"], arguments), "Event Recorded");
+        _gtag('event', eventAction, params);
+    };
+
+    /**
+     * Tracks an event when the given element is clicked.
+     * Uses a callback to ensure that the request to the analytics services
+     * completes before the default click action happens. This is useful if
+     * the link would otherwise navigate away from the page.
+     * @param {(object|string)} element - The element (or a selector) whose clicks you want to track.
+     * @param {string} eventCategory - The event category
+     * @param {string} eventAction - The event action
+     * @param {string} eventLabel - (optional) The event label
+     * @param {string} eventValue - (optional) The event value
+     * @param {object} eventParameters - (optional) Extra event parameters
+     */
+    var trackClick = function (element, eventCategory, eventAction, eventLabel, eventValue, eventParameters) {
+        _utils.trackClickHelper(
+            element,
+            function (callbackFn) {
+                trackEvent(eventCategory, eventAction, eventLabel, eventValue, eventParameters, callbackFn);
+            }
+        );
+        logger.debug.log(logger.fmt.labelArgs(["Element", "Category", "Action", "Label", "Value", "Parameters"], arguments), "Added Click Tracker");
+    };
+
+    /**
+     * Helper function that pre-fills the eventCategory field for all the
+     * tracking helper functions. Useful if you want to track a lot of items
+     * in a particular area of the site.
+     * e.g. "Report Builder" would be the category
+     *
+     * @param {string} eventCategory - The event category
+     */
+    var trackCategory = function (eventCategory) {
+        return {
+            /**
+             * @param {string} eventAction - The event action
+             * @param {string} eventLabel - (optional) The event label
+             * @param {string} eventValue - (optional) The event value
+             * @param {object} eventOptions - (optional) Options for the event call. Often used: hitCallback
+             */
+            event: function (eventAction, eventLabel, eventValue, eventOptions) {
+                trackEvent.apply(null, _.union([eventCategory], Array.from(arguments)));
+            },
+            /**
+             * @param {(object|string)} element - The element (or a selector) whose clicks you want to track.
+             * @param {string} eventAction - The event action
+             * @param {string} eventLabel - (optional) The event label
+             * @param {string} eventValue - (optional) The event value
+             */
+            click: function (element, eventAction, eventLabel, eventValue) {
+                trackClick.apply(null, _.union([arguments[0], eventCategory], Array.from(arguments).splice(1)));
+            },
+        };
+    };
+
+    return {
+        logger: logger,
+        track: {
+            event: trackEvent,
+            click: trackClick,
+        },
+        trackCategory: trackCategory,
+    };
+});

--- a/corehq/apps/analytics/static/analytics/js/google.js
+++ b/corehq/apps/analytics/static/analytics/js/google.js
@@ -122,7 +122,7 @@ hqDefine('analytics/js/google', function () {
              * @param {function} eventCallback - (optional) Event callback fn
              */
             event: function (eventAction, eventLabel, eventValue, eventParameters, eventCallback) {
-                trackEvent.apply(null, _.union([eventCategory], Array.from(arguments)));
+                trackEvent(eventCategory, eventAction, eventLabel, eventValue, eventParameters, eventCallback);
             },
             /**
              * @param {(object|string)} element - The element (or a selector) whose clicks you want to track.
@@ -132,7 +132,7 @@ hqDefine('analytics/js/google', function () {
              * @param {object} eventParameters - (optional) Extra event parameters
              */
             click: function (element, eventAction, eventLabel, eventValue, eventParameters) {
-                trackClick.apply(null, _.union([arguments[0], eventCategory], Array.from(arguments).splice(1)));
+                trackClick(element, eventCategory, eventLabel, eventValue, eventParameters);
             },
         };
     };

--- a/corehq/apps/analytics/static/analytics/js/initial.js
+++ b/corehq/apps/analytics/static/analytics/js/initial.js
@@ -55,7 +55,7 @@ hqDefine('analytics/js/initial', function () {
             if (optTrue !== undefined) {
                 data = data ? optTrue : optDefault;
             } else {
-                data = data || optDefault
+                data = data || optDefault;
             }
             return data;
         };

--- a/corehq/apps/analytics/static/analytics/js/initial.js
+++ b/corehq/apps/analytics/static/analytics/js/initial.js
@@ -71,18 +71,14 @@ hqDefine('analytics/js/initial', function () {
             _abTests = _gather(_abSelector, {});
         }
         if (_.isUndefined(_abTestsByApi[apiName])) {
-            var tests = _.map(_abTests, function (val, key) {
+            _abTestsByApi[apiName] = _.compact(_.map(_abTests, function (val, key) {
                 if (key.startsWith(apiName)) {
                     return {
                         slug: _.last(key.split('.')),
                         context: val,
                     };
                 }
-            });
-            tests = _.filter(tests, function (t) {
-                return !_.isUndefined(t);
-            });
-            _abTestsByApi[apiName] = tests;
+            }));
         }
         return _abTests;
     };

--- a/corehq/apps/analytics/static/analytics/js/initial.js
+++ b/corehq/apps/analytics/static/analytics/js/initial.js
@@ -1,0 +1,98 @@
+/* globals $ */
+/**
+ *  Fetches all the initialization data needed for the different analytics platforms.
+ */
+hqDefine('analytics/js/initial', function () {
+    'use strict';
+    var _selector = '.initial-analytics-data',
+        _gather =  hqImport('hqwebapp/js/initial_page_data').gather,
+        _initData = {},
+        _abSelector = '.analytics-ab-tests',
+        _abTests,
+        _abTestsByApi = {};
+
+    /**
+     * Helper function to create the namespaced slug for the initial_analytics_data
+     * eg apiName.key
+     * @param {string} apiName
+     * @param {string} key
+     * @returns {string}
+     * @private
+     */
+    var _getSlug = function (apiName, key) {
+        return apiName + '.' + key;
+    };
+
+    /**
+     * Get the namespaced initial_analytics_data value.
+     * @param {string} apiName
+     * @param {string} key
+     * @returns {*} value
+     * @private
+     */
+    var _getNamespacedData = function (apiName, key) {
+        var slug = _getSlug(apiName, key);
+        if (_initData[slug] === undefined) {
+            _initData = _gather(_selector, _initData);
+        }
+        return _initData[slug];
+    };
+
+    /**
+     * Returns a get function namespaced to the specified API.
+     * @param apiName
+     * @returns {Function}
+     */
+    var getFn = function (apiName) {
+        /**
+         * Helper function for returning the data
+         * @param {string} key
+         * @param {*} optDefault - (optional) value returned if the fetched value is undefined or false
+         * @param {*} optTrue - (optional) value returned if the fetched value is true
+         */
+        return function (key, optDefault, optTrue) {
+            var data = _getNamespacedData(apiName, key);
+            if (optTrue !== undefined) {
+                data = data ? optTrue : optDefault;
+            } else {
+                data = data || optDefault
+            }
+            return data;
+        };
+    };
+
+    /**
+     * Fetches all AB Tests for a given API name
+     * @param {string} apiName
+     * @returns {array} array of abTests
+     */
+    var getAbTests = function (apiName) {
+        if (_.isUndefined(_abTests)) {
+            _abTests = _gather(_abSelector, {});
+        }
+        if (_.isUndefined(_abTestsByApi[apiName])) {
+            var tests = _.map(_abTests, function (val, key) {
+                if (key.startsWith(apiName)) {
+                    return {
+                        slug: _.last(key.split('.')),
+                        context: val,
+                    };
+                }
+            });
+            tests = _.filter(tests, function (t) {
+                return !_.isUndefined(t);
+            });
+            _abTestsByApi[apiName] = tests;
+        }
+        return _abTests;
+    };
+
+    $(function() {
+        _initData = _gather(_selector, _initData);
+    });
+
+    return {
+        getFn: getFn,
+        getAbTests: getAbTests,
+    };
+});

--- a/corehq/apps/analytics/static/analytics/js/kissmetrics.js
+++ b/corehq/apps/analytics/static/analytics/js/kissmetrics.js
@@ -27,7 +27,7 @@ hqDefine('analytics/js/kissmetrics', function () {
     KmqWrapper.prototype.pushNew = function () {
         Array.prototype.push.apply(this, arguments);
     };
-    _kmq = new KmqWrapper(_kmq);
+    _kmq = new KmqWrapper(_kmq); // eslint-disable-line no-global-assign
 
     /**
      * Push data to _kmq by command type.

--- a/corehq/apps/analytics/static/analytics/js/kissmetrics.js
+++ b/corehq/apps/analytics/static/analytics/js/kissmetrics.js
@@ -1,0 +1,152 @@
+/* globals _, _kmq */
+
+var _kmq = _kmq || [];
+
+hqDefine('analytics/js/kissmetrics', function () {
+    'use strict';
+    var _get = hqImport('analytics/js/initial').getFn('kissmetrics'),
+        _abTests = hqImport('analytics/js/initial').getAbTests('kissmetrics'),
+        logger = hqImport('analytics/js/logging').getLoggerForApi('Kissmetrics'),
+        _utils = hqImport('analytics/js/utils'),
+        _init = {};
+
+    logger.verbose.addCategory('data', 'DATA');
+    logger.debug.addCategory('ab', 'AB TEST');
+
+    window.dataLayer = window.dataLayer || [];
+
+    var KmqWrapper = function (originalObject) {
+        Array.call(this, originalObject);
+    };
+    KmqWrapper.prototype = Object.create(Array.prototype);
+    KmqWrapper.prototype.constructor = KmqWrapper;
+    KmqWrapper.prototype.push = function () {
+        logger.deprecated.log(arguments, '_kmq.push');
+        Array.prototype.push.apply(this, arguments);
+    };
+    KmqWrapper.prototype.pushNew = function () {
+        Array.prototype.push.apply(this, arguments);
+    };
+    _kmq = new KmqWrapper(_kmq);
+
+    /**
+     * Push data to _kmq by command type.
+     * @param {string} commandName
+     * @param {object} properties
+     * @param {function|undefined} callbackFn - optional
+     * @param {string|undefined} eventName - optional
+     */
+    var _kmqPushCommand = function (commandName, properties, callbackFn, eventName) {
+        var command, data;
+        command = _.filter([commandName, eventName, properties, callbackFn], function (a) {
+            return !_.isUndefined(a);
+        });
+        _kmq.pushNew(command);
+        data = {
+            event: 'km_' + commandName,
+        };
+        if (eventName) data.km_event = eventName;
+        if (properties) data.km_property = properties;
+        window.dataLayer.push(data);
+        logger.verbose.log(command, ['window._kmq.push', 'window.dataLayer.push', '_kmqPushCommand', commandName]);
+    };
+
+    /**
+     * Initialization function for kissmetrics libraries
+     * @param srcUrl
+     * @private
+     */
+    var _kms = function (srcUrl) {
+        logger.verbose.data(srcUrl, "Injected Script");
+        _utils.insertAsyncScript(srcUrl);
+    };
+
+    _init.apiId = _get('apiId');
+    logger.verbose.data(_init.apiId || "NONE SET", "API ID");
+
+    // Initialize Kissmetrics
+    if (_init.apiId) {
+        _kms('//i.kissmetrics.com/i.js');
+        _kms('//doug1izaerwt3.cloudfront.net/' + _init.apiId + '.1.js');
+    }
+
+    // Initialize Kissmetrics AB Tests
+    _.each(_abTests, function (ab, testName) {
+        var test = {};
+        testName = _.last(testName.split('.'));
+        if (_.isObject(ab) && ab.version) {
+            test[ab.name || testName] = ab.version;
+        } else {
+            test[testName] = ab;
+        }
+        logger.debug.ab(test, "New Test: " + testName);
+        _kmqPushCommand('set', test);
+    });
+
+    /**
+     * Identifies the current user
+     * @param {string} identity - A unique ID to identify the session.
+     */
+    var identify = function (identity) {
+        logger.debug.log(arguments, 'Identify');
+        _kmqPushCommand('identify', identity);
+    };
+
+    /**
+     * Sets traits for the current user
+     * @param {object} traits - an object of traits
+     * @param {function} callbackFn - (optional) callback function
+     * @param {integer} timeout - (optional) timeout in milliseconds
+     */
+    var identifyTraits = function (traits, callbackFn, timeout) {
+        logger.debug.log(logger.fmt.labelArgs(["Traits", "Callback Function", "Timeout"], arguments), 'Identify Traits (Set)');
+        callbackFn = _utils.createSafeCallback(callbackFn, timeout);
+        _kmqPushCommand('set', traits, callbackFn);
+    };
+
+    /**
+     * Records an event and its properties
+     * @param {string} name - Name of event to be tracked
+     * @param {object} properties - (optional) Properties related to the event being tracked
+     * @param {function} callbackFn - (optional) Function to be called after the event is tracked.
+     * @param {integer} timeout - (optional) Timeout for safe callback
+     */
+    var trackEvent = function (name, properties, callbackFn, timeout) {
+        logger.debug.log(arguments, 'RECORD EVENT');
+        callbackFn = _utils.createSafeCallback(callbackFn, timeout);
+        _kmqPushCommand('record', properties, callbackFn, name);
+    };
+
+    /**
+     * Tags an HTML element to record an event when its clicked
+     * @param {string} selector - The ID or class of the element to track.
+     * @param {string} name - The name of the event to record.
+     * @param {object} properties - optional Properties related to the event being recorded.
+     */
+    var trackClick = function (selector, name, properties) {
+        logger.debug.log(logger.fmt.labelArgs(["Selector", "Name", "Properties"], arguments), 'Track Click');
+        _kmqPushCommand('trackClick', properties, undefined, name);
+    };
+
+    /**
+     * Tags a link that takes someone to another domain and provides enough time to record an event when the link is clicked, before being redirected.
+     * @param {string} selector - The ID or class of the element to track.
+     * @param {string} name - The name of the event to record.
+     * @param {object} properties - optional Properties related to the event being recorded.
+     */
+    var trackOutboundLink = function (selector, name, properties) {
+        logger.debug.log(logger.fmt.labelArgs(["Selector", "Name", "Properties"], arguments), 'Track Click on Outbound Link');
+        _kmqPushCommand('trackClickOnOutboundLink', properties, undefined, name);
+    };
+
+    return {
+        logger: logger,
+        identify: identify,
+        identifyTraits: identifyTraits,
+        track: {
+            event: trackEvent,
+            click: trackClick,
+            outboundLink: trackOutboundLink,
+        },
+    };
+});

--- a/corehq/apps/analytics/static/analytics/js/kissmetrics.js
+++ b/corehq/apps/analytics/static/analytics/js/kissmetrics.js
@@ -38,9 +38,7 @@ hqDefine('analytics/js/kissmetrics', function () {
      */
     var _kmqPushCommand = function (commandName, properties, callbackFn, eventName) {
         var command, data;
-        command = _.filter([commandName, eventName, properties, callbackFn], function (a) {
-            return !_.isUndefined(a);
-        });
+        command = _.compact([commandName, eventName, properties, callbackFn]);
         _kmq.pushNew(command);
         data = {
             event: 'km_' + commandName,

--- a/corehq/apps/analytics/static/analytics/js/kissmetrics.js
+++ b/corehq/apps/analytics/static/analytics/js/kissmetrics.js
@@ -54,7 +54,7 @@ hqDefine('analytics/js/kissmetrics', function () {
      * @param srcUrl
      * @private
      */
-    var _kms = function (srcUrl) {
+    var _addKissmetricsScript = function (srcUrl) {
         logger.verbose.data(srcUrl, "Injected Script");
         _utils.insertAsyncScript(srcUrl);
     };
@@ -64,8 +64,8 @@ hqDefine('analytics/js/kissmetrics', function () {
 
     // Initialize Kissmetrics
     if (_init.apiId) {
-        _kms('//i.kissmetrics.com/i.js');
-        _kms('//doug1izaerwt3.cloudfront.net/' + _init.apiId + '.1.js');
+        _addKissmetricsScript('//i.kissmetrics.com/i.js');
+        _addKissmetricsScript('//doug1izaerwt3.cloudfront.net/' + _init.apiId + '.1.js');
     }
 
     // Initialize Kissmetrics AB Tests

--- a/corehq/apps/analytics/static/analytics/js/kissmetrics.js
+++ b/corehq/apps/analytics/static/analytics/js/kissmetrics.js
@@ -121,8 +121,8 @@ hqDefine('analytics/js/kissmetrics', function () {
      * @param {string} name - The name of the event to record.
      * @param {object} properties - optional Properties related to the event being recorded.
      */
-    var trackClick = function (selector, name, properties) {
-        logger.debug.log(logger.fmt.labelArgs(["Selector", "Name", "Properties"], arguments), 'Track Click');
+    var internalClick = function (selector, name, properties) {
+        logger.debug.log(logger.fmt.labelArgs(["Selector", "Name", "Properties"], arguments), 'Track Internal Click');
         _kmqPushCommand('trackClick', properties, undefined, name);
     };
 
@@ -143,7 +143,7 @@ hqDefine('analytics/js/kissmetrics', function () {
         identifyTraits: identifyTraits,
         track: {
             event: trackEvent,
-            click: trackClick,
+            internalClick: internalClick,
             outboundLink: trackOutboundLink,
         },
     };

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -10,11 +10,19 @@
  */
 hqDefine('analytics/js/logging', function () {
     'use strict';
+
+    var _makeLevel = function (name, style) {
+        return {
+            name: name,
+            style: style,
+        };
+    };
+
     var _LEVELS = {
-        warning: ['WARNING', 'color: #994f00;'],
-        verbose: ['VERBOSE', 'color: #685c53;'],
-        debug: ['DEBUG', 'color: #004ebc;'],
-        deprecated: ['DEPRECATED', 'color: #e53e30;'],
+        warning: _makeLevel('WARNING', 'color: #994f00;'),
+        verbose: _makeLevel('VERBOSE', 'color: #685c53;'),
+        debug: _makeLevel('DEBUG', 'color: #004ebc;'),
+        deprecated: _makeLevel('DEPRECATED', 'color: #e53e30;'),
     };
 
     var _printPretty = function (message) {
@@ -56,7 +64,7 @@ hqDefine('analytics/js/logging', function () {
 
     var _getStyle = function (level) {
         var levelOptions = _LEVELS[level];
-        return (levelOptions) ? levelOptions[1] : "";
+        return (levelOptions) ? levelOptions.style : "";
     };
 
     var Message = function (value, level) {
@@ -144,7 +152,7 @@ hqDefine('analytics/js/logging', function () {
             return new Level(slug, name, logger);
         };
         _.each(_LEVELS, function (options, key) {
-            logger[key] = logger.createLevel(key, options[0]);
+            logger[key] = logger.createLevel(key, options.name);
         });
         logger.fmt = {};
         logger.fmt.groupMsg = function (title, message) {

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -77,6 +77,11 @@ hqDefine('analytics/js/logging', function () {
         return msg;
     };
 
+    /**
+     * Used to format console log messages better by combining them into
+     * groups so that it's easier to skim data vs info text on the console output
+     * and improve readability.
+     */
     var Group = function (title, message) {
         var grp = {};
         grp.title = title;

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -114,7 +114,7 @@ hqDefine('analytics/js/logging', function () {
             },
             setCategory: function (category) {
                 _log.category = category;
-            }
+            },
         };
     };
 

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -1,5 +1,4 @@
 /* globals _, JSON */
-/* jshint devel: true */
 /**
  * To Use this library, enable the feature flag ANALYTICS_NEW.
  *
@@ -21,7 +20,7 @@ hqDefine('analytics/js/logging', function () {
     var _printPretty = function (message) {
         var _title, _value, _grp;
         if (_.isUndefined(message.value)) {
-            console.log("Message was undefined");
+            console.log("Message was undefined");  // eslint-disable-line no-console
         } else if (message.value.isGroup) {
             _grp = message.value;
             _grp.level = message.level;
@@ -65,7 +64,7 @@ hqDefine('analytics/js/logging', function () {
         msg.level = level;
         msg.value = value;
         msg.print = function () {
-            console.log(msg.value);
+            console.log(msg.value);  // eslint-disable-line no-console
         };
         return msg;
     };
@@ -79,10 +78,10 @@ hqDefine('analytics/js/logging', function () {
         grp.isRaw = false;
         grp.isGroup = true;
         grp.print = function () {
-            var _printGrp = (grp.isCollapsed) ? console.groupCollapsed : console.group;
+            var _printGrp = (grp.isCollapsed) ? console.groupCollapsed : console.group;  // eslint-disable-line no-console
             _printGrp("%c%s", _getStyle(grp.level), grp.title);
             (grp.isRaw) ? grp.message.print() : _printPretty(grp.message);
-            console.groupEnd();
+            console.groupEnd();  // eslint-disable-line no-console
         };
         return grp;
     };

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -105,10 +105,7 @@ hqDefine('analytics/js/logging', function () {
          * @private
          */
         _log.getPrefix = function (messagePrefix) {
-            var prefix = _.flatten([level.prefix, logger.prefix, _log.category, messagePrefix]);
-            prefix = _.filter(prefix, function (p) {
-                return !_.isUndefined(p);
-            });
+            var prefix = _.compact(_.flatten([level.prefix, logger.prefix, _log.category, messagePrefix]));
             return prefix.join(' | ') + '    ';
         };
         return {
@@ -164,14 +161,11 @@ hqDefine('analytics/js/logging', function () {
          * @param {Arguments} args
          */
         logger.fmt.labelArgs = function (labels, args) {
-            var final = _.map(labels, function (label, ind) {
+            return _.compact(_.map(labels, function (label, ind) {
                 if (args[ind]) {
                     return logger.fmt.groupMsg(label, args[ind]);
                 }
-            });
-            return _.filter(final, function (fin) {
-                return !_.isUndefined(fin);
-            });
+            }));
         };
         return logger;
     };

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -26,19 +26,19 @@ hqDefine('analytics/js/logging', function () {
     };
 
     var _printPretty = function (message) {
-        var _title, _value, _grp;
+        var _title, _value, _group;
         if (_.isUndefined(message.value)) {
             console.log("Message was undefined");  // eslint-disable-line no-console
         } else if (message.value.isGroup) {
-            _grp = message.value;
-            _grp.level = message.level;
-            _grp.print();
+            _group = message.value;
+            _group.level = message.level;
+            _group.print();
         } else if (_.isArguments(message.value)) {
             _title = "Arguments (" + message.value.length + ")    " + _.map(Array.from(message.value), JSON.stringify).join('    ');
             _value = Array.from(message.value);
-            _grp = new Group(_title, new Message(_value, message.level));
-            _grp.isCollapsed = true;
-            _grp.print();
+            _group = new Group(_title, new Message(_value, message.level));
+            _group.isCollapsed = true;
+            _group.print();
         } else if (_.isArray(message.value)) {
             _.each(message.value, function (msg) {
                 _printPretty(new Message(msg, message.level));
@@ -47,16 +47,16 @@ hqDefine('analytics/js/logging', function () {
             // DOM element
             _title = "#" + message.value.get(0).id + " ." + message.value.get(0).className.split(' ').join('.');
             _value = message.value.get(0).outerHTML;
-            _grp = new Group(_title, new Message(_value, message.level));
-            _grp.isCollapsed = true;
-            _grp.print();
+            _group = new Group(_title, new Message(_value, message.level));
+            _group.isCollapsed = true;
+            _group.print();
         } else if (!_.isString(message.value) && !_.isUndefined(message.value)) {
             _title = JSON.stringify(message.value);
             _value = message.value;
-            _grp = new Group(_title, new Message(_value, message.level));
-            _grp.isCollapsed = true;
-            _grp.isRaw = true;
-            _grp.print();
+            _group = new Group(_title, new Message(_value, message.level));
+            _group.isCollapsed = true;
+            _group.isRaw = true;
+            _group.print();
         } else {
             message.print();
         }

--- a/corehq/apps/analytics/static/analytics/js/logging.js
+++ b/corehq/apps/analytics/static/analytics/js/logging.js
@@ -1,0 +1,177 @@
+/* globals _, JSON */
+/* jshint devel: true */
+/**
+ * To Use this library, enable the feature flag ANALYTICS_NEW.
+ *
+ * To enable logging, enable the following INTERNAL feature flags to see each level:
+ * DEBUG: ANALYTICS_DEBUG
+ * VERBOSE: ANALYTICS_VERBOSE
+ * WARNING, DEPRECATED: ANALYTICS_DEPRECATED
+ *
+ */
+hqDefine('analytics/js/logging', function () {
+    'use strict';
+    var _LEVELS = {
+        warning: ['WARNING', 'color: #994f00;'],
+        verbose: ['VERBOSE', 'color: #685c53;'],
+        debug: ['DEBUG', 'color: #004ebc;'],
+        deprecated: ['DEPRECATED', 'color: #e53e30;'],
+    };
+
+    var _printPretty = function (message) {
+        var _title, _value, _grp;
+        if (_.isUndefined(message.value)) {
+            console.log("Message was undefined");
+        } else if (message.value.isGroup) {
+            _grp = message.value;
+            _grp.level = message.level;
+            _grp.print();
+        } else if (_.isArguments(message.value)) {
+            _title = "Arguments (" + message.value.length + ")    " + _.map(Array.from(message.value), JSON.stringify).join('    ');
+            _value = Array.from(message.value);
+            _grp = new Group(_title, new Message(_value, message.level));
+            _grp.isCollapsed = true;
+            _grp.print();
+        } else if (_.isArray(message.value)) {
+            _.each(message.value, function (msg) {
+                _printPretty(new Message(msg, message.level));
+            });
+        } else if (_.isObject(message.value) && _.has(message.value, 0) && _.isElement(message.value[0])) {
+            // DOM element
+            _title = "#" + message.value.get(0).id + " ." + message.value.get(0).className.split(' ').join('.');
+            _value = message.value.get(0).outerHTML;
+            _grp = new Group(_title, new Message(_value, message.level));
+            _grp.isCollapsed = true;
+            _grp.print();
+        } else if (!_.isString(message.value) && !_.isUndefined(message.value)) {
+            _title = JSON.stringify(message.value);
+            _value = message.value;
+            _grp = new Group(_title, new Message(_value, message.level));
+            _grp.isCollapsed = true;
+            _grp.isRaw = true;
+            _grp.print();
+        } else {
+            message.print();
+        }
+    };
+
+    var _getStyle = function (level) {
+        var levelOptions = _LEVELS[level];
+        return (levelOptions) ? levelOptions[1] : "";
+    };
+
+    var Message = function (value, level) {
+        var msg = {};
+        msg.level = level;
+        msg.value = value;
+        msg.print = function () {
+            console.log(msg.value);
+        };
+        return msg;
+    };
+
+    var Group = function (title, message) {
+        var grp = {};
+        grp.title = title;
+        grp.level = message.level;
+        grp.message = message;
+        grp.isCollapsed = false;
+        grp.isRaw = false;
+        grp.isGroup = true;
+        grp.print = function () {
+            var _printGrp = (grp.isCollapsed) ? console.groupCollapsed : console.group;
+            _printGrp("%c%s", _getStyle(grp.level), grp.title);
+            (grp.isRaw) ? grp.message.print() : _printPretty(grp.message);
+            console.groupEnd();
+        };
+        return grp;
+    };
+
+    var Log = function(level, logger) {
+        var _log = {};
+        _log.level = level.slug;
+        _log.isVisible = level.isVisible;
+
+        /**
+         * Helper function for creating the logging prefix.
+         * @returns {string}
+         * @private
+         */
+        _log.getPrefix = function (messagePrefix) {
+            var prefix = _.flatten([level.prefix, logger.prefix, _log.category, messagePrefix]);
+            prefix = _.filter(prefix, function (p) {
+                return !_.isUndefined(p);
+            });
+            return prefix.join(' | ') + '    ';
+        };
+        return {
+            getPrint: function () {
+                return function (messageValue, messagePrefix) {
+                    if (_log.isVisible) {
+                        var group = new Group(_log.getPrefix(messagePrefix), new Message(messageValue, _log.level));
+                        group.print();
+                    }
+                };
+            },
+            setCategory: function (category) {
+                _log.category = category;
+            }
+        };
+    };
+
+    var Level = function (_levelSlug, _levelPrefix, _logger) {
+        var _get = hqImport('analytics/js/initial').getFn('logging'),
+            _levelData = {
+                slug: _levelSlug,
+                prefix: _levelPrefix,
+                isVisible: _get(_levelSlug),
+            },
+            level = {};
+        level.addCategory = function (slug, category) {
+            if (_.isUndefined(level[slug])) {
+                var _log = new Log(_levelData, _logger);
+                _log.setCategory(category);
+                level[slug] = _log.getPrint();
+            }
+        };
+        level.addCategory('log');
+        return level;
+    };
+
+    var Logger = function (_prefix) {
+        var logger = {};
+        logger.prefix = _prefix;
+        logger.createLevel = function (slug, name) {
+            return new Level(slug, name, logger);
+        };
+        _.each(_LEVELS, function (options, key) {
+            logger[key] = logger.createLevel(key, options[0]);
+        });
+        logger.fmt = {};
+        logger.fmt.groupMsg = function (title, message) {
+            return new Group(title, new Message(message));
+        };
+        /**
+         * Outputs a list of group messages that maps argument labels to their values.
+         * @param {string[]} labels
+         * @param {Arguments} args
+         */
+        logger.fmt.labelArgs = function (labels, args) {
+            var final = _.map(labels, function (label, ind) {
+                if (args[ind]) {
+                    return logger.fmt.groupMsg(label, args[ind]);
+                }
+            });
+            return _.filter(final, function (fin) {
+                return !_.isUndefined(fin);
+            });
+        };
+        return logger;
+    };
+
+    return {
+        getLoggerForApi: function (apiName) {
+            return new Logger(apiName);
+        },
+    };
+});

--- a/corehq/apps/analytics/static/analytics/js/utils.js
+++ b/corehq/apps/analytics/static/analytics/js/utils.js
@@ -1,0 +1,100 @@
+/* globals _, JSON */
+hqDefine('analytics/js/utils', function () {
+    'use strict';
+
+    /**
+     * A helper function for for tracking google analytics events after a click
+     * on an element in the dom.
+     *
+     * @param {(object|string)} element - A DOM element, jQuery object, or selector.
+     * @param {function} trackFunction -
+     *      A function that takes a single optional callback.
+     *      If called without the callback, this function should
+     *      record an event. If called with a callback, this
+     *      function should record an event and call the
+     *      callback when finished.
+     */
+    var trackClickHelper = function (element, trackFunction) {
+        var eventHandler = function (event) {
+            var $this = $(this);
+            if (event.metaKey || event.ctrlKey || event.which === 2  // which === 2 for middle click
+                || event.currentTarget.target && event.currentTarget !== "_self") {
+                // The current page isn't being redirected so just track the click
+                // and don't prevent the default click action.
+                trackFunction();
+            } else {
+                // Track how many trackLinkHelper-related handlers
+                // this event has, so we only actually click
+                // once, after they're all complete.
+                var $target = $(event.delegateTarget);
+                var count = $target.data("track-link-count") || 0;
+                count++;
+                $target.data("track-link-count", count);
+
+                event.preventDefault();
+                var callbackCalled = false;
+                var callback = function () {
+                    if (!callbackCalled) {
+                        var $target = $(event.delegateTarget);
+                        var count = $target.data("track-link-count");
+                        count--;
+                        $target.data("track-link-count", count);
+                        if (!count) {
+                            document.location = $this.attr('href');
+                        }
+                        callbackCalled = true;
+                    }
+                };
+                // callback might not get executed if, say, gtag can't be reached.
+                setTimeout(callback, 2000);
+                trackFunction(callback);
+            }
+        };
+        if (typeof element === 'string') {
+            $(element).on('click', eventHandler);
+        } else {
+            if (element.nodeType){
+                element = $(element);
+            }
+            element.click(eventHandler);
+        }
+    };
+
+    /**
+     * Inserts a <script async src="srcUrl" type="text/javascript"></script>
+     * tag into the DOM.
+     * @param {string} srcUrl
+     */
+    var insertAsyncScript = function (srcUrl) {
+        setTimeout(function(){
+            var d = document,
+                f = d.getElementsByTagName('script')[0],
+                s = d.createElement('script');
+            s.type = 'text/javascript';
+            s.async = true;
+            s.src = srcUrl;
+            f.parentNode.insertBefore(s, f);
+        }, 1);
+    };
+
+    /**
+     * Makes sure an analytics callback ONCE is called even if the command fails
+     * @param {function} callback
+     * @param {integer} timeout - (optional)
+     * @returns {function} once callback
+     */
+    var createSafeCallback = function (callback, timeout) {
+        var oneTimeCallback = callback;
+        if (_.isFunction(callback)){
+            oneTimeCallback = _.once(callback);
+            setInterval(oneTimeCallback, timeout ? timeout : 2000);
+        }
+        return oneTimeCallback;
+    };
+
+    return {
+        trackClickHelper: trackClickHelper,
+        insertAsyncScript: insertAsyncScript,
+        createSafeCallback: createSafeCallback,
+    };
+});

--- a/corehq/apps/analytics/templates/analytics/analytics_js.html
+++ b/corehq/apps/analytics/templates/analytics/analytics_js.html
@@ -1,0 +1,8 @@
+{% load hq_shared_tags %}
+<script src="{% static 'analytics/js/initial.js' %}"></script>
+<script src="{% static 'analytics/js/utils.js' %}"></script>
+<script src="{% static 'analytics/js/logging.js' %}"></script>
+<script src="{% static 'analytics/js/google.js' %}"></script>
+<script src="{% static 'analytics/js/kissmetrics.js' %}"></script>
+<script src="{% static 'analytics/js/deprecated.js' %}"></script>
+

--- a/corehq/apps/analytics/templates/analytics/initial/all.html
+++ b/corehq/apps/analytics/templates/analytics/initial/all.html
@@ -1,0 +1,3 @@
+{% include 'analytics/initial/google.html' %}
+{% include 'analytics/initial/kissmetrics.html' %}
+{% include 'analytics/initial/logging.html' %}

--- a/corehq/apps/analytics/templates/analytics/initial/google.html
+++ b/corehq/apps/analytics/templates/analytics/initial/google.html
@@ -1,0 +1,12 @@
+{% load hq_shared_tags %}
+{% initial_analytics_data 'google.apiId' ANALYTICS_IDS.GOOGLE_ANALYTICS_API_ID %}
+{% if request.couch_user %}
+  {% initial_analytics_data 'google.userId' request.couch_user.userID %}
+  {% initial_analytics_data 'google.userIsDimagi' request.couch_user.is_dimagi %}
+  {% initial_analytics_data 'google.userIsCommCare' request.couch_user.is_commcare_user %}
+  {% initial_analytics_data 'google.userHasBuiltApp' request.couch_user.has_built_app %}
+  {% initial_analytics_data 'google.userDaysSinceCreated' request.couch_user.days_since_created %}
+{% endif %}
+{% if domain %}
+  {% initial_analytics_data 'google.domain' domain|escapejs %}
+{% endif %}

--- a/corehq/apps/analytics/templates/analytics/initial/kissmetrics.html
+++ b/corehq/apps/analytics/templates/analytics/initial/kissmetrics.html
@@ -1,0 +1,2 @@
+{% load hq_shared_tags %}
+{% initial_analytics_data 'kissmetrics.apiId' ANALYTICS_IDS.KISSMETRICS_KEY  %}

--- a/corehq/apps/analytics/templates/analytics/initial/logging.html
+++ b/corehq/apps/analytics/templates/analytics/initial/logging.html
@@ -1,0 +1,5 @@
+{% load hq_shared_tags %}
+{% initial_analytics_data 'logging.debug' request|toggle_enabled:"ANALYTICS_DEBUG" %}
+{% initial_analytics_data 'logging.verbose' request|toggle_enabled:"ANALYTICS_VERBOSE" %}
+{% initial_analytics_data 'logging.warning' request|toggle_enabled:"ANALYTICS_WARNING" %}
+{% initial_analytics_data 'logging.deprecated' request|toggle_enabled:"ANALYTICS_WARNING" %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -8,7 +8,7 @@
  */
 hqDefine('hqwebapp/js/initial_page_data', function () {
     var data_selector = ".initial-page-data",
-        data = {},
+        _initData = {},
         url_selector = ".commcarehq-urls",
         urls = {};
 
@@ -35,10 +35,10 @@ hqDefine('hqwebapp/js/initial_page_data', function () {
      * Fetch a named value.
      */
     var get = function(name) {
-        if (data[name] === undefined) {
-            data = gather(data_selector, data);
+        if (_initData[name] === undefined) {
+            _initData = gather(data_selector, _initData);
         }
-        return data[name];
+        return _initData[name];
     };
 
     // http://stackoverflow.com/a/21903119/240553
@@ -86,7 +86,7 @@ hqDefine('hqwebapp/js/initial_page_data', function () {
     };
 
     $(function() {
-        data = gather(data_selector, data);
+        _initData = gather(data_selector, _initData);
         urls = gather(url_selector, urls);
     });
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -207,15 +207,16 @@
         {% block head %}
         {% endblock %}
 
-        {% include 'hqwebapp/includes/analytics_all.html' %}
-
-        {% if is_saas_environment and not request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}
-        {% if not request.user.is_authenticated or request.couch_user.days_since_created < 31 %}
-        {% compress js %}
-        <script src="{% static 'hqwebapp/js/drift.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/hubspot_drift.js' %}"></script>
-        {% endcompress %}
-        {% endif %}
+        {% if not USE_NEW_ANALYTICS and not request|toggle_enabled:"ANALYTICS_NEW" %}
+          {% include 'hqwebapp/includes/analytics_all.html' %}
+          {% if is_saas_environment and not request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}
+            {% if not request.user.is_authenticated or request.couch_user.days_since_created < 31 %}
+              {% compress js %}
+              <script src="{% static 'hqwebapp/js/drift.js' %}"></script>
+              <script src="{% static 'hqwebapp/js/hubspot_drift.js' %}"></script>
+              {% endcompress %}
+            {% endif %}
+          {% endif %}
         {% endif %}
 
 
@@ -407,19 +408,41 @@
             {# do not override this block, use registerurl template tag to populate #}
         {% endblock %}
         </div>
+        {% if request|toggle_enabled:"ANALYTICS_NEW" or USE_NEW_ANALYTICS %}
+        {% include 'analytics/initial/all.html' %}
+        <div class="initial-analytics-data hide">
+        {% block initial_analytics_data %}
+            {# do not override this block, use initial_analytics_data template tag to populate #}
+        {% endblock %}
+        </div>
+        <div class="analytics-ab-tests hide">
+        {% block analytics_ab_test %}
+            {# do not override this block, use analytics_ab_test template tag to populate #}
+        {% endblock %}
+        </div>
+        {% endif %}
 
         {# javascript below this line #}
 
         {# HQ Specific Libraries #}
         <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
+
+        {# Core dependencies for analytics & HQ's libraries #}
+        {% compress js %}
+        <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
+        {% endcompress %}
+
+        {% if request|toggle_enabled:"ANALYTICS_NEW" or USE_NEW_ANALYTICS %}
+        {% include 'analytics/analytics_js.html' %}
+        {% endif %}
+
         {% compress js %}
         <script src="{% static 'hqwebapp/js/ajax_csrf_setup.js' %}"></script>
         <script src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>
         <script src="{% static 'hqwebapp/js/layout.js' %}"></script>
         <script src="{% static 'hqwebapp/js/hq.helpers.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
         <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>
         <script src="{% static 'hqwebapp/js/main.js' %}"></script>
         {% endcompress %}
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -655,15 +655,13 @@ def html_attr(value):
     return escape(value)
 
 
-@register.tag
-def initial_page_data(parser, token):
+def _create_page_data(parser, token, node_slug):
     split_contents = token.split_contents()
     tag = split_contents[0]
     name = parse_literal(split_contents[1], parser, tag)
     value = parser.compile_filter(split_contents[2])
 
     class FakeNode(template.Node):
-
         def render(self, context):
             resolved = value.resolve(context)
             return (u"<div data-name=\"{}\" data-value=\"{}\"></div>"
@@ -671,7 +669,22 @@ def initial_page_data(parser, token):
 
     nodelist = NodeList([FakeNode()])
 
-    return AddToBlockNode(nodelist, 'initial_page_data')
+    return AddToBlockNode(nodelist, node_slug)
+
+
+@register.tag
+def initial_page_data(parser, token):
+    return _create_page_data(parser, token, 'initial_page_data')
+
+
+@register.tag
+def initial_analytics_data(parser, token):
+    return _create_page_data(parser, token, 'initial_analytics_data')
+
+
+@register.tag
+def analytics_ab_test(parser, token):
+    return _create_page_data(parser, token, 'analytics_ab_test')
 
 
 @register.inclusion_tag('hqwebapp/basic_errors.html')

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1351,3 +1351,31 @@ TWO_FACTOR_SUPERUSER_ROLLOUT = StaticToggle(
     TAG_INTERNAL,
     [NAMESPACE_USER]
 )
+
+ANALYTICS_NEW = StaticToggle(
+    'analytics_new',
+    "Use refactored analytics across all of HQ (for QA purposes).",
+    TAG_INTERNAL,
+    [NAMESPACE_USER]
+)
+
+ANALYTICS_DEBUG = StaticToggle(
+    'analytics_debug',
+    "Turn on DEBUG level output for debugging analytics.",
+    TAG_INTERNAL,
+    [NAMESPACE_USER]
+)
+
+ANALYTICS_VERBOSE = StaticToggle(
+    'analytics_verbose',
+    "Turn on VERBOSE level output for debugging analytics.",
+    TAG_INTERNAL,
+    [NAMESPACE_USER]
+)
+
+ANALYTICS_WARNING = StaticToggle(
+    'analytics_warning',
+    "Turn on WARNING level output for debugging analytics.",
+    TAG_INTERNAL,
+    [NAMESPACE_USER]
+)

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -72,13 +72,11 @@ def current_url_name(request):
 
 
 def js_api_keys(request):
-    from corehq import toggles
     if hasattr(request, 'couch_user') and request.couch_user and not request.couch_user.analytics_enabled:
         return {}  # disable js analytics
     return {
         'ANALYTICS_IDS': settings.ANALYTICS_IDS,
-        'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG,
-        'USE_NEW_ANALYTICS': toggles.ANALYTICS_DEBUG.enabled_for_request(request) or hasattr(request, 'use_new_analytics'),
+        'USE_NEW_ANALYTICS': hasattr(request, 'use_new_analytics'),
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -72,11 +72,13 @@ def current_url_name(request):
 
 
 def js_api_keys(request):
+    from corehq import toggles
     if hasattr(request, 'couch_user') and request.couch_user and not request.couch_user.analytics_enabled:
         return {}  # disable js analytics
     return {
         'ANALYTICS_IDS': settings.ANALYTICS_IDS,
         'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG,
+        'USE_NEW_ANALYTICS': toggles.ANALYTICS_DEBUG.enabled_for_request(request) or hasattr(request, 'use_new_analytics'),
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
 


### PR DESCRIPTION
@orangejenny 

Here we go. Currently in a state to support the old analytics and new analytics. Using the library is controlled by a feature flag to help with QAing on production to make sure the new library doesn't throw any JS errors.

The debug levels of the new library are controlled by feature flags to enable analytics debugging output on production.

Still need to add support for
- drift
- hubspot