### PR TITLE
Example of spec representation

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -57,6 +57,9 @@ class PropertyNameGetterSpec(JsonObject):
     property_name = DefaultProperty(required=True)
     datatype = DataTypeProperty(required=False)
 
+    def __str__(self):
+        return "Case's {property_name} property with a datatype of {datatype}".format(property_name=self.property_name, datatype=self.datatype)
+
     def configure(self, property_name_expression):
         self._property_name_expression = property_name_expression
 


### PR DESCRIPTION
@sheelio @esoergel you guys both have interest in this so this is what I had in mind. It'll get tricky to explain these in a good way once you start having sub expressions. I'm not sure how I would word that.

There would also need to be a view that goes through each column and prints out each of these.

```
In [1]: from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec

In [2]: prop = PropertyNameGetterSpec(type='property_name', property_name='propname', datatype='string')

In [3]: print prop
Case's propname property with a datatype of string
```