### PR TITLE
Block typing in date picker

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -493,6 +493,10 @@ function DateTimeEntryBase(question, options) {
 
     self.afterRender = function() {
         self.$picker = $('#' + self.entryId);
+        // Disable typing in the date picker
+        self.$picker.keydown(function() {
+            return false;
+        });
         var datepickerOpts = {
             timepicker: self.timepicker,
             datepicker: self.datepicker,


### PR DESCRIPTION
Addresses [this ticket](https://manage.dimagi.com/default.asp?268211#1442756). Turns out its pretty straightforward to type a nonsense date into the date widget. This change blocks that behavior (making the HTML element disabled or readonly prevented the function of the picker modal). 

After implementing this, though, I'm wondering whether the typing functionality might be preferred/appreciated by some users and whether this is a feature rather than a bug - @orangejenny @sheelio any thoughts? 