### PR TITLE
add feature flag for domain to retry failed SMS messages indefinitely

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -49,7 +49,7 @@ def handle_unsuccessful_processing_attempt(msg):
     msg.num_processing_attempts += 1
     if msg.num_processing_attempts < settings.SMS_QUEUE_MAX_PROCESSING_ATTEMPTS:
         delay_processing(msg, settings.SMS_QUEUE_REPROCESS_INTERVAL)
-    elif RETRY_SMS_INDEFINITELY.enabled(msg.domain):
+    elif msg.direction == OUTGOING and RETRY_SMS_INDEFINITELY.enabled(msg.domain):
         delay_processing(msg, settings.SMS_QUEUE_REPROCESS_INDEFINITELY_INTERVAL)
     else:
         msg.set_system_error(SMS.ERROR_TOO_MANY_UNSUCCESSFUL_ATTEMPTS)

--- a/corehq/apps/sms/tests/test_queueing.py
+++ b/corehq/apps/sms/tests/test_queueing.py
@@ -13,6 +13,9 @@ from django.test.utils import override_settings
 from mock import Mock, patch
 from six.moves import range
 
+from corehq.toggles import RETRY_SMS_INDEFINITELY, NAMESPACE_DOMAIN
+from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
+
 
 def patch_datetime_api(timestamp):
     return patch('corehq.apps.sms.api.get_utcnow', new=Mock(return_value=timestamp))
@@ -75,6 +78,8 @@ class QueueingTestCase(BaseSMSTest):
         QueuedSMS.objects.all().delete()
         SMS.objects.filter(domain=self.domain).delete()
         self.domain_obj.delete()
+
+        clear_toggle_cache(RETRY_SMS_INDEFINITELY.slug, self.domain, NAMESPACE_DOMAIN)
 
         super(QueueingTestCase, self).tearDown()
 
@@ -179,6 +184,66 @@ class QueueingTestCase(BaseSMSTest):
         self.assertEqual(reporting_sms.error, True)
         self.assertEqual(reporting_sms.num_processing_attempts, settings.SMS_QUEUE_MAX_PROCESSING_ATTEMPTS)
         self.assertBillableDoesNotExist(reporting_sms.couch_id)
