### PR TITLE
Allow clearing date spans in reports

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -49,7 +49,7 @@
 
         var $el = $(this);
         $el.daterangepicker(config);
-        $el.on('cancel.daterangepicker', function(ev, picker) {
+        $el.on('cancel.daterangepicker', function() {
             $el.val('');
         });
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -37,7 +37,8 @@
             timePicker: false,
             locale: {
                 format: 'YYYY-MM-DD',
-                separator: separator
+                separator: separator,
+                cancelLabel: gettext('Clear'),
             }
         };
         var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
@@ -46,7 +47,11 @@
             config.endDate = getLocalDate(enddate);
         }
 
-        $(this).daterangepicker(config);
+        var $el = $(this);
+        $el.daterangepicker(config);
+        $el.on('cancel.daterangepicker', function(ev, picker) {
+            $el.val('');
+        });
 
         if (! hasStartAndEndDate){
             $(this).val("");

--- a/corehq/apps/reports/templates/reports/filters/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/datespan.html
@@ -8,6 +8,7 @@
                    id="filter_range"
                    class="date-range-picker form-control report-filter-datespan"
                    value="{{ datespan.startdate|date:'Y-m-d' }} to {{ datespan.enddate|date:'Y-m-d' }}"
+                   placeholder="{% trans "Show All Dates"|escapejs %}"
                    data-init="{% block init_filter %}{% if slug == 'datespan' %}1{% endif %}{% endblock %}"
                    data-separator="{% html_attr separator %}" 
                    data-report-labels="{% html_attr report_labels %}"

--- a/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
@@ -14,7 +14,5 @@
     if (!$(filter_id).val() && $(filter_id_start).val() && $(filter_id_end).val()) {
         var text = $(filter_id_start).val() + $().getDateRangeSeparator() + $(filter_id_end).val();
         $(filter_id).val(text);
-    } else if (!$(filter_id).val()) {
-        $(filter_id).val(gettext("Show All Dates"));
     }
 })($, gettext);


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266238

Took a suggestion from the [daterangepicker docs](http://www.daterangepicker.com/) and replaced the "Cancel" button with a "Clear" button.

@dimagi/product What do y'all think? It does get rid of the ability to cancel, but it saves adding another button.

Before
<img width="768" alt="screen shot 2017-11-28 at 10 50 26 pm" src="https://user-images.githubusercontent.com/1486591/33357178-bd4ac8ec-d48e-11e7-9546-529912669c57.png">

After
<img width="783" alt="screen shot 2017-11-28 at 10 49 52 pm" src="https://user-images.githubusercontent.com/1486591/33357185-c1b9be6a-d48e-11e7-9e6e-7fecdc298aad.png">