### PR TITLE
ViewModel to support pulling from multiple OpenMRS instances

### DIFF
--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -65,6 +65,9 @@ class OpenmrsImporterForm(forms.Form):
                                  help_text=_('e.g. "http://www.example.com/openmrs"'))
     username = forms.CharField(label=_('Username'), required=True)
     password = forms.CharField(label=_('Password'), widget=forms.PasswordInput, required=False)
+    location_id = forms.CharField(label=_('Location ID'), required=False,
+                                  help_text='If a project space has multiple OpenMRS servers to import from, for '
+                                            'which CommCare location is this OpenMRS server authoritative?')
     import_frequency = forms.ChoiceField(label=_('Import Frequency'), choices=IMPORT_FREQUENCY_CHOICES,
                                          help_text=_('How often should cases be imported?'), required=False)
     log_level = forms.TypedChoiceField(label=_('Log Level'), required=False, choices=LOG_LEVEL_CHOICES, coerce=int)
@@ -98,6 +101,7 @@ class OpenmrsImporterForm(forms.Form):
                 crispy.Field('server_url'),
                 crispy.Field('username'),
                 crispy.Field('password'),
+                crispy.Field('location_id'),  # TODO: Look up ID. Use type-ahead on name.
                 crispy.Field('import_frequency'),
                 crispy.Field('log_level'),
 
@@ -147,6 +151,7 @@ class OpenmrsImporterForm(forms.Form):
             if self.cleaned_data['password']:
                 # Don't save it if it hasn't been changed.
                 importer.password = b64_aes_encrypt(self.cleaned_data['password'])
+            importer.location_id = self.cleaned_data['location_id']
             importer.import_frequency = self.cleaned_data['import_frequency']
             importer.log_level = self.cleaned_data['log_level']
 

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -89,46 +89,6 @@ class OpenmrsImporterForm(forms.Form):
     column_map = JsonField(label=_('Map columns to properties'), required=True, expected_type=list,
                            help_text=_('e.g. [{"column": "givenName", "property": "first_name"}, ...]'))
 
