### PR TITLE
move followup / outcome due tests to reconciliation task

### DIFF
--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -4,6 +4,7 @@ from cStringIO import StringIO
 from dimagi.utils.csv import UnicodeWriter
 from collections import defaultdict, namedtuple
 import pytz
+import sys
 
 from celery import group
 from celery.task import periodic_task, task
@@ -286,15 +287,19 @@ class EpisodeAdherenceUpdate(object):
         self._cache_dose_taken_by_date = False
 
     @memoized
-    def get_doses_data(self):
+    def get_fixture_column(self, fixture_column_name):
         # return 'doses_per_week' by 'schedule_id' from the Fixture data
         fixtures = get_itemlist(self.domain)
         doses_per_week_by_schedule_id = {}
         for f in fixtures:
             schedule_id = f.fields[SCHEDULE_ID_FIXTURE].field_list[0].field_value
-            doses_per_week = int(f.fields["doses_per_week"].field_list[0].field_value)
+            doses_per_week = int(f.fields[fixture_column_name].field_list[0].field_value)
             doses_per_week_by_schedule_id[schedule_id] = doses_per_week
         return doses_per_week_by_schedule_id
+
+    @memoized
+    def get_doses_data(self):
+        return self.get_fixture_column('doses_per_week')
 
     @memoized
     def get_valid_adherence_cases(self):
@@ -396,6 +401,9 @@ class EpisodeAdherenceUpdate(object):
             adherence_schedule_date_start,
             dose_status_by_date
         ))
+        update.update(self.get_ip_followup_test_threshold_dates(dose_status_by_date))
+        update.update(self.get_cp_followup_test_threshold_dates(dose_status_by_date))
+        update.update(self.get_outcome_due_threshold_dates(dose_status_by_date))
 
         return self.check_and_return(update)
 
@@ -500,6 +508,46 @@ class EpisodeAdherenceUpdate(object):
 
         return update
 
+    def get_dates_threshold_crossed_and_expected(self, dosage_threshold, dose_status_by_date):
+        adherence_date_threshold_crossed = self.get_date_of_nth_dose(dosage_threshold, dose_status_by_date)
+        if adherence_date_threshold_crossed:
+            adherence_date_test_expected = adherence_date_threshold_crossed + datetime.timedelta(days=7)
+        else:
+            adherence_date_test_expected = ''
+        return adherence_date_threshold_crossed, adherence_date_test_expected
+
+    def get_ip_followup_test_threshold_dates(self, dose_status_by_date):
+        ip_dosage_threshold = self.get_dose_count_ip() - self.get_doses_per_week()
+        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(ip_dosage_threshold, dose_status_by_date)
+        return {
+            'adherence_ip_date_followup_test_expected': date_expected,
+            'adherence_ip_date_threshold_crossed': date_crossed or '',
+        }
+
+    def get_cp_followup_test_threshold_dates(self, dose_status_by_date):
+        cp_dosage_threshold = self.get_dose_count_cp() - self.get_doses_per_week()
+        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(cp_dosage_threshold, dose_status_by_date)
+        return {
+            'adherence_cp_date_followup_test_expected': date_expected,
+            'adherence_cp_date_threshold_crossed': date_crossed or '',
+        }
+
+    def get_outcome_due_threshold_dates(self, dose_status_by_date):
+        outcome_due_dosage_threshold = self.get_dose_count_outcome_due() - self.get_doses_per_week()
+        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(outcome_due_dosage_threshold, dose_status_by_date)
+        return {
+            'adherence_date_outcome_due': date_expected,
+        }
+
+    @staticmethod
+    def get_date_of_nth_dose(dose_count, dose_status_by_date):
+        doses_to_date = 0
+        for dose_date in sorted(dose_status_by_date):
+            if dose_status_by_date[dose_date].taken:
+                doses_to_date += 1
+                if doses_to_date == dose_count:
+                    return dose_date
+
     @memoized
     def get_doses_per_week(self):
         # calculate 'expected_doses_taken' score
@@ -513,6 +561,42 @@ class EpisodeAdherenceUpdate(object):
             )
             return 0
         return doses_per_week
