### PR TITLE
Ce/default basic

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -19,7 +19,7 @@ API_KEY = 'api_key'
 TOKEN = 'token'
 
 
-def determine_authtype_from_header(request, default=None):
+def determine_authtype_from_header(request, default=DIGEST):
     """
     Guess the auth type, based on the headers found in the request.
     """
@@ -35,12 +35,10 @@ def determine_authtype_from_header(request, default=None):
 
     # If there is no HTTP_AUTHORIZATION header, we return a 401 along with the necessary
     # headers for digest auth
-    if default is None:
-        default = DIGEST
     return default
 
 
-def determine_authtype_from_request(request, default=None):
+def determine_authtype_from_request(request, default=DIGEST):
     """
     Guess the auth type, based on the (phone's) user agent or the
     headers found in the request.
@@ -51,8 +49,6 @@ def determine_authtype_from_request(request, default=None):
         ANDROID: BASIC,
     }
     user_type = guess_phone_type_from_user_agent(user_agent)
-    if default is None:
-        default = DIGEST
     if user_type is not None:
         return type_to_auth_map.get(user_type, default)
     else:

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -19,7 +19,7 @@ API_KEY = 'api_key'
 TOKEN = 'token'
 
 
-def determine_authtype_from_header(request):
+def determine_authtype_from_header(request, default=None):
     """
     Guess the auth type, based on the headers found in the request.
     """
@@ -35,10 +35,12 @@ def determine_authtype_from_header(request):
 
     # If there is no HTTP_AUTHORIZATION header, we return a 401 along with the necessary
     # headers for digest auth
-    return DIGEST
+    if default is None:
+        default = DIGEST
+    return default
 
 
-def determine_authtype_from_request(request):
+def determine_authtype_from_request(request, default=None):
     """
     Guess the auth type, based on the (phone's) user agent or the
     headers found in the request.
@@ -49,10 +51,12 @@ def determine_authtype_from_request(request):
         ANDROID: BASIC,
     }
     user_type = guess_phone_type_from_user_agent(user_agent)
+    if default is None:
+        default = DIGEST
     if user_type is not None:
-        return type_to_auth_map.get(user_type, DIGEST)
+        return type_to_auth_map.get(user_type, default)
     else:
-        return determine_authtype_from_header(request)
+        return determine_authtype_from_header(request, default)
 
 
 def guess_phone_type_from_user_agent(user_agent):

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -214,7 +214,7 @@ def login_or_token_ex(allow_cc_users=False, allow_sessions=True):
     return _login_or_challenge(tokenauth, allow_cc_users=allow_cc_users, allow_sessions=allow_sessions)
 
 
-def login_or_digest_or_basic_or_apikey():
+def login_or_digest_or_basic_or_apikey(default=DIGEST):
     def decorator(fn):
         @wraps(fn)
         def _inner(request, *args, **kwargs):
@@ -222,7 +222,7 @@ def login_or_digest_or_basic_or_apikey():
                 BASIC: login_or_basic_ex(allow_cc_users=True),
                 DIGEST: login_or_digest_ex(allow_cc_users=True),
                 API_KEY: login_or_api_key_ex(allow_cc_users=True)
-            }[determine_authtype_from_request(request)]
+            }[determine_authtype_from_request(request, default)]
             if not function_wrapper:
                 return HttpResponseForbidden()
             return function_wrapper(fn)(request, *args, **kwargs)
@@ -230,12 +230,10 @@ def login_or_digest_or_basic_or_apikey():
     return decorator
 
 
-def login_or_digest_or_basic_or_apikey_or_token(default=None):
+def login_or_digest_or_basic_or_apikey_or_token(default=DIGEST):
     def decorator(fn):
         @wraps(fn)
         def _inner(request, *args, **kwargs):
