### PR TITLE
include db alias for uniqueness

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -178,7 +178,7 @@ def check_postgres():
         except OperationalError:
             c_status = 'FAIL'
             connected = False
-        status_str += "%s:%s " % (settings.DATABASES[db]['NAME'], c_status)
+        status_str += "%s:%s:%s " % (db, settings.DATABASES[db]['NAME'], c_status)
 
     a_user = User.objects.first()
     if a_user is None:


### PR DESCRIPTION
When running read queries on standby nodes (ICDS) the DB name is the same so include the django alias as well.