### PR TITLE
Make main.js depend on alert_user.js

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -437,17 +437,12 @@
                 <script src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>
                 <script src="{% static 'hqwebapp/js/layout.js' %}"></script>
                 <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
+                <script src="{% static 'hqwebapp/js/alert_user.js' %}"></script>
                 <script src="{% static 'hqwebapp/js/main.js' %}"></script>
             {% endcompress %}
         {% endif %}
 
         {# JavaScript Display Logic Libaries #}
-
-        {% if not requirejs_main %}
-        {% compress js %}
-        <script src="{% static 'hqwebapp/js/alert_user.js' %}"></script>
-        {% endcompress %}
-        {% endif %}
 
         {% if request.couch_user and not requirejs_main %}
         <script src="{% static 'notifications/js/notifications_service.js' %}"></script>


### PR DESCRIPTION
Product: this fixes a regression where creating a saved report with the same name as an existing saved report would fail without a useful error message.

https://manage.dimagi.com/default.asp?266956

This is a band-aid for a more systemic problem introduced in https://github.com/dimagi/commcare-hq/pull/18116

When a module is migrated to RequireJS, its dependencies are added to its `hqDefine` call, plus calls to `hqImport` are removed, so this:
```
hqDefine("app/js/utils", function() {
   hqImport("otherApp/js/utils").doSomething();
   ...
});
```
becomes this:
```
hqDefine("app/js/utils", ["otherApp/js/utils"], function(otherUtils) {
   otherUtils.doSomething();
   ...
});
```
Until the migration is complete, migrated modules still get used in non-RequireJS environments. When a migrated module is used on a non-migrated page, hqModules.js [looks up](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js#L65-L72) the dependencies from COMMCAREHQ_MODULES and passes them along as parameters. This happens in `hqDefine`, so, at the time the module is defined. Previously, dependencies weren't fetched until `hqImport` was called, which could happen anywhere. So now non-RequireJS pages are even more dependent on the order of script tags than they previously were.

main.js has ~always depended on alert_user.js, even though the main.js script tag comes first. Previously this wasn't a problem because the `hqImport` call to import alert_user happened to be inside a save function that wouldn't get called until the page and all its scripts had fully loaded.

RequireJS does support requiring modules in the same ad hoc fashion that `hqImport` allowed, but I think we should make a convention out of **not** doing that unless it's necessary to prevent a circular dependency. Here, that's not the case. This PR just re-orders the script tags.

If this comes up repeatedly, it might be worth looking into re-introducing something like `hqImport` that does nothing on RequireJS pages and grabs the correct module from COMMCAREHQ_MODULES on non-RequireJS pages. But I went a ways down that path and a) didn't get something fully working and b) found the normal module code harder to work with (can expand on that if needed).

@millerdev 
code buddy @calellowitz 