### PR TITLE
Case Property Changes Modal

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/proptable/property_table.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/proptable/property_table.html
@@ -14,12 +14,14 @@
                 <tr>
                     {% for cell in row %}
                     {% if not cell.colspan %}
-                        <th title="{{ cell.expr }}"
-                            {% if cell.info_url %}
-                            data-bind="openRemoteModal: '{{ cell.info_url }}'"
-                            {% endif %}
-                        >
-                        {{ cell.name }}
+                    <th title="{{ cell.expr }}">
+                        {% if cell.info_url %}
+                            <a href="#" data-bind="openRemoteModal: '{{ cell.info_url }}'">
+                                {{ cell.name }}
+                            </a>
+                        {% else %}
+                            {{ cell.name }}
+                        {% endif %}
                     </th>
                     <td>
                         {{ cell.value }}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/proptable/property_table.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/proptable/property_table.html
@@ -14,7 +14,11 @@
                 <tr>
                     {% for cell in row %}
                     {% if not cell.colspan %}
-                    <th title="{{ cell.expr }}">
+                        <th title="{{ cell.expr }}"
+                            {% if cell.info_url %}
+                            data-bind="openRemoteModal: '{{ cell.info_url }}'"
+                            {% endif %}
+                        >
                         {{ cell.name }}
                     </th>
                     <td>

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -118,7 +118,7 @@ def _to_html(val, key=None, level=0, timeago=False):
     return mark_safe(ret)
 
 
-def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
+def get_display_data(data, prop_def, processors=None, timezone=pytz.utc, info_url=None):
     # when prop_def came from a couchdbkit document, it will be a LazyDict with
     # a broken pop method.  This conversion also has the effect of a shallow
     # copy, which we want.
@@ -165,7 +165,8 @@ def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
     return {
         "expr": expr_name,
         "name": name,
-        "value": val
+        "value": val,
+        "info_url": info_url.replace("__placeholder__", expr) if info_url is not None else None,
     }
 
 
@@ -188,7 +189,7 @@ def eval_expr(expr, dict_data):
         return dict_data.get(expr, None)
 
 
