### PR TITLE
Switch mobile endpoints to @mobile_auth

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -23,7 +23,7 @@ from corehq.apps.app_manager.util import get_app, LatestAppInfo
 from corehq.apps.case_search.models import QueryMergeException
 from corehq.apps.case_search.utils import CaseSearchCriteria
 from corehq.apps.domain.decorators import (
-    api_auth,
+    mobile_auth,
     check_domain_migration,
     mobile_auth_or_token,
 )
@@ -56,7 +56,7 @@ def restore(request, domain, app_id=None):
 
 
 @location_safe
-@api_auth
+@mobile_auth
 @check_domain_migration
 def search(request, domain):
     """
@@ -104,7 +104,7 @@ def _handle_es_exception(request, exception, query_addition_debug_details):
 @location_safe
 @csrf_exempt
 @require_POST
-@api_auth
+@mobile_auth
 @check_domain_migration
 def claim(request, domain):
     """
@@ -238,7 +238,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     return restore_config.get_response(), restore_config.timing_context
 
 
-@api_auth
+@mobile_auth
 @require_GET
 def heartbeat(request, domain, app_build_id):
     """
@@ -314,7 +314,7 @@ def heartbeat(request, domain, app_build_id):
 
 
 @location_safe
-@api_auth
+@mobile_auth
 @require_GET
 def get_next_id(request, domain):
     bucket_id = request.GET.get('pool_id')


### PR DESCRIPTION
Followup from https://github.com/dimagi/commcare-hq/pull/18846

I believe these endpoints are all intended to be accessed from mobile and should be decorated thusly.  Note that this drops support for digest auth for these endpoints.  Essentially, this reverts the behavior change from https://github.com/dimagi/commcare-hq/pull/18274 (they [defaulted to basic auth](https://github.com/dimagi/commcare-hq/blob/bba48ddd9a54ee6ff6b4789e2954a52a94d48c10/corehq/apps/ota/views.py), since no alternate default was provided).  Cal switched `restore` and `fetch_key_records` in https://github.com/dimagi/commcare-hq/pull/18826, this similarly switches these other endpoints.

@calellowitz @czue 