### PR TITLE
Fix app preview red dot not appearing when forms/modules are rearranged

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -156,16 +156,8 @@ hqDefine('app_manager/js/app_manager', function () {
         setInterval(_checkPublishStatus, 20000);
 
         // sniff ajax calls to other urls that make app changes
-        $(document).ajaxComplete(function(e, xhr, options) {
-            if (/edit_form_attr/.test(options.url) ||
-                /edit_module_attr/.test(options.url) ||
-                /edit_module_detail_screens/.test(options.url) ||
-                /edit_app_attr/.test(options.url) ||
-                /edit_form_actions/.test(options.url) ||
-                /edit_commcare_settings/.test(options.url) ||
-                /patch_xform/.test(options.url)) {
-                module.setPublishStatus(true);
-            }
+        hqImport("app_manager/js/app_manager_utils").handleAjaxAppChange(function() {
+            module.setPublishStatus(true);
         });
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
@@ -1,6 +1,4 @@
 hqDefine('app_manager/js/app_manager_utils', function () {
-    var app_manager_utils = {};
-
     var get_bitly_to_phonetic_dict = function () {
         var nato_phonetic = {
             "A": "Alpha",
@@ -52,7 +50,7 @@ hqDefine('app_manager/js/app_manager_utils', function () {
     };
 
     var bitly_to_phonetic;
-    app_manager_utils.bitly_nato_phonetic = function (bitly_url) {
+    var bitly_nato_phonetic = function (bitly_url) {
         /**
          * We use this method to explicitly spell out the bitly code for
          * users who have trouble reading the letters (esp. 1 and l, O and 0)
@@ -70,5 +68,28 @@ hqDefine('app_manager/js/app_manager_utils', function () {
             return phonetics.join(' ');
         }
     };
-    return app_manager_utils;
+
+    var handleAjaxAppChange = function(callback) {
+        $(document).ajaxComplete(function(e, xhr, options) {
+            var match = options.url.match(/\/apps\/(.*)/);
+            if (match) {
+                suffix = match[1];  // first captured group
+                if (/^edit_form_attr/.test(suffix) ||
+                    /^edit_module_attr/.test(suffix) ||
+                    /^edit_module_detail_screens/.test(suffix) ||
+                    /^edit_app_attr/.test(suffix) ||
+                    /^edit_form_actions/.test(suffix) ||
+                    /^edit_commcare_settings/.test(suffix) ||
+                    /^rearrange/.test(suffix) ||
+                    /^patch_xform/.test(suffix)) {
+                    callback();
+                }
+            }
+        });
+    };
+
+    return {
+        bitly_nato_phonetic: bitly_nato_phonetic,
+        handleAjaxAppChange: handleAjaxAppChange,
+    };
 });

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
@@ -73,7 +73,7 @@ hqDefine('app_manager/js/app_manager_utils', function () {
         $(document).ajaxComplete(function(e, xhr, options) {
             var match = options.url.match(/\/apps\/(.*)/);
             if (match) {
-                suffix = match[1];  // first captured group
+                var suffix = match[1];  // first captured group
                 if (/^edit_form_attr/.test(suffix) ||
                     /^edit_module_attr/.test(suffix) ||
                     /^edit_module_detail_screens/.test(suffix) ||

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -209,16 +209,8 @@ hqDefine('app_manager/js/preview_app', function() {
             hqImport('analytix/js/kissmetrix').track.event("[app-preview] Clicked Refresh App Preview");
             hqImport('analytix/js/google').track.event("App Preview", "Clicked Refresh App Preview");
         });
-        $(document).ajaxComplete(function(e, xhr, options) {
-            if (/edit_form_attr/.test(options.url) ||
-                /edit_module_attr/.test(options.url) ||
-                /edit_module_detail_screens/.test(options.url) ||
-                /edit_app_attr/.test(options.url) ||
-                /edit_form_actions/.test(options.url) ||
-                /edit_commcare_settings/.test(options.url) ||
-                /patch_xform/.test(options.url)) {
-                $(module.SELECTORS.BTN_REFRESH).addClass('app-out-of-date');
-            }
+        hqImport("app_manager/js/app_manager_utils").handleAjaxAppChange(function() {
+            $(module.SELECTORS.BTN_REFRESH).addClass('app-out-of-date');
         });
         var onload = function() {
             if (localStorage.getItem(module.DATA.TABLET)) {

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -11,7 +11,6 @@
 
 {% block js %}{{  block.super }}
   {% compress js %}
-      <script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
       <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
       <script src="{% static 'app_manager/js/releases/releases.js' %}"></script>
       <script src="{% static 'app_manager/js/releases/language_profiles.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -10,6 +10,7 @@
 {% block js %}
     {{ block.super }}
     {% compress js %}
+    <script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
     <script src="{% static 'app_manager/js/preview_app.js' %}"></script>
     <script src="{% static 'app_manager/js/apps_base.js' %}"></script>
     <script src="{% static 'app_manager/js/app_manager.js' %}"></script>

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -57,6 +57,7 @@
 {% endblock %}
 
 {% block js %}
+<script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
 <script src="{% static 'cloudcare/js/preview_app/preview_app.js' %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
As reported in field-dev. The actual bug fix is just adding rearrange to the list of urls. The rest of the changes make this logic shared between app preview's red dot and app builder's  purple "Updates available to publish" banner.

This code is a little fragile, discussion [here](https://github.com/dimagi/commcare-hq/pull/16308#discussion_r121703824)

@calellowitz / @biyeun 
fyi @wpride 