### PR TITLE
Fix owner_ids not matching assigned facility

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -193,7 +193,7 @@ def property_changed_in_action(case_transaction, case_id, case_property_name):
     for update in case_updates:
         if update.id == case_id:
             actions.append((update.modified_on_str, update.get_update_action(), case_transaction))
-            if include_create_fields:
+            if include_create_fields and case_transaction.action_type == CASE_ACTION_CREATE:
                 actions.append((update.modified_on_str, update.get_create_action(), case_transaction))
 
     for (modified_on, action, case_transaction) in actions:
@@ -231,7 +231,7 @@ def get_datetime_case_property_changed(case, case_property_name, value):
 
 def get_all_changes_to_case_property(case, case_property_name):
     case_property_changes = []
-    case_transactions = [a for a in case.actions if a.action_type == 'update']
+    case_transactions = case.actions
     for transaction in case_transactions:
         property_changed_info = property_changed_in_action(transaction, case.case_id, case_property_name)
         if property_changed_info:

--- a/custom/enikshay/management/commands/reassign_from_facility.py
+++ b/custom/enikshay/management/commands/reassign_from_facility.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import, print_function
+
+import csv
+import datetime
+
+import six
+from django.core.management.base import BaseCommand
+
+from casexml.apps.case.util import get_all_changes_to_case_property
+from corehq.apps.hqcase.utils import bulk_update_cases
+from corehq.util.log import with_progress_bar
+from custom.enikshay.case_utils import (
+    get_all_episode_ids,
+    iter_all_active_person_episode_cases,
+)
+from dimagi.utils.chunked import chunked
+
+MJK = 'df661f7aaf384e9c98d88beeedb83050'
+ALERT_INDIA = 'af50474dd6b747b29a2934b7b0359bdf'
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('--commit', action='store_true')
+
+    def handle(self, domain, **options):
+        commit = options['commit']
+
+        filename = "reassign_from_facility-{}.csv".format(datetime.datetime.now().strftime('%Y-%m-%d_%H.%M.%S'))
+        columns = ['case_id', 'facility_assigned_to', 'owner_id',
+                   'last_owner_id_changed', 'last_facility_assigned_to_changed', 'note']
+
+        case_ids = get_all_episode_ids(domain)
+        cases = iter_all_active_person_episode_cases(domain, case_ids, sector='private')
+        bad_cases = []
+        to_update = []
+        for person, _ in with_progress_bar(cases, length=len(case_ids)):
+            facility_assigned_to = person.get_case_property('facility_assigned_to')
+            owner_id = person.owner_id
+            if facility_assigned_to == owner_id:
+                continue
+            if not facility_assigned_to and owner_id in [MJK, ALERT_INDIA]:
+                # cases with a blank facility and owned by MJK or Alert-India are known about already
+                continue
+
+            owner_id_changes = sorted(get_all_changes_to_case_property(person, 'owner_id'),
+                                      key=lambda c: c.modified_on, reverse=True)
+            facility_id_changes = sorted(get_all_changes_to_case_property(person, 'facility_assigned_to'),
+                                         key=lambda c: c.modified_on, reverse=True)
+
+            case_dict = {
+                'case_id': person.case_id,
+                'facility_assigned_to': facility_assigned_to,
+                'owner_id': owner_id,
+            }
+            try:
+                case_dict['last_owner_id_changed'] = owner_id_changes[0].modified_on
+                case_dict['last_facility_assigned_to_changed'] = facility_id_changes[0].modified_on
+                if owner_id_changes[0].modified_on < facility_id_changes[0].modified_on:
+                    case_dict['note'] = 'updated'
+                    to_update.append((person.case_id, {"owner_id": facility_assigned_to}, False))
+                else:
+                    case_dict['note'] = 'not updated'
+            except IndexError as e:
+                case_dict['last_owner_id_changed'] = None
+                case_dict['last_facility_assigned_to_changed'] = None
+                case_dict['note'] = 'no changes found: {}'.format(six.text_type(e))
+
+            bad_cases.append(case_dict)
+
+        if commit:
+            print("Updating: ", len(to_update), " cases")
+            for update in chunked(to_update, 100):
+                bulk_update_cases(domain, update, self.__module__)
+        else:
+            print("Would have updated: ", len(to_update), " cases")
+
+        with open(filename, 'w') as f:
+            writer = csv.DictWriter(f, fieldnames=columns)
+            writer.writeheader()
+            for case in bad_cases:
+                writer.writerow(case)


### PR DESCRIPTION
Somehow we messed up the owner_ids of ~3000 cases: https://manage.dimagi.com/default.asp?266113
Luckily, we stored this data on the case in a different property.

This task checks where this property doesn't match. If the `owner_id` was updated after the `facility_assigned_to` then we assume this was intentional, and don't reset the `owner_id`.

@emord 