### PR TITLE
prep for running filter conversion script

### DIFF
--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -899,7 +899,7 @@ def _has_at_least_one_translation(row, prefix, langs):
     :param langs:
     :return:
     """
-    return bool(filter(None, [row.get(prefix + '_' + l) for l in langs]))
+    return any(row.get(prefix + '_' + l) for l in langs)
 
 
 def _get_col_key(translation_type, language):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -152,6 +152,7 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.reports.daterange import get_daterange_start_end_dates, get_simple_dateranges
 from jsonpath_rw import jsonpath, parse
 import six
+from six.moves import filter
 from six.moves import range
 from six.moves import map
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -64,6 +64,7 @@ from corehq.apps.users.decorators import require_can_edit_commcare_users
 from corehq.apps.users.views import BaseUserSettingsView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.exceptions import XFormNotFound
+from six.moves import filter
 from six.moves import map
 
 

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -28,6 +28,7 @@ from corehq.util.quickcache import quickcache
 from . import const
 from .const import StockActions
 import six
+from six.moves import filter
 
 
 STOCK_ACTION_ORDER = [

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext as _
 
 from .dbaccessors import get_by_domain_and_type
 import six
+from six.moves import filter
 
 
 CUSTOM_DATA_FIELD_PREFIX = "data-field"

--- a/corehq/apps/reports/exportfilters.py
+++ b/corehq/apps/reports/exportfilters.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from casexml.apps.case.xform import is_device_report
+from six.moves import filter  # keep unused import so py3 conversion scripts don't rewrite file
 
 
 def form_matches_users(form, users):

--- a/corehq/apps/userreports/tests/test_filters.py
+++ b/corehq/apps/userreports/tests/test_filters.py
@@ -4,6 +4,7 @@ from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.filters import ANDFilter, ORFilter, NOTFilter
 from corehq.apps.userreports.filters.factory import FilterFactory
 from corehq.apps.userreports.specs import FactoryContext
+from six.moves import filter  # keep unused import so py3 conversion scripts don't rewrite file
 
 
 class PropertyMatchFilterTest(SimpleTestCase):

--- a/corehq/util/couch_helpers.py
+++ b/corehq/util/couch_helpers.py
@@ -6,6 +6,7 @@ from copy import copy
 from mimetypes import guess_type
 from corehq.util.pagination import paginate_function, PaginationEventHandler, ArgsProvider
 import six
+from six.moves import filter
 
 
 class CouchAttachmentsBuilder(object):

--- a/custom/enikshay/tests/test_user_setup.py
+++ b/custom/enikshay/tests/test_user_setup.py
@@ -31,6 +31,7 @@ from ..user_setup import (
     set_enikshay_device_id,
 )
 from ..models import IssuerId
+from six.moves import filter
 
 
 @flag_enabled('ENIKSHAY')

--- a/custom/enikshay/two_b_datamigration/management/commands/import_drtb_cases.py
+++ b/custom/enikshay/two_b_datamigration/management/commands/import_drtb_cases.py
@@ -122,6 +122,7 @@ from custom.enikshay.two_b_datamigration.models import MigratedDRTBCaseCounter
 from custom.enikshay.user_setup import compress_nikshay_id
 from dimagi.utils.decorators.memoized import memoized
 import six
+from six.moves import filter
 from six.moves import range
 
 logger = logging.getLogger('two_b_datamigration')

--- a/custom/enikshay/two_b_release_1/management/commands/enikshay_2b_case_properties.py
+++ b/custom/enikshay/two_b_release_1/management/commands/enikshay_2b_case_properties.py
@@ -23,6 +23,7 @@ from custom.enikshay.case_utils import (
     CASE_TYPE_EPISODE, CASE_TYPE_TEST, CASE_TYPE_TRAIL,
     CASE_TYPE_DRTB_HIV_REFERRAL, CASE_TYPE_SECONDARY_OWNER)
 from custom.enikshay.const import ENROLLED_IN_PRIVATE, CASE_VERSION
+from six.moves import filter
 from six.moves import input
 
 logger = logging.getLogger('two_b_datamigration')
@@ -205,7 +206,7 @@ class ENikshay2BMigrator(object):
                 yield person
 
     def migrate_person_case_set(self, person):
-        changes = filter(None,
+        changes = list(filter(None,
             [self.migrate_person(person.person, person.occurrences, person.episodes)]
             + [self.migrate_occurrence(occurrence, person.episodes) for occurrence in person.occurrences]
             + [self.migrate_episode(episode, person.episodes) for episode in person.episodes]
@@ -215,7 +216,7 @@ class ENikshay2BMigrator(object):
             + [self.open_secondary_owners(drtb_hiv, person.person, person.occurrences)
                for drtb_hiv in person.drtb_hiv]
             + [self.close_drtb_hiv(drtb_hiv) for drtb_hiv in person.drtb_hiv]
-        )
+        ))
         if self.commit:
             self.factory.create_or_update_cases(changes)
 

--- a/custom/enikshay/two_b_release_1/management/commands/enikshay_2b_cbnaat_fix.py
+++ b/custom/enikshay/two_b_release_1/management/commands/enikshay_2b_cbnaat_fix.py
@@ -7,6 +7,7 @@ from django.core.management import BaseCommand
 from casexml.apps.case.mock import CaseStructure, CaseFactory
 from casexml.apps.case.xform import get_case_updates
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from six.moves import filter
 
 logger = logging.getLogger('enikshay_2b_cbnaat_fix')
 

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -10,6 +10,7 @@ from corehq.apps.userreports.specs import TypeProperty
 from corehq.elastic import mget_query
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from dimagi.ext.jsonobject import JsonObject, ListProperty, StringProperty, DictProperty, BooleanProperty
+from six.moves import filter
 from six.moves import map
 
 
@@ -195,7 +196,7 @@ class FormsInDateExpressionSpec(JsonObject):
             return xform
 
         forms = mget_query('forms', xform_ids, ['form.meta.timeEnd', 'xmlns', '_id'])
-        forms = filter(None, list(map(_transform_time_end, forms)))
+        forms = list(filter(None, map(_transform_time_end, forms)))
         context.set_cache_value(cache_key, forms)
         return forms
 


### PR DESCRIPTION
These changes will make the PR for running ```python-modernize . -w -f libmodernize.fixes.fix_filter``` much cleaner.

Recommend 🐡 

First commit replaces a usage of ```filter``` with a cleaner implementation.

Second commit adds a ```filter``` import statement so conversion scripts won't apply to overridden usages of ```filter```.

Third commit adds a ```filter``` import statement to prevent the conversion script from replacing ```filter(None, ...)``` syntax with a messier list comprehension.  I only did this in cases where it was obviously ok to do, and will let the conversion script replace with list comprehensions in all other occurrences.

@dimagi/py3 