+
+    def test_outgoing_failure_indefinite_retry(self, process_sms_delay_mock, enqueue_directly_mock):
+        timestamp = datetime(2016, 1, 1, 12, 0)
+        update_toggle_cache(RETRY_SMS_INDEFINITELY.slug, self.domain, True, NAMESPACE_DOMAIN)
+
+        with patch_datetime_api(timestamp):
+            send_sms(self.domain, None, '+999123', 'test outgoing')
+
+        self.assertEqual(enqueue_directly_mock.call_count, 1)
+        self.assertEqual(self.queued_sms_count, 1)
+        self.assertEqual(self.reporting_sms_count, 0)
+
+        for i in range(settings.SMS_QUEUE_MAX_PROCESSING_ATTEMPTS):
+            queued_sms = self.get_queued_sms()
+            self.assertEqual(queued_sms.domain, self.domain)
+            self.assertEqual(queued_sms.phone_number, '+999123')
+            self.assertEqual(queued_sms.text, 'test outgoing')
+            self.assertEqual(queued_sms.datetime_to_process, timestamp)
+            self.assertEqual(queued_sms.processed, False)
+            self.assertEqual(queued_sms.error, False)
+            self.assertEqual(queued_sms.num_processing_attempts, i)
+
+            with patch_failed_send() as send_mock, patch_datetime_tasks(timestamp + timedelta(seconds=1)):
+                process_sms(queued_sms.pk)
+
+            self.assertEqual(process_sms_delay_mock.call_count, 0)
+            self.assertBillableDoesNotExist(queued_sms.couch_id)
+
+            self.assertEqual(send_mock.call_count, 1)
+            self.assertEqual(self.queued_sms_count, 1)
+            self.assertEqual(self.reporting_sms_count, 0)
+            timestamp += timedelta(minutes=settings.SMS_QUEUE_REPROCESS_INTERVAL)
+
+        timestamp += (
+            timedelta(minutes=settings.SMS_QUEUE_REPROCESS_INDEFINITELY_INTERVAL)
+            - timedelta(minutes=settings.SMS_QUEUE_REPROCESS_INTERVAL)
+        )
+        queued_sms = self.get_queued_sms()
+        self.assertEqual(queued_sms.domain, self.domain)
+        self.assertEqual(queued_sms.phone_number, '+999123')
+        self.assertEqual(queued_sms.text, 'test outgoing')
+        self.assertEqual(queued_sms.datetime_to_process, timestamp)
+        self.assertEqual(queued_sms.processed, False)
+        self.assertEqual(queued_sms.error, False)
+        self.assertEqual(queued_sms.num_processing_attempts, settings.SMS_QUEUE_MAX_PROCESSING_ATTEMPTS)
+
+        with patch_successful_send() as send_mock, patch_datetime_tasks(timestamp + timedelta(seconds=1)):
+            process_sms(queued_sms.pk)
+
+        self.assertEqual(send_mock.call_count, 1)
+        self.assertEqual(self.queued_sms_count, 0)
+        self.assertEqual(self.reporting_sms_count, 1)
+
+        reporting_sms = self.get_reporting_sms()
+        self.assertEqual(reporting_sms.processed, True)
+        self.assertEqual(reporting_sms.error, False)
+        self.assertEqual(reporting_sms.num_processing_attempts, settings.SMS_QUEUE_MAX_PROCESSING_ATTEMPTS + 1)
+
+        self.assertEqual(process_sms_delay_mock.call_count, 0)
+        self.assertBillableExists(reporting_sms.couch_id)
 
     def test_outgoing_failure_recovery(self, process_sms_delay_mock, enqueue_directly_mock):
         timestamp = datetime(2016, 1, 1, 12, 0)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -880,7 +880,7 @@ RETRY_SMS_INDEFINITELY = StaticToggle(
     'Enikshay: Retry SMS indefinitely',
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN],
-    description='Requeues an SMS that has reached the maximum number of unsuccessful attempts.',
+    description='Leaves on the queue an SMS that has reached the maximum number of unsuccessful attempts.',
 )
 
 OPENMRS_INTEGRATION = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -875,6 +875,14 @@ BETS_INTEGRATION = StaticToggle(
     always_enabled={"enikshay"},
 )
 
+RETRY_SMS_INDEFINITELY = StaticToggle(
+    'retry_sms_indefinitely',
+    'Enikshay: Retry SMS indefinitely',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+    description='Requeues an SMS that has reached the maximum number of unsuccessful attempts.',
+)
+
 OPENMRS_INTEGRATION = StaticToggle(
     'openmrs_integration',
     'FGH: Enable OpenMRS integration',

--- a/settings.py
+++ b/settings.py
@@ -623,6 +623,10 @@ SMS_QUEUE_PROCESSING_LOCK_TIMEOUT = 5
 # for a single SMS
 SMS_QUEUE_REPROCESS_INTERVAL = 5
 
+# Number of minutes to wait before retrying an SMS that has reached
+# the default maximum number of processing attempts
+SMS_QUEUE_REPROCESS_INDEFINITELY_INTERVAL = 60 * 6
+
 # Max number of processing attempts before giving up on processing the SMS
 SMS_QUEUE_MAX_PROCESSING_ATTEMPTS = 3
 


### PR DESCRIPTION
Product Note: Adds feature flag for enikshay so outgoing SMS messages that have reached the maximum number of failed attempts can still be retried, at a less frequent interval than the normal retry schedule, instead of never attempting the SMS again.

Set the retry interval for SMSs that have failed the maximum number of times to 6 hours.

https://trello.com/c/687nFMt2/281-configure-sms-reminders-to-dictate-whether-messages-are-sticky-which-can-be-retried

@gcapalbo @ctsims 