### PR TITLE
adding user param to hs form submissions and fixing invite form

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -295,7 +295,7 @@ def send_hubspot_form(form_id, request, user=None):
     pulls out relevant info from request object before sending to celery since
     requests cannot be pickled
     """
-    if user is not None:
+    if user is None:
         user = getattr(request, 'couch_user', None)
     if request and user and user.is_web_user():
         meta = get_meta(request)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -290,15 +290,16 @@ def track_confirmed_account_on_hubspot(webuser):
         })
 
 
-def send_hubspot_form(form_id, request):
+def send_hubspot_form(form_id, request, user=None):
     """
     pulls out relevant info from request object before sending to celery since
     requests cannot be pickled
     """
-    user = getattr(request, 'couch_user', None)
+    if user is not None:
+        user = getattr(request, 'couch_user', None)
     if request and user and user.is_web_user():
         meta = get_meta(request)
-        send_hubspot_form_task.delay(form_id, request.couch_user, request.COOKIES, meta)
+        send_hubspot_form_task.delay(form_id, user, request.COOKIES, meta)
 
 
 @analytics_task()

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -742,7 +742,7 @@ class UserInvitationView(object):
                     track_workflow(request.POST['email'],
                                    "New User Accepted a project invitation",
                                    {"New User Accepted a project invitation": "yes"})
-                    send_hubspot_form(HUBSPOT_NEW_USER_INVITE_FORM, request)
+                    send_hubspot_form(HUBSPOT_NEW_USER_INVITE_FORM, request, user)
                     return HttpResponseRedirect(reverse("domain_homepage", args=[invitation.domain]))
             else:
                 if CouchUser.get_by_username(invitation.email):


### PR DESCRIPTION
@orangejenny 
For users accepting an invite, the user model was not attached to the request as it had not been created when the relevant middleware runs. This allows you to pass a user to hubspot forms