### PR TITLE
Revert "Fix "Attempted relative import in non-package""

### DIFF
--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import re
 import sh
-from sh_verbose import ShVerbose
+from .sh_verbose import ShVerbose
 
 
 def get_git(path=None):


### PR DESCRIPTION
Reverts dimagi/commcare-hq#18582

This breaks staging deploys, maybe because of [this line](https://github.com/dimagi/commcare-hq/blob/master/scripts/rebuildstaging.py#L40)? I fiddled with it briefly but don't really have context for this change and need to deploy staging.

@millerdev 