### PR TITLE
Remove fab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,6 +34,3 @@
 [submodule "corehq/apps/prelogin"]
 	path = corehq/apps/prelogin
 	url = https://github.com/dimagi/commcarehq-prelogin.git
-[submodule "deployment/commcare-hq-deploy"]
-	path = deployment/commcare-hq-deploy
-	url = https://github.com/dimagi/commcare-hq-deploy.git

--- a/fabfile.py
+++ b/fabfile.py
@@ -76,15 +76,18 @@ if 'y' == input('Do you want instructions for how to migrate? [y/N]'):
     You will always need to enter the ansible virtualenv to run fab from now on,
     but if you use the following alias, you can run it from anywhere.
 
-      alias fab=fab -f ~/.commcare-cloud/repo/fab/fabfile.py
+      alias fab='fab -f ~/.commcare-cloud/repo/fab/fabfile.py'
 
-    to add this to your .bash_profile you can run
+    to make alias always available, add it to the profile file you use for your aliases,
+    possibly one of the following:
 
-      echo "alias fab=fab -f ~/.commcare-cloud/repo/fab/fabfile.py" >> ~/.bash_profile
+      echo "alias fab='fab -f ~/.commcare-cloud/repo/fab/fabfile.py'" >> ~/.profile
+      echo "alias fab='fab -f ~/.commcare-cloud/repo/fab/fabfile.py'" >> ~/.bash_profile
+      echo "alias fab='fab -f ~/.commcare-cloud/repo/fab/fabfile.py'" >> ~/.bashrc
 
     Now from anywhere
 
-      # workon ansible
+      workon ansible
       fab production deploy
 """)
 exit(1)

--- a/fabfile.py
+++ b/fabfile.py
@@ -15,9 +15,10 @@ print()
 time.sleep(2)
 if 'y' == input('Do you want instructions for how to migrate? [y/N]'):
     print()
-    ansible_repo = os.path.join(os.path.dirname(__file__), '..', 'commcarehq-ansible')
+    ansible_repo = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'commcarehq-ansible'))
     if not os.path.isdir(os.path.join(ansible_repo, '.git')):
-        print("""
+        if 'y' != input('Do you have a local commcarehq-ansible repository already? [y/N]'):
+            print("""
     Set up commcarehq-ansible
     =========================
 
@@ -32,9 +33,25 @@ if 'y' == input('Do you want instructions for how to migrate? [y/N]'):
       mkvirtualenv ansible
 
 """)
