### PR TITLE
Fix old exports

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -1024,12 +1024,7 @@ class CaseExportSchema(HQExportSchema):
 
     @property
     def has_case_history_table(self):
-        case_history_table = [table for table in self.tables if table.label == 'Case History']
-        return any(
-            column.selected
-            for table in case_history_table
-            for column in table.columns
-        )
+        return False  # This check is only for new exports
 
 
 class DefaultFormExportSchema(DefaultExportSchema):


### PR DESCRIPTION
@dannyroberts @emord
https://manage.dimagi.com/default.asp?266678
New exports have a check for a table with the label 'Case History'.  This was causing an [exception](https://sentry.io/dimagi/commcarehq/issues/412148968/events/10179986964/) when old exports were accessed, as they didn't have the method being checked for.  The fix was to add that method also to old exports, but the logic at least (if not also the spirit) was specific to new exports, so that [errored](https://sentry.io/dimagi/commcarehq/issues/412148968/) too.  This PR just assumes old exports don't have case history, which is true at least of the export in question.  @emord do you know whether any old exports may have case history tables, and if so, how to identify them?