### PR TITLE
"choices" will be empty for lookup table questions

### DIFF
--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -97,7 +97,7 @@ class ExpressionIndicatorSpec(IndicatorSpecBase):
 
 class ChoiceListIndicatorSpec(PropertyReferenceIndicatorSpecBase):
     type = TypeProperty('choice_list')
-    choices = ListProperty(required=True)
+    choices = ListProperty()
     select_style = StringProperty(choices=['single', 'multiple'])
 
     def get_operator(self):


### PR DESCRIPTION
Context: [FB 264864](https://manage.dimagi.com/default.asp?264864)

Unfortunately when `jsonobject` validates required ListProperties, it doesn't differentiate between present and empty. When the value of the `choices` property is an empty list, it fails validation even though it is present.

`choices` will be empty for checkbox and multiple choice questions that get their choices from lookup tables. This change allows Report Builder to handle lookup table questions gracefully.

buddy @millerdev 
