### PR TITLE
SMS Survey Refactor: 2

### DIFF
--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -20,6 +20,8 @@ from corehq.apps.reminders.util import enqueue_reminder_directly, get_two_way_nu
 from couchdbkit.exceptions import ResourceConflict
 from couchdbkit.resource import ResourceNotFound
 from corehq.apps.smsforms.app import submit_unfinished_form
+from corehq.apps.smsforms.models import SQLXFormsSession
+from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import ServerTime, UserTime
 from dimagi.utils.couch import LockableMixIn, CriticalSection
@@ -1003,7 +1005,9 @@ class CaseReminderHandler(Document):
                     if self.method == METHOD_SMS_SURVEY and self.submit_partial_forms and iteration > 1:
                         # This is to make sure we submit the unfinished forms even when fast-forwarding to the next event after system downtime
                         for session_id in reminder.xforms_session_ids:
-                            submit_unfinished_form(session_id, self.include_case_side_effects)
+                            contact_id = SQLXFormsSession.get_contact_id_from_session_id(session_id)
+                            with critical_section_for_smsforms_sessions(contact_id):
+                                submit_unfinished_form(session_id, self.include_case_side_effects)
                 else:
                     reminder.next_fire = reminder.next_fire + timedelta(minutes = reminder.current_event.callback_timeout_intervals[reminder.callback_try_count])
                     reminder.callback_try_count += 1
@@ -1064,7 +1068,9 @@ class CaseReminderHandler(Document):
                 reminder.xforms_session_ids = old_xforms_session_ids
             elif prev_definition is not None and prev_definition.submit_partial_forms:
                 for session_id in old_xforms_session_ids:
-                    submit_unfinished_form(session_id, prev_definition.include_case_side_effects)
+                    contact_id = SQLXFormsSession.get_contact_id_from_session_id(session_id)
+                    with critical_section_for_smsforms_sessions(contact_id):
+                        submit_unfinished_form(session_id, prev_definition.include_case_side_effects)
     
     def get_active(self, reminder, now, case):
         schedule_not_finished = not (self.max_iteration_count != REPEAT_SCHEDULE_INDEFINITELY and reminder.schedule_iteration_num > self.max_iteration_count)

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -13,6 +13,7 @@ from corehq.apps.sms.messages import *
 from corehq.apps.sms.handlers.form_session import validate_answer
 from corehq.apps.sms.util import touchforms_error_is_config_error
 from corehq.apps.smsforms.models import SQLXFormsSession
