### PR TITLE
Data Preview Expression Trace Tool

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -202,8 +202,8 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
 
         self.debugTraceOptions = ko.observableArray([
             new DebugResponseLevel("Output", "basic"),
-            new DebugResponseLevel("Output + Reduced Trace", "reduce"),
-            new DebugResponseLevel("Output + Deep Trace", "deep"),
+            new DebugResponseLevel("Output + Eval Summary", "reduce"),
+            new DebugResponseLevel("Output + Full Evaluation", "deep"),
         ]);
         self.xpath = ko.observable('');
         self.xpath = ko.observable('');

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -180,6 +180,11 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
         }.bind(this));
     };
 
+    var DebugResponseLevel = function(label, key) {
+        this.key = key;
+        this.label = label;
+    };
+
     var EvaluateXPath = function(options) {
         var self = this;
         self.options = options || {};
@@ -192,18 +197,37 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
             domain: null,
             sessionType: SessionTypes.FORM,
         });
+
+
+
+        self.debugTraceOptions = ko.observableArray([
+            new DebugResponseLevel("Output", "basic"),
+            new DebugResponseLevel("Output + Reduced Trace", "reduce"),
+            new DebugResponseLevel("Output + Deep Trace", "deep")
+        ])
+        self.xpath = ko.observable('');
         self.xpath = ko.observable('');
         self.selectedXPath = ko.observable('');
+        self.selectedDebugOption = ko.observable('basic');
         self.$xpath = null;
         self.newXPathQuery = function (data) {
             return {
                 status: data.status,
                 output: data.output,
+                trace: data.trace,
                 xpath: data.xpath,
                 successResult: function () {
                     if (this.success()) {
                         return self.formatResult(data.output);
                     }
+                },
+                traceResult: function () {
+                    if (this.success()) {
+                        return self.formatResult(data.trace);
+                    }
+                },
+                hasTrace: function () {
+                    return this.trace;
                 },
                 errorResult: function () {
                     if (!this.success()) {
@@ -261,12 +285,14 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
                     restoreAs: self.options.restoreAs,
                     domain: self.options.domain,
                     xpath: xpath,
+                    debugOutput: self.selectedDebugOption().key
                 },
                 self.options.sessionType
             ).done(function(response) {
                 var xPathQuery = self.newXPathQuery({
                     status: response.status,
                     output: response.output,
+                    trace: response.trace,
                     xpath: xpath,
                 });
                 self.xPathQuery(xPathQuery);

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -203,8 +203,8 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
         self.debugTraceOptions = ko.observableArray([
             new DebugResponseLevel("Output", "basic"),
             new DebugResponseLevel("Output + Reduced Trace", "reduce"),
-            new DebugResponseLevel("Output + Deep Trace", "deep")
-        ])
+            new DebugResponseLevel("Output + Deep Trace", "deep"),
+        ]);
         self.xpath = ko.observable('');
         self.xpath = ko.observable('');
         self.selectedXPath = ko.observable('');
@@ -285,7 +285,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
                     restoreAs: self.options.restoreAs,
                     domain: self.options.domain,
                     xpath: xpath,
-                    debugOutput: self.selectedDebugOption().key
+                    debugOutput: self.selectedDebugOption().key,
                 },
                 self.options.sessionType
             ).done(function(response) {

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -94,6 +94,11 @@
         codeMirror: xPathQuery.successResult()
     "></textarea>
     <!--/ko-->
+    <!--ko if: options.useCodeMirror && xPathQuery.hasTrace()-->
+    <textarea type="text" data-bind="
+        codeMirror: xPathQuery.traceResult()
+    "></textarea>
+    <!--/ko-->
     <!--ko if: !options.useCodeMirror && xPathQuery.successResult()-->
         <pre data-bind="text: xPathQuery.successResult()"></pre>
     <!--/ko-->
@@ -122,6 +127,9 @@
                     value="Evaluate Selection"
                     type="button"
                     data-bind="css: { disabled: !selectedXPath() }, click: onClickSelectedXPath"/>
+                <div class="col-sm-3 pull-right">
+                    <select class="form-control" data-bind="value: selectedDebugOption, options: debugTraceOptions, optionsText: 'label'"></select>
+                </div>
             </div>
         </div>
         <div class="col-sm-12" data-bind="template: {


### PR DESCRIPTION
Allows the Data Preview tab to produce "Trace" outputs which can be used to debug why expressions are returning the values they are.

![image](https://user-images.githubusercontent.com/155066/32966179-ee9a26b8-cba6-11e7-8165-34f25f697ed8.png)

Default behavior is unchanged (when dropdown is set to 'Output')

Depends on:
https://github.com/dimagi/formplayer/pull/546

@dimagi/product How do we make decisions about changes to "Highly Technical, but also technically available to all users" features?