### PR TITLE
Conditional Alerts UI: Step 3

### DIFF
--- a/corehq/apps/hqwebapp/async_handler.py
+++ b/corehq/apps/hqwebapp/async_handler.py
@@ -56,6 +56,12 @@ class BaseAsyncHandler(object):
         self.request = request
         self.data = request.POST if request.method == 'POST' else request.GET
         self.action = self.data.get('action')
+        # When used with the javascript BaseSelect2Handler, some field names might have hyphens,
+        # for example if the Django form has a 'prefix' attribute specified.
+        # Convert hyphens to underscores for the purposes of this integration, since python method
+        # names can't have hyphens.
+        if self.action:
+            self.action = self.action.replace('-', '_')
 
     def _fmt_error(self, error):
         return json.dumps({

--- a/corehq/messaging/scheduling/async_handlers.py
+++ b/corehq/messaging/scheduling/async_handlers.py
@@ -11,14 +11,14 @@ from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 class MessagingRecipientHandler(BaseAsyncHandler):
     slug = 'scheduling_recipients'
     allowed_actions = [
-        'user_recipients',
-        'user_group_recipients',
-        'user_organization_recipients',
-        'case_group_recipients',
+        'schedule_user_recipients',
+        'schedule_user_group_recipients',
+        'schedule_user_organization_recipients',
+        'schedule_case_group_recipients',
     ]
 
     @property
-    def user_recipients_response(self):
+    def schedule_user_recipients_response(self):
         domain = self.request.domain
         query = self.data.get('searchString')
         users = get_search_users_in_domain_es_query(domain, query, 10, 0)
@@ -30,7 +30,7 @@ class MessagingRecipientHandler(BaseAsyncHandler):
         return ret
 
     @property
-    def user_group_recipients_response(self):
+    def schedule_user_group_recipients_response(self):
         domain = self.request.domain
         query = self.data.get('searchString')
         group_result = (
@@ -48,7 +48,7 @@ class MessagingRecipientHandler(BaseAsyncHandler):
         ]
 
     @property
-    def user_organization_recipients_response(self):
+    def schedule_user_organization_recipients_response(self):
         domain = self.request.domain
         query = self.data.get('searchString')
         result = (
@@ -64,7 +64,7 @@ class MessagingRecipientHandler(BaseAsyncHandler):
         ]
 
     @property
-    def case_group_recipients_response(self):
+    def schedule_case_group_recipients_response(self):
         domain = self.request.domain
         query = self.data.get('searchString')
         return [

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1083,6 +1083,9 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 if schedule.start_day_of_week >= 0:
                     result['start_day_of_week'] = str(schedule.start_day_of_week)
 
+        if self.initial_rule:
+            self.add_initial_recipients(self.initial_rule.memoized_actions[0].definition.recipients, result)
+
         return result
 
     def get_timing_layout_fields(self):

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -97,11 +97,6 @@ class ScheduleForm(Form):
     CONTENT_SMS_SURVEY = 'sms_survey'
     CONTENT_IVR_SURVEY = 'ivr_survey'
 
-    schedule_name = CharField(
-        required=True,
-        label=_('Schedule Name'),
-        max_length=1000,
-    )
     send_frequency = ChoiceField(
         required=True,
         label=_('Send'),
@@ -365,7 +360,6 @@ class ScheduleForm(Form):
 
     def get_scheduling_layout_fields(self):
         return [
-            crispy.Field('schedule_name'),
             crispy.Field(
                 'send_frequency',
                 data_bind='value: send_frequency',
@@ -899,9 +893,22 @@ class ScheduleForm(Form):
 
 class BroadcastForm(ScheduleForm):
 
+    schedule_name = CharField(
+        required=True,
+        label=_('Schedule Name'),
+        max_length=1000,
+    )
+
     def __init__(self, domain, schedule, broadcast, *args, **kwargs):
         self.initial_broadcast = broadcast
         super(BroadcastForm, self).__init__(domain, schedule, *args, **kwargs)
+
+    def get_scheduling_layout_fields(self):
+        result = [
+            crispy.Field('schedule_name'),
+        ]
+        result.extend(super(BroadcastForm, self).get_scheduling_layout_fields())
+        return result
 
     def compute_initial(self):
         result = super(BroadcastForm, self).compute_initial()

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -752,6 +752,9 @@ class ScheduleForm(Form):
             ),
         }
 
+    def distill_start_offset(self):
+        raise NotImplementedError()
+
     def assert_alert_schedule(self, schedule):
         if not isinstance(schedule, AlertSchedule):
             raise TypeError("Expected AlertSchedule")
@@ -787,6 +790,7 @@ class ScheduleForm(Form):
                 form_data['send_time'],
                 content,
                 total_iterations=total_iterations,
+                start_offset=self.distill_start_offset(),
                 extra_options=extra_scheduling_options,
             )
         else:
@@ -795,6 +799,7 @@ class ScheduleForm(Form):
                 form_data['send_time'],
                 content,
                 total_iterations=total_iterations,
+                start_offset=self.distill_start_offset(),
                 extra_options=extra_scheduling_options,
             )
 
@@ -939,6 +944,9 @@ class BroadcastForm(ScheduleForm):
 
         return validate_date(self.cleaned_data.get('start_date'))
 
+    def distill_start_offset(self):
+        return 0
+
     def save_immediate_broadcast(self, schedule):
         form_data = self.cleaned_data
         recipients = self.distill_recipients()
@@ -991,7 +999,12 @@ class BroadcastForm(ScheduleForm):
 class ConditionalAlertScheduleForm(ScheduleForm):
 
     SEND_TIME_SPECIFIC_TIME = 'SPECIFIC_TIME'
-    START_DATE_IMMEDIATELY = 'IMMEDIATELY'
+
+    START_DATE_RULE_TRIGGER = 'RULE_TRIGGER'
+
+    START_OFFSET_ZERO = 'ZERO'
+    START_OFFSET_NEGATIVE = 'NEGATIVE'
+    START_OFFSET_POSITIVE = 'POSITIVE'
 
     send_time_type = ChoiceField(
         required=True,
@@ -1003,8 +1016,23 @@ class ConditionalAlertScheduleForm(ScheduleForm):
     start_date_type = ChoiceField(
         required=True,
         choices=(
-            (START_DATE_IMMEDIATELY, _("The date the rule is satisfied")),
+            (START_DATE_RULE_TRIGGER, _("The date the rule is satisfied")),
         )
+    )
+
+    start_offset_type = ChoiceField(
+        required=False,
+        choices=(
+            (START_OFFSET_ZERO, _("Exactly on this date")),
+            (START_OFFSET_NEGATIVE, _("Before this date by")),
+            (START_OFFSET_POSITIVE, _("After this date by")),
+        )
+    )
+
+    start_offset = IntegerField(
+        label='',
+        required=False,
+        min_value=1,
     )
 
     def __init__(self, domain, schedule, rule, *args, **kwargs):
@@ -1040,6 +1068,27 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                     ),
                     css_class='col-sm-4',
                 ),
+                data_bind='visible: showStartDateInput',
+            ),
+            hqcrispy.B3MultiField(
+                ugettext("Begin"),
+                crispy.Div(
+                    twbscrispy.InlineField(
+                        'start_offset_type',
+                        data_bind='value: start_offset_type',
+                    ),
+                    css_class='col-sm-4',
+                ),
+                crispy.Div(
+                    twbscrispy.InlineField('start_offset'),
+                    css_class='col-sm-2',
+                    data_bind="visible: start_offset_type() !== '%s'" % self.START_OFFSET_ZERO,
+                ),
+                crispy.Div(
+                    crispy.HTML("<span>%s</span>" % ugettext("days(s)")),
+                    data_bind="visible: start_offset_type() !== '%s'" % self.START_OFFSET_ZERO,
+                ),
+                data_bind="visible: send_frequency() === '%s'" % self.SEND_DAILY,
             ),
         ]
 
