### PR TITLE
Allow date opened to be updated with case importer

### DIFF
--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext as _
 import itertools
 from corehq.apps.case_importer.util import get_case_properties_for_case_type, \
     RESERVED_FIELDS
+from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 from dimagi.ext import jsonobject
 
 
@@ -27,7 +28,7 @@ def _combine_field_specs(field_specs, exclude_fields):
 def get_suggested_case_fields(domain, case_type, exclude=None):
     exclude_fields = set(RESERVED_FIELDS) | set(exclude or [])
 
-    special_field_specs = (field_spec for field_spec in get_special_fields())
+    special_field_specs = (field_spec for field_spec in get_special_fields(domain))
 
     dynamic_field_specs = (FieldSpec(field=field, show_in_menu=True)
                            for field in get_case_properties_for_case_type(domain, case_type))
@@ -45,8 +46,8 @@ class FieldSpec(jsonobject.StrictJsonObject):
     discoverable = jsonobject.BooleanProperty(default=True)
 
 
-def get_special_fields():
-    return [
+def get_special_fields(domain=None):
+    special_fields = [
         FieldSpec(
             field='name',
             description=_("This field will be used to set the case's name."),
@@ -87,3 +88,14 @@ def get_special_fields():
             description=_("This field will be used to close cases. "
                           "Any case with 'yes' in this column will be closed.")),
     ]
+    if domain and BULK_UPLOAD_DATE_OPENED.enabled(domain):
+        special_fields.append(
+            FieldSpec(
+                field='date_opened',
+                description=_(
+                    "The date opened property for this case will be changed. "
+                    "Please do not use unless you know what you are doing"
+                )
+            )
+        )
+    return special_fields

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -9,6 +9,7 @@ from corehq.apps.case_importer.tracking.analytics import \
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import get_importer_error_message
 from corehq.util.datadog.gauges import datadog_gauge_task
+from casexml.apps.case.const import CASE_TAG_DATE_OPENED
 from casexml.apps.case.mock import CaseBlock, CaseBlockError
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.case_importer.const import LookupErrors, ImportErrors
@@ -19,6 +20,7 @@ from corehq.apps.export.tasks import add_inferred_export_properties
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from couchdbkit.exceptions import ResourceNotFound
 from corehq.util.soft_assert import soft_assert
+from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 import uuid
 from soil.progress import set_task_progress
 
@@ -228,6 +230,12 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
                 }
 
         case_name = fields_to_update.pop('name', None)
+
+        if BULK_UPLOAD_DATE_OPENED.enabled(domain):
+            date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
+            if date_opened:
+                extras['date_opened'] = date_opened
+
         if not case:
             id = uuid.uuid4().hex
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1398,6 +1398,13 @@ FILTERED_BULK_USER_DOWNLOAD = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+BULK_UPLOAD_DATE_OPENED = StaticToggle(
+    'bulk_upload_date_opened',
+    "Allow updating of the date_opened field with the bulk uploader",
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+)
+
 ICDS_LIVEQUERY = PredictablyRandomToggle(
     'icds_livequery',
     'ICDS: Enable livequery case sync for a random subset of ICDS users',


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266615#1434384

To update the `date_opened` (or `opened_on` or `opened_date`) through the importer, turn on that flag and add a column called `date_opened`. 

I'm not sure if we should add some messaging to the UI for when you are trying to do this without the flag enabled, because I think right now it will just ignore that property (which maintains the current behaviour).

@sravfeyn 