### PR TITLE
Make drift ID secret

### DIFF
--- a/corehq/apps/analytics/templates/analytics/initial/drift.html
+++ b/corehq/apps/analytics/templates/analytics/initial/drift.html
@@ -1,6 +1,5 @@
 {% load hq_shared_tags %}
 
-{# TODO: API id was already publicly visible, but it should be moved into settings #}
 {% if ANALYTICS_CONFIG.DEBUG %}
     {# Developer is working on analytics #}
     {% initial_analytics_data 'drift.apiId' ANALYTICS_IDS.DRIFT_ID %}

--- a/corehq/apps/analytics/templates/analytics/initial/drift.html
+++ b/corehq/apps/analytics/templates/analytics/initial/drift.html
@@ -3,11 +3,11 @@
 {# TODO: API id was already publicly visible, but it should be moved into settings #}
 {% if ANALYTICS_CONFIG.DEBUG %}
     {# Developer is working on analytics #}
-    {% initial_analytics_data 'drift.apiId' '7456r8nz2u34' %}
+    {% initial_analytics_data 'drift.apiId' ANALYTICS_IDS.DRIFT_ID %}
 {% elif not is_saas_environment %}
     {# Don't include: this is an enterprise environment #}
 {% elif request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}
     {# Don't include: this is a user test and the Drift popup would be a distraction #}
 {% elif not request.user.is_authenticated or request.couch_user.days_since_created < 31 %}
-    {% initial_analytics_data 'drift.apiId' '7456r8nz2u34' %}
+    {% initial_analytics_data 'drift.apiId' ANALYTICS_IDS.DRIFT_ID %}
 {% endif %}

--- a/settings.py
+++ b/settings.py
@@ -725,7 +725,8 @@ ANALYTICS_IDS = {
     'KISSMETRICS_KEY': '',
     'HUBSPOT_API_KEY': '',
     'HUBSPOT_API_ID': '',
-    'GTM_ID': ''
+    'GTM_ID': '',
+    'DRIFT_ID': '',
 }
 
 ANALYTICS_CONFIG = {


### PR DESCRIPTION
@orangejenny @biyeun 
This previously would have meant that anyone installing HQ themselves would have access to Mackenzie for help. Which is cool, but I don't think was our intention.

Depends on: https://github.com/dimagi/commcarehq-ansible/pull/1150
@sravfeyn 
