### PR TITLE
Max columns

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -74,6 +74,9 @@ STATIC_CASE_PROPS = [
     "user_id",
 ]
 
+# PostgreSQL limit = 1600. Sane limit = 500?
+MAX_COLUMNS = 500
+
 
 class FilterField(JsonField):
     """
@@ -432,7 +435,7 @@ class DataSourceBuilder(object):
                 return_list.append(indicator)
                 return_list_set.add(as_hashable)
 
-        return return_list
+        return return_list[:MAX_COLUMNS]
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -398,27 +398,22 @@ class DataSourceBuilder(object):
             Each object has a "property" and "aggregation" key
         :param filters: A list of filter configuration objects
         """
-        indicators = []
+
+        def get_key(i):
+            return i['column_id'], i['type']
+
+        indicators = {}
         for column in columns:
             column_option = self.report_column_options[column['property']]
-            indicators.extend(column_option.get_indicators(column['aggregation'], is_multiselect_chart_report))
+            for indicator in column_option.get_indicators(column['aggregation'], is_multiselect_chart_report):
+                indicators.setdefault(get_key(indicator), indicator)
 
         for filter in filters:
             property = self.data_source_properties[filter['property']]
             indicator = property.to_report_filter_indicator(filter)
-            indicators.append(indicator)
+            indicators.setdefault(get_key(indicator), indicator)
 
-        # remove duplicates
-        # There can be duplicates because filters and columns could be based on the same property
-        indicators_without_dups = []
-        seen_indicator_ids = set()
-        for i in indicators:
-            if (i['column_id'], i['type']) not in seen_indicator_ids:
-                indicators_without_dups.append(i)
-                seen_indicator_ids.add((i['column_id'], i['type']))
-        indicators = indicators_without_dups
-
-        return indicators
+        return list(indicators.values())
 
     def all_possible_indicators(self):
         indicators = {}

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -421,21 +421,13 @@ class DataSourceBuilder(object):
         return indicators
 
     def all_possible_indicators(self):
-        indicators = []
+        indicators = {}
         for column_option in self.report_column_options.values():
             for agg in column_option.aggregation_options:
-                indicators.extend(column_option.get_indicators(agg))
+                for indicator in column_option.get_indicators(agg):
+                    indicators.setdefault(str(indicator), indicator)
 
-        # Remove duplicates
-        return_list = []
-        return_list_set = set()
-        for indicator in indicators:
-            as_hashable = str(indicator)
-            if as_hashable not in return_list_set:
-                return_list.append(indicator)
-                return_list_set.add(as_hashable)
-
-        return return_list[:MAX_COLUMNS]
+        return list(indicators.values())[:MAX_COLUMNS]
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -408,9 +408,9 @@ class DataSourceBuilder(object):
             for indicator in column_option.get_indicators(column['aggregation'], is_multiselect_chart_report):
                 indicators.setdefault(get_key(indicator), indicator)
 
-        for filter in filters:
-            property = self.data_source_properties[filter['property']]
-            indicator = property.to_report_filter_indicator(filter)
+        for filter_ in filters:
+            property_ = self.data_source_properties[filter_['property']]
+            indicator = property_.to_report_filter_indicator(filter_)
             indicators.setdefault(get_key(indicator), indicator)
 
         return list(indicators.values())

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -402,7 +402,7 @@ class DataSourceBuilder(object):
         def get_key(i):
             return i['column_id'], i['type']
 
-        indicators = {}
+        indicators = OrderedDict()
         for column in columns:
             column_option = self.report_column_options[column['property']]
             for indicator in column_option.get_indicators(column['aggregation'], is_multiselect_chart_report):
@@ -416,7 +416,7 @@ class DataSourceBuilder(object):
         return list(indicators.values())
 
     def all_possible_indicators(self):
-        indicators = {}
+        indicators = OrderedDict()
         for column_option in self.report_column_options.values():
             for agg in column_option.aggregation_options:
                 for indicator in column_option.get_indicators(agg):


### PR DESCRIPTION
Context: [FB 265374][1], [FB 265429][2]

Report Builder creates a table in PostgreSQL for its Report Preview. Each form question gets 2 or 4 columns each depending on data type, and multiple choice answers get 2 or 4 columns per answer. For really big forms, the column count can exceed PostgreSQL's max. 

This PR drops the column count to a manageable number. It isn't very smart about it though. It just takes the first 500. (This value is arbitrary and open for discussion.) Other options might be to drop multiple choice answers first, or columns for less-frequently-used aggregations, maybe. But as a first shot, this should allow users to proceed. This code is only called by [`_build_temp_data_source()`][3].

When reproing this bug, I noticed that Report Builder's initial indicator selection doesn't always result in a valid report config. We should deal with that too, but I'll do that in a separate PR.

@sheelio (Would it be rude to tag Noah for a review? :upside_down_face: ) cc @millerdev 


  [1]: https://manage.dimagi.com/default.asp?265374
  [2]: https://manage.dimagi.com/default.asp?265429
  [3]: https://github.com/dimagi/commcare-hq/blob/ef569e8e883131b294e2986dbe195b31b671a3ff/corehq/apps/userreports/views.py#L294