### PR TITLE
Fix bug preventing resume iteration with old state

### DIFF
--- a/corehq/util/doc_processor/sql.py
+++ b/corehq/util/doc_processor/sql.py
@@ -44,8 +44,12 @@ def resumable_sql_model_iterator(iteration_key, reindex_accessor, chunk_size=100
     that were previously yielded may be yielded again if the iteration
     is stopped and later resumed.
     """
+    NULL = object()
 
-    def data_function(from_db, last_id):
+    def data_function(from_db, filter_value, last_id=NULL):
+        if last_id is NULL:
+            # adapt to old iteration states
+            last_id = filter_value
         return reindex_accessor.get_docs(from_db, last_id, limit=chunk_size)
 
     args_provider = SqlModelArgsProvider(reindex_accessor.sql_db_aliases)

--- a/corehq/util/tests/test_doc_processor.py
+++ b/corehq/util/tests/test_doc_processor.py
@@ -205,6 +205,18 @@ class BaseResumableSqlModelIteratorTest(object):
         self.itr = self.get_iterator()
         self.assertEqual([doc["_id"] for doc in self.itr], self.all_doc_ids[4:])
 
+    def test_resume_iteration_with_v1_persistent_state(self):
+        itr = iter(self.itr)
+        self.assertEqual([next(itr)["_id"] for i in range(6)], self.all_doc_ids[:6])
+        # simulate old state
+        # do not change this unless there are no existing iterations in progress
+        arg0, arg1 = self.itr.state.args
+        self.itr.state.args = [arg0, "legacy/ignored filter_value", arg1]
+        self.itr._save_state()
+        # stop/resume iteration
+        self.itr = self.get_iterator()
+        self.assertEqual([doc["_id"] for doc in self.itr], self.all_doc_ids[4:])
+
     def test_resume_iteration_with_new_chunk_size(self):
         def data_function(*args, **kw):
             chunk = real_data_function(*args, **kw)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/18630/files#r153854092

This prevented resuming the blob db migration. When I tried to restart it today I got the following error:
```
Traceback (most recent call last):
  File "manage.py", line 132, in <module>
    execute_from_command_line(sys.argv)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/python_env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/home/cchq/www/production/releases/2017-11-29_10.33/python_env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/python_env/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/python_env/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/util/decorators.py", line 26, in decorated
    return fn(*args, **kwds)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/util/decorators.py", line 26, in decorated
    return fn(*args, **kwds)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/blobs/management/commands/run_blob_migration.py", line 81, in handle
    do_migration()
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/blobs/management/commands/run_blob_migration.py", line 64, in do_migration
    chunk_size=chunk_size,
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/blobs/migrate.py", line 573, in migrate
    one_migrated, one_skipped = item.migrate(filen(n), *args, **kw)
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/blobs/migrate.py", line 524, in migrate
    return processor.run()
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/util/doc_processor/interface.py", line 200, in run
    for doc in self.document_iterator:
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/util/doc_processor/sql.py", line 55, in __iter__
    for doc in super(ResumableModelIterator, self).__iter__():
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/util/pagination.py", line 194, in __iter__
    for item in paginate_function(self.data_function, resumable_args, event_handler):
  File "/home/cchq/www/production/releases/2017-11-29_10.33/corehq/util/pagination.py", line 102, in paginate_function
    results = data_function(*args, **kwargs)
TypeError: data_function() takes exactly 2 arguments (3 given)
```
cc @gcapalbo 