### PR TITLE
python-modernize . -w -f lib2to3.fixes.fix_ws_comma

### DIFF
--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -1194,13 +1194,13 @@ class TestToManyDictField(TestCase):
         dehydrated_bundle = source_resource.full_dehydrate(bundle)
 
         self.assertTrue('other_models' in dehydrated_bundle.data)
-        self.assertEqual(dehydrated_bundle.data['other_models']['first_other']['id'] , 'foo')
+        self.assertEqual(dehydrated_bundle.data['other_models']['first_other']['id'], 'foo')
         self.assertEqual(dehydrated_bundle.data['other_models']['second_other']['id'], 'bar')
 
         bundle = source_resource.build_bundle(obj=source_objs[1])
         dehydrated_bundle = source_resource.full_dehydrate(bundle)
 
-        self.assertEqual(dehydrated_bundle.data['other_models']['first_other']['id'] , 'bar')
+        self.assertEqual(dehydrated_bundle.data['other_models']['first_other']['id'], 'bar')
         self.assertEqual(dehydrated_bundle.data['other_models']['second_other']['id'], 'baz')
 
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5798,7 +5798,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             return
         if new_lang in self.langs:
             raise AppEditingError("Language %s already exists!" % new_lang)
-        for i,lang in enumerate(self.langs):
+        for i, lang in enumerate(self.langs):
             if lang == old_lang:
                 self.langs[i] = new_lang
         for profile in self.build_profiles:

--- a/corehq/apps/app_manager/templatetags/url_extras.py
+++ b/corehq/apps/app_manager/templatetags/url_extras.py
@@ -55,7 +55,7 @@ class URLEncodeNode(template.Node):
             params[key] = [v.encode('utf-8') if isinstance(v, six.text_type) else v
                            for v in val]
 
-        for key,val in self.extra_params.items():
+        for key, val in self.extra_params.items():
             key = template.Variable(key).resolve(context)
             val = template.Variable(val).resolve(context)
             params[key] = val

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -54,7 +54,7 @@ class AppManagerTest(TestCase):
         for i in range(3):
             module = self.app.add_module(Module.new_module("Module%d" % i, "en"))
             for j in range(3):
-                self.app.new_form(module.id, name="Form%s-%s" % (i,j), attachment=self.xform_str, lang="en")
+                self.app.new_form(module.id, name="Form%s-%s" % (i, j), attachment=self.xform_str, lang="en")
             module = self.app.get_module(i)
             detail = module.ref_details.short
             detail.columns.append(
@@ -112,7 +112,7 @@ class AppManagerTest(TestCase):
         self.app.delete_form(self.app.modules[0].unique_id,
                              self.app.modules[0].forms[0].unique_id)
         self.assertEqual(len(self.app.modules), 3)
-        for module, i in zip(self.app.get_modules(), [2,3,3]):
+        for module, i in zip(self.app.get_modules(), [2, 3, 3]):
             self.assertEqual(len(module.forms), i)
 
     def testDeleteModule(self):
@@ -122,7 +122,7 @@ class AppManagerTest(TestCase):
     def testSwapModules(self):
         m0 = self.app.modules[0].name['en']
         m1 = self.app.modules[1].name['en']
-        self.app.rearrange_modules(0,1)
+        self.app.rearrange_modules(0, 1)
         self.assertEqual(self.app.modules[0].name['en'], m1)
         self.assertEqual(self.app.modules[1].name['en'], m0)
 

--- a/corehq/apps/builds/jadjar.py
+++ b/corehq/apps/builds/jadjar.py
@@ -70,7 +70,7 @@ def sign_jar(jad, jar, use_j2me_endpoint=False):
     key_alias   = settings.JAR_SIGN['key_alias']
     store_pass  = settings.JAR_SIGN['store_pass']
     key_pass    = settings.JAR_SIGN['key_pass']
-    jad_tool    = os.path.join(os.path.abspath(os.path.dirname(__file__)),'JadTool.jar')
+    jad_tool    = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'JadTool.jar')
     # remove traces of former jar signings, if any
     jad.update({
         "MIDlet-Certificate-1-1" : None,

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -151,7 +151,7 @@ class Group(QuickCachedDocumentMixin, UndoableDocument):
                 group_id
             ))
         index = 0
-        for i in range(0,len(self.path)):
+        for i in range(0, len(self.path)):
             if self.path[i] == group_id:
                 index = i
                 break

