### PR TITLE
 ignore user and domain sync_delay for v2

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -142,7 +142,7 @@ class ReportFixturesProvider(BaseReportFixturesProvider):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        if not self.uses_reports:
+        if not self.uses_reports(restore_state):
             return []
 
         restore_user = restore_state.restore_user
@@ -267,7 +267,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        if not self.uses_reports:
+        if not self.uses_reports(restore_state):
             return []
 
         restore_user = restore_state.restore_user

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -34,24 +34,27 @@ from corehq.apps.app_manager.dbaccessors import (
 MOBILE_UCR_RANDOM_THRESHOLD = 1000
 
 
-def _should_sync(restore_state):
+def _should_sync(restore_state, is_v2):
     last_sync_log = restore_state.last_sync_log
     if not last_sync_log or restore_state.overwrite_cache:
         return True
 
-    sync_interval = restore_state.restore_user.get_mobile_ucr_sync_interval()
-    if sync_interval is None and restore_state.params.app:
-        app = restore_state.params.app
-        if restore_state.params.app.copy_of:
-            # get sync interval from latest app version so that we don't have to deploy a new version
-            # to make changes to the sync interval
-            try:
-                app = get_brief_app(restore_state.domain, restore_state.params.app.copy_of)
-            except NoResultFound:
-                pass
-        sync_interval = app.mobile_ucr_sync_interval
-    if sync_interval is None:
-        sync_interval = restore_state.project.default_mobile_ucr_sync_interval
+    sync_interval = None
+    if not is_v2:
+        # in v2 sync delay is handled per report in the app
+        sync_interval = restore_state.restore_user.get_mobile_ucr_sync_interval()
+        if sync_interval is None and restore_state.params.app:
+            app = restore_state.params.app
+            if restore_state.params.app.copy_of:
+                # get sync interval from latest app version so that we don't have to deploy a new version
+                # to make changes to the sync interval
+                try:
+                    app = get_brief_app(restore_state.domain, restore_state.params.app.copy_of)
+                except NoResultFound:
+                    pass
+            sync_interval = app.mobile_ucr_sync_interval
+        if sync_interval is None:
+            sync_interval = restore_state.project.default_mobile_ucr_sync_interval
 
     sync_interval = sync_interval and sync_interval * 3600  # convert to seconds
     return (
@@ -62,9 +65,9 @@ def _should_sync(restore_state):
 
 
 class BaseReportFixturesProvider(FixtureProvider):
-    def uses_reports(self, restore_state):
+    def uses_reports(self, restore_state, is_v2=False):
         restore_user = restore_state.restore_user
-        if not toggles.MOBILE_UCR.enabled(restore_user.domain) or not _should_sync(restore_state):
+        if not toggles.MOBILE_UCR.enabled(restore_user.domain) or not _should_sync(restore_state, is_v2):
             return False
 
         if toggles.PREVENT_MOBILE_UCR_SYNC.enabled(restore_user.domain):
@@ -267,7 +270,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        if not self.uses_reports(restore_state):
+        if not self.uses_reports(restore_state, is_v2=True):
             return []
 
         restore_user = restore_state.restore_user

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5284,8 +5284,6 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     use_grid_menus = BooleanProperty(default=False)
     grid_form_menus = StringProperty(default='none',
                                      choices=['none', 'all', 'some'])
-    mobile_ucr_sync_interval = IntegerProperty()
-
     add_ons = DictProperty()
 
     def has_modules(self):

--- a/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
@@ -263,6 +263,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
         var availableReports = options.availableReports || [];
         var saveURL = options.saveURL;
         self.supportSyncDelay = options.supportSyncDelay;
+        self.globalSyncDelay = options.globalSyncDelay;
         self.staticFilterData = options.staticFilterData;
         self.languages = options.languages;
         self.lang = options.lang;

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -166,14 +166,6 @@
   default: 'none'
   since: '2.24'
 
-- id: mobile_ucr_sync_interval
-  name: Mobile Reports Update Frequency
-  description: Minimum duration between updates to mobile report data (hours).
-  toggle: MOBILE_UCR
-  values: ['none', '0', '1', '2', '4', '6', '8', '12', '24']
-  value_names: ['Use project level setting', 'Update on every sync', '1 hour', '2 hours', '4 hours', '6 hours', '8 hours', '12 hours', '24 hours']
-  default: 'none'
-
 - id: mobile_ucr_restore_version
   name: Mobile UCR Restore Version
   description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR+V2">Help Site</a>

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -78,7 +78,6 @@
     - properties.log_prop_daily  # Daily Log Sending Frequency
     - hq.secure_submissions
     - hq.translation_strategy
-    - hq.mobile_ucr_sync_interval
     - hq.mobile_ucr_restore_version
 
 - title: 'Disabled'

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
@@ -39,7 +39,15 @@
                         <th>{% trans "Report" %}</th>
                         <th>{% trans "Display Text" %}</th>
                         <th>{% trans "Description" %}</th>
-                        <th data-bind="visible: $root.supportSyncDelay">{% trans "Sync Delay (in hours)" %}</th>
+                        <th data-bind="visible: $root.supportSyncDelay">
+                            {% trans "Sync Delay (in hours)" %}
+                            <span class="hq-help-template"
+                                data-title="Sync Delay"
+                                data-content="Hours to delay before sending new report data to mobile devices. Final value is MAX(domain delay, report delay)."
+                                data-placement="left"
+                            ></span>
+                        </th>
+
                         <th>
                             {% trans "Data Table" %}
                             <span class="hq-help-template"
@@ -89,8 +97,11 @@
                                 </p>
                             </div>
                         </td>
-                        <td>
-                            <input type="number" class="form-control" data-bind="value: syncDelay, visible: $root.supportSyncDelay">
+                        <td data-bind="visible: $root.supportSyncDelay">
+                            <input type="number" class="form-control" data-bind="value: syncDelay">
+                            <p data-bind="visible: $root.globalSyncDelay > 0">
+                                {% trans "Domain sync delay set to: " %}<span data-bind="text: $root.globalSyncDelay"></span>{% trans " hours." %}
+                            </p>
                         </td>
                         <td>
                             <label>

--- a/corehq/apps/app_manager/tests/data/suite/app_case_detail_instances.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_case_detail_instances.json
@@ -2,7 +2,6 @@
   "comment": "",
   "short_odk_url": null,
   "domain": "jennytraining",
-  "mobile_ucr_sync_interval": null,
   "short_url": null,
   "_rev": "2-d58483fed91873382ebd99ac03669b2f",
   "deployment_date": null,

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -104,7 +104,6 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         self.assert_docs_equal(normal_app, brief_normal_app)
 
     def test_get_brief_app(self):
-        self.apps[0].mobile_ucr_sync_interval = 7
         self.apps[0].save()
         brief_app = get_brief_app(self.domain, self.apps[0]._id)
         self.assertIsNotNone(brief_app)
@@ -113,7 +112,6 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         exepcted_app = self._make_app_brief(self.apps[0])
         exepcted_app.anonymous_cloudcare_hash = None
         self.assert_docs_equal(brief_app, exepcted_app)
-        self.assertEqual(brief_app.mobile_ucr_sync_interval, 7)
 
     def test_get_brief_app_not_found(self):
         with self.assertRaises(NoResultFound):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -230,7 +230,6 @@ def get_settings_values(app):
     # the admin_password hash shouldn't be sent to the client
     hq_settings.pop('admin_password', None)
     # convert int to string
-    hq_settings['mobile_ucr_sync_interval'] = str(hq_settings.get('mobile_ucr_sync_interval', 'none'))
     hq_settings['mobile_ucr_restore_version'] = str(hq_settings.get('mobile_ucr_restore_version', '1.0'))
 
     domain = Domain.get_by_name(app.domain)

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -657,7 +657,6 @@ def edit_app_attr(request, domain, app_id, attr):
         # RemoteApp only
         'profile_url',
         'manage_urls',
-        'mobile_ucr_sync_interval',
         'mobile_ucr_restore_version',
     ]
     if attr not in attributes:
@@ -694,7 +693,6 @@ def edit_app_attr(request, domain, app_id, attr):
         ('comment', None),
         ('custom_base_url', None),
         ('use_j2me_endpoint', None),
-        ('mobile_ucr_sync_interval', parse_sync_interval),
         ('mobile_ucr_restore_version', None),
     )
     for attribute, transformation in easy_attrs:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -18,6 +18,7 @@ from corehq.apps.app_manager import add_ons
 from corehq.apps.app_manager.views.media_utils import process_media_attribute, \
     handle_media_edits
 from corehq.apps.case_search.models import case_search_enabled_for_domain
+from corehq.apps.domain.models import Domain
 from corehq.apps.reports.daterange import get_simple_dateranges
 
 from dimagi.utils.logging import notify_exception
@@ -249,6 +250,7 @@ def _get_report_module_context(app, module):
             'dataPathPlaceholders': data_path_placeholders,
             'languages': app.langs,
             'supportSyncDelay': app.mobile_ucr_restore_version != MOBILE_UCR_VERSION_1,
+            'globalSyncDelay': Domain.get_by_name(app.domain).default_mobile_ucr_sync_interval,
         },
         'static_data_options': {
             'filterChoices': filter_choices,

--- a/corehq/apps/export/tests/data/app_with_subcases.json
+++ b/corehq/apps/export/tests/data/app_with_subcases.json
@@ -71,7 +71,6 @@
     "logo_refs": {},
     "media_language_map": {},
     "minimum_use_threshold": "15",
-    "mobile_ucr_sync_interval": null,
     "modules": [
         {
             "auto_select_case": false,

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -135,7 +135,7 @@ class AppAwareSyncTests(TestCase):
         with patch.object(ConfigurableReportDataSource, 'get_data') as get_data_mock:
             get_data_mock.return_value = self.rows
             fixtures = call_fixture_generator(report_fixture_generator, self.user, app=self.app3)
-        self.assertEqual(len(fixtures), 1)
+        self.assertEqual(len(fixtures), 0)
 
     def test_user_restore(self):
         from casexml.apps.phone.tests.utils import MockDevice

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -341,13 +341,6 @@ class UpdateCommCareUserInfoForm(BaseUserInfoForm, UpdateUserRoleForm):
         ),
         widget=forms.HiddenInput())
 
-    mobile_ucr_sync_interval = forms.IntegerField(
-        label=ugettext_lazy("Mobile report sync delay"),
-        required=False,
-        help_text=ugettext_lazy("Time to wait between sending updated mobile report data to users (hours)."),
-        widget=forms.HiddenInput()
-    )
-
     def __init__(self, *args, **kwargs):
         super(UpdateCommCareUserInfoForm, self).__init__(*args, **kwargs)
         self.fields['role'].help_text = _(mark_safe(
@@ -358,9 +351,6 @@ class UpdateCommCareUserInfoForm(BaseUserInfoForm, UpdateUserRoleForm):
         ))
         if toggles.ENABLE_LOADTEST_USERS.enabled(self.domain):
             self.fields['loadtest_factor'].widget = forms.TextInput()
-
-        if toggles.MOBILE_UCR.enabled(self.domain):
-            self.fields['mobile_ucr_sync_interval'].widget = forms.NumberInput()
 
     @property
     def direct_properties(self):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1503,8 +1503,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
     is_anonymous = BooleanProperty(default=False)
 
-    mobile_ucr_sync_interval = IntegerProperty()
-
     @classmethod
     def wrap(cls, data):
         # migrations from using role_id to using the domain_memberships

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -116,9 +116,6 @@ class OTARestoreUser(object):
     def get_ucr_filter_value(self, ucr_filter, ui_filter):
         return ucr_filter.get_filter_value(self._couch_user, ui_filter)
 
-    def get_mobile_ucr_sync_interval(self):
-        return None
-
     @memoized
     def get_locations_to_sync(self):
         from corehq.apps.locations.fixtures import get_location_fixture_queryset
@@ -209,9 +206,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
         from corehq.apps.fixtures.models import UserFixtureType
 
         return self._couch_user.fixture_status(UserFixtureType.LOCATION)
-
-    def get_mobile_ucr_sync_interval(self):
-        return self._couch_user.mobile_ucr_sync_interval
 
 
 class CaseState(LooselyEqualDocumentSchema, IndexHoldingMixIn):


### PR DESCRIPTION
When looking at this I was also wondering if we need a way to override this for specific users e.g. during training or for 'test' users.