### PR TITLE
Include suffix in column name truncation

### DIFF
--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -119,9 +119,7 @@ class QuestionColumnOption(ColumnOption):
         else:
             data_type = None  # use the default
 
-        column_id = get_column_name(self._property.strip("/"))
-        if data_type:
-            column_id += ("_" + data_type)
+        column_id = get_column_name(self._property.strip("/"), suffix=data_type)
         return make_form_question_indicator(
             self._question_source, column_id, data_type, root_doc=is_multiselect_chart_report
         )
@@ -236,7 +234,7 @@ class CasePropertyColumnOption(ColumnOption):
         return map[self._get_aggregation_config(aggregation)]
 
     def get_indicator(self, aggregation, is_multiselect_chart_report=False):
-        column_id = get_column_name(self._property) + "_" + self._get_datatype(aggregation)
+        column_id = get_column_name(self._property, suffix=self._get_datatype(aggregation))
         return make_case_property_indicator(self._property, column_id, datatype=self._get_datatype(aggregation))
 
 

--- a/corehq/apps/userreports/sql/util.py
+++ b/corehq/apps/userreports/sql/util.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import hashlib
 
 
-def get_column_name(path):
+def get_column_name(path, suffix=None):
     """
     :param path: xpath from form or case
     :return: column name for postgres
@@ -21,5 +21,6 @@ def get_column_name(path):
         end = end.encode('unicode-escape')
         return hashlib.sha1('{}_{}'.format(hashlib.sha1(front).hexdigest(), end)).hexdigest()[:8]
 
-    new_parts = path[-54:].split("/")
-    return "_".join(new_parts + [_hash(parts)])
+    new_parts = path.split("/")
+    full_name = "_".join(filter(None, new_parts + [_hash(parts), suffix]))
+    return full_name[-63:]

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -62,3 +62,19 @@ class UtilitiesTestCase(SimpleTestCase):
         self.assertNotEqual(real, trap2)
         self.assertNotEqual(real, trap3)
         self.assertEqual(trap4, trap4_expected)
+
+    def test_column_name_suffix(self):
+        self.assertEqual(
+            get_column_name("its/a/path", suffix="string"),
+            "its_a_path_dab095d5_string"
+        )
+
+    def test_column_length_with_suffix(self):
+        long_path = ("its/a/path/that/also/happens/to/be/a/bunch/longer/than/"
+                     "sixty/three/characters")
+        column_name = get_column_name(long_path, suffix="decimal")
+        self.assertEqual(len(column_name), 63)
+        self.assertEqual(
+            column_name,
+            '_be_a_bunch_longer_than_sixty_three_characters_6174b354_decimal',
+        )


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?267577
Postgres truncates column names to a max of 63 characters.  Previously the datatype suffix was appended after truncation, which meant that long names didn't match the DB.
@sheelio @kaapstorm