### PR TITLE
preventDefault action when submitting case claim query

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -42,7 +42,7 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
         },
 
         submitAction: function (e) {
-            e.preventDefault()
+            e.preventDefault();
             var payload = {};
             var fields = $(".query-field");
             var model = this.parentModel;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -41,7 +41,8 @@ FormplayerFrontend.module("Menus.Views", function (Views, FormplayerFrontend, Ba
             'click @ui.submitButton': 'submitAction',
         },
 
-        submitAction: function () {
+        submitAction: function (e) {
+            e.preventDefault()
             var payload = {};
             var fields = $(".query-field");
             var model = this.parentModel;


### PR DESCRIPTION
The default behavior of the submit button was causing the screen to reload after submitting  a case claim query when we just want Marionette to update the page asynchronously. 