### PR TITLE
don't fail to export UCR when there are / in the title

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -424,7 +424,7 @@ def _indicator_metrics(date_created=None):
 @task
 def export_ucr_async(export_table, download_id, title, user):
     use_transfer = settings.SHARED_DRIVE_CONF.transfer_enabled
-    filename = u'{}.xlsx'.format(title)
+    filename = u'{}.xlsx'.format(title.replace(u'/', u'?'))
     file_path = get_download_file_path(use_transfer, filename)
     export_from_tables(export_table, file_path, Format.XLS_2007)
     expose_download(use_transfer, file_path, filename, download_id, 'xlsx')


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?265680

Product Note: Currently, UCRs fail to export if there is a "/" in the title.  This fixes the bug by replacing "/" with "?".