### PR TITLE
Temporary: initialize analytics loggers on module definition

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/drift.js
+++ b/corehq/apps/analytics/static/analytix/js/drift.js
@@ -21,7 +21,7 @@ hqDefine('analytix/js/drift', [
         _global = initialAnalytics.getFn('global'),
         _data = {},
         _drift = {},
-        logger;
+        logger = logging.getLoggerForApi('Drift');
 
     var __init__ = function () {
         logger = logging.getLoggerForApi('Drift');

--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -22,7 +22,7 @@ hqDefine('analytix/js/google', [
         _data = {},
         module = {},
         _gtag = function () {},
-        logger;
+        logger = logging.getLoggerForApi('Google Analytics');
 
     var __init__ = function () {
         _data.apiId = _get('apiId');

--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -17,7 +17,7 @@ hqDefine('analytix/js/hubspot', [
     var _get = initialAnalytics.getFn('hubspot'),
         _global = initialAnalytics.getFn('global'),
         _data = {},
-        logger;
+        logger = logging.getLoggerForApi('Hubspot');
 
     var _hsq = window._hsq = window._hsq || [];
 

--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -18,7 +18,7 @@ hqDefine('analytix/js/kissmetrix', [
         _global = initialAnalytics.getFn('global'),
         _allAbTests = {},
         _init = {},
-        logger;
+        logger = logging.getLoggerForApi('Kissmetrics');
 
     window.dataLayer = window.dataLayer || [];
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -16,10 +16,10 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
      *  Find any unregistered data. Error on any duplicates.
      */
     var gather = function(selector, existing) {
-        if (document.readyState !== "complete") {
+        /*if (document.readyState !== "complete") {
             console.assert(false, "Attempt to call initial_page_data.gather before document is ready"); // eslint-disable-line no-console
             $.get('/assert/initial_page_data/');
-        }
+        }*/
 
         existing = existing || {};
         $(selector).each(function() {


### PR DESCRIPTION
App preview is breaking for enikshay, I think because of the order in which document ready handlers are called. Haven't been able to reproduce locally or on prod.

Loggers shouldn't be created until the document is ready, because they depend on initial page data, so https://github.com/dimagi/commcare-hq/pull/18859/commits/edac51e393570466231dbbcf9b64e7f683d3a9d8 moved them to a document ready handler.

However, the ready handler that creates the loggers might not execute before other handlers that try to call them. The right way to fix this is probably to treat logger initialization as a promise. This PR is a band-aid that will initialize the loggers immediately (and possibly incorrectly, that is, logs may not display when they should be displaying...but that's not a user-facing problem).

Also turning off the assertion added in https://github.com/dimagi/commcare-hq/pull/18860 since this re-introduces code that tries to access initial page data before the document is ready, which would mean a deluge of email.

code buddy @gcapalbo 