@@ -1048,6 +1097,44 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             return super(ConditionalAlertScheduleForm, self).clean_send_time()
 
         return None
+
+    def clean_start_offset_type(self):
+        self.cleaned_data('send_frequency') != self.SEND_DAILY:
+            return None
+
+        value = self.cleaned_data.get('start_offset_type')
+
+        if not value:
+            raise ValidationError(ugettext("This field is required"))
+
+        if (
+            value == self.START_OFFSET_NEGATIVE and
+            self.cleaned_data.get('start_date_type') == self.START_DATE_RULE_TRIGGER
+        ):
+            raise ValidationError(ugettext("You may not start sending before the day that the rule triggers."))
+
+        return value
+
+    def distill_start_offset(self):
+        send_frequency = self.cleaned_data.get('send_frequency')
+        start_offset_type = self.cleaned_data.get('start_offset_type')
+
+        if (
+            send_frequency == self.SEND_DAILY and
+            start_offset_type in (self.START_OFFSET_NEGATIVE, self.START_OFFSET_POSITIVE)
+        ):
+
+            start_offset = self.cleaned_data.get('start_offset')
+
+            if start_offset is None:
+                raise ValidationError(ugettext("This field is required"))
+
+            if start_offset_type == self.START_OFFSET_NEGATIVE:
+                return -1 * start_offset
+            else:
+                return start_offset
+
+        return 0
 
 
 class ConditionalAlertForm(Form):

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -327,7 +327,10 @@ class ScheduleForm(Form):
             for field_name, field in self.fields.items():
                 field.disabled = True
 
