### PR TITLE
Rework javascript setup for project health dashboard

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -96,6 +96,7 @@ class GenericReportView(object):
     description = None  # Human-readable description of the report
     report_template_path = None
     report_partial_path = None
+    js_scripts = None
 
     asynchronous = False
     hide_filters = False
@@ -478,6 +479,7 @@ class GenericReportView(object):
                 report_title=self.report_title or self.rendered_report_title,
                 report_subtitles=self.report_subtitles,
                 export_target=self.export_target,
+                js_scripts=self.js_scripts,
                 js_options=self.js_options,
             ),
             current_config_id=current_config_id,

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -290,6 +290,7 @@ class ProjectHealthDashboard(ProjectReport):
 
     exportable = True
     emailable = True
+    js_scripts = ['reports/js/project_health_dashboard.js']
 
     @property
     @memoized

--- a/corehq/apps/reports/static/reports/js/project_health_dashboard.js
+++ b/corehq/apps/reports/static/reports/js/project_health_dashboard.js
@@ -143,11 +143,13 @@ hqDefine("reports/js/project_health_dashboard", function() {
         });
     }
 
-    $(function() {
-        var six_months_reports = hqImport("hqwebapp/js/initial_page_data").get("six_months_reports");
-        setupCharts(six_months_reports);
-        setupPopovers();
-        setupLineChart(six_months_reports);
-        setupDataTables();
+    $(document).ajaxSuccess(function(event, xhr, settings) {
+        if (settings.url.match(/reports\/async\/project_health/)) {
+            var sixMonthsReports = $("#six-months-reports").data("value");
+            setupCharts(sixMonthsReports);
+            setupPopovers();
+            setupLineChart(sixMonthsReports);
+            setupDataTables();
+        }
     });
 });

--- a/corehq/apps/reports/templates/reports/async/default.html
+++ b/corehq/apps/reports/templates/reports/async/default.html
@@ -58,9 +58,3 @@
         </div>
     </div>
 {% endblock %}
-
-<div class="initial-page-data" class="hide">
-{% block initial_page_data %}
-    {# do not override this block, use initial_page_data template tag to populate #}
-{% endblock %}
-</div>

--- a/corehq/apps/reports/templates/reports/async/project_health_dashboard.html
+++ b/corehq/apps/reports/templates/reports/async/project_health_dashboard.html
@@ -4,12 +4,8 @@
 {% load report_tags %}
 {% load i18n %}
 
-{% block js %}{{ block.super }}
-    <script src="{% static "reports/js/project_health_dashboard.js" %}"></script>
-{% endblock %}
-
 {% block reportcontent %}
-{% initial_page_data 'six_months_reports' six_months_reports %}
+<div id="six-months-reports" class="hide" data-value='{{ six_months_reports|JSON }}'></div>
 <div class="row">
     <div class="col-md-12">
         {% include "reports/project_health/partials/last_month_stats.html" %}

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -20,6 +20,9 @@
     <script src="{% static 'reports/js/reports.async.js' %}"></script>
     <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
     {% endcompress %}
+    {% for script in report.js_scripts %}
+        <script src="{{ script|static }}"></script>
+    {% endfor %}
 {% endblock %}
 
 {% block stylesheets %}


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/16869 was re-including `project_health_dashboard.js` every time a user clicked Apply, redefining the module, which throws an error when the new requirejs code is used (https://manage.dimagi.com/default.asp?264729).

I'm expecting to rework this code when I get back to externalizing js for reports and have a better overall picture of how js is used there. Dynamically including script tags definitely won't work in a requirejs world.

@millerdev / @sravfeyn 





https://manage.dimagi.com/default.asp?264729

