### PR TITLE
Remove list of exports from dashboard

### DIFF
--- a/corehq/apps/dashboard/models.py
+++ b/corehq/apps/dashboard/models.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import
 from django.urls import reverse, resolve, Resolver404
 from corehq.tabs.uitab import url_is_location_safe
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
-from corehq.apps.export.models.new import FormExportInstance, CaseExportInstance
-from corehq.apps.export.views import ExportsPermissionsMixin, user_can_view_deid_exports
-from corehq.apps.reports.models import ReportConfig, CaseExportSchema, FormExportSchema
+from corehq.apps.reports.models import ReportConfig
 from dimagi.utils.decorators.memoized import memoized
 
 
@@ -187,53 +185,3 @@ class AppsPaginator(TilePaginator):
 
         return [self._fmt_item(a.name,
                                _get_app_url(a)) for a in apps]
-
-
-class DataPaginator(TilePaginator, ExportsPermissionsMixin):
-
-    @property
-    def total(self):
-        return len(self.case_exports) + len(self.form_exports)
-
-    @property
-    @memoized
-    def has_deid_view_permissions(self):
-        return user_can_view_deid_exports(self.request.domain, self.request.couch_user)
-
-    @property
-    @memoized
-    def form_exports(self):
-        exports = []
-        if self.has_edit_permissions:
-            from corehq.apps.export.dbaccessors import get_form_exports_by_domain
-            exports = get_form_exports_by_domain(self.request.domain, self.has_deid_view_permissions)
-        return exports
-
-    @property
-    @memoized
-    def case_exports(self):
-        exports = []
-        if self.has_edit_permissions:
-            from corehq.apps.export.dbaccessors import get_case_exports_by_domain
-            exports = get_case_exports_by_domain(self.request.domain, self.has_deid_view_permissions)
-        return exports
-
-    def _paginated_items(self, items_per_page, skip):
-        exports = (self.form_exports + self.case_exports)
-        exports = sorted(exports, key=lambda item: item.name.lower())
-        exports = exports[skip:skip + items_per_page]
-        for export in exports:
-            urlname = ''
-            if isinstance(export, CaseExportInstance):
-                urlname = 'new_export_download_cases'
-            elif isinstance(export, FormExportInstance):
-                urlname = 'new_export_download_forms'
-            elif isinstance(export, CaseExportSchema):
-                urlname = 'export_download_cases'
-            elif isinstance(export, FormExportSchema):
-                urlname = 'export_download_forms'
-            if urlname:
-                yield self._fmt_item(
-                    export.name,
-                    reverse(urlname, args=(self.request.domain, export.get_id))
-                )

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -11,7 +11,6 @@ from corehq import privileges
 from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_brief_apps_in_domain
 from corehq.apps.dashboard.models import (
     AppsPaginator,
-    DataPaginator,
     ReportsPaginator,
     Tile,
     Tile,
@@ -177,7 +176,6 @@ def _get_default_tiles(request):
             title=_('Data'),
             slug='data',
             icon='fcc fcc-data',
-            paginator_class=DataPaginator,
             urlname="data_interfaces_default",
             visibility_check=can_edit_data,
             help_text=_('Export and manage data'),


### PR DESCRIPTION
It can be very slow and isn't frequently used
https://manage.dimagi.com/default.asp?266770

Before:
![screenshot from 2018-01-15 16-11-56](https://user-images.githubusercontent.com/2367539/34962036-115b9c76-fa10-11e7-9b67-528171d26944.png)

After:
![screenshot from 2018-01-15 16-13-01](https://user-images.githubusercontent.com/2367539/34962045-19288202-fa10-11e7-8562-b2ef7db7185e.png)

@dimagi/product FYI