### PR TITLE
Wait until document is ready to call analytics init functions

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/drift.js
+++ b/corehq/apps/analytics/static/analytix/js/drift.js
@@ -55,10 +55,13 @@ hqDefine('analytix/js/drift', [
             hubspot.trackEvent('Identified via Drift');
         });
     };
-    if (_global('isEnabled')) {
-        __init__();
-        logger.debug.log("Initialized");
-    }
+
+    $(function() {
+        if (_global('isEnabled')) {
+            __init__();
+            logger.debug.log("Initialized");
+        }
+    });
 
     // no methods just yet
     return {

--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -67,10 +67,12 @@ hqDefine('analytix/js/google', [
         _gtag('config', _data.apiId, _data.user);
     };
 
-    if (_global('isEnabled')) {
-        __init__();
-        logger.debug.log('Initialized');
-    }
+    $(function() {
+        if (_global('isEnabled')) {
+            __init__();
+            logger.debug.log('Initialized');
+        }
+    });
 
     /**
      * Helper function for sending a Google Analytics Event.

--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -30,10 +30,13 @@ hqDefine('analytix/js/hubspot', [
             });
         }
     };
-    if (_global('isEnabled')) {
-        __init__();
-        logger.debug.log('Initialized');
-    }
+
+    $(function() {
+        if (_global('isEnabled')) {
+            __init__();
+            logger.debug.log('Initialized');
+        }
+    });
 
     /**
      * Sends data to Hubspot to identify the current session.

--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -79,10 +79,12 @@ hqDefine('analytix/js/kissmetrix', [
         });
     };
 
-    if (_global('isEnabled')) {
-        __init__();
-        logger.debug.log("Initialized");
-    }
+    $(function() {
+        if (_global('isEnabled')) {
+            __init__();
+            logger.debug.log("Initialized");
+        }
+    });
 
     /**
      * Identifies the current user


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266675

This fixes a couple of regressions, though to my knowledge only the first one has been reported:
- can't save groups
- can't delete groups
- can't create a scheduled report
- on mobile workers page, can't update phone number, can't delete user, can't update user info
- can't close case from single case view
- can't restore a form from case history
- can't publish to exchange

This functionality may still be broken for users who have adblockers turned on. I'm working on addressing that.

@nickpell Can this get into today's deploy?
code buddy @calellowitz 