### PR TITLE
App Diff: Hide headings where there are no changes

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_diff.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_diff.js
@@ -88,9 +88,13 @@ hqDefine('app_manager/js/releases/app_diff', function () {
             ).done(function(appDataOneJson, appDataTwoJson) {
                 try {
                     self.$el.html(self.generateHtmlDiff(appDataOneJson, appDataTwoJson));
-                    self.$el.find('.diff-questions:not(:has(.diff-change))').html(
-                        '<i>' + gettext('No changes detected') + '</i>'
-                    );
+                    // Hide headings with no changes
+                    self.$el.find('.diff-module:not(:has(.diff-change))').hide();
+                    self.$el.find('.diff-form:not(:has(.diff-change))').hide();
+                    self.$el.find('.diff-question:not(:has(.diff-change))').hide();
+                    self.$el.find('.diff-case-type:not(:has(.diff-change))').hide();
+                    self.$el.find('.diff-case-property:not(:has(.diff-change))').hide();
+                    self.$el.find('.diff-case-action:not(:has(.diff-change))').hide();
                 } catch (e) {
                     self.showError();
                     throw e;
@@ -240,7 +244,7 @@ hqDefine('app_manager/js/releases/app_diff', function () {
             );
             var lines = [
                 HtmlUtils.makeLi(sanitize(formName), 'diff-form', 'file-o'),
-                HtmlUtils.makeLi(gettext('Save Questions'), 'diff-underline fa-ul', '', true),
+                HtmlUtils.makeLi(gettext('Save Questions'), 'diff-case-action diff-underline fa-ul', '', true),
                 HtmlUtils.makeUl('diff-questions diff-save-questions fa-ul'),
                 _.map(self.saveQuestions, function(q) { return q.toString(); }).join('\n'),
                 HtmlUtils.closeUl(),


### PR DESCRIPTION
In the App Diff, we show every question even if there are no changes. This is pretty hard to parse for large apps. This hides all the headings where there are no changes. (Solutions easy win)

@sheelio 
@gcapalbo 