### PR TITLE
add UI for editing dynamic random toggles

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -4,6 +4,7 @@ hqDefine('toggle_ui/js/edit-flag', function () {
     function ToggleView() {
         var self = this;
         self.items = ko.observableArray();
+        self.randomness = ko.observable();
 
         self.init = function (config) {
             self.padded_ns = {};
@@ -15,6 +16,7 @@ hqDefine('toggle_ui/js/edit-flag', function () {
             });
             self.init_items(config);
             self.latest_use = ko.observable(config.last_used._latest || '');
+            self.randomness(config.randomness);
         };
 
         self.init_items = function (config) {
@@ -64,7 +66,8 @@ hqDefine('toggle_ui/js/edit-flag', function () {
                     type: 'post',
                     url: hqImport('hqwebapp/js/initial_page_data').reverse('edit_toggle') + location.search,
                     data: {
-                        item_list: JSON.stringify(items)
+                        item_list: JSON.stringify(items),
+                        randomness: self.randomness(),
                     },
                     dataType: 'json',
                     success: function (data) {
@@ -93,6 +96,8 @@ hqDefine('toggle_ui/js/edit-flag', function () {
             items: initial_page_data('items'),
             namespaces: initial_page_data('namespaces'),
             last_used: initial_page_data('last_used'),
+            is_random_editable: initial_page_data('is_random_editable'),
+            randomness: initial_page_data('randomness'),
         });
         $home.koApplyBindings(view);
         $home.on('change', 'input', view.change);

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -83,24 +83,6 @@
                 </div>
                 {% endif %}
                 <h4>{% trans "Enabled toggle items" %}</h4>
-                <div>
-                    {% if toggle_meta.randomness %}
-                        <p>
-                            {% blocktrans with percent=toggle_meta.randomness_percent namespace=toggle_meta.namespaces.0 %}
-                            And <strong>{{ percent }}%</strong> of all other {{ namespace }}s.
-                            {% endblocktrans %}
-                            {% if not expanded and namespace == 'domain' %}
-                                <a href="{% url 'edit_toggle' toggle_meta.slug %}?expand=true">({% trans "see all" %})</a>
-                            {% endif %}
-                            <br/>
-                            <ul>
-                                <li>
-                                    <span class="text-muted">{% trans "Go to the project settings page to see if a toggle is randomly enabled for your domain." %}</span>
-                                </li>
-                            </ul>
-                        </p>
-                    {% endif %}
-                </div>
                 <hr/>
                 {% if allows_items %}
                 <div class="row" data-bind="visible: latest_use().name">
@@ -131,26 +113,6 @@
                 {% endfor %}
                 {% endif %}
             </div>
-            {% if expanded %}
-                <hr/>
-                <h1>{% trans "All domain/toggle statuses" %}</h1>
-                    <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>{% trans "Domain" %}</th>
-                            <th>{% trans "Enabled?" %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    {% for domain, enabled in domain_toggle_list %}
-                        <tr {% if enabled %}class="info"{% endif %}>
-                            <td>{{ domain }}</td>
-                            <td>{{ enabled }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -82,9 +82,9 @@
                     <input id="randomness-edit" class="input-medium form-control" type="number" data-bind="value: randomness">
                 </div>
                 {% endif %}
+                {% if allows_items %}
                 <h4>{% trans "Enabled toggle items" %}</h4>
                 <hr/>
-                {% if allows_items %}
                 <div class="row" data-bind="visible: latest_use().name">
                     <div class="col-sm-6">
                         Most recently updated: <strong data-bind="text:latest_use().name"></strong>: <span data-bind="text:latest_use().date"></span>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -33,6 +33,8 @@
     {% initial_page_data 'items' toggle.enabled_users %}
     {% initial_page_data 'namespaces' namespaces %}
     {% initial_page_data 'last_used' last_used %}
+    {% initial_page_data 'is_random_editable' is_random_editable %}
+    {% initial_page_data 'randomness' toggle_meta.randomness %}
     <div class="row" style="margin-bottom: 50px;">
         <div class="col-sm-12">
             {% if not usage_info %}
@@ -44,7 +46,12 @@
             {% if toggle_meta.description %}
                 <p>{{ toggle_meta.description|safe }}</p>
             {% endif %}
-            <p><span class="label label-{{ toggle_meta.tag.css_class }}">{{ toggle_meta.tag.name }}</span></p>
+            <p>
+                <span class="label label-{{ toggle_meta.tag.css_class }}">{{ toggle_meta.tag.name }}</span>
+                {% if is_random %}
+                    <span class="label label-info">Random: {{ toggle_meta.randomness }}</span>
+                {% endif %}
+            </p>
             <p>{{ toggle_meta.tag.description }}</p>
             {% if toggle_meta.help_link %}
             <p><a href="{{ toggle_meta.help_link }}" target="_blank">{% trans "More information" %}</a></p>
@@ -69,14 +76,20 @@
             <hr/>
             <div id="toggle_editing_ko">
                 <div data-bind="saveButton: saveButton"></div>
+                {% if is_random_editable %}
+                <div class="input-group">
+                    <label for="randomness-edit">Randomness Level: </label>
+                    <input id="randomness-edit" class="input-medium form-control" type="number" data-bind="value: randomness">
+                </div>
+                {% endif %}
                 <h4>{% trans "Enabled toggle items" %}</h4>
                 <div>
                     {% if toggle_meta.randomness %}
                         <p>
-                            {% blocktrans with percent=toggle_meta.randomness_percent namespace=toggle_meta.namespace %}
+                            {% blocktrans with percent=toggle_meta.randomness_percent namespace=toggle_meta.namespaces.0 %}
                             And <strong>{{ percent }}%</strong> of all other {{ namespace }}s.
                             {% endblocktrans %}
-                            {% if not expanded %}
+                            {% if not expanded and namespace == 'domain' %}
                                 <a href="{% url 'edit_toggle' toggle_meta.slug %}?expand=true">({% trans "see all" %})</a>
                             {% endif %}
                             <br/>
@@ -89,6 +102,7 @@
                     {% endif %}
                 </div>
                 <hr/>
+                {% if allows_items %}
                 <div class="row" data-bind="visible: latest_use().name">
                     <div class="col-sm-6">
                         Most recently updated: <strong data-bind="text:latest_use().name"></strong>: <span data-bind="text:latest_use().date"></span>
@@ -115,6 +129,7 @@
                         <i class="fa fa-plus"></i> {% trans "Add " %}{{ namespace }}
                     </button>
                 {% endfor %}
+                {% endif %}
             </div>
             {% if expanded %}
                 <hr/>

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -111,10 +111,6 @@ class ToggleEditView(ToggleBaseView):
         return reverse(self.urlname, args=[self.toggle_slug])
 
     @property
-    def expanded(self):
-        return self.request.GET.get('expand') == 'true'
-
-    @property
     def usage_info(self):
         return self.request.GET.get('usage_info') == 'true'
 
@@ -159,7 +155,6 @@ class ToggleEditView(ToggleBaseView):
         context = {
             'toggle_meta': toggle_meta,
             'toggle': toggle,
-            'expanded': self.expanded,
             'namespaces': namespaces,
             'usage_info': self.usage_info,
             'server_environment': settings.SERVER_ENVIRONMENT,
@@ -167,11 +162,6 @@ class ToggleEditView(ToggleBaseView):
             'is_random_editable': self.is_random_editable,
             'allows_items': all(n in ALL_NAMESPACES for n in namespaces)
         }
-        if self.expanded and NAMESPACE_DOMAIN in namespaces:
-            context['domain_toggle_list'] = sorted(
-                [(row['key'], toggle_meta.enabled(row['key'])) for row in Domain.get_all(include_docs=False)],
-                key=lambda domain_tup: (not domain_tup[1], domain_tup[0])
-            )
         if self.usage_info:
             context['last_used'] = _get_usage_info(toggle)
         return context

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 import json
 from collections import Counter
 from couchdbkit.exceptions import ResourceNotFound
+import decimal
 from django.conf import settings
+from django.contrib import messages
 from django.urls import reverse
 from django.http.response import Http404, HttpResponse
 from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext_lazy as _
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster, \
     toggle_js_user_cachebuster
 from couchforms.analytics import get_last_form_submission_received
@@ -15,7 +18,8 @@ from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.toggle_ui.utils import find_static_toggle
 from corehq.apps.users.models import CouchUser
 from corehq.apps.hqwebapp.decorators import use_datatables
-from corehq.toggles import all_toggles, ALL_TAGS, NAMESPACE_USER, NAMESPACE_DOMAIN
+from corehq.toggles import all_toggles, ALL_TAGS, NAMESPACE_USER, NAMESPACE_DOMAIN, \
+    DynamicallyPredictablyRandomToggle, PredictablyRandomToggle, ALL_NAMESPACES
 from toggle.models import Toggle
 from toggle.shortcuts import clear_toggle_cache, parse_toggle
 import six
@@ -119,6 +123,14 @@ class ToggleEditView(ToggleBaseView):
         return self.args[0] if len(self.args) > 0 else self.kwargs.get('toggle', "")
 
     @property
+    def is_random(self):
+        return isinstance(self.static_toggle, PredictablyRandomToggle)
+
+    @property
+    def is_random_editable(self):
+        return isinstance(self.static_toggle, DynamicallyPredictablyRandomToggle)
+
+    @property
     def static_toggle(self):
         """
         Returns the corresponding toggle definition from corehq/toggles.py
@@ -143,15 +155,19 @@ class ToggleEditView(ToggleBaseView):
     def page_context(self):
         toggle_meta = self.toggle_meta()
         toggle = self.get_toggle()
+        namespaces = [NAMESPACE_USER if n is None else n for n in toggle_meta.namespaces]
         context = {
             'toggle_meta': toggle_meta,
             'toggle': toggle,
             'expanded': self.expanded,
-            'namespaces': [NAMESPACE_USER if n is None else n for n in toggle_meta.namespaces],
+            'namespaces': namespaces,
             'usage_info': self.usage_info,
             'server_environment': settings.SERVER_ENVIRONMENT,
+            'is_random': self.is_random_editable,
+            'is_random_editable': self.is_random_editable,
+            'allows_items': all(n in ALL_NAMESPACES for n in namespaces)
         }
-        if self.expanded:
+        if self.expanded and NAMESPACE_DOMAIN in namespaces:
             context['domain_toggle_list'] = sorted(
                 [(row['key'], toggle_meta.enabled(row['key'])) for row in Domain.get_all(include_docs=False)],
                 key=lambda domain_tup: (not domain_tup[1], domain_tup[0])
@@ -163,6 +179,8 @@ class ToggleEditView(ToggleBaseView):
     def post(self, request, *args, **kwargs):
         toggle = self.get_toggle()
         item_list = request.POST.get('item_list', [])
+        randomness = request.POST.get('randomness', None)
+        randomness = decimal.Decimal(randomness) if randomness else None
         if item_list:
             item_list = json.loads(item_list)
             item_list = [u.strip() for u in item_list if u and u.strip()]
@@ -170,6 +188,15 @@ class ToggleEditView(ToggleBaseView):
         previously_enabled = set(toggle.enabled_users)
         currently_enabled = set(item_list)
         toggle.enabled_users = item_list
+
+        save_randomness = (
+            self.is_random_editable and randomness is not None
+        )
+        if save_randomness and (0 <= randomness <= 1):
+            setattr(toggle, DynamicallyPredictablyRandomToggle.RANDOMNESS_KEY, randomness)
+        elif save_randomness:
+            messages.error(request, _("The randomness value {} must be between 0 and 1".format(randomness)))
+
         toggle.save()
 
         changed_entries = previously_enabled ^ currently_enabled  # ^ means XOR


### PR DESCRIPTION
Follows up with a UI for https://github.com/dimagi/commcare-hq/pull/18881

![image](https://user-images.githubusercontent.com/66555/34145008-c437470c-e49c-11e7-8b54-9e86d0f883d6.png)

This is a minimum viable UI for this. If you try to save an invalid value it just fails silently and then shows you a warning when you refresh the page. This seemed like maybe it would be fine given that it's superuser only?

This also removes the ability to expand a random toggle to all domains, which [has been broken](https://sentry.io/dimagi/commcarehq/issues/420728216/) [since this commit](https://github.com/dimagi/commcare-hq/pull/18082) and also seemed to be a possible performance problem since it gets all domain names in the system.