### PR TITLE
Report Builder: Handle missing columns in current version

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -405,6 +405,7 @@ class DataSourceBuilder(object):
 
         indicators = OrderedDict()
         for column in columns:
+            # Property is only set if the column exists in report_column_options
             if column['property']:
                 column_option = self.report_column_options[column['property']]
                 for indicator in column_option.get_indicators(column['calculation'],
@@ -412,6 +413,7 @@ class DataSourceBuilder(object):
                     indicators.setdefault(str(indicator), indicator)
 
         for filter_ in filters:
+            # Property is only set if the filter exists in report_column_options
             if filter_['property']:
                 property_ = self.data_source_properties[filter_['property']]
                 indicator = property_.to_report_filter_indicator(filter_)

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -405,14 +405,14 @@ class DataSourceBuilder(object):
 
         indicators = OrderedDict()
         for column in columns:
-            if column['exists_in_current_version']:
+            if column['property']:
                 column_option = self.report_column_options[column['property']]
                 for indicator in column_option.get_indicators(column['calculation'],
                                                               is_multiselect_chart_report):
                     indicators.setdefault(str(indicator), indicator)
 
         for filter_ in filters:
-            if filter_['exists_in_current_version']:
+            if filter_['property']:
                 property_ = self.data_source_properties[filter_['property']]
                 indicator = property_.to_report_filter_indicator(filter_)
                 indicators.setdefault(str(indicator), indicator)

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -405,14 +405,17 @@ class DataSourceBuilder(object):
 
         indicators = OrderedDict()
         for column in columns:
-            column_option = self.report_column_options[column['property']]
-            for indicator in column_option.get_indicators(column['calculation'], is_multiselect_chart_report):
-                indicators.setdefault(str(indicator), indicator)
+            if column['exists_in_current_version']:
+                column_option = self.report_column_options[column['property']]
+                for indicator in column_option.get_indicators(column['calculation'],
+                                                              is_multiselect_chart_report):
+                    indicators.setdefault(str(indicator), indicator)
 
         for filter_ in filters:
-            property_ = self.data_source_properties[filter_['property']]
-            indicator = property_.to_report_filter_indicator(filter_)
-            indicators.setdefault(str(indicator), indicator)
+            if filter_['exists_in_current_version']:
+                property_ = self.data_source_properties[filter_['property']]
+                indicator = property_.to_report_filter_indicator(filter_)
+                indicators.setdefault(str(indicator), indicator)
 
         return list(indicators.values())
 

--- a/corehq/apps/userreports/static/userreports/js/builder_view_models.js
+++ b/corehq/apps/userreports/static/userreports/js/builder_view_models.js
@@ -149,6 +149,7 @@ hqDefine('userreports/js/builder_view_models', function () {
             calculation: self.calculation(),
             pre_value: self.filterValue(),
             pre_operator: self.filterOperator(),
+            exists_in_current_version: self.existsInCurrentVersion(),
         };
     };
     /**

--- a/corehq/apps/userreports/static/userreports/js/builder_view_models.js
+++ b/corehq/apps/userreports/static/userreports/js/builder_view_models.js
@@ -149,7 +149,6 @@ hqDefine('userreports/js/builder_view_models', function () {
             calculation: self.calculation(),
             pre_value: self.filterValue(),
             pre_operator: self.filterOperator(),
-            exists_in_current_version: self.existsInCurrentVersion(),
         };
     };
     /**


### PR DESCRIPTION
Product Note: This fixes a bug in report builder which would cause an error if  it was being edited if the report has a case property or form question that no longer existed in the application.  

@esoergel 
This should better handle missing columns (though I don't love how report builder generally handles form questions / case properties that used to exist but no longer exist).  
  