+from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
 from corehq.apps.reminders.models import (
     METHOD_SMS,
     METHOD_SMS_SURVEY,
@@ -189,17 +190,18 @@ def handle_domain_keywords(v, text, msg, text_words, sessions):
 
 
 def sms_keyword_handler(v, text, msg):
-    text = text.strip()
-    if text == "":
-        return False
+    with critical_section_for_smsforms_sessions(v.owner_id):
+        text = text.strip()
+        if text == "":
+            return False
 
-    sessions = SQLXFormsSession.get_all_open_sms_sessions(v.domain, v.owner_id)
-    text_words = text.upper().split()
+        sessions = SQLXFormsSession.get_all_open_sms_sessions(v.domain, v.owner_id)
+        text_words = text.upper().split()
 
-    if text.startswith("#"):
-        return handle_global_keywords(v, text, msg, text_words, sessions)
-    else:
-        return handle_domain_keywords(v, text, msg, text_words, sessions)
+        if text.startswith("#"):
+            return handle_global_keywords(v, text, msg, text_words, sessions)
+        else:
+            return handle_domain_keywords(v, text, msg, text_words, sessions)
 
 
 def _handle_structured_sms(domain, args, contact_id, session_id,

--- a/corehq/apps/sms/tests/inbound_handlers.py
+++ b/corehq/apps/sms/tests/inbound_handlers.py
@@ -9,8 +9,24 @@ from corehq.apps.smsforms.app import submit_unfinished_form
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from datetime import date, time
+from mock import patch
 
 
+class MockContextManager(object):
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+def mock_critical_section_for_smsforms_sessions(contact_id):
+    return MockContextManager()
+
+
+@patch('corehq.apps.smsforms.util.critical_section_for_smsforms_sessions',
+       new=mock_critical_section_for_smsforms_sessions)
 class KeywordTestCase(TouchformsTestCase):
     """
     Must be run manually (see util.TouchformsTestCase)
@@ -743,6 +759,8 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertLastOutboundSMSEquals(self.user2, "Default SMS Response")
 
 
+@patch('corehq.apps.smsforms.util.critical_section_for_smsforms_sessions',
+       new=mock_critical_section_for_smsforms_sessions)
 class PartialFormSubmissionTestCase(TouchformsTestCase):
     """
     Must be run manually (see util.TouchformsTestCase)

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -5,8 +5,8 @@ from corehq.apps.cloudcare.touchforms_api import CaseSessionDataHelper
 from corehq.apps.smsforms.util import process_sms_form_complete
 from corehq.apps.users.models import CouchUser
 from corehq.form_processor.utils import is_commcarecase
+from corehq.messaging.scheduling.util import utcnow
 from .models import XFORMS_SESSION_SMS, SQLXFormsSession
-from datetime import datetime
 from touchforms.formplayer.api import (
     XFormsConfig,
     DigestAuth,
@@ -123,7 +123,7 @@ def submit_unfinished_form(session_id, include_case_side_effects=False):
         case_tag_regex = re.compile("^(\{.*\}){0,1}case$") # Use regex in order to search regardless of namespace
         meta_tag_regex = re.compile("^(\{.*\}){0,1}meta$")
         timeEnd_tag_regex = re.compile("^(\{.*\}){0,1}timeEnd$")
-        current_timstamp = json_format_datetime(datetime.utcnow())
+        current_timstamp = json_format_datetime(utcnow())
         for child in root:
             if case_tag_regex.match(child.tag) is not None:
                 # Found the case tag

--- a/corehq/apps/smsforms/management/commands/handle_survey_actions.py
+++ b/corehq/apps/smsforms/management/commands/handle_survey_actions.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
+from corehq.apps.smsforms.models import SQLXFormsSession
+from corehq.apps.smsforms.tasks import handle_due_survey_action
+from corehq.sql_db.util import handle_connection_failure
+from datetime import datetime
+from dimagi.utils.couch.cache.cache_core import get_redis_client
+from dimagi.utils.logging import notify_exception
+from django.core.management.base import BaseCommand
+from time import sleep
+
+
+def skip_domain(domain):
+    return any_migrations_in_progress(domain)
+
+
+class Command(BaseCommand):
+    help = "Spawns tasks to handle the next actions due in SMS surveys"
+
+    def get_enqueue_lock(self, session_id, current_action_due):
+        client = get_redis_client()
+        key = "create-task-for-smsforms-session-%s-%s" % (
+            session_id,
+            current_action_due.strftime('%Y-%m-%d %H:%M:%S')
+        )
+        return client.lock(key, timeout=60 * 60)
+
+    def get_survey_sessions_due_for_action(self):
+        return SQLXFormsSession.objects.filter(
+            session_is_open=True,
+            current_action_due__lt=datetime.utcnow(),
+        ).values_list('domain', 'connection_id', 'session_id', 'current_action_due')
+
+    @handle_connection_failure()
+    def create_tasks(self):
+        for domain, connection_id, session_id, current_action_due in self.get_survey_sessions_due_for_action():
+            if skip_domain(domain):
+                continue
+
+            enqueue_lock = self.get_enqueue_lock(session_id, current_action_due)
+            if enqueue_lock.acquire(blocking=False):
+                handle_due_survey_action.delay(domain, connection_id, session_id)
+
+    def handle(self, **options):
+        while True:
+            try:
+                self.create_tasks()
+            except:
+                notify_exception(None, message="Could not fetch due survey actions")
+            sleep(10)

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -201,6 +201,17 @@ class SQLXFormsSession(models.Model):
 
         return session
 
+    @classmethod
+    def get_contact_id_from_session_id(cls, session_id):
+        result = list(cls.objects.filter(session_id=session_id).values_list('connection_id', flat=True))
+
+        if len(result) == 0:
+            raise cls.DoesNotExist
+        elif len(result) > 1:
+            raise cls.MultipleObjectsReturned
+
+        return result[0]
+
     @property
     def current_action_is_a_reminder(self):
         return self.current_reminder_num < len(self.reminder_intervals)

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 from corehq.apps.sms.util import strip_plus
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.messaging.scheduling.util import utcnow
 from couchdbkit import MultipleResultsFound
 from django.contrib.postgres.fields import JSONField
 from django.db import models
@@ -100,7 +101,7 @@ class SQLXFormsSession(models.Model):
         """
         self.session_is_open = False
         self.completed = completed
-        self.modified_time = self.end_time = datetime.utcnow()
+        self.modified_time = self.end_time = utcnow()
 
     @property
     def related_subevent(self):
@@ -175,7 +176,7 @@ class SQLXFormsSession(models.Model):
             reminder_intervals=None, submit_partially_completed_forms=False,
             include_case_updates_in_partial_submissions=False):
 
-        now = datetime.utcnow()
+        now = utcnow()
 
         session = cls(
             couch_id=uuid.uuid4().hex,
@@ -230,7 +231,7 @@ class SQLXFormsSession(models.Model):
             self.current_action_due = self.start_time + timedelta(minutes=self.expire_after)
 
     def move_to_next_action(self):
-        while self.current_action_is_a_reminder and self.current_action_due < datetime.utcnow():
+        while self.current_action_is_a_reminder and self.current_action_due < utcnow():
             self.current_reminder_num += 1
             self.set_current_action_due_timestamp()
 

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -229,6 +229,11 @@ class SQLXFormsSession(models.Model):
         else:
             self.current_action_due = self.start_time + timedelta(minutes=self.expire_after)
 
+    def move_to_next_action(self):
+        while self.current_action_is_a_reminder and self.current_action_due < datetime.utcnow():
+            self.current_reminder_num += 1
+            self.set_current_action_due_timestamp()
+
 
 def get_session_by_session_id(id):
     return SQLXFormsSession.by_session_id(id)

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,6 +1,8 @@
+from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
 from corehq.util.celery_utils import no_result_task
 
 
 @no_result_task(queue='reminder_queue')
 def handle_due_survey_action(domain, connection_id, session_id):
-    pass
+    with critical_section_for_smsforms_sessions(connection_id):
+        pass

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
 from corehq.messaging.scheduling.util import utcnow

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,8 +1,24 @@
+from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
 from corehq.util.celery_utils import no_result_task
+from datetime import datetime
 
 
 @no_result_task(queue='reminder_queue')
 def handle_due_survey_action(domain, contact_id, session_id):
     with critical_section_for_smsforms_sessions(contact_id):
-        pass
+        session = SQLXFormsSession.by_session_id(session_id)
+        if (
+            not session
+            or not session.session_is_open
+            or session.current_action_due > datetime.utcnow()
+        ):
+            return
+
+        if session.current_action_is_a_reminder:
+            # Resend the current survey question to the contact
+            session.move_to_next_action()
+            session.save()
+        else:
+            # End the session
+            pass

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -22,4 +22,6 @@ def handle_due_survey_action(domain, contact_id, session_id):
             session.save()
         else:
             # End the session
-            pass
+            if not session.submit_partially_completed_forms:
+                session.end(False)
+                session.save()

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,7 +1,7 @@
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
+from corehq.messaging.scheduling.util import utcnow
 from corehq.util.celery_utils import no_result_task
-from datetime import datetime
 
 
 @no_result_task(queue='reminder_queue')
@@ -11,7 +11,7 @@ def handle_due_survey_action(domain, contact_id, session_id):
         if (
             not session
             or not session.session_is_open
-            or session.current_action_due > datetime.utcnow()
+            or session.current_action_due > utcnow()
         ):
             return
 

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,0 +1,6 @@
+from corehq.util.celery_utils import no_result_task
+
+
+@no_result_task(queue='reminder_queue')
+def handle_due_survey_action(domain, connection_id, session_id):
+    pass

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -3,6 +3,6 @@ from corehq.util.celery_utils import no_result_task
 
 
 @no_result_task(queue='reminder_queue')
-def handle_due_survey_action(domain, connection_id, session_id):
-    with critical_section_for_smsforms_sessions(connection_id):
+def handle_due_survey_action(domain, contact_id, session_id):
+    with critical_section_for_smsforms_sessions(contact_id):
         pass

--- a/corehq/apps/smsforms/tests/test_sql_session.py
+++ b/corehq/apps/smsforms/tests/test_sql_session.py
@@ -7,15 +7,8 @@ from django.test import TestCase
 from corehq.apps.sms.handlers.form_session import get_single_open_session_or_close_multiple
 from corehq.apps.smsforms.models import SQLXFormsSession, XFORMS_SESSION_TYPES, XFORMS_SESSION_SMS, \
     XFORMS_SESSION_IVR
-from mock import patch
+from mock import patch, Mock
 from six.moves import range
-
-
-class MockObject(object):
-
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            setattr(self, k, v)
 
 
 class SQLSessionTestCase(TestCase):
@@ -154,10 +147,10 @@ class SQLSessionTestCase(TestCase):
         utcnow_mock.return_value = datetime(2018, 1, 1, 0, 0)
         session = SQLXFormsSession.create_session_object(
             'test',
-            MockObject(get_id='contact_id'),
+            Mock(get_id='contact_id'),
             '+9990001',
-            MockObject(get_id='app_id'),
-            MockObject(xmlns='xmlns'),
+            Mock(get_id='app_id'),
+            Mock(xmlns='xmlns'),
             expire_after=24 * 60,
         )
         self.assertTrue(session.session_is_open)
@@ -179,10 +172,10 @@ class SQLSessionTestCase(TestCase):
         utcnow_mock.return_value = datetime(2018, 1, 1, 0, 0)
         session = SQLXFormsSession.create_session_object(
             'test',
-            MockObject(get_id='contact_id'),
+            Mock(get_id='contact_id'),
             '+9990001',
-            MockObject(get_id='app_id'),
-            MockObject(xmlns='xmlns'),
+            Mock(get_id='app_id'),
+            Mock(xmlns='xmlns'),
             expire_after=24 * 60,
             reminder_intervals=[30, 60]
         )
@@ -221,10 +214,10 @@ class SQLSessionTestCase(TestCase):
         utcnow_mock.return_value = datetime(2018, 1, 1, 0, 0)
         session = SQLXFormsSession.create_session_object(
             'test',
-            MockObject(get_id='contact_id'),
+            Mock(get_id='contact_id'),
             '+9990001',
-            MockObject(get_id='app_id'),
-            MockObject(xmlns='xmlns'),
+            Mock(get_id='app_id'),
+            Mock(xmlns='xmlns'),
             expire_after=24 * 60,
             reminder_intervals=[30, 60]
         )

--- a/corehq/apps/smsforms/util.py
+++ b/corehq/apps/smsforms/util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from corehq.apps.receiverwrapper.util import submit_form_locally
+from dimagi.utils.couch import CriticalSection
 
 
 def form_requires_input(form):
@@ -19,3 +20,7 @@ def process_sms_form_complete(session, form, completed=True):
     session.end(completed=completed)
     session.submission_id = result.xform.form_id
     session.save()
+
+
+def critical_section_for_smsforms_sessions(contact_id):
+    return CriticalSection(['smsforms-sessions-lock-for-contact-%s' % contact_id], timeout=5 * 60)


### PR DESCRIPTION
The next step in the SMS survey refactor, this locks out all places in the code that edit sms survey sessions and introduces a new process that polls for sessions that have actions due, spawning celery tasks to handle the action.

The last step in this refactor will be to remove all sms survey functionality from the reminders framework (except for initiating the survey), and letting the new celery task handle all survey-related actions after that.

review with `?w=1`

@proteusvacuum 