### PR TITLE
Add ability to show report metrics to async backed reports

### DIFF
--- a/custom/enikshay/templates/enikshay/ucr/monitored_report.html
+++ b/custom/enikshay/templates/enikshay/ucr/monitored_report.html
@@ -1,0 +1,16 @@
+{% extends "userreports/configurable_report.html" %}
+{% load i18n %}
+{% block reporttable %}
+    {% if hours_behind %}
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="well well-sm">
+                    {% blocktrans %}
+                        This report may not reflect forms submitted in the last <strong>{{ hours_behind }}</strong> hours.
+                    {% endblocktrans %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    {{ block.super }}
+{% endblock reporttable%}

--- a/custom/enikshay/ucr/views.py
+++ b/custom/enikshay/ucr/views.py
@@ -28,13 +28,12 @@ class MonitoredReport(CustomConfigurableReport):
         """
         now = datetime.utcnow()
 
-        oldest_indicator = (
-            AsyncIndicator.objects
-            .filter(indicator_config_ids__contains=[self.spec.config_id])
-            .aggregate(Min('date_created'))
-        )
-        if oldest_indicator['date_created__min'] is not None:
-            hours_behind = (now - oldest_indicator['date_created__min']).total_seconds() / (60 * 60)
+        try:
+            oldest_indicator = (
+                AsyncIndicator.objects
+                .filter(indicator_config_ids__contains=[self.spec.config_id])
+            )[0]
+            hours_behind = (now - oldest_indicator.date_created).total_seconds() / (60 * 60)
             return int(1 + (hours_behind // 12)) * 12
-
-        return None
+        except IndexError:
+            return None

--- a/custom/enikshay/ucr/views.py
+++ b/custom/enikshay/ucr/views.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import division
+
+from datetime import datetime
+
+from django.db.models import Min
+
+from corehq.apps.userreports.models import AsyncIndicator
+from corehq.apps.userreports.reports.view import CustomConfigurableReport
+
+
+class MonitoredReport(CustomConfigurableReport):
+    """For reports backed by an async datasource, shows an indication of how far
+    behind the report might be, in increments of 12 hours.
+
+    """
+
+    template_name = 'enikshay/ucr/monitored_report.html'
+
+    @property
+    def page_context(self):
+        context = super(MonitoredReport, self).page_context
+        context['hours_behind'] = self.hours_behind()
+        return context
+
+    def hours_behind(self):
+        """returns the number of hours behind this report is, to the nearest 12 hour bucket.
+        """
+        now = datetime.utcnow()
+
+        oldest_indicator = (
+            AsyncIndicator.objects
+            .filter(indicator_config_ids__contains=[self.spec.config_id])
+            .aggregate(Min('date_created'))
+        )
+        if oldest_indicator['date_created__min'] is not None:
+            hours_behind = (now - oldest_indicator['date_created__min']).total_seconds() / (60 * 60)
+            return int(1 + (hours_behind // 12)) * 12
+
+        return None

--- a/custom/enikshay/ucr/views.py
+++ b/custom/enikshay/ucr/views.py
@@ -3,8 +3,6 @@ from __future__ import division
 
 from datetime import datetime
 
-from django.db.models import Min
-
 from corehq.apps.userreports.models import AsyncIndicator
 from corehq.apps.userreports.reports.view import CustomConfigurableReport
 


### PR DESCRIPTION
This adds the ability to add a message to eNikshay reports backed by async datasources with the amount of time behind this report might be (to the nearest 12 hour increment). 

https://trello.com/c/nHZeKx8I/256-reports-indicator-liveness

![screenshot from 2018-01-11 21-23-04](https://user-images.githubusercontent.com/146896/34857030-a09353a4-f716-11e7-886e-042a665e7cc8.png)

To add this to reports, we add 
```json
"custom_configurable_report": "custom.enikshay.ucr.views.MonitoredReport"
```
to the report config. This has the unfortunate effect of changing the report URL, but I think is fine for now. 

@emord curious what you think of this approach
@gcapalbo buddy