### PR TITLE
Don't use FormplayerFrontend to get tz offset

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -1,4 +1,4 @@
-/* globals CodeMirror, gettext, Clipboard, FormplayerFrontend */
+/* globals CodeMirror, gettext, Clipboard */
 hqDefine('cloudcare/js/debugger/debugger', function () {
 
     /**
@@ -466,7 +466,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
             return API.request(url, 'menu_debugger_content', params);
         },
         request: function(url, action, params) {
-            params['tz_offset_millis'] = FormplayerFrontend.request('timezoneOffset');
+            params['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
             return $.ajax({
                 type: 'POST',
                 url: url + "/" + action,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -1,4 +1,4 @@
-/*global Formplayer, FormplayerFrontend */
+/*global Formplayer */
 
 // IE compliance
 if (!Array.prototype.indexOf) {
@@ -149,7 +149,7 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
     // stupid hack for now to make up for both being used in different requests
     requestParams['session_id'] = self.session_id;
     requestParams['debuggerEnabled'] = self.debuggerEnabled;
-    requestParams['tz_offset_millis'] = FormplayerFrontend.request('timezoneOffset');
+    requestParams['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
     if (this.blockingRequestInProgress) {
         return;
     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -91,11 +91,6 @@ FormplayerFrontend.reqres.setHandler('lastRecordedLocation', function() {
     }
 });
 
-FormplayerFrontend.reqres.setHandler('timezoneOffset', function() {
-    // JS's implementation of getTimezoneOffset() returns the offset in minutes and (inexplicably) with the sign inverted
-    return (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
-});
-
 FormplayerFrontend.on('clearBreadcrumbs', function () {
     $('#persistent-case-tile').html("");
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -11,7 +11,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
         queryFormplayer: function (params, route) {
             var user = FormplayerFrontend.request('currentUser'),
                 lastRecordedLocation = FormplayerFrontend.request('lastRecordedLocation'),
-                timezoneOffsetMillis = FormplayerFrontend.request('timezoneOffset'),
+                timezoneOffsetMillis = (new Date()).getTimezoneOffset() * 60 * 1000 * -1,
                 formplayerUrl = user.formplayer_url,
                 displayOptions = user.displayOptions || {},
                 defer = $.Deferred(),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
@@ -55,7 +55,7 @@ FormplayerFrontend.module("Sessions", function (Sessions, FormplayerFrontend, Ba
                     "username": user.username,
                     "domain": user.domain,
                     "restoreAs": user.restoreAs,
-                    "tz_offset_millis": FormplayerFrontend.request('timezoneOffset'),
+                    "tz_offset_millis": (new Date()).getTimezoneOffset() * 60 * 1000 * -1,
                 }),
                 url: formplayerUrl + '/incomplete-form',
                 success: function (request) {


### PR DESCRIPTION
Will fix https://manage.dimagi.com/default.asp?268497

Since in general it's not totally clear to us when and why `FormplayerFrontend` is or isn't accessible, it seemed safest to remove its usage for this purpose entirely. The only reason for getting the tz offset via a call to `FormplayerFrontend` to begin with was for cleanliness of unification, so it doesn't seem worth the potential for further issues. 

Also removes the places where I added `FormplayerFrotend` to the `/* global */` comment at the top of a couple of files (done in https://github.com/dimagi/commcare-hq/pull/19045)