### PR TITLE
Case search details

### DIFF
--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -66,7 +66,7 @@ def current_language():
 
 @pattern('m%d.%s.title')
 def detail_title_locale(detail_type):
-    if detail_type.startswith('case'):
+    if detail_type.startswith('case') or detail_type.startswith('search'):
         return "cchq.case"
     elif detail_type.startswith('referral'):
         return "cchq.referral"

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -124,7 +124,9 @@ from corehq.apps.app_manager.util import (
     get_correct_app_class,
     get_and_assert_practice_user_in_domain,
     LatestAppInfo,
-    update_report_module_ids)
+    update_report_module_ids,
+    module_offers_search,
+)
 from corehq.apps.app_manager.xform import XForm, parse_xml as _parse_xml, \
     validate_xform
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
@@ -2547,6 +2549,10 @@ class ModuleDetailsMixin():
         except Exception:
             return []
 
+    @property
+    def search_detail(self):
+        return deepcopy(self.case_details.short)
+
     def rename_lang(self, old_lang, new_lang):
         super(Module, self).rename_lang(old_lang, new_lang)
         for case_list in (self.case_list, self.referral_list):
@@ -2560,12 +2566,15 @@ class ModuleDetailsMixin():
         return json.dumps(source) if dump_json else source
 
     def get_details(self):
-        return (
+        details = [
             ('case_short', self.case_details.short, True),
             ('case_long', self.case_details.long, True),
             ('ref_short', self.ref_details.short, False),
             ('ref_long', self.ref_details.long, False),
-        )
+        ]
+        if module_offers_search(self):
+            details.append(('search_short', self.search_detail, True))
+        return tuple(details)
 
     def validate_details_for_build(self):
         errors = []

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -44,6 +44,10 @@ from corehq import toggles
 from dimagi.utils.decorators.memoized import memoized
 
 
+DetailColumnInfo = namedtuple('DetailColumnInfo',
+                              'column sort_element order')
+
+
 class DetailContributor(SectionContributor):
     section_name = 'details'
 
@@ -184,6 +188,9 @@ class DetailContributor(SectionContributor):
                 #   column_info.column: an instance of app_manager.models.DetailColumn
                 #   column_info.sort_element: an instance of app_manager.models.SortElement
                 #   column_info.order: an integer
