### PR TITLE
Report Builder: Cleanup

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -746,29 +746,6 @@ class ConfigureNewReportBase(forms.Form):
                 for i in indicators:
                     self._report_columns_by_column_id[i['column_id']] = column
 
-
-        # NOTE: The corresponding knockout view model is defined in:
-        #       templates/userreports/reportbuilder/configure_report.html
-        self.helper = FormHelper()
-        self.helper.form_class = "form form-horizontal form-config-report"
-        self.helper.label_class = 'col-sm-3 col-md-2 col-lg-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
-        self.helper.attrs['data_bind'] = "submit: submitHandler"
-        self.helper.form_id = "report-config-form"
-
-        buttons = [
-            StrictButton(
-                _(self.button_text),
-                css_class="btn btn-primary disable-on-submit",
-                type="submit",
-            )
-        ]
-        # Add a back button if we aren't editing an existing report
-        self.helper.layout = crispy.Layout(
-            self.container_fieldset,
-            hqcrispy.FormActions(crispy.ButtonHolder(*buttons)),
-        )
-
     def _bootstrap(self, existing_report):
         """
         Use an existing report to initialize some of the instance variables of this
@@ -788,67 +765,6 @@ class ConfigureNewReportBase(forms.Form):
                 "Report builder data source doesn't reference an application. "
                 "It is likely this report has been customized and it is no longer editable. "
             ))
-
-    @property
-    def column_config_template(self):
-        return render_to_string('userreports/partials/property_list_configuration.html')
-
-    @property
-    def container_fieldset(self):
-        """
-        Return the first fieldset in the form.
-        """
-        return crispy.Div(
-            self.user_filter_fieldset
-        )
-
-    @property
-    def validation_error_text(self):
-        return crispy.HTML(
-            """<div class="alert alert-danger"
-                    data-bind="text: validationErrorText,
-                               visible: showValidationError">
-               </div>"""
-        )
-
-    @property
-    def user_filter_fieldset(self):
-        """
-        Return a fieldset representing the markup used for configuring the
-        user filters.
-        """
-        return crispy.Fieldset(
-            _legend(
-                _("User Filters"),
-                _("Add filters to your report to allow viewers to select which data the report will display. "
-                  "These filters will be displayed at the top of your report.")
-            ),
-            crispy.Div(
-                crispy.HTML(self.column_config_template),
-                id="user-filters-table",
-                data_bind='with: userFiltersList'
-            ),
-            crispy.Hidden('user_filters', None, data_bind="value: userFiltersList.serializedProperties")
-        )
-
-    @property
-    def default_filter_fieldset(self):
-        """
-        Return a fieldset representing the markup used for configuring the
-        default filters.
-        """
-        return crispy.Fieldset(
-            _legend(
-                _("Default Filters"),
-                _("These filters are not displayed to report viewers and are always applied to the data.")
-            ),
-            crispy.Div(
-                crispy.HTML(self.column_config_template),
-                id="default-filters-table",
-                data_bind='with: defaultFiltersList'
-            ),
-            crispy.Hidden('default_filters', None, data_bind="value: defaultFiltersList.serializedProperties")
-        )
 
     @property
     def _configured_columns(self):
@@ -1404,16 +1320,6 @@ class ConfigureMapReportForm(ConfigureListReportForm):
         super(ConfigureMapReportForm, self).__init__(
             report_name, app_id, source_type, report_source_id, existing_report, *args, **kwargs
         )
-        if self.source_type == "form":
-            self.fields['location'].widget = QuestionSelect(
-                attrs={'class': 'input-large'},
-                ko_value='groupBy'
-            )
-        else:
-            self.fields['location'].widget = Select2(
-                attrs={'class': 'input-large'},
-                ko_value="groupBy"
-            )
         self.fields['location'].choices = self._location_choices
 
         # Set initial value of location

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -630,16 +630,6 @@ class DataSourceBuilder(object):
         return self._ds_config_kwargs(indicators, is_multiselect_chart_report, multiselect_field)
 
 
-def _legend(title, subtext):
-    """
-    Return a string to be used in a crispy form Fieldset legend.
-    This function is just a light wrapped around some simple templating.
-    """
-    return u'{title}</br><div class="subtext"><small>{subtext}</small></div>'.format(
-        title=title, subtext=subtext
-    )
-
-
 class DataSourceForm(forms.Form):
     report_name = forms.CharField()
 
@@ -1159,10 +1149,6 @@ class ConfigureListReportForm(ConfigureNewReportBase):
         null_values=([],),
         required=False,
         widget=forms.HiddenInput,
-    )
-    column_legend_fine_print = ugettext_noop(
-        u"Add columns to your report to display information from cases or form submissions. You may rearrange the "
-        u"order of the columns by dragging the arrows next to the column."
     )
 
     @property

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -799,7 +799,7 @@ class ConfigureNewReportBase(forms.Form):
         if location:
             configured_columns += [{
                 "property": location,
-                "aggregation": "simple"  # Not aggregated
+                "calculation": "simple"  # Not aggregated
             }]
         return configured_columns
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1271,7 +1271,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
             elif self.cleaned_data['chart'] == "pie":
                 return [{
                     "type": "pie",
-                    "aggregation_column": "column_agg_0",
+                    "aggregation_column": get_agged_columns()[0]['column_id'],
                     "value_column": get_non_agged_columns()[0]['column_id'],
                 }]
         return []

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -400,24 +400,28 @@ class DataSourceBuilder(object):
         :param filters: A list of filter configuration objects
         """
 
