### PR TITLE
Use a smaller scroll page size to avoid timeouts

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -336,7 +336,8 @@ def get_export_documents(export_instance, filters):
     # We believe we can occasionally hit the 5m limit to process a single scroll window
     # with a window size of 1000 (https://manage.dimagi.com/default.asp?248384).
     # Thus, smaller window size is intentional
-    return query.size(500).scroll()
+    # Another option we have is to bump the "scroll" parameter up from "5m"
+    return query.size(200).scroll()
 
 
 def _get_export_query(export_instance, filters):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?267392
https://sentry.io/dimagi/commcarehq/issues/428226096/
Looks like a repeat of https://manage.dimagi.com/default.asp?248384#BugEvent.1297392
@emord @dannyroberts pinging you because you worked on this last time

@millerdev @mkangia code buddies