### PR TITLE
Fix for regression: can't create exports

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -266,7 +266,7 @@ hqDefine('export/js/models', function () {
         if (this.isNew()) {
             eventCategory = constants.ANALYTICS_EVENT_CATEGORIES[this.type()];
             hqImport('analytix/js/google').track.event(eventCategory, 'Custom export creation', '');
-            hqImport('analytix/js/kissmetrix').track.event("Clicked 'Create' in export edit page", callback);
+            hqImport('analytix/js/kissmetrix').track.event("Clicked 'Create' in export edit page", {}, callback);
         } else if (this.export_format !== constants.EXPORT_FORMATS.HTML) {
             callback();
         }


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266305

Similar to https://github.com/dimagi/commcare-hq/pull/18688 and https://github.com/dimagi/commcare-hq/pull/18703 in that an analytics callback wasn't being fired, but just because of an error in the call rather than a problem with the analytics code itself.

Introduced in https://github.com/dimagi/commcare-hq/commit/aeda83e313c1cd55ea4c5c659558300298858cfc

@calellowitz / @mkangia 
fyi @biyeun 