### PR TITLE
Proactively convert to bytestring for kafka.

### DIFF
--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -94,12 +94,12 @@ def _get_topic_offsets(topics, latest):
     for topic in topics:
         partitions = list(partition_meta.get(topic, {}))
         for partition in partitions:
-            offsets[(topic, partition)] = None
-            offset_requests.append(OffsetRequest(topic, partition, time_value, num_offsets))
+            offsets[(kafka_bytestring(topic), partition)] = None
+            offset_requests.append(OffsetRequest(kafka_bytestring(topic), partition, time_value, num_offsets))
 
     responses = client.send_offset_request(offset_requests)
     for r in responses:
-        offsets[(r.topic, r.partition)] = r.offsets[0]
+        offsets[(kafka_bytestring(r.topic), r.partition)] = r.offsets[0]
 
     return offsets
 


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/402058318/

I think this just affects datadog metrics. pillows were still processing when i looked on prod

@snopoke @nickpell 