### PR TITLE
Removed es_head from docker file.

### DIFF
--- a/docker/Dockerfile_es
+++ b/docker/Dockerfile_es
@@ -1,7 +1,0 @@
-FROM elasticsearch:1.7.4
-
-# Install HEAD plugin
-# https://mobz.github.io/elasticsearch-head/
-RUN plugin -i mobz/elasticsearch-head
-
-COPY files/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -21,16 +21,15 @@ redis:
     - "6379:6379"
 
 elasticsearch:
-  build: .
-  dockerfile: Dockerfile_es
+  extends:
+    file: hq-compose.yml
+    service: elasticsearch
   command: elasticsearch --cluster.name=${ES_CLUSTER_NAME}
   environment:
     ES_CLUSTER_NAME: ES_CLUSTER_NAME
     ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
   ports:
     - "9200:9200"
-  volumes:
-    - ${DATA_VOLUME_PREFIX}elasticsearch:/usr/share/elasticsearch/data
 
 kafka:
   extends:


### PR DESCRIPTION
@snopoke this won't work when we upgrade (due to changes in plugins) and it can be installed as a chrome plugin now https://chrome.google.com/webstore/detail/elasticsearch-head/ffmkiejjmecolpfloofpjologoblkegm/