### PR TITLE
Moved timing support for async indicators away from crontab.

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -231,7 +231,7 @@ def delete_data_source_task(domain, config_id):
 
 
 @periodic_task(
-    run_every='*/5', queue=settings.CELERY_PERIODIC_QUEUE
+    run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE
 )
 def run_queue_async_indicators_task():
     """ASYNC_INDICATOR_QUEUE_TIMES will be of the format:

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 import logging
 
 from botocore.vendored.requests.exceptions import ReadTimeout
@@ -231,10 +231,28 @@ def delete_data_source_task(domain, config_id):
 
 
 @periodic_task(
-    run_every=settings.ASYNC_INDICATOR_QUEUE_CRONTAB, queue=settings.CELERY_PERIODIC_QUEUE
+    run_every='*/5', queue=settings.CELERY_PERIODIC_QUEUE
 )
 def run_queue_async_indicators_task():
-    queue_async_indicators.delay()
+    """ASYNC_INDICATOR_QUEUE_TIMES will be of the format:
+    {
+        '*': [(begin_hour, end_hour), (begin_hour, end_hour), ...] catch all for days
+        '1': [(begin_hour, end_hour), ...] hours for Monday (Monday 1, Sunday 7)
+    }
+    All times UTC
+    """
+    if not settings.ASYNC_INDICATOR_QUEUE_TIMES:
+        queue_async_indicators.delay()
+        return
+
+    hours_for_today = settings.ASYNC_INDICATOR_QUEUE_TIMES.get(date.today().isoweekday())
+    if not hours_for_today:
+        hours_for_today = settings.ASYNC_INDICATOR_QUEUE_TIMES.get('*')
+
+    for valid_hours in hours_for_today:
+        if valid_hours[0] <= datetime.utcnow().hour <= valid_hours[1]:
+            queue_async_indicators.delay()
+            break
 
 
 @serial_task('queue-async-indicators', timeout=30 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)

--- a/settings.py
+++ b/settings.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
-import importlib
 from collections import defaultdict
+import importlib
 import os
 
-from celery.schedules import crontab
 from django.contrib import messages
 import settingshelper as helper
 
@@ -915,7 +914,7 @@ ENIKSHAY_PRIVATE_API_PASSWORD = None
 # number of docs for UCR to queue asynchronously at once
 # ideally # of documents it takes to process in ~30 min
 ASYNC_INDICATORS_TO_QUEUE = 10000
-ASYNC_INDICATOR_QUEUE_CRONTAB = crontab(minute="*/5")
+ASYNC_INDICATOR_QUEUE_TIMES = None
 DAYS_TO_KEEP_DEVICE_LOGS = 60
 
 MAX_RULE_UPDATES_IN_ONE_RUN = 10000


### PR DESCRIPTION
This will allow ICDS to run all day on sunday. ansible pr incoming

@czue @nickpell 