### PR TITLE
only try to process docs that have associated indicators

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -306,7 +306,7 @@ def save_document(doc_ids):
         indicator_config_ids = first_indicator.indicator_config_ids
 
         with timer:
-            for doc in doc_store.iter_documents(doc_ids):
+            for doc in doc_store.iter_documents(indicator_by_doc_id.keys()):
                 indicator = indicator_by_doc_id[doc['_id']]
                 successfully_processed, to_remove = _save_document_helper(indicator, doc)
                 if successfully_processed:


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/309028178/?environment=icds-new

I don't have a good model for when this error would trigger, but it seems to happen a lot. Basically some of the `doc_ids` that get passed to the `save_document` task no longer have an associated indicator and are causing the whole lot to fail. I assume due to parallel processing? Not sure if the locks are meant to help but they are not preventing all errors.

Fyi @emord in case you wanted to look closer into this when you get back. Seems to have been coming up consistently for a long time.