### PR TITLE
Add FormPlayer to docker script

### DIFF
--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -33,9 +33,9 @@ formplayer:
     - couch
     - redis
   expose:
-    - 8080
+    - 8010
   ports:
-    - "8080:8080"
+    - "8010:8010"
 
 postgres:
   extends:

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -21,6 +21,22 @@ web:
     - ..:/mnt/commcare-hq-ro:ro
     - hqservice-lib:/mnt/lib
 
+formplayer:
+  extends:
+    file: hq-compose.yml
+    service: formplayer
+  environment:
+    DEPENDENT_SERVICES: "COUCH:5984 POSTGRES:5432 REDIS:6379"
+    WEB_HOST: "web"
+  links:
+    - postgres
+    - couch
+    - redis
+  expose:
+    - 8080
+  ports:
+    - "8080:8080"
+
 postgres:
   extends:
     file: hq-compose-services.yml

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -10,9 +10,9 @@ formplayer:
     - couch
     - redis
   expose:
-    - 8080
+    - 8010
   ports:
-    - "8080:8080"
+    - "8010:8010"
 
 postgres:
   extends:

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -1,3 +1,19 @@
+formplayer:
+  extends:
+    file: hq-compose.yml
+    service: formplayer
+  environment:
+    DEPENDENT_SERVICES: "COUCH:5984 POSTGRES:5432 REDIS:6379"
+    WEB_HOST: "dockerhost"
+  links:
+    - postgres
+    - couch
+    - redis
+  expose:
+    - 8080
+  ports:
+    - "8080:8080"
+
 postgres:
   extends:
     file: hq-compose.yml

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -30,7 +30,7 @@ formplayer:
     DEPENDENT_SERVICES: "COUCH:5984 POSTGRES:5432 REDIS:6379"
     WEB_HOST: "dockerhost"
   expose:
-    - "8080"
+    - "8010"
 
 postgres:
   image: dimagi/docker-postgresql

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -24,6 +24,14 @@ web:
     - ..:/mnt/commcare-hq-ro${RO}
     - ${VOLUME_PREFIX}lib:/mnt/lib
 
+formplayer:
+  image: dimagi/formplayer
+  environment:
+    DEPENDENT_SERVICES: "COUCH:5984 POSTGRES:5432 REDIS:6379"
+    WEB_HOST: "dockerhost"
+  expose:
+    - "8080"
+
 postgres:
   image: dimagi/docker-postgresql
   environment:

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -244,6 +244,8 @@ if os.environ.get("COMMCAREHQ_BOOTSTRAP") == "yes":
     TOUCHFORMS_API_USER = 'admin@example.com'
     TOUCHFORMS_API_PASSWORD = 'password'
 
+    FORMPLAYER_URL = 'http://formplayer:8010'
+
     CCHQ_API_THROTTLE_REQUESTS = 200
     CCHQ_API_THROTTLE_TIMEFRAME = 10
 

--- a/scripts/get_webhost
+++ b/scripts/get_webhost
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Returns the IP address of the default gateway on the Docker network
+
+CONTAINER=$(docker container ls | awk '/formplayer/ { print $1 }')
+docker exec $CONTAINER sh -c 'cat /etc/hosts | grep webhost'


### PR DESCRIPTION
Somewhere in here there is a bug related to networking; FormPlayer fails to run because to can't connect to Postgres. The host and port seem correct, but I'm guessing the FormPlayer container can't reach the Postrges container.

I have been testing with 
```bash
$ scripts/docker formplayer
```

My next attempts to debug will be not to start FormPlayer, and just to shell into the container and test connectivity.

@millerdev cc @snopoke 

(Also unsure whether `WEB:8000` should be included in `DEPENDENT_SERVICES`)