### PR TITLE
Don't include blank case properties in 99DOTS API

### DIFF
--- a/custom/enikshay/integrations/ninetyninedots/api_spec.py
+++ b/custom/enikshay/integrations/ninetyninedots/api_spec.py
@@ -193,14 +193,13 @@ class BasePatientPayload(StrictJsonObject):
             case = cases[case_type]
             for spec_property in api_spec.params_by_case_type(cls._sector, case_type):
                 if spec_property.getter:
-                    payload_kwargs[spec_property.api_param_name] = to_function(spec_property.getter)(
+                    prop = to_function(spec_property.getter)(
                         case.dynamic_case_properties(),
                         spec_property.get_by_sector('case_properties', cls._sector)
                     )
                 else:
-                    payload_kwargs[spec_property.api_param_name] = case.get_case_property(
-                        spec_property.get_by_sector('case_property', cls._sector)
-                    )
+                    prop = case.get_case_property(spec_property.get_by_sector('case_property', cls._sector))
+                payload_kwargs[spec_property.api_param_name] = prop or None
 
         payload_kwargs.update(cls.get_locations(person_case, episode_case))
         return cls(payload_kwargs)

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -344,6 +344,7 @@ class TestPayloadGeneratorBase(ENikshayCaseStructureMixin, ENikshayLocationStruc
         expected_payload.update(locations)
         actual_payload = json.loads(self._get_actual_payload(casedb))
         self.assertDictContainsSubset(expected_payload, actual_payload)
+        return actual_payload
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -420,6 +421,7 @@ class TestUpdatePatientPayloadGenerator(TestPayloadGeneratorBase):
         return UpdatePatientPayloadGenerator(None).get_payload(None, casedb[self.person_id])
 
     def test_get_payload(self):
+        self.person.attrs['update']['language_code'] = ''
         cases = self.create_case_structure()
         cases[self.person_id] = self.assign_person_to_location(self.phi.location_id)
         expected_numbers = u"+91{}, +91{}, +91{}".format(
@@ -427,7 +429,8 @@ class TestUpdatePatientPayloadGenerator(TestPayloadGeneratorBase):
             self.secondary_phone_number.replace("0", ""),
             self.other_number.replace("0", "")
         )
-        self._assert_payload_contains_subset(cases, expected_numbers)
+        payload = self._assert_payload_contains_subset(cases, expected_numbers)
+        self.assertFalse('language_code' in payload)
 
     def test_handle_success(self):
         cases = self.create_case_structure()


### PR DESCRIPTION
If the param has choices defined and the case property has `''` stored to it, the api spec was rightfully throwing an error because `''` isn't one of the allowed choices.

@mkangia 
buddy @sravfeyn 