### PR TITLE
Rename kissmetrics module to kissmetrix

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -2,7 +2,7 @@
 
 var _kmq = window._kmq = _kmq || [];
 
-hqDefine('analytix/js/kissmetrics', function () {
+hqDefine('analytix/js/kissmetrix', function () {
     'use strict';
     var _get = hqImport('analytix/js/initial').getFn('kissmetrics'),
         _global = hqImport('analytix/js/initial').getFn('global'),

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -226,10 +226,10 @@ hqDefine('app_manager/js/app_manager', function () {
                             $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
                             if (dataType === "case") {
                                 hqImport('analytix/js/google').track.event("Added Case List Menu");
-                                hqImport('analytix/js/kissmetrics').track.event("Added Case List Menu");
+                                hqImport('analytix/js/kissmetrix').track.event("Added Case List Menu");
                             } else if (dataType === "survey") {
                                 hqImport('analytix/js/google').track.event("Added Surveys Menu");
-                                hqImport('analytix/js/kissmetrics').track.event("Added Surveys Menu");
+                                hqImport('analytix/js/kissmetrix').track.event("Added Surveys Menu");
                             }
                             $form.submit();
                         }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -47,7 +47,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
                 app_manager.updateDOM(data.update);
                 $('.js-preview-toggle').removeAttr('disabled');
                 if (initial_page_data("days_since_created")) {
-                    hqImport('analytix/js/kissmetrics').track.event('Saved the Form Builder within first 24 hours');
+                    hqImport('analytix/js/kissmetrix').track.event('Saved the Form Builder within first 24 hours');
                 }
             },
             onReady: function() {
@@ -65,7 +65,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
                 }
                 if (initial_page_data('days_since_created') === 0) {
                     $("#formdesigner").vellum("get").data.core.form.on("question-create", function() {
-                        hqImport('analytix/js/kissmetrics').track.event('Added question in Form Builder within first 24 hours');
+                        hqImport('analytix/js/kissmetrix').track.event('Added question in Form Builder within first 24 hours');
                     });
                 }
             },
@@ -79,7 +79,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
         define("moment", [], function () { return window.moment; });
         define("vellum/hqAnalytics", [], function () {
             function workflow(message) {
-                hqImport('analytix/js/kissmetrics').track.event(message);
+                hqImport('analytix/js/kissmetrix').track.event(message);
             }
 
             function usage(label, group, message) {
@@ -131,7 +131,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
                 }
             });
         });
-        hqImport('analytix/js/kissmetrics').track.event('Entered the Form Builder');
+        hqImport('analytix/js/kissmetrix').track.event('Entered the Form Builder');
 
         hqImport('app_manager/js/app_manager').setAppendedPageTitle(django.gettext("Edit Form"));
 
@@ -178,7 +178,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
         });
         $('#edit-form-name-modal').koApplyBindings(editDetails);
         $("#edit-form-name-modal button[type='submit']").click(function() {
-            hqImport('analytix/js/kissmetrics').track.event("Renamed form from form builder");
+            hqImport('analytix/js/kissmetrix').track.event("Renamed form from form builder");
         });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -65,7 +65,7 @@ hqDefine("app_manager/js/forms/form_view", function() {
 
         // Analytics for renaming form
         $(".appmanager-edit-title").on('click', '.btn-success', function() {
-            hqImport('analytix/js/kissmetrics').track.event("Renamed form from form settings page");
+            hqImport('analytix/js/kissmetrix').track.event("Renamed form from form settings page");
         });
 
         // Settings > Logic

--- a/corehq/apps/app_manager/static/app_manager/js/hq.app_data_drilldown.ng.js
+++ b/corehq/apps/app_manager/static/app_manager/js/hq.app_data_drilldown.ng.js
@@ -145,7 +145,7 @@
                 $scope.resetForm();
             });
             $(formModalSelector).on('show.bs.modal', function () {
-                hqImport('analytix/js/kissmetrics').track.event("Clicked New Export");
+                hqImport('analytix/js/kissmetrix').track.event("Clicked New Export");
             });
         }
 

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -40,7 +40,7 @@ hqDefine('app_manager/js/preview_app', function() {
         $(module.SELECTORS.PREVIEW_ACTION_TEXT_HIDE).removeClass('hide');
 
         if (triggerAnalytics) {
-            hqImport('analytix/js/kissmetrics').track.event("[app-preview] Clicked Show App Preview");
+            hqImport('analytix/js/kissmetrix').track.event("[app-preview] Clicked Show App Preview");
             hqImport('analytix/js/google').track.event("App Preview", "Clicked Show App Preview");
         }
 
@@ -58,7 +58,7 @@ hqDefine('app_manager/js/preview_app', function() {
         if (localStorage.getItem(module.DATA.TABLET)) $offsetContainer.removeClass('offset-for-tablet');
 
         if (triggerAnalytics) {
-            hqImport('analytix/js/kissmetrics').track.event("[app-preview] Clicked Hide App Preview");
+            hqImport('analytix/js/kissmetrix').track.event("[app-preview] Clicked Hide App Preview");
             hqImport('analytix/js/google').track.event("App Preview", "Clicked Hide App Preview");
         }
     };
@@ -70,7 +70,7 @@ hqDefine('app_manager/js/preview_app', function() {
         _private.triggerPreviewEvent('tablet-view');
 
         if (triggerAnalytics) {
-            hqImport('analytix/js/kissmetrics').track.event('[app-preview] User turned on tablet mode');
+            hqImport('analytix/js/kissmetrix').track.event('[app-preview] User turned on tablet mode');
         }
     };
 
@@ -81,7 +81,7 @@ hqDefine('app_manager/js/preview_app', function() {
         _private.triggerPreviewEvent('phone-view');
 
         if (triggerAnalytics) {
-            hqImport('analytix/js/kissmetrics').track.event('[app-preview] User turned off tablet mode');
+            hqImport('analytix/js/kissmetrix').track.event('[app-preview] User turned off tablet mode');
         }
     };
 
@@ -206,7 +206,7 @@ hqDefine('app_manager/js/preview_app', function() {
         $('.js-preview-refresh').click(function() {
             $(module.SELECTORS.BTN_REFRESH).removeClass('app-out-of-date');
             _private.triggerPreviewEvent('refresh');
-            hqImport('analytix/js/kissmetrics').track.event("[app-preview] Clicked Refresh App Preview");
+            hqImport('analytix/js/kissmetrix').track.event("[app-preview] Clicked Refresh App Preview");
             hqImport('analytix/js/google').track.event("App Preview", "Clicked Refresh App Preview");
         });
         $(document).ajaxComplete(function(e, xhr, options) {

--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
@@ -20,7 +20,7 @@ hqDefine("app_manager/js/releases/app_view_release_manager", function() {
     }
 
     $("#onboarding-video").click(function() {
-        hqImport('analytix/js/kissmetrics').track.event('Clicked onboarding video link');
+        hqImport('analytix/js/kissmetrix').track.event('Clicked onboarding video link');
     });
 
     // View changes / app diff
@@ -48,7 +48,7 @@ hqDefine("app_manager/js/releases/app_view_release_manager", function() {
     }
 
     $(function() {
-        hqImport('analytix/js/kissmetrics').track.event('Visited the Release Manager');
+        hqImport('analytix/js/kissmetrix').track.event('Visited the Release Manager');
         if (initial_page_data('confirm')) {
             hqImport('analytix/js/google').track.event('User actions', 'User created login', window.location.pathname);
             hqImport('analytix/js/google').track.event('User actions', 'Forms', 'Name Your First Project');

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -120,7 +120,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.click_app_code = function() {
             self.get_app_code();
             hqImport('analytix/js/google').track.event('App Manager', 'Initiate Install', 'Get App Code');
-            hqImport('analytix/js/kissmetrics').track.event('Initiate Installation Method');
+            hqImport('analytix/js/kissmetrix').track.event('Initiate Installation Method');
         };
         
         self.get_app_code = function() {
@@ -169,7 +169,7 @@ hqDefine('app_manager/js/releases/releases', function () {
 
         self.clickDeploy = function () {
             hqImport('analytix/js/google').track.event('App Manager', 'Deploy Button', self.id());
-            hqImport('analytix/js/kissmetrics').track.event('Clicked Deploy');
+            hqImport('analytix/js/kissmetrix').track.event('Clicked Deploy');
             $.post(releasesMain.reverse('hubspot_click_deploy'));
             self.get_short_odk_url();
         };
@@ -192,7 +192,7 @@ hqDefine('app_manager/js/releases/releases', function () {
 
         self.trackScan = function() {
             hqImport('analytix/js/google').track.event('App Manager', 'Initiate Install', 'Show Bar Code');
-            hqImport('analytix/js/kissmetrics').track.event('Initiate Installation Method');
+            hqImport('analytix/js/kissmetrix').track.event('Initiate Installation Method');
         };
 
         self.reveal_java_download = function(){

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -31,7 +31,7 @@
     <p>
         <button class="btn btn-success" data-bind="
             click: function() {
-                hqImport('analytix/js/kissmetrics').track.event('Clicked Make New Version');
+                hqImport('analytix/js/kissmetrix').track.event('Clicked Make New Version');
                           return makeNewBuild();
             },
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -79,7 +79,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
                 self.updating(true);
                 self.onUpdate();
             }
-            hqImport('analytix/js/kissmetrics').track.event('[app-preview] User toggled CloudCare debugger');
+            hqImport('analytix/js/kissmetrix').track.event('[app-preview] User toggled CloudCare debugger');
         };
         self.collapseNavbar = function() {
             $('.navbar-collapse').collapse('hide');
@@ -362,7 +362,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
                     self.recentXPathQueries.slice(0, 6)
                 );
             });
-            hqImport('analytix/js/kissmetrics').track.event('[app-preview] User evaluated XPath');
+            hqImport('analytix/js/kissmetrix').track.event('[app-preview] User evaluated XPath');
         };
 
         self.onMouseUp = function() {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -147,7 +147,7 @@ FormplayerFrontend.on('startForm', function (data) {
         if (resp.status === "success") {
             showSuccess(gettext("Form successfully saved"), $("#cloudcare-notifications"), 10000);
             if (user.environment === FormplayerFrontend.Constants.PREVIEW_APP_ENVIRONMENT) {
-                hqImport('analytix/js/kissmetrics').track.event("[app-preview] User submitted a form");
+                hqImport('analytix/js/kissmetrix').track.event("[app-preview] User submitted a form");
                 hqImport('analytix/js/google').track.event("App Preview", "User submitted a form");
             }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -88,7 +88,7 @@ FormplayerFrontend.module("Apps.Views", function (Views, FormplayerFrontend, Bac
         },
         startApp: function(e) {
             e.preventDefault();
-            hqImport('analytix/js/kissmetrics').track.event("[app-preview] User clicked Start App");
+            hqImport('analytix/js/kissmetrix').track.event("[app-preview] User clicked Start App");
             hqImport('analytix/js/google').track.event("App Preview", "User clicked Start App");
             FormplayerFrontend.trigger("app:select", this.appId);
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/models.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/models.js
@@ -23,7 +23,7 @@ FormplayerFrontend.module("Users.Models", function(Models, FormplayerFrontend, B
         },
 
         trackVersionChange: function(model) {
-            hqImport('analytix/js/kissmetrics').track.event(
+            hqImport('analytix/js/kissmetrix').track.event(
                 '[app-preview] App version changed',
                 {
                     previousVersion: model.previous('versionInfo'),

--- a/corehq/apps/dashboard/static/dashboard/js/dashboard_new_user.js
+++ b/corehq/apps/dashboard/static/dashboard/js/dashboard_new_user.js
@@ -1,14 +1,14 @@
 /* globals hqDefine */
 hqDefine("static/dashboard/js/dashboard_new_user", function() {
     $(function() {
-        hqImport('analytix/js/kissmetrics').track.event('Visited new user dashboard');
+        hqImport('analytix/js/kissmetrix').track.event('Visited new user dashboard');
         var $links = [];
         var templates = hqImport('hqwebapp/js/initial_page_data').get('templates');
         _.each(templates, function(template, index) {
             $links.push($('.dashboard-link[data-index="' + index + '"]'));
             hqImport('analytix/js/google').track.click($links[index], 'Dashboard', 'Welcome Tile', template.action);
-            hqImport('analytix/js/kissmetrics').track.internalClick($links[index], template.description);
-            hqImport('analytix/js/kissmetrics').track.internalClick($links[index], 'Clicked App Template Tile');
+            hqImport('analytix/js/kissmetrix').track.internalClick($links[index], template.description);
+            hqImport('analytix/js/kissmetrix').track.internalClick($links[index], 'Clicked App Template Tile');
         });
     });
 });

--- a/corehq/apps/dashboard/static/dashboard/js/hq_dashboard.ng.js
+++ b/corehq/apps/dashboard/static/dashboard/js/hq_dashboard.ng.js
@@ -231,7 +231,7 @@
                     }
                     for (var i in currentVal.workflow_labels) {
                         var label = currentVal.workflow_labels[i];
-                        hqImport('analytix/js/kissmetrics').track.internalClick(element, label);
+                        hqImport('analytix/js/kissmetrix').track.internalClick(element, label);
                     }
                 }
             });

--- a/corehq/apps/export/static/export/js/customize_export.js
+++ b/corehq/apps/export/static/export/js/customize_export.js
@@ -406,7 +406,7 @@ var CustomExportView = {
             }
 
             if (!self.custom_export._id || !self.custom_export._id()) {
-                hqImport('analytix/js/kissmetrics').track.event("Clicked 'Create' in export edit page");
+                hqImport('analytix/js/kissmetrix').track.event("Clicked 'Create' in export edit page");
             }
             self.save(false);
         };

--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -138,7 +138,7 @@
             $scope.formData['location_restricted_mobile_worker'] = hqImport('reports/js/reports.util').urlSerialize($('form[name="exportFiltersForm"]'));
             $scope.prepareExportError = null;
             $scope.preparingExport = true;
-            hqImport('analytix/js/kissmetrics').track.event("Clicked Prepare Export");
+            hqImport('analytix/js/kissmetrix').track.event("Clicked Prepare Export");
             djangoRMI.prepare_custom_export({
                 exports: $scope.exportList,
                 max_column_size: self._maxColumnSize,
@@ -282,7 +282,7 @@
             hqImport('analytix/js/google').track.event(
                 "Download Export",
                             hqImport('export/js/utils').capitalize(exportDownloadService.exportType), "Saved");
-            hqImport('analytix/js/kissmetrics').track.event("Clicked Download button");
+            hqImport('analytix/js/kissmetrix').track.event("Clicked Download button");
         };
     };
     download_export.controller(exportsControllers);

--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -109,7 +109,7 @@
             $scope.updateBulkStatus();
         };
         $scope.sendExportAnalytics = function() {
-            hqImport('analytix/js/kissmetrics').track.event("Clicked Export button");
+            hqImport('analytix/js/kissmetrix').track.event("Clicked Export button");
         };
         $scope.updateEmailedExportData = function (component, exp) {
             $('#modalRefreshExportConfirm-' + exp.id + '-' + (component.groupId ? component.groupId : '')).modal('hide');

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -266,7 +266,7 @@ hqDefine('export/js/models', function () {
         if (this.isNew()) {
             eventCategory = constants.ANALYTICS_EVENT_CATEGORIES[this.type()];
             hqImport('analytix/js/google').track.event(eventCategory, 'Custom export creation', '');
-            hqImport('analytix/js/kissmetrics').track.event("Clicked 'Create' in export edit page", callback);
+            hqImport('analytix/js/kissmetrix').track.event("Clicked 'Create' in export edit page", callback);
         } else if (this.export_format !== constants.EXPORT_FORMATS.HTML) {
             callback();
         }

--- a/corehq/apps/export/static/export/spec/DownloadExportFormController.prepare.spec.mo.js
+++ b/corehq/apps/export/static/export/spec/DownloadExportFormController.prepare.spec.mo.js
@@ -29,7 +29,7 @@ describe('DownloadExportFormController - Prepare Download', function() {
             var userTypeCall = hqImport('analytix/js/google').track.event.getCall(lastCallNum - 1);
             assert.isTrue(userTypeCall.calledWith("Download Export", 'Select "user type"', "mobile"));
             assert.isTrue(hqImport('analytix/js/google').track.event.lastCall.calledWith("Download Export", "Form", "Regular"));
-            assert.isTrue(hqImport('analytix/js/kissmetrics').track.event.lastCall.calledWith("Clicked Prepare Export"));
+            assert.isTrue(hqImport('analytix/js/kissmetrix').track.event.lastCall.calledWith("Clicked Prepare Export"));
         });
 
         it('user type analytics', function () {
@@ -46,7 +46,7 @@ describe('DownloadExportFormController - Prepare Download', function() {
                 var userTypeCall = hqImport('analytix/js/google').track.event.getCall(lastCallNum - i);
                 assert.isTrue(userTypeCall.calledWith("Download Export", 'Select "user type"', testUserTypes[testUserTypes.length - i]));
             }
-            assert.isTrue(hqImport('analytix/js/kissmetrics').track.event.lastCall.calledWith("Clicked Prepare Export"));
+            assert.isTrue(hqImport('analytix/js/kissmetrix').track.event.lastCall.calledWith("Clicked Prepare Export"));
         });
 
         it('bulk form analytics', function () {
@@ -57,7 +57,7 @@ describe('DownloadExportFormController - Prepare Download', function() {
             DnldExpData.currentScope.prepareExport();
             DnldExpData.$httpBackend.flush();
             assert.isTrue(hqImport('analytix/js/google').track.event.lastCall.calledWith("Download Export", "Form", "Bulk"));
-            assert.isTrue(hqImport('analytix/js/kissmetrics').track.event.lastCall.calledWith("Clicked Prepare Export"));
+            assert.isTrue(hqImport('analytix/js/kissmetrix').track.event.lastCall.calledWith("Clicked Prepare Export"));
         });
 
         it('start exportDownloadService', function () {
@@ -72,7 +72,7 @@ describe('DownloadExportFormController - Prepare Download', function() {
             assert.isTrue(DnldExpData.currentScope.downloadInProgress);
             assert.isFalse(DnldExpData.exportDownloadService.isMultimediaDownload);
             assert.equal(DnldExpData.exportDownloadService.downloadId, downloadId);
-            assert.isTrue(hqImport('analytix/js/kissmetrics').track.event.lastCall.calledWith("Clicked Prepare Export"));
+            assert.isTrue(hqImport('analytix/js/kissmetrix').track.event.lastCall.calledWith("Clicked Prepare Export"));
         });
 
         it('poll download progress', function () {

--- a/corehq/apps/export/static/export/spec/DownloadProgressController.spec.mo.js
+++ b/corehq/apps/export/static/export/spec/DownloadProgressController.spec.mo.js
@@ -135,7 +135,7 @@ describe('DownloadProgressController', function() {
                     DnldExpData.exportDownloadService.exportType = 'form';
                     DnldExpData.currentScope.sendAnalytics();
                     assert.isTrue(hqImport('analytix/js/google').track.event.lastCall.calledWith("Download Export", "Form", "Saved"));
-                    assert.isTrue(hqImport('analytix/js/kissmetrics').track.event.lastCall.calledWith("Clicked Download button"));
+                    assert.isTrue(hqImport('analytix/js/kissmetrix').track.event.lastCall.calledWith("Clicked Download button"));
                 });
             });
         });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/rollout_modal.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/rollout_modal.js
@@ -7,7 +7,7 @@ hqDefine("hqwebapp/js/rollout_modal", function() {
     function snooze(slug) {
         $.cookie(cookieName(slug), true, { expires: 3, path: '/' });
         _trackSoftRollout.event("snooze", slug);
-        hqImport('analytix/js/kissmetrics').track.event("Soft Rollout snooze " + slug);
+        hqImport('analytix/js/kissmetrix').track.event("Soft Rollout snooze " + slug);
     }
 
     function cookieName(slug) {
@@ -45,7 +45,7 @@ hqDefine("hqwebapp/js/rollout_modal", function() {
                 },
             });
             _trackSoftRollout.event("enable", slug);
-            hqImport('analytix/js/kissmetrics').track.event("Soft Rollout enable " + slug);
+            hqImport('analytix/js/kissmetrix').track.event("Soft Rollout enable " + slug);
         });
 
         // User clicks to snooze
@@ -75,7 +75,7 @@ hqDefine("hqwebapp/js/rollout_modal", function() {
                 },
             });
             _trackSoftRollout.event("disable", slug);
-            hqImport('analytix/js/kissmetrics').track.event("Soft Rollout disable " + slug);
+            hqImport('analytix/js/kissmetrix').track.event("Soft Rollout disable " + slug);
         });
     });
 });

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -36,7 +36,7 @@
     <script>
         hqImport('analytix/js/google').track.event = sinon.spy();
         hqImport('analytix/js/google').track.click = sinon.spy();
-        hqImport('analytix/js/kissmetrics').track.event = sinon.spy();
+        hqImport('analytix/js/kissmetrix').track.event = sinon.spy();
     </script>
   </head>
   <body>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -63,7 +63,7 @@ requires imports/proptable.html to be included in the main template
                 }
             );
             _analytics_usage('Archive Form Submission', analyticsCallback);
-            hqImport('analytix/js/kissmetrics').track.event("Clicked on Archive Form", {}, analyticsCallback);
+            hqImport('analytix/js/kissmetrix').track.event("Clicked on Archive Form", {}, analyticsCallback);
 
             return false;
         });

--- a/corehq/apps/tour/README.md
+++ b/corehq/apps/tour/README.md
@@ -39,7 +39,7 @@ Ideally, you should *avoid* heavily subclassing `StaticGuidedTour`, as that will
                     onShown: function () {
                         // this is a good callback to do fancy things like add analytics.
                         // other useful callbacks are `onHide`. 
-                        hqImport('analytix/js/kissmetrics').track.event('comment');
+                        hqImport('analytix/js/kissmetrix').track.event('comment');
                     }
                 },
                 // below is a good example if you wanted to add/remove classes to highlight the 

--- a/corehq/apps/userreports/static/userreports/js/builder_view_models.js
+++ b/corehq/apps/userreports/static/userreports/js/builder_view_models.js
@@ -274,7 +274,7 @@ hqDefine('userreports/js/builder_view_models', function () {
         this.columns.push(this._createListItem());
         if (!_.isEmpty(this.analyticsAction) && !_.isEmpty(this.analyticsLabel)){
             hqImport('userreports/js/report_analytics').track.event(this.analyticsAction, this.analyticsLabel);
-            hqImport('analytix/js/kissmetrics').track.event("Clicked " + this.analyticsAction + " in Report Builder");
+            hqImport('analytix/js/kissmetrix').track.event("Clicked " + this.analyticsAction + " in Report Builder");
         }
         if (_.isFunction(this.addItemCallback)) {
             this.addItemCallback();

--- a/corehq/apps/userreports/static/userreports/js/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_report.js
@@ -19,7 +19,7 @@ hqDefine("userreports/js/configurable_report", function() {
             });
             hqImport('userreports/js/report_analytics').track.event("Loaded Report Builder Report");
             $editReportButton.click(function () {
-                hqImport('analytix/js/kissmetrics').track.event("RBv2 - Click Edit Report");
+                hqImport('analytix/js/kissmetrix').track.event("RBv2 - Click Edit Report");
             });
         }
 

--- a/corehq/apps/userreports/static/userreports/js/data_source_select.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_select.js
@@ -10,7 +10,7 @@ hqDefine("userreports/js/data_source_select", function() {
         $("#report-builder-form").koApplyBindings(dataSourceSelector);
         $('#js-next-data-source').click(function () {
             hqImport('userreports/js/report_analytics').track.event('Data Source Next', hqImport('hqwebapp/js/main').capitalize(dataSourceSelector.sourceType()));
-            hqImport('analytix/js/kissmetrics').track.event("RBv2 - Data Source");
+            hqImport('analytix/js/kissmetrix').track.event("RBv2 - Data Source");
         });
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/report_analytics.js
+++ b/corehq/apps/userreports/static/userreports/js/report_analytics.js
@@ -4,7 +4,7 @@ hqDefine('userreports/js/report_analytics', function() {
     var trackReportBuilder = hqImport('analytix/js/google').trackCategory("Report Builder v2");
     $(function () {
         $('#js-click-preview-subscribe').click(function () {
-            hqImport('analytix/js/kissmetrics').track.event("RBv2 - Clicks on Subscribe Link in Preview Message Bar");
+            hqImport('analytix/js/kissmetrix').track.event("RBv2 - Clicks on Subscribe Link in Preview Message Bar");
         });
 
         $('#create-new-report-left-nav').click(function () {

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -7,7 +7,7 @@ var reportBuilder = function () {  // eslint-disable-line
     var constants = hqImport('userreports/js/constants');
 
     var _kmq_track_click = function (action) {
-        hqImport('analytix/js/kissmetrics').track.event("RBv2 - " + action);
+        hqImport('analytix/js/kissmetrix').track.event("RBv2 - " + action);
     };
 
     var ColumnProperty = function (getDefaultDisplayText, getPropertyObject, reorderColumns, hasDisplayText) {


### PR DESCRIPTION
Same idea as https://github.com/dimagi/commcare-hq/pull/18650 - for our RequireJS setup, module name needs to match filename.

https://github.com/dimagi/commcarehq-prelogin/pull/148 needs to be deployed at the same time as this.

@calellowitz / @nickpell / @biyeun 

Apropos of nothing, this is my 1000th HQ PR. Whee.