-        layout_fields = [
+        self.helper.layout = crispy.Layout(*self.get_layout_fields())
+
+    def get_layout_fields(self):
+        return [
             crispy.Fieldset(
                 ugettext("Scheduling"),
                 *self.get_scheduling_layout_fields()
@@ -341,19 +344,6 @@ class ScheduleForm(Form):
                 *self.get_content_layout_fields()
             )
         ]
-
-        if not self.readonly_mode:
-            layout_fields += [
-                hqcrispy.FormActions(
-                    twbscrispy.StrictButton(
-                        _("Save"),
-                        css_class='btn-primary',
-                        type='submit',
-                    ),
-                ),
-            ]
-
-        self.helper.layout = crispy.Layout(*layout_fields)
 
     def get_timing_layout_fields(self):
         raise NotImplementedError()
@@ -897,6 +887,20 @@ class BroadcastForm(ScheduleForm):
     def __init__(self, domain, schedule, broadcast, *args, **kwargs):
         self.initial_broadcast = broadcast
         super(BroadcastForm, self).__init__(domain, schedule, *args, **kwargs)
+
+    def get_layout_fields(self):
+        result = super(BroadcastForm, self).get_layout_fields()
+        if not self.readonly_mode:
+            result.append(
+                hqcrispy.FormActions(
+                    twbscrispy.StrictButton(
+                        _("Save"),
+                        css_class='btn-primary',
+                        type='submit',
+                    ),
+                )
+            )
+        return result
 
     def get_timing_layout_fields(self):
         return [

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1023,9 +1023,9 @@ class ConditionalAlertScheduleForm(ScheduleForm):
     start_offset_type = ChoiceField(
         required=False,
         choices=(
-            (START_OFFSET_ZERO, _("Exactly on this date")),
-            (START_OFFSET_NEGATIVE, _("Before this date by")),
-            (START_OFFSET_POSITIVE, _("After this date by")),
+            (START_OFFSET_ZERO, _("Exactly on the start date")),
+            (START_OFFSET_NEGATIVE, _("Before the start date by")),
+            (START_OFFSET_POSITIVE, _("After the start date by")),
         )
     )
 

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -973,6 +973,13 @@ class BroadcastForm(ScheduleForm):
         return (broadcast, schedule)
 
 
+class ConditionalAlertScheduleForm(ScheduleForm):
+
+    def __init__(self, domain, schedule, rule, *args, **kwargs):
+        self.initial_rule = rule
+        super(ConditionalAlertScheduleForm, self).__init__(domain, schedule, *args, **kwargs)
+
+
 class ConditionalAlertForm(Form):
     # Prefix to avoid name collisions; this means all input
     # names in the HTML are prefixed with "conditional-alert-"

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1062,6 +1062,24 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         self.initial_rule = rule
         super(ConditionalAlertScheduleForm, self).__init__(domain, schedule, *args, **kwargs)
 
+    def compute_initial(self):
+        result = super(ConditionalAlertScheduleForm, self).compute_initial()
+        if self.initial_schedule:
+            if isinstance(self.initial_schedule, TimedSchedule):
+                if schedule.start_offset == 0:
+                    result['start_offset_type'] = self.START_OFFSET_ZERO
+                elif schedule.start_offset > 0:
+                    result['start_offset_type'] = self.START_OFFSET_POSITIVE
+                    result['start_offset'] = schedule.start_offset
+                else:
+                    result['start_offset_type'] = self.START_OFFSET_NEGATIVE
+                    result['start_offset'] = abs(schedule.start_offset)
+
+                if schedule.start_day_of_week >= 0:
+                    result['start_day_of_week'] = str(schedule.start_day_of_week)
+
+        return result
+
     def get_timing_layout_fields(self):
         return [
             hqcrispy.B3MultiField(

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1065,7 +1065,8 @@ class ConditionalAlertScheduleForm(ScheduleForm):
     def compute_initial(self):
         result = super(ConditionalAlertScheduleForm, self).compute_initial()
         if self.initial_schedule:
-            if isinstance(self.initial_schedule, TimedSchedule):
+            schedule = self.initial_schedule
+            if isinstance(schedule, TimedSchedule):
                 if schedule.start_offset == 0:
                     result['start_offset_type'] = self.START_OFFSET_ZERO
                 elif schedule.start_offset > 0:
@@ -1269,10 +1270,18 @@ class ConditionalAlertForm(Form):
         required=True,
     )
 
-    def __init__(self, domain, *args, **kwargs):
+    def __init__(self, domain, rule, *args, **kwargs):
+        self.domain = domain
+        self.initial_rule = rule
+
+        if kwargs.get('initial'):
+            raise ValueError("Initial values are set by the form")
+
+        if self.initial_rule:
+            kwargs['initial'] = self.compute_initial()
+
         super(ConditionalAlertForm, self).__init__(*args, **kwargs)
 
-        self.domain = domain
         self.helper = FormHelper()
         self.helper.label_class = 'col-xs-2 col-xs-offset-1'
         self.helper.field_class = 'col-xs-2'
@@ -1284,6 +1293,11 @@ class ConditionalAlertForm(Form):
                 crispy.Field('name'),
             ),
         )
+
+    def compute_initial(self):
+        return {
+            'name': self.initial_rule.name,
+        }
 
 
 class ConditionalAlertCriteriaForm(CaseRuleCriteriaForm):

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -1,0 +1,54 @@
+hqDefine("scheduling/js/conditional_alert_list", function() {
+    $(function() {
+        var conditonal_alert_list_url = hqImport("hqwebapp/js/initial_page_data").reverse("conditional_alert_list");
+        var loader_src = hqImport("hqwebapp/js/initial_page_data").get("loader_src");
+
+        $("#conditional-alert-list").dataTable({
+            "lengthChange": false,
+            "filter": false,
+            "sort": false,
+            "displayLength": 10,
+            "processing": true,
+            "serverSide": true,
+            "ajaxSource": conditonal_alert_list_url,
+            "fnServerParams": function(aoData) {
+                aoData.push({"name": "action", "value": "list_conditional_alerts"});
+            },
+            "sDom": "rtp",
+            "language": {
+                "emptyTable": gettext('There are no alerts to display.'),
+                "infoEmpty": gettext('There are no alerts to display.'),
+                "processing": '<img src="' + loader_src + '" /> ' + gettext('Loading alerts...'),
+                "info": gettext('Showing _START_ to _END_ of _TOTAL_ alerts'),
+            },
+            "columnDefs": [
+                {
+                    "targets": [0],
+                    "render": function() {
+                        return 'Delete button';
+                    },
+                },
+                {
+                    "targets": [1],
+                    "render": function(data, type, row) {
+                        var id = row[row.length - 1];
+                        var url = hqImport("hqwebapp/js/initial_page_data").reverse('edit_conditional_alert', id);
+                        return "<a href='" + url + "'>" + data + "</a>";
+                    },
+                },
+                {
+                    "targets": [3],
+                    "render": function(data) {
+                        return data ? gettext("Active") : gettext("Inactive");
+                    },
+                },
+                {
+                    "targets": [4],
+                    "render": function() {
+                        return 'Activate or Deactivate button';
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
@@ -10,6 +10,7 @@ hqDefine("scheduling/js/create_schedule.ko", function() {
         self.send_time = ko.observable(initial_values.send_time);
         self.send_time_type = ko.observable(initial_values.send_time_type);
         self.start_date = ko.observable(initial_values.start_date);
+        self.start_date_type = ko.observable(initial_values.start_date_type);
         self.stop_type = ko.observable(initial_values.stop_type);
         self.occurrences = ko.observable(initial_values.occurrences);
         self.recipient_types = ko.observableArray(initial_values.recipient_types || []);

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
@@ -11,6 +11,7 @@ hqDefine("scheduling/js/create_schedule.ko", function() {
         self.send_time_type = ko.observable(initial_values.send_time_type);
         self.start_date = ko.observable(initial_values.start_date);
         self.start_date_type = ko.observable(initial_values.start_date_type);
+        self.start_offset_type = ko.observable(initial_values.start_offset_type);
         self.stop_type = ko.observable(initial_values.stop_type);
         self.occurrences = ko.observable(initial_values.occurrences);
         self.recipient_types = ko.observableArray(initial_values.recipient_types || []);

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
@@ -171,8 +171,8 @@ hqDefine("scheduling/js/create_schedule.ko", function() {
         };
 
         self.init = function () {
-            self.initDatePicker($("#id_start_date"));
-            self.initTimePicker($("#id_send_time"));
+            self.initDatePicker($("#id_schedule-start_date"));
+            self.initTimePicker($("#id_schedule-send_time"));
             self.setOccurrencesOptionText(self.send_frequency());
         };
     };

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
@@ -4,7 +4,6 @@ hqDefine("scheduling/js/create_schedule.ko", function() {
             select2_case_group_recipients) {
         var self = this;
 
-        self.schedule_name = ko.observable(initial_values.schedule_name);
         self.send_frequency = ko.observable(initial_values.send_frequency);
         self.weekdays = ko.observableArray(initial_values.weekdays || []);
         self.days_of_month = ko.observableArray(initial_values.days_of_month || []);

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
@@ -8,6 +8,7 @@ hqDefine("scheduling/js/create_schedule.ko", function() {
         self.weekdays = ko.observableArray(initial_values.weekdays || []);
         self.days_of_month = ko.observableArray(initial_values.days_of_month || []);
         self.send_time = ko.observable(initial_values.send_time);
+        self.send_time_type = ko.observable(initial_values.send_time_type);
         self.start_date = ko.observable(initial_values.start_date);
         self.stop_type = ko.observable(initial_values.stop_type);
         self.occurrences = ko.observable(initial_values.occurrences);

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.ko.js
@@ -67,7 +67,7 @@ hqDefine("scheduling/js/create_schedule.ko", function() {
         self.setOccurrencesOptionText = function(newValue) {
             var occurrences = $('option[value="after_occurrences"]');
             if(newValue === 'daily') {
-                occurrences.text(gettext("After days:"));
+                occurrences.text(gettext("After occurrences:"));
             } else if(newValue === 'weekly') {
                 occurrences.text(gettext("After weeks:"));
             } else if(newValue === 'monthly') {

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert.html
@@ -1,4 +1,4 @@
-{% extends "hqwebapp/base_section.html" %}
+{% extends "scheduling/create_schedule_base.html" %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 {% load i18n %}
@@ -7,7 +7,7 @@
     <script src="{% static 'data_interfaces/js/case_rule_criteria.js' %}"></script>
 {% endblock %}
 
-{% block page_content %}
+{% block page_content %}{{ block.super }}
 {% include 'data_interfaces/partials/case_rule_criteria.html' with form=criteria_form %}
 
 <div class="row">
@@ -32,7 +32,8 @@
                 </div>
                 <div class="tab-pane" id="schedule">
                     <div class="row">
-                        <div class="col-sm-12">
+                        <div id="create-schedule-form" class="col-sm-12">
+                            {% crispy schedule_form %}
                         </div>
                     </div>
                 </div>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -2,11 +2,33 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% block js %}{{ block.super }}
+    <script src="{% static "scheduling/js/conditional_alert_list.js" %}"></script>
+{% endblock %}
+
 {% block page_content %}
+    {% registerurl 'conditional_alert_list' domain %}
+    {% registerurl 'edit_conditional_alert' domain '---' %}
+    {% initial_page_data 'loader_src' 'hqwebapp/images/ajax-loader.gif'|static %}
+
     <div class="btn-group">
         <a href="{% url 'create_conditional_alert' domain %}" class="btn btn-success">
             <i class="fa fa-plus"></i>
             {% trans "New Conditional Message" %}
         </a>
+    </div>
+    <h4>{% trans 'Conditional Messages' %}</h4>
+    <div>
+        <table id="conditional-alert-list" class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th class="col-md-2">{% trans 'Delete' %}</th>
+                    <th class="col-md-4">{% trans 'Name' %}</th>
+                    <th class="col-md-2">{% trans 'Case Type' %}</th>
+                    <th class="col-md-2">{% trans 'Status' %}</th>
+                    <th class="col-md-2">{% trans 'Action' %}</th>
+                </tr>
+            </thead>
+        </table>
     </div>
 {% endblock %}

--- a/corehq/messaging/scheduling/templates/scheduling/partial/time_picker.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partial/time_picker.html
@@ -1,4 +1,4 @@
-<div class="input-group bootstrap-timepicker col-sm-6">
+<div class="input-group bootstrap-timepicker col-sm-4">
     <input id="id_schedule-send_time" type="text" name="schedule-send_time" data-bind="value: send_time" class="form-control" />
     <span class="input-group-addon"><i class="fa fa-clock-o"></i></span>
 </div>

--- a/corehq/messaging/scheduling/urls.py
+++ b/corehq/messaging/scheduling/urls.py
@@ -17,6 +17,6 @@ urlpatterns = [
         name=EditScheduleView.urlname),
     url(r'^conditional/$', ConditionalAlertListView.as_view(), name=ConditionalAlertListView.urlname),
     url(r'^conditional/add/$', CreateConditionalAlertView.as_view(), name=CreateConditionalAlertView.urlname),
-    url(r'^conditional/edit/(?P<rule_id>[\d]+)/$', EditConditionalAlertView.as_view(),
+    url(r'^conditional/edit/(?P<rule_id>[\w-]+)/$', EditConditionalAlertView.as_view(),
         name=EditConditionalAlertView.urlname),
 ]

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -335,13 +335,14 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
 
         basic_info_form_valid = self.basic_info_form.is_valid()
         criteria_form_valid = self.criteria_form.is_valid()
+        schedule_form_valid = self.schedule_form.is_valid()
 
         if self.read_only_mode:
             # Don't allow making changes to rules that have custom
             # criteria/actions unless the user has permission to
             return HttpResponseBadRequest()
 
-        if basic_info_form_valid and criteria_form_valid:
+        if basic_info_form_valid and criteria_form_valid and schedule_form_valid:
             if not self.is_system_admin and self.criteria_form.requires_system_admin_to_save:
                 # Don't allow adding custom criteria/actions to rules
                 # unless the user has permission to
@@ -360,6 +361,7 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
 
                 rule.name = self.basic_info_form.cleaned_data['name']
                 self.criteria_form.save_criteria(rule)
+                self.schedule_form.save_rule_action_and_schedule(rule)
             return HttpResponseRedirect(reverse(ConditionalAlertListView.urlname, args=[self.domain]))
 
         return self.get(request, *args, **kwargs)


### PR DESCRIPTION
spec: https://docs.google.com/document/d/1iJq6EHEYTppIx0p2UMsIr8q3qKk_bFAAfvojtMsxvH4/edit#

This integrates the scheduling form into the conditional alert UI, fills in the edit conditional alert view, and fills in the conditional alert list view, allowing a full create-list-edit workflow. The rest of the scheduling and recipient options will follow in subsequent PRs.

Best reviewed commit by commit.

screen shot:
![schedule-integration](https://user-images.githubusercontent.com/1028814/33554365-611f97d8-d8ca-11e7-9125-f052b674fc4a.png)

Product: This feature flag isn't enabled yet for anyone as the new reminder UI is under active development.

@millerdev 