### PR TITLE
Restrict form counts query to only selected users

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
-from collections import defaultdict, namedtuple
+
 import datetime
-from six.moves.urllib.parse import urlencode
 import math
 import operator
+from collections import defaultdict, namedtuple
+
+from django.conf import settings
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_noop
 from pygooglechart import ScatterChart
-from corehq.apps.locations.dbaccessors import user_ids_at_locations
-from corehq.apps.locations.models import SQLLocation
-from corehq.apps.locations.permissions import conditionally_location_safe
 import pytz
 
 from corehq import toggles
@@ -18,7 +18,7 @@ from corehq.apps.es.aggregations import (
     FilterAggregation,
     MissingAggregation,
 )
-from corehq.apps.locations.permissions import location_safe
+from corehq.apps.locations.permissions import conditionally_location_safe, location_safe
 from corehq.apps.reports import util
 from corehq.apps.reports.analytics.esaccessors import (
     get_last_submission_time_for_users,
@@ -53,17 +53,16 @@ from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util import flatten_list
 from corehq.util.timezones.conversions import ServerTime, PhoneTime
 from corehq.util.view_utils import absolute_reverse
-from django.conf import settings
 from dimagi.utils.couch.safe_index import safe_index
 from dimagi.utils.dates import DateSpan, today_or_tomorrow
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_date, string_to_utc_datetime
-from django.utils.translation import ugettext as _, ugettext_lazy
-from django.utils.translation import ugettext_noop
+
 import six
 from functools import reduce
 from six.moves import range
 from six.moves import map
+from six.moves.urllib.parse import urlencode
 
 
 TOO_MUCH_DATA = ugettext_noop(

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -157,7 +157,6 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
     slug = 'case_activity'
     fields = ['corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
               'corehq.apps.reports.filters.select.CaseTypeFilter']
-    all_users = None
     display_data = ['percent']
     emailable = True
     description = ugettext_lazy("Followup rates on active cases.")
@@ -284,13 +283,13 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
 
     @property
     @memoized
-    def all_users(self):
+    def selected_users(self):
         return _get_selected_users(self.domain, self.request)
 
     @property
     @memoized
     def users_by_id(self):
-        return {user.user_id: user for user in self.all_users}
+        return {user.user_id: user for user in self.selected_users}
 
     @property
     @memoized
@@ -302,9 +301,9 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
     def paginated_users(self):
         if self.sort_column is None:
             return sorted(
-                self.all_users, key=lambda u: u.raw_username, reverse=self.pagination.desc
+                self.selected_users, key=lambda u: u.raw_username, reverse=self.pagination.desc
             )[self.pagination.start:self.pagination.start + self.pagination.count]
-        return self.all_users
+        return self.selected_users
 
     @property
     @memoized
@@ -824,11 +823,11 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
 
     @property
     def total_records(self):
-        return len(self.all_users)
+        return len(self.selected_users)
 
     @property
     @memoized
-    def all_users(self):
+    def selected_users(self):
         return _get_selected_users(self.domain, self.request)
 
     def paginate_list(self, data_list):
@@ -840,7 +839,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
             return data_list
 
     def users_by_username(self, order):
-        users = self.all_users
+        users = self.selected_users
         if order == "desc":
             users.reverse()
         return self.paginate_list(users)
@@ -854,17 +853,17 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         if EMWF.show_all_mobile_workers(self.request.GET.getlist(EMWF.slug)):
             user_ids = None  # Don't restrict query by user ID
         else:
-            user_ids = [u.user_id for u in self.all_users]
+            user_ids = [u.user_id for u in self.selected_users]
 
         results = get_counts_by_user(self.domain, datespan, user_ids)
         return self.users_sorted_by_count(results, order)
 
     def users_sorted_by_count(self, count_dict, order):
-        # Split all_users into those in count_dict and those not.
+        # Split selected_users into those in count_dict and those not.
         # Sort the former by count and return
         users_with_forms = []
         users_without_forms = []
-        for user in self.all_users:
+        for user in self.selected_users:
             u_id = user['user_id']
             if u_id in count_dict:
                 users_with_forms.append((count_dict[u_id], user))
@@ -909,7 +908,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
 
     @property
     def get_all_rows(self):
-        rows = [self.get_row(user) for user in self.all_users]
+        rows = [self.get_row(user) for user in self.selected_users]
         self.total_row = self.get_row()
         return rows
 
@@ -921,7 +920,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         if user:
             user_ids = [user.user_id]
         else:
-            user_ids = [u.user_id for u in self.all_users]
+            user_ids = [u.user_id for u in self.selected_users]
 
         if self.is_submission_time:
             get_counts_by_date = get_submission_counts_by_date

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -851,11 +851,12 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         else:
             get_counts_by_user = get_completed_counts_by_user
 
-        results = get_counts_by_user(
-            self.domain,
-            datespan,
-        )
+        if EMWF.show_all_mobile_workers(self.request.GET.getlist(EMWF.slug)):
+            user_ids = None  # Don't restrict query by user ID
+        else:
+            user_ids = [u.user_id for u in self.all_users]
 
+        results = get_counts_by_user(self.domain, datespan, user_ids)
         return self.users_sorted_by_count(results, order)
 
     def users_sorted_by_count(self, count_dict, order):


### PR DESCRIPTION
Current behavior pulls stats on all users even when filtered.  This is only relevant when sorting by a column other than username (the default).  Just something I stumbled across randomly.

@emord FYI - I think you've been looking in to report optimizations, wanted to flag in case you had any reservations.
@millerdev @mkangia buddies