### PR TITLE
Remove broken test

### DIFF
--- a/custom/icds_reports/static/icds_reports/js/spec/kpi.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/kpi.directive.spec.js
@@ -62,13 +62,14 @@ describe('Kpi Directive', function () {
         assert.equal(result, expected);
     });
 
-    it('tests shows percent info from month parameter', function () {
-        $location.search('month', new Date().getMonth());
-        var expected = true;
+    // FIXME
+    // it('tests shows percent info from month parameter', function () {
+        // $location.search('month', new Date().getMonth());
+        // var expected = true;
 
-        var result = controller.showPercentInfo();
-        assert.equal(result, expected);
-    });
+        // var result = controller.showPercentInfo();
+        // assert.equal(result, expected);
+    // });
 
     it('tests not shows percent info from wrong month parameter', function () {
         $location.search('month', new Date().getMonth() + 1);


### PR DESCRIPTION
introduced here https://github.com/dimagi/commcare-hq/pull/18832
My guess is this broke when the year or month changed.  Even checking out the original version now this test fails.
@mkangia