### PR TITLE
Add jQuery UI to core_libraries.html

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer-common/base.html
+++ b/corehq/apps/cloudcare/templates/formplayer-common/base.html
@@ -109,23 +109,8 @@
         <script src="{% static 'less/dist/less-1.7.3.min.js' %}"></script>
         {% endif %}
 
-        {% javascript_libraries underscore=True ko=True hq=True analytics=True %}
+        {% javascript_libraries underscore=True jquery_ui=True ko=True hq=True analytics=True %}
         <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
-
-        {% compress js %}
-        <script src="{% static 'jquery-ui/ui/core.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/widget.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/mouse.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/position.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/menu.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/autocomplete.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/button.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/datepicker.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/draggable.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/resizable.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/droppable.js' %}"></script>
-        <script src="{% static 'jquery-ui/ui/sortable.js' %}"></script>
-        {% endcompress %}
 
         {% compress js %}
         <script src="{% static 'cloudcare/js/preview_app/dragscroll.js' %}"></script>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -170,25 +170,7 @@
         {% endif %}
 
         {% if not requirejs_main %}
-            {% javascript_libraries underscore=True ko=True hq=True analytics=True %}
-        {% endif %}
-
-        {% if request.use_jquery_ui and not requirejs_main %}
-        {% compress js %}
-            <!-- UI libraries needed for all other widgets and interactions -->
-            <script src="{% static 'jquery-ui/ui/core.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widget.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/mouse.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/position.js' %}"></script>
-
-            <!-- Individual widgets and interactions -->
-            <script src="{% static 'jquery-ui/ui/button.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/datepicker.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/draggable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/resizable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/droppable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/sortable.js' %}"></script>
-        {% endcompress %}
+            {% javascript_libraries underscore=True jquery_ui=request.use_jquery_ui ko=True hq=True analytics=True %}
         {% endif %}
 
         {# Up here because if daterangepicker is called from within a form widget, #}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
@@ -7,6 +7,7 @@
     Options. Note that setting these to False will not necessarily exclude that library,
     as a different library may depend on it.
         underscore: Include underscore
+        jquery_ui: Include jQuery UI
         ko: Include knockout
         analytics: Include Google Analytics, Kissmetrics, etc.
         hq: Include initial_page_data and hq.helpers.js, needed for most HQ pages.
@@ -25,8 +26,33 @@
     <script src="{% static 'jquery-form/dist/jquery.form.min.js' %}"></script>
     <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
     <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>
-    <script src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
 {% endcompress %}
+
+{% if jquery_ui %}
+    {% compress js %}
+        <!-- UI libraries needed for all other widgets and interactions -->
+        <script src="{% static 'jquery-ui/ui/core.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/widget.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/mouse.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/position.js' %}"></script>
+
+        <!-- Individual widgets and interactions -->
+        <script src="{% static 'jquery-ui/ui/menu.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/autocomplete.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/button.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/datepicker.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/draggable.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/resizable.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/droppable.js' %}"></script>
+        <script src="{% static 'jquery-ui/ui/sortable.js' %}"></script>
+    {% endcompress %}
+{% endif %}
+
+{% comment %}
+    jQuery UI, if included, needs to appear before bootstrap's JavaScript;
+    otherwise the two tooltip widgets and two button widgets conflict.
+{% endcomment %}
+<script src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
 
 {% comment %}
     Required for inline edit widget. Also used by cloudcare.

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -748,7 +748,7 @@ def javascript_libraries(context, **kwargs):
     return {
         'request': getattr(context, 'request', None),
         'underscore': kwargs.pop('underscore', False),
-        'jquery': kwargs.pop('jquery', False),
+        'jquery_ui': kwargs.pop('jquery_ui', False),
         'ko': kwargs.pop('ko', False),
         'analytics': kwargs.pop('analytics', False),
         'hq': kwargs.pop('hq', False),


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/18745

Found a new dependency: jQuery UI, if included, needs to go after jQuery but before Bootstrap. Otherwise reports break. Dependency management is fun.

@millerdev / @emord 

@nickpell this needs to go into the next deploy