### PR TITLE
Bump version to latest (supports Python 3.6)

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -10,7 +10,7 @@ Sphinx==1.3.1
 sphinx-rtd-theme==0.1.9
 docutils==0.12
 jenkinsapi==0.2.28
-fixture==1.5.9
+fixture==1.5.11
 sniffer==0.4.0
 psutil==5.1.3  # for memory profiling
 django-extensions==1.7.7


### PR DESCRIPTION
Can't really tell since recent releases are not documented anywhere I could find, but 1.5.9 may also support Python 3.

@nickpell 