+                if "search" in id and column_info.sort_element and column_info.sort_element.type == 'index':
+                    # search details can't have index elements, so remove the sort element
+                    column_info = DetailColumnInfo(column_info.column, None, None)
                 fields = get_column_generator(
                     self.app, module, detail, parent_tab_nodeset=nodeset,
                     detail_type=detail_type, *column_info
@@ -438,8 +445,6 @@ def get_detail_column_infos(detail_type, detail, include_sort):
     This is not intented to be a widely used format
     just a packaging of column info into a form most convenient for rendering
     """
-    DetailColumnInfo = namedtuple('DetailColumnInfo',
-                                  'column sort_element order')
     if not include_sort:
         return [DetailColumnInfo(column, None, None) for column in detail.get_columns()]
 

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
 from corehq.apps.case_search.models import CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY
-from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper, get_instances_for_module
+from corehq.apps.app_manager.suite_xml.sections.details import get_instances_for_module
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Command,
     Display,
@@ -102,14 +102,13 @@ class RemoteRequestFactory(object):
         ]
 
     def _build_remote_request_datums(self):
-        details_helper = DetailsHelper(self.app)
         return [SessionDatum(
             id='case_id',
             nodeset=(CaseTypeXpath(self.module.case_type)
                      .case(instance_name=RESULTS_INSTANCE)),
             value='./@case_id',
-            detail_select=details_helper.get_detail_id_safe(self.module, 'case_short'),
-            detail_confirm=details_helper.get_detail_id_safe(self.module, 'case_long'),
+            detail_select=id_strings.detail(self.module, 'search_short'),
+            detail_confirm=id_strings.detail(self.module, 'case_long'),
         )]
 
     def _get_remote_request_query_datums(self):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import SuiteContributorByModule
 from corehq.apps.case_search.models import CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY
-from corehq.apps.app_manager.suite_xml.sections.details import get_instances_for_module
+from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper, get_instances_for_module
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Command,
     Display,
@@ -102,13 +102,14 @@ class RemoteRequestFactory(object):
         ]
 
     def _build_remote_request_datums(self):
+        details_helper = DetailsHelper(self.app)
         return [SessionDatum(
             id='case_id',
             nodeset=(CaseTypeXpath(self.module.case_type)
                      .case(instance_name=RESULTS_INSTANCE)),
             value='./@case_id',
-            detail_select=id_strings.detail(self.module, 'search_short'),
-            detail_confirm=id_strings.detail(self.module, 'case_long'),
+            detail_select=details_helper.get_detail_id_safe(self.module, 'search_short'),
+            detail_confirm=details_helper.get_detail_id_safe(self.module, 'case_long'),
         )]
 
     def _get_remote_request_query_datums(self):

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -44,7 +44,7 @@
              nodeset="instance('results')/results/case[@case_type='case']"
              value="./@case_id"
              detail-confirm="m0_case_long"
-             detail-select="m0_case_short"/>
+             detail-select="m0_search_short"/>
     </session>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -43,4 +43,66 @@
       </stack>
     </action>
   </detail>
+  <detail id="m0_search_short">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_whatever_2.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="instance('reports')/report[1]/name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+  <detail id="m0_case_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_long.case_whatever_2.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="instance('ledgerdb')/ledgers/name/name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -43,37 +43,6 @@
       </stack>
     </action>
   </detail>
-  <detail id="m0_search_short">
-    <title>
-      <text>
-        <locale id="cchq.case"/>
-      </text>
-    </title>
-    <field>
-      <header>
-        <text>
-          <locale id="m0.case_short.case_name_1.header"/>
-        </text>
-      </header>
-      <template>
-        <text>
-          <xpath function="case_name"/>
-        </text>
-      </template>
-    </field>
-    <field>
-      <header>
-        <text>
-          <locale id="m0.case_short.case_whatever_2.header"/>
-        </text>
-      </header>
-      <template>
-        <text>
-          <xpath function="instance('reports')/report[1]/name"/>
-        </text>
-      </template>
-    </field>
-  </detail>
   <detail id="m0_case_long">
     <title>
       <text>
@@ -101,6 +70,37 @@
       <template>
         <text>
           <xpath function="instance('ledgerdb')/ledgers/name/name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+  <detail id="m0_search_short">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.search_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.search_short.case_whatever_2.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="instance('reports')/report[1]/name"/>
         </text>
       </template>
     </field>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -34,7 +34,7 @@
              nodeset="instance('results')/results/case[@case_type='case']"
              value="./@case_id"
              detail-confirm="m0_case_long"
-             detail-select="m0_case_short"/>
+             detail-select="m0_search_short"/>
     </session>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -29,7 +29,7 @@
              nodeset="instance('results')/results/case[@case_type='case']"
              value="./@case_id"
              detail-confirm="m0_case_long"
-             detail-select="m0_case_short"/>
+             detail-select="m0_search_short"/>
     </session>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/data/suite/sort-cache-search.xml
+++ b/corehq/apps/app_manager/tests/data/suite/sort-cache-search.xml
@@ -1,0 +1,21 @@
+<partial>
+  <detail id="m0_search_short">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+</partial>

--- a/corehq/apps/app_manager/tests/data/suite/sort-cache-search.xml
+++ b/corehq/apps/app_manager/tests/data/suite/sort-cache-search.xml
@@ -8,7 +8,7 @@
     <field>
       <header>
         <text>
-          <locale id="m0.case_short.case_name_1.header"/>
+          <locale id="m0.search_short.case_name_1.header"/>
         </text>
       </header>
       <template>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -13,6 +13,9 @@ from corehq.apps.app_manager.exceptions import SuiteValidationError, DuplicateIn
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     Application,
+    CaseSearch,
+    CaseSearchProperty,
+    DefaultCaseSearchProperty,
     DetailColumn,
     FormActionCondition,
     GraphConfiguration,
@@ -138,6 +141,26 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             self.get_xml('sort-cache'),
             app.create_suite(),
             "./detail[@id='m0_case_short']"
+        )
+
+    def test_sort_cache_search(self):
+        app = Application.wrap(self.get_json('suite-advanced'))
+        app.modules[0].search_config = CaseSearch(
+            properties=[CaseSearchProperty(name='name', label={'en': 'Name'})],
+        )
+        detail = app.modules[0].case_details.short
+        detail.sort_elements.append(
+            SortElement(
+                field=detail.columns[0].field,
+                type='index',
+                direction='descending',
+                blanks='first',
+            )
+        )
+        self.assertXmlPartialEqual(
+            self.get_xml('sort-cache-search'),
+            app.create_suite(),
+            "./detail[@id='m0_search_short']"
         )
 
     def test_sort_calculation(self):

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -81,10 +81,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
     def test_case_search_action(self):
         """
-        Case search action should be added to case list
+        Case search action should be added to case list and a new search detail should be created
         """
         suite = self.app.create_suite()
-        self.assertXmlPartialEqual(self.get_xml('search_command_detail'), suite, "./detail[1]")
+        self.assertXmlPartialEqual(self.get_xml('search_command_detail'), suite, "./detail")
 
     def test_case_search_action_relevant_condition(self):
         condition = "'foo' = 'bar'"


### PR DESCRIPTION
This adds new case search specific "short" details with id `m{x}_search_short` for modules that have case search enabled, serving 2 purposes:
- If "cache and index" is enabled on the "base" detail (`m{x}_case_short`), we remove this from the case search specific detail, as the mobile doesn't know how to break the cache when search results are returned. 
- The mobile can now trust that the actions included on the case search short detail are "real", i.e. the case search detail never includes the "Search All Cases" action, but inherits other actions from its "case_short" detail. 

https://trello.com/c/qG0wBM7U/207-cache-and-index-updates-on-mobile

Curious whether it is worth copying the `case_long` details too, or better to leave that as is, since I don't think that is currently causing any issues. @ctsims what do you think? 