### PR TITLE
Fix ICDS Tableau dashboard

### DIFF
--- a/custom/icds_reports/templates/icds_reports/tableau.html
+++ b/custom/icds_reports/templates/icds_reports/tableau.html
@@ -61,6 +61,7 @@
     <script type="text/javascript" src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'tableau.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'knockout/dist/knockout.js' %}"></script>
+    <script type="text/javascript" src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
     <script type="text/javascript" src="{% static 'hqwebapp/js/hq.helpers.js' %}"></script>
     <script type="text/javascript" src="{% static 'select2/dist/js/select2.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'underscore/underscore.js' %}"></script>


### PR DESCRIPTION
Broke because https://github.com/dimagi/commcare-hq/pull/18116 changed `hq.helpers.js` to use `hqDefine` but this template didn't have `hqModules.js` available.

@emord 