### PR TITLE
'dict' object has no attribute 'commcare_version'

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -215,7 +215,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                 if devices:
                     device = max(devices, key=lambda dev: dev['last_used'])
                     if device.get('commcare_version', None):
-                        commcare_version = _get_commcare_version(device.commcare_version)
+                        commcare_version = _get_commcare_version(device['commcare_version'])
             if last_sub and last_sub.get('submission_date'):
                 last_seen = string_to_utc_datetime(last_sub['submission_date'])
             if last_sync and last_sync.get('sync_date'):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?268705
Users are pulled from ES and left unwrapped, so 'devices' is a json array.
https://sentry.io/dimagi/commcarehq/issues/272053140/
@millerdev @mkangia