### PR TITLE
Mk 265955 kill user sync history

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -83,16 +83,6 @@ class SelectMobileWorkerFilter(BaseSingleOptionFilter):
         return default
 
 
-class AltPlaceholderMobileWorkerFilter(SelectMobileWorkerFilter):
-    default_text = ugettext_noop('Enter a worker')
-    is_paginated = True
-
-    @property
-    def pagination_source(self):
-        from corehq.apps.reports.filters.api import MobileWorkersOptionsView
-        return reverse(MobileWorkersOptionsView.urlname, args=[self.domain])
-
-
 class SelectCaseOwnerFilter(SelectMobileWorkerFilter):
     label = ugettext_noop("Select Case Owner")
     default_text = ugettext_noop("All Case Owners")

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -6,7 +6,7 @@ import pytz
 import json
 
 from celery.utils.log import get_task_logger
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, HttpResponseRedirect
 from django.template.context import RequestContext
 from django.template.loader import render_to_string
 from django.shortcuts import render
@@ -138,8 +138,8 @@ class GenericReportView(object):
     parent_report_class = None
 
     is_deprecated = False
-    deprecation_email_message = None
-    deprecation_message = None
+    deprecation_email_message = ugettext("This report has been deprecated.")
+    deprecation_message = ugettext("This report has been deprecated.")
 
     def __init__(self, request, base_context=None, domain=None, **kwargs):
         if not self.name or not self.section_name or self.slug is None or not self.dispatcher:
@@ -566,7 +566,12 @@ class GenericReportView(object):
 
     @property
     def deprecate_response(self):
-        raise NotImplementedError
+        from django.contrib import messages
+        messages.warning(
+            self.request,
+            self.deprecation_message
+        )
+        return HttpResponseRedirect(self.request.META.get('HTTP_REFERER', '/'))
 
     @property
     def view_response(self):

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -137,6 +137,10 @@ class GenericReportView(object):
     # against.
     parent_report_class = None
 
