### PR TITLE
Don't add search detail if there is a custom detail defined

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2573,7 +2573,7 @@ class ModuleDetailsMixin():
             ('ref_short', self.ref_details.short, False),
             ('ref_long', self.ref_details.long, False),
         ]
-        if module_offers_search(self):
+        if module_offers_search(self) and not self.case_details.short.custom_xml:
             details.append(('search_short', self.search_detail, True))
         return tuple(details)
 
@@ -3523,7 +3523,7 @@ class AdvancedModule(ModuleBase):
             ('product_short', self.product_details.short, self.get_app().commtrack_enabled),
             ('product_long', self.product_details.long, False),
         ]
-        if module_offers_search(self):
+        if module_offers_search(self) and not self.case_details.short.custom_xml:
             details.append(('search_short', self.search_detail, True))
         return details
 

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -103,12 +103,17 @@ class RemoteRequestFactory(object):
 
     def _build_remote_request_datums(self):
         details_helper = DetailsHelper(self.app)
+        if self.module.case_details.short.custom_xml:
+            short_detail_id = 'case_short'
+        else:
+            short_detail_id = 'search_short'
+
         return [SessionDatum(
             id='case_id',
             nodeset=(CaseTypeXpath(self.module.case_type)
                      .case(instance_name=RESULTS_INSTANCE)),
             value='./@case_id',
-            detail_select=details_helper.get_detail_id_safe(self.module, 'search_short'),
+            detail_select=details_helper.get_detail_id_safe(self.module, short_detail_id),
             detail_confirm=details_helper.get_detail_id_safe(self.module, 'case_long'),
         )]
 

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -1,0 +1,54 @@
+<partial>
+  <remote-request>
+    <post url="https://www.example.com/a/test_domain/phone/claim-case/"
+          relevant="instance('groups')/groups/group and count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">
+      <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+    </post>
+    <command id="search_command.m0">
+      <display>
+        <text>
+          <locale id="case_search.m0"/>
+        </text>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="groups" src="jr://fixture/user-groups"/>
+    <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
+    <instance id="locations" src="jr://fixture/locations"/>
+    <session>
+      <query url="https://www.example.com/a/test_domain/phone/search/"
+             storage-instance="results"
+             template="case">
+        <data key="case_type" ref="'case'"/>
+        <data key="include_closed" ref="'False'"/>
+        <data key="&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;"/>
+        <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
+        <prompt key="name">
+          <display>
+            <text>
+              <locale id="search_property.m0.name"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="dob">
+          <display>
+            <text>
+              <locale id="search_property.m0.dob"/>
+            </text>
+          </display>
+        </prompt>
+      </query>
+      <datum id="case_id"
+             nodeset="instance('results')/results/case[@case_type='case']"
+             value="./@case_id"
+             detail-confirm="m0_case_long"
+             detail-select="m0_case_short"/>
+    </session>
+    <stack>
+      <push>
+        <rewind value="instance('commcaresession')/session/data/case_id"/>
+      </push>
+    </stack>
+  </remote-request>
+</partial>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -175,4 +175,45 @@
       </template>
     </field>
   </detail>
+  <detail id="m2_case_short"/>
+  <detail id="m2_case_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m2.case_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+  <detail id="m3_case_short"/>
+  <detail id="m3_case_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m3.case_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+
 </partial>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -68,6 +68,15 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('remote_request'), suite, "./remote-request[1]")
 
+    def test_remote_request_custom_detail(self):
+        """Remote requests for modules with custom details point to the custom detail
+        """
+        self.module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
+        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
+            get_url_base_patch.return_value = 'https://www.example.com'
+            suite = self.app.create_suite()
+        self.assertXmlPartialEqual(self.get_xml('remote_request_custom_detail'), suite, "./remote-request[1]")
+
     def test_duplicate_remote_request(self):
         """
         Adding a second search config should not affect the initial one.
@@ -84,11 +93,22 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         """
         Case search action should be added to case list and a new search detail should be created
         """
-        advanced_module = self.app.add_module(AdvancedModule.new_module("advanced", None))
-        advanced_module.search_config = CaseSearch(
+        # Regular and advanced modules should get the search detail
+        search_config = CaseSearch(
             command_label={'en': 'Advanced Search'},
             properties=[CaseSearchProperty(name='name', label={'en': 'Name'})]
         )
+        advanced_module = self.app.add_module(AdvancedModule.new_module("advanced", None))
+        advanced_module.search_config = search_config
+
+        # Modules with custom xml should not get the search detail
+        module_custom = self.app.add_module(Module.new_module("custom_xml", None))
+        module_custom.search_config = search_config
+        module_custom.case_details.short.custom_xml = "<detail id='m2_case_short'></detail>"
+        advanced_module_custom = self.app.add_module(AdvancedModule.new_module("advanced with custom_xml", None))
+        advanced_module_custom.search_config = search_config
+        advanced_module_custom.case_details.short.custom_xml = "<detail id='m3_case_short'></detail>"
+
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_command_detail'), suite, "./detail")
 


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/408053932/

If there is a custom detail, it overwrites whatever HQ generates. This prevents HQ from expecting there to be a special case_search detail if there is a custom detail defined.
@orangejenny @sheelio 

@mkangia code buddy