### PR TITLE
update sqlagg to 0.9.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -53,7 +53,7 @@ socketpool==0.5.3
 markdown==2.2.1
 amqp==1.4.7
 amqplib==1.0.2
-sqlagg==0.8.0
+sqlagg==0.9.0
 django-redis==4.2
 redis==2.10.5
 # WeasyPrint==0.20.2


### PR DESCRIPTION
sqlagg 0.9.0 is py3 compatible