### PR TITLE
UCRs don't have an is_deprecated property

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -482,7 +482,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         except Exception:
             pass
 
-        if self.report.is_deprecated:
+        if getattr(self.report, 'is_deprecated', False):
             return ReportContent(
                 self.report.deprecation_email_message or
                 _("[DEPRECATED] %s report has been deprecated and will stop working soon. "


### PR DESCRIPTION
@mkangia
https://manage.dimagi.com/default.asp?267453
https://sentry.io/dimagi/commcarehq/issues/422090706/
Introduced https://github.com/dimagi/commcare-hq/pull/18789
Only seen a couple times, which kinda surprises me - I would've thought more UCRs used scheduled reports