### PR TITLE
Reports: Disallow future dates in date spans

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -35,6 +35,7 @@
             showDropdowns: true,
             ranges: ranges,
             timePicker: false,
+            maxDate: new Date(),
             locale: {
                 format: 'YYYY-MM-DD',
                 separator: separator,


### PR DESCRIPTION
Dev Patel requested in https://manage.dimagi.com/default.asp?266238 that we not allow date spans in reports to reach into the future. Sounds reasonable to me. @dimagi/product is this okay with you?

@calellowitz 