-def get_tables_as_rows(data, definition, processors=None, timezone=pytz.utc):
+def get_tables_as_rows(data, definition, processors=None, timezone=pytz.utc, info_url=None):
     """
     Return a low-level definition of a group of tables, given a data object and
     a high-level declarative definition of the table rows and value
@@ -200,7 +201,7 @@ def get_tables_as_rows(data, definition, processors=None, timezone=pytz.utc):
 
     for section in definition:
         rows = [
-            [get_display_data(data, prop, timezone=timezone, processors=processors) for prop in row]
+            [get_display_data(data, prop, timezone=timezone, processors=processors, info_url=info_url) for prop in row]
             for row in section['layout']
         ]
 

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -201,9 +201,13 @@ def get_tables_as_rows(data, definition, processors=None, timezone=pytz.utc, inf
 
     for section in definition:
         rows = [
-            [get_display_data(data, prop, timezone=timezone, processors=processors, info_url=info_url) for prop in row]
-            for row in section['layout']
-        ]
+            [get_display_data(
+                data,
+                prop,
+                timezone=timezone,
+                processors=processors,
+                info_url=info_url) for prop in row]
+            for row in section['layout']]
 
         max_row_len = max(map(len, rows)) if rows else 0
         for row in rows:

--- a/corehq/apps/hqwebapp/tests/test_proptable_tags.py
+++ b/corehq/apps/hqwebapp/tests/test_proptable_tags.py
@@ -14,7 +14,7 @@ class CaseDisplayDataTest(SimpleTestCase):
             'color': 'red'
         }
         self.assertEqual(get_display_data(data, column),
-                         {'expr': 'color', 'name': 'favorite color', 'value': 'red'})
+                         {'expr': 'color', 'name': 'favorite color', 'value': 'red', 'info_url': None})
 
     def test_get_display_data_no_name(self):
         column = {
@@ -23,7 +23,8 @@ class CaseDisplayDataTest(SimpleTestCase):
         data = {
             'color': 'red'
         }
-        self.assertEqual(get_display_data(data, column), {'expr': 'color', 'name': 'color', 'value': 'red'})
+        self.assertEqual(get_display_data(data, column),
+                         {'expr': 'color', 'name': 'color', 'value': 'red', 'info_url': None})
 
     def test_get_display_data_function(self):
         get_color = lambda x: x['color']
@@ -35,4 +36,13 @@ class CaseDisplayDataTest(SimpleTestCase):
             'color': 'red'
         }
         self.assertEqual(get_display_data(data, column),
-                         {'expr': 'favorite color', 'name': 'favorite color', 'value': 'red'})
+                         {'expr': 'favorite color', 'name': 'favorite color', 'value': 'red', 'info_url': None})
+
+    def test_get_display_data_info_url(self):
+        column = {'expr': 'colour'}
+        data = {'colour': 'red'}
+        info_url = "/stuff/__placeholder__/other_stuff"
+        self.assertEqual(
+            get_display_data(data, column, info_url=info_url),
+            {'expr': 'colour', 'name': 'colour', 'value': 'red', 'info_url': '/stuff/colour/other_stuff'}
+        )

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -46,6 +46,7 @@ from .views import (
     default,
     old_saved_reports,
     case_forms,
+    case_property_changes,
     case_xml,
     rebuild_case_view,
     resave_case,
@@ -125,6 +126,7 @@ urlpatterns = [
     url(r'^case_data/(?P<case_id>[\w\-]+)/export_transactions/$',
         export_case_transactions, name="export_case_transactions"),
     url(r'^case_data/(?P<case_id>[\w\-]+)/(?P<xform_id>[\w\-:]+)/$', case_form_data, name="case_form_data"),
+    url(r'^case_data/(?P<case_id>[\w\-]+)/case_property/(?P<case_property_name>[\w_.]+)/$', case_property_changes, name="case_property_changes"),
 
     # Download and view form data
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/$', FormDataView.as_view(), name=FormDataView.urlname),

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -126,7 +126,8 @@ urlpatterns = [
     url(r'^case_data/(?P<case_id>[\w\-]+)/export_transactions/$',
         export_case_transactions, name="export_case_transactions"),
     url(r'^case_data/(?P<case_id>[\w\-]+)/(?P<xform_id>[\w\-:]+)/$', case_form_data, name="case_form_data"),
-    url(r'^case_data/(?P<case_id>[\w\-]+)/case_property/(?P<case_property_name>[\w_.]+)/$', case_property_changes, name="case_property_changes"),
+    url(r'^case_data/(?P<case_id>[\w\-]+)/case_property/(?P<case_property_name>[\w_.]+)/$',
+        case_property_changes, name="case_property_changes"),
 
     # Download and view form data
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/$', FormDataView.as_view(), name=FormDataView.urlname),

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1299,6 +1299,7 @@ class CaseDetailsView(BaseProjectReportSectionView):
                     self.urlname, args=[self.domain, case_id]),
                 "show_transaction_export": toggles.COMMTRACK.enabled(
                     self.request.user.username),
+                "property_details_enabled": toggles.SUPPORT.enabled(self.request.user.username),
             },
             "show_case_rebuild": toggles.SUPPORT.enabled(self.request.user.username),
             "can_edit_data": self.request.couch_user.can_edit_data,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -17,6 +17,7 @@ from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION, CASE_EXPORT_PE
     DEID_EXPORT_PERMISSION
 from corehq.form_processor.utils.general import use_sqlite_backend
 from corehq.tabs.tabclasses import ProjectReportsTab
+from corehq.util.timezones.conversions import ServerTime
 import langcodes
 import os
 import pytz
@@ -1315,9 +1316,7 @@ def form_to_json(domain, form, timezone=None):
     if timezone is None:
         received_on = json_format_datetime(form.received_on)
     else:
-        offset = timezone.utcoffset(datetime.utcnow())
-        local_received_on = form.received_on + offset
-        received_on = local_received_on.strftime("%Y-%m-%d %H:%M")
+        received_on = ServerTime(form.received_on).user_time(timezone).done().strftime("%Y-%m-%d %H:%M")
 
     return {
         'id': form.form_id,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1359,7 +1359,7 @@ def case_forms(request, domain, case_id):
 def case_property_changes(request, domain, case_id, case_property_name):
     """Returns all changes to a case property
     """
-    case = CaseAccessors(domain).get_case(case_id)
+    case = _get_case_or_404(domain, case_id)
     changes = []
     timezone = get_timezone_for_user(request.couch_user, domain)
     for change in reversed(get_all_changes_to_case_property(case, case_property_name)):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1369,7 +1369,6 @@ def case_property_changes(request, domain, case_id, case_property_name):
 
     context = {
         'domain': domain,
-        'case_id': case_id,
         'timezone': timezone.localize(datetime.utcnow()).tzname(),
         'property_name': case_property_name,
         'changes': changes,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1363,11 +1363,13 @@ def case_property_changes(request, domain, case_id, case_property_name):
     changes = []
     timezone = get_timezone_for_user(request.couch_user, domain)
     for change in reversed(get_all_changes_to_case_property(case, case_property_name)):
-        form_json = form_to_json(domain, change.transaction.form, timezone=timezone)
-        form_json['new_value'] = change.new_value
-        changes.append(form_json)
+        change_json = form_to_json(domain, change.transaction.form, timezone=timezone)
+        change_json['new_value'] = change.new_value
+        changes.append(change_json)
 
     context = {
+        'domain': domain,
+        'case_id': case_id,
         'timezone': timezone.localize(datetime.utcnow()).tzname(),
         'property_name': case_property_name,
         'changes': changes,

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
@@ -1,5 +1,6 @@
 $(function () {
     $("#history").koApplyBindings(new XFormListViewModel());
+    $("#properties").koApplyBindings();
 });
 
 function pad_zero(val) {

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
@@ -7,7 +7,7 @@
         <div class="modal-body">
             <table class="table table-striped table-hover">
                 <thead>
-                    <th>{% trans 'Received' %}</th>
+                    <th>{% trans 'Received' %} ({{ timezone }})</th>
                     <th>{% trans 'Form' %}</th>
                     <th>{% trans 'New Value' %}</th>
                 </thead>
@@ -15,7 +15,7 @@
                     {% for change in changes %}
                         <tr>
                             <td>{{ change.received_on }}</td>
-                            <td>{{ change.readable_name }}</td>
+                            <td><a href="#!history?form_id={{ change.id }}">{{ change.readable_name }}</a></td>
                             <td>{{ change.new_value }}</td>
                         </tr>
                     {% endfor %}

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
@@ -2,6 +2,7 @@
 <div class="modal-dialog" >
     <div class="modal-content">
         <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             <h3>{{ property_name }}</h3>
         </div>
         <div class="modal-body">
@@ -21,6 +22,9 @@
                     {% endfor %}
                 </tbody>
             </table>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</button>
         </div>
     </div>
 </div>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<div class="modal-dialog" >
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3>{{ property_name }}</h3>
+        </div>
+        <div class="modal-body">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <th>{% trans 'Received' %}</th>
+                    <th>{% trans 'Form' %}</th>
+                    <th>{% trans 'New Value' %}</th>
+                </thead>
+                <tbody>
+                    {% for change in changes %}
+                        <tr>
+                            <td>{{ change.received_on }}</td>
+                            <td>{{ change.readable_name }}</td>
+                            <td>{{ change.new_value }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
@@ -17,7 +17,7 @@
                     {% for change in changes %}
                         <tr>
                             <td>{{ change.received_on }}</td>
-                            <td><a href="{% url 'case_details' domain case_id %}#!history?form_id={{ change.id }}" target="_blank">{{ change.readable_name }}</a></td>
+                            <td><a href="{% url 'render_form_data' domain change.id %}" target="_blank">{{ change.readable_name }}</a></td>
                             <td>{{ change.user.username }}</td>
                             <td>{{ change.new_value }}</td>
                         </tr>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
@@ -16,7 +16,7 @@
                     {% for change in changes %}
                         <tr>
                             <td>{{ change.received_on }}</td>
-                            <td><a href="#!history?form_id={{ change.id }}">{{ change.readable_name }}</a></td>
+                            <td><a href="{% url 'case_details' domain case_id %}#!history?form_id={{ change.id }}" target="_blank">{{ change.readable_name }}</a></td>
                             <td>{{ change.new_value }}</td>
                         </tr>
                     {% endfor %}

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_property_modal.html
@@ -1,15 +1,16 @@
 {% load i18n %}
-<div class="modal-dialog" >
+<div class="modal-dialog modal-lg" >
     <div class="modal-content">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h3>{{ property_name }}</h3>
+            <h4>{% trans "Changes to" %}: <strong>{{ property_name }}</strong></h4>
         </div>
         <div class="modal-body">
             <table class="table table-striped table-hover">
                 <thead>
                     <th>{% trans 'Received' %} ({{ timezone }})</th>
                     <th>{% trans 'Form' %}</th>
+                    <th>{% trans 'User' %}</th>
                     <th>{% trans 'New Value' %}</th>
                 </thead>
                 <tbody>
@@ -17,6 +18,7 @@
                         <tr>
                             <td>{{ change.received_on }}</td>
                             <td><a href="{% url 'case_details' domain case_id %}#!history?form_id={{ change.id }}" target="_blank">{{ change.readable_name }}</a></td>
+                            <td>{{ change.user.username }}</td>
                             <td>{{ change.new_value }}</td>
                         </tr>
                     {% endfor %}

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -246,12 +246,15 @@ def render_case(case, options):
         definition = get_default_definition(
             dynamic_keys, num_columns=DYNAMIC_CASE_PROPERTIES_COLUMNS)
 
+        info_url = None
+        if options.get('property_details_enabled'):
+            info_url = reverse('case_property_changes', args=[case.domain, case.case_id, '__placeholder__'])
+
         dynamic_properties = _get_tables_as_rows(
             dynamic_data,
             definition,
-            info_url=reverse('case_property_changes', args=[
-                case.domain, case.case_id, '__placeholder__'
-            ]))
+            info_url=info_url,
+        )
     else:
         dynamic_properties = None
 

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -246,7 +246,12 @@ def render_case(case, options):
         definition = get_default_definition(
             dynamic_keys, num_columns=DYNAMIC_CASE_PROPERTIES_COLUMNS)
 
-        dynamic_properties = _get_tables_as_rows(dynamic_data, definition)
+        dynamic_properties = _get_tables_as_rows(
+            dynamic_data,
+            definition,
+            info_url=reverse('case_property_changes', args=[
+                case.domain, case.case_id, '__placeholder__'
+            ]))
     else:
         dynamic_properties = None
 

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -219,3 +219,14 @@ def get_datetime_case_property_changed(case, case_property_name, value):
     if property_changed_info:
         # get the date that case_property changed
         return parse_datetime(property_changed_info.modified_on)
+
+
+def get_all_changes_to_case_property(case, case_property_name):
+    case_property_changes = []
+    case_transactions = case.actions
+    for transaction in case_transactions:
+        property_changed_info = property_changed_in_action(transaction, case.case_id, case_property_name)
+        if property_changed_info:
+            case_property_changes.append(property_changed_info)
+
+    return case_property_changes

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -184,36 +184,38 @@ def iter_cases(case_ids, strip_history=False, wrap=True):
             yield case
 
 
-def get_case_property_changed_info(case, case_property_name, value):
-    """Returns the datetime a particular case property was changed to a specific value
-
-    Not performant!
-    """
+def property_changed_in_action(case_transaction, case_id, case_property_name):
     from casexml.apps.case.xform import get_case_updates
     PropertyChangedInfo = namedtuple("PropertyChangedInfo", 'transaction new_value modified_on')
+    update_actions = [
+        (update.modified_on_str, update.get_update_action(), case_transaction)
+        for update in get_case_updates(case_transaction.form)
+        if update.id == case_id
+    ]
+    for (modified_on, update_action, case_transaction) in update_actions:
+        if update_action:
+            property_changed = update_action.dynamic_properties.get(case_property_name)
+            if property_changed:
+                return PropertyChangedInfo(case_transaction, property_changed, modified_on)
+    return False
 
-    def property_changed_in_action(case_transaction, case_property_name):
-        update_actions = [
-            (update.modified_on_str, update.get_update_action(), case_transaction)
-            for update in get_case_updates(case_transaction.form)
-            if update.id == case.case_id
-        ]
-        for (modified_on, update_action, case_transaction) in update_actions:
-            if update_action:
-                property_changed = update_action.dynamic_properties.get(case_property_name)
-                if property_changed:
-                    return PropertyChangedInfo(case_transaction, property_changed, modified_on)
-        return False
 
+def get_latest_property_change_to_value(case, case_property_name, value):
+    """Returns a PropertyChangedInfo namedtuple for the last time case_property_name changed to "value"
+    """
     case_transactions = case.actions
     for i, case_transaction in enumerate(case_transactions):
-        property_changed_info = property_changed_in_action(case_transaction, case_property_name)
+        property_changed_info = property_changed_in_action(case_transaction, case.case_id, case_property_name)
         if property_changed_info and property_changed_info.new_value == value:
             return property_changed_info
 
 
 def get_datetime_case_property_changed(case, case_property_name, value):
-    property_changed_info = get_case_property_changed_info(case, case_property_name, value)
+    """Returns the datetime a particular case property was changed to a specific value
+
+    Not performant!
+    """
+    property_changed_info = get_latest_property_change_to_value(case, case_property_name, value)
     if property_changed_info:
         # get the date that case_property changed
         return parse_datetime(property_changed_info.modified_on)

--- a/custom/enikshay/management/commands/nikshay_registration_notification_time_report.py
+++ b/custom/enikshay/management/commands/nikshay_registration_notification_time_report.py
@@ -11,7 +11,7 @@ from django.conf import settings
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.dbaccessors import iter_repeat_records_by_domain
-from casexml.apps.case.util import get_case_property_changed_info
+from casexml.apps.case.util import get_latest_property_change_to_value
 from corehq.util.timezones.utils import get_timezone_for_domain
 
 
@@ -62,9 +62,9 @@ class Command(BaseCommand):
                 last_notification_attempt = repeat_record.attempts[-1]
                 assert last_notification_attempt.succeeded
                 assert repeat_record.last_checked == last_notification_attempt.datetime
-                property_changed_info = get_case_property_changed_info(episode_case,
-                                                                       "treatment_initiated",
-                                                                       "yes_phi")
+                property_changed_info = get_latest_property_change_to_value(episode_case,
+                                                                            "treatment_initiated",
+                                                                            "yes_phi")
                 xform = property_changed_info.transaction.form
                 form_received_on = pytz.utc.localize(xform.received_on).astimezone(timezone)
                 property_modified_on = parse_datetime(property_changed_info.modified_on).astimezone(timezone)


### PR DESCRIPTION
Tired of searching for the form that updated a specific case property? Want to see the progression of how a specific thing changed over time? Then this PR is for you! 

This shows a modal when you click on the case property name on the case_data report which shows you the history of a particular case property. Really useful if you have a lot of forms updating a small set of case properties. 

![screenshot from 2017-11-17 17-21-18](https://user-images.githubusercontent.com/146896/32971562-c0bde512-cbbb-11e7-8335-ad146d9eb7ef.png)

![screenshot from 2017-11-17 17-14-18](https://user-images.githubusercontent.com/146896/32971382-02ec6644-cbbb-11e7-9f41-feca044d5405.png)

Looking for UI feedback here (@biyeun, @orangejenny). I'm not happy with adding link styling to every case property on this page, as it is a page that is used all the time, and all the blue might get overwhelming... 

@mkangia code buddy