### PR TITLE
Clean up location model methods

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -629,16 +629,6 @@ class SQLLocation(MPTTModel):
         # For backwards compatability
         return self
 
-    def parents(self):
-        # get locations in path except the last one which is self
-        return SQLLocation.objects.get_locations(self.path[:-1])
-
-    def get_parent_of_type(self, parent_type):
-        parents = self.parents().filter(location_type__name=parent_type)
-        if len(parents) > 1:
-            raise ValueError("More than one parents for the same type")
-        return parents
-
 
 def filter_for_archived(locations, include_archive_ancestors):
     """

--- a/custom/enikshay/location_utils.py
+++ b/custom/enikshay/location_utils.py
@@ -1,18 +1,19 @@
 from __future__ import absolute_import
 from collections import namedtuple
 
+from corehq.apps.locations.models import SQLLocation
 from custom.enikshay.exceptions import NikshayLocationNotFound, NikshayCodeNotFound
 
 
 def get_health_establishment_hierarchy_codes(location):
     def get_parent(parent_type):
-        parent = location.get_parent_of_type(parent_type)
-        if not parent:
+        try:
+            return location.get_ancestors().get(location_type__name=parent_type)
+        except SQLLocation.DoesNotExist:
             raise NikshayLocationNotFound(
                 "Missing parent of type {location_type} for {location_id}".format(
                     location_type=parent_type,
                     location_id=location.location_id))
-        return parent[0]
 
     HealthEstablishmentHierarchy = namedtuple('HealthEstablishmentHierarchy', 'stcode dtcode')
     state = get_parent('sto')


### PR DESCRIPTION
@mkangia @millerdev
Just ran across these two methods that looked like they could be dropped.

`self.path` calls `self.get_ancestors()`, so `.parents` was doing a query to get
all ancestor IDs, then passing those IDs back to the DB in a second query.

`get_parent_of_type` can be replaced by the `get` queryset method, which will
raise an exception if multiple results are returned.