### PR TITLE
always preserve form IDs in linked apps

### DIFF
--- a/corehq/apps/app_manager/management/commands/overwrite_app.py
+++ b/corehq/apps/app_manager/management/commands/overwrite_app.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         self.to_domain = to_domain
         app = get_current_app(self.to_domain, to_app_id)
         latest_master_build = get_app(None, from_app_id, latest=True)
-        overwrite_app(app, latest_master_build, self.report_map, maintain_ids=True)
+        overwrite_app(app, latest_master_build, self.report_map)
 
     @property
     def report_map(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -116,7 +116,7 @@ from corehq.apps.app_manager.util import (
     save_xform,
     is_usercase_in_use,
     actions_use_usercase,
-    update_unique_ids,
+    update_form_unique_ids,
     app_callout_templates,
     xpath_references_case,
     xpath_references_user_case,
@@ -5829,7 +5829,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             raise RearrangeError()
 
     def scrub_source(self, source):
-        source = update_unique_ids(source)
+        source = update_form_unique_ids(source)
         return update_report_module_ids(source)
 
     def copy_form(self, module_id, form_id, to_module_id):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -124,7 +124,7 @@ from corehq.apps.app_manager.util import (
     get_correct_app_class,
     get_and_assert_practice_user_in_domain,
     LatestAppInfo,
-)
+    update_report_module_ids)
 from corehq.apps.app_manager.xform import XForm, parse_xml as _parse_xml, \
     validate_xform
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
@@ -5829,7 +5829,8 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             raise RearrangeError()
 
     def scrub_source(self, source):
-        return update_unique_ids(source)
+        source = update_unique_ids(source)
+        return update_report_module_ids(source)
 
     def copy_form(self, module_id, form_id, to_module_id):
         """

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4501,8 +4501,8 @@ class VersionedDoc(LazyBlobDoc):
                 attachments[name] = self.lazy_fetch_attachment(name)
         return attachments
 
-    def save_attachments(self, attachments):
-        with self.atomic_blobs():
+    def save_attachments(self, attachments, save=None):
+        with self.atomic_blobs(save=save):
             for name, attachment in attachments.items():
                 if re.match(ATTACHMENT_REGEX, name):
                     self.put_attachment(attachment, name)

--- a/corehq/apps/app_manager/tests/test_linked_apps.py
+++ b/corehq/apps/app_manager/tests/test_linked_apps.py
@@ -170,7 +170,14 @@ class TestRemoteLinkedApps(BaseLinkedAppsTest):
         linked_app = _mock_pull_remote_master(
             self.master_app_with_report_modules, self.linked_app, {'id': 'mapped_id'}
         )
-        self.assertEqual(self.master_app_with_report_modules.get_attachments(), linked_app.get_attachments())
+        master_id_map = _get_form_id_map(self.master_app_with_report_modules)
+        linked_id_map = _get_form_id_map(linked_app)
+        for xmlns, master_form_id in master_id_map.items():
+            linked_form_id = linked_id_map[xmlns]
+            self.assertEqual(
+                self.master_app_with_report_modules.get_form(master_form_id).source,
+                linked_app.get_form(linked_form_id).source
+            )
 
     def test_get_missing_media_list(self):
         image_path = 'jr://file/commcare/case_list_image.jpg'

--- a/corehq/apps/app_manager/tests/test_linked_apps.py
+++ b/corehq/apps/app_manager/tests/test_linked_apps.py
@@ -59,7 +59,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
         linked_app = Application.get(self.linked_app._id)
         self.assertEqual(linked_app.modules[0].report_configs[0].report_id, 'mapped_id')
 
-    def test_overwrite_app_maintain_ids_true(self):
+    def test_overwrite_app_maintain_ids(self):
         module = self.plain_master_app.add_module(Module.new_module('M1', None))
         module.new_form('f1', None, self.get_xml('very_simple_form'))
 
@@ -68,7 +68,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
         id_map_before = _get_form_id_map(self.linked_app)
 
-        overwrite_app(self.linked_app, self.plain_master_app, {}, maintain_ids=True)
+        overwrite_app(self.linked_app, self.plain_master_app, {})
         self.assertEqual(
             id_map_before,
             _get_form_id_map(LinkedApplication.get(self.linked_app._id))

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -399,7 +399,7 @@ def get_cloudcare_session_data(domain_name, form, couch_user):
     return session_data
 
 
-def update_unique_ids(app_source, id_map=None):
+def update_form_unique_ids(app_source, id_map=None):
     from corehq.apps.app_manager.models import form_id_references, jsonpath_update
 
     app_source = deepcopy(app_source)

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -421,10 +421,6 @@ def update_unique_ids(app_source, id_map=None):
     if id_map is None:
         id_map = {}
     for m, module in enumerate(app_source['modules']):
-        if module['module_type'] == 'report':
-            for config in module['report_configs']:
-                config['uuid'] = uuid.uuid4().hex
-
         for f, form in enumerate(module['forms']):
             old_id = form['unique_id']
             new_id = change_form_unique_id(app_source['modules'][m]['forms'][f], id_map)
@@ -435,6 +431,15 @@ def update_unique_ids(app_source, id_map=None):
             if reference.value in id_changes:
                 jsonpath_update(reference, id_changes[reference.value])
 
+    return app_source
+
+
+def update_report_module_ids(app_source):
+    app_source = deepcopy(app_source)
+    for module in app_source['modules']:
+        if module['module_type'] == 'report':
+            for config in module['report_configs']:
+                config['uuid'] = uuid.uuid4().hex
     return app_source
 
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import json
 import uuid
+from functools import partial
 from urllib import urlencode
 from django.contrib import messages
 from django.urls import reverse
@@ -193,8 +194,8 @@ def _update_form_ids(app, master_app, id_map):
 
     attachments = app_source.pop('_attachments')
     new_wrapped_app = Application.wrap(updated_source)
-    new_wrapped_app = new_wrapped_app.save_attachments(attachments)
-    return new_wrapped_app
+    save = partial(new_wrapped_app.save, increment_version=False)
+    return new_wrapped_app.save_attachments(attachments, save)
 
 
 def get_practice_mode_configured_apps(domain, mobile_worker_id=None):

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -17,7 +17,7 @@ from corehq.apps.app_manager.exceptions import AppEditingError, \
     ModuleNotFoundException, FormNotFoundException
 from corehq.apps.app_manager.models import Application, ReportModule, enable_usercase_if_necessary, CustomIcon
 
-from corehq.apps.app_manager.util import update_unique_ids
+from corehq.apps.app_manager.util import update_form_unique_ids
 
 CASE_TYPE_CONFLICT_MSG = (
     "Warning: The form's new module "
@@ -190,7 +190,7 @@ def _update_form_ids(app, master_app, id_map):
     app_source.pop('external_blobs')
     app_source['_attachments'] = _attachments
 
-    updated_source = update_unique_ids(app_source, id_map)
+    updated_source = update_form_unique_ids(app_source, id_map)
 
     attachments = app_source.pop('_attachments')
     new_wrapped_app = Application.wrap(updated_source)

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -150,6 +150,8 @@ def overwrite_app(app, master_build, report_map=None, maintain_ids=False):
     ])
     master_json = master_build.to_json()
     app_json = app.to_json()
+    id_map = _get_form_id_map(app_json)  # do this before we change the source
+
     for key, value in master_json.iteritems():
         if key not in excluded_fields:
             app_json[key] = value
@@ -166,7 +168,6 @@ def overwrite_app(app, master_build, report_map=None, maintain_ids=False):
             else:
                 raise AppEditingError('Report map not passed to overwrite_app')
     if maintain_ids:
-        id_map = _get_form_id_map(app_json)
         wrapped_app = _update_form_ids(wrapped_app, master_build, id_map)
     wrapped_app.copy_attachments(master_build)
     enable_usercase_if_necessary(wrapped_app)

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -143,7 +143,7 @@ def get_blank_form_xml(form_name):
     })
 
 
-def overwrite_app(app, master_build, report_map=None, maintain_ids=False):
+def overwrite_app(app, master_build, report_map=None):
     excluded_fields = set(Application._meta_fields).union([
         'date_created', 'build_profiles', 'copy_history', 'copy_of',
         'name', 'comment', 'doc_type', '_LAZY_ATTACHMENTS', 'practice_mobile_worker_id'
@@ -167,8 +167,8 @@ def overwrite_app(app, master_build, report_map=None, maintain_ids=False):
                         raise AppEditingError('Dynamic UCR used in linked app')
             else:
                 raise AppEditingError('Report map not passed to overwrite_app')
-    if maintain_ids:
-        wrapped_app = _update_form_ids(wrapped_app, master_build, id_map)
+
+    wrapped_app = _update_form_ids(wrapped_app, master_build, id_map)
     wrapped_app.copy_attachments(master_build)
     enable_usercase_if_necessary(wrapped_app)
     wrapped_app.save(increment_version=False)

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -169,9 +169,7 @@ def overwrite_app(app, master_build, report_map=None):
                 raise AppEditingError('Report map not passed to overwrite_app')
 
     wrapped_app = _update_form_ids(wrapped_app, master_build, id_map)
-    wrapped_app.copy_attachments(master_build)
     enable_usercase_if_necessary(wrapped_app)
-    wrapped_app.save(increment_version=False)
     return wrapped_app
 
 


### PR DESCRIPTION
This won't have any impact on existing linked apps (which have the same form IDs as their master app). Any new linked apps, or new forms added to existing linked apps will have different IDs from the master app.

Can review by commit :fish: 

