### PR TITLE
Expire messages in the celery events queue after 2 hours

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -596,6 +596,10 @@ ENIKSHAY_QUEUE = CELERY_MAIN_QUEUE
 # time limit is exceeded.
 CELERYD_TASK_SOFT_TIME_LIMIT = 86400 * 2  # 2 days in seconds
 
+# http://docs.celeryproject.org/en/3.1/configuration.html#celery-event-queue-ttl
+# Keep messages in the events queue only for 2 hours
+CELERY_EVENT_QUEUE_TTL = 2 * 60 * 60
+
 # websockets config
 WEBSOCKET_URL = '/ws/'
 WS4REDIS_PREFIX = 'ws'


### PR DESCRIPTION
The events queue (which seems to be used by monitoring tools like flower) grows out of control when lots of tasks are created.  I saw a large number of messages in the events queue today and I think this was one thing that was making us run out of space in rabbitmq so quickly.

@dimagi/scale-team 