### PR TITLE
Include attachments in form repeaters for SQL domains

### DIFF
--- a/corehq/apps/api/util.py
+++ b/corehq/apps/api/util.py
@@ -48,11 +48,17 @@ def get_obj(bundle_or_obj):
         return bundle_or_obj
 
 
-def form_to_es_form(xform_instance):
+def form_to_es_form(xform_instance, include_attachments=False):
+    # include_attachments is only relevant for SQL domains; they're always
+    # included for Couch domains
     from corehq.pillows.xform import transform_xform_for_elasticsearch, xform_pillow_filter
     from corehq.apps.api.models import ESXFormInstance
+    from corehq.form_processor.models import XFormInstanceSQL
 
-    json_form = xform_instance.to_json()
+    if include_attachments and isinstance(xform_instance, XFormInstanceSQL):
+        json_form = xform_instance.to_json(include_attachments=True)
+    else:
+        json_form = xform_instance.to_json()
     if not xform_pillow_filter(json_form):
         es_form = transform_xform_for_elasticsearch(json_form)
         return ESXFormInstance(es_form)

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -308,7 +308,7 @@ class FormRepeaterJsonPayloadGenerator(BasePayloadGenerator):
         from corehq.apps.api.resources.v0_4 import XFormInstanceResource
         from corehq.apps.api.util import form_to_es_form
         res = XFormInstanceResource()
-        bundle = res.build_bundle(obj=form_to_es_form(form))
+        bundle = res.build_bundle(obj=form_to_es_form(form, include_attachments=True))
         return res.serialize(None, res.full_dehydrate(bundle), 'application/json')
 
     @property


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?265044
Product Note: Data forwarding with forms will also include any attachments (like pictures). This didn't used to work on newer SQL based projects