### PR TITLE
Move remote-modals.js logic into main.js

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -278,6 +278,17 @@ hqDefine("hqwebapp/js/main", function() {
                 }
             }
         });
+
+        // EULA and CDA modals
+        _.each($(".remote-modal"), function(modal) {
+            var $modal = $(modal);
+            $modal.on("show show.bs.modal", function() {
+                $(this).find(".fetched-data").load($(this).data("url"));
+            });
+            if ($modal.data("show")) {
+                $modal.modal('show');
+            }
+        });
     });
 
     var capitalize = function(string) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -285,7 +285,7 @@ hqDefine("hqwebapp/js/main", function() {
             $modal.on("show show.bs.modal", function() {
                 $(this).find(".fetched-data").load($(this).data("url"));
             });
-            if ($modal.data("show")) {
+            if ($modal.data("showOnPageLoad")) {
                 $modal.modal('show');
             }
         });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/remote-modals.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/remote-modals.js
@@ -1,7 +1,0 @@
-$(function() {
-    _.each($(".remote-modal"), function(modal) {
-        $(modal).on("show show.bs.modal", function() {
-            $(this).find(".fetched-data").load($(this).data("url"));
-        });
-    });
-});

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -575,11 +575,6 @@
         {# Report Issue #}
         {% include 'hqwebapp/includes/modal_report_issue.html' %}
 
-        {# Remote modals (EULA and CDA) #}
-        {% compress js %}
-            <script src="{% static 'hqwebapp/js/remote-modals.js' %}"></script>
-        {% endcompress %}
-
         {# EULA #}
         {% if request.couch_user and not request.couch_user.is_eula_signed and not request.couch_user.is_anonymous %}
             {% include 'hqwebapp/includes/modal_eula.html' with needs_agreement=True %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/modal_eula.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="modal fade remote-modal" id="eulaModal" data-url="{% url "eula_basic" %}" data-show="{% if needs_agreement %}1{% endif %}">
+<div class="modal fade remote-modal" id="eulaModal" data-url="{% url "eula_basic" %}" data-show-on-page-load="{% if needs_agreement %}1{% endif %}">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/modal_eula.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="modal fade remote-modal" id="eulaModal" data-url="{% url "eula_basic" %}">
+<div class="modal fade remote-modal" id="eulaModal" data-url="{% url "eula_basic" %}" data-show="{% if needs_agreement %}1{% endif %}">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
@@ -31,10 +31,3 @@
             </div>
     </div>
 </div>
-{% if needs_agreement %}
-    <script>
-        $(function(){
-            $('#eulaModal').modal('show');
-        });
-    </script>
-{% endif %}


### PR DESCRIPTION
`remote-modals.js` is short enough that I'd rather add it to `main.js` than add it to RequireJS config as a separate module.

@millerdev / @gcapalbo 