### PR TITLE
Use parent_location_id directly

### DIFF
--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -57,12 +57,8 @@ def location_parent_id(spec, context):
         "related_doc_type": "Location",
         "doc_id_expression": spec['location_id_expression'],
         "value_expression": {
-            "type": "array_index",
-            'array_expression': {
-                'type': 'property_name',
-                'property_name': 'lineage'
-            },
-            'index_expression': 0,
+            "type": "property_name",
+            "property_name": "parent_location_id",
         }
     }
     return ExpressionFactory.from_spec(spec, context)


### PR DESCRIPTION
Once upon a time, this wasn't available, so people used lineage as a workaround.
@sravfeyn