### PR TITLE
Remove django-devserver requirement

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,5 +1,4 @@
 django-debug-toolbar==1.8
-django-devserver>=0.7.0
 guppy==0.1.10
 werkzeug==0.11.15
 line_profiler==1.0


### PR DESCRIPTION
If you want to use this while we still support Python 2 (probably a while yet) then you can manually install it in your virtualenv. After we switch to Python 3 you can use https://github.com/coagulant/django-devserver

@nickpell 