### PR TITLE
Delay instantaneous episode update

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/utils.py
+++ b/custom/enikshay/integrations/ninetyninedots/utils.py
@@ -17,7 +17,7 @@ from custom.enikshay.case_utils import (
     get_adherence_cases_between_dates,
 )
 from custom.enikshay.exceptions import ENikshayCaseNotFound
-from custom.enikshay.tasks import EpisodeUpdater
+from custom.enikshay.tasks import update_single_episode
 
 
 class AdherenceCaseFactory(object):
@@ -152,17 +152,8 @@ class AdherenceCaseFactory(object):
         ])
 
     def update_episode_adherence_properties(self):
-        try:
-            updater = EpisodeUpdater(self.domain)
-            updater.update_single_case(self._episode_case)
-        except Exception as e:
-            raise AdherenceException(
-                "Error calculating episode updates for beneficiary: {}, episode case_id({}): {}".format(
-                    self._person_case.case_id,
-                    self._episode_case.case_id,
-                    e
-                )
-            )
+        # update episode 10 minutes later to give the adherence datasource time to catch up
+        update_single_episode.apply_async(args=[self.domain, self._episode_case], countdown=600)
 
 
 def create_adherence_cases(domain, person_id, adherence_points):

--- a/custom/enikshay/integrations/ninetyninedots/views.py
+++ b/custom/enikshay/integrations/ninetyninedots/views.py
@@ -64,7 +64,7 @@ def update_patient_adherence(request, domain):
         validate_adherence_values(adherence_values)
         factory.create_adherence_cases(adherence_values)
     except AdherenceException as e:
-        return json_response({"error": e}, status_code=400)
+        return json_response({"error": six.text_type(e)}, status_code=400)
 
     try:
         factory.update_episode_adherence_properties(domain, beneficiary_id)

--- a/custom/enikshay/integrations/ninetyninedots/views.py
+++ b/custom/enikshay/integrations/ninetyninedots/views.py
@@ -67,7 +67,7 @@ def update_patient_adherence(request, domain):
         return json_response({"error": six.text_type(e)}, status_code=400)
 
     try:
-        factory.update_episode_adherence_properties(domain, beneficiary_id)
+        factory.update_episode_adherence_properties()
     except AdherenceException as e:
         notify_exception(
             request,

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -191,14 +191,6 @@ class EpisodeUpdater(object):
 
         return BatchStatus(update_count, noupdate_count, success_count, errors, case_batches, t.interval)
 
-    def update_single_case(self, episode_case):
-        # updates a single episode_case.
-        assert episode_case.domain == self.domain
-        update_json = EpisodeAdherenceUpdate(self.domain, episode_case).update_json()
-        if update_json:
-            update_case(self.domain, episode_case.case_id, update_json,
-                        device_id="%s.%s" % (__name__, type(self).__name__))
-
     def _get_open_episode_cases(self, case_ids):
         case_accessor = CaseAccessors(self.domain)
         episode_cases = case_accessor.iter_cases(case_ids)
@@ -779,3 +771,11 @@ def get_updated_fields(existing_properties, new_properties):
         if existing_value != new_value:
             updated_fields[prop] = value
     return updated_fields
+
+
+@task
+def update_single_episode(domain, episode_case):
+    update_json = EpisodeAdherenceUpdate(domain, episode_case).update_json()
+    if update_json:
+        update_case(domain, episode_case.case_id, update_json,
+                    device_id="%s.%s" % (__name__, 'update_single_episode'))

--- a/custom/enikshay/tests/test_adherence_updates.py
+++ b/custom/enikshay/tests/test_adherence_updates.py
@@ -25,6 +25,7 @@ from custom.enikshay.tasks import (
     EpisodeAdherenceUpdate,
     calculate_dose_status_by_day,
     get_datastore,
+    update_single_episode,
 )
 from custom.enikshay.tests.utils import (
     get_person_case_structure,
@@ -766,8 +767,7 @@ class TestAdherenceUpdater(TestCase):
             'schedule1',
             []
         )
-        updater = EpisodeUpdater(self.domain)
-        updater.update_single_case(episode)
+        update_single_episode(self.domain, episode)
 
         episode = CaseAccessors(self.domain).get_case(episode.case_id)
         self.assertDictEqual(


### PR DESCRIPTION
https://trello.com/c/rctE2lqF/266-immediately-updating-adherence-counts-with-99dots-data-doesnt-work-as-adherence-pillow-can-be-behind

@mkangia 
Also fixes a bug where exceptions weren't sent properly to 99DOTS. 