+
+    def get_dose_count_by_threshold(self, threshold):
+        dose_count_by_adherence_schedule = self.get_fixture_column(threshold)
+        adherence_schedule_id = self.episode.get_case_property('adherence_schedule_id') or DAILY_SCHEDULE_ID
+        dose_count = dose_count_by_adherence_schedule.get(adherence_schedule_id)
+        if dose_count is None:
+            soft_assert('{}@{}'.format('npellegrino', 'dimagi.com'))(
+                False,
+                "No fixture item found with schedule_id {}".format(adherence_schedule_id)
+            )
+            return sys.maxint
+        return dose_count
+
+    @memoized
+    def get_dose_count_ip(self):
+        threshold = (
+            'dose_count_ip_new_patient' if self.episode.get_case_property('patient_type_choice') == 'new'
+            else 'dose_count_ip_recurring_patient'
+        )
+        return self.get_dose_count_by_threshold(threshold)
+
+    @memoized
+    def get_dose_count_cp(self):
+        threshold = (
+            'dose_count_cp_new_patient' if self.episode.get_case_property('patient_type_choice') == 'new'
+            else 'dose_count_cp_recurring_patient'
+        )
+        return self.get_dose_count_by_threshold(threshold)
+
+    @memoized
+    def get_dose_count_outcome_due(self):
+        threshold = (
+            'dose_count_outcome_due_new_patient' if self.episode.get_case_property('patient_type_choice') == 'new'
+            else 'dose_count_outcome_due_recurring_patient'
+        )
+        return self.get_dose_count_by_threshold(threshold)
 
     def check_and_return(self, update_dict):
         """

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -577,7 +577,7 @@ class EpisodeAdherenceUpdate(object):
                 False,
                 "No fixture item found with schedule_id {}".format(adherence_schedule_id)
             )
-            return sys.maxint
+            return sys.maxsize
         return dose_count
 
     @memoized

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -518,7 +518,9 @@ class EpisodeAdherenceUpdate(object):
 
     def get_ip_followup_test_threshold_dates(self, dose_status_by_date):
         ip_dosage_threshold = self.get_dose_count_ip() - self.get_doses_per_week()
-        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(ip_dosage_threshold, dose_status_by_date)
+        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(
+            ip_dosage_threshold, dose_status_by_date
+        )
         return {
             'adherence_ip_date_followup_test_expected': date_expected,
             'adherence_ip_date_threshold_crossed': date_crossed or '',
@@ -526,7 +528,9 @@ class EpisodeAdherenceUpdate(object):
 
     def get_cp_followup_test_threshold_dates(self, dose_status_by_date):
         cp_dosage_threshold = self.get_dose_count_cp() - self.get_doses_per_week()
-        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(cp_dosage_threshold, dose_status_by_date)
+        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(
+            cp_dosage_threshold, dose_status_by_date
+        )
         return {
             'adherence_cp_date_followup_test_expected': date_expected,
             'adherence_cp_date_threshold_crossed': date_crossed or '',
@@ -534,7 +538,9 @@ class EpisodeAdherenceUpdate(object):
 
     def get_outcome_due_threshold_dates(self, dose_status_by_date):
         outcome_due_dosage_threshold = self.get_dose_count_outcome_due() - self.get_doses_per_week()
-        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(outcome_due_dosage_threshold, dose_status_by_date)
+        date_crossed, date_expected = self.get_dates_threshold_crossed_and_expected(
+            outcome_due_dosage_threshold, dose_status_by_date
+        )
         return {
             'adherence_date_outcome_due': date_expected,
         }

--- a/custom/enikshay/tests/test_adherence_updates.py
+++ b/custom/enikshay/tests/test_adherence_updates.py
@@ -149,7 +149,12 @@ class TestAdherenceUpdater(TestCase):
         self.data_store.adapter.clear_table()
         FormProcessorTestUtils.delete_all_cases()
 
-    def _create_episode_case(self, adherence_schedule_date_start=None, adherence_schedule_id=None, extra_properties=None):
+    def _create_episode_case(
+            self,
+            adherence_schedule_date_start=None,
+            adherence_schedule_id=None,
+            extra_properties=None,
+    ):
         person = get_person_case_structure(
             self.person_id,
             self.user.user_id,
@@ -200,7 +205,8 @@ class TestAdherenceUpdater(TestCase):
             for adherence_case in adherence_cases
         ]
         episode = self.create_episode_case(
-            adherence_schedule_date_start, adherence_schedule_id, adherence_cases, extra_properties=episode_properties,
+            adherence_schedule_date_start, adherence_schedule_id, adherence_cases,
+            extra_properties=episode_properties,
         )
 
         updater = EpisodeAdherenceUpdate(self.domain, episode)

--- a/custom/enikshay/tests/test_adherence_updates.py
+++ b/custom/enikshay/tests/test_adherence_updates.py
@@ -11,6 +11,7 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.userreports.tasks import rebuild_indicators, queue_async_indicators
+from corehq.util.test_utils import update_case
 
 from custom.enikshay.const import (
     DOSE_MISSED,
@@ -65,11 +66,38 @@ class TestAdherenceUpdater(TestCase):
 
     @classmethod
     def setupFixtureData(cls):
-        cls.fixture_data = {
-            'schedule1': '7',
-            'schedule2': '14',
-            'schedule3': '21',
-        }
+        cls.fixture_data = [
+            {
+                SCHEDULE_ID_FIXTURE: 'schedule1',
+                'doses_per_week': '7',
+                'dose_count_ip_new_patient': '56',
+                'dose_count_ip_recurring_patient': '84',
+                'dose_count_cp_new_patient': '112',
+                'dose_count_cp_recurring_patient': '140',
+                'dose_count_outcome_due_new_patient': '168',
+                'dose_count_outcome_due_recurring_patient': '168',
+            },
+            {
+                SCHEDULE_ID_FIXTURE: 'schedule2',
+                'doses_per_week': '14',
+                'dose_count_ip_new_patient': '24',
+                'dose_count_ip_recurring_patient': '36',
+                'dose_count_cp_new_patient': '54',
+                'dose_count_cp_recurring_patient': '66',
+                'dose_count_outcome_due_new_patient': '78',
+                'dose_count_outcome_due_recurring_patient': '78',
+            },
+            {
+                SCHEDULE_ID_FIXTURE: 'schedule3',
+                'doses_per_week': '21',
+                'dose_count_ip_new_patient': '24',
+                'dose_count_ip_recurring_patient': '36',
+                'dose_count_cp_new_patient': '54',
+                'dose_count_cp_recurring_patient': '66',
+                'dose_count_outcome_due_new_patient': '78',
+                'dose_count_outcome_due_recurring_patient': '78',
+            },
+        ]
         cls.data_type = FixtureDataType(
             domain=cls.domain,
             tag=DAILY_SCHEDULE_FIXTURE_NAME,
@@ -88,25 +116,19 @@ class TestAdherenceUpdater(TestCase):
         )
         cls.data_type.save()
         cls.data_items = []
-        for _id, value in six.iteritems(cls.fixture_data):
+        for row in cls.fixture_data:
             data_item = FixtureDataItem(
                 domain=cls.domain,
                 data_type_id=cls.data_type.get_id,
                 fields={
-                    SCHEDULE_ID_FIXTURE: FieldList(
-                        field_list=[
-                            FixtureItemField(
-                                field_value=_id,
-                            )
-                        ]
-                    ),
-                    "doses_per_week": FieldList(
+                    column_name: FieldList(
                         field_list=[
                             FixtureItemField(
                                 field_value=value,
                             )
                         ]
                     )
+                    for column_name, value in six.iteritems(row)
                 },
                 item_attributes={},
             )
@@ -127,7 +149,7 @@ class TestAdherenceUpdater(TestCase):
         self.data_store.adapter.clear_table()
         FormProcessorTestUtils.delete_all_cases()
 
-    def _create_episode_case(self, adherence_schedule_date_start=None, adherence_schedule_id=None):
+    def _create_episode_case(self, adherence_schedule_date_start=None, adherence_schedule_id=None, extra_properties=None):
         person = get_person_case_structure(
             self.person_id,
             self.user.user_id,
@@ -138,13 +160,16 @@ class TestAdherenceUpdater(TestCase):
             person
         )
 
+        extra_update = {
+            'adherence_schedule_date_start': adherence_schedule_date_start,
+            'adherence_schedule_id': adherence_schedule_id
+        }
+        extra_update.update(extra_properties or {})
+
         episode_structure = get_episode_case_structure(
             self.episode_id,
             occurrence,
-            extra_update={
-                'adherence_schedule_date_start': adherence_schedule_date_start,
-                'adherence_schedule_id': adherence_schedule_id
-            }
+            extra_update=extra_update,
         )
         cases = {case.case_id: case for case in self.factory.create_or_update_cases([episode_structure])}
         episode_case = cases[self.episode_id]
@@ -163,7 +188,7 @@ class TestAdherenceUpdater(TestCase):
         ])
 
     def assert_update(self, purge_date, adherence_schedule_date_start,
-                      adherence_schedule_id, adherence_cases,
+                      adherence_schedule_id, adherence_cases, episode_properties=None,
                       date_today_in_india=None, output=None):
         adherence_cases = [
             {
@@ -175,7 +200,7 @@ class TestAdherenceUpdater(TestCase):
             for adherence_case in adherence_cases
         ]
         episode = self.create_episode_case(
-            adherence_schedule_date_start, adherence_schedule_id, adherence_cases
+            adherence_schedule_date_start, adherence_schedule_id, adherence_cases, extra_properties=episode_properties,
         )
 
         updater = EpisodeAdherenceUpdate(self.domain, episode)
@@ -202,9 +227,10 @@ class TestAdherenceUpdater(TestCase):
             self,
             adherence_schedule_date_start,
             adherence_schedule_id,
-            adherence_cases
+            adherence_cases,
+            extra_properties=None,
     ):
-        episode = self._create_episode_case(adherence_schedule_date_start, adherence_schedule_id)
+        episode = self._create_episode_case(adherence_schedule_date_start, adherence_schedule_id, extra_properties)
         adherence_cases = self._create_adherence_cases(adherence_cases)
         self._rebuild_indicators()
         return episode
@@ -338,7 +364,7 @@ class TestAdherenceUpdater(TestCase):
             output={   # should be purge_date
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
                 # co-efficient (aggregated_score_date_calculated - adherence_schedule_date_start)
-                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 # no dose taken before aggregated_score_date_calculated
                 'aggregated_score_count_taken': 0,
                 # latest recorded
@@ -346,6 +372,144 @@ class TestAdherenceUpdater(TestCase):
                 # total 3 taken, unknown is not counted
                 'adherence_total_doses_taken': 3
             }
+        )
+
+    def _generate_doses_taken(self, start_date, num_days, dose_status=None):
+        return [
+            (start_date + datetime.timedelta(days=i), dose_status or DTIndicators[0])
+            for i in range(num_days)
+        ]
+
+    def test_ip_date_followup_blank_schedule1(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 5),
+            output={
+                'adherence_total_doses_taken': 5,
+                'adherence_ip_date_followup_test_expected': '',
+                'adherence_ip_date_threshold_crossed': '',
+            },
+        )
+
+    def test_ip_date_followup_set_schedule1(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 100),
+            output={
+                'adherence_total_doses_taken': 100,
+                'adherence_ip_date_followup_test_expected': '2016-04-12',
+                'adherence_ip_date_threshold_crossed': '2016-04-05',
+            },
+        )
+
+    def test_cp_date_followup_blank_schedule1(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 5),
+            output={
+                'adherence_total_doses_taken': 5,
+                'adherence_cp_date_followup_test_expected': '',
+                'adherence_cp_date_threshold_crossed': '',
+            },
+        )
+
+    def test_cp_date_followup_set_schedule1(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 200),
+            output={
+                'adherence_total_doses_taken': 200,
+                'adherence_cp_date_followup_test_expected': '2016-06-07',
+                'adherence_cp_date_threshold_crossed': '2016-05-31',
+            },
+        )
+
+    def test_outcome_due_blank_schedule1(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 5),
+            output={
+                'adherence_total_doses_taken': 5,
+                'adherence_date_outcome_due': '',
+            },
+        )
+
+    def test_outcome_due_set_schedule1(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 200),
+            output={
+                'adherence_total_doses_taken': 200,
+                'adherence_date_outcome_due': '2016-07-05',
+            },
+        )
+
+    def test_ip_date_followup_blank_schedule1_new_patient(self):
+        update_case(self.domain, self.episode_id, {'patient_type_choice': 'new'})
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 5),
+            output={
+                'adherence_total_doses_taken': 5,
+                'adherence_ip_date_followup_test_expected': '',
+                'adherence_ip_date_threshold_crossed': '',
+            },
+        )
+
+    def test_ip_date_followup_set_schedule1_new_patient(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 200),
+            episode_properties={'patient_type_choice': 'new'},
+            output={
+                'adherence_total_doses_taken': 200,
+                'adherence_ip_date_followup_test_expected': '2016-03-15',
+                'adherence_ip_date_threshold_crossed': '2016-03-08',
+            },
+        )
+
+    def test_ip_date_followup_blank_schedule2(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule2',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 5),
+            output={
+                'adherence_total_doses_taken': 5,
+                'adherence_ip_date_followup_test_expected': '',
+                'adherence_ip_date_threshold_crossed': '',
+            },
+        )
+
+    def test_ip_date_followup_set_schedule2(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule2',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 200),
+            output={
+                'adherence_total_doses_taken': 200,
+                'adherence_ip_date_followup_test_expected': '2016-02-17',
+                'adherence_ip_date_threshold_crossed': '2016-02-10',
+            },
+        )
+
+    def test_ip_date_followup_blank_doses_missed(self):
+        self.assert_update(
+            datetime.date(2016, 1, 20),
+            datetime.date(2016, 1, 20), 'schedule1',
+            self._generate_doses_taken(datetime.date(2016, 1, 20), 200, dose_status=DOSE_MISSED),
+            output={
+                'adherence_total_doses_taken': 0,
+                'adherence_ip_date_followup_test_expected': '',
+                'adherence_ip_date_threshold_crossed': '',
+            },
         )
 
     def test_multiple_adherence_cases_all_less(self):
@@ -361,7 +525,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={   # set to latest adherence_date, exclude 14th because its unknown
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 12),
-                'expected_doses_taken': int((3.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((3.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 2,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 12),
                 'adherence_total_doses_taken': 2
@@ -380,7 +544,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 12),
-                'expected_doses_taken': int((3.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((3.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 2,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 12),
                 'adherence_total_doses_taken': 2
@@ -399,7 +563,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
-                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 2,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 21),
                 'adherence_total_doses_taken': 2
@@ -417,7 +581,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 11),
-                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 1,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 11),
                 'adherence_total_doses_taken': 1
@@ -434,7 +598,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 11),
-                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 1,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 11),
                 'adherence_total_doses_taken': 1
@@ -466,7 +630,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 11),
-                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((2.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 0,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 11),
                 'adherence_total_doses_taken': 0
@@ -498,7 +662,7 @@ class TestAdherenceUpdater(TestCase):
             ],
             output={
                 'aggregated_score_date_calculated': datetime.date(2016, 1, 20),
-                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data['schedule1'])),
+                'expected_doses_taken': int((11.0 / 7) * int(self.fixture_data[0]['doses_per_week'])),
                 'aggregated_score_count_taken': 0,
                 'adherence_latest_date_recorded': datetime.date(2016, 1, 22),
                 'adherence_total_doses_taken': 0


### PR DESCRIPTION
Implements https://trello.com/c/yPOJBpPU/284-followup-test-dates-reconciliation-task-based-on-adherence
Fixes https://manage.dimagi.com/default.asp?257841

Also includes a refactor to the task and to tests to support fixture items other than just doses per week.

@proteusvacuum @mkangia @esoergel 

