### PR TITLE
revert to correct check

### DIFF
--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -87,7 +87,7 @@ def _get_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exp
         from corehq.apps.export.utils import revert_new_exports
         exports += revert_new_exports(new_exports)
     if not has_deid_permissions:
-        exports = [e for e in exports if e.is_safe]
+        exports = [e for e in exports if not e.is_safe]
     return sorted(exports, key=lambda x: x.name)
 
 


### PR DESCRIPTION
ref: https://github.com/dimagi/commcare-hq/pull/18606/files/089e99d10918639acc0c0644de6b611096bf0f92#diff-9f9d725e8ca653954d8185b645b981ffR90
@orangejenny `is_safe` means `is_deidentified`

Fixes a bug in exports list that prevents exports from being shown