### PR TITLE
Add maintenance scripts to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ And for production environments you may want:
 
     $ pip install -r requirements/prod-requirements.txt
     
-Note that once you're up and running, you'll want to periodically re-run these steps, and a few others, to keep your environment up to date. Some developers have found it helpful to automate this task with [this script](https://gist.github.com/dannyroberts/5391823) to update all code, including submodules, and [this script](https://gist.github.com/orangejenny/c817e83d296457758d18914b2792831a) to update code and do a few more tasks like run migrations and update libraries.
+Note that once you're up and running, you'll want to periodically re-run these steps, and a few others, to keep your environment up to date. Some developers have found it helpful to automate this task with [this script](https://gist.github.com/dannyroberts/5391823) to update all code, including submodules, and [this script](https://gist.github.com/orangejenny/c817e83d296457758d18914b2792831a) to update code and do a few more tasks like run migrations and update libraries. These scripts can also be found in and run from the scripts/ directory of this repository.
 
 #### Setup localsettings
 

--- a/scripts/hammer.sh
+++ b/scripts/hammer.sh
@@ -1,0 +1,9 @@
+function hammer() {
+    git checkout master
+    git pull origin master
+    git submodule update --init --recursive
+    pip install -r requirements/requirements.txt -r requirements/dev-requirements.txt -r requirements/prod-requirements.txt
+    find . -name '*.pyc' -delete
+    ./manage.py migrate
+    bower install
+}

--- a/scripts/update-code.sh
+++ b/scripts/update-code.sh
@@ -1,0 +1,13 @@
+function delete-pyc() {
+    find . -name '*.pyc' -delete
+}
+function pull-latest-master() {
+    git checkout master; git pull origin master
+    git submodule update --init
+    git submodule foreach --recursive 'git checkout master; git pull origin master &'
+    until [ -z "$(ps aux | grep '[g]it pull')" ]; do sleep 1; done
+}
+function update-code() {
+    pull-latest-master
+    delete-pyc
+}


### PR DESCRIPTION
These have been living in separate gists only; seems silly not to just keep them in the scripts/ dir, which already has some other stuff like this.