### PR TITLE
Allow firefox to scroll live preview

### DIFF
--- a/corehq/apps/hqwebapp/static/preview_app/less/preview_app/scrollable.less
+++ b/corehq/apps/hqwebapp/static/preview_app/less/preview_app/scrollable.less
@@ -25,4 +25,6 @@
 // Hiding scrollbars for the different browsers, generally only works on windows.
 .scrollable-container::-webkit-scrollbar { width: 0 !important }
 .scrollable-container { -ms-overflow-style: none; }
-.scrollable-container { overflow: -moz-scrollbars-none; }
+@-moz-document url-prefix() {
+    .scrollable-container { overflow-y: auto; }
+}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?267094#1434888
based on: https://stackoverflow.com/a/953491/2957657

I think having scrollbars and being able to scroll > hiding scrollbars and not being able to scroll. 

There are a bunch of hacky ways we could hide the scrollbar in firefox, but all of them include wrapping everything in an outer div, and making the inner div larger than that by a set number of pixels (thereby "hiding" the scrollbar). This seems less preferable than just having scrollbars, which I believe are a useful feature of UIs. 

@orangejenny @biyeun 
buddy @sravfeyn 

### Chrome
![screenshot from 2017-12-15 12-04-56](https://user-images.githubusercontent.com/146896/34052394-327659c0-e190-11e7-8a3a-e9de9c9a14bd.png)

### Firefox
![screenshot from 2017-12-15 12-04-38](https://user-images.githubusercontent.com/146896/34052395-32948bac-e190-11e7-8ec9-1d09f2cb78f3.png)
