### PR TITLE
Report Builder: Remove count indicator

### DIFF
--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -313,11 +313,15 @@ class CountColumn(ColumnOption):
         return {
             "column_id": "count",
             "display_name": "Count",
-            "type": "expression",
-            "datatype": "integer",
-            "expression": {
-                "type": "constant",
-                "constant": 1
+            "type": "boolean",
+            "filter": {
+                "type": "boolean_expression",
+                "operator": "eq",
+                "expression": {
+                    "type": "constant",
+                    "constant": 1
+                },
+                "property_value": 1
             }
         }
 

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -311,9 +311,14 @@ class CountColumn(ColumnOption):
 
     def get_indicator(self, aggregation, is_multiselect_chart_report=False):
         return {
+            "column_id": "count",
             "display_name": "Count",
-            "type": "count",
-            "column_id": "count"
+            "type": "expression",
+            "datatype": "integer",
+            "expression": {
+                "type": "constant",
+                "constant": 1
+            }
         }
 
     def to_column_dicts(self, index, display_text, aggregation, is_aggregated_on=False):


### PR DESCRIPTION
@kaapstorm 

The count indicator type has been deprecated so this switches to using an expression instead.

FYI @emord 