### PR TITLE
Fix Kissmetrics data flow

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -66,6 +66,18 @@ hqDefine('analytix/js/kissmetrix', [
             _addKissmetricsScript('//doug1izaerwt3.cloudfront.net/' + _init.apiId + '.1.js');
         }
 
+        // Identify user and HQ instance
+        // This needs to happen before any events are sent or any traits are set
+        var username = _get('username');
+        if (username) {
+            identify(username);
+            var traits = {
+                'is_dimagi': _get('isDimagi'),
+                'hq_instance': _get('hqInstance'),
+            };
+            identifyTraits(traits);
+        }
+
         // Initialize Kissmetrics AB Tests
         _.each(_abTests, function (ab, testName) {
             var test = {};
@@ -88,7 +100,7 @@ hqDefine('analytix/js/kissmetrix', [
 
     /**
      * Identifies the current user
-     * @param {string} identity - A unique ID to identify the session.
+     * @param {string} identity - A unique ID to identify the session. Typically the user's email address.
      */
     var identify = function (identity) {
         if (_global('isEnabled')) {

--- a/corehq/apps/analytics/templates/analytics/initial/kissmetrics.html
+++ b/corehq/apps/analytics/templates/analytics/initial/kissmetrics.html
@@ -1,2 +1,9 @@
 {% load hq_shared_tags %}
 {% initial_analytics_data 'kissmetrics.apiId' ANALYTICS_IDS.KISSMETRICS_KEY  %}
+{% if request.couch_user %}
+    {% initial_analytics_data 'kissmetrics.username' request.couch_user.username %}
+    {% initial_analytics_data 'kissmetrics.isDimagi' request.couch_user.is_dimagi|BOOL  %}
+{% endif %}
+{% if ANALYTICS_CONFIG.HQ_INSTANCE %}
+    {% initial_analytics_data 'kissmetrics.hqInstance' ANALYTICS_CONFIG.HQ_INSTANCE %}
+{% endif %}

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -77,6 +77,7 @@ def js_api_keys(request):
         return {}  # disable js analytics
     return {
         'ANALYTICS_IDS': settings.ANALYTICS_IDS,
+        'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG,
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
 


### PR DESCRIPTION
Fixes issue 1 [here](https://docs.google.com/document/d/1EJazRzP8CfGqG6SkiR9VW5bL3863MJvwopOoQhQJjB0/edit). We've been sending events, but the funnel reports are broken, looks like it's because the logic that identifies users in kissmetrics was lost during https://github.com/dimagi/commcare-hq/pull/18615 

This PR replicates the [old logic](https://github.com/dimagi/commcare-hq/blob/jls/pre-analytics-refactor/corehq/apps/hqwebapp/templates/hqwebapp/includes/analytics_all.html#L134-L142) in the new code.

This should go into the next deploy.

@biyeun / @calellowitz 