### PR TITLE
make xml optional in admin restore

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -34,7 +34,7 @@
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
                     </div>
 
-                    {% if show_xml %}
+                    {% if not hide_xml %}
                     <div>
                         <ul class="nav nav-tabs" role="tablist">
                             <li role="presentation" class="active"><a href="#payload-tab" role="tab" data-toggle="tab">Payload</a></li>
@@ -67,7 +67,7 @@
                                         {% endfor %}
                                     </tbody>
                                 </table>
-                    {% if show_xml %}
+                    {% if not hide_xml %}
                             </div>
                         </div>
                     </div>

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -34,14 +34,14 @@
                         <div>
                             Number of cases by case type
                         </div>
-                    {% endif %}
                     <div>
-                        {% for case_type, count in case_type_counts.items %}
-                            <div>
-                                &emsp;{{case_type}}: {{count}}
-                            </div>
-                        {% endfor %}
+                        <ul>
+                            {% for case_type, count in case_type_counts.items %}
+                                <li>{{case_type}}: {{count}}</li>
+                            {% endfor %}
+                        </ul>
                     </div>
+                    {% endif %}
                     <div>
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
                     </div>
@@ -49,14 +49,14 @@
                         <div>
                             Number of locations by location type
                         </div>
-                    {% endif %}
                     <div>
-                        {% for location_type, count in location_type_counts.items %}
-                            <div>
-                                &emsp;{{location_type}}: {{count}}
-                            </div>
-                        {% endfor %}
+                        <ul>
+                            {% for location_type, count in location_type_counts.items %}
+                                <li>{{location_type}}: {{count}}</li>
+                            {% endfor %}
+                        </ul>
                     </div>
+                    {% endif %}
                     <div>
                         Number of reports in this restore: <strong>{{num_reports}}</strong>
                     </div>
@@ -64,14 +64,14 @@
                         <div>
                             Number of rows by report
                         </div>
-                    {% endif %}
                     <div>
-                        {% for report_id, row_count in report_row_counts.items %}
-                            <div>
-                                &emsp;{{report_id}}: {{row_count}}
-                            </div>
-                        {% endfor %}
+                        <ul>
+                            {% for report_id, row_count in report_row_counts.items %}
+                                <li>{{report_id}}: {{row_count}}</li>
+                            {% endfor %}
+                        </ul>
                     </div>
+                    {% endif %}
 
                     <div>
                         <ul class="nav nav-tabs" role="tablist">

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -31,7 +31,21 @@
                         Number of cases in this restore: <strong>{{num_cases}}</strong>
                     </div>
                     <div>
+                        {% for case_type, count in case_type_counts.items %}
+                            <div>
+                                &emsp;{{case_type}}: {{count}}
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <div>
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
+                    </div>
+                    <div>
+                        {% for location_type, count in location_type_counts.items %}
+                            <div>
+                                &emsp;{{location_type}}: {{count}}
+                            </div>
+                        {% endfor %}
                     </div>
 
                     <div>

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -34,13 +34,13 @@
                         <div>
                             Number of cases by case type
                         </div>
-                    <div>
-                        <ul>
-                            {% for case_type, count in case_type_counts.items %}
-                                <li>{{case_type}}: {{count}}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
+                        <div>
+                            <ul>
+                                {% for case_type, count in case_type_counts.items %}
+                                    <li>{{case_type}}: {{count}}</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
                     {% endif %}
                     <div>
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
@@ -49,13 +49,13 @@
                         <div>
                             Number of locations by location type
                         </div>
-                    <div>
-                        <ul>
-                            {% for location_type, count in location_type_counts.items %}
-                                <li>{{location_type}}: {{count}}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
+                        <div>
+                            <ul>
+                                {% for location_type, count in location_type_counts.items %}
+                                    <li>{{location_type}}: {{count}}</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
                     {% endif %}
                     <div>
                         Number of reports in this restore: <strong>{{num_reports}}</strong>
@@ -64,13 +64,13 @@
                         <div>
                             Number of rows by report
                         </div>
-                    <div>
-                        <ul>
-                            {% for report_id, row_count in report_row_counts.items %}
-                                <li>{{report_id}}: {{row_count}}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
+                        <div>
+                            <ul>
+                                {% for report_id, row_count in report_row_counts.items %}
+                                    <li>{{report_id}}: {{row_count}}</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
                     {% endif %}
 
                     <div>

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -47,6 +47,16 @@
                             </div>
                         {% endfor %}
                     </div>
