### PR TITLE
hypelink when available

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -25,12 +25,7 @@
             </div>
             {% if doc_id %}
                 <h3>Doc {{ doc_id }} {{ es_info.status }}</h3>
-                <p>
-                Doc type: {{ couch_info.doc_type }}
-                {% if hq_url %}
-                    (<a href="{{hq_url}}">View on CommCareHQ</a>)
-                {% endif %}
-                </p>
+                <p>Doc type: {{ couch_info.doc_type }}</p>
                 {% for index, es_doc in es_info.found_indices.items %}
                     <p>Found in index: {{ index }}</p>
                     <div class="row">

--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -25,7 +25,12 @@
             </div>
             {% if doc_id %}
                 <h3>Doc {{ doc_id }} {{ es_info.status }}</h3>
-                <p>Doc type: {{ couch_info.doc_type }}</p>
+                <p>
+                Doc type: {{ couch_info.doc_type }}
+                {% if hq_url %}
+                    (<a href="{{hq_url}}">View on CommCareHQ</a>)
+                {% endif %}
+                </p>
                 {% for index, es_doc in es_info.found_indices.items %}
                     <p>Found in index: {{ index }}</p>
                     <div class="row">

--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -25,7 +25,9 @@
             </div>
             {% if doc_id %}
                 <h3>Doc {{ doc_id }} {{ es_info.status }}</h3>
-                <p>Doc type: {{ couch_info.doc_type }}</p>
+                <p>Doc type: {{ couch_info.doc_type }}
+                    (<a href="{% url 'global_quick_find' %}?q={{ doc_id }}">View on CommCareHQ</a>)
+                </p>
                 {% for index, es_doc in es_info.found_indices.items %}
                     <p>Found in index: {{ index }}</p>
                     <div class="row">

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -954,26 +954,6 @@ def doc_in_es(request):
     def to_json(doc):
         return json.dumps(doc, indent=4, sort_keys=True) if doc else "NOT FOUND!"
 
-    def hq_url(doc):
-        if not doc:
-            return
-        from corehq.apps.users.views.mobile.users import EditCommCareUserView
-        from corehq.apps.users.views import EditWebUserView
-        from corehq.apps.userreports.views import EditDataSourceView, ConfigureReport
-
-        doc_type = doc.get('doc_type')
-        url_map = {
-            'Application': 'view_app',
-            'CommCareUser': EditCommCareUserView.urlname,
-            'WebUser': EditWebUserView.urlname,
-            'DataSourceConfiguration': EditDataSourceView.urlname,
-            'ReportConfiguration': ConfigureReport.urlname,
-        }
-        if doc_type in url_map:
-            return reverse(url_map[doc_type], args=[doc['domain'], doc_id])
-        else:
-            return None
-
     query = {"filter": {"ids": {"values": [doc_id]}}}
     found_indices = {}
     es_doc_type = None
@@ -984,7 +964,6 @@ def doc_in_es(request):
             found_indices[index] = to_json(es_doc)
             es_doc_type = es_doc_type or es_doc.get('doc_type')
 
-    couch_info = _lookup_id_in_database(doc_id)
     context = {
         "doc_id": doc_id,
         "es_info": {
@@ -992,8 +971,7 @@ def doc_in_es(request):
             "doc_type": es_doc_type,
             "found_indices": found_indices,
         },
-        "couch_info": couch_info,
-        "hq_url": hq_url(json.loads(couch_info.get('doc'))),
+        "couch_info": _lookup_id_in_database(doc_id),
     }
     return render(request, "hqadmin/doc_in_es.html", context)
 


### PR DESCRIPTION
When you search in HQ by doc_id, a corresponding HQ link for that doc will be displayed if available. For e.g. if you search for an application ID, a link to view the app will be displayed.

<img width="582" alt="screen shot 2017-12-04 at 4 27 24 pm" src="https://user-images.githubusercontent.com/829142/33549362-360ed63a-d910-11e7-9487-dfdb4eab4343.png">
