### PR TITLE
Add decorator to cache UCR expressions

### DIFF
--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from jsonobject import DefaultProperty
 
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.userreports.decorators import ucr_context_cache
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.util.quickcache import quickcache
@@ -85,14 +86,9 @@ class AncestorLocationExpression(JsonObject):
     def __call__(self, item, context=None):
         location_id = self._location_id_expression(item, context)
         location_type = self._location_type_expression(item, context)
+        return self._get_ancestor(location_id, location_type)
 
-        cache_key = (self.__class__.__name__, location_id, location_type)
-        if context.get_cache_value(cache_key, False) is not False:
-            return context.get_cache_value(cache_key)
-        ancestor_json = self._get_ancestor(location_id, location_type)
-        context.set_cache_value(cache_key, ancestor_json)
-        return ancestor_json
-
+    @ucr_context_cache(vary_on=('location_id', 'location_type',))
     def _get_ancestor(self, location_id, location_type):
         try:
             location = SQLLocation.objects.get(location_id=location_id)

--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -86,10 +86,11 @@ class AncestorLocationExpression(JsonObject):
     def __call__(self, item, context=None):
         location_id = self._location_id_expression(item, context)
         location_type = self._location_type_expression(item, context)
-        return self._get_ancestor(location_id, location_type)
+        return self._get_ancestor(location_id, location_type, context)
 
+    @staticmethod
     @ucr_context_cache(vary_on=('location_id', 'location_type',))
-    def _get_ancestor(self, location_id, location_type):
+    def _get_ancestor(location_id, location_type, context):
         try:
             location = SQLLocation.objects.get(location_id=location_id)
             ancestor = location.get_ancestors(include_self=False).get(location_type__name=location_type)

