### PR TITLE
keep attachments around after saving

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -625,6 +625,10 @@ class FormAccessorSQL(AbstractFormAccessor):
 
         form.clear_tracked_models()
 
+        # keep these around since we might need them still e.g publishing changes to kafka
+        form.cached_attachments = unsaved_attachments
+
+
     @staticmethod
     def update_form(form, publish_changes=True):
         from corehq.form_processor.change_publishers import publish_form_saved

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -91,6 +91,10 @@ class FormAccessorTestsSQL(TestCase):
 
     def test_get_with_attachments(self):
         form = create_form_for_test(DOMAIN)
+        form = FormAccessorSQL.get_form(form.form_id)  # refetch to clear cached attachments
+        with self.assertNumQueries(1, using=db_for_read_write(XFormAttachmentSQL)):
+            form.get_attachment_meta('form.xml')
+
         with self.assertNumQueries(1, using=db_for_read_write(XFormAttachmentSQL)):
             form.get_attachment_meta('form.xml')
 


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/264603632/

Not 100% sure what happened in this event but it would be better if we didn't have to fetch the attachments back out of Riak immediately after we've just written them in.