### PR TITLE
Add eslint for indenting switch cases

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         // First option can be off, warn, or error
         "comma-dangle": ["warn", "always-multiline"],
         "eqeqeq": ["error"],
-        "indent": ["warn", 4, {indentSwitchCase: true}],
+        "indent": ["warn", 4, {"SwitchCase":1}],
         "linebreak-style": ["error", "unix"],
         "semi": ["error", "always"],
     }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         // First option can be off, warn, or error
         "comma-dangle": ["warn", "always-multiline"],
         "eqeqeq": ["error"],
-        "indent": ["warn", 4],
+        "indent": ["warn", 4, {indentSwitchCase: true}],
         "linebreak-style": ["error", "unix"],
         "semi": ["error", "always"],
     }

--- a/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
@@ -49,18 +49,18 @@ function days_in_month(month, year) {
 
 function next_interval(date, interval) {
     switch(interval) {
-        case "day":
-            date.setUTCDate(date.getUTCDate() + 1);
-            break;
-        case "week":
-            date.setUTCDate(date.getUTCDate() + 7);
-            break;
-        case "month":
-            date.setUTCDate(date.getUTCDate() + days_in_month(date.getUTCMonth(), date.getUTCFullYear()));
-            break;
-        case "year":
-            date.setUTCDate(date.getUTCDate() + days_in_year(date.getUTCFullYear()));
-            break;
+    case "day":
+        date.setUTCDate(date.getUTCDate() + 1);
+        break;
+    case "week":
+        date.setUTCDate(date.getUTCDate() + 7);
+        break;
+    case "month":
+        date.setUTCDate(date.getUTCDate() + days_in_month(date.getUTCMonth(), date.getUTCFullYear()));
+        break;
+    case "year":
+        date.setUTCDate(date.getUTCDate() + days_in_year(date.getUTCFullYear()));
+        break;
     }
     return date;
 }

--- a/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
@@ -49,18 +49,18 @@ function days_in_month(month, year) {
 
 function next_interval(date, interval) {
     switch(interval) {
-    case "day":
-        date.setUTCDate(date.getUTCDate() + 1);
-        break;
-    case "week":
-        date.setUTCDate(date.getUTCDate() + 7);
-        break;
-    case "month":
-        date.setUTCDate(date.getUTCDate() + days_in_month(date.getUTCMonth(), date.getUTCFullYear()));
-        break;
-    case "year":
-        date.setUTCDate(date.getUTCDate() + days_in_year(date.getUTCFullYear()));
-        break;
+        case "day":
+            date.setUTCDate(date.getUTCDate() + 1);
+            break;
+        case "week":
+            date.setUTCDate(date.getUTCDate() + 7);
+            break;
+        case "month":
+            date.setUTCDate(date.getUTCDate() + days_in_month(date.getUTCMonth(), date.getUTCFullYear()));
+            break;
+        case "year":
+            date.setUTCDate(date.getUTCDate() + days_in_year(date.getUTCFullYear()));
+            break;
     }
     return date;
 }


### PR DESCRIPTION
This will make it so that eslint requires the `case:` statements in a switch block to be indented 4 spaces past where the `switch()` statement falls, rather than being at the same level of indentation. Currently, stickler actually gives an error if you format things the correct way, which is very annoying.

FYI @dimagi/js-team 