### PR TITLE
added try/except and error logger when create pdf file

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -260,15 +260,21 @@ def prepare_issnip_monthly_register_reports(domain, user, awcs, pdf_format, mont
             report_context['reports'].append(context)
         else:
             report_context['reports'] = [context]
-            create_pdf_file(
-                pdf_hash,
-                report_context
-            )
+            try:
+                create_pdf_file(
+                    pdf_hash,
+                    report_context
+                )
+            except Exception as ex:
+                celery_task_logger.error(ex.message)
 
     if pdf_format == 'many':
         cache_key = zip_folder(pdf_files)
     else:
-        cache_key = create_pdf_file(uuid.uuid4().hex, report_context)
+        try:
+            cache_key = create_pdf_file(uuid.uuid4().hex, report_context)
+        except Exception as ex:
+            celery_task_logger.error(ex.message)
 
     params = {
         'domain': 'icds-cas',


### PR DESCRIPTION
Hi @czue 

I added ```try/except``` when I create a PDF file. I can't reproduce on my local machine why users don't receive emails with link to the file. I think we have some problem with this. Could you deploy this on the India server as soon as possible.

Regards,
Łukasz