### PR TITLE
apply KO bindings

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/import_data_dict.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/import_data_dict.html
@@ -3,6 +3,10 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
+{% block js %}{{ block.super }}
+    <script src="{% static 'hqwebapp/js/bulk_upload_file.js' %}"></script>
+{% endblock %}
+
 {% block page_breadcrumbs %}
     <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
         <li>


### PR DESCRIPTION
Makes sure that the import button for the data dictionary import is disabled before a file is uploaded.

https://manage.dimagi.com/default.asp?264926