### PR TITLE
Allow selecting parent cases in shadow forms with their own details

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -358,7 +358,7 @@ class EntriesHelper(object):
             else:
                 parent_filter = ''
 
-            detail_module = module if module.module_type == 'shadow' else datum['module']
+            detail_module = datum['module']
             detail_persistent = self.get_detail_persistent_attr(datum['module'], detail_module, "case_short")
             detail_inline = self.get_detail_inline_attr(datum['module'], detail_module, "case_short")
 

--- a/corehq/apps/app_manager/tests/test_shadow_modules.py
+++ b/corehq/apps/app_manager/tests/test_shadow_modules.py
@@ -381,3 +381,26 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
             self.factory.app.create_suite(),
             "./entry/form"
         )
+
+    def test_parent_selection_first(self):
+        """https://manage.dimagi.com/default.asp?267251#1436434
+        """
+        self.single_form_module, self.form3 = self.factory.new_basic_module('basic_module', 'cow')
+        self.shadow_module = self.factory.new_shadow_module(
+            'shadow_module', self.single_form_module, with_form=False)
+
+        self.caselist_menu, self.form4 = self.factory.new_basic_module('caselist_only', 'ghost')
+        self.factory.form_requires_case(self.form3, parent_case_type='ghost')
+        self.factory.form_requires_case(self.form4)
+
+        expected_datum = """
+            <partial>
+              <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='ghost'][@status='open']"
+                     value="./@case_id" detail-select="m5_case_short"/>
+            </partial>
+        """
+        self.assertXmlPartialEqual(
+            expected_datum,
+            self.factory.app.create_suite(),
+            './entry/session/datum[@id="parent_id"]'
+        )


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?267251

If you select "Select Parent First" and chose a different case list, shadow modules just ignore what you selected. This looks like it was intentional to do that. https://github.com/dimagi/commcare-hq/commit/1c24973ca602758c470dbc5c52e5aa84a05b0b2b#diff-a86df6df8b6c62195748605648bce855R374

However, I'm not sure if what I've done here is bad from a shadow forms perspoective.Pinging @orangejenny if you have some other insights that I might be missing as to why this was set up the way it was previously?

@dannyroberts interrupt buddy
@sravfeyn code buddy