### PR TITLE
add async indicator profiling command

### DIFF
--- a/corehq/apps/userreports/management/commands/profile_async_indicators.py
+++ b/corehq/apps/userreports/management/commands/profile_async_indicators.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         configs = {}
         docs = {}
         for indicator in indicators:
-            docs[indicator.doc_id] = get_document_store(indicator.doc_type).get_document(indicator.doc_id)
+            docs[indicator.doc_id] = get_document_store(domain, indicator.doc_type).get_document(indicator.doc_id)
             for config_id in indicator.indicator_config_ids:
                 configs[config_id] = _get_config(config_id)
 

--- a/corehq/apps/userreports/management/commands/profile_async_indicators.py
+++ b/corehq/apps/userreports/management/commands/profile_async_indicators.py
@@ -38,7 +38,8 @@ class Command(BaseCommand):
             'docs': docs,
             'configs': configs,
         }
-        cProfile.runctx('_simulate_indicator_saves', {}, local_variables, 'async_ucr_stats.log')
+        cProfile.runctx('_simulate_indicator_saves(indicators, docs, configs)', {},
+                        local_variables, 'async_ucr_stats.log')
         print_profile_stats('async_ucr_stats.log', sort_by)
 
 

--- a/corehq/apps/userreports/management/commands/profile_async_indicators.py
+++ b/corehq/apps/userreports/management/commands/profile_async_indicators.py
@@ -1,0 +1,54 @@
+from __future__ import print_function
+from __future__ import absolute_import
+import cProfile
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.userreports.document_stores import get_document_store
+from corehq.apps.userreports.management.commands.profile_data_source import print_profile_stats
+from corehq.apps.userreports.models import AsyncIndicator
+from corehq.apps.userreports.specs import EvaluationContext
+from corehq.apps.userreports.tasks import _get_config
+
+
+class Command(BaseCommand):
+    help = "Profile async indicator processing time"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('count', type=int)
+        parser.add_argument('--sort', dest='sort', action='store', default='time')
+
+    def handle(self, domain, count, **options):
+        sort_by = options['sort']
+        indicators = AsyncIndicator.objects.filter(domain=domain).order_by('-date_created')[:count]
+        print('processing {} indicators'.format(len(indicators)))
+
+        # build up data source configs and docs
+        configs = {}
+        docs = {}
+        for indicator in indicators:
+            docs[indicator.doc_id] = get_document_store(indicator.doc_type).get_document(indicator.doc_id)
+            for config_id in indicator.indicator_config_ids:
+                configs[config_id] = _get_config(config_id)
+
+        local_variables = {
+            '_simulate_indicator_saves': _simulate_indicator_saves,
+            'indicators': indicators,
+            'docs': docs,
+            'configs': configs,
+        }
+        cProfile.runctx('_simulate_indicator_saves', {}, local_variables, 'async_ucr_stats.log')
+        print_profile_stats('async_ucr_stats.log', sort_by)
+
+
+def _simulate_indicator_saves(indicators, docs, configs):
+    for indicator in indicators:
+        _simulate_async_indicator_save(indicator, docs[indicator.doc_id, configs])
+
+
+def _simulate_async_indicator_save(indicator, doc, configs):
+    eval_context = EvaluationContext(doc)
+    for config_id in indicator.indicator_config_ids:
+        config = configs[config_id]
+        config.get_all_values(doc, eval_context)

--- a/corehq/apps/userreports/management/commands/profile_async_indicators.py
+++ b/corehq/apps/userreports/management/commands/profile_async_indicators.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
 
 def _simulate_indicator_saves(indicators, docs, configs):
     for indicator in indicators:
-        _simulate_async_indicator_save(indicator, docs[indicator.doc_id, configs])
+        _simulate_async_indicator_save(indicator, docs[indicator.doc_id], configs)
 
 
 def _simulate_async_indicator_save(indicator, doc, configs):

--- a/corehq/apps/userreports/management/commands/profile_data_source.py
+++ b/corehq/apps/userreports/management/commands/profile_data_source.py
@@ -27,34 +27,38 @@ class Command(BaseCommand):
         local_variables = {'config': config, 'doc': doc}
 
         cProfile.runctx('config.get_all_values(doc)', {}, local_variables, 'ucr_stats.log')
-        p = pstats.Stats('ucr_stats.log')
-        p.sort_stats(sort_by)
+        print_profile_stats('ucr_stats.log', sort_by)
 
-        print("Top 50 functions by {}\n".format(sort_by))
-        p.print_stats(50)
 
-        print("Specs timing\n")
-        p.print_stats('userreports.*specs.*\(__call__\)')
+def print_profile_stats(filename, sort_by):
+    p = pstats.Stats(filename)
+    p.sort_stats(sort_by)
 
-        print("Socket recvs\n")
-        p.print_stats('recv')
+    print("Top 50 functions by {}\n".format(sort_by))
+    p.print_stats(50)
 
-        print("Doc retrievals\n")
-        p.print_stats('document_store.*\(get_document\)')
+    print("Specs timing\n")
+    p.print_stats('userreports.*specs.*\(__call__\)')
 
-        print("Postgres queries\n")
-        p.print_stats('execute.*psycopg')
+    print("Socket recvs\n")
+    p.print_stats('recv')
 
-        print("ES queries\n")
-        p.print_stats('es_query.py.*\(run\)')
+    print("Doc retrievals\n")
+    p.print_stats('document_store.*\(get_document\)')
 
-        print("""
-        Note: Due to overhead in profiling, these times are much larger than the real times.
+    print("Postgres queries\n")
+    p.print_stats('execute.*psycopg')
 
-        Next Steps:
-           1) choose one of the previous calls to investigate
-           2) use print_callees or print_callers to follow the calls
-              * usage https://docs.python.org/2/library/profile.html#pstats.Stats.print_stats
-           3) check out branch je/time-ucr to get logs for processing time of each column
-              (you'll likely need to rebase it on latest master)
-        """)
+    print("ES queries\n")
+    p.print_stats('es_query.py.*\(run\)')
+
+    print("""
+    Note: Due to overhead in profiling, these times are much larger than the real times.
+
+    Next Steps:
+       1) choose one of the previous calls to investigate
+       2) use print_callees or print_callers to follow the calls
+          * usage https://docs.python.org/2/library/profile.html#pstats.Stats.print_stats
+       3) check out branch je/time-ucr to get logs for processing time of each column
+          (you'll likely need to rebase it on latest master)
+    """)


### PR DESCRIPTION
I wanted a more realistic way to profile async indicators in bulk to make sure we don't overfit any optimizations to something that happens once per N instead of once per batch as well as overfit for any individual case/dataset. @emord 

review with `w=1`