--- a/corehq/apps/hqadmin/history.py
+++ b/corehq/apps/hqadmin/history.py
@@ -26,7 +26,7 @@ def get_recent_changes(db, limit):
     changes = c.fetch(limit=limit, descending=True, include_docs=True)['results']
     for row in changes:
         yield {
-            'id':row['id'],
+            'id': row['id'],
             'rev': row['changes'][0]['rev'],
             'domain': row['doc'].get('domain', '[no domain]'),
             'doc_type': row['doc'].get('doc_type', '[no doc_type]'),

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -117,7 +117,7 @@ datespan_default = datespan_in_request(
 
 def get_rabbitmq_management_url():
     if settings.BROKER_URL.startswith('amqp'):
-        amqp_parts = settings.BROKER_URL.replace('amqp://','').split('/')
+        amqp_parts = settings.BROKER_URL.replace('amqp://', '').split('/')
         mq_management_url = amqp_parts[0].replace('5672', '15672')
         return "http://%s" % mq_management_url.split('@')[-1]
     else:

--- a/corehq/apps/hqwebapp/templatetags/mainreport_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/mainreport_tags.py
@@ -13,7 +13,7 @@ register = template.Library()
 
 @register.simple_tag
 def get_daterange_links(view_name, args={}):
-    base_link = reverse(view_name,kwargs=args)
+    base_link = reverse(view_name, kwargs=args)
     return get_daterange_links_raw(base_link, args)
 
 
@@ -39,7 +39,7 @@ def get_daterange_links_raw(base_link, args={}):
 
 
 @register.simple_tag
-def get_daterange_links_basic(base_link, days=[0,7,30,90], args={}):
+def get_daterange_links_basic(base_link, days=[0, 7, 30, 90], args={}):
     '''Allows you to pass in a list of day counts representing how 
        far to go back for each link. For known links it will generate
        a pretty string to display the time, otherwise it will say
@@ -108,7 +108,7 @@ def aggregate_section_totals(section_name, results_arr, daily):
         if summation == []:
             summation = summation + itemarr[-1]
         else:
-            for i in range(0,len(itemarr[-1])):
+            for i in range(0, len(itemarr[-1])):
                 summation[i] += itemarr[-1][i]
                 
     ret = ''

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -48,7 +48,7 @@ class BootstrapAddressField(MultiValueField):
     def __init__(self,num_lines=3,*args,**kwargs):
         fields = tuple([CharField(widget=TextInput(attrs={'class':'input-xxlarge'})) for _ in range(0, num_lines)])
         self.widget = BootstrapAddressFieldWidget(widgets=[field.widget for field in fields])
-        super(BootstrapAddressField,self).__init__(fields=fields,*args,**kwargs)
+        super(BootstrapAddressField, self).__init__(fields=fields,*args,**kwargs)
 
     def compress(self, data_list):
         return data_list

--- a/corehq/apps/indicators/models.py
+++ b/corehq/apps/indicators/models.py
@@ -214,7 +214,7 @@ class IndicatorDefinition(Document, AdminCRUDDocumentMixin):
             descending=True,
             **couch_key
         ).all()
-        return [item.get('key',[])[-1] for item in data]
+        return [item.get('key', [])[-1] for item in data]
 
     @classmethod
     @memoized

--- a/corehq/apps/ivr/api.py
+++ b/corehq/apps/ivr/api.py
@@ -68,8 +68,8 @@ def validate_answer(answer, question):
 
 def format_ivr_response(text, app):
     return {
-        "text_to_say" : text,
-        "audio_file_url" : convert_media_path_to_hq_url(text, app) if text.startswith("jr://") else None,
+        "text_to_say": text,
+        "audio_file_url": convert_media_path_to_hq_url(text, app) if text.startswith("jr://") else None,
     }
 
 

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -122,7 +122,7 @@ CASE_CRITERIA = "CASE_CRITERIA"
 ON_DATETIME = "ON_DATETIME"
 START_CONDITION_TYPES = [CASE_CRITERIA, ON_DATETIME]
 
-SURVEY_METHOD_LIST = ["SMS","CATI"]
+SURVEY_METHOD_LIST = ["SMS", "CATI"]
 
 UI_FREQUENCY_ADVANCED = "ADVANCED"
 UI_FREQUENCY_CHOICES = [UI_FREQUENCY_ADVANCED]
@@ -890,7 +890,7 @@ class CaseReminderHandler(Document):
             user_id=user_id,
             method=self.method,
             active=True,
-            start_date=date(now.year, now.month, now.day) if (now.hour == 0 and now.minute == 0 and now.second == 0 and now.microsecond == 0) else date(local_now.year,local_now.month,local_now.day),
+            start_date=date(now.year, now.month, now.day) if (now.hour == 0 and now.minute == 0 and now.second == 0 and now.microsecond == 0) else date(local_now.year, local_now.month, local_now.day),
             schedule_iteration_num=1,
             current_event_sequence_num=0,
             callback_try_count=0,

--- a/corehq/apps/reports/standard/domains.py
+++ b/corehq/apps/reports/standard/domains.py
@@ -105,7 +105,7 @@ def es_domain_query(params=None, facets=None, domains=None, start_at=None, size=
     if domains is not None:
         q["query"] = {
             "in" : {
-                "name" : domains,
+                "name": domains,
             }
         }
 
@@ -121,8 +121,8 @@ def es_domain_query(params=None, facets=None, domains=None, start_at=None, size=
                 "must": {
                     "match" : {
                         "_all" : {
-                            "query" : search_query,
-                            "operator" : "and", }}}}}
+                            "query": search_query,
+                            "operator": "and", }}}}}
 
     q["facets"] = {}
     if show_stats:

--- a/corehq/apps/reports/standard/ivr.py
+++ b/corehq/apps/reports/standard/ivr.py
@@ -116,7 +116,7 @@ class CallReport(BaseCommConnectLogReport):
                 self._fmt_timestamp(timestamp),
                 self._fmt_contact_link(call.couch_recipient, doc_info),
                 self._fmt(phone_number),
-                self._fmt(direction_map.get(call.direction,"-")),
+                self._fmt(direction_map.get(call.direction, "-")),
                 self._fmt(form_name),
                 self._fmt("-"),
                 self._fmt(answered),
@@ -190,9 +190,9 @@ class ExpectedCallbackReport(ProjectReport, ProjectReportParametersMixin, Generi
         result = []
         
         status_descriptions = {
-            CALLBACK_PENDING : _("Pending"),
-            CALLBACK_RECEIVED : _("Received"),
-            CALLBACK_MISSED : _("Missed"),
+            CALLBACK_PENDING: _("Pending"),
+            CALLBACK_RECEIVED: _("Received"),
+            CALLBACK_MISSED: _("Missed"),
         }
         
         # Store the results of lookups for faster loading

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -124,7 +124,7 @@ def monthly_reports():
         send_delayed_report(report_id)
 
 
-@periodic_task(run_every=crontab(hour="23", minute="59", day_of_week="*"), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE','celery'))
+@periodic_task(run_every=crontab(hour="23", minute="59", day_of_week="*"), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def saved_exports():
     for group_config_id in get_doc_ids_by_class(HQGroupExportConfiguration):
         export_for_group_async.delay(group_config_id)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1047,7 +1047,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         couch_user_post_save.send_robust(sender='couch_user', couch_user=self)
 
     def delete_phone_number(self, phone_number):
-        for i in range(0,len(self.phone_numbers)):
+        for i in range(0, len(self.phone_numbers)):
             if self.phone_numbers[i] == phone_number:
                 del self.phone_numbers[i]
                 break

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -459,7 +459,7 @@ def generate_sortables_from_facets(results, params=None):
 
     def generate_facet_dict(f_name, ft):
         if isinstance(ft['term'], six.text_type): #hack to get around unicode encoding issues. However it breaks this specific facet
-            ft['term'] = ft['term'].encode('ascii','replace')
+            ft['term'] = ft['term'].encode('ascii', 'replace')
 
         return {'name': ft["term"],
                 'count': ft["count"],

--- a/corehq/ex-submodules/auditcare/decorators/login.py
+++ b/corehq/ex-submodules/auditcare/decorators/login.py
@@ -59,11 +59,11 @@ def get_user_attempt(request):
     if USE_USER_AGENT:
         ua = request.META.get('HTTP_USER_AGENT', '<unknown>')
 
-        attempts = AccessAudit.view('auditcare/login_events', key=['ip_ua',ip, ua], include_docs=True, limit=25).all()
+        attempts = AccessAudit.view('auditcare/login_events', key=['ip_ua', ip, ua], include_docs=True, limit=25).all()
 
         #attempts = AccessAttempt.objects.filter( user_agent=ua, ip_address=ip )
     else:
-        attempts = AccessAudit.view('auditcare/login_events',key=['ip', ip], include_docs=True, limit=25).all()
+        attempts = AccessAudit.view('auditcare/login_events', key=['ip', ip], include_docs=True, limit=25).all()
         #attempts = AccessAttempt.objects.filter( ip_address=ip )
 
     attempts = sorted(attempts, key=lambda x: x.event_date, reverse=True)

--- a/corehq/ex-submodules/auditcare/forms.py
+++ b/corehq/ex-submodules/auditcare/forms.py
@@ -11,7 +11,7 @@ class SignaledAuthenticationForm(AuthenticationForm):
         if username and password:
             self.user_cache = authenticate(username=username, password=password)
             if self.user_cache is None:
-                user_login_failed.send(sender=self,request=self.request,username=username) # This is new
+                user_login_failed.send(sender=self, request=self.request, username=username) # This is new
                 raise forms.ValidationError(_("Please enter a correct username and password. Note that both fields are case-sensitive."))
             elif not self.user_cache.is_active:
                 raise forms.ValidationError(_("This account is inactive."))

--- a/corehq/ex-submodules/auditcare/management/commands/compute_diffs.py
+++ b/corehq/ex-submodules/auditcare/management/commands/compute_diffs.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         for model, count in model_dict.items():
             #for each model type, query ALL audit instances.
             print("### %s" % (model))
-            model_counts = db.view('auditcare/model_actions_by_id', group=True, startkey=[model,u''], endkey=[model,u'z']).all()
+            model_counts = db.view('auditcare/model_actions_by_id', group=True, startkey=[model, u''], endkey=[model, u'z']).all()
             #within a given model, query ALL instances
 
             #sort the models by id, then by rev descending
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                 num = mc['value']
                 model_uuid = mc['key'][1]
                 #now for each model uuid, do a query again to get all the rev numbers
-                item_revs = db.view('auditcare/model_actions_by_id', reduce=False, startkey=[model,model_uuid], endkey=[model,model_uuid]).all()
+                item_revs = db.view('auditcare/model_actions_by_id', reduce=False, startkey=[model, model_uuid], endkey=[model, model_uuid]).all()
                 revs = sorted([(x['id'], x['value']) for x in item_revs], key=lambda y: y[1], reverse=True)
                 #tuples of (audit_id, rev_id)
                 #print "%s:%s -> %s" % (model, model_uuid, revs)

--- a/corehq/ex-submodules/auditcare/management/commands/resolve_urls.py
+++ b/corehq/ex-submodules/auditcare/management/commands/resolve_urls.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     def handle(self, **options):
         consolidated = set(show_urls.show_urls(urls.urlpatterns))
         for raw_path, view_name in consolidated:
-            path = raw_path.replace('^', '/').replace('$','')
+            path = raw_path.replace('^', '/').replace('$', '')
             try:
                 print('%s|"%s"' % (path, view_name))
                 #print "%s\t%s" % (resolve_to_name(path), view_name)

--- a/corehq/ex-submodules/auditcare/signals.py
+++ b/corehq/ex-submodules/auditcare/signals.py
@@ -88,7 +88,7 @@ for full_str in settings.AUDIT_MODEL_SAVE:
     comps = full_str.split('.')
     model_class = comps[-1]
     mod_str = '.'.join(comps[0:-1])
-    mod = __import__(mod_str, {},{},[model_class])
+    mod = __import__(mod_str, {}, {}, [model_class])
     if hasattr(mod, model_class):
         audit_model = getattr(mod, model_class)
         if issubclass(audit_model, models.Model):

--- a/corehq/ex-submodules/auditcare/tests/auth.py
+++ b/corehq/ex-submodules/auditcare/tests/auth.py
@@ -109,7 +109,7 @@ class AuthenticationTestCase(TestCase):
         self.assertEquals(first_audit.failures_since_start, 1)
         start_failures = first_audit.failures_since_start
 
-        for n in range(1,3):
+        for n in range(1, 3):
             #we are logging in within the cooloff period, so let's check to see if it doesn't increment.
             response = self.client.post(reverse('auth_login'), {'username': 'mockmock@mockmock.com', 'password': 'wrongwrongwrong'})
             next_count = AccessAudit.view('auditcare/login_events', key=['user', 'mockmock@mockmock.com']).count()
@@ -122,7 +122,7 @@ class AuthenticationTestCase(TestCase):
         time.sleep(3)
         response = self.client.post(reverse('auth_login'), {'username': 'mockmock@mockmock.com', 'password': 'wrongwrong'})
         cooled_audit = get_latest_access(['user', 'mockmock@mockmock.com'])
-        self.assertEquals(cooled_audit.failures_since_start,1)
+        self.assertEquals(cooled_audit.failures_since_start, 1)
 
 
 

--- a/corehq/ex-submodules/auditcare/utils/resolver.py
+++ b/corehq/ex-submodules/auditcare/utils/resolver.py
@@ -23,7 +23,7 @@ def _resolver_resolve_to_name(self, path):
         new_path = path[match.end():]
         for pattern in self.url_patterns:
             try:
-                name = _pattern_resolve_to_name(pattern,new_path)
+                name = _pattern_resolve_to_name(pattern, new_path)
             except Resolver404 as e:
                 tried.extend([(pattern.regex.pattern + '   ' + t) for t in e.args[0]['tried']])
             else:
@@ -35,7 +35,7 @@ def _resolver_resolve_to_name(self, path):
 
 def resolve_to_name(path, urlconf=None):
     r = get_resolver(urlconf)
-    if isinstance(r,RegexURLPattern):
-        return _pattern_resolve_to_name(r,path)
+    if isinstance(r, RegexURLPattern):
+        return _pattern_resolve_to_name(r, path)
     else:
-        return _resolver_resolve_to_name(r,path)
+        return _resolver_resolve_to_name(r, path)

--- a/corehq/ex-submodules/auditcare/views.py
+++ b/corehq/ex-submodules/auditcare/views.py
@@ -121,7 +121,7 @@ def single_model_history(request, model_name, *args, **kwargs):
     # it's for a particular model
     context=RequestContext(request)
     db = AccessAudit.get_db()
-    vals = db.view('auditcare/model_actions_by_id', group=True, startkey=[model_name,u''], endkey=[model_name,u'z']).all()
+    vals = db.view('auditcare/model_actions_by_id', group=True, startkey=[model_name, u''], endkey=[model_name, u'z']).all()
     model_dict= dict((x['key'][1], x['value']) for x in vals)
     context['instances_dict']=model_dict
     context['model'] = model_name

--- a/corehq/ex-submodules/couchexport/tests/test_schema.py
+++ b/corehq/ex-submodules/couchexport/tests/test_schema.py
@@ -17,7 +17,7 @@ class ExportSchemaTest(TestCase, DocTestMixin):
     def testSaveAndLoad(self):
         index = ["foo", 2]
         schema = ExportSchema(index=index, timestamp=datetime.utcnow())
-        inner = {"dict": {"bar": 1, "baz": [2,3]},
+        inner = {"dict": {"bar": 1, "baz": [2, 3]},
                  "list": ["foo", "bar"],
                  "dictlist": [{"bip": 1, "bop": "blah"},
                               {"bip": 2, "bop": "blah2"}],

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -407,7 +407,7 @@ class Excel2003ExportWriter(ExportWriter):
         sheet = self.tables[sheet_index]
         # have to deal with primary ids
         for i, val in enumerate(row):
-            sheet.write(row_index,i,six.text_type(val))
+            sheet.write(row_index, i, six.text_type(val))
         self.table_indices[sheet_index] = row_index + 1
 
     def _close(self):

--- a/corehq/ex-submodules/dimagi/utils/data/generator.py
+++ b/corehq/ex-submodules/dimagi/utils/data/generator.py
@@ -56,7 +56,7 @@ def username_from_name(name):
 
 
 def random_phonenumber(numdigits=11):
-    return "+" + "".join(str(random.randint(0,9)) for i in range(numdigits))
+    return "+" + "".join(str(random.randint(0, 9)) for i in range(numdigits))
 
 
 def instantiate(generator_or_value):

--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -398,7 +398,7 @@ def get_day_of_month(year, month, count):
     just creating the date object is to support negative numbers
     e.g. pass in -1 for "last"
     """
-    r = rrule(MONTHLY, dtstart=datetime.datetime(year,month, 1),
+    r = rrule(MONTHLY, dtstart=datetime.datetime(year, month, 1),
               byweekday=(MO, TU, WE, TH, FR, SA, SU),
               bysetpos=count)
     res = r[0]
@@ -412,7 +412,7 @@ def get_business_day_of_month(year, month, count):
     Count can also be negative, e.g. pass in -1 for "last"
     """
     r = rrule(MONTHLY, byweekday=(MO, TU, WE, TH, FR), 
-              dtstart=datetime.datetime(year,month, 1),
+              dtstart=datetime.datetime(year, month, 1),
               bysetpos=count)
     res = r[0]
     if (res == None or res.month != month or res.year != year):
@@ -436,7 +436,7 @@ def get_business_day_of_month_before(year, month, day):
             except ValueError:
                 adate = datetime.datetime(year, month, 28)
     r = rrule(MONTHLY, byweekday=(MO, TU, WE, TH, FR), 
-              dtstart=datetime.datetime(year,month,1))
+              dtstart=datetime.datetime(year, month, 1))
     res = r.before(adate, inc=True)
     if (res == None or res.month != month or res.year != year):
         raise ValueError("No dates found in range. is there a flaw in your logic?")

--- a/corehq/ex-submodules/dimagi/utils/dev/couchdb_module.py
+++ b/corehq/ex-submodules/dimagi/utils/dev/couchdb_module.py
@@ -33,7 +33,7 @@ class CouchDBDevModule(DevServerModule):
         def output_stacktrace(row, count=1):
             if SHOW_STACKTRACE:
                 filtered_stacktrace = [x for x in row['stacktrace'] if 'site-packages' not in x[0]]
-                self.logger.debug('\n\t'.join(["%s:%s" % (x[0],x[1]) for x in filtered_stacktrace[-count-STACKTRACE_SIZE:]]))
+                self.logger.debug('\n\t'.join(["%s:%s" % (x[0], x[1]) for x in filtered_stacktrace[-count-STACKTRACE_SIZE:]]))
 
         if SHOW_VERBOSE:
             self.logger.debug("GET raw output")

--- a/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
+++ b/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
@@ -85,8 +85,8 @@ class ProfileMiddleware(MiddlewareMixin):
                 mygroups[ group ] += time
 
         return "<pre>" + \
-               " ---- By file ----\n\n" + self.get_summary(mystats,sum) + "\n" + \
-               " ---- By group ---\n\n" + self.get_summary(mygroups,sum) + \
+               " ---- By file ----\n\n" + self.get_summary(mystats, sum) + "\n" + \
+               " ---- By group ---\n\n" + self.get_summary(mygroups, sum) + \
                "</pre>"
 
     def process_response(self, request, response):

--- a/corehq/ex-submodules/dimagi/utils/management/commands/prime_views.py
+++ b/corehq/ex-submodules/dimagi/utils/management/commands/prime_views.py
@@ -17,7 +17,7 @@ DESIGN_SK = "_design"
 DESIGN_EK = "_design0"
 
 POOL_SIZE=12
-REPEAT_INTERVAL = getattr(settings,'PRIME_VIEWS_INTERVAL', 3600)
+REPEAT_INTERVAL = getattr(settings, 'PRIME_VIEWS_INTERVAL', 3600)
 
 
 def get_unique_dbs():
@@ -48,7 +48,7 @@ def do_prime(app_label, design_doc_name, view_name, verbose=False):
             sys.stdout.flush()
     except ResourceNotFound:
         if verbose:
-            sys.stdout.write('!=>%s/%s/%s' % (app_label,design_doc_name, view_name))
+            sys.stdout.write('!=>%s/%s/%s' % (app_label, design_doc_name, view_name))
             sys.stdout.flush()
 
 

--- a/corehq/ex-submodules/dimagi/utils/post.py
+++ b/corehq/ex-submodules/dimagi/utils/post.py
@@ -118,7 +118,7 @@ def post_data(data, url, curl_command="curl", use_curl=False,
 
             params.append(url)
             p = subprocess.Popen(params,
-                                 stdout=PIPE,stderr=PIPE,shell=False)
+                                 stdout=PIPE, stderr=PIPE, shell=False)
             errors = p.stderr.read()
             results = p.stdout.read()
         else:

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -100,7 +100,7 @@ class DownloadBase(object):
         if self.transfer_encoding is not None:
             response['Transfer-Encoding'] = self.transfer_encoding
         response['Content-Disposition'] = self.content_disposition
-        for k,v in self.extras.items():
+        for k, v in self.extras.items():
             response[k] = v
         return response
 

--- a/corehq/messaging/ivrbackends/kookoo/tests/outbound.py
+++ b/corehq/messaging/ivrbackends/kookoo/tests/outbound.py
@@ -57,14 +57,14 @@ class KooKooTestCase(TouchformsTestCase):
             .set_schedule_manually(EVENT_AS_SCHEDULE, 1, [
                 CaseReminderEvent(
                     day_num=0,
-                    fire_time=time(12,0),
+                    fire_time=time(12, 0),
                     fire_time_type=FIRE_TIME_DEFAULT,
                     callback_timeout_intervals=[30],
                     form_unique_id=self.apps[0].modules[0].forms[0].unique_id,
                 ),
                 CaseReminderEvent(
                     day_num=0,
-                    fire_time=time(13,0),
+                    fire_time=time(13, 0),
                     fire_time_type=FIRE_TIME_DEFAULT,
                     callback_timeout_intervals=[30],
                     form_unique_id=self.apps[0].modules[0].forms[1].unique_id,

--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -34,8 +34,8 @@ class HttpBackendForm(BackendForm):
     method = ChoiceField(
         label=ugettext_noop("HTTP Request Method"),
         choices=(
-            ("GET","GET"),
-            ("POST","POST")
+            ("GET", "GET"),
+            ("POST", "POST")
         ),
     )
     additional_params = RecordListField(

--- a/custom/_legacy/pact/api.py
+++ b/custom/_legacy/pact/api.py
@@ -184,7 +184,7 @@ def prepare_case_update_xml_block(casedoc, couch_user, update_dict, submit_date)
     case_nsmap = {'n1': 'http://commcarehq.org/case/transaction/v2'}
 
     def make_update(update_elem, updates):
-        for k,v in updates.items():
+        for k, v in updates.items():
             if v is not None:
                 sub_element(update_elem, '{%(ns)s}%(tag)s' % {'ns': case_nsmap['n1'], 'tag': k}, v)
 

--- a/custom/_legacy/pact/enums.py
+++ b/custom/_legacy/pact/enums.py
@@ -100,7 +100,7 @@ PACT_DOT_CHOICES_DICT = dict(x for x in PACT_DOT_CHOICES)
 
 
 PACT_REGIMEN_CHOICES = (
-    ('None',[('', '-- None --'),]),
+    ('None', [('', '-- None --'),]),
     ('QD - Once a day', [
         ('morning', 'Morning'),
         ('noon', 'Noon'),

--- a/custom/_legacy/pact/forms/patient_form.py
+++ b/custom/_legacy/pact/forms/patient_form.py
@@ -32,7 +32,7 @@ class PactPatientForm(Form):
     race = forms.ChoiceField(choices=PACT_RACE_CHOICES)
     preferred_language = forms.ChoiceField(choices=PACT_LANGUAGE_CHOICES)
 
-    mass_health_expiration = forms.DateField(label = "Mass Health expiration date (m/d/y)", input_formats=['%m/%d/%Y',''], widget=forms.DateInput(format = '%m/%d/%Y'), required=False)
+    mass_health_expiration = forms.DateField(label = "Mass Health expiration date (m/d/y)", input_formats=['%m/%d/%Y', ''], widget=forms.DateInput(format = '%m/%d/%Y'), required=False)
     ssn = forms.CharField(label="Social Security Number", required=False)
 
     hp = forms.ChoiceField(label="Primary health promoter", choices=())

--- a/custom/_legacy/pact/forms/weekly_schedule_form.py
+++ b/custom/_legacy/pact/forms/weekly_schedule_form.py
@@ -7,7 +7,7 @@ from corehq.apps.users.models import CommCareUser
 from dimagi.utils.decorators.memoized import memoized
 from pact.enums import PACT_DOMAIN
 
-DAYS_OF_WEEK = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday']
+DAYS_OF_WEEK = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
 
 
 def make_uuid():

--- a/custom/_legacy/pact/lib/quicksect.py
+++ b/custom/_legacy/pact/lib/quicksect.py
@@ -114,7 +114,7 @@ def main():
     test = None
     intlist = []
     for x in range(20000):
-        start = random.randint(0,1000000)
+        start = random.randint(0, 1000000)
         end = start + random.randint(1, 1000)
         if test: test = test.insert( start, end )
         else: test = IntervalNode( start, end )

--- a/custom/_legacy/pact/management/commands/__init__.py
+++ b/custom/_legacy/pact/management/commands/__init__.py
@@ -37,6 +37,6 @@ class PactMigrateCommand(BaseCommand):
         except urllib2.HTTPError as e:
             print("\t\t\tError: %s: %s" % (url, e))
             if retry < RETRY_LIMIT:
-                print("Retry %d/%d" % (retry,RETRY_LIMIT))
+                print("Retry %d/%d" % (retry, RETRY_LIMIT))
                 return self.get_url(url, retry=retry+1)
             return None

--- a/custom/_legacy/pact/models.py
+++ b/custom/_legacy/pact/models.py
@@ -309,7 +309,7 @@ class PactPatientCase(CommCareCase):
 
     @property
     def phones(self):
-        for ix in range(1,6):
+        for ix in range(1, 6):
             if hasattr(self, 'Phone%d' % ix) and hasattr(self, 'Phone%dType' % ix):
                 number = getattr(self, "Phone%d" % ix, None)
                 if number is not None and number != "":

--- a/custom/_legacy/pact/tests/dots_algorithm.py
+++ b/custom/_legacy/pact/tests/dots_algorithm.py
@@ -14,7 +14,7 @@ def _observationGenerator(encounter_date, observation_date, adherence=DOT_ADHERE
 
 
 def generateDirect(encounter_date, observation_date, adherence=DOT_ADHERENCE_EMPTY):
-    obs = _observationGenerator(encounter_date,observation_date, adherence=adherence)
+    obs = _observationGenerator(encounter_date, observation_date, adherence=adherence)
     obs.method=DOT_OBSERVATION_DIRECT
     return obs
 
@@ -30,19 +30,19 @@ def generateReconciliation():
 
 
 def generatePillbox(encounter_date, observation_date, adherence=DOT_ADHERENCE_EMPTY):
-    obs = _observationGenerator(encounter_date,observation_date, adherence=adherence)
+    obs = _observationGenerator(encounter_date, observation_date, adherence=adherence)
     obs.method=DOT_OBSERVATION_PILLBOX
     return obs
 
 
 def generateSelf(encounter_date, observation_date, adherence=DOT_ADHERENCE_EMPTY):
-    obs = _observationGenerator(encounter_date,observation_date, adherence=adherence)
+    obs = _observationGenerator(encounter_date, observation_date, adherence=adherence)
     obs.method=DOT_OBSERVATION_SELF
     return obs
 
 
 def generateAny(encounter_date, observation_date, adherence=DOT_ADHERENCE_EMPTY):
-    obs = _observationGenerator(encounter_date,observation_date, adherence=adherence)
+    obs = _observationGenerator(encounter_date, observation_date, adherence=adherence)
     obs.method=random.choice([DOT_OBSERVATION_PILLBOX, DOT_OBSERVATION_PILLBOX])
     return obs
 
@@ -134,7 +134,7 @@ class dotsAlgorithmTests(TestCase):
         self.assertEqual(no_direct_winner.encounter_date, no_direct_sorted[0].encounter_date)
 
         #at least one direct
-        direct = generateDirect(datetime.utcnow() + timedelta(days=random.randint(-100,100)), observed_date)
+        direct = generateDirect(datetime.utcnow() + timedelta(days=random.randint(-100, 100)), observed_date)
         with_direct = [generateAny(x, observed_date) for x in encounter_dates] + [direct]
         random.shuffle(with_direct)
 

--- a/custom/_legacy/pact/tests/regimen_properties.py
+++ b/custom/_legacy/pact/tests/regimen_properties.py
@@ -10,7 +10,7 @@ class RegimenPropertiesTests(TestCase):
 
     def testStringToDictRegimensNum(self):
         #assure that all frequencies line up ok
-        for freq in range(1,5):
+        for freq in range(1, 5):
             regimens = PACT_REGIMEN_CHOICES[freq][1]
             for drug_type in art_nonart:
                 for regimen_tuple in regimens:

--- a/custom/bihar/reports/display.py
+++ b/custom/bihar/reports/display.py
@@ -150,7 +150,7 @@ class MCHMotherDisplay(MCHDisplay):
                 elif children_count > 1 and "child_info" in form_dict:
                     child_list = form_dict["child_info"]
 
-                for idx,child in enumerate(child_list):
+                for idx, child in enumerate(child_list):
                     case_child = {}
                     if "case" in child:
                         case_child = CommCareCase.get(child["case"]["@case_id"])
@@ -484,7 +484,7 @@ class MCHChildDisplay(MCHDisplay):
 
                 parent_json = parent_case.case_properties()
 
-                setattr(self, "_father_mother_name", "%s, %s" %(get_property(parent_json,"husband_name"), get_property(parent_json, "mother_name")))
+                setattr(self, "_father_mother_name", "%s, %s" %(get_property(parent_json, "husband_name"), get_property(parent_json, "mother_name")))
                 setattr(self, "_full_mcts_id", get_property(parent_json, "full_mcts_id"))
                 setattr(self, "_ward_number", get_property(parent_json, "ward_number"))
                 setattr(self, "_mobile_number", get_property(parent_case, 'mobile_number'))

--- a/custom/bihar/tests/test_case_assigment.py
+++ b/custom/bihar/tests/test_case_assigment.py
@@ -100,7 +100,7 @@ class CaseAssignmentTest(TestCase):
         assign_case(self.primary.case_id, self.primary_user._id, include_subcases=True, include_parent_cases=True,
                     exclude_function=exclude_fn)
         self._check_state(new_owner_id=self.primary_user._id, expected_changed=[
-            self.grandmother, self.parent, self.son, self.daughter,self.granddaughter, self.grandson2
+            self.grandmother, self.parent, self.son, self.daughter, self.granddaughter, self.grandson2
         ])
 
     def test_assign_bad_index_ref(self):

--- a/custom/fri/api.py
+++ b/custom/fri/api.py
@@ -132,8 +132,8 @@ def get_message_bank(domain, risk_profile=None, for_comparing=False):
         result = []
         for message in messages:
             result.append({
-                "message" : message,
-                "compare_string" : letters_only(message.message),
+                "message": message,
+                "compare_string": letters_only(message.message),
             })
         return result
     else:

--- a/custom/fri/forms.py
+++ b/custom/fri/forms.py
@@ -71,8 +71,8 @@ class MessageBankForm(Form):
                 raise ValidationError(_("Message at row %(row_num)s is longer than 160 characters.") % {"row_num" : row_num})
 
             messages.append({
-                "msg_id" : msg_id,
-                "text" : text,
+                "msg_id": msg_id,
+                "text": text,
             })
             message_ids[msg_id] = True
             row_num += 1

--- a/custom/fri/models.py
+++ b/custom/fri/models.py
@@ -11,14 +11,14 @@ PROFILE_G = "G"
 PROFILE_H = "H"
 PROFILES = [PROFILE_A, PROFILE_B, PROFILE_C, PROFILE_D, PROFILE_E, PROFILE_F, PROFILE_G, PROFILE_H]
 PROFILE_DESC = {
-    PROFILE_A : "A - HIV+",
-    PROFILE_B : "B - ART non",
-    PROFILE_C : "C - IDU",
-    PROFILE_D : "D - PSE/CSV",
-    PROFILE_E : "E - Top",
-    PROFILE_F : "F - Bottom",
-    PROFILE_G : "G - General",
-    PROFILE_H : "H - Other",
+    PROFILE_A: "A - HIV+",
+    PROFILE_B: "B - ART non",
+    PROFILE_C: "C - IDU",
+    PROFILE_D: "D - PSE/CSV",
+    PROFILE_E: "E - Top",
+    PROFILE_F: "F - Bottom",
+    PROFILE_G: "G - General",
+    PROFILE_H: "H - Other",
 }
 
 

--- a/custom/fri/reports/reports.py
+++ b/custom/fri/reports/reports.py
@@ -68,7 +68,7 @@ class MessageBankReport(FRIReport):
     @property
     def template_context(self):
         result = {
-            "is_previewer" : self.request.couch_user.is_previewer(),
+            "is_previewer": self.request.couch_user.is_previewer(),
         }
         return result
 
@@ -166,7 +166,7 @@ class MessageReport(FRIReport, DatespanMixin):
             DataTablesColumn(_("Message ID")),
             DataTablesColumn(_("Direction")),
         )
-        header.custom_sort = [[1, "asc"],[0, "asc"],[3, "asc"]]
+        header.custom_sort = [[1, "asc"], [0, "asc"], [3, "asc"]]
         return header
 
     def _case_name(self, contact, reverse=False):
@@ -266,7 +266,7 @@ class MessageReport(FRIReport, DatespanMixin):
                 self._fmt_timestamp(timestamp),
                 self._fmt(message.text),
                 self._fmt(message.fri_id or "-"),
-                self._fmt(direction_map.get(message.direction,"-")),
+                self._fmt(direction_map.get(message.direction, "-")),
             ])
         return result
 
@@ -292,8 +292,8 @@ class PHEDashboardReport(FRIReport):
     @property
     def template_context(self):
         result = {
-            "fri_message_bank_url" : reverse(CustomProjectReportDispatcher.name(), args=[self.domain, MessageBankReport.slug]),
-            "fri_chat_actions" : [self._open_chat_action(case._id) for case in self.interactive_participants],
+            "fri_message_bank_url": reverse(CustomProjectReportDispatcher.name(), args=[self.domain, MessageBankReport.slug]),
+            "fri_chat_actions": [self._open_chat_action(case._id) for case in self.interactive_participants],
         }
         return result
 

--- a/custom/hope/const.py
+++ b/custom/hope/const.py
@@ -44,7 +44,7 @@ MOTHER_EVENTS_ATTRIBUTES = [
     ('DLYT', 'registration_date', '_HOPE_mother_registration_date'),
     ('DLYT', 'existing_child_count', '_HOPE_mother_existing_child_count'),
     ('DLYT', 'age_of_beneficiary', '_HOPE_mother_age'),
-    ('DLYT', 'bpl_indicator','_HOPE_mother_bpl_indicator'),
+    ('DLYT', 'bpl_indicator', '_HOPE_mother_bpl_indicator'),
     ('DLYT', 'delivery_date', '_HOPE_mother_delivery_date'),
     ('DLYT', 'time_of_birth', '_HOPE_mother_time_of_birth'),
     ('DLYT', 'tubal_ligation', '_HOPE_mother_tubal_ligation'),

--- a/custom/hope/models.py
+++ b/custom/hope/models.py
@@ -353,7 +353,7 @@ class HOPECase(CommCareCase):
 
     @property
     def _HOPE_mother_all_anc_doses_given(self):
-        anc_dose_dates = [self.get_case_property('anc_%d_date' % (n+1)) for n in range(0,4)]
+        anc_dose_dates = [self.get_case_property('anc_%d_date' % (n+1)) for n in range(0, 4)]
         return self.bool_to_yesno(len([date for date in anc_dose_dates if bool(date)]) >= 4)
 
     @property

--- a/custom/m4change/reports/sql_data.py
+++ b/custom/m4change/reports/sql_data.py
@@ -52,7 +52,7 @@ class AncHmisCaseSqlData(SqlData):
 
     @property
     def group_by(self):
-        return ["domain","location_id"]
+        return ["domain", "location_id"]
 
 
 class ProjectIndicatorsCaseSqlData(SqlData):
@@ -104,7 +104,7 @@ class ProjectIndicatorsCaseSqlData(SqlData):
 
     @property
     def group_by(self):
-        return ["domain","mother_id","location_id"]
+        return ["domain", "mother_id", "location_id"]
 
 
 class LdHmisCaseSqlData(SqlData):
@@ -213,7 +213,7 @@ class ImmunizationHmisCaseSqlData(SqlData):
             DatabaseColumn(_("Location ID"), SimpleColumn("location_id")),
             DatabaseColumn(_("OPV0 - birth "), SumColumn("opv_0_total")),
             DatabaseColumn(_("Hep.B0 - birth"), SumColumn("hep_b_0_total")),
-            DatabaseColumn(_("BCG"),SumColumn("bcg_total")),
+            DatabaseColumn(_("BCG"), SumColumn("bcg_total")),
             DatabaseColumn(_("OPV1"), SumColumn("opv_1_total")),
             DatabaseColumn(_("HEP.B1"), SumColumn("hep_b_1_total")),
             DatabaseColumn(_("Penta.1"), SumColumn("penta_1_total")),
@@ -237,7 +237,7 @@ class ImmunizationHmisCaseSqlData(SqlData):
 
     @property
     def group_by(self):
-        return ["domain","location_id"]
+        return ["domain", "location_id"]
 
 
 class McctMonthlyAggregateFormSqlData(SqlData):
@@ -294,7 +294,7 @@ class McctMonthlyAggregateFormSqlData(SqlData):
 
     @property
     def group_by(self):
-        return ["domain","location_id"]
+        return ["domain", "location_id"]
 
 
 class AllHmisCaseSqlData(SqlData):

--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -87,7 +87,7 @@ def _ucla_form_modifier(form, question_ids):
                 xform.data_node.append(element)
 
                 # Add bind
-                xform.itext_node.addprevious(_make_elem("bind",{
+                xform.itext_node.addprevious(_make_elem("bind", {
                     "nodeset": xform.resolve_path(hidden_value_path),
                     "calculate": '"'+hidden_value_text+'"'
                 }))

--- a/custom/world_vision/filters.py
+++ b/custom/world_vision/filters.py
@@ -37,7 +37,7 @@ class LocationFilter(BaseDrilldownOptionFilter):
         return hierarchy
 
     def get_labels(self):
-        return [(v['name'], v['prop']) for k,v in sorted(LOCATION_HIERARCHY.iteritems())]
+        return [(v['name'], v['prop']) for k, v in sorted(LOCATION_HIERARCHY.iteritems())]
 
     @property
     def filter_context(self):

--- a/custom/world_vision/sqldata/child_sqldata.py
+++ b/custom/world_vision/sqldata/child_sqldata.py
@@ -424,7 +424,7 @@ class NutritionFeedingDetails(BaseSqlData):
     def rows(self):
         from custom.world_vision import CHILD_INDICATOR_TOOLTIPS
         result = []
-        for i in range(0,4):
+        for i in range(0, 4):
             result.append([{'sort_key': self.columns[2*i].header, 'html': self.columns[2*i].header,
                             'tooltip': self.get_tooltip(CHILD_INDICATOR_TOOLTIPS['nutrition_details'], self.columns[2*i].slug)},
                            {'sort_key': self.data[self.columns[2*i].slug], 'html': self.data[self.columns[2*i].slug]},

--- a/custom/world_vision/sqldata/mother_sqldata.py
+++ b/custom/world_vision/sqldata/mother_sqldata.py
@@ -214,7 +214,7 @@ class AnteNatalCareServiceOverviewExtended(AnteNatalCareServiceOverview):
                   {'sort_key': self.data[self.columns[0].slug], 'html': self.data[self.columns[0].slug]},
                   {'sort_key': 'n/a', 'html': 'n/a'},
                   {'sort_key': 'n/a', 'html': 'n/a'}]]
-        for i in range(1,15):
+        for i in range(1, 15):
             result.append([{'sort_key': self.columns[i].header, 'html': self.columns[i].header,
                             'tooltip': self.get_tooltip(MOTHER_INDICATOR_TOOLTIPS['ante_natal_care_service_details'], self.columns[i].slug)},
                            {'sort_key': self.data[self.columns[i].slug], 'html': self.data[self.columns[i].slug]},
@@ -458,7 +458,7 @@ class PostnatalCareOverview(BaseSqlData):
     def rows(self):
         from custom.world_vision import MOTHER_INDICATOR_TOOLTIPS
         result = []
-        for i in range(0,4):
+        for i in range(0, 4):
             result.append([{'sort_key': self.columns[i].header, 'html': self.columns[i].header,
                             'tooltip': self.get_tooltip(MOTHER_INDICATOR_TOOLTIPS['postnatal_care_details'], self.columns[i].slug)},
                            {'sort_key': self.data[self.columns[i].slug], 'html': self.data[self.columns[i].slug]},


### PR DESCRIPTION
This is included in futurize's [stage1](http://python-future.org/automatic_conversion.html#stage-1-safe-fixes) fixers, so I'm applying it even though it's not necessary for python3.  Applying the fixer now will make it easier to check for regressions with the stage1 fixers later on.

w=1 confirms that these are whitespace only changes

@dimagi/py3 