### PR TITLE
Flag updates from OpenMRS

### DIFF
--- a/corehq/motech/openmrs/const.py
+++ b/corehq/motech/openmrs/const.py
@@ -16,3 +16,6 @@ IMPORT_FREQUENCY_CHOICES = (
     (IMPORT_FREQUENCY_WEEKLY, _('Weekly')),
     (IMPORT_FREQUENCY_MONTHLY, _('Monthly')),
 )
+
+
+XMLNS_OPENMRS = 'http://commcarehq.org/openmrs-integration'  # Form XMLNS to indicate imported from OpenMRS

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -63,8 +63,7 @@ class OpenmrsRepeater(CaseRepeater):
         """
         if super(OpenmrsRepeater, self).allowed_to_forward(case):
             last_form = FormAccessors(case.domain).get_form(case.xform_ids[-1])
-            from_openmrs = last_form.xmlns == XMLNS_OPENMRS
-            return not from_openmrs
+            return last_form.xmlns != XMLNS_OPENMRS
         return False
 
     def get_payload(self, repeat_record):

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -24,7 +24,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.dbaccessors import get_all_users_by_location
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.users.models import CommCareUser
-from corehq.motech.openmrs.const import IMPORT_FREQUENCY_WEEKLY, IMPORT_FREQUENCY_MONTHLY
+from corehq.motech.openmrs.const import IMPORT_FREQUENCY_WEEKLY, IMPORT_FREQUENCY_MONTHLY, XMLNS_OPENMRS
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.models import POSIX_MILLISECONDS
@@ -146,6 +146,7 @@ def import_patients_of_owner(requests, importer, domain_name, owner, location=No
         domain_name,
         username=owner.username,
         user_id=owner.user_id,
+        xmlns=XMLNS_OPENMRS,
     )
 
 


### PR DESCRIPTION
This is to prevent changes imported from OpenMRS being forwarded back to OpenMRS.

@dannyroberts please check my logic here: First, my assumption* that this is necessary; second, that using an XMLNS is the best way to flag updates from OpenMRS; and third, that pulling out the last of `case.xform_ids` will give me the last form.

cc @sheelio, buddy @biyeun 

*I'm postponing the need to install OpenMRS's "Reporting API" module, check/create a report, and pull some patients. It's inevitable though, I guess.