### PR TITLE
make case_id not advanced in form exports

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -309,6 +309,7 @@ class ExportColumn(DocumentSchema):
         :returns: An ExportColumn instance
         """
         is_case_update = item.tag == PROPERTY_TAG_CASE and not isinstance(item, CaseIndexItem)
+        is_case_id = is_case_update and item.path[-1].name == '@case_id'
         is_case_history_update = item.tag == PROPERTY_TAG_UPDATE
         is_label_question = isinstance(item, LabelItem)
 
@@ -316,7 +317,7 @@ class ExportColumn(DocumentSchema):
         constructor_args = {
             "item": item,
             "label": item.readable_path if not is_case_history_update else item.label,
-            "is_advanced": is_case_update or is_label_question,
+            "is_advanced": not is_case_id and (is_case_update or is_label_question),
         }
 
         if isinstance(item, GeopointItem):

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -141,6 +141,8 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
         for table in instance.tables:
             table.selected = True
             for column in table.columns:
+                if column.item.path[-1].name == '@case_id' and not column.item.transform:
+                    self.assertFalse(column.is_advanced)
                 column.selected = True
 
         with patch('corehq.apps.export.export.get_export_documents') as docs:

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -578,7 +578,7 @@ class TestExportInstanceFromSavedInstance(TestCase):
         self.assertEqual(len(instance.tables[0].columns), 4 + len(MAIN_FORM_TABLE_PROPERTIES))
         self.assertEqual(
             len([c for c in instance.tables[0].columns if c.is_advanced]),
-            len([x for x in MAIN_FORM_TABLE_PROPERTIES if x.is_advanced]) + 2  # + @case_id, case_name
+            len([x for x in MAIN_FORM_TABLE_PROPERTIES if x.is_advanced]) + 1  # case_name
         )
 
     def _get_instance(self, build_ids_and_versions):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?268865

Product note:
This moves the `form.case.@case_id` column (or any other case ID column) out of the advanced questions. This will only impact exports created after this is deployed so won't change any existing exports.