### PR TITLE
Analytics: fix A/B tests (again)

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/drift.js
+++ b/corehq/apps/analytics/static/analytix/js/drift.js
@@ -20,14 +20,14 @@ hqDefine('analytix/js/drift', [
     var _get = initialAnalytics.getFn('drift'),
         _drift = {},
         _logger = logging.getLoggerForApi('Drift'),
-        _ready; // eslint-disable-line no-unused-vars
+        _ready = $.Deferred(); // eslint-disable-line no-unused-vars
 
     $(function () {
         var apiId = _get('apiId'),
             scriptUrl = "https://js.driftt.com/include/" + utils.getDateHash() + "/" + apiId + '.js';
 
         _logger = logging.getLoggerForApi('Drift');
-        _ready = utils.initApi(apiId, scriptUrl, _logger, function() {
+        _ready = utils.initApi(_ready, apiId, scriptUrl, _logger, function() {
             _drift = window.driftt = window.drift = window.driftt || [];
             if (!_drift.init && !_drift.invoked ) {
                 _drift.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ];

--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -22,7 +22,7 @@ hqDefine('analytix/js/google', [
         _data = {},
         module = {},
         _logger = logging.getLoggerForApi('Google Analytics'),
-        _ready;
+        _ready = $.Deferred();
 
     var _gtag = function () {
         // This should never run, because all calls to _gtag should be
@@ -35,7 +35,7 @@ hqDefine('analytix/js/google', [
             scriptUrl = '//www.googletagmanager.com/gtag/js?id=' + apiId;
 
         _logger = logging.getLoggerForApi('Google Analytics');
-        _ready = utils.initApi(apiId, scriptUrl, _logger, function() {
+        _ready = utils.initApi(_ready, apiId, scriptUrl, _logger, function() {
             window.dataLayer = window.dataLayer || [];
             _gtag = function () {
                 window.dataLayer.push(arguments);

--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -16,7 +16,7 @@ hqDefine('analytix/js/hubspot', [
     'use strict';
     var _get = initialAnalytics.getFn('hubspot'),
         _logger = logging.getLoggerForApi('Hubspot'),
-        _ready;
+        _ready = $.Deferred();
 
     var _hsq = window._hsq = window._hsq || [];
 
@@ -25,7 +25,7 @@ hqDefine('analytix/js/hubspot', [
             scriptUrl = '//js.hs-analytics.net/analytics/' + utils.getDateHash() + '/' + apiId + '.js';
 
         _logger = logging.getLoggerForApi('Hubspot');
-        _ready = utils.initApi(apiId, scriptUrl, _logger);
+        _ready = utils.initApi(_ready, apiId, scriptUrl, _logger);
     });
 
     /**

--- a/corehq/apps/analytics/static/analytix/js/initial.js
+++ b/corehq/apps/analytics/static/analytix/js/initial.js
@@ -1,5 +1,6 @@
 /**
  *  Fetches all the initialization data needed for the different analytics platforms.
+ *  Note that all of this initialization data is undefined until the document is ready.
  */
 hqDefine('analytix/js/initial', [
     'jquery',

--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -18,7 +18,7 @@ hqDefine('analytix/js/kissmetrix', [
         _allAbTests = {},
         _init = {},
         _logger = logging.getLoggerForApi('Kissmetrics'),
-        _ready;
+        _ready = $.Deferred();
 
     window.dataLayer = window.dataLayer || [];
 
@@ -54,7 +54,7 @@ hqDefine('analytix/js/kissmetrix', [
             ];
 
         _logger = logging.getLoggerForApi('Kissmetrics');
-        _ready = utils.initApi(apiId, scriptUrls, _logger, function() {
+        _ready = utils.initApi(_ready, apiId, scriptUrls, _logger, function() {
             // Identify user and HQ instance
             // This needs to happen before any events are sent or any traits are set
             var username = _get('username');
@@ -165,6 +165,15 @@ hqDefine('analytix/js/kissmetrix', [
         return _allAbTests[testSlug];
     };
 
+    /**
+     * Run some code once all data and scripts are loaded.
+     * @param callback
+     * @returns Nothing
+     */
+    var whenReadyAlways = function(callback) {
+        _ready.always(callback);
+    };
+
     return {
         identify: identify,
         identifyTraits: identifyTraits,
@@ -174,5 +183,6 @@ hqDefine('analytix/js/kissmetrix', [
             outboundLink: trackOutboundLink,
         },
         getAbTest: getAbTest,
+        whenReadyAlways: whenReadyAlways,
     };
 });

--- a/corehq/apps/analytics/static/analytix/js/utils.js
+++ b/corehq/apps/analytics/static/analytix/js/utils.js
@@ -90,6 +90,8 @@ hqDefine('analytix/js/utils', [
 
     /**
      * Initialize an API.
+     * @param {Deferred} ready The promise to return (see below). Passed as a parameter
+     *  so the calling code can attach callbacks to it before calling this function.
      * @param {string} apiId
      * @param {string/array} scriptUrls - Accepts string or array of strings
      * @param {Logger} logger
@@ -99,9 +101,7 @@ hqDefine('analytix/js/utils', [
      *  This promise will be rejected if the API fails to initialize for any reason, most
      *  likely because analytics is disabled or because a script failed to load.
      */
-    var initApi = function(apiId, scriptUrls, logger, initCallback) {
-        var ready = $.Deferred();
-
+    var initApi = function(ready, apiId, scriptUrls, logger, initCallback) {
         logger.verbose.log(apiId || "NOT SET", ["DATA", "API ID"]);
 
         if (_.isString(scriptUrls)) {

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -15,38 +15,40 @@ hqDefine('registration/js/new_user.ko', function () {
     var _private = {},
         _kissmetrics = hqImport('analytix/js/kissmetrix');
 
-    _private.isAbPersona = _kissmetrics.getAbTest('New User Persona Field') === 'show_persona';
-    _private.isAbPhoneNumber = _kissmetrics.getAbTest('New User Phone Number') === 'show_number';
+    _kissmetrics.whenReadyAlways(function() {
+        _private.isAbPersona = _kissmetrics.getAbTest('New User Persona Field') === 'show_persona';
+        _private.isAbPhoneNumber = _kissmetrics.getAbTest('New User Phone Number') === 'show_number';
 
-    _private.rmiUrl = null;
-    _private.csrf = null;
-    _private.showPasswordFeedback = false;
-    _private.rmi = function () {
-        throw "Please call initRMI first.";
-    };
-    _private.resetEmailFeedback = function (isValidating) {
-        throw "please call setResetEmailFeedbackFn. " +
-              "Expects boolean isValidating. " + isValidating;
-    };
-    _private.submitAttemptAnalytics = function (data) {  // eslint-disable-line no-unused-vars
-        _kissmetrics.track.event("Clicked Create Account");
-    };
-    _private.getPhoneNumberFn = function () {
-        // number to return phone number
-    };
+        _private.rmiUrl = null;
+        _private.csrf = null;
+        _private.showPasswordFeedback = false;
+        _private.rmi = function () {
+            throw "Please call initRMI first.";
+        };
+        _private.resetEmailFeedback = function (isValidating) {
+            throw "please call setResetEmailFeedbackFn. " +
+                  "Expects boolean isValidating. " + isValidating;
+        };
+        _private.submitAttemptAnalytics = function (data) {  // eslint-disable-line no-unused-vars
+            _kissmetrics.track.event("Clicked Create Account");
+        };
+        _private.getPhoneNumberFn = function () {
+            // number to return phone number
+        };
 
-    _private.submitSuccessAnalytics = function (data) {
-        _kissmetrics.track.event("Account Creation was Successful");
-        if (_private.isAbPersona) {
-            _kissmetrics.track.event("Persona Field Filled Out", {
-                personaChoice: data.persona,
-                personaOther: data.persona_other,
-            });
-        }
-        if (_private.isAbPhoneNumber) {
-            _kissmetrics.track.event("Phone Number Field Filled Out");
-        }
-    };
+        _private.submitSuccessAnalytics = function (data) {
+            _kissmetrics.track.event("Account Creation was Successful");
+            if (_private.isAbPersona) {
+                _kissmetrics.track.event("Persona Field Filled Out", {
+                    personaChoice: data.persona,
+                    personaOther: data.persona_other,
+                });
+            }
+            if (_private.isAbPhoneNumber) {
+                _kissmetrics.track.event("Phone Number Field Filled Out");
+            }
+        };
+    });
 
     module.setResetEmailFeedbackFn = function (callback) {
         // use this function to reset the form-control-feedback ui
@@ -320,7 +322,7 @@ hqDefine('registration/js/new_user.ko', function () {
 
             var submitData = _getDataForSubmission();
             _private.submitAttemptAnalytics(submitData);
-            
+
             _private.rmi(
                 "register_new_user",
                 {data : submitData},

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -15,26 +15,30 @@ hqDefine('registration/js/new_user.ko', function () {
     var _private = {},
         _kissmetrics = hqImport('analytix/js/kissmetrix');
 
+    _private.rmiUrl = null;
+    _private.csrf = null;
+    _private.showPasswordFeedback = false;
+    _private.rmi = function () {
+        throw "Please call initRMI first.";
+    };
+    _private.resetEmailFeedback = function (isValidating) {
+        throw "please call setResetEmailFeedbackFn. " +
+              "Expects boolean isValidating. " + isValidating;
+    };
+    _private.submitAttemptAnalytics = function (data) {  // eslint-disable-line no-unused-vars
+        _kissmetrics.track.event("Clicked Create Account");
+    };
+    _private.getPhoneNumberFn = function () {
+        // number to return phone number
+    };
+    _private.submitSuccessAnalytics = function () {
+        // analytics haven't loaded yet or at all, fail silently
+    };
+
+    // Can't set up analytics until the values for the A/B tests are ready
     _kissmetrics.whenReadyAlways(function() {
         _private.isAbPersona = _kissmetrics.getAbTest('New User Persona Field') === 'show_persona';
         _private.isAbPhoneNumber = _kissmetrics.getAbTest('New User Phone Number') === 'show_number';
-
-        _private.rmiUrl = null;
-        _private.csrf = null;
-        _private.showPasswordFeedback = false;
-        _private.rmi = function () {
-            throw "Please call initRMI first.";
-        };
-        _private.resetEmailFeedback = function (isValidating) {
-            throw "please call setResetEmailFeedbackFn. " +
-                  "Expects boolean isValidating. " + isValidating;
-        };
-        _private.submitAttemptAnalytics = function (data) {  // eslint-disable-line no-unused-vars
-            _kissmetrics.track.event("Clicked Create Account");
-        };
-        _private.getPhoneNumberFn = function () {
-            // number to return phone number
-        };
 
         _private.submitSuccessAnalytics = function (data) {
             _kissmetrics.track.event("Account Creation was Successful");


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?268059

Because the logic in `new_user.ko.js` is now waiting on analytics to be ready, `resetEmailFeedback` was getting set to the dummy, error-throwing version *after* register_new_user.js called `setResetEmailFeedbackFn` set it to the real version.

Fix by reducing the code that waits on analytics to be only the code that really depends on knowing the values of the A/B tests.

@calellowitz I'd like to release this tomorrow if possible; our A/B tests are still non-functional.