### PR TITLE
Guessing patient identity: Review / sanity check

### DIFF
--- a/corehq/motech/openmrs/guessers.py
+++ b/corehq/motech/openmrs/guessers.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+
+
+PATIENT_GUESSERS = []
+
+
+def register_patient_guesser(class_):
+    PATIENT_GUESSERS.append(class_)
+    return class_
+
+
+class PatientGuesserBase(object):
+    """
+    A PatientGuesser is used to guess patient identity if ID matchers
+    fail.
+    """
+
+    def guess_patients(self, requests, case, case_config):
+        """
+        Given a case, search OpenMRS for possible matches. Return the
+        best guesses. If just one guess is returned, it will be chosen.
+
+        NOTE:: False positives can result in overwriting one patient
+               with the data of another. It is definitely better to
+               return no results than to return an invalid result.
+               Guesses should be logged.
+
+        """
+        raise NotImplementedError

--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -13,7 +13,7 @@ from corehq.motech.openmrs.repeater_helpers import (
 from dimagi.utils.parsing import string_to_utc_datetime
 
 
-def send_openmrs_data(requests, form_json, openmrs_config, case_trigger_infos, form_question_values):
+def send_openmrs_data(domain, requests, form_json, openmrs_config, case_trigger_infos, form_question_values):
     provider_uuid = getattr(openmrs_config, 'openmrs_provider', None)
     problem_log = []
     person_uuids = []
@@ -21,7 +21,7 @@ def send_openmrs_data(requests, form_json, openmrs_config, case_trigger_infos, f
     for info in case_trigger_infos:
         assert isinstance(info, CaseTriggerInfo)
         # todo: create patient if it doesn't exist?
-        person_uuid = sync_openmrs_patient(requests, info, openmrs_config, problem_log)
+        person_uuid = sync_openmrs_patient(domain, requests, info, openmrs_config, problem_log)
         person_uuids.append(person_uuid)
 
     logger.debug('OpenMRS patient(s) found: ', person_uuids)
@@ -54,8 +54,8 @@ def send_openmrs_visit(requests, info, form_config, person_uuid, provider_uuid, 
     )
 
 
-def sync_openmrs_patient(requests, info, openmrs_config, problem_log):
-    patient = get_patient(requests, info, openmrs_config, problem_log)
+def sync_openmrs_patient(domain, requests, info, openmrs_config, problem_log):
+    patient = get_patient(domain, requests, info, openmrs_config, problem_log)
     if patient is None:
         raise ValueError('CommCare patient was not found in OpenMRS')
     person_uuid = patient['person']['uuid']

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -112,3 +112,4 @@ class OpenmrsConfig(DocumentSchema):
     openmrs_provider = StringProperty(required=False)
     case_config = SchemaProperty(OpenmrsCaseConfig)
     form_configs = ListProperty(OpenmrsFormConfig)
+    patient_guesser = StringProperty(required=False)

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -58,8 +58,14 @@ class OpenmrsRepeater(CaseRepeater):
                           for id_matcher in self.openmrs_config.case_config.id_matchers])
         form_question_values = get_form_question_values(form_json)
 
-        send_openmrs_data(Requests(self.url, self.username, self.password), form_json, self.openmrs_config,
-                          case_trigger_infos, form_question_values)
+        send_openmrs_data(
+            self.domain,
+            Requests(self.url, self.username, self.password),
+            form_json,
+            self.openmrs_config,
+            case_trigger_infos,
+            form_question_values
+        )
 
         return repeat_record.handle_success(None)
 

--- a/custom/possible_health/motech/openmrs/guessers.py
+++ b/custom/possible_health/motech/openmrs/guessers.py
@@ -1,0 +1,60 @@
+from collections import OrderedDict
+
+from corehq.motech.openmrs.guessers import (
+    register_patient_guesser,
+    PatientGuesserBase,
+)
+
+
+SEARCHABLE_PROPERTIES = [
+    'bahmni_id',
+    'household_id',
+    'last_name',
+]
+PROPERTY_WEIGHTS = OrderedDict([
+    ('bahmni_id', 0.9),
+    ('household_id', 0.9),
+    ('dob', 0.75),
+    ('first_name', 0.025),
+    ('last_name', 0.025),  # first_name + last_name = 5%
+    ('municipality', 0.2),
+])
+THRESHOLD = 1
+
+
+@register_patient_guesser
+class PossibleHealthPatientGuesser(PatientGuesserBase):
+
+    def __init__(self):
+        self.property_map = {}
+
+    def set_property_map(self, case_config)
+        """
+        Set self.property_map to map OpenMRS properties/attributes to
+        case properties.
+        """
+        # TODO: ...
+        pass
+
+    def get_weight(self, patient, case):
+        return sum(
+            weight
+            for prop, weight in PROPERTY_WEIGHTS.items()
+            if patient[self.property_map[prop]] == case.get_case_property(prop)
+        )
+
+    def guess_patients(self, requests, case, case_config):
+        """
+        Matches cases to patients by iterating PROPERTY_WEIGHTS until
+        a threshold of 1 is reached.
+        """
+        self.set_property_map(case_config)
+
+        guesses = {}  # key on OpenMRS UUID to filter duplicates
+        for prop in SEARCHABLE_PROPERTIES:
+            value = case.get_case_property(prop)
+            response = requests.get('/ws/rest/v1/patient', {'q': value, 'v': 'full'})
+            for patient in response.json()['results']:
+                if self.get_weight(patient, case) >= THRESHOLD:
+                    guesses[patient['uuid']] = patient
+        return guesses.values()


### PR DESCRIPTION
Hey this is just a sanity check on my approach.

Some projects need a custom way to try to match OpenMRS patients to CommCare cases, if they can't make a definitive match on an ID.

I want a way to keep this custom code outside the Motech code, but still allow the OpenMRS config for a repeater to pull it in. So I'm defining a class to make these guesses, and registering it. The repeater can then select the class in its OpenMRS config.

This code is incomplete, but I hope it gives you a clear idea of where I'm heading. I just wanted to check that this approach not only makes sense, but is also the best way to do this. Please let me know what you think.

@nickpell I think @dannyroberts has a lot more context on this. Please don't feel obliged to try to wrap your head around Motech's OpenMRS repeater just for this. But if you do have an opinion on registering custom classes (and the best way to do that) and allowing users to select them, I'm interested to hear it.

@dannyroberts @nickpell cc @sheelio 