-        def get_key(i):
-            return i['column_id'], i['type']
-
         indicators = OrderedDict()
         for column in columns:
             column_option = self.report_column_options[column['property']]
             for indicator in column_option.get_indicators(column['aggregation'], is_multiselect_chart_report):
-                indicators.setdefault(get_key(indicator), indicator)
+                indicators.setdefault(str(indicator), indicator)
 
         for filter_ in filters:
             property_ = self.data_source_properties[filter_['property']]
             indicator = property_.to_report_filter_indicator(filter_)
-            indicators.setdefault(get_key(indicator), indicator)
+            indicators.setdefault(str(indicator), indicator)
 
         return list(indicators.values())
 
-    def all_possible_indicators(self):
+    def all_possible_indicators(self, columns=[], filters=[]):
+        """
+        Will generate a set of possible indicators for the datasource making sure to include the
+        provided columns and filters
+        """
         indicators = OrderedDict()
+        for i in self.indicators(columns, filters):
+            indicators.setdefault(str(i), i)
+
         for column_option in self.report_column_options.values():
             for agg in column_option.aggregation_options:
                 for indicator in column_option.get_indicators(agg):

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1302,7 +1302,7 @@ class ConfigureListReportForm(ConfigureNewReportBase):
         for i, conf in enumerate(self.cleaned_data['columns']):
             columns.extend(
                 self.ds_builder.report_column_options[conf['property']].to_column_dicts(
-                    i, conf['display_text'], "simple"
+                    i, conf.get('display_text', conf['property']), "simple"
                 )
             )
         return columns

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -711,7 +711,6 @@ class ConfigureNewReportBase(forms.Form):
     default_filters = FilterField(required=False)
     report_title = forms.CharField(widget=forms.HiddenInput, required=False)
     report_description = forms.CharField(widget=forms.HiddenInput, required=False)
