### PR TITLE
Fix rebuildstaging

### DIFF
--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -314,7 +314,7 @@ def main():
     config = yaml.load(stdin)
     config = BranchConfig.wrap(config)
     config.normalize()
-    args = set(sys.argv[1:])
+    args = set(sys.argv[2:])
     verbose = '-v' in args
     do_push = '--no-push' not in args
     args.discard('-v')


### PR DESCRIPTION
scripts/rebuildstaging now calls

    python -m scripts.rebuildstaging scripts/rebuildstaging.py < scripts/staging.yaml "$@"

So now we need to skip the first two args

@dannyroberts @nickpell