### PR TITLE
Add requeue button to forwarded records page

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_details.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_details.html
@@ -17,6 +17,10 @@
 {% endblock %}
 
 {% block page_content %}
+
+{# This is used in case/partials/repeat_records.html #}
+{% registerurl 'requeue_repeat_record' case.domain %}
+
 <div class="hq-generic-report">
     {% render_case case case_display_options %}
     {% if can_edit_data %}

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/repeat_records.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/repeat_records.js
@@ -5,7 +5,7 @@ $(function(){
             reverse = hqImport('hqwebapp/js/initial_page_data').reverse;
         $btn.disableButton();
         $.post({
-            url: reverse('requeue_repeat_record'),
+            url: reverse('requeue_repeat_record'), // this url is added to the page in case_details.html
             data: { record_id: recordId },
             success: function() {
                 $btn.removeSpinnerFromButton();

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/repeat_records.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/repeat_records.js
@@ -1,0 +1,22 @@
+$(function(){
+    $('.requeue-record-payload').click(function() {
+        var $btn = $(this),
+            recordId = $btn.data().recordId,
+            reverse = hqImport('hqwebapp/js/initial_page_data').reverse;
+        $btn.disableButton();
+        $.post({
+            url: reverse('requeue_repeat_record'),
+            data: { record_id: recordId },
+            success: function() {
+                $btn.removeSpinnerFromButton();
+                $btn.text(gettext('Requeued'));
+                $btn.addClass('btn-success');
+            },
+            error: function() {
+                $btn.removeSpinnerFromButton();
+                $btn.text(gettext('Failed'));
+                $btn.addClass('btn-danger');
+            },
+        });
+    });
+});

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
@@ -1,4 +1,12 @@
 {% load i18n %}
+{% load hq_shared_tags %}
+
+{% registerurl 'requeue_repeat_record' case.domain %}
+
+{% block js %}
+    <script src="{% static "case/js/repeat_records.js" %}"></script>
+{% endblock js %}
+
 <table class="table table-striped table-hover">
     <thead>
         <tr>
@@ -31,27 +39,3 @@
         {% endfor %}
     </tbody>
 </table>
-{% block js-inline %}
-    <script>
-     $('.requeue-record-payload').click(function() {
-         var $btn = $(this),
-             recordId = $btn.data().recordId;
-         $btn.disableButton();
-
-         $.post({
-             url: "{% url 'requeue_repeat_record' case.domain %}",
-             data: { record_id: recordId },
-             success: function() {
-                 $btn.removeSpinnerFromButton();
-                 $btn.text(gettext('Requeued'));
-                 $btn.addClass('btn-success');
-             },
-             error: function() {
-                 $btn.removeSpinnerFromButton();
-                 $btn.text(gettext('Failed'));
-                 $btn.addClass('btn-danger');
-             },
-         });
-     });
-    </script>
-{% endblock js-inline %}

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% registerurl 'requeue_repeat_record' case.domain %}
-
 {% block js %}
     <script src="{% static "case/js/repeat_records.js" %}"></script>
 {% endblock js %}

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
@@ -6,6 +6,7 @@
             <th>{% trans "URL" %}</th>
             <th>{% trans "Status" %}</th>
             <th>{% trans "Attempts" %}</th>
+            <th>{% trans "Action" %}</th>
         </tr>
     </thead>
     <tbody>
@@ -19,7 +20,38 @@
                         <div>{{ attempt.datetime }}: {{ attempt.message }}</div>
                     {% endfor %}
                 </td>
+                <td>
+                    <a class="btn btn-default requeue-record-payload"
+                       role="button"
+                       data-record-id="{{ repeat_record.record_id }}">
+                        {% trans "Requeue Request" %}
+                    </a>
+                </td>
             </tr>
         {% endfor %}
     </tbody>
 </table>
+{% block js-inline %}
+    <script>
+     $('.requeue-record-payload').click(function() {
+         var $btn = $(this),
+             recordId = $btn.data().recordId;
+         $btn.disableButton();
+
+         $.post({
+             url: "{% url 'requeue_repeat_record' case.domain %}",
+             data: { record_id: recordId },
+             success: function() {
+                 $btn.removeSpinnerFromButton();
+                 $btn.text(gettext('Requeued'));
+                 $btn.addClass('btn-success');
+             },
+             error: function() {
+                 $btn.removeSpinnerFromButton();
+                 $btn.text(gettext('Failed'));
+                 $btn.addClass('btn-danger');
+             },
+         });
+     });
+    </script>
+{% endblock js-inline %}

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -531,6 +531,10 @@ class RepeatRecord(Document):
     next_check = DateTimeProperty()
     succeeded = BooleanProperty(default=False)
 
+    @property
+    def record_id(self):
+        return self._id
+
     @classmethod
     def wrap(cls, data):
         should_bootstrap_attempts = ('attempts' not in data)


### PR DESCRIPTION
This adds a requeue button to the forwarded records page on the case data report. This will more easily allow support and end users to retrigger forwarded records.

![screenshot from 2018-01-18 15-04-51](https://user-images.githubusercontent.com/146896/35118818-13a12e58-fc61-11e7-9065-2504bf11fd53.png)

@gcapalbo 