### PR TITLE
proper handling for no profile

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -10,7 +10,6 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
-from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_all_built_app_ids_and_versions, get_app
 from corehq.apps.app_manager.decorators import safe_download, safe_cached_download
 from corehq.apps.app_manager.exceptions import ModuleNotFoundException, \
@@ -32,6 +31,13 @@ BAD_BUILD_MESSAGE = _("Sorry: this build is invalid. Try deleting it and rebuild
                       "If error persists, please contact us at commcarehq-support@dimagi.com")
 
 
+def _get_profile(request):
+    profile = request.GET.get('profile')
+    if profile not in (None, 'None'):
+        return profile
+    else:
+        return None
+
 @safe_download
 def download_odk_profile(request, domain, app_id):
     """
@@ -43,7 +49,7 @@ def download_odk_profile(request, domain, app_id):
         make_async_build.delay(request.app, username)
     else:
         request._always_allow_browser_caching = True
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_profile(is_odk=True, build_profile_id=profile),
         content_type="commcare/profile"
@@ -57,7 +63,7 @@ def download_odk_media_profile(request, domain, app_id):
         make_async_build.delay(request.app, username)
     else:
         request._always_allow_browser_caching = True
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_profile(is_odk=True, with_media=True, build_profile_id=profile),
         content_type="commcare/profile"
@@ -73,7 +79,7 @@ def download_suite(request, domain, app_id):
     if not request.app.copy_of:
         previous_version = request.app.get_latest_app(released_only=False)
         request.app.set_form_versions(previous_version)
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_suite(build_profile_id=profile)
     )
@@ -88,7 +94,7 @@ def download_media_suite(request, domain, app_id):
     if not request.app.copy_of:
         previous_version = request.app.get_latest_app(released_only=False)
         request.app.set_media_versions(previous_version)
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_media_suite(build_profile_id=profile)
     )
@@ -100,7 +106,7 @@ def download_app_strings(request, domain, app_id, lang):
     See Application.create_app_strings
 
     """
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_app_strings(lang, build_profile_id=profile)
     )
@@ -112,7 +118,7 @@ def download_xform(request, domain, app_id, module_id, form_id):
     See Application.fetch_xform
 
     """
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     try:
         return HttpResponse(
             request.app.fetch_xform(module_id, form_id, build_profile_id=profile)
@@ -328,7 +334,7 @@ def download_profile(request, domain, app_id):
         make_async_build.delay(request.app, username)
     else:
         request._always_allow_browser_caching = True
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_profile(build_profile_id=profile)
     )
@@ -341,7 +347,7 @@ def download_media_profile(request, domain, app_id):
         make_async_build.delay(request.app, username)
     else:
         request._always_allow_browser_caching = True
-    profile = request.GET.get('profile')
+    profile = _get_profile(request)
     return HttpResponse(
         request.app.create_profile(with_media=True, build_profile_id=profile)
     )

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -33,7 +33,7 @@ BAD_BUILD_MESSAGE = _("Sorry: this build is invalid. Try deleting it and rebuild
 
 def _get_profile(request):
     profile = request.GET.get('profile')
-    if profile not in (None, 'None'):
+    if profile not in request.app.build_profiles:
         return profile
     else:
         return None

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -33,7 +33,7 @@ BAD_BUILD_MESSAGE = _("Sorry: this build is invalid. Try deleting it and rebuild
 
 def _get_profile(request):
     profile = request.GET.get('profile')
-    if profile not in request.app.build_profiles:
+    if profile in request.app.build_profiles:
         return profile
     else:
         return None


### PR DESCRIPTION
Fixes regression where updating to latest saved state was failing on mobile.

@orangejenny cc: @sravfeyn 
sometimes mobile sends the build profile as `'None'` the string, instead of nothing. this handles that.