### PR TITLE
Report Builder: Enable Default Filters in Preview

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -308,6 +308,7 @@ var reportBuilder = function () {  // eslint-disable-line
             selectablePropertyOptions: self.selectablePropertyOptions,
         });
         self.defaultFilterList.serializedProperties.subscribe(function () {
+            self.refreshPreview();
             self.saveButton.fire("change");
         });
         self.previewError = ko.observable(false);
@@ -418,6 +419,12 @@ var reportBuilder = function () {  // eslint-disable-line
         };
 
         self.serialize = function () {
+            // Clear invalid defaullt filters
+            default_filters = JSON.parse(self.defaultFilterList.serializedProperties())
+            default_filters = _.filter(
+                default_filters,
+                function(c){return c.property && c.pre_value;}
+            );
             return {
                 "existing_report": self.existingReportId,
                 "report_title": $('#report-title').val(), // From the inline-edit component
@@ -427,7 +434,7 @@ var reportBuilder = function () {  // eslint-disable-line
                 "chart": self.selectedChart(),
                 "columns": JSON.parse(self.columnList.serializedProperties()),
                 "location": self.location_field(),
-                "default_filters": JSON.parse(self.defaultFilterList.serializedProperties()),
+                "default_filters": default_filters,
                 "user_filters": JSON.parse(self.filterList.serializedProperties()),
             };
         };

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -420,7 +420,7 @@ var reportBuilder = function () {  // eslint-disable-line
 
         self.serialize = function () {
             // Clear invalid defaullt filters
-            default_filters = JSON.parse(self.defaultFilterList.serializedProperties())
+            var default_filters = JSON.parse(self.defaultFilterList.serializedProperties());
             default_filters = _.filter(
                 default_filters,
                 function(c){return c.property && c.pre_value;}

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -781,9 +781,8 @@ class ReportPreview(BaseDomainView):
         report_data = json.loads(six.moves.urllib.parse.unquote(request.body))
         form_class = _get_form_type(report_data['report_type'])
 
-        # ignore filters
+        # ignore user filters
         report_data['user_filters'] = []
-        report_data['default_filters'] = []
 
         _munge_report_data(report_data)
 


### PR DESCRIPTION
Product Note: This updates report builder preview to respond to changes in the default filters.  This was based on watching fullstory and users were confused with the default filters not working well in Preview.