### PR TITLE
Fix gracefully degrading case history

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1000,8 +1000,8 @@ class CaseExportInstance(ExportInstance):
         case_history_table = [table for table in self.tables if table.label == 'Case History']
         return any(
             column.selected
-            for column in table.columns
             for table in case_history_table
+            for column in table.columns
         )
 
 

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -1010,6 +1010,15 @@ class CaseExportSchema(HQExportSchema):
 
         return props
 
+    @property
+    def has_case_history_table(self):
+        case_history_table = [table for table in self.tables if table.label == 'Case History']
+        return any(
+            column.selected
+            for table in case_history_table
+            for column in table.columns
+        )
+
 
 class DefaultFormExportSchema(DefaultExportSchema):
 


### PR DESCRIPTION
I believe this should fix https://manage.dimagi.com/default.asp?266678

@emord while I was looking at this, I also noticed the syntax in `has_case_history_table`'s double comprehension is reversed. It wasn't failing hard because (I believe) the local variable table from the comprehension above is bleeding in and covering for the fact that it's not getting set from within that comprehension.