-    def __init__(self, *args, **kwargs):
-        super(OpenmrsImporterForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
-        self.helper.layout = crispy.Layout(
-            crispy.Fieldset(
-                _('Edit OpenMRS Importer'),
-                crispy.Field('server_url'),
-                crispy.Field('username'),
-                crispy.Field('password'),
-                crispy.Field('location_id'),  # TODO: Look up ID. Use type-ahead on name.
-                crispy.Field('import_frequency'),
-                crispy.Field('log_level'),
-
-                crispy.Field('report_uuid'),
-                crispy.Field('report_params'),
-                crispy.Field('case_type'),
-                crispy.Field('owner_id'),
-                crispy.Field('location_type_name'),
-                crispy.Field('external_id_column'),
-                crispy.Field('name_columns'),
-                crispy.Field('column_map'),
-            ),
-            hqcrispy.FormActions(
-                StrictButton(
-                    _("Update OpenMRS Importer"),
-                    type="submit",
-                    css_class='btn-primary',
-                ),
-                StrictButton(
-                    _('Import Now'),
-                    type='button',
-                    id='btn-import-now',
-                    css_class='btn-default',
-                ),
-            ),
-        )
-
     def clean(self):
         cleaned_data = super(OpenmrsImporterForm, self).clean()
         if bool(cleaned_data.get('owner_id')) == bool(cleaned_data.get('location_type_name')):

--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -35,6 +35,9 @@ class OpenmrsImporter(Document):
     username = StringProperty()
     password = StringProperty()
 
+    # If a domain has multiple OpenmrsImporter instances, for which CommCare location is this one authoritative?
+    location_id = StringProperty()
+
     # How often should cases be imported
     import_frequency = StringProperty(choices=IMPORT_FREQUENCY_CHOICES, default=IMPORT_FREQUENCY_MONTHLY)
 
@@ -56,7 +59,8 @@ class OpenmrsImporter(Document):
 
     # If report_params includes "{{ location }}" then location_type_name is used to determine which locations to
     # pull the report for. Those locations will need an "openmrs_uuid" param set. Imported cases will be owned by
-    # the first mobile worker assigned to that location.
+    # the first mobile worker assigned to that location. If this OpenmrsImporter.location_id is set, only
+    # sub-locations will be returned
     location_type_name = StringProperty()
 
     # external_id should always be the OpenMRS UUID of the patient (and not, for example, a national ID number)

--- a/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
+++ b/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
@@ -1,0 +1,108 @@
+/* globals hqDefine, ko, $, _, gettext */
+
+hqDefine('openmrs/js/openmrs_importers', function () {
+    'use strict';
+
+    var module = {};
+
+    var OpenmrsImporter = function (properties) {
+        var self = this;
+
+        self.server_url = ko.observable(properties["server_url"]);
+        // We are using snake_case for property names so that they
+        // match Django form field names. That way we can iterate the
+        // fields of an unbound Django form in
+        // openmrs_importer_template.html and bind to these properties
+        // using the Django form field names.
+        self.username = ko.observable(properties["username"]);
+        self.password = ko.observable(properties["password"]);
+        self.location_id = ko.observable(properties["location_id"]);
+        self.import_frequency = ko.observable(properties["import_frequency"]);
+        self.log_level = ko.observable(properties["log_level"]);
+        self.report_uuid = ko.observable(properties["report_uuid"]);
+        self.report_params = ko.observable(properties["report_params"]);
+        self.case_type = ko.observable(properties["case_type"]);
+        self.owner_id = ko.observable(properties["owner_id"]);
+        self.location_type_name = ko.observable(properties["location_type_name"]);
+        self.external_id_column = ko.observable(properties["external_id_column"]);
+        self.name_columns = ko.observable(properties["name_columns"]);
+        self.column_map = ko.observable(properties["column_map"]);
+
+        self.import_frequency_options = [
+            {"value": "weekly", "text": gettext("Weekly")},
+            {"value": "monthly", "text": gettext("Monthly")},
+        ];
+        self.log_level_options = [
+            {"value": 99, "text": gettext("Disable logging")},
+            {"value": 40, "text": "Error"},  // Don't translate the names of log levels
+            {"value": 20, "text": "Info"},
+        ];
+
+        self.serialize = function () {
+            return {
+                "server_url": self.server_url(),
+                "username": self.username(),
+                "password": self.password(),
+                "location_id": self.location_id(),
+                "import_frequency": self.import_frequency(),
+                "log_level": self.log_level(),
+                "report_uuid": self.report_uuid(),
+                "report_params": self.report_params(),
+                "case_type": self.case_type(),
+                "owner_id": self.owner_id(),
+                "location_type_name": self.location_type_name(),
+                "external_id_column": self.external_id_column(),
+                "name_columns": self.name_columns(),
+                "column_map": self.column_map(),
+            };
+        };
+    };
+
+    module.OpenmrsImporters = function (openmrsImporters, importNowUrl) {
+        var self = this;
+        var alert_user = hqImport("hqwebapp/js/alert_user").alert_user;
+
+        self.openmrsImporters = ko.observableArray()
+
+        self.init = function () {
+            if (openmrsImporters.length > 0) {
+                for (var i = 0; i < openmrsImporters.length; i++) {
+                    var openmrsImporter = new OpenmrsImporter(openmrsImporters[i]);
+                    self.openmrsImporters.push(openmrsImporter);
+                }
+            } else {
+                self.addOpenmrsImporter()
+            }
+        };
+
+        self.addOpenmrsImporter = function () {
+            self.openmrsImporters.push(new OpenmrsImporter({}));
+        };
+
+        self.removeOpenmrsImporter = function (openmrsImporter) {
+            self.openmrsImporters.remove(openmrsImporter);
+        };
+
+        self.submit = function (form) {
+            var openmrsImporters = [];
+            for (var i = 0; i < self.openmrsImporters().length; i++) {
+                var openmrsImporter = self.openmrsImporters()[i];
+                openmrsImporters.push(openmrsImporter.serialize());
+            }
+            $.post(
+                form.action,
+                {'openmrs_importers': JSON.stringify(openmrsImporters)},
+                function (data) { alert_user(data['message'], 'success', true); }
+            ).fail(function () { alert_user(gettext('Unable to save OpenMRS Importers'), 'danger'); });
+        };
+
+        self.importNow = function () {
+            $.post(importNowUrl, {}, function (data) {
+                alert_user(gettext("Importing from OpenMRS will begin shortly."), "success");
+            }).fail(function () {
+                alert_user(gettext("Failed to schedule task to import from OpenMRS."), "danger");
+            });
+        };
+    };
+    return module;
+});

--- a/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
+++ b/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
@@ -62,7 +62,7 @@ hqDefine('openmrs/js/openmrs_importers', function () {
         var self = this;
         var alert_user = hqImport("hqwebapp/js/alert_user").alert_user;
 
-        self.openmrsImporters = ko.observableArray()
+        self.openmrsImporters = ko.observableArray();
 
         self.init = function () {
             if (openmrsImporters.length > 0) {
@@ -71,7 +71,7 @@ hqDefine('openmrs/js/openmrs_importers', function () {
                     self.openmrsImporters.push(openmrsImporter);
                 }
             } else {
-                self.addOpenmrsImporter()
+                self.addOpenmrsImporter();
             }
         };
 
@@ -97,7 +97,7 @@ hqDefine('openmrs/js/openmrs_importers', function () {
         };
 
         self.importNow = function () {
-            $.post(importNowUrl, {}, function (data) {
+            $.post(importNowUrl, {}, function () {
                 alert_user(gettext("Importing from OpenMRS will begin shortly."), "success");
             }).fail(function () {
                 alert_user(gettext("Failed to schedule task to import from OpenMRS."), "danger");

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -174,7 +174,11 @@ def import_patients_to_domain(domain_name, force=False):
                         location_type=importer.location_type_name, domain=domain_name)
                 )
                 continue
-            locations = SQLLocation.objects.filter(domain=domain_name, location_type=location_type).all()
+            if importer.location_id:
+                location = SQLLocation.objects.filter(domain=domain_name).get(importer.location_id)
+                locations = location.get_descendants.filter(location_type=location_type)
+            else:
+                locations = SQLLocation.objects.filter(domain=domain_name, location_type=location_type)
             for location in locations:
                 # Assign cases to the first user in the location, not to the location itself
                 try:

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -152,6 +152,32 @@ def import_patients_to_domain(domain_name, force=False):
     """
     Iterates OpenmrsImporters of a domain, and imports patients
 
+    Who owns the imported cases?
+
+    If `importer.owner_id` is set, then the server will be queried
+    once. All patients, regardless of their location, will be assigned
+    to the mobile worker whose ID is `importer.owner_id`.
+
+    If `importer.location_type_name` is set, then check whether the
+    OpenmrsImporter's location is set with `importer.location_id`.
+
+    If `importer.location_id` is given, then the server will be queried
+    for each location among its descendants whose type is
+    `importer.location_type_name`. The request's query parameters will
+    include that descendant location's OpenMRS UUID. Imported cases
+    will be owned by the first mobile worker in that location.
+
+    If `importer.location_id` is given, then the server will be queried
+    for each location in the project space whose type is
+    `importer.location_type_name`. As when `importer.location_id` is
+    specified, the request's query parameters will include that
+    location's OpenMRS UUID, and imported cases will be owned by the
+    first mobile worker in that location.
+
+    ..NOTE:: As you can see from the description above, if
+             `importer.owner_id` is set then `importer.location_id` is
+             not used.
+
     :param domain_name: The name of the domain
     :param force: Import regardless of the configured import frequency / today's date
     """

--- a/corehq/motech/openmrs/templates/openmrs/importers.html
+++ b/corehq/motech/openmrs/templates/openmrs/importers.html
@@ -3,20 +3,77 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
+{% block stylesheets %}{{ block.super }}
+    <link rel="stylesheet" href="{% static 'codemirror/lib/codemirror.css' %}" />
+    <link rel="stylesheet" href="{% static 'codemirror/addon/fold/foldgutter.css' %}"/>
+    <style>
+        .CodeMirror {
+            border: 1px solid #ccc;
+            height: auto;
+            max-width: 800px;
+        }
+    </style>
+{% endblock %}
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
+    <script src="{% static 'codemirror/mode/javascript/javascript.js' %}"></script>
+    <script src="{% static 'codemirror/addon/fold/foldcode.js' %}"></script>
+    <script src="{% static 'codemirror/addon/fold/foldgutter.js' %}"></script>
+    <script src="{% static 'codemirror/addon/fold/brace-fold.js' %}"></script>
+
+    <script src="{% static 'userreports/js/base.js' %}"></script>
+    <script src="{% static 'openmrs/js/openmrs_importers.js' %}"></script>
+{% endblock %}
+
 {% block js-inline %}{{ block.super }}
     <script>
-        var alert_user = hqImport("hqwebapp/js/alert_user").alert_user;
-
-        $("#btn-import-now").click(function() {
-            $.post("{% url 'openmrs_import_now' domain %}", {}, function (data) {
-                alert_user(gettext("Importing from OpenMRS will begin shortly."), "success");
-            }).fail(function () {
-                alert_user(gettext("Failed to schedule task to import from OpenMRS."), "danger");
-            });
-        });
+    $(function () {
+        var OpenmrsImporters = hqImport('openmrs/js/openmrs_importers').OpenmrsImporters;
+        var viewModel = new OpenmrsImporters(
+            {{ openmrs_importers|JSON }},
+            "{% url 'openmrs_import_now' domain %}"
+        );
+        viewModel.init();
+        $('#openmrs-importers').koApplyBindings(viewModel);
+    });
     </script>
 {% endblock %}
 
 {% block page_content %}
-    {% crispy openmrs_importer_form %}
+{% include 'openmrs/partials/openmrs_importer_template.html' %}
+
+<form id="openmrs-importers"
+      class="form-horizontal"
+      method="post"
+      data-bind="submit: submit">
+
+    <div data-bind="template: {
+                        name: 'importer_template',
+                        foreach: openmrsImporters,
+                        as: 'openmrsImporter'
+                    }"></div>
+
+    <p>
+        <button type="button"
+                class="btn btn-success"
+                data-bind="click: addOpenmrsImporter">
+            <i class="fa fa-plus"></i>
+            {% trans "Add OpenMRS Importer" %}
+        </button>
+    </p>
+
+    <div class="form-actions">
+        <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
+            <button class="btn btn-primary" type="submit">
+                {% trans "Update OpenMRS Importers" %}
+            </button>
+            <button class="btn btn-default"
+                    type="button"
+                    data-bind="click: importNow">
+                {% trans "Import Now" %}
+            </button>
+        </div>
+    </div>
+</form>
 {% endblock %}

--- a/corehq/motech/openmrs/templates/openmrs/partials/openmrs_importer_template.html
+++ b/corehq/motech/openmrs/templates/openmrs/partials/openmrs_importer_template.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+
+<script type="text/html" id="importer_template">
+    <fieldset>
+        <legend>{% trans "OpenMRS Importer" %}</legend>
+
+        <div class="col-sm-8">&nbsp;</div>
+        <div class="col-sm-4">
+            <button type="button"
+                    class="btn btn-danger"
+                    data-bind="click: $root.removeOpenmrsImporter">{% trans "Remove" %}</button>
+        </div>
+
+        {% for field in form %}
+        <div class="form-group">
+            <label class="control-label col-sm-3 col-md-2{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+            <div class="controls col-sm-9 col-md-8 col-lg-6">
+                {% if field.field.widget.input_type == 'select' %}
+                <select class="select form-control"
+                        data-bind="options: {{ field.html_name }}_options,
+                                   optionsText: 'text',
+                                   optionsValue: 'value',
+                                   value: {{ field.html_name }}"></select>
+                {% elif 'textarea' in field.field.widget.template_name %}
+                <textarea name="form_configs"
+                          {% if field.field.required %}required=""{% endif %}
+                          rows="10"
+                          cols="40"
+                          class="jsonwidget form-control"
+                          data-bind="value: {{ field.html_name }}"></textarea>
+                {% else %}
+                <input class="textinput textInput form-control"
+                       {% if field.field.required %}required=""{% endif %}
+                       {% if field.field.widget.input_type == 'password' %}type="password"{% else %}type="text"{% endif %}
+                       data-bind="value: {{ field.html_name }}" />
+                {% endif %}
+                {% if field.help_text %}
+                <p class="help-block">{{ field.help_text|safe }}</p>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+
+    </fieldset>
+</script>

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import json
 
-from django.forms import formset_factory
 from django.http import JsonResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -1,29 +1,39 @@
 from __future__ import absolute_import
 import json
+
+from django.forms import formset_factory
 from django.http import JsonResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.decorators.http import require_http_methods
+
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views import BaseProjectSettingsView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
+from corehq.motech.openmrs.models import OpenmrsImporter
 from corehq.motech.openmrs.tasks import import_patients_to_domain
 from corehq.motech.repeaters.models import RepeatRecord
 from corehq.motech.repeaters.views import AddCaseRepeaterView
 from corehq.motech.openmrs.openmrs_config import OpenmrsCaseConfig, OpenmrsFormConfig
 from corehq.motech.openmrs.forms import OpenmrsConfigForm, OpenmrsImporterForm
+from corehq.motech.openmrs.models import ColumnMapping
 from corehq.motech.openmrs.repeater_helpers import (
     Requests,
     get_patient_identifier_types,
     get_person_attribute_types,
 )
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
+from corehq.motech.utils import b64_aes_encrypt
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.web import json_response
 from six.moves import map
+
+
+PASSWORD_PLACEHOLDER = '*' * 16
 
 
 class OpenmrsRepeaterView(AddCaseRepeaterView):
@@ -144,29 +154,60 @@ class OpenmrsImporterView(BaseProjectSettingsView):
     page_title = ugettext_lazy("OpenMRS Importers")
     template_name = 'openmrs/importers.html'
 
-    def post(self, request, *args, **kwargs):
-        form = self.openmrs_importer_form
-        if form.is_valid():
-            form.save(self.domain)
-            get_openmrs_importers_by_domain.clear(request.domain)
-            return HttpResponseRedirect(self.page_url)
-        context = self.get_context_data(**kwargs)
-        return self.render_to_response(context)
+    def _update_importer(self, importer, data):
+        for key, value in data.items():
+            if key == 'password' and value != PASSWORD_PLACEHOLDER:
+                value = b64_aes_encrypt(value)
+            elif key == 'report_params':
+                value = json.loads(value)
+            elif key == 'column_map':
+                list_of_dicts = json.loads(value)
+                value = [ColumnMapping(**d) for d in list_of_dicts]
+            setattr(importer, key, value)
+        importer.save()
 
-    @property
-    @memoized
-    def openmrs_importer_form(self):
-        importers = get_openmrs_importers_by_domain(self.request.domain)
-        if importers:
-            initial = dict(importers[0])  # TODO: Support multiple
-            initial['column_map'] = [{k: v for k, v in dict(m).items() if k != 'doc_type'}  # Just for the pretty
-                                     for m in initial['column_map']]
-        else:
-            initial = {}
-        if self.request.method == 'POST':
-            return OpenmrsImporterForm(self.request.POST, initial=initial)
-        return OpenmrsImporterForm(initial=initial)
+    def post(self, request, *args, **kwargs):
+        try:
+            new_openmrs_importers = json.loads(request.POST['openmrs_importers'])
+            current_openmrs_importers = get_openmrs_importers_by_domain(request.domain)
+            i = -1
+            for i, openmrs_importer in enumerate(current_openmrs_importers):
+                if i < len(new_openmrs_importers):
+                    self._update_importer(openmrs_importer, new_openmrs_importers[i])
+                else:
+                    # Delete removed OpenMRS Importers
+                    openmrs_importer.delete()
+            if i + 1 < len(new_openmrs_importers):
+                # Insert new OpenMRS Importers
+                for j in range(i + 1, len(new_openmrs_importers)):
+                    openmrs_importer = OpenmrsImporter(domain=request.domain)
+                    self._update_importer(openmrs_importer, new_openmrs_importers[j])
+            get_openmrs_importers_by_domain.clear(request.domain)
+            return json_response({'message': _('OpenMRS Importers saved'), 'error': None})
+        except Exception as err:
+            return json_response({'message': None, 'error': str(err)}, status_code=500)
 
     @property
     def page_context(self):
-        return {'openmrs_importer_form': self.openmrs_importer_form}
+        # TODO: JsonField fields must render with CodeMirror
+        # TODO: Look up locations for location_id field.
+
+        openmrs_importers = []
+        for importer in get_openmrs_importers_by_domain(self.request.domain):
+            dict_ = dict(importer)
+            dict_['password'] = PASSWORD_PLACEHOLDER
+            dict_['report_params'] = json.dumps(dict_['report_params'], indent=2)
+            dict_['column_map'] = json.dumps([
+                {k: v for k, v in dict(m).items() if not (
+                    # Drop '"doc_type": ColumnMapping' from each column mapping.
+                    k == 'doc_type' or
+                    # Drop "data_type" if it's not specified
+                    (k == 'data_type' and v is None)
+                )}
+                for m in dict_['column_map']
+            ], indent=2)
+            openmrs_importers.append(dict_)
+        return {
+            'openmrs_importers': openmrs_importers,
+            'form': OpenmrsImporterForm(),  # Use an unbound form to render openmrs_importer_template.html
+        }


### PR DESCRIPTION
This change replaces a crispy form with a ViewModel for managing configuration for OpenMRS's Reporting API. 

This is for projects that have multiple OpenMRS servers that CommCare needs to import patients from.

:blowfish: probably easier

@dannyroberts cc @nickpell 
