### PR TITLE
Don't init ab tests until page is loaded

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -16,7 +16,6 @@ hqDefine('analytix/js/kissmetrix', [
     'use strict';
     var _get = initialAnalytics.getFn('kissmetrics'),
         _global = initialAnalytics.getFn('global'),
-        _abTests = initialAnalytics.getAbTests('kissmetrics'),
         logger = logging.getLoggerForApi('Kissmetrics'),
         _allAbTests = {},
         _init = {};
@@ -79,7 +78,8 @@ hqDefine('analytix/js/kissmetrix', [
         }
 
         // Initialize Kissmetrics AB Tests
-        _.each(_abTests, function (ab, testName) {
+        var abTests = initialAnalytics.getAbTests('kissmetrics');
+        _.each(abTests, function (ab, testName) {
             var test = {};
             testName = _.last(testName.split('.'));
             if (_.isObject(ab) && ab.version) {


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/18860 found its first bug.

Would be good to merge this one soon, as it may actually be interfering with AB test data.

@calellowitz / @biyeun 