### PR TITLE
Tweaks to cmitfb scripts logging

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_all_apps_to_cmitfb.py
@@ -32,9 +32,8 @@ class Command(BaseCommand):
         failures = {}
         for hit in hits:
             try:
-                call_command('migrate_app_to_cmitfb', hit['_id'], dry_run=not(commit))
+                call_command('migrate_app_to_cmitfb', hit['_id'], dry_run=not(commit), fail_hard=True)
             except Exception:
-                logger.info('migration failed')
                 failures[hit['_id']] = hit['domain']
 
         for id, domain in six.iteritems(failures):


### PR DESCRIPTION
There are 211 apps with vellum_case_management=False on prod, but the output of migrate_all_apps_to_cmitfb is a little annoying to read through.

@emord 
cc @calellowitz 