### PR TITLE
Restore proper search icon size in web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -11,7 +11,7 @@
           <input type="text" class="form-control" placeholder="Search" id="searchText">
           <div class="input-group-btn">
             <button class="btn btn-default" type="button" id="case-list-search-button">
-                <i class="fa fa-search fa-4x" aria-hidden="true"></i>
+                <i class="fa fa-search" aria-hidden="true"></i>
             </button>
           </div>
         </div>


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266389

Fixes regression where search icon in web apps was appearing too large.

Directly caused by https://github.com/dimagi/commcare-hq/pull/18709/commits/ae21524652623d3dc715004464b7a843afa0d22a which turned out not to be a glyphicons-specific workaround. But it also turns out that there's a specific class being applied to this icon to make it 4 times bigger than normal, so removing that sets the icon back to normal size.

@calellowitz 