### PR TITLE
Dont fail hard when fetching url for repeat records without repeaters

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2427,7 +2427,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
     def _make_row(self, record):
         row = [
             self._make_state_label(record),
-            record.url if record.url else _(u'Unable to generate url for record'),
+            record.repeater.get_url if record.repeater else _(u'Unable to generate url for record'),
             self._format_date(record.last_checked) if record.last_checked else '---',
             self._format_date(record.next_check) if record.next_check else '---',
             render_to_string('domain/repeaters/partials/attempt_history.html', {'record': record}),

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -527,12 +527,16 @@ class RepeatRecord(Document):
     @property
     @memoized
     def repeater(self):
-        return Repeater.get(self.repeater_id)
+        try:
+            return Repeater.get(self.repeater_id)
+        except ResourceNotFound:
+            return None
 
     @property
     def url(self):
         warnings.warn("RepeatRecord.url is deprecated. Use Repeater.get_url instead", DeprecationWarning)
-        return self.repeater.get_url(self)
+        if self.repeater:
+            return self.repeater.get_url(self)
 
     @property
     def state(self):


### PR DESCRIPTION
[Sentry](https://sentry.io/dimagi/commcarehq/issues/353119705/)
[ticket](https://manage.dimagi.com/default.asp?266458#1428820)

Changes in PR:
1. Fix bug: Dont fail hard when missing deleted repeaters for repeat records.
2. Skip use of deprecated method `url` on repeat record.