### PR TITLE
add LogLongRequestMiddleware

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -144,6 +144,7 @@ MIDDLEWARE = [
     'corehq.middleware.SentryContextMiddleware',
     'corehq.apps.domain.middleware.DomainMigrationMiddleware',
     'corehq.middleware.TimeoutMiddleware',
+    'corehq.middleware.LogLongRequestMiddleware',
     'corehq.apps.domain.middleware.CCHQPRBACMiddleware',
     'corehq.apps.domain.middleware.DomainHistoryMiddleware',
     'corehq.apps.domain.project_access.middleware.ProjectAccessMiddleware',


### PR DESCRIPTION
to log request details to sentry when a request takes longer than 2 minutes.
This is so I can look into http://manage.dimagi.com/default.asp?266770, but is useful for such cases in general.

I don't expect it to be a performance hit at all, as nothing (other than two calls to utcnow and calculating the difference) is done in the vast majority of cases, and it just adds one sentry to already very long requests.

We've done a similar thing in formplayer and it's been suuuper useful