### PR TITLE
Revert "Allow clearing date spans in reports"

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -37,8 +37,7 @@
             timePicker: false,
             locale: {
                 format: 'YYYY-MM-DD',
-                separator: separator,
-                cancelLabel: gettext('Clear'),
+                separator: separator
             }
         };
         var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
@@ -47,11 +46,7 @@
             config.endDate = getLocalDate(enddate);
         }
 
-        var $el = $(this);
-        $el.daterangepicker(config);
-        $el.on('cancel.daterangepicker', function() {
-            $el.val('');
-        });
+        $(this).daterangepicker(config);
 
         if (! hasStartAndEndDate){
             $(this).val("");

--- a/corehq/apps/reports/templates/reports/filters/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/datespan.html
@@ -8,7 +8,6 @@
                    id="filter_range"
                    class="date-range-picker form-control report-filter-datespan"
                    value="{{ datespan.startdate|date:'Y-m-d' }} to {{ datespan.enddate|date:'Y-m-d' }}"
-                   placeholder="{% trans "Show All Dates"|escapejs %}"
                    data-init="{% block init_filter %}{% if slug == 'datespan' %}1{% endif %}{% endblock %}"
                    data-separator="{% html_attr separator %}" 
                    data-report-labels="{% html_attr report_labels %}"

--- a/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
@@ -14,5 +14,7 @@
     if (!$(filter_id).val() && $(filter_id_start).val() && $(filter_id_end).val()) {
         var text = $(filter_id_start).val() + $().getDateRangeSeparator() + $(filter_id_end).val();
         $(filter_id).val(text);
+    } else if (!$(filter_id).val()) {
+        $(filter_id).val(gettext("Show All Dates"));
     }
 })($, gettext);


### PR DESCRIPTION
Reverts dimagi/commcare-hq#18711
See https://manage.dimagi.com/default.asp?266238

An issue with this came up during testing: when you clear dates and Apply, somewhere along the line they get defaulted back to the report's default date range. I don't have the bandwidth to investigate (originally pulled the ticket off the interrupt queue because it looked like a very easy win), just going to revert and put it back on the queue.

@calellowitz 