### PR TITLE
disable default Subscription Manager

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -305,7 +305,7 @@ class SubscriptionFilterAsyncHandler(BaseSingleOptionFilterAsyncHandler):
 
     @property
     def query(self):
-        query = Subscription.objects
+        query = Subscription.visible_objects
         if self.action == 'contract_id':
             query = query.exclude(
                 salesforce_contract_id=None

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -292,7 +292,7 @@ class SubscriptionInterface(AddItemInterface):
 
     @property
     def _subscriptions(self):
-        queryset = Subscription.objects.all()
+        queryset = Subscription.visible_objects.all()
 
         if StartDateFilter.use_filter(self.request):
             queryset = queryset.filter(

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -68,7 +68,7 @@ class DomainInvoiceFactory(object):
                 )
 
     def _get_subscriptions(self):
-        subscriptions = Subscription.objects.filter(
+        subscriptions = Subscription.visible_objects.filter(
             Q(date_end=None) | (
                 Q(date_end__gt=self.date_start)
                 & Q(date_end__gt=F('date_start'))

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -981,11 +981,16 @@ class Subscriber(models.Model):
             raise SubscriptionChangeError("The upgrade was not successful.")
 
 
-class SubscriptionManager(models.Manager):
+class VisibleSubscriptionManager(models.Manager):
 
     def get_queryset(self):
-        return super(SubscriptionManager, self).get_queryset().filter(is_hidden_to_ops=False)
+        return super(VisibleSubscriptionManager, self).get_queryset().filter(is_hidden_to_ops=False)
 
+
+class DisabledManager(models.Manager):
+
+    def get_queryset(self):
+        raise NotImplementedError
 
 class Subscription(models.Model):
     """
@@ -1026,7 +1031,9 @@ class Subscription(models.Model):
     is_hidden_to_ops = models.BooleanField(default=False)
     skip_auto_downgrade = models.BooleanField(default=False)
 
-    objects = SubscriptionManager()
+    visible_objects = VisibleSubscriptionManager()
+    visible_and_suppressed_objects = models.Manager()
+    objects = DisabledManager()
 
     class Meta:
         app_label = 'accounting'
@@ -1075,7 +1082,7 @@ class Subscription(models.Model):
 
     @property
     def next_subscription_filter(self):
-        return (Subscription.objects.
+        return (Subscription.visible_objects.
                 filter(subscriber=self.subscriber, date_start__gt=self.date_start).
                 exclude(pk=self.pk).
                 filter(Q(date_end__isnull=True) | ~Q(date_start=F('date_end'))))
@@ -1100,7 +1107,7 @@ class Subscription(models.Model):
         conflicts with other subscriptions related to this subscriber.
         """
         assert date_start is not None
-        for sub in Subscription.objects.filter(
+        for sub in Subscription.visible_objects.filter(
             subscriber=self.subscriber,
         ).exclude(
             id=self.id,
@@ -1578,7 +1585,7 @@ class Subscription(models.Model):
         date_start = date_start or today
 
         # find subscriptions that end in the future / after this subscription
-        available_subs = Subscription.objects.filter(
+        available_subs = Subscription.visible_objects.filter(
             subscriber=subscriber,
         )
 
@@ -1625,7 +1632,7 @@ class Subscription(models.Model):
             return last_subscription
 
         adjustment_method = adjustment_method or SubscriptionAdjustmentMethod.INTERNAL
-        subscription = Subscription.objects.create(
+        subscription = Subscription.visible_objects.create(
             account=account,
             plan_version=plan_version,
             subscriber=subscriber,
@@ -1655,7 +1662,7 @@ class Subscription(models.Model):
                                            date_start=None):
         subscriber = Subscriber.objects.get_or_create(domain=domain)[0]
         date_start = date_start or datetime.date.today()
-        last_subscription = Subscription.objects.filter(
+        last_subscription = Subscription.visible_objects.filter(
             subscriber=subscriber, date_end=date_start
         )
         if not last_subscription.exists():

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1548,7 +1548,7 @@ class Subscription(models.Model):
     @classmethod
     def get_active_subscription_by_domain(cls, domain_name):
         try:
-            return cls.objects.select_related(
+            return cls.visible_objects.select_related(
                 'plan_version__role'
             ).get(
                 is_active=True,

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -534,7 +534,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         in the future.
         """
         from corehq.apps.accounting.models import Subscription
-        later_subs = Subscription.objects.filter(
+        later_subs = Subscription.visible_objects.filter(
             subscriber__domain=self.domain.name,
             date_start__gt=self.date_start
         ).order_by('date_start')

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -79,7 +79,7 @@ def _activate_subscription(subscription):
 
 
 def activate_subscriptions(based_on_date=None):
-    starting_subscriptions = Subscription.objects.filter(
+    starting_subscriptions = Subscription.visible_objects.filter(
         is_active=False,
     )
     if based_on_date:
@@ -130,7 +130,7 @@ def _deactivate_subscription(subscription):
 
 
 def deactivate_subscriptions(based_on_date=None):
-    ending_subscriptions = Subscription.objects.filter(
+    ending_subscriptions = Subscription.visible_objects.filter(
         is_active=True,
     )
     if based_on_date:
@@ -150,7 +150,7 @@ def deactivate_subscriptions(based_on_date=None):
 
 def warn_subscriptions_still_active(based_on_date=None):
     ending_date = based_on_date or datetime.date.today()
-    subscriptions_still_active = Subscription.objects.filter(
+    subscriptions_still_active = Subscription.visible_objects.filter(
         date_end__lte=ending_date,
         is_active=True,
     )
@@ -160,7 +160,7 @@ def warn_subscriptions_still_active(based_on_date=None):
 
 def warn_subscriptions_not_active(based_on_date=None):
     based_on_date = based_on_date or datetime.date.today()
-    subscriptions_not_active = Subscription.objects.filter(
+    subscriptions_not_active = Subscription.visible_objects.filter(
         Q(date_end=None) | Q(date_end__gt=based_on_date),
         date_start__lte=based_on_date,
         is_active=False,
@@ -171,7 +171,7 @@ def warn_subscriptions_not_active(based_on_date=None):
 
 def warn_active_subscriptions_per_domain_not_one():
     for domain_name in Domain.get_all_names():
-        active_subscription_count = Subscription.objects.filter(
+        active_subscription_count = Subscription.visible_objects.filter(
             subscriber__domain=domain_name,
             is_active=True,
         ).count()
@@ -317,7 +317,7 @@ def remind_dimagi_contact_subscription_ending_60_days():
 def send_subscription_reminder_emails(num_days):
     today = datetime.date.today()
     date_in_n_days = today + datetime.timedelta(days=num_days)
-    ending_subscriptions = Subscription.objects.filter(
+    ending_subscriptions = Subscription.visible_objects.filter(
         date_end=date_in_n_days, do_not_email_reminder=False, is_trial=False
     )
     for subscription in ending_subscriptions:
@@ -335,7 +335,7 @@ def send_subscription_reminder_emails(num_days):
 def send_subscription_reminder_emails_dimagi_contact(num_days):
     today = datetime.date.today()
     date_in_n_days = today + datetime.timedelta(days=num_days)
-    ending_subscriptions = (Subscription.objects
+    ending_subscriptions = (Subscription.visible_objects
                             .filter(is_active=True)
                             .filter(date_end=date_in_n_days)
                             .filter(do_not_email_reminder=False)
@@ -455,7 +455,7 @@ def weekly_digest():
     today = datetime.date.today()
     in_forty_days = today + datetime.timedelta(days=40)
 
-    ending_in_forty_days = [sub for sub in Subscription.objects.filter(
+    ending_in_forty_days = [sub for sub in Subscription.visible_objects.filter(
             date_end__lte=in_forty_days,
             date_end__gte=today,
             is_active=True,
@@ -575,7 +575,7 @@ def update_exchange_rates(app_id=settings.OPEN_EXCHANGE_RATES_API_ID):
 
 
 def ensure_explicit_community_subscription(domain_name, from_date):
-    if not Subscription.objects.filter(
+    if not Subscription.visible_objects.filter(
         Q(date_end__gt=from_date) | Q(date_end__isnull=True),
         date_start__lte=from_date,
         subscriber__domain=domain_name,
@@ -584,7 +584,7 @@ def ensure_explicit_community_subscription(domain_name, from_date):
 
 
 def assign_explicit_community_subscription(domain_name, start_date, account=None):
-    future_subscriptions = Subscription.objects.filter(
+    future_subscriptions = Subscription.visible_objects.filter(
         date_start__gt=start_date,
         subscriber__domain=domain_name,
     )

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -354,7 +354,7 @@ class TestCreditTransfers(BaseAccountingTest):
         second_sub.save()
         third_sub = second_sub.renew_subscription()
         deactivate_subscriptions(second_sub.date_end)
-        third_sub = Subscription.objects.get(id=third_sub.id)
+        third_sub = Subscription.visible_objects.get(id=third_sub.id)
 
         third_credits = self._ensure_transfer(second_credits)
         for credit_line in third_credits:

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -36,8 +36,8 @@ class TestExplicitCommunitySubscriptions(TestCase):
     def test_no_preexisting_subscription(self):
         self._assign_community_subscriptions()
 
-        self.assertEqual(Subscription.objects.count(), 1)
-        subscription = Subscription.objects.all()[0]
+        self.assertEqual(Subscription.visible_objects.count(), 1)
+        subscription = Subscription.visible_objects.all()[0]
         self.assertEqual(subscription.subscriber.domain, self.domain.name)
         self.assertEqual(subscription.date_start, self.from_date)
         self.assertIsNone(subscription.date_end)
@@ -53,9 +53,9 @@ class TestExplicitCommunitySubscriptions(TestCase):
 
         self._assign_community_subscriptions()
 
-        self.assertEqual(Subscription.objects.count(), 1)
-        self.assertFalse(Subscription.objects.exclude(subscriber__domain=self.domain.name).exists())
-        self.assertEqual(Subscription.objects.all()[0], preexisting_subscription)
+        self.assertEqual(Subscription.visible_objects.count(), 1)
+        self.assertFalse(Subscription.visible_objects.exclude(subscriber__domain=self.domain.name).exists())
+        self.assertEqual(Subscription.visible_objects.all()[0], preexisting_subscription)
 
     def test_preexisting_future_subscription(self):
         future_subscription_start_date = self.from_date + timedelta(days=10)
@@ -69,15 +69,15 @@ class TestExplicitCommunitySubscriptions(TestCase):
 
         self._assign_community_subscriptions()
 
-        self.assertEqual(Subscription.objects.count(), 2)
-        self.assertFalse(Subscription.objects.exclude(subscriber__domain=self.domain.name).exists())
-        self.assertIsNotNone(Subscription.objects.get(
+        self.assertEqual(Subscription.visible_objects.count(), 2)
+        self.assertFalse(Subscription.visible_objects.exclude(subscriber__domain=self.domain.name).exists())
+        self.assertIsNotNone(Subscription.visible_objects.get(
             date_start=self.from_date,
             date_end=future_subscription_start_date,
             plan_version=self._most_recently_created_community_plan_version,
             skip_invoicing_if_no_feature_charges=True,
         ))
-        self.assertIsNotNone(Subscription.objects.get(
+        self.assertIsNotNone(Subscription.visible_objects.get(
             date_start=future_subscription_start_date,
             plan_version=plan_version,
         ))
@@ -96,15 +96,15 @@ class TestExplicitCommunitySubscriptions(TestCase):
 
         self._assign_community_subscriptions()
 
-        self.assertEqual(Subscription.objects.count(), 2)
-        self.assertFalse(Subscription.objects.exclude(subscriber__domain=self.domain.name).exists())
-        self.assertIsNotNone(Subscription.objects.get(
+        self.assertEqual(Subscription.visible_objects.count(), 2)
+        self.assertFalse(Subscription.visible_objects.exclude(subscriber__domain=self.domain.name).exists())
+        self.assertIsNotNone(Subscription.visible_objects.get(
             date_start=self.from_date,
             date_end=None,
             plan_version=self._most_recently_created_community_plan_version,
             skip_invoicing_if_no_feature_charges=True,
         ))
-        self.assertIsNotNone(Subscription.objects.get(
+        self.assertIsNotNone(Subscription.visible_objects.get(
             date_start=past_subscription_start_date,
             date_end=past_subscription_end_date,
             plan_version=plan_version,

--- a/corehq/apps/accounting/tests/test_model_validation.py
+++ b/corehq/apps/accounting/tests/test_model_validation.py
@@ -23,7 +23,7 @@ class TestCreditAdjustmentValidation(BaseAccountingTest):
             created_by='test@example.com',
             currency=generator.init_default_currency(),
         )
-        subscription = Subscription.objects.create(
+        subscription = Subscription.visible_objects.create(
             account=account,
             date_start=date.today(),
             plan_version=generator.subscribable_plan_version(),

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -98,23 +98,23 @@ class TestSubscription(BaseAccountingTest):
 
     def test_no_activation(self):
         tasks.activate_subscriptions(based_on_date=self.subscription.date_start - datetime.timedelta(30))
-        subscription = Subscription.objects.get(id=self.subscription.id)
+        subscription = Subscription.visible_objects.get(id=self.subscription.id)
         self.assertFalse(subscription.is_active)
 
     def test_activation(self):
         tasks.activate_subscriptions(based_on_date=self.subscription.date_start)
-        subscription = Subscription.objects.get(id=self.subscription.id)
+        subscription = Subscription.visible_objects.get(id=self.subscription.id)
         self.assertTrue(subscription.is_active)
 
     def test_no_deactivation(self):
         tasks.activate_subscriptions(based_on_date=self.subscription.date_start)
         tasks.deactivate_subscriptions(based_on_date=self.subscription.date_end - datetime.timedelta(30))
-        subscription = Subscription.objects.get(id=self.subscription.id)
+        subscription = Subscription.visible_objects.get(id=self.subscription.id)
         self.assertTrue(subscription.is_active)
 
     def test_deactivation(self):
         tasks.deactivate_subscriptions(based_on_date=self.subscription.date_end)
-        subscription = Subscription.objects.get(id=self.subscription.id)
+        subscription = Subscription.visible_objects.get(id=self.subscription.id)
         self.assertFalse(subscription.is_active)
 
     def test_deletions(self):
@@ -125,11 +125,11 @@ class TestSubscription(BaseAccountingTest):
     def test_is_hidden_to_ops(self):
         self.subscription.is_hidden_to_ops = True
         self.subscription.save()
-        self.assertEqual(0, len(Subscription.objects.filter(id=self.subscription.id)))
+        self.assertEqual(0, len(Subscription.visible_objects.filter(id=self.subscription.id)))
 
         self.subscription.is_hidden_to_ops = False
         self.subscription.save()
-        self.assertEqual(1, len(Subscription.objects.filter(id=self.subscription.id)))
+        self.assertEqual(1, len(Subscription.visible_objects.filter(id=self.subscription.id)))
 
     def test_next_subscription(self):
         this_subscription_date_end = self.subscription.date_end

--- a/corehq/apps/accounting/tests/test_new_domain_subscription.py
+++ b/corehq/apps/accounting/tests/test_new_domain_subscription.py
@@ -65,7 +65,7 @@ class TestNewDomainSubscription(BaseAccountingTest):
             date_start=week_after_30, date_end=next_year,
         )
 
-        final_sub = Subscription.objects.get(pk=subscription.id)
+        final_sub = Subscription.visible_objects.get(pk=subscription.id)
 
         self.assertEqual(final_sub.date_start, week_after_30)
         self.assertEqual(final_sub.date_end, next_year)

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -356,7 +356,7 @@ def cancel_future_subscriptions(domain_name, from_date, web_user):
         SubscriptionAdjustment,
         SubscriptionAdjustmentReason,
     )
-    for later_subscription in Subscription.objects.filter(
+    for later_subscription in Subscription.visible_objects.filter(
         subscriber__domain=domain_name,
         date_start__gt=from_date,
     ).order_by('date_start').all():

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -182,7 +182,7 @@ class ManageBillingAccountView(BillingAccountsSectionView, AsyncHandlerMixin):
             'subscription_list': [
                 (sub, Invoice.objects.filter(subscription=sub).latest('date_due').date_due
                       if Invoice.objects.filter(subscription=sub).count() else 'None on record',
-                ) for sub in Subscription.objects.filter(account=self.account).order_by('subscriber__domain', 'date_end')
+                ) for sub in Subscription.visible_objects.filter(account=self.account).order_by('subscriber__domain', 'date_end')
             ],
         }
 
@@ -312,7 +312,7 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
     @memoized
     def subscription(self):
         try:
-            return Subscription.objects.get(id=self.subscription_id)
+            return Subscription.visible_objects.get(id=self.subscription_id)
         except Subscription.DoesNotExist:
             raise Http404()
 

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -181,8 +181,10 @@ class ManageBillingAccountView(BillingAccountsSectionView, AsyncHandlerMixin):
             'contact_form': self.contact_form,
             'subscription_list': [
                 (sub, Invoice.objects.filter(subscription=sub).latest('date_due').date_due
-                      if Invoice.objects.filter(subscription=sub).count() else 'None on record',
-                ) for sub in Subscription.visible_objects.filter(account=self.account).order_by('subscriber__domain', 'date_end')
+                      if Invoice.objects.filter(subscription=sub).count() else 'None on record')
+                for sub in Subscription.visible_objects.filter(account=self.account).order_by(
+                    'subscriber__domain', 'date_end'
+                )
             ],
         }
 

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -180,8 +180,11 @@ class ManageBillingAccountView(BillingAccountsSectionView, AsyncHandlerMixin):
             'basic_form': self.basic_account_form,
             'contact_form': self.contact_form,
             'subscription_list': [
-                (sub, Invoice.objects.filter(subscription=sub).latest('date_due').date_due
-                      if Invoice.objects.filter(subscription=sub).count() else 'None on record')
+                (
+                    sub,
+                    Invoice.objects.filter(subscription=sub).latest('date_due').date_due
+                    if Invoice.objects.filter(subscription=sub).count() else 'None on record'
+                )
                 for sub in Subscription.visible_objects.filter(account=self.account).order_by(
                     'subscriber__domain', 'date_end'
                 )

--- a/corehq/apps/api/accounting.py
+++ b/corehq/apps/api/accounting.py
@@ -163,7 +163,7 @@ class SubscriptionResource(ModelResource):
     subscriber = fields.IntegerField('subscriber_id', null=True)
 
     class Meta(AccountingResourceMeta):
-        queryset = Subscription.objects.all().order_by('pk')
+        queryset = Subscription.visible_objects.all().order_by('pk')
         fields = ['id', 'salesforce_contract_id', 'date_start', 'date_end', 'date_delay_invoicing',
                   'date_created', 'is_active', 'do_not_invoice', 'auto_generate_credits', 'is_trial',
                   'service_type', 'pro_bono_status', 'last_modified', 'funding_source', 'is_hidden_to_ops',

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -105,7 +105,7 @@ def _terminate_subscriptions(domain_name):
                 new_subscription=None,
             )
 
-        Subscription.objects.filter(
+        Subscription.visible_objects.filter(
             Q(date_start__gt=today) | Q(date_start=today, is_active=False),
             subscriber__domain=domain_name,
         ).update(is_hidden_to_ops=True)

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -17,7 +17,6 @@ from corehq.apps.accounting.models import (
     FeatureType,
     SoftwarePlanEdition,
     Subscription,
-    SubscriptionManager,
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.ivr.models import Call
@@ -165,7 +164,7 @@ class TestDeleteDomain(TestCase):
     def test_active_subscription_terminated(self):
         self.domain.delete()
 
-        terminated_subscription = Subscription.objects.get(subscriber__domain=self.domain.name)
+        terminated_subscription = Subscription.visible_objects.get(subscriber__domain=self.domain.name)
         self.assertFalse(terminated_subscription.is_active)
         self.assertIsNotNone(terminated_subscription.date_end)
 
@@ -182,7 +181,7 @@ class TestDeleteDomain(TestCase):
         self.domain.delete()
 
         self.assertTrue(
-            super(SubscriptionManager, Subscription.objects).get_queryset().get(
+            Subscription.visible_and_suppressed_objects.get(
                 id=next_subscription.id
             ).is_hidden_to_ops
         )

--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -201,7 +201,7 @@ def get_active_countries_stats_data(domains, datespan, interval,
 
 
 def domains_matching_plan(software_plan_edition, start, end):
-    matching_subscriptions = Subscription.objects.filter(
+    matching_subscriptions = Subscription.visible_objects.filter(
         Q(date_start__lte=end) & Q(date_end__gte=start),
         plan_version__plan__edition=software_plan_edition,
     )
@@ -213,7 +213,7 @@ def domains_matching_plan(software_plan_edition, start, end):
 
 
 def plans_on_date(software_plan_edition, date):
-    matching_subscriptions = Subscription.objects.filter(
+    matching_subscriptions = Subscription.visible_objects.filter(
         Q(date_start__lte=date) & Q(date_end__gte=date),
         plan_version__plan__edition=software_plan_edition,
     )

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -621,7 +621,7 @@ class BugReportView(View):
                 domain_object.project_description = new_project_description
                 domain_object.save()
 
-            matching_subscriptions = Subscription.objects.filter(
+            matching_subscriptions = Subscription.visible_objects.filter(
                 is_active=True,
                 subscriber__domain=domain,
             )

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -17,7 +17,7 @@ from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFacto
 
 def transform_domain_for_elasticsearch(doc_dict):
     doc_ret = copy.deepcopy(doc_dict)
-    sub = Subscription.objects.filter(subscriber__domain=doc_dict['name'], is_active=True)
+    sub = Subscription.visible_objects.filter(subscriber__domain=doc_dict['name'], is_active=True)
     doc_ret['deployment'] = doc_ret.get('deployment', None) or {}
     countries = doc_ret['deployment'].get('countries', [])
     doc_ret['deployment']['countries'] = []


### PR DESCRIPTION
This has been requested in the past to make it more explicit that suppressed subscriptions are hidden from the default queryset.