### PR TITLE
Add search_details to Advanced Modules

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3511,13 +3511,20 @@ class AdvancedModule(ModuleBase):
     def all_forms_require_a_case(self):
         return all(form.requires_case() for form in self.forms)
 
+    @property
+    def search_detail(self):
+        return deepcopy(self.case_details.short)
+
     def get_details(self):
-        return (
+        details = [
             ('case_short', self.case_details.short, True),
             ('case_long', self.case_details.long, True),
             ('product_short', self.product_details.short, self.get_app().commtrack_enabled),
             ('product_long', self.product_details.long, False),
-        )
+        ]
+        if module_offers_search(self):
+            details.append(('search_short', self.search_detail, True))
+        return details
 
     def get_case_errors(self, needs_case_type, needs_case_detail, needs_referral_detail=False):
 

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -105,4 +105,74 @@
       </template>
     </field>
   </detail>
+  <detail id="m1_case_short">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m1.case_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+    <action>
+      <display>
+        <text>
+          <locale id="case_search.m1"/>
+        </text>
+      </display>
+      <stack>
+        <push>
+          <mark/>
+          <command value="'search_command.m1'"/>
+        </push>
+      </stack>
+    </action>
+  </detail>
+  <detail id="m1_case_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m1.case_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+  <detail id="m1_search_short">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m1.search_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
 </partial>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -5,6 +5,7 @@ from mock import patch
 
 from corehq.apps.app_manager.const import CLAIM_DEFAULT_RELEVANT_CONDITION
 from corehq.apps.app_manager.models import (
+    AdvancedModule,
     Application,
     Module,
     CaseSearch,
@@ -83,6 +84,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         """
         Case search action should be added to case list and a new search detail should be created
         """
+        advanced_module = self.app.add_module(AdvancedModule.new_module("advanced", None))
+        advanced_module.search_config = CaseSearch(
+            command_label={'en': 'Advanced Search'},
+            properties=[CaseSearchProperty(name='name', label={'en': 'Name'})]
+        )
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_command_detail'), suite, "./detail")
 


### PR DESCRIPTION
Apparently Advanced Modules don't inherit from `ModuleDetailsMixin`, which is a bit confusing. 

@mkangia code buddy