### PR TITLE
Various 99DOTS fixes

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -8,6 +8,7 @@ from django.utils.dateparse import parse_date
 from corehq.motech.repeaters.repeater_generators import BasePayloadGenerator
 from corehq.motech.repeaters.exceptions import RequestConnectionError
 from custom.enikshay.case_utils import (
+    get_person_case,
     get_occurrence_case_from_episode,
     get_person_case_from_occurrence,
     get_open_episode_case_from_person,
@@ -264,14 +265,7 @@ class AdherencePayloadGenerator(NinetyNineDotsBasePayloadGenerator):
 
     def get_payload(self, repeat_record, adherence_case):
         domain = adherence_case.domain
-        episode_case = get_episode_case_from_adherence(domain, adherence_case.case_id)
-        if episode_case.closed:
-            raise ENikshayCaseNotFound
-        person_case = get_person_case_from_occurrence(
-            domain, get_occurrence_case_from_episode(
-                domain, episode_case.case_id
-            ).case_id
-        )
+        person_case = get_person_case(domain, adherence_case.case_id)
         adherence_case_properties = adherence_case.dynamic_case_properties()
         date = parse_date(adherence_case.dynamic_case_properties().get('adherence_date'))
         payload = {

--- a/custom/enikshay/integrations/tests/test_case_properties_changed.py
+++ b/custom/enikshay/integrations/tests/test_case_properties_changed.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+import uuid
+
+from django.test import TestCase, override_settings
+
+from casexml.apps.case.mock import CaseBlock
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from custom.enikshay.integrations.utils import case_properties_changed
+
+
+@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+class TestCasePropertiesChanged(TestCase):
+    def setUp(self):
+        self.domain = 'domain'
+        create_domain(self.domain)
+        case_type = "case"
+        self.case_id = uuid.uuid4().hex
+        submit_case_blocks(CaseBlock(
+            self.case_id, case_type=case_type, create=True).as_string(), self.domain
+        )
+        caseblock1 = CaseBlock(
+            self.case_id,
+            case_type=case_type,
+            update={'property_1': 'updated'},
+        )
+        caseblock2 = CaseBlock(
+            self.case_id,
+            case_type=case_type,
+            update={'property_2': 'updated'},
+        )
+        blocks = [caseblock1.as_string(), caseblock2.as_string()]
+        submit_case_blocks(blocks, self.domain)[1][0]
+
+    def test_case_properties_changed(self):
+        case = CaseAccessors(self.domain).get_case(self.case_id)
+        self.assertTrue(case_properties_changed(case, ['property_1', 'property_2']))

--- a/custom/enikshay/integrations/tests/test_case_properties_changed.py
+++ b/custom/enikshay/integrations/tests/test_case_properties_changed.py
@@ -32,7 +32,7 @@ class TestCasePropertiesChanged(TestCase):
             update={'property_2': 'updated'},
         )
         blocks = [caseblock1.as_string(), caseblock2.as_string()]
-        submit_case_blocks(blocks, self.domain)[1][0]
+        submit_case_blocks(blocks, self.domain)
 
     def test_case_properties_changed(self):
         case = CaseAccessors(self.domain).get_case(self.case_id)


### PR DESCRIPTION
- Allow adding adherence cases to previously closed cases: [trello](https://trello.com/c/iwsaCvxh/14-patient-exists-but-no-occurrence-cases). Happens if the case has a treatment outcome, but 99DOTS hasn't sent all past adherences yet
- Allow sending adherence cases to 99DOTS even if the episode is closed: [trello](https://trello.com/c/DklzzvkA/18-sending-adherence-cases-for-cases-closed-immediately-after-fails). This happens if a treatment outcome is recorded immediately after an adherence case is sent, but hasn't yet been updated.
- Also adds a test for [this](https://trello.com/c/SFQCmFHH/5-treatment-outcomes-recorded-in-public-sector-not-reflected-in-99dots), which I thought was happening because of the multiple case blocks updating the same case, but was actually because the cases in question had failed to be registered properly in 99DOTS. 

@calellowitz 