### PR TITLE
Adds a button to navigate easily to OpenMRS repeater config

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/repeater_row.html
+++ b/corehq/apps/domain/templates/domain/admin/repeater_row.html
@@ -29,7 +29,7 @@
             >
             {% trans "View forwarded records" %}
         </a>
-        {% if cls == 'OpenmrsRepeater' %}
+        {% if cls == 'OpenmrsRepeater' and gefingerpoken %}
         <a class="btn btn-default" href="{% url 'openmrs_edit_config' domain repeater.get_id %}">
             {% trans "Configure" %}
         </a>

--- a/corehq/apps/domain/templates/domain/admin/repeater_row.html
+++ b/corehq/apps/domain/templates/domain/admin/repeater_row.html
@@ -29,6 +29,11 @@
             >
             {% trans "View forwarded records" %}
         </a>
+        {% if cls == 'OpenmrsRepeater' %}
+        <a class="btn btn-default" href="{% url 'openmrs_edit_config' domain repeater.get_id %}">
+            {% trans "Configure" %}
+        </a>
+        {% endif %}
         <a class="btn btn-danger" href="#stop_forwarding_{{ repeater.get_id }}" data-toggle="modal"><i
                 class="fa fa-remove"></i> {% trans "Stop Forwarding" %}</a>
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2510,6 +2510,8 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
         return {
             'repeaters': self.repeaters,
             'pending_record_count': RepeatRecord.count(self.domain),
+            'gefingerpoken': self.request.couch_user.is_superuser or
+                             toggles.IS_DEVELOPER.enabled(self.request.couch_user.username)
         }
 
 


### PR DESCRIPTION
Allows users to click a button instead of manually entering a URL ... but still maintains a barrier to entry for users who shouldn't be poking around.
