### PR TITLE
Fixture restore cache invalidation

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
@@ -54,16 +54,15 @@ class _RestoreCache(_CacheAccessor):
 
     @classmethod
     def _make_cache_key(cls, domain, user_id, sync_log_id, device_id):
-        # to invalidate all restore cache keys, increment the number below
-        hashable_key = '0,{prefix},{domain},{user},{sync_log_id},{device_id},{loadtest_factor},{fixture_freshness_token}'.format(
-            domain=domain,
-            prefix=cls.prefix,
-            user=user_id,
-            sync_log_id=sync_log_id or '',
-            device_id=device_id or '',
-            loadtest_factor=get_loadtest_factor_for_user(domain, user_id),
-            fixture_freshness_token=get_fixture_freshness_token(domain, user_id),
-        )
+        hashable_key = ','.join([unicode(part) for part in [
+            domain,
+            cls.prefix,
+            user_id,
+            sync_log_id or '',
+            device_id or '',
+            get_loadtest_factor_for_user(domain, user_id),
+            get_fixture_freshness_token(domain, user_id),
+        ]])
         return hashlib.md5(hashable_key).hexdigest()
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
@@ -73,7 +73,7 @@ class _RestoreCache(_CacheAccessor):
 
     @classmethod
     def _make_cache_key(cls, domain, user_id, sync_log_id, device_id):
-        hashable_key = ','.join([unicode(part) for part in [
+        hashable_key = ','.join([str(part) for part in [
             domain,
             cls.prefix,
             user_id,


### PR DESCRIPTION
This is a "prefactor" for https://manage.dimagi.com/default.asp?266045. Right now it basically does nothing (except globally bust restore caches due to a change in the key structure). But it exposes a function called `invalidate_restore_cache` that lets you invalidate caches for a single user or an entire domain.

This lets us implement invalidation workflows such as (a) invalidate restore for users affected by a fixture update (b) invalidate restores for a whole domain if it's too hard to figure out from a fixture upload what users' caches to invalidate or there are too many of them (?) (c) when a user's location or group assignment changes, invalidate their restore cache, etc.

Does this seem like a reasonable approach?