### PR TITLE
ICDS - add error into pdf file

### DIFF
--- a/custom/icds_reports/utils.py
+++ b/custom/icds_reports/utils.py
@@ -439,6 +439,7 @@ def zip_folder(pdf_files):
         zip_file.writestr('ISSNIP_monthly_register_{}.pdf'.format(pdf_file['location_name']), file)
     zip_file.close()
     client.set(zip_hash, in_memory.getvalue())
+    client.expire(zip_hash, 24 * 60 * 60)
     return zip_hash
 
 
@@ -446,9 +447,14 @@ def create_pdf_file(pdf_hash, pdf_context):
     template = get_template("icds_reports/icds_app/pdf/issnip_monthly_register.html")
     resultFile = cStringIO()
     client = get_redis_client()
+    try:
+        pdf_page = template.render(pdf_context)
+    except Exception as ex:
+        pdf_page = str(ex)
     pisa.CreatePDF(
-        template.render(pdf_context),
-        dest=resultFile)
+        pdf_page,
+        dest=resultFile,
+        show_error_as_pdf=True)
     client.set(pdf_hash, resultFile.getvalue())
     client.expire(pdf_hash, 24 * 60 * 60)
     resultFile.close()


### PR DESCRIPTION
Hi @czue ,

This change should help and is only to figure out why PDF export don't work on the production. With data which I have I can't reproduce issue with exporting. 

This should be deployed only on India server.

Please let me know if you have any questions.

Regards,
Łukasz