+    is_deprecated = False
+    deprecation_email_message = None
+    deprecation_message = None
+
     def __init__(self, request, base_context=None, domain=None, **kwargs):
         if not self.name or not self.section_name or self.slug is None or not self.dispatcher:
             raise NotImplementedError("Missing a required parameter: (name: %(name)s, section_name: %(section_name)s,"
@@ -561,18 +565,25 @@ class GenericReportView(object):
         self.context.update(self._validate_context_dict(self.report_context))
 
     @property
+    def deprecate_response(self):
+        raise NotImplementedError
+
+    @property
     def view_response(self):
         """
             Intention: Not to be overridden in general.
             Renders the general view of the report template.
         """
-        self.update_template_context()
-        template = self.template_base
-        if not self.asynchronous:
-            self.update_filter_context()
-            self.update_report_context()
-            template = self.template_report
-        return render(self.request, template, self.context)
+        if self.is_deprecated:
+            return self.deprecate_response
+        else:
+            self.update_template_context()
+            template = self.template_base
+            if not self.asynchronous:
+                self.update_filter_context()
+                self.update_report_context()
+                template = self.template_report
+            return render(self.request, template, self.context)
 
     @property
     @request_cache()

--- a/corehq/apps/reports/management/commands/find_saved_reports_with_slug.py
+++ b/corehq/apps/reports/management/commands/find_saved_reports_with_slug.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, print_function
+
+from django.conf import settings
+from dimagi.utils.couch.cache import cache_core
+from corehq.apps.reports.models import ReportConfig
+
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('report_slug')
+
+    def handle(self, report_slug, *args, **options):
+        kwargs = {'stale': settings.COUCH_STALE_QUERY}
+        key = ["name slug"]
+        result = cache_core.cached_view(
+            ReportConfig.get_db(),
+            "reportconfig/configs_by_domain",
+            reduce=False, include_docs=False,
+            startkey=key, endkey=key + [{}],
+            **kwargs)
+        for report_config in result:
+            domain, owner_id, slug = report_config['key'][1:4]
+            if slug == report_slug:
+                print("%s, %s, %s" % (
+                    domain, owner_id, slug
+                ))

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -480,6 +480,15 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         except Exception:
             pass
 
+        if self.report.is_deprecated:
+            return ReportContent(
+                self.report.deprecation_email_message or
+                _("[DEPRECATED] %s report has been deprecated and will stop working soon. "
+                  "Please update your saved reports email settings if needed." % self.report.name
+                  ),
+                None,
+            )
+
         from django.http import HttpRequest, QueryDict
         mock_request = HttpRequest()
         mock_request.couch_user = self.owner

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -291,14 +291,22 @@ class SyncHistoryReport(DeploymentsReport):
     # To be removed. Link deactivated on 6th Dec 2017.
     name = ugettext_noop("User Sync History")
     slug = "sync_history"
+    is_deprecated = True
+    deprecation_email_message = ugettext_lazy(
+        "The Sync History report has been deprecated. You can use the Application Status report to identify "
+        "the last time a user synced. This saved email will stop working within the next two months. "
+        "Please update your saved reports email settings if needed.")
+    deprecation_message = ugettext_lazy(
+        "The Sync History report has been deprecated. "
+        "You can use the Application Status report to identify the last time a user synced."
+    )
 
     @property
-    def view_response(self):
+    def deprecate_response(self):
         from django.contrib import messages
-        messages.success(
+        messages.warning(
             self.request,
-            _('Sync History Report is not being maintained anymore and will be removed soon. '
-              'Please report an issue if you have any concerns regarding this.')
+            self.deprecation_message
         )
         return HttpResponseRedirect(
             reverse(ApplicationStatusReport.dispatcher.name(), args=[],

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from datetime import date, datetime, timedelta
 
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext as _, ugettext_lazy
 
@@ -408,6 +409,18 @@ class SyncHistoryReport(DeploymentsReport):
             return min(self.MAX_LIMIT, int(self.request.GET.get('limit', self.DEFAULT_LIMIT)))
         except ValueError:
             return self.DEFAULT_LIMIT
+
+    @property
+    def view_response(self):
+        from django.contrib import messages
+        messages.success(
+            self.request,
+            _('Sync History Report is not being maintained anymore and will be removed soon. '
+              'Please report an issue if you have any concerns regarding this.')
+        )
+        return HttpResponseRedirect(
+            reverse(ApplicationStatusReport.dispatcher.name(), args=[],
+                    kwargs={'domain': self.domain, 'report_slug': ApplicationStatusReport.slug}))
 
 
 def _get_sort_key(date):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -8,8 +8,6 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import ugettext_noop, ugettext as _, ugettext_lazy
 
-from casexml.apps.phone.analytics import get_sync_logs_for_user
-from casexml.apps.phone.models import SyncLogAssertionError
 from couchdbkit import ResourceNotFound
 from corehq.apps.es.aggregations import DateHistogram
 from corehq.apps.hqwebapp.decorators import use_nvd3
@@ -25,13 +23,11 @@ from phonelog.models import UserErrorEntry
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app, get_brief_apps_in_domain
 from corehq.apps.es import UserES
-from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import user_display_string
 from corehq.const import USER_DATE_FORMAT
-from corehq.util.couch import get_document_or_404
 
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
+from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.filters.select import SelectApplicationFilter
 from corehq.apps.reports.generic import GenericTabularReport, GetParamsMixin, PaginatedReportMixin
 from corehq.apps.reports.standard import ProjectReportParametersMixin, ProjectReport
@@ -292,123 +288,9 @@ def _choose_latest_version(*app_versions):
 
 
 class SyncHistoryReport(DeploymentsReport):
-    DEFAULT_LIMIT = 10
-    MAX_LIMIT = 1000
+    # To be removed. Link deactivated on 6th Dec 2017.
     name = ugettext_noop("User Sync History")
     slug = "sync_history"
-    emailable = True
-    fields = ['corehq.apps.reports.filters.users.AltPlaceholderMobileWorkerFilter']
-
-    @property
-    def report_subtitles(self):
-        return [_('Shows the last (up to) {} times a user has synced.').format(self.limit)]
-
-    @property
-    def disable_pagination(self):
-        return self.limit == self.DEFAULT_LIMIT
-
-    @property
-    def headers(self):
-        headers = DataTablesHeader(
-            DataTablesColumn(_("Sync Date"), sort_type=DTSortType.NUMERIC),
-            DataTablesColumn(_("# of Cases"), sort_type=DTSortType.NUMERIC),
-            DataTablesColumn(_("Sync Duration"), sort_type=DTSortType.NUMERIC)
-        )
-        if self.show_extra_columns:
-            headers.add_column(DataTablesColumn(_("Sync Log")))
-            headers.add_column(DataTablesColumn(_("Sync Log Type")))
-            headers.add_column(DataTablesColumn(_("Previous Sync Log")))
-            headers.add_column(DataTablesColumn(_("Error Info")))
-            headers.add_column(DataTablesColumn(_("State Hash")))
-            headers.add_column(DataTablesColumn(_("Last Submitted")))
-            headers.add_column(DataTablesColumn(_("Last Cached")))
-
-        headers.custom_sort = [[0, 'desc']]
-        return headers
-
-    @property
-    def rows(self):
-        base_link_url = '{}?id={{id}}'.format(reverse('raw_couch'))
-
-        user_id = self.request.GET.get('individual')
-        if not user_id:
-            return []
-
-        # security check
-        get_document_or_404(CommCareUser, self.domain, user_id)
-
-        def _sync_log_to_row(sync_log):
-            def _fmt_duration(duration):
-                if isinstance(duration, int):
-                    return format_datatables_data(
-                        '<span class="{cls}">{text}</span>'.format(
-                            cls=_bootstrap_class(duration or 0, 60, 20),
-                            text=_('{} seconds').format(duration),
-                        ),
-                        duration
-                    )
-                else:
-                    return format_datatables_data(
-                        '<span class="label label-default">{text}</span>'.format(
-                            text=_("Unknown"),
-                        ),
-                        -1,
-                    )
-
-            def _fmt_id(sync_log_id):
-                href = base_link_url.format(id=sync_log_id)
-                return '<a href="{href}" target="_blank">{id:.5}...</a>'.format(
-                    href=href,
-                    id=sync_log_id
-                )
-
-            def _fmt_error_info(sync_log):
-                if not sync_log.had_state_error:
-                    return u'<span class="label label-success">&#10003;</span>'
-                else:
-                    return (u'<span class="label label-danger">X</span>'
-                            u'State error {}<br>Expected hash: {:.10}...').format(
-                        _naturaltime_with_hover(sync_log.error_date),
-                        sync_log.error_hash,
-                    )
-
-            def _get_state_hash_display(sync_log):
-                try:
-                    return u'{:.10}...'.format(sync_log.get_state_hash())
-                except SyncLogAssertionError as e:
-                    return _(u'Error computing hash! {}').format(e)
-
-            num_cases = sync_log.case_count()
-            columns = [
-                _fmt_date(sync_log.date),
-                format_datatables_data(num_cases, num_cases),
-                _fmt_duration(sync_log.duration),
-            ]
-            if self.show_extra_columns:
-                columns.append(_fmt_id(sync_log.get_id))
-                columns.append(sync_log.log_format)
-                columns.append(_fmt_id(sync_log.previous_log_id) if sync_log.previous_log_id else '---')
-                columns.append(_fmt_error_info(sync_log))
-                columns.append(_get_state_hash_display(sync_log))
-                columns.append(_naturaltime_with_hover(sync_log.last_submitted))
-                columns.append(u'{}<br>{:.10}'.format(_naturaltime_with_hover(sync_log.last_cached),
-                                                      sync_log.hash_at_last_cached))
-
-            return columns
-
-        return [_sync_log_to_row(sync_log)
-                for sync_log in get_sync_logs_for_user(user_id, self.limit)]
-
-    @property
-    def show_extra_columns(self):
-        return self.request.user and toggles.SUPPORT.enabled(self.request.user.username)
-
-    @property
-    def limit(self):
-        try:
-            return min(self.MAX_LIMIT, int(self.request.GET.get('limit', self.DEFAULT_LIMIT)))
-        except ValueError:
-            return self.DEFAULT_LIMIT
 
     @property
     def view_response(self):


### PR DESCRIPTION
Product Note: Sync History Report is deprecated and redirects to App Status Report Page with message:
`The Sync History report has been deprecated. You can use the Application Status report to identify the last time a user synced.`
And any schedule emails would show:
`The Sync History report has been deprecated. You can use the Application Status report to identify the last time a user synced. This saved email will stop working within the next two months. Please update your saved reports email settings if needed.`

https://manage.dimagi.com/default.asp?265955

This PR adds a generic way to deprecate reports. Once a report is flagged as deprecated  (in code, no UI), Link to that report will redirect user back to previous page or any other configured page with message:
`This report has been deprecated.` or a custom message which can be added for that report on deprecation.
Same applies for saved reports using the deprecated report. Links on those pages will redirect user with the same message as above.

Similarly for any emails sent out for this report under Scheduled reports will show a message in the mail
`This report has been deprecated.` or a custom email message which was added for that report on deprecation.