### PR TITLE
wip: get form json from ES if available

### DIFF
--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -171,9 +171,10 @@ class FormsInDateExpressionSpec(JsonObject):
             context.set_cache_value(cache_key, count)
             return count
 
-        form_ids = [x['_id'] for x in xforms]
-        xforms = FormAccessors(domain).get_forms(form_ids)
-        xforms = [self._get_form_json(f, context) for f in xforms if f.domain == domain]
+        es_forms_by_id = {x['_id']: x for x in xforms}
+        xforms = FormAccessors(domain).get_forms(es_forms_by_id.keys())
+
+        xforms = [self._get_form_json(f, context, es_forms_by_id) for f in xforms if f.domain == domain]
 
         context.set_cache_value(cache_key, xforms)
         return xforms
@@ -195,7 +196,7 @@ class FormsInDateExpressionSpec(JsonObject):
             xform['timeEnd'] = datetime.strptime(time, '%Y-%m-%dT%H:%M:%S.%fZ').date()
             return xform
 
-        forms = mget_query('forms', xform_ids, ['form.meta.timeEnd', 'xmlns', '_id'])
+        forms = mget_query('forms', xform_ids, source=True)
         forms = list(filter(None, map(_transform_time_end, forms)))
         context.set_cache_value(cache_key, forms)
         return forms
@@ -210,12 +211,17 @@ class FormsInDateExpressionSpec(JsonObject):
         context.set_cache_value(cache_key, xform_ids)
         return xform_ids
 
-    def _get_form_json(self, form, context):
+    def _get_form_json(self, form, context, es_map):
         cache_key = (XFORM_CACHE_KEY_PREFIX, form.get_id)
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 
-        form_json = form.to_json()
+        if form.form_id in es_map:
+            # if available in the ES results, avoid a call to riak
+            form_json = es_map[form.form_id]
+        else:
+            form_json = form.to_json()
+
         context.set_cache_value(cache_key, form_json)
         return form_json
 


### PR DESCRIPTION
@emord curious to get your input on this. In my [initial profiling exploration](https://gist.github.com/czue/6580a94b37e18d3e587ded5767922b96) this lops of about 1/3 of the processing time (admittedly for a random case / datasource pair).

I think there are some significant potential problems/assumptions here:

- Would getting the full doc from ES cause too much load on the cluster? I know it has been a source of instability
- Would switching to this model break all the shared caching that's been setup because the docs would be too big?
- Does the form coming out of ES actually match perfectly what's in Riak?
- Probably others I'm overlooking