### PR TITLE
add dynamically configurable random toggle

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -228,8 +228,8 @@ class PredictablyRandomToggle(StaticToggle):
         super(PredictablyRandomToggle, self).__init__(slug, label, tag, list(namespaces),
                                                       help_link=help_link, description=description,
                                                       always_disabled=always_disabled)
-        assert namespaces, 'namespaces must be defined!'
-        assert 0 <= randomness <= 1, 'randomness must be between 0 and 1!'
+        _ensure_valid_namespaces(namespaces)
+        _ensure_valid_randomness(randomness)
         self.randomness = randomness
 
     @property
@@ -286,8 +286,8 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
         super(PredictablyRandomToggle, self).__init__(slug, label, tag, list(namespaces),
                                                       help_link=help_link, description=description,
                                                       always_disabled=always_disabled)
-        assert namespaces, 'namespaces must be defined!'
-        assert 0 <= default_randomness <= 1, 'default randomness must be between 0 and 1!'
+        _ensure_valid_namespaces(namespaces)
+        _ensure_valid_randomness(default_randomness)
         self.default_randomness = default_randomness
 
     @property
@@ -370,6 +370,16 @@ def toggle_values_by_name(username=None, domain=None):
     return {toggle_name: (toggle.enabled(username, NAMESPACE_USER) or
                           toggle.enabled(domain, NAMESPACE_DOMAIN))
             for toggle_name, toggle in all_toggles_by_name().items()}
+
+
+def _ensure_valid_namespaces(namespaces):
+    if not namespaces:
+        raise Exception('namespaces must be defined!')
+
+
+def _ensure_valid_randomness(randomness):
+    if 0 <= randomness <= 1:
+        raise Exception('randomness must be between 0 and 1!')
 
 
 APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -12,6 +12,7 @@ from django.utils.safestring import mark_safe
 
 from couchdbkit import ResourceNotFound
 from corehq.util.quickcache import quickcache
+from toggle.models import Toggle
 from toggle.shortcuts import toggle_enabled, set_toggle
 import six
 
@@ -150,7 +151,6 @@ class StaticToggle(object):
         return decorator
 
     def get_enabled_domains(self):
-        from toggle.models import Toggle
         try:
             toggle = Toggle.get(self.slug)
         except ResourceNotFound:
@@ -293,7 +293,6 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
     @property
     @quickcache(vary_on=['self.slug'])
     def randomness(self):
-        from toggle.models import Toggle
         # a bit hacky: leverage couch's dynamic properties to just tack this onto the couch toggle doc
         try:
             toggle = Toggle.get(self.slug)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -378,7 +378,7 @@ def _ensure_valid_namespaces(namespaces):
 
 
 def _ensure_valid_randomness(randomness):
-    if 0 <= randomness <= 1:
+    if not 0 <= randomness <= 1:
         raise Exception('randomness must be between 0 and 1!')
 
 


### PR DESCRIPTION
I thought it might be useful to have a toggle that we could configure dynamically and turned out to be quite easy to implement.

The specific use case is that I want to PoC something in ICDS UCR processing and be able to ratchet it up and down depending on whether it starts to cause problems. But I imagine it could be useful in other future places as well? basically anything where the toggle is controlling a system thing instead of a user thing.

any thoughts as to whether there's any reason this is a bad idea to exist? if approved i'll look into adding to the UI as well.
