### PR TITLE
Remove a bunch of unused enikshay user_setup code

### DIFF
--- a/custom/enikshay/tests/test_user_setup.py
+++ b/custom/enikshay/tests/test_user_setup.py
@@ -22,9 +22,6 @@ from ..const import (
     AGENCY_USER_FIELDS,
 )
 from ..user_setup import (
-    LOC_TYPES_TO_USER_TYPES,
-    validate_usertype,
-    get_site_code,
     ENikshayLocationFormSet,
     compress_nikshay_id,
     get_new_username_and_id,
@@ -35,7 +32,6 @@ from six.moves import filter
 
 
 @flag_enabled('ENIKSHAY')
-@mock.patch('custom.enikshay.user_setup.skip_custom_setup', lambda *args: False)
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class TestUserSetupUtils(TestCase):
     domain = 'enikshay-user-setup'
@@ -57,7 +53,8 @@ class TestUserSetupUtils(TestCase):
         user_fields = CustomDataFieldsDefinition.get_or_create(
             cls.domain, CUSTOM_USER_DATA_FIELD_TYPE)
 
-        usertypes = [t for types in LOC_TYPES_TO_USER_TYPES.values() for t in types]
+        usertypes = ['to', 'tbhv', 'mo-phi', 'sts', 'stls', 'lt-dmc', 'lt-cdst',
+                     'dto', 'deo', 'cto', 'sto', 'drtb-hiv']
         user_fields.fields = [
             CustomDataField(slug='usertype', is_multiple_choice=True, choices=usertypes),
             CustomDataField(slug='is_test'),
@@ -92,22 +89,6 @@ class TestUserSetupUtils(TestCase):
             errors = form.errors.as_text()
         msg = "{} has errors: \n{}".format(form.__class__.__name__, errors)
         self.assertTrue(form.is_valid(), msg)
-
-    def assertInvalid(self, form):
-        msg = "{} has no errors".format(form.__class__.__name__)
-        self.assertFalse(form.is_valid(), msg)
-
-    def make_location(self, name, loc_type, parent):
-        loc = SQLLocation.objects.create(
-            domain=self.domain,
-            name=name,
-            site_code=name,
-            location_type=self.location_types[loc_type],
-            parent=self.locations[parent],
-            metadata={'nikshay_code': name},
-        )
-        self.addCleanup(loc.delete)
-        return loc
 
     def make_user(self, username, location):
         user = CommCareUser.create(
@@ -165,81 +146,6 @@ class TestUserSetupUtils(TestCase):
             is_new=True,
         )
 
-    def test_validate_usertype(self):
-        user = self.make_user('jon-snow@website', 'DTO')
-        loc_type = self.location_types['dto'].code
-
-        # Try submitting an invalid usertype
-        custom_data = CustomDataEditor(
-            field_view=UserFieldsView,
-            domain=self.domain,
-            existing_custom_data=user.user_data,
-            post_dict={'data-field-usertype': ['sto']},
-        )
-        validate_usertype(loc_type, 'sto', custom_data)
-        self.assertInvalid(custom_data)
-
-        # Try submitting a valid usertype
-        custom_data = CustomDataEditor(
-            field_view=UserFieldsView,
-            domain=self.domain,
-            existing_custom_data=user.user_data,
-            post_dict={'data-field-usertype': ['deo']},  # invalid usertype
-        )
-        validate_usertype(loc_type, 'deo', custom_data)
-        self.assertValid(custom_data)
-
-    def test_signal(self):
-        # This test runs the whole callback via a signal as an integration test
-        # To verify that it's working, it checks for errors triggered in `validate_usertype`
-        user = self.make_user('atargaryon@nightswatch.onion', 'DTO')
-        data = {
-            'first_name': 'Aemon',
-            'last_name': 'Targaryon',
-            'language': '',
-            'loadtest_factor': '',
-            'role': '',
-            'form_type': 'update-user',
-            'email': 'atargaryon@nightswatch.onion',
-            'data-field-usertype': ['tbhv'],  # invalid usertype
-        }
-        user_form = UpdateCommCareUserInfoForm(
-            data=data,
-            existing_user=user,
-            domain=self.domain,
-        )
-        custom_data = CustomDataEditor(
-            field_view=UserFieldsView,
-            domain=self.domain,
-            existing_custom_data=user.user_data,
-            post_dict=data,
-        )
-        self.assertValid(user_form)
-        self.assertValid(custom_data)
-        # TODO update this test to account for form subclasses
-        # self.assertValid(user_form)
-        # self.assertInvalid(custom_data)  # there should be an error
-
-        # data['data-field-usertype'] = 'dto'  # valid usertype
-        # form = UpdateCommCareUserInfoForm(
-        #     data=data,
-        #     existing_user=user,
-        #     domain=self.domain,
-        # )
-        # self.assertValid(form)
-
-    def test_validate_nikshay_code(self):
-        parent = self.locations['CTO']
-        form = self.make_new_location_form('winterfell', 'dto', parent=parent,
-                                           location_fields={'nikshay_code': '123'})
-        self.assertValid(form)
-        form.save()
-
-        # Making a new location with the same parent and nikshay_code should fail
-        form = self.make_new_location_form('castle_black', 'dto', parent=parent,
-                                           location_fields={'nikshay_code': '123'})
-        self.assertInvalid(form)
-
     def test_issuer_id(self):
         areo = self.make_user('ahotah@martell.biz', 'DTO')
         areo_number = areo.user_data['id_issuer_number']
@@ -287,26 +193,6 @@ class TestUserSetupUtils(TestCase):
             [l.name for l in ellaria.get_sql_locations(self.domain)],
             [self.locations['DRTB-HIV'].name, self.locations['DTO'].name]
         )
-
-    def test_get_site_code(self):
-        for expected, name, nikshay_code, type_code, parent in [
-            ('sto_nikshaycode', 'mysto', 'nikshaycode', 'sto', self.locations['CTD']),
-            ('cdst_nikshaycode', 'mycdst', 'nikshaycode', 'cdst', self.locations['STO']),
-            ('cto_sto_mycto', 'mycto', 'nikshaycode', 'cto', self.locations['STO']),
-            ('drtbhiv_dto', 'mydrtb-hiv', 'nikshaycode', 'drtb-hiv', self.locations['DTO']),
-            ('dto_cto_nikshaycode', 'mydto', 'nikshaycode', 'dto', self.locations['CTO']),
-            ('tu_dto_nikshaycode', 'mytu', 'nikshaycode', 'tu', self.locations['DTO']),
-            ('phi_tu_nikshaycode', 'myphi', 'nikshaycode', 'phi', self.locations['TU']),
-            ('dmc_tu_nikshaycode', 'mydmc', 'nikshaycode', 'dmc', self.locations['TU']),
-
-            # remove spaces and lowercase from nikshay code
-            ('cdst_nikshay_code', 'mycdst', 'Nikshay Code', 'cdst', self.locations['STO']),
-            # single digit integer nikshay codes get prefixed with 0
-            ('cdst_01', 'mycdst', '1', 'cdst', self.locations['STO']),
-            # make name a slug
-            ('cto_sto_cra-z_nm3', 'cRa-Z n@m3', 'nikshaycode', 'cto', self.locations['STO']),
-        ]:
-            self.assertEqual(expected, get_site_code(name, nikshay_code, type_code, parent))
 
     def test_conflicting_username(self):
         def id_to_username(issuer_id):

--- a/custom/enikshay/user_setup.py
+++ b/custom/enikshay/user_setup.py
@@ -1,17 +1,9 @@
-"""
-This uses signals to hook in to user and location forms for custom validation
-and some autogeneration. These additions are turned on by a feature flag, but
-domain and HQ admins are excepted, in case we ever need to violate the
-assumptions laid out here.
-"""
 from __future__ import absolute_import
 import math
-import re
 import uuid
 from crispy_forms import layout as crispy
 from django import forms
 from django.core.validators import RegexValidator
-from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from dimagi.utils.decorators.memoized import memoized
 from corehq import toggles
@@ -29,125 +21,6 @@ from .const import (
     PRIVATE_SECTOR_WORKER_ROLE,
 )
 from .models import AgencyIdCounter, IssuerId
-from six.moves import range
-from six.moves import map
-
-TYPES_WITH_REQUIRED_NIKSHAY_CODES = ['sto', 'dto', 'tu', 'dmc', 'phi']
-LOC_TYPES_TO_USER_TYPES = {
-    'phi': ['to', 'tbhv', 'mo-phi'],
-    'tu': ['sts', 'stls'],
-    'dmc': ['lt-dmc'],
-    'cdst': ['lt-cdst'],
-    'dto': ['dto', 'deo'],
-    'cto': ['cto'],
-    'sto': ['sto'],
-    'drtb-hiv': ['drtb-hiv'],
-}
-
-
-def skip_custom_setup(domain, request_user):
-    return True  # We're gonna revisit this, turning off for now
-    return not toggles.ENIKSHAY.enabled(domain) or request_user.is_domain_admin(domain)
-
-
-def clean_user_callback(sender, domain, request_user, user, forms, **kwargs):
-    if skip_custom_setup(domain, request_user):
-        return
-
-    new_user_form = forms.get('NewMobileWorkerForm')
-    update_user_form = forms.get('UpdateCommCareUserInfoForm')
-    custom_data = forms.get('CustomDataEditor')
-    location_form = forms.get('CommtrackUserForm')
-
-    if update_user_form or new_user_form:
-        if not custom_data:
-            raise AssertionError("Expected user form and custom data form to be submitted together")
-
-        if sender == 'LocationFormSet':
-            location_type = new_user_form.data['location_type']
-        elif new_user_form:
-            location_type = validate_location(domain, new_user_form).location_type.code
-        else:
-            location = user.get_sql_location(domain)
-            if not location:
-                return
-            location_type = user.get_sql_location(domain).location_type.code
-
-        if 'usertype' not in custom_data.form.cleaned_data:
-            return  # There was probably a validation error
-        usertype = custom_data.form.cleaned_data['usertype']
-        validate_usertype(location_type, usertype, custom_data)
-        if new_user_form:
-            pass
-        else:
-            validate_role_unchanged(domain, user, update_user_form)
-
-    if location_form:
-        location_form.add_error('assigned_locations', _("You cannot edit the location of existing users."))
-
-
-def validate_usertype(location_type, usertype, custom_data):
-    """Restrict choices for custom user data role field based on the chosen
-    location's type"""
-    allowable_usertypes = LOC_TYPES_TO_USER_TYPES[location_type]
-    if usertype not in allowable_usertypes:
-        msg = _("'User Type' must be one of the following: {}").format(', '.join(allowable_usertypes))
-        custom_data.form.add_error('usertype', msg)
-
-
-def validate_role_unchanged(domain, user, user_form):
-    """Web user role is not editable"""
-    existing_role = user.get_domain_membership(domain).role
-    if not existing_role:
-        return
-    existing_role_id = existing_role.get_qualified_id()
-    specified_role_id = user_form.cleaned_data['role']
-    if existing_role_id != specified_role_id:
-        msg = _("You cannot modify the user's role.  It must be {}").format(existing_role.name)
-        user_form.add_error('role', msg)
-
-
-def validate_location(domain, user_form):
-    """Force a location to be chosen"""
-    from corehq.apps.locations.models import SQLLocation
-    location_id = user_form.cleaned_data['location_id']
-    if location_id:
-        try:
-            return SQLLocation.active_objects.get(
-                domain=domain, location_id=location_id)
-        except SQLLocation.DoesNotExist:
-            pass
-    user_form.add_error('location_id', _("You must select a location."))
-
-
-def get_site_code(name, nikshay_code, type_code, parent):
-
-    def code_ify(word):
-        return slugify(re.sub(r'\s+', '_', word))
-
-    nikshay_code = code_ify(nikshay_code)
-    if nikshay_code in list(map(str, list(range(0, 10)))):
-        nikshay_code = "0{}".format(nikshay_code)
-
-    parent_site_code = parent.site_code
-    parent_prefix = ('drtbhiv_' if parent.location_type.code == 'drtb-hiv' else
-                     "{}_".format(parent.location_type.code))
-    if parent_site_code.startswith(parent_prefix):
-        parent_site_code = parent_site_code[len(parent_prefix):]
-
-    name_code = code_ify(name)
-
-    if type_code in ['sto', 'cdst']:
-        return '_'.join([type_code, nikshay_code])
-    elif type_code == 'cto':
-        return '_'.join([type_code, parent_site_code, name_code])
-    elif type_code == 'drtb-hiv':
-        return '_'.join(['drtbhiv', parent_site_code])
-    elif type_code in ['dto', 'tu', 'dmc', 'phi']:
-        return '_'.join([type_code, parent_site_code, nikshay_code])
-    elif type_code in ['ctd', 'drtb']:
-        return None  # we don't do anything special for these yet
-    return None
 
 
 def save_user_callback(sender, couch_user, **kwargs):
@@ -265,13 +138,6 @@ def add_drtb_hiv_to_dto(domain, user):
 
 def connect_signals():
     commcare_user_post_save.connect(save_user_callback, dispatch_uid="save_user_callback")
-
-
-# pcp -> MBBS
-# pac -> AYUSH/other
-# plc -> Private Lab
-# pcc -> pharmacy / chemist
-# dto -> Field officer??
 
 
 def _make_fields_type_specific(domain, form, fields_to_loc_types):
@@ -476,24 +342,6 @@ class ENikshayLocationFormSet(LocationFormSet):
         form.fields.pop('username')
         return form
 
-    @memoized
-    def is_valid(self):
-        if skip_custom_setup(self.domain, self.request_user):
-            return super(ENikshayLocationFormSet, self).is_valid()
-
-        for form in self.forms:
-            form.errors
-
-        if self.location_form.is_new_location:
-            self.validate_nikshay_code()
-            self.set_site_code()
-        else:
-            self.validate_nikshay_code_unchanged()
-
-        self.set_available_tests()
-
-        return all(form.is_valid() for form in self.forms)
-
     def save(self):
         if (self.location_form.cleaned_data['location_type_object'].code in AGENCY_LOCATION_TYPES
                 and self.include_user_forms):
@@ -512,43 +360,3 @@ class ENikshayLocationFormSet(LocationFormSet):
         else:
             role = roles[0]
             user.set_role(self.domain, role.get_qualified_id())
-
-    def set_site_code(self):
-        # https://docs.google.com/document/d/1Pr19kp5cQz9412Q1lbVgszeZJTv0XRzizb0bFHDxvoA/edit#heading=h.9v4rs82o0soc
-        nikshay_code = self.custom_location_data.form.cleaned_data.get('nikshay_code') or ''
-        type_code = self.location_form.cleaned_data['location_type']
-        parent = self.location_form.cleaned_data['parent']
-        name = self.location_form.cleaned_data['name']
-        self.location_form.cleaned_data['site_code'] = get_site_code(
-            name, nikshay_code, type_code, parent)
-
-    def validate_nikshay_code(self):
-        """When locations are created, enforce that a custom location data field
-        (Nikshay code) is unique amongst sibling locations"""
-        from corehq.apps.locations.models import SQLLocation
-        nikshay_code = self.custom_location_data.form.cleaned_data.get('nikshay_code', None)
-        loctype = self.location_form.cleaned_data['location_type']
-        if loctype not in TYPES_WITH_REQUIRED_NIKSHAY_CODES:
-            return
-        if not nikshay_code:
-            self.location_form.add_error(None, "You cannot create this location without providing a nikshay_code.")
-        parent = self.location_form.cleaned_data['parent']
-        sibling_codes = [
-            loc.metadata.get('nikshay_code', None)
-            for loc in SQLLocation.objects.filter(domain=self.domain, parent=parent)
-        ]
-        if nikshay_code in sibling_codes:
-            msg = "Nikshay Code '{}' is already in use.".format(nikshay_code)
-            self.custom_location_data.form.add_error('nikshay_code', msg)
-
-    def validate_nikshay_code_unchanged(self):
-        """Block edit of custom location data nikshay code after creation"""
-        specified_nikshay_code = self.custom_location_data.form.cleaned_data.get('nikshay_code', None)
-        existing_nikshay_code = self.location.metadata.get('nikshay_code', None)
-        if existing_nikshay_code and specified_nikshay_code != existing_nikshay_code:
-            msg = "You cannot modify the Nikshay Code of an existing location."
-            self.custom_location_data.form.add_error('nikshay_code', msg)
-
-    def set_available_tests(self):
-        if self.location_form.cleaned_data['location_type'] == 'cdst':
-            self.location.metadata['tests_available'] = 'cbnaat'


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/18857 inspired me to clean this up at least a little

This work was started, then there were some spec changes and it was deprioritized, and eventually I just ended up turning much of it off.  It's been sitting around long enough that we should just remove it, and add some back in if/when it becomes relevant again.

This should have no functional changes, note that `skip_custom_setup` currently returns `True`, so I went through and removed everything that only happened if that was `False`

@sravfeyn