-            if default is None:
-                default = DIGEST
             function_wrapper = {
                 BASIC: login_or_basic_ex(allow_cc_users=True),
                 DIGEST: login_or_digest_ex(allow_cc_users=True),

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -230,16 +230,18 @@ def login_or_digest_or_basic_or_apikey():
     return decorator
 
 
-def login_or_digest_or_basic_or_apikey_or_token():
+def login_or_digest_or_basic_or_apikey_or_token(default=None):
     def decorator(fn):
         @wraps(fn)
         def _inner(request, *args, **kwargs):
+            if default is None:
+                default = DIGEST
             function_wrapper = {
                 BASIC: login_or_basic_ex(allow_cc_users=True),
                 DIGEST: login_or_digest_ex(allow_cc_users=True),
                 API_KEY: login_or_api_key_ex(allow_cc_users=True),
                 TOKEN: login_or_token_ex(allow_cc_users=True),
-            }[determine_authtype_from_request(request)]
+            }[determine_authtype_from_request(request, default)]
             if not function_wrapper:
                 return HttpResponseForbidden()
             return function_wrapper(fn)(request, *args, **kwargs)

--- a/corehq/apps/mobile_auth/views.py
+++ b/corehq/apps/mobile_auth/views.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import datetime
 
+from corehq.apps.domain.auth import BASIC
 from corehq.util.datadog.utils import count_by_response_code
 from django.http import HttpResponse, HttpResponseNotFound
 from django.views.decorators.http import require_GET
@@ -61,7 +62,7 @@ class FetchKeyRecords(object):
         )
 
 
-@login_or_digest_or_basic_or_apikey()
+@login_or_digest_or_basic_or_apikey(default=BASIC)
 @require_GET
 @count_by_response_code('commcare.auth_keys.fetch.count')
 def fetch_key_records(request, domain):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -8,10 +8,9 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET
 from iso8601 import iso8601
 
-from casexml.apps.phone.exceptions import InvalidSyncLogException
+
+from corehq.apps.domain.auth import BASIC
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
-from corehq.util.datadog.gauges import datadog_counter
-from corehq.util.datadog.utils import bucket_value
 from dimagi.utils.logging import notify_exception
 from casexml.apps.case.cleanup import claim_case, get_first_claim
 from casexml.apps.case.fixtures import CaseDBFixture
@@ -44,7 +43,7 @@ from corehq.apps.users.util import update_device_meta, update_latest_builds, upd
 
 @location_safe
 @handle_401_response
-@login_or_digest_or_basic_or_apikey_or_token()
+@login_or_digest_or_basic_or_apikey_or_token(default=BASIC)
 @check_domain_migration
 def restore(request, domain, app_id=None):
     """

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -5,7 +5,7 @@ import re
 from couchdbkit import ResourceNotFound
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import ApplicationBase
-from corehq.apps.domain.auth import determine_authtype_from_request
+from corehq.apps.domain.auth import determine_authtype_from_request, BASIC
 from corehq.apps.receiverwrapper.exceptions import LocalSubmissionError
 from corehq.form_processor.submission_post import SubmissionPost
 from corehq.form_processor.utils import convert_xform_to_json
@@ -211,7 +211,7 @@ def determine_authtype(request):
     if request.GET.get('authtype'):
         return request.GET['authtype']
 
-    return determine_authtype_from_request(request)
+    return determine_authtype_from_request(request, default=BASIC)
 
 
 def from_demo_user(form_json):


### PR DESCRIPTION
@esoergel @proteusvacuum @snopoke 
https://manage.dimagi.com/default.asp?266722
This fixes a bug where old versions of commcare on android 6.0.1 cannot log in because of a bug in the digest auth libraries being used. This defaults mobile login to basic auth (which i believe is intended anyway).  It reverts some of the changes made to default everything to digest, but I do not believe it should break any functionality that relies on that since it should only affect the three phone endpoints (sync, submission, and keys).
This also revealed an issue with this check https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/auth.py#L58 . Notably the user agent for android phone does not always (or maybe ever) contain android.

This issue is resolved in newer mobile versions, but ICDS is stuck on the old LTS version