### PR TITLE
Remove escape characters from search query

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -165,8 +165,7 @@ def replace_custom_query_variables(query_addition, criteria, ignore_patterns):
         to_add = re.escape(value)
         query_addition = re.sub(key, to_add, query_addition)
 
-    query_addition = query_addition.replace('\\', '\\\\')
-
+    query_addition = query_addition.replace('\\', '')
     return json.loads(query_addition)
 
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?265167#1419523

https://github.com/dimagi/commcare-hq/pull/18293 was causing valid searches with regex escaped characters to fail (it was replacing `-` with `\\-`).

The downside of this is we can no longer have replaceable search parameters with backslashes, but I think that's an acceptable tradeoff, unless there is a very simple other way I can do this. 

@calellowitz 
FYI @snopoke 