### PR TITLE
Wrap hq_extensions.js in hqDefine

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq_extensions.jquery.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq_extensions.jquery.js
@@ -1,4 +1,4 @@
-(function () {
+hqDefine("hqwebapp/js/hq_extensions.jquery", function() {
     'use strict';
     $.extend({
         postGo: function (url, params) {
@@ -37,4 +37,4 @@
             return params;
         }
     });
-}());
+});

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -439,6 +439,7 @@
 
         {% compress js %}
         <script src="{% static 'hqwebapp/js/ajax_csrf_setup.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/hq_extensions.jquery.js' %}"></script>
         <script src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>
         <script src="{% static 'hqwebapp/js/layout.js' %}"></script>
         <script src="{% static 'hqwebapp/js/hq.helpers.js' %}"></script>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base_mobile.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base_mobile.html
@@ -52,6 +52,7 @@
     {% include "hqwebapp/includes/jquery.html" %}
     {% compress js %}
     {% include "hqwebapp/includes/core_libraries.html" %}
+    <script src="{% static 'hqwebapp/js/hq_extensions.jquery.js' %}"></script>
     {% endcompress %}
 
     <link rel="shortcut icon" href="{% static 'hqwebapp/images/favicon.png' %}" />

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
@@ -2,5 +2,4 @@
 <script src="{% static 'jquery-form/dist/jquery.form.min.js' %}"></script>
 <script src="{% static 'underscore/underscore.js' %}"></script>
 <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
-<script src="{% static 'hqwebapp/js/hq_extensions.jquery.js' %}"></script>
 <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>


### PR DESCRIPTION
Needed for RequireJS. Might be nice to kill hq_extensions altogether - we don't use it in many places, and dynamically creating a form instead of doing an ajax call is a little bit of a weird pattern - but not today.

`sms/chat.html` and `mocha/base.html` both also use `core_libraries.html` but the sms app doesn't use `postGo` or `unparam` (or the `submit` or `post-link` classes, which call `postGo`), and I don't think we have any js tests that depend on it. I don't think `base_mobile.html` actually needs to include hq_extensions but am not 100% sure of that, so included it.

@calellowitz / @millerdev 