### PR TITLE
Make daily saved export url consistent

### DIFF
--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -117,7 +117,7 @@ urlpatterns = [
     url(r"^custom/new/case/download/(?P<export_id>[\w\-]+)/$",
         DownloadNewCaseExportView.as_view(),
         name=DownloadNewCaseExportView.urlname),
-    url(r"^custom/dailysaved/download/(?P<export_instance_id>[\w\-]+)/$",
+    url(r"^custom/daily_saved/download/(?P<export_instance_id>[\w\-]+)/$",
         download_daily_saved_export,
         name="download_daily_saved_export"),
     url(r"^custom/new/sms/download/$",
@@ -169,9 +169,6 @@ urlpatterns = [
         DailySavedExportPaywall.as_view(),
         name=DailySavedExportPaywall.urlname),
 
-    url(r"^custom/dailysaved/download/(?P<export_instance_id>[\w\-]+)/$",
-        download_daily_saved_export,
-        name="download_daily_saved_export"),
     url(r"^build_full_schema/$",
         GenerateSchemaFromAllBuildsView.as_view(),
         name=GenerateSchemaFromAllBuildsView.urlname),


### PR DESCRIPTION
Minor, but I got briefly tripped up by `daily_saved` vs `dailysaved` while doing https://github.com/dimagi/commcare-hq/pull/18726

Calling this all-users-all-enviroments is kind of pedantic - the only way a user would be affected is if they have a daily saved export bookmarked, and making them update that URL seems minor enough.

@calellowitz / @mkangia 