### PR TITLE
fix `timeEnd` `KeyError` on elasticsearch ICDS UCRs

### DIFF
--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -179,13 +179,7 @@ class FormsInDateExpressionSpec(JsonObject):
             context.set_cache_value(cache_key, count)
             return count
 
-        if ICDS_UCR_ELASTICSEARCH_DOC_LOADING.enabled(case_id, NAMESPACE_OTHER):
-            def _clean(f):
-                del f['timeEnd']  # for parity with what comes out of Riak
-                return f
-
-            xforms = list(map(_clean, xforms))
-        else:
+        if not ICDS_UCR_ELASTICSEARCH_DOC_LOADING.enabled(case_id, NAMESPACE_OTHER):
             form_ids = [x['_id'] for x in xforms]
             xforms = FormAccessors(domain).get_forms(form_ids)
             xforms = FormsInDateExpressionSpec._get_form_json_list(case_id, xforms, context, domain)
@@ -236,9 +230,6 @@ class FormsInDateExpressionSpec(JsonObject):
     def _bulk_get_form_json_from_es(forms):
         form_ids = [form.form_id for form in forms]
         es_forms = FormsInDateExpressionSpec._bulk_get_forms_from_elasticsearch(form_ids, source=True)
-        for f in es_forms:
-            # for parity with what comes out of Riak
-            del f['timeEnd']
         return {
             f['_id']: f for f in es_forms
         }

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -1,58 +1,63 @@
 from __future__ import absolute_import
-from copy import deepcopy
 from datetime import datetime
 import uuid
 
 from django.test import SimpleTestCase, TestCase, override_settings
-import mock
 
 from casexml.apps.case.const import CASE_INDEX_CHILD
-from casexml.apps.case.mock import CaseStructure, CaseFactory, CaseIndex
+from casexml.apps.case.mock import CaseIndex
+from casexml.apps.case.mock import CaseStructure, CaseFactory
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.specs import EvaluationContext
+from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
+from corehq.pillows.xform import transform_xform_for_elasticsearch
 from corehq.toggles import ICDS_UCR_ELASTICSEARCH_DOC_LOADING, DynamicallyPredictablyRandomToggle, NAMESPACE_OTHER
 from custom.icds_reports.ucr.expressions import icds_get_related_docs_ids
+from corehq.util.elastic import ensure_index_deleted
+from pillowtop.es_utils import initialize_index_and_mapping
 from toggle.models import Toggle
-
-es_form_cache = []
-
-
-def mget_query_fake(index, ids, source):
-    return [
-        {"_id": form['_id'], "_source": form}
-        for form in es_form_cache
-        if form['_id'] in ids
-    ]
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
-@mock.patch('custom.icds_reports.ucr.expressions.mget_query', mget_query_fake)
 class TestFormsExpressionSpecWithFilter(TestCase):
 
     @classmethod
     def setUpClass(cls):
         super(TestFormsExpressionSpecWithFilter, cls).setUpClass()
-        global es_form_cache
         cls.domain = uuid.uuid4().hex
         factory = CaseFactory(domain=cls.domain)
         [cls.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
         cls.forms = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case.xform_ids)]
-        for form in cls.forms:
-            es_form_cache.append(deepcopy(form))
+
         # redundant case to create extra forms that shouldn't be in the results for cls.case
         [cls.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
         cls.forms_b = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case_b.xform_ids)]
-        for form in cls.forms_b:
-            es_form_cache.append(deepcopy(form))
+
+        cls._setup_es_for_data()
+
+    @classmethod
+    def _setup_es_for_data(cls):
+        cls.es = get_es_new()
+        cls.es_indices = [XFORM_INDEX_INFO]
+        for index_info in cls.es_indices:
+            initialize_index_and_mapping(cls.es, index_info)
+
+        for form in cls.forms + cls.forms_b:
+            es_form = transform_xform_for_elasticsearch(form)
+            send_to_elasticsearch('forms', es_form)
+
+        for index_info in cls.es_indices:
+            cls.es.indices.refresh(index_info.index)
 
     @classmethod
     def tearDownClass(cls):
-        global es_form_cache
-        es_form_cache = []
         delete_all_xforms()
         delete_all_cases()
+        for index_info in cls.es_indices:
+            ensure_index_deleted(index_info.index)
         super(TestFormsExpressionSpecWithFilter, cls).tearDownClass()
 
     def _make_expression(self, from_statement=None, to_statement=None, xmlns=None, count=False):
@@ -115,7 +120,7 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         forms = expression(self.case.to_json(), context)
 
         self.assertEqual(len(forms), 1)
-        self.assertEqual(forms, self.forms)
+        self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
 
     def test_from_outside_date_range(self):
         expression = self._make_expression('iteration - 2', 'iteration - 1')
@@ -130,7 +135,7 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         forms = expression(self.case.to_json(), context)
 
         self.assertEqual(len(forms), 1)
-        self.assertEqual(forms, self.forms)
+        self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
 
     def test_from_incorrect_xmlns(self):
         expression = self._make_expression('iteration - 1', 'iteration + 1', 'silly-xmlns')
@@ -159,7 +164,7 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         forms = expression(self.case.to_json(), context)
 
         self.assertEqual(len(forms), 1)
-        self.assertEqual(forms, self.forms)
+        self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
 
         expression = self._make_expression(to_statement='iteration - 3')
         context = EvaluationContext({"domain": self.domain}, 0)
@@ -174,7 +179,7 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         forms = expression(self.case.to_json(), context)
 
         self.assertEqual(len(forms), 1)
-        self.assertEqual(forms, self.forms)
+        self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
 
         expression = self._make_expression(from_statement='iteration + 3')
         context = EvaluationContext({"domain": self.domain}, 0)

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -122,6 +122,18 @@ class TestFormsExpressionSpecWithFilter(TestCase):
         self.assertEqual(len(forms), 1)
         self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
 
+    def test_results_from_cache(self):
+        # reuse the context to test an edge case in caching
+        expression_1 = self._make_expression('iteration - 1', 'iteration + 1')
+        context = EvaluationContext({"domain": self.domain}, 0)
+        forms = expression_1(self.case.to_json(), context)
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
+        expression_2 = self._make_expression('iteration - 2', 'iteration + 1')
+        forms = expression_2(self.case.to_json(), context)
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms[0]['_id'], self.forms[0]['_id'])
+
     def test_from_outside_date_range(self):
         expression = self._make_expression('iteration - 2', 'iteration - 1')
         context = EvaluationContext({"domain": self.domain}, 0)


### PR DESCRIPTION
This fixes [this error](https://sentry.io/dimagi/commcarehq/issues/427615729/) as well as adds a test for it. It also converts the test to use real elasticsearch

@emord I *think* I prefer using real elasticsearch to the mocks, but am open to an opposing viewpoint. I'll just leave this here for you to look at when you get back since it's not urgent.