### PR TITLE
just call the callback when not needed to track the event

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -85,6 +85,8 @@ hqDefine('analytix/js/google', function () {
             }
             logger.debug.log(logger.fmt.labelArgs(["Category", "Action", "Label", "Value", "Parameters", "Callback"], arguments), "Event Recorded");
             _gtag('event', eventAction, params);
+        } else if (eventCallback) {
+            eventCallback();
         }
     };
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266052

introduced #18615

Not sure if @biyeun wants to do this differently so just sharing a possible fix

`_global('isEnabled')` is enabled only for sass environment which is production. Hence just call the callback without tracking the event when non-sass environment