### PR TITLE
Add TU ID to the agency registration page

### DIFF
--- a/custom/enikshay/const.py
+++ b/custom/enikshay/const.py
@@ -192,6 +192,7 @@ AGENCY_USER_FIELDS = [
 
 AGENCY_LOCATION_FIELDS = [
     ('private_sector_org_id', "Private Sector Org ID", []),
+    ('nikshay_tu_id', "Nikshay TU id", []),
 ]
 
 DSTB_EPISODE_TYPE = "confirmed_tb"


### PR DESCRIPTION
Custom fields added to this constant are always displayed on the new agency registration page, even if they're not marked as required.
@dannyroberts @nickpell