+        else:
+            print("""
+    Link commcarehq-ansible repo
+    ============================
+
+    Symlink your commcarehq-ansible repo so that it lives alongside this one:
+
+      ln -s <path/to/commcarehq-ansible> {ansible_repo}
+
+    When you have done that, run
+
+      fab
+
+    to see more instructions.
+""".format(ansible_repo=ansible_repo))
+            exit(1)
     else:
         print("✓ You already have the commcarehq-ansible repo alonside this one: {}"
-              .format(os.path.realpath(ansible_repo)))
+              .format(ansible_repo))
         print()
         time.sleep(1)
     print("""

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,11 +1,87 @@
-from __future__ import absolute_import
-import sys
+# coding: utf-8
+from __future__ import print_function
+from __future__ import unicode_literals
+import os
+import time
 
-if __name__ == '__main__':
-    import settings
-    from corehq.apps.hqadmin.pillow_settings import test_pillow_settings
+print()
+print("Hey things have changed.")
+print()
+time.sleep(1)
+print("We now do deploys from the commcarehq-ansible directory or the control machine.")
+print()
+time.sleep(2)
+if 'y' == raw_input('Do you want instructions for how to migrate? [y/N]'):
+    print()
+    ansible_repo = os.path.join(os.path.dirname(__file__), '..', 'commcarehq-ansible')
+    if not os.path.isdir(os.path.join(ansible_repo, '.git')):
+        print("""
+    Set up commcarehq-ansible
+    =========================
 
-    if sys.argv[1] == 'test_pillows':
-        test_pillow_settings(sys.argv[2], settings.PILLOWTOPS)
-else:
-    from fab.fabfile import *
+    Put the commcarehq-ansible repo alongside this one like so:
+
+      cd ..
+      git clone https://github.com/dimagi/commcarehq-ansible.git
+      cd commcarehq-ansible
+
+    Now make a virtualenv for ansible:
+
+      mkvirtualenv ansible
+
+""")
+    else:
+        print("✓ You already have the commcarehq-ansible repo alonside this one: {}".format(os.path.realpath(ansible_repo)))
+        print()
+        time.sleep(1)
+    print("""
+    Make your ansible environment fab-ready
+    =======================================
+
+    Enter the commcarehq-ansible repo and make sure you have the latest
+
+      cd ../commcarehq-ansible
+      git pull
+
+    enter the env
+
+      workon ansible
+
+    do the necessary pip installs
+
+      pip install -r fab/requirements.txt
+
+    and make sure the necessary files are in the right place
+
+      ./control/check_install.sh
+
+    Run a fab command!
+    ==================
+
+    Enter the fab directory of commcarehq-ansible
+
+      cd commcarehq-ansible/fab
+
+    Run your fab command
+
+      fab production deploy
+
+
+    Bonus: Run fab from any directory
+    =================================
+
+    You will always need to enter the ansible virtualenv to run fab from now on,
+    but if you use the following alias, you can run it from anywhere.
+
+      alias fab=fab -f ~/.commcare-cloud/fab/fabfile.py
+
+    to add this to your .bash_profile you can run
+
+      echo "alias fab=fab -f ~/.commcare-cloud/fab/fabfile.py" >> ~/.bash_profile
+
+    Now from anywhere
+
+      # workon ansible
+      fab production deploy
+""")
+exit(1)

--- a/fabfile.py
+++ b/fabfile.py
@@ -73,11 +73,11 @@ if 'y' == raw_input('Do you want instructions for how to migrate? [y/N]'):
     You will always need to enter the ansible virtualenv to run fab from now on,
     but if you use the following alias, you can run it from anywhere.
 
-      alias fab=fab -f ~/.commcare-cloud/fab/fabfile.py
+      alias fab=fab -f ~/.commcare-cloud/repo/fab/fabfile.py
 
     to add this to your .bash_profile you can run
 
-      echo "alias fab=fab -f ~/.commcare-cloud/fab/fabfile.py" >> ~/.bash_profile
+      echo "alias fab=fab -f ~/.commcare-cloud/repo/fab/fabfile.py" >> ~/.bash_profile
 
     Now from anywhere
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import absolute_import
+from six.moves import input
 import os
 import time
 
@@ -11,7 +13,7 @@ time.sleep(1)
 print("We now do deploys from the commcarehq-ansible directory or the control machine.")
 print()
 time.sleep(2)
-if 'y' == raw_input('Do you want instructions for how to migrate? [y/N]'):
+if 'y' == input('Do you want instructions for how to migrate? [y/N]'):
     print()
     ansible_repo = os.path.join(os.path.dirname(__file__), '..', 'commcarehq-ansible')
     if not os.path.isdir(os.path.join(ansible_repo, '.git')):
@@ -31,7 +33,8 @@ if 'y' == raw_input('Do you want instructions for how to migrate? [y/N]'):
 
 """)
     else:
-        print("✓ You already have the commcarehq-ansible repo alonside this one: {}".format(os.path.realpath(ansible_repo)))
+        print("✓ You already have the commcarehq-ansible repo alonside this one: {}"
+              .format(os.path.realpath(ansible_repo)))
         print()
         time.sleep(1)
     print("""

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -3,8 +3,6 @@ guppy==0.1.10
 werkzeug==0.11.15
 line_profiler==1.0
 git+git://github.com/dimagi/couchdbkit-debugpanel.git
-Fabric==1.10.2
-ansible==2.4.1
 Sphinx==1.3.1
 sphinx-rtd-theme==0.1.9
 docutils==0.12


### PR DESCRIPTION
~Only merge _after_ https://github.com/dimagi/commcarehq-ansible/pull/1179~

This is Part Two of https://github.com/dimagi/commcarehq-ansible/pull/1179, and removes the commcare-hq-deploy submodule from commcare-hq, as it now lives under commcarehq-ansible/fab as part of that repo (and not as a submodule).

Before merging this PR, merge:
- https://github.com/dimagi/commcarehq-ansible/pull/1204 (improve check_install.sh output)

Right after merging this PR, merge:
- https://github.com/dimagi/commcare-hq-deploy/pull/489 (Deprecate commcare-hq-deploy repo)