### PR TITLE
Gateway error handling improvements

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -2181,6 +2181,15 @@ class SQLSMSBackend(SQLMobileBackend):
         proxy = True
         app_label = 'sms'
 
+    def get_max_simultaneous_connections(self):
+        """
+        Return None to ignore.
+        Otherwise, return the maximum number of simultaneous connections
+        that should be allowed when making requests to the gateway API
+        for sending outbound SMS.
+        """
+        return None
+
     def get_sms_rate_limit(self):
         """
         Override to use rate limiting. Return None to not use rate limiting,

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -129,6 +129,32 @@ def message_is_stale(msg, utcnow):
         return True
 
 
+def connection_slot_key_base(backend):
+    return 'backend-%s-connection-slot-' % backend.couch_id
+
+
+def reserve_connection_slot(backend, max_simultaneous_connections):
+    with CriticalSection(['reserve-connection-slot-for-%' % backend.couch_id]):
+        client = get_redis_client()
+        key_base = connection_slot_key_base(backend)
+        slot_keys = client.keys(key_base + '*')
+        slot_numbers = [int(slot_key.replace(key_base, '')) for slot_key in slot_keys]
+
+        for slot_number in range(1, max_simultaneous_connections + 1):
+            if slot_number not in slot_numbers:
+                key = key_base + slot_number
+                client.set(key, 1)
+                client.expire(key, 60)
+                return slot_number
+
+    return None
+
+
+def free_connection_slot(backend, slot):
+    client = get_redis_client()
+    client.delete(connection_slot_key_base(backend) + slot)
+
+
 def handle_outgoing(msg):
     """
     Should return a requeue flag, so if it returns True, the message will be
@@ -139,6 +165,7 @@ def handle_outgoing(msg):
     sms_rate_limit = backend.get_sms_rate_limit()
     use_rate_limit = sms_rate_limit is not None
     use_load_balancing = isinstance(backend, PhoneLoadBalancingMixin)
+    max_simultaneous_connections = backend.get_max_simultaneous_connections()
     orig_phone_number = None
 
     if use_load_balancing:
@@ -154,11 +181,20 @@ def handle_outgoing(msg):
             # Requeue the message and try it again shortly
             return True
 
+    if max_simultaneous_connections:
+        connection_slot = reserve_connection_slot(backend, max_simultaneous_connections)
+        if not connection_slot:
+            # Requeue the message and try it again shortly
+            return True
+
     result = send_message_via_backend(
         msg,
         backend=backend,
         orig_phone_number=orig_phone_number
     )
+
+    if max_simultaneous_connections:
+        free_connection_slot(backend, connection_slot)
 
     if msg.error:
         remove_from_queue(msg)

--- a/corehq/messaging/smsbackends/push/models.py
+++ b/corehq/messaging/smsbackends/push/models.py
@@ -52,6 +52,13 @@ class PushBackend(SQLSMSBackend):
         app_label = 'sms'
         proxy = True
 
+    def get_max_simultaneous_connections(self):
+        """
+        Only allow a maximum of eight simultaneous connections to the gateway
+        when sending outbound SMS as per the documentation.
+        """
+        return 8
+
     @classmethod
     def get_available_extra_fields(cls):
         return [

--- a/settings.py
+++ b/settings.py
@@ -1561,7 +1561,7 @@ IVR_BACKEND_MAP = {
 }
 
 # The number of seconds to use as a timeout when making gateway requests
-SMS_GATEWAY_TIMEOUT = 30
+SMS_GATEWAY_TIMEOUT = 5
 IVR_GATEWAY_TIMEOUT = 60
 
 # These are functions that can be called


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?267665

We've recently had some instances where there is a large volume of queued messages belonging to one gateway which is experiencing downtime. This causes a few problems which this PR solves by:

- using a more reasonable timeout value so that these messages don't block processing of other messages for so long

- only notifying exceptions about a down gateway once an hour per gateway so that we don't use up so many sentry events

- enforces a maximum number of 8 simultaneous connections to the push backend, which was previously enforced by setting the concurrency on the sms celery worker to 8. now that this will happen in the code, we can bump the number of sms workers we use to keep messages flowing when one gateway is down.

@orangejenny 