### PR TITLE
Switch to mainline nose-exclude

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,7 +4,7 @@ git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 fakecouch==0.0.10
 mocker==1.1.1
 nose==1.3.7
-git+git://github.com/millerdev/nose-exclude@exclude-tests-env#egg=nose-exclude
+nose-exclude==0.5.0
 testil
 unittest2
 requests-mock


### PR DESCRIPTION
Should be python3 ready. As of today, all commits to [`nose-exclude`](https://github.com/kgrandis/nose-exclude) beyond 0.5.0 only add new versions of python as test targets (no new features or bug fixes). Tested locally, status is green on python 3.6.

@nickpell @dimagi/py3 