-    button_text = ugettext_noop('Done')
 
     def __init__(self, report_name, app_id, source_type, report_source_id, existing_report=None, *args, **kwargs):
         """
@@ -723,7 +722,6 @@ class ConfigureNewReportBase(forms.Form):
 
         if self.existing_report:
             self._bootstrap(self.existing_report)
-            self.button_text = _('Save')
         else:
             self.report_name = report_name
             assert source_type in ['case', 'form']

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -315,10 +315,10 @@ var reportBuilder = function () {  // eslint-disable-line
         self._pendingUpdate = false;
         self.refreshPreview = function (serializedColumns) {
             if (self._suspendPreviewRefresh) {
-                self._pendingUpdate = true
+                self._pendingUpdate = true;
             } else {
                 self._suspendPreviewRefresh = true;
-                self._pendingUpdate = false
+                self._pendingUpdate = false;
 
                 serializedColumns = typeof serializedColumns !== "undefined" ? serializedColumns : self.columnList.serializedProperties();
                 $('#preview').hide();
@@ -340,21 +340,20 @@ var reportBuilder = function () {  // eslint-disable-line
                         }
                     )),
                     dataType: 'json',
-                    success: self.renderReportPreview,
                     success: function (data) {
-                        self._suspendPreviewRefresh = false
+                        self._suspendPreviewRefresh = false;
                         if (self._pendingUpdate) {
                             self.refreshPreview();
                         } else {
-                            self.renderReportPreview(data)
+                            self.renderReportPreview(data);
                         }
                     },
                     error: function () {
-                        self._suspendPreviewRefresh = false
+                        self._suspendPreviewRefresh = false;
                         if (self._pendingUpdate) {
                             self.refreshPreview();
                         } else {
-                            self.previewError(true)
+                            self.previewError(true);
                         }
                     },
                 });

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -529,21 +529,7 @@ class ConfigureReport(ReportBuilderView):
     def _get_ds_config_kwargs(self, app_source, initial_columns, initial_filters):
         app = Application.get(app_source.application)
         builder = DataSourceBuilder(self.domain, app, app_source.source_type, app_source.source)
-        return {
-            'display_name': builder.data_source_name,
-            'referenced_doc_type': builder.source_doc_type,
-            'configured_filter': builder.filter,
-            'configured_indicators': builder.all_possible_indicators(columns=initial_columns,
-                                                                     filters=initial_filters),
-            'base_item_expression': builder.base_item_expression(False),
-            'meta': DataSourceMeta(
-                build=DataSourceBuildInformation(
-                    source_id=app_source.source,
-                    app_id=app._id,
-                    app_version=app.version,
-                )
-            )
-        }
+        return builder.get_temp_ds_config_kwargs(initial_columns, initial_filters)
 
     def _expire_data_source(self, data_source_config_id):
         always_eager = hasattr(settings, "CELERY_ALWAYS_EAGER") and settings.CELERY_ALWAYS_EAGER

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -525,7 +525,12 @@ class ConfigureReport(ReportBuilderView):
             request = request or self.request
             return request.GET.get('report_name', '')
 
+    @memoized
     def _build_temp_data_source(self, app_source, username):
+        """
+        Build a temp datasource and return the ID
+        """
+
         data_source_config = DataSourceConfiguration(
             domain=self.domain,
             table_id=_clean_table_name(self.domain, uuid.uuid4().hex),
@@ -547,13 +552,6 @@ class ConfigureReport(ReportBuilderView):
             countdown=TEMP_DATA_SOURCE_LIFESPAN
         )
         settings.CELERY_ALWAYS_EAGER = always_eager
-
-    @memoized
-    def _get_preview_data_source(self):
-        """
-        Return the ID of the report's DataSourceConfiguration
-        """
-        return self._build_temp_data_source(self.app_source, request.user.username)
 
     def _get_existing_report_type(self):
         if self.existing_report:
@@ -625,8 +623,8 @@ class ConfigureReport(ReportBuilderView):
             'source_id': self.source_id,
             'application': self.app_id,
             'report_preview_url': reverse(ReportPreview.urlname,
-                                          args=[self.domain, self._get_preview_data_source()]),
-            'preview_datasource_id': self._get_preview_data_source(),
+                                          args=[self.domain, self._build_temp_data_source()]),
+            'preview_datasource_id': self._build_temp_data_source(),
             'report_builder_events': self.request.session.pop(REPORT_BUILDER_EVENTS_KEY, []),
             'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
             'date_range_options': [r._asdict() for r in get_simple_dateranges()],

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -506,7 +506,6 @@ class ConfigureReport(ReportBuilderView):
             request = request or self.request
             return request.GET.get('report_name', '')
 
-    @memoized
     def _build_temp_data_source(self, initial_columns, initial_filters):
         """
         Build a temp datasource and return the ID

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -743,21 +743,6 @@ def _munge_report_data(report_data):
     :param report_data:
     :return:
     """
-    agg_columns = []
-    if report_data['report_type'] == "table":
-        clean_columns = []
-
-        for col in report_data['columns']:
-            if col['calculation'] == "Group By":
-                agg_columns.append(col)
-            else:
-                clean_columns.append(col)
-        agg_columns = [x['property'] for x in agg_columns]
-
-        report_data['columns'] = clean_columns
-
-    report_data['group_by'] = agg_columns or None
-
     report_data['columns'] = json.dumps(report_data['columns'])
     report_data['user_filters'] = json.dumps(report_data['user_filters'])
     report_data['default_filters'] = json.dumps(report_data['default_filters'])

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -608,12 +608,7 @@ class ConfigureReport(ReportBuilderView):
         report_form = form_type(
             self.page_name, self.app_id, self.source_type, self.source_id, self.existing_report
         )
-        initial_columns = [c._asdict() for c in report_form.initial_columns]
-        initial_user_filters = [f._asdict() for f in report_form.initial_user_filters]
-        initial_default_filters = [f._asdict() for f in report_form.initial_default_filters]
-
-        temp_ds_id = self._build_temp_data_source(initial_columns,
-                                                  initial_user_filters + initial_default_filters)
+        temp_ds_id = self._build_temp_data_source([],[])
         return {
             'existing_report': self.existing_report,
             'report_description': self.report_description,
@@ -623,9 +618,9 @@ class ConfigureReport(ReportBuilderView):
             'column_options': [p.to_view_model() for p in report_form.report_column_options.values()],
             # TODO: Consider renaming this because it's more like "possible" data source props
             'data_source_properties': [p.to_view_model() for p in report_form.data_source_properties.values()],
-            'initial_user_filters': initial_user_filters,
-            'initial_default_filters': initial_default_filters,
-            'initial_columns': initial_columns,
+            'initial_user_filters': [f._asdict() for f in report_form.initial_user_filters],
+            'initial_default_filters': [f._asdict() for f in report_form.initial_default_filters],
+            'initial_columns': [c._asdict() for c in report_form.initial_columns],
             'initial_location': self._get_initial_location(report_form),
             'initial_chart_type': self._get_initial_chart_type(),
             'source_type': self.source_type,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -703,7 +703,7 @@ class ReportPreview(BaseDomainView):
             report_data
         )
         if bound_form.is_valid():
-            temp_report = bound_form.create_temp_report(data_source)
+            temp_report = bound_form.create_temp_report(data_source, self.request.user.username)
             response_data = ConfigurableReport.report_preview_data(self.domain, temp_report)
             if response_data:
                 return json_response(response_data)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -286,23 +286,6 @@ class ReportBuilderView(BaseDomainView):
     def section_url(self):
         return reverse(ReportBuilderDataSourceSelect.urlname, args=[self.domain])
 
-    @staticmethod
-    def filter_data_source_changes(data_source_config_id):
-        """
-        Add filter to data source to prevent it from being updated by DB changes
-        """
-        # Reload using the ID instead of just passing in the object to avoid ResourceConflicts
-        data_source_config = DataSourceConfiguration.get(data_source_config_id)
-        data_source_config.configured_filter = {
-            # An expression that is always false:
-            "type": "boolean_expression",
-            "operator": "eq",
-            "expression": 1,
-            "property_value": 2,
-        }
-        data_source_config.validate()
-        data_source_config.save()
-
 
 @quickcache(["domain"], timeout=0, memoize_timeout=4)
 def paywall_home(domain):
@@ -556,7 +539,7 @@ class ConfigureReport(ReportBuilderView):
         report_form = form_type(
             self.page_name, self.app_id, self.source_type, self.source_id, self.existing_report
         )
-        temp_ds_id = report_form.create_temp_data_source()
+        temp_ds_id = report_form.create_temp_data_source(self.request.user.username)
 
         return {
             'existing_report': self.existing_report,


### PR DESCRIPTION
This PR does a few things:
- It cleans up a lot of old v1 related code
- It removes the special "group_by" field from the Table report to simplify the code
- It reduces the frequency that the report is refreshed
- It makes a number of changes to the preview report temp data source functionality:
  - It cleans up the code for building / managing the temp data sources
  - It forces the temp data source to include any columns that were chosen in the report
  - It optionally rebuilds the temp data source when the report preview is refreshed (if required)