--- a/corehq/apps/userreports/decorators.py
+++ b/corehq/apps/userreports/decorators.py
@@ -51,7 +51,7 @@ def ucr_context_cache(vary_on=()):
     """
     def decorator(fn):
         assert 'context' in fn.func_code.co_varnames
-        assert isinstance(vary_on, (tuple, list))
+        assert isinstance(vary_on, tuple)
 
         @wraps(fn)
         def _inner(*args, **kwargs):

--- a/corehq/apps/userreports/decorators.py
+++ b/corehq/apps/userreports/decorators.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+import hashlib
+import inspect
 from functools import wraps
 
 from django.conf import settings
@@ -39,3 +41,32 @@ def catch_and_raise_exceptions(func):
         except TableNotFoundException:
             raise TableNotFoundWarning
     return _inner
+
+
+def ucr_context_cache(vary_on=()):
+    """
+    Decorator which caches calculations performed during a UCR EvaluationContext
+    The decorated function or method must have a parameter called 'context'
+    which will be used by this decorator to store the cache.
+    """
+    def decorator(fn):
+        assert 'context' in fn.func_code.co_varnames
+        assert isinstance(vary_on, (tuple, list))
+
+        @wraps(fn)
+        def _inner(*args, **kwargs):
+            # shamelessly stolen from quickcache
+            callargs = inspect.getcallargs(fn, *args, **kwargs)
+            context = callargs['context']
+            prefix = '{}.{}'.format(
+                fn.__name__[:40] + (fn.__name__[40:] and '..'),
+                hashlib.md5(inspect.getsource(fn)).hexdigest()[-8:]
+            )
+            cache_key = (prefix,) + tuple(callargs[arg_name] for arg_name in vary_on)
+            if context.exists_in_cache(cache_key):
+                return context.get_cache_value(cache_key)
+            res = fn(*args, **kwargs)
+            context.set_cache_value(cache_key, res)
+            return res
+        return _inner
+    return decorator

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -230,7 +230,7 @@ class RelatedDocExpressionSpec(JsonObject):
 
     def get_value(self, doc_id, context):
         assert context.root_doc['domain']
-        doc = self._get_document(self.related_doc_type, doc_id)
+        doc = self._get_document(self.related_doc_type, doc_id, context)
         # explicitly use a new evaluation context since this is a new document
         return self._value_expression(doc, EvaluationContext(doc, 0))
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -355,7 +355,7 @@ class SubcasesExpressionSpec(JsonObject):
         return self._get_subcases(case_id, context)
 
     @ucr_context_cache(vary_on=('case_id',))
-   def _get_subcases(self, case_id, context):
+    def _get_subcases(self, case_id, context):
         domain = context.root_doc['domain']
         return [c.to_json() for c in CaseAccessors(domain).get_reverse_indexed_cases([case_id])]
 

--- a/custom/enikshay/expressions.py
+++ b/custom/enikshay/expressions.py
@@ -388,6 +388,7 @@ class MostRecentEpisodeCaseFromPerson(JsonObject):
 
     def __call__(self, item, context=None):
         person_id = self._person_id_expression(item, context)
+        domain = context.root_doc['domain']
 
         @ucr_context_cache(vary_on=('person_id',))
         def _cached_get(person_id, context):

--- a/custom/enikshay/expressions.py
+++ b/custom/enikshay/expressions.py
@@ -5,6 +5,7 @@ from jsonobject import DefaultProperty, BooleanProperty
 from jsonobject.properties import ListProperty, StringProperty
 import six
 
+from corehq.apps.userreports.decorators import ucr_context_cache
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -17,13 +18,9 @@ from dimagi.ext.jsonobject import JsonObject
 from dimagi.utils.dates import force_to_datetime
 
 
+@ucr_context_cache(vary_on=('case_id',))
 def _get_case_forms(domain, case_id, context):
-    cache_key = ('_get_case_forms', case_id)
-    if context.get_cache_value(cache_key) is not None:
-        return context.get_cache_value(cache_key)
-    xforms = FormProcessorInterface(domain).get_case_forms(case_id)
-    context.set_cache_value(cache_key, xforms)
-    return xforms
+    return FormProcessorInterface(domain).get_case_forms(case_id)
 
 
 class FirstCaseFormWithXmlns(JsonObject):
@@ -153,38 +150,22 @@ class ReferralExpressionBase(JsonObject):
         return None
 
     @staticmethod
+    @ucr_context_cache(vary_on=('person_id',))
     def _get_referral(context, domain, person_id):
-        cache_key = (ReferralExpressionBase.__name__, "_get_referral", person_id)
-        if context.get_cache_value(cache_key, False) is not False:
-            return context.get_cache_value(cache_key)
-
         referral = get_open_referral_case_from_person(domain, person_id)
         if referral and (referral.dynamic_case_properties().get("referral_status") == "rejected"):
             referral = None
-        context.set_cache_value(cache_key, referral)
         return referral
 
     @staticmethod
+    @ucr_context_cache(vary_on=('referral_id',))
     def _get_referral_by_id(context, domain, referral_id):
-        cache_key = (ReferralExpressionBase.__name__, "_get_referral_by_id", referral_id)
-        if context.get_cache_value(cache_key, False) is not False:
-            return context.get_cache_value(cache_key)
-
-        referral = CaseAccessors(domain).get_case(referral_id)
-
-        context.set_cache_value(cache_key, referral)
-        return referral
+        return CaseAccessors(domain).get_case(referral_id)
 
     @staticmethod
+    @ucr_context_cache(vary_on=('person_id',))
     def _get_trail(context, domain, person_id):
-        cache_key = (ReferralExpressionBase.__name__, "_get_trail", person_id)
-
-        if context.get_cache_value(cache_key, False) is not False:
-            return context.get_cache_value(cache_key)
-
-        trail = get_latest_trail_case_from_person(domain, person_id)
-        context.set_cache_value(cache_key, trail)
-        return trail
+        return get_latest_trail_case_from_person(domain, person_id)
 
     def _handle_referral_case(self, referral):
         raise NotImplementedError
@@ -372,24 +353,18 @@ class MostRecentReferralCaseFromPerson(JsonObject):
         person_id = self._person_id_expression(item, context)
         domain = context.root_doc['domain']
 
-        cache_key = (
-            MostRecentEpisodeCaseFromPerson.__name__,
-            "enikshay_most_recent_referral_from_person",
-            person_id
-        )
-        if context.get_cache_value(cache_key, False) is not False:
-            return context.get_cache_value(cache_key)
+        @ucr_context_cache(vary_on=('person_id',))
+        def _cached_get(person_id, context):
+            if not person_id:
+                return None
+            try:
+                referral = get_most_recent_referral_case_from_person(domain, person_id)
+            except ENikshayCaseNotFound:
+                referral = None
+            if referral:
+                return referral.to_json()
 
-        if not person_id:
-            return None
-        try:
-            referral = get_most_recent_referral_case_from_person(domain, person_id)
-        except ENikshayCaseNotFound:
-            referral = None
-        context.set_cache_value(cache_key, referral)
-        if referral:
-            return referral.to_json()
-        return None
+        return _cached_get(person_id, context)
 
 
 def most_recent_referral_expression(spec, context):
@@ -413,24 +388,19 @@ class MostRecentEpisodeCaseFromPerson(JsonObject):
 
     def __call__(self, item, context=None):
         person_id = self._person_id_expression(item, context)
-        cache_key = (
-            MostRecentEpisodeCaseFromPerson.__name__,
-            "enikshay_most_recent_episode_from_person",
-            person_id
-        )
-        if context.get_cache_value(cache_key, False) is not False:
-            return context.get_cache_value(cache_key)
-        domain = context.root_doc['domain']
-        if not person_id:
-            return None
-        try:
-            episode = get_most_recent_episode_case_from_person(domain, person_id)
-        except ENikshayCaseNotFound:
-            episode = None
-        context.set_cache_value(cache_key, episode)
-        if episode:
-            return episode.to_json()
-        return None
+
+        @ucr_context_cache(vary_on=('person_id',))
+        def _cached_get(person_id, context):
+            if not person_id:
+                return None
+            try:
+                episode = get_most_recent_episode_case_from_person(domain, person_id)
+            except ENikshayCaseNotFound:
+                episode = None
+            if episode:
+                return episode.to_json()
+
+        return _cached_get(person_id, context)
 
 
 def most_recent_episode_expression(spec, context):


### PR DESCRIPTION
There's a lot of repeated boilerplate around caching UCR expressions in the context cache.  This PR attempts to simplify that.  There are a bunch more places where this could be used, but I figure this is a decent enough starting place.
@emord @sravfeyn

@dannyroberts I copied much of the cache key stuff from quickcache - you might wanna have a looksee.