+                    <div>
+                        Number of reports in this restore: <strong>{{num_reports}}</strong>
+                    </div>
+                    <div>
+                        {% for report_id, row_count in report_row_counts.items %}
+                            <div>
+                                &emsp;{{report_id}}: {{row_count}}
+                            </div>
+                        {% endfor %}
+                    </div>
 
                     <div>
                         <ul class="nav nav-tabs" role="tablist">

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -34,7 +34,6 @@
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
                     </div>
 
-                    {% if not hide_xml %}
                     <div>
                         <ul class="nav nav-tabs" role="tablist">
                             <li role="presentation" class="active"><a href="#payload-tab" role="tab" data-toggle="tab">Payload</a></li>
@@ -43,10 +42,13 @@
 
                         <div class="tab-content">
                             <div role="tabpanel" class="tab-pane active" id="payload-tab">
-                                <pre id="payload">{{ payload }}</pre>
+                                {% if not hide_xml %}
+                                    <pre id="payload">{{ payload }}</pre>
+                                {% else %}
+                                    XML is hidden
+                                {% endif %}
                             </div>
                             <div role="tabpanel" class="tab-pane" id="timing-tab">
-                    {% endif %}
                                 <table id="timingTable" class="table">
                                     <thead>
                                         <tr>
@@ -67,11 +69,9 @@
                                         {% endfor %}
                                     </tbody>
                                 </table>
-                    {% if not hide_xml %}
                             </div>
                         </div>
                     </div>
-                    {% endif %}
                 </div>
     </body>
 </html>

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -33,6 +33,8 @@
                     <div>
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
                     </div>
+
+                    {% if show_xml %}
                     <div>
                         <ul class="nav nav-tabs" role="tablist">
                             <li role="presentation" class="active"><a href="#payload-tab" role="tab" data-toggle="tab">Payload</a></li>
@@ -44,6 +46,7 @@
                                 <pre id="payload">{{ payload }}</pre>
                             </div>
                             <div role="tabpanel" class="tab-pane" id="timing-tab">
+                    {% endif %}
                                 <table id="timingTable" class="table">
                                     <thead>
                                         <tr>
@@ -64,9 +67,11 @@
                                         {% endfor %}
                                     </tbody>
                                 </table>
+                    {% if show_xml %}
                             </div>
                         </div>
                     </div>
+                    {% endif %}
                 </div>
     </body>
 </html>

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -30,6 +30,11 @@
                     <div>
                         Number of cases in this restore: <strong>{{num_cases}}</strong>
                     </div>
+                    {% if case_type_counts %}
+                        <div>
+                            Number of cases by case type
+                        </div>
+                    {% endif %}
                     <div>
                         {% for case_type, count in case_type_counts.items %}
                             <div>
@@ -40,6 +45,11 @@
                     <div>
                         Number of locations in this restore: <strong>{{num_locations}}</strong>
                     </div>
+                    {% if location_type_counts %}
+                        <div>
+                            Number of locations by location type
+                        </div>
+                    {% endif %}
                     <div>
                         {% for location_type, count in location_type_counts.items %}
                             <div>
@@ -50,6 +60,11 @@
                     <div>
                         Number of reports in this restore: <strong>{{num_reports}}</strong>
                     </div>
+                    {% if report_row_counts %}
+                        <div>
+                            Number of rows by report
+                        </div>
+                    {% endif %}
                     <div>
                         {% for report_id, row_count in report_row_counts.items %}
                             <div>

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -33,4 +33,6 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'num_cases': 0,
                 'num_locations': 0,
                 'hide_xml': False,
+                'case_type_counts': {},
+                'location_type_counts': {},
             })

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -32,5 +32,5 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'timing_data': [],
                 'num_cases': 0,
                 'num_locations': 0,
-                'show_xml': True,
+                'hide_xml': False,
             })

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -32,7 +32,9 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'timing_data': [],
                 'num_cases': 0,
                 'num_locations': 0,
+                'num_reports': 0,
                 'hide_xml': False,
                 'case_type_counts': {},
                 'location_type_counts': {},
+                'report_row_counts': {},
             })

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -32,4 +32,5 @@ class AdminRestoreViewTests(SimpleTestCase):
                 'timing_data': [],
                 'num_cases': 0,
                 'num_locations': 0,
+                'show_xml': True,
             })

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -529,7 +529,7 @@ class AdminRestoreView(TemplateView):
             )
             num_reports = len(reports)
             report_row_counts = {
-                report.attrib['id']: len(report.findall('{{{0}}}rows/{{{0}}}row'.format(RESPONSE_XMLNS)))
+                report.attrib['report_id']: len(report.findall('{{{0}}}rows/{{{0}}}row'.format(RESPONSE_XMLNS)))
                 for report in reports
             }
         else:

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -531,7 +531,7 @@ class AdminRestoreView(TemplateView):
             num_cases = 0
             num_locations = 0
         formatted_payload = etree.tostring(xml_payload, pretty_print=True)
-        show_xml = self.request.GET.get('show_xml', 'true') == 'true'
+        hide_xml = self.request.GET.get('hide_xml') == 'true'
         context.update({
             'payload': formatted_payload,
             'restore_id': restore_id_element.text if restore_id_element is not None else None,
@@ -539,7 +539,7 @@ class AdminRestoreView(TemplateView):
             'timing_data': timing_context.to_list(),
             'num_cases': num_cases,
             'num_locations': num_locations,
-            'show_xml': show_xml,
+            'hide_xml': hide_xml,
         })
         return context
 

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -531,6 +531,7 @@ class AdminRestoreView(TemplateView):
             num_cases = 0
             num_locations = 0
         formatted_payload = etree.tostring(xml_payload, pretty_print=True)
+        show_xml = self.request.GET.get('show_xml', 'true') == 'true'
         context.update({
             'payload': formatted_payload,
             'restore_id': restore_id_element.text if restore_id_element is not None else None,
@@ -538,6 +539,7 @@ class AdminRestoreView(TemplateView):
             'timing_data': timing_context.to_list(),
             'num_cases': num_cases,
             'num_locations': num_locations,
+            'show_xml': show_xml,
         })
         return context
 

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -524,6 +524,14 @@ class AdminRestoreView(TemplateView):
             )
             num_locations = len(locations)
             location_type_counts = dict(Counter(location.attrib['type'] for location in locations))
+            reports = xml_payload.findall(
+                "{{{0}}}fixture[@id='commcare:reports']/{{{0}}}reports/".format(RESPONSE_XMLNS)
+            )
+            num_reports = len(reports)
+            report_row_counts = {
+                report.attrib['id']: len(report.findall('{{{0}}}rows/{{{0}}}row'.format(RESPONSE_XMLNS)))
+                for report in reports
+            }
         else:
             if response.status_code in (401, 404):
                 # corehq.apps.ota.views.get_restore_response couldn't find user or user didn't have perms
@@ -541,6 +549,8 @@ class AdminRestoreView(TemplateView):
             case_type_counts = {}
             num_locations = 0
             location_type_counts = {}
+            num_reports = 0
+            report_row_counts = {}
         formatted_payload = etree.tostring(xml_payload, pretty_print=True)
         hide_xml = self.request.GET.get('hide_xml') == 'true'
         context.update({
@@ -550,9 +560,11 @@ class AdminRestoreView(TemplateView):
             'timing_data': timing_context.to_list(),
             'num_cases': num_cases,
             'num_locations': num_locations,
+            'num_reports': num_reports,
             'hide_xml': hide_xml,
             'case_type_counts': case_type_counts,
             'location_type_counts': location_type_counts,
+            'report_row_counts': report_row_counts,
         })
         return context
 

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -513,7 +513,12 @@ class AdminRestoreView(TemplateView):
             restore_id_element = xml_payload.find('{{{0}}}Sync/{{{0}}}restore_id'.format(SYNC_XMLNS))
             cases = xml_payload.findall('{http://commcarehq.org/case/transaction/v2}case')
             num_cases = len(cases)
-            case_type_counts = dict(Counter(case.getchildren()[0].getchildren()[0].text for case in cases))
+            case_type_counts = dict(Counter(
+                case.find(
+                    '{http://commcarehq.org/case/transaction/v2}create/'
+                    '{http://commcarehq.org/case/transaction/v2}case_type'
+                ).text for case in cases
+            ))
             locations = xml_payload.findall(
                 "{{{0}}}fixture[@id='locations']/{{{0}}}locations/{{{0}}}location".format(RESPONSE_XMLNS)
             )


### PR DESCRIPTION
https://trello.com/c/Lq73nOLU/250-restore-page-with-stats-only-no-xml
Product Note: The page that lets you download a User Restore can be configured to just show you how long the restore takes and other restore stats (instead of the actual restore).  This is useful if your restore is massive and crashes the browser.