### PR TITLE
add proof of concept for preventing logging passwords to sentry

### DIFF
--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import re
 from django.conf import settings
 from raven.contrib.django import DjangoClient
@@ -52,7 +52,7 @@ class HQSentryClient(DjangoClient):
             return False
 
         try:
-            value = unicode(ex_value)
+            value = str(ex_value)
             if looks_sensitive(value):
                 return False
         except Exception:

--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -48,6 +48,15 @@ class HQSanitzeSystemPasswordsProcessor(SanitizePasswordsProcessor):
             return self._regex.sub(self.MASK, value)
         return value
 
+    def process(self, data, **kwargs):
+        data = super(HQSanitzeSystemPasswordsProcessor, self).process(data, **kwargs)
+        if 'exception' in data and 'values' in data['exception']:
+            # sentry's data structure is rather silly/complicated
+            for value in data['exception']['values'] or []:
+                if 'value' in value:
+                    value['value'] = self.sanitize('value', value['value'])
+        return data
+
 
 class HQSentryClient(DjangoClient):
 

--- a/corehq/util/tests/test_sentry.py
+++ b/corehq/util/tests/test_sentry.py
@@ -1,0 +1,24 @@
+import uuid
+from django.test import SimpleTestCase, override_settings
+from corehq.util.sentry import looks_sensitive
+
+
+class HQSentryTest(SimpleTestCase):
+
+    def test_couch_password(self):
+        couch_pw = uuid.uuid4().hex
+        couch_pw2 = uuid.uuid4().hex
+        overridden_dbs = {
+            'db{}'.format(i): {
+                'COUCH_HTTPS': False,
+                'COUCH_SERVER_ROOT': '127.0.0.1:5984',
+                'COUCH_USERNAME': 'commcarehq',
+                'COUCH_PASSWORD': pw,
+                'COUCH_DATABASE_NAME': 'commcarehq',
+            }
+            for i, pw in enumerate([couch_pw, couch_pw2])
+        }
+        with override_settings(COUCH_DATABASES=overridden_dbs):
+            self.assertTrue(looks_sensitive('something leaking the {}'.format(couch_pw)))
+            self.assertTrue(looks_sensitive('something else leaking the {}'.format(couch_pw2)))
+            self.assertFalse(looks_sensitive('something not leaking the password'.format(couch_pw)))

--- a/corehq/util/tests/test_sentry.py
+++ b/corehq/util/tests/test_sentry.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import uuid
 from django.test import SimpleTestCase, override_settings
 from corehq.util.sentry import looks_sensitive

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -252,7 +252,6 @@ def configure_sentry(base_dir, server_env, pub_key, priv_key, project_id):
         'tags': {},
         'include_versions': False,  # performance without this is bad
         'processors': (
-            'raven.processors.SanitizePasswordsProcessor',
             'raven.processors.RemovePostDataProcessor',
             'corehq.util.sentry.HQSanitzeSystemPasswordsProcessor',
         ),

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -254,6 +254,7 @@ def configure_sentry(base_dir, server_env, pub_key, priv_key, project_id):
         'processors': (
             'raven.processors.SanitizePasswordsProcessor',
             'raven.processors.RemovePostDataProcessor',
+            'corehq.util.sentry.HQSanitzeSystemPasswordsProcessor',
         ),
         'ignore_exceptions': [
             'KeyboardInterrupt'


### PR DESCRIPTION
possible attempt at resolving [this issue](https://trello.com/c/DtU7YDeZ/19-change-couch-password). If this seems reasonable we can (should) also extend it to postgres and other sensitive values.

attempts to obfuscate the passwords everywhere using something that piggyback's off sentry's own [password obfuscation logic](https://docs.sentry.io/clients/python/advanced/#sanitizing-data).

thoughts on whether something like this is worth it or if there are any better approaches we could try?