### PR TITLE
Mk update reconciliation report

### DIFF
--- a/custom/enikshay/forms.py
+++ b/custom/enikshay/forms.py
@@ -12,6 +12,8 @@ class ReconciliationTaskForm(forms.Form):
                        ]
     email = forms.EmailField(label='Your email')
     commit = forms.BooleanField(label='Commit Changes', required=False)
+    person_case_ids = forms.CharField(label='Person Case Ids', required=False,
+                                        help_text="Comma separated person case ids to process")
     task = forms.ChoiceField(label='Task', choices=(
         [('all', 'All')] + [(choice, choice.capitalize().replace('_', ' ')) for choice in permitted_tasks]
     ))
@@ -28,6 +30,7 @@ class ReconciliationTaskForm(forms.Form):
                 crispy.Field('email'),
                 crispy.Field('commit'),
                 crispy.Field('task'),
+                crispy.Field('person_case_ids'),
             ),
             ButtonHolder(
                 Submit(

--- a/custom/enikshay/forms.py
+++ b/custom/enikshay/forms.py
@@ -13,7 +13,7 @@ class ReconciliationTaskForm(forms.Form):
     email = forms.EmailField(label='Your email')
     commit = forms.BooleanField(label='Commit Changes', required=False)
     person_case_ids = forms.CharField(label='Person Case Ids', required=False,
-                                        help_text="Comma separated person case ids to process")
+                                      help_text="Comma separated person case ids to process")
     task = forms.ChoiceField(label='Task', choices=(
         [('all', 'All')] + [(choice, choice.capitalize().replace('_', ' ')) for choice in permitted_tasks]
     ))

--- a/custom/enikshay/management/commands/base_model_reconciliation.py
+++ b/custom/enikshay/management/commands/base_model_reconciliation.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import csv
 from datetime import datetime
 

--- a/custom/enikshay/management/commands/base_model_reconciliation.py
+++ b/custom/enikshay/management/commands/base_model_reconciliation.py
@@ -6,6 +6,8 @@ from django.core.mail import EmailMessage
 
 from django.conf import settings
 
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from custom.enikshay.case_utils import CASE_TYPE_OCCURRENCE
 from custom.enikshay.const import ENROLLED_IN_PRIVATE
 
 DOMAIN = "enikshay"
@@ -67,3 +69,9 @@ class BaseModelReconciliationCommand(BaseCommand):
     @staticmethod
     def get_first_opened_case(all_cases):
         return sorted(all_cases, key=lambda x: x.opened_on)[0]
+
+
+def get_all_occurrence_case_ids_from_person(person_case_id):
+    case_accessor = CaseAccessors(DOMAIN)
+    all_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
+    return [case.case_id for case in all_cases if case.type == CASE_TYPE_OCCURRENCE]

--- a/custom/enikshay/management/commands/drug_resistance_reconciliation.py
+++ b/custom/enikshay/management/commands/drug_resistance_reconciliation.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from collections import defaultdict
 
 from django.core.management.base import CommandError

--- a/custom/enikshay/management/commands/drug_resistance_reconciliation.py
+++ b/custom/enikshay/management/commands/drug_resistance_reconciliation.py
@@ -12,6 +12,7 @@ from custom.enikshay.case_utils import (
 from custom.enikshay.management.commands.base_model_reconciliation import (
     BaseModelReconciliationCommand,
     DOMAIN,
+    get_all_occurrence_case_ids_from_person,
 )
 from custom.enikshay.exceptions import ENikshayCaseNotFound
 from custom.enikshay.const import (
@@ -43,6 +44,7 @@ class Command(BaseModelReconciliationCommand):
         self.drug_id_values = []
         self.sensitivity_values = []
         self.case_accessor = CaseAccessors(DOMAIN)
+        self.person_case_ids = options.get('person_case_ids')
         # iterate all occurrence cases
         for occurrence_case_id in self._get_open_occurrence_case_ids_to_process():
             # Need to consider only public app cases so skip updates if enrolled in private
@@ -145,22 +147,31 @@ class Command(BaseModelReconciliationCommand):
                              "Picked first opened.")
 
     def _get_open_occurrence_case_ids_to_process(self):
-        from corehq.sql_db.util import get_db_aliases_for_partitioned_query
-        dbs = get_db_aliases_for_partitioned_query()
-        for db in dbs:
-            case_ids = (
-                CommCareCaseSQL.objects
-                .using(db)
-                .filter(domain=DOMAIN, type="occurrence", closed=False)
-                .values_list('case_id', flat=True)
-            )
-            num_case_ids = len(case_ids)
-            if self.log_progress:
-                print("processing %d docs from db %s" % (num_case_ids, db))
-            for i, case_id in enumerate(case_ids):
-                yield case_id
+        if self.person_case_ids:
+            num_case_ids = len(self.person_case_ids)
+            for i, case_id in enumerate(self.person_case_ids):
+                occurrence_case_ids = get_all_occurrence_case_ids_from_person(case_id)
+                for occurrence_case_id in occurrence_case_ids:
+                    yield occurrence_case_id
                 if i % 1000 == 0 and self.log_progress:
-                    print("processed %d / %d docs from db %s" % (i, num_case_ids, db))
+                    print("processed %d / %d docs" % (i, num_case_ids))
+        else:
+            from corehq.sql_db.util import get_db_aliases_for_partitioned_query
+            dbs = get_db_aliases_for_partitioned_query()
+            for db in dbs:
+                case_ids = (
+                    CommCareCaseSQL.objects
+                    .using(db)
+                    .filter(domain=DOMAIN, type="occurrence", closed=False)
+                    .values_list('case_id', flat=True)
+                )
+                num_case_ids = len(case_ids)
+                if self.log_progress:
+                    print("processing %d docs from db %s" % (num_case_ids, db))
+                for i, case_id in enumerate(case_ids):
+                    yield case_id
+                    if i % 1000 == 0 and self.log_progress:
+                        print("processed %d / %d docs from db %s" % (i, num_case_ids, db))
 
     def close_cases(self, all_cases, occurrence_case_id, drug_id, retain_case, retain_reason):
         # remove duplicates in case ids to remove so that we dont retain and close

--- a/custom/enikshay/management/commands/drug_resistance_reconciliation.py
+++ b/custom/enikshay/management/commands/drug_resistance_reconciliation.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import defaultdict
 
 from django.core.management.base import CommandError

--- a/custom/enikshay/management/commands/duplicate_occurrences_and_episodes_reconciliation.py
+++ b/custom/enikshay/management/commands/duplicate_occurrences_and_episodes_reconciliation.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from django.core.management.base import CommandError
 from django.utils.dateparse import parse_date
 from corehq.apps.hqcase.utils import bulk_update_cases

--- a/custom/enikshay/management/commands/duplicate_occurrences_and_episodes_reconciliation.py
+++ b/custom/enikshay/management/commands/duplicate_occurrences_and_episodes_reconciliation.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.core.management.base import CommandError
 from django.utils.dateparse import parse_date
 from corehq.apps.hqcase.utils import bulk_update_cases

--- a/custom/enikshay/management/commands/investigations_reconciliation.py
+++ b/custom/enikshay/management/commands/investigations_reconciliation.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from collections import defaultdict
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors

--- a/custom/enikshay/management/commands/investigations_reconciliation.py
+++ b/custom/enikshay/management/commands/investigations_reconciliation.py
@@ -67,11 +67,11 @@ class Command(BaseModelReconciliationCommand):
                     investigations_to_be_reconciled = self.episode_case_needs_reconciliation(episode_case)
                     if investigations_to_be_reconciled:
                         for interval_type, investigation_cases in investigations_to_be_reconciled.items():
-                            self.reconcile_investigation_cases(episode_case_id, investigation_cases, csvfile)
+                            self.reconcile_investigation_cases(episode_case_id, investigation_cases)
 
         self.email_report()
 
-    def reconcile_investigation_cases(self, episode_case_id, investigation_cases, csvfile):
+    def reconcile_investigation_cases(self, episode_case_id, investigation_cases):
         # fetch latest investigation case which would retain final values
         latest_investigation_case = sorted(investigation_cases, key=lambda x: x.modified_on)[0]
         retain_case_id = latest_investigation_case.case_id

--- a/custom/enikshay/management/commands/investigations_reconciliation.py
+++ b/custom/enikshay/management/commands/investigations_reconciliation.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import defaultdict
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors

--- a/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
+++ b/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
@@ -78,10 +78,6 @@ class Command(BaseModelReconciliationCommand):
         try:
             person_case = get_person_case_from_occurrence(DOMAIN, occurrence_case_id)
         except ENikshayCaseNotFound:
-            self.writerow({
-                "occurrence_case_id": occurrence_case_id,
-                "notes": "person case not found",
-            })
             return False
         return super(Command, self).public_app_case(person_case)
 

--- a/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
+++ b/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
@@ -76,6 +76,9 @@ class Command(BaseModelReconciliationCommand):
         return self.get_first_opened_case(referral_cases)
 
     def public_app_case(self, occurrence_case_id):
+        # set person case as None to make sure its fetched each time and not
+        # carry forwarded from a previous call
+        self.person_case = None
         try:
             self.person_case = get_person_case_from_occurrence(DOMAIN, occurrence_case_id)
         except ENikshayCaseNotFound:

--- a/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
+++ b/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from corehq.apps.hqcase.utils import bulk_update_cases
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCaseSQL

--- a/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
+++ b/custom/enikshay/management/commands/multiple_open_referrals_reconciliation.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from corehq.apps.hqcase.utils import bulk_update_cases
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCaseSQL

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -765,9 +765,10 @@ def get_updated_fields(existing_properties, new_properties):
 
 
 @task(queue='background_queue', ignore_result=True)
-def run_model_reconciliation(command_name, email, commit=False):
+def run_model_reconciliation(command_name, email, person_case_ids=None, commit=False):
     call_command(command_name,
                  recipient=email,
+                 person_case_ids=person_case_ids,
                  commit=commit)
 
 

--- a/custom/enikshay/views.py
+++ b/custom/enikshay/views.py
@@ -8,6 +8,7 @@ from django.views.generic.base import View, TemplateView
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
+from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from soil import MultipleTaskDownload
 
@@ -65,16 +66,42 @@ class ReconciliationTaskView(TemplateView):
         kwargs['reconciliation_form'] = ReconciliationTaskForm()
         return super(ReconciliationTaskView, self).get_context_data(**kwargs)
 
+    @staticmethod
+    def parse_person_case_ids(person_case_ids, domain):
+        """
+        ensure case ids are open person cases
+        :param person_case_ids: comma separated case id
+        :return: parsed case ids or return None in case unable to
+        """
+        person_case_ids = person_case_ids.split(',')
+        case_accessor = CaseAccessors(domain)
+        try:
+            person_cases = case_accessor.get_cases(person_case_ids)
+        except CaseNotFound:
+            return None
+        parsed_person_case_ids = []
+        for person_case in person_cases:
+            if not person_case or person_case.type != 'person' or person_case.closed:
+                return None
+            else:
+                parsed_person_case_ids.append(person_case.case_id)
+        return parsed_person_case_ids
+
     @method_decorator(domain_admin_required)
     def post(self, request, *args, **kwargs):
         def run_task(task_name):
             run_model_reconciliation.delay(
                 task_name,
                 request.POST.get('email'),
-                (request.POST.get('commit') == 'on')
+                person_case_ids,
+                (request.POST.get('commit') == 'on'),
             )
-
         task_requested = request.POST.get('task')
+        person_case_ids = None
+        if request.POST.get('person_case_ids'):
+            person_case_ids = self.parse_person_case_ids(request.POST.get('person_case_ids'), request.domain)
+            if not person_case_ids:
+                return JsonResponse({'message': 'Please check person ids. They should be open person cases'})
         if task_requested == 'all':
             for task_to_run in ReconciliationTaskForm.permitted_tasks:
                 run_task(task_to_run)

--- a/custom/enikshay/views.py
+++ b/custom/enikshay/views.py
@@ -7,7 +7,7 @@ from django.views.generic.base import View, TemplateView
 
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from corehq import toggles
-from corehq.apps.domain.decorators import domain_admin_required
+from corehq.apps.domain.decorators import domain_admin_required, require_superuser
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from soil import MultipleTaskDownload
@@ -54,7 +54,7 @@ class EpisodeTaskStatusView(TemplateView):
 class ReconciliationTaskView(TemplateView):
     template_name = "enikshay/reconciliation_tasks.html"
 
-    @method_decorator(domain_admin_required)
+    @method_decorator(require_superuser)
     def get(self, request, *args, **kwargs):
         return super(ReconciliationTaskView, self).get(request, *args, **kwargs)
 
@@ -87,7 +87,7 @@ class ReconciliationTaskView(TemplateView):
                 parsed_person_case_ids.append(person_case.case_id)
         return parsed_person_case_ids
 
-    @method_decorator(domain_admin_required)
+    @method_decorator(require_superuser)
     def post(self, request, *args, **kwargs):
         def run_task(task_name):
             run_model_reconciliation.delay(


### PR DESCRIPTION
following up an improvement in #18027

This adds ability to process on specific cases by passing person case ids. The view ensures that the case ids are for open person cases and notifies the user in case any id is not.