### PR TITLE
Soft assert when initial page data is accessed before page is complet…

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -16,6 +16,11 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
      *  Find any unregistered data. Error on any duplicates.
      */
     var gather = function(selector, existing) {
+        if (document.readyState !== "complete") {
+            console.assert(false, "Attempt to call initial_page_data.gather before document is ready");
+            $.get('/assert/initial_page_data/');
+        }
+
         existing = existing || {};
         $(selector).each(function() {
             _.each($(this).children(), function(div) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -17,7 +17,7 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
      */
     var gather = function(selector, existing) {
         if (document.readyState !== "complete") {
-            console.assert(false, "Attempt to call initial_page_data.gather before document is ready");
+            console.assert(false, "Attempt to call initial_page_data.gather before document is ready"); // eslint-disable no-console
             $.get('/assert/initial_page_data/');
         }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -17,7 +17,7 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
      */
     var gather = function(selector, existing) {
         if (document.readyState !== "complete") {
-            console.assert(false, "Attempt to call initial_page_data.gather before document is ready"); // eslint-disable no-console
+            console.assert(false, "Attempt to call initial_page_data.gather before document is ready"); // eslint-disable-line no-console
             $.get('/assert/initial_page_data/');
         }
 

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -12,7 +12,7 @@ from corehq.apps.hqwebapp.views import (
     MaintenanceAlertsView, redirect_to_default,
     yui_crossdomain, password_change, no_permissions, login, logout, debug_notify,
     quick_find, osdd, create_alert, activate_alert, deactivate_alert, jserror, dropbox_upload, domain_login,
-    retrieve_download, toggles_js, couch_doc_counts, server_up, BugReportView)
+    assert_initial_page_data, retrieve_download, toggles_js, couch_doc_counts, server_up, BugReportView)
 from corehq.apps.hqwebapp.session_details_endpoint.views import SessionDetailsView
 
 urlpatterns = [
@@ -29,6 +29,7 @@ urlpatterns = [
     url(r'^reports/$', redirect_to_default),
     url(r'^bug_report/$', BugReportView.as_view(), name='bug_report'),
     url(r'^debug/notify/$', debug_notify, name='debug_notify'),
+    url(r'^assert/initial_page_data/$', assert_initial_page_data, name='assert_initial_page_data'),
     url(r'^search/$', quick_find, name="global_quick_find"),
     url(r'^searchDescription.xml$', osdd, name="osdd"),
     url(r'^messaging-pricing', PublicSMSRatesView.as_view(), name=PublicSMSRatesView.urlname),

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -76,6 +76,7 @@ from corehq.util.datadog.const import DATADOG_UNKNOWN
 from corehq.util.datadog.metrics import JSERROR_COUNT
 from corehq.util.datadog.utils import create_datadog_event, sanitize_url
 from corehq.util.datadog.gauges import datadog_counter
+from corehq.util.soft_assert import soft_assert
 from corehq.util.view_utils import reverse
 import six
 from six.moves import range
@@ -503,6 +504,17 @@ def dropbox_upload(request, download_id):
         )
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+
+
+# TODO jschweers: Remove this in Q2 2018 if it hasn't been triggered,
+# change initial_page_data.js to throw an error
+@require_GET
+def assert_initial_page_data(request):
+    _assert = soft_assert(['jschweers' + '@' + 'dimagi.com'])
+    _assert(False, 'Initial page data called before page load complete', {
+        'page': request.META['HTTP_REFERER'],
+    })
+    return json_response({'success': True})
 
 
 @require_superuser


### PR DESCRIPTION
…ely loaded

It's typically an error to try to access initial page data before the page is fully loaded. Not always - if the script is loaded after the html data block has been defined, it'll work - but relying on the order of tags is risky. This would have caught https://github.com/dimagi/commcare-hq/pull/18805

Hold off on merge because this is going to be going off constantly until https://github.com/dimagi/commcare-hq/pull/18859 is merged

@calellowitz / @millerdev 