### PR TITLE
make threshold for LogLongRequestMiddleware 10 minutes

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -102,7 +102,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if hasattr(request, '_profile_starttime'):
             duration = datetime.datetime.utcnow() - request._profile_starttime
-            if duration > datetime.timedelta(minutes=2):
+            if duration > datetime.timedelta(minutes=10):
                 notify_exception(request, "Request took a very long time.", details={
                     'duration': duration.total_seconds(),
                 })


### PR DESCRIPTION
instead of 2, in order to reduce the number of sentry events we get