### PR TITLE
Add user toggle back to UCR

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -477,7 +477,7 @@ USER_CONFIGURABLE_REPORTS = StaticToggle(
     'user_reports',
     'User configurable reports UI',
     TAG_SOLUTIONS,
-    [NAMESPACE_DOMAIN],
+    [NAMESPACE_DOMAIN, NAMESPACE_USER],
     description=(
         "A feature which will allow your domain to create User Configurable Reports."
     ),


### PR DESCRIPTION
Restores the user option for the UCR feature flag.  (Need to a different plan to restrict UCRs per project)