### PR TITLE
Don't allow invalid XML in ID mappings

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
@@ -210,7 +210,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
             return self.isItemDuplicated(key) || self.hasBadXML(key);
         };
 
-        self.hasError = function(a, b, c) {
+        self.hasError = function() {
             return self.duplicatedItems().length > 0
                 || _.find(self.items(), function(i) { return self.hasBadXML(i.key()); });
         };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
@@ -198,7 +198,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
 
         self.hasBadXML = function(key) {
             if (self.values_are_icons() || self.values_are_conditions()) {
-                // Expresion can contain whatever
+                // Expressions can contain whatever
                 return false;
             }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
@@ -123,6 +123,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
                     placeholder: django.gettext('Calculation'),
                     duplicated: django.gettext('Calculation is duplicated'),
                     addButton: django.gettext('Add Image'),
+                    badXML: django.gettext('Calculation contains an invalid character.'),
                 };
             }
             else if (this.values_are_conditions()) {
@@ -130,6 +131,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
                     placeholder: django.gettext('Calculation'),
                     duplicated: django.gettext('Calculation is duplicated'),
                     addButton: django.gettext('Add Key, Value Mapping'),
+                    badXML: django.gettext('Calculation contains an invalid character.'),
                 };
             }
             else {
@@ -137,6 +139,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
                     placeholder: django.gettext('Key'),
                     duplicated: django.gettext('Key is duplicated'),
                     addButton: django.gettext('Add Key, Value Mapping'),
+                    badXML: django.gettext('Key contains an invalid character.'),
                 };
             }
         }, this);
@@ -191,6 +194,25 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
 
         self.isItemDuplicated = function(key) {
             return self.duplicatedItems.indexOf(key) !== -1;
+        };
+
+        self.hasBadXML = function(key) {
+            if (self.values_are_icons() || self.values_are_conditions()) {
+                // Expresion can contain whatever
+                return false;
+            }
+
+            // IDs shouldn't have invalid XML characters
+            return key.match(/[&<>"']/);
+        };
+
+        self.keyHasError = function(key) {
+            return self.isItemDuplicated(key) || self.hasBadXML(key);
+        };
+
+        self.hasError = function(a, b, c) {
+            return self.duplicatedItems().length > 0
+                || _.find(self.items(), function(i) { return self.hasBadXML(i.key()); });
         };
 
         self.getItems = function () {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/key_value_mapping.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/key_value_mapping.html
@@ -4,7 +4,7 @@
     <form class="form-horizontal hq-enum-editor" action="">
         <fieldset data-bind="sortable: items">
             <div class="form-group hq-input-map container-fluid well well-sm"
-                 data-bind="css: {'has-error': $parent.isItemDuplicated(ko.utils.unwrapObservable(key))},
+                 data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
                             attr: {'data-order': _sortableOrder}">
                 <div class="row">
                     <div class="col-sm-1">
@@ -16,9 +16,9 @@
                                    class="enum-key form-control"
                                    data-bind="value: key, attr: {placeholder: $parent.labels().placeholder}"/>
                             <div class="help-block" data-bind='visible: $parent.isItemDuplicated(ko.utils.unwrapObservable(key)),
-                            text: $parent.labels().duplicated'>
-                                Key is duplicated.
-                            </div>
+                                                               text: $parent.labels().duplicated'></div>
+                            <div class="help-block" data-bind='visible: $parent.hasBadXML(ko.utils.unwrapObservable(key)),
+                                                               text: $parent.labels().badXML'></div>
                         </div>
 
                     <div class="col-sm-1 text-center" style="width: 3px">
@@ -83,8 +83,8 @@
                 <div class="modal-footer">
                     <button class="btn btn-default" data-dismiss="modal">Cancel</button>
                     <button class="btn btn-primary" data-dismiss="modal"
-                            data-bind="disable: ko.utils.unwrapObservable($data.mapList.duplicatedItems).length > 0,
-                            text: (ko.utils.unwrapObservable($data.mapList.duplicatedItems).length > 0) ? 'Fix errors' : 'OK',
+                            data-bind="disable: $data.mapList.hasError(),
+                            text: $data.mapList.hasError() ? 'Fix errors' : 'OK',
                             click: save"></button>
                 </div>
             </div>


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?265790

Stop allowing invalid XML (`&`, `<`, `>`, `"`, `'`) in ids for properties formatted using id mapping on case list/detail.

@calellowitz / @nickpell 