### PR TITLE
Order sql query to get deterministic output.

### DIFF
--- a/custom/icds_reports/ucr/tests/base_test.py
+++ b/custom/icds_reports/ucr/tests/base_test.py
@@ -88,7 +88,7 @@ class BaseICDSDatasourceTest(TestCase, TestFileMixin):
             now.return_value = datetime.combine(start_date, datetime.min.time()) + relativedelta(months=1)
             _iteratively_build_table(self.datasource)
             queue_async_indicators()
-        query = self._get_query_object().filter_by(doc_id=case_id)
+        query = self._get_query_object().filter_by(doc_id=case_id).order_by(self.adapter.get_table().columns.month)
         self.assertEqual(query.count(), len(cases))
 
         for index, test_values in cases:


### PR DESCRIPTION
Neither I nor @nickpell can repro this locally, but some tests fail with

```
======================================================================
FAIL: custom.icds_reports.ucr.tests.test_child_health_monthly:TestChildHealthDataSource.test_ebf_no_ebf_reasons1
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vendor/lib/python2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/mnt/commcare-hq-ro/custom/icds_reports/ucr/tests/test_child_health_monthly.py", line 1304, in test_ebf_no_ebf_reasons1
    self._run_iterative_monthly_test(case_id=case_id, cases=cases)
  File "/mnt/commcare-hq-ro/custom/icds_reports/ucr/tests/base_test.py", line 96, in _run_iterative_monthly_test
    self.assertEqual(row['month'], start_date + relativedelta(months=index))
AssertionError: datetime.date(2016, 4, 1) != datetime.date(2016, 2, 1)
```

Maybe this will work?

buddy @proteusvacuum 