### PR TITLE
Call clearProgress after async exception

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -23,6 +23,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                             menus.fetch($.extend(true, {}, options, { data: newOptionsData }));
                         }, gettext('Waiting for server progress'));
                     } else if (response.hasOwnProperty('exception')){
+                        FormplayerFrontend.trigger('clearProgress');
                         FormplayerFrontend.trigger(
                             'showError',
                             response.exception || FormplayerFrontend.Constants.GENERIC_ERROR,


### PR DESCRIPTION
We weren't properly clearly out the async restore dialog when we received an error on async restore