### PR TITLE
clear resume info for static ucrs as well

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -155,8 +155,8 @@ def _iteratively_build_table(config, resume_helper=None, in_place=False, limit=-
 
         resume_helper.add_completed_case_type_or_xmlns(case_type_or_xmlns)
 
+    resume_helper.clear_resume_info()
     if not id_is_static(indicator_config_id):
-        resume_helper.clear_resume_info()
         if in_place:
             config.meta.build.finished_in_place = True
         else:


### PR DESCRIPTION
@emord @czue cc: @dannyroberts 
the resume info was not being cleared for static reports upon completion which made attempts to rebuild them exit immediately.  appears to have been the case since https://github.com/dimagi/commcare-hq/pull/11745

Did you purposefully exclude those @czue or is this an oversight. want to make sure this will not break anything