### PR TITLE
Remove deprecation warning

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -170,18 +170,10 @@ def namedtupledict(name, fields):
 
     def __getitem__(self, item):
         if isinstance(item, basestring):
-            warnings.warn(
-                "namedtuple fields should be accessed as attributes",
-                DeprecationWarning,
-            )
             return getattr(self, item)
         return cls.__getitem__(self, item)
 
     def get(self, item, default=None):
-        warnings.warn(
-            "namedtuple fields should be accessed as attributes",
-            DeprecationWarning,
-        )
         return getattr(self, item, default)
     # return a subclass of cls that has the above __getitem__
     return type(name, (cls,), {


### PR DESCRIPTION
When accessing any user filter (e.g. in the case list report, user sync history, etc.), you get a `DeprecationWarning: namedtuple fields should be accessed as attributes`, which is raised here: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/util.py#L173-L176

The `SimplifiedUserInfo` class is basically the only use we have for this `namedtupledict`. This class is accessed in a bunch of places through the `util._report_user_dict` function... where in most cases the "dict" is accessed like a "dict" normally is. 

Instead of changing all the references, I just deleted the `DeprecationWarning`, since this `namedtupledict` doesn't seem like it gets much use. 

@mkangia 