### PR TITLE
Add type=hidden to inputs that should be hidden

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/appnav_menu.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/appnav_menu.html
@@ -7,7 +7,7 @@
         <form method="post"
               action="{% url "rearrange" domain app.id 'modules' %}">
               {% csrf_token %}
-              <input name="ajax" value="true" />
+              <input name="ajax" value="true" type="hidden" />
         </form>
     </li>
     {% with module as selected_module %}
@@ -25,7 +25,7 @@
                         <form method="post"
                               action="{% url "rearrange" domain app.id 'forms' %}">
                               {% csrf_token %}
-                              <input name="ajax" value="true" />
+                              <input name="ajax" value="true" type="hidden" />
                         </form>
                     </li>
                     {% with nav_form as selected_form %}


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?268345

Product: this fixes a regression where Firefox users sometimes see input boxes in the app builder menu.

No idea why this is intermittent. Also kind of weird that Chrome infers that these inputs are hidden.

@calellowitz 