### PR TITLE
Reindex all indices on reset

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -73,7 +73,10 @@ class Command(BaseCommand):
         runs = []
         all_es_indices = get_all_expected_es_indices()
         es = get_es_new()
-        indices_needing_reindex = [info for info in all_es_indices if not es.indices.exists(info.index)]
+        if options['reset']:
+            indices_needing_reindex = list(all_es_indices)
+        else:
+            indices_needing_reindex = [info for info in all_es_indices if not es.indices.exists(info.index)]
 
         if not indices_needing_reindex:
             print('Nothing needs to be reindexed')

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -59,6 +59,9 @@ class DomainReindexerFactory(ReindexerFactory):
     ]
 
     def build(self):
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_domain_kafka_to_elasticsearch_pillow(),
             change_provider=CouchViewChangeProvider(
@@ -72,5 +75,5 @@ class DomainReindexerFactory(ReindexerFactory):
             ),
             elasticsearch=get_es_new(),
             index_info=DOMAIN_INDEX_INFO,
-            **self.options
+            **options
         )

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -42,6 +42,9 @@ class GroupReindexerFactory(ReindexerFactory):
     ]
 
     def build(self):
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_group_pillow(),
             change_provider=CouchViewChangeProvider(
@@ -55,5 +58,5 @@ class GroupReindexerFactory(ReindexerFactory):
             ),
             elasticsearch=get_es_new(),
             index_info=GROUP_INDEX_INFO,
-            **self.options
+            **options
         )

--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -111,12 +111,16 @@ class LedgerV1ReindexerFactory(ReindexerFactory):
 
     def build(self):
         from corehq.apps.commtrack.models import StockState
+
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_ledger_to_elasticsearch_pillow(),
             change_provider=DjangoModelChangeProvider(StockState, _ledger_v1_to_change),
             elasticsearch=get_es_new(),
             index_info=LEDGER_INDEX_INFO,
-            **self.options
+            **options
         )
 
 

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -68,10 +68,13 @@ class ReportCaseReindexerFactory(ReindexerFactory):
         """
         domains = getattr(settings, 'ES_CASE_FULL_INDEX_DOMAINS', [])
         change_provider = get_domain_case_change_provider(domains=domains)
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_report_case_to_elasticsearch_pillow(),
             change_provider=change_provider,
             elasticsearch=get_es_new(),
             index_info=REPORT_CASE_INDEX_INFO,
-            **self.options
+            **options
         )

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -71,10 +71,13 @@ class ReportFormReindexerFactory(ReindexerFactory):
         """
         domains = getattr(settings, 'ES_XFORM_FULL_INDEX_DOMAINS', [])
         change_provider = get_domain_form_change_provider(domains=domains)
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_report_xform_to_elasticsearch_pillow(),
             change_provider=change_provider,
             elasticsearch=get_es_new(),
             index_info=REPORT_XFORM_INDEX_INFO,
-            **self.options
+            **options
         )

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -44,12 +44,16 @@ class SmsReindexerFactory(ReindexerFactory):
 
     def build(self):
         from corehq.apps.sms.models import SMS
+
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_sql_sms_pillow(),
             change_provider=DjangoModelChangeProvider(SMS, _sql_sms_to_change),
             elasticsearch=get_es_new(),
             index_info=SMS_INDEX_INFO,
-            **self.options
+            **options
         )
 
 

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -139,6 +139,9 @@ class UserReindexerFactory(ReindexerFactory):
     ]
 
     def build(self):
+        args = ElasticPillowReindexer.__init__.__code__.co_varnames
+        # Drop options that are not kwargs of the reindexer (like "reset")
+        options = {k: v for k, v in self.options.items() if k in args}
         return ElasticPillowReindexer(
             pillow=get_user_pillow(),
             change_provider=CouchViewChangeProvider(
@@ -150,5 +153,5 @@ class UserReindexerFactory(ReindexerFactory):
             ),
             elasticsearch=get_es_new(),
             index_info=USER_INDEX_INFO,
-            **self.options
+            **options
         )


### PR DESCRIPTION
Resolves the following:
```
$ ./manage.py ptop_preindex --reset
Nothing needs to be reindexed
```

Labelling "hold off" because this change results in `reset=True` to be passed to `__init__` methods of Reindexer subclasses, and they don't all take `reset` as a param. e.g. ElasticPillowReindexer [doesn't](https://github.com/dimagi/commcare-hq/blob/0bc070384366bf3674f112c32cf0be1baec958c0/corehq/ex-submodules/pillowtop/reindexer/reindexer.py#L150-L150) but ResumableBulkElasticPillowReindexer [does](https://github.com/dimagi/commcare-hq/blob/0bc070384366bf3674f112c32cf0be1baec958c0/corehq/ex-submodules/pillowtop/reindexer/reindexer.py#L243-L243).

@snopoke cc @javierwilson buddy @millerdev 