### PR TITLE
Async UCR metric for average time behind

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 from collections import defaultdict
 from datetime import datetime, timedelta
 import logging
@@ -383,7 +384,7 @@ def async_indicators_metrics():
             (now - indicator.date_created).total_seconds()
             for indicator in oldest_100_indicators
         ]
-        avg_lag = float(sum(lags)) / len(lags)
+        avg_lag = sum(lags) / len(lags)
         datadog_gauge('commcare.async_indicator.oldest_created_indicator_avg', avg_lag)
 
     for config_id, metrics in six.iteritems(_indicator_metrics()):


### PR DESCRIPTION
@calellowitz you'll probably be interested. This takes the 100 earliest created docs in the queue and averages the lag. This way any random/intermittent errors that occur and increase the "oldest created indicator" metric will hopefully be averaged out and this will give a more real metric. For example, right now on ICDS the first one in the queue is from 1 AM and the 6th is from 5 PM so 5 records that had some (likely db related) error are raising that metric by 16 hours

@proteusvacuum 