### PR TITLE
Make report title observable

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -102,6 +102,14 @@ var reportBuilder = function () {  // eslint-disable-line
         self.dateRangeOptions = config['dateRangeOptions'];
 
         self.existingReportId = config['existingReport'];
+        self.reportTitle = ko.observable(config['reportTitle']);
+        self.reportTitle.subscribe(function () {
+            self.saveButton.fire('change');
+        });
+        self.reportDescription = ko.observable(config['reportDescription']);
+        self.reportDescription.subscribe(function () {
+            self.saveButton.fire('change');
+        });
 
         self.columnOptions = config["columnOptions"];  // Columns that could be added to the report
         self.reportPreviewUrl = config["reportPreviewUrl"];  // Fetch the preview data asynchronously.
@@ -445,8 +453,8 @@ var reportBuilder = function () {  // eslint-disable-line
             );
             return {
                 "existing_report": self.existingReportId,
-                "report_title": $('#report-title').val(), // From the inline-edit component
-                "report_description": $('#report-description').val(),  // From the inline-edit component
+                "report_title": self.reportTitle(),
+                "report_description": self.reportDescription(),
                 "report_type": self.reportType(),
                 "aggregate": self.isAggregationEnabled(),
                 "chart": self.selectedChart(),

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -55,7 +55,7 @@
     <div class="page-edit-header">
       <div class="page-edit-title h1">
         <inline-edit params="
-          value: '{{ report_title|escapejs }}',
+          value: reportTitle,
           id: 'report-title',
           placeholder: '{% trans "Enter report name here"|escapejs %}',
           cols: 50,
@@ -63,7 +63,7 @@
       </div>
       <div class="page-edit-description">
         <inline-edit params="
-          value: {% if report_description %}'{{ report_description|escapejs }}'{% else %}null{% endif %},
+          value: reportDescription,
           id: 'report-description',
           placeholder: '{% trans "Enter report description here"|escapejs %}',
           readOnlyClass: 'app-comment',
@@ -309,6 +309,8 @@
             "previewDatasourceId": "{{ preview_datasource_id }}",
             "existingReport": {% if existing_report %}{{ existing_report.get_id|JSON }}{% else %}null{% endif %},
             "existingReportType": {{ existing_report_type|JSON }},
+            "reportTitle": "{{ report_title|escapejs }}",
+            "reportDescription": {% if report_description %}"{{ report_description|escapejs }}"{% else %}null{% endif %},
             "dataSourceProperties": {{ data_source_properties|JSON }},
             "initialDefaultFilters": {{ initial_default_filters|JSON }},
             "initialUserFilters": {{ initial_user_filters|JSON }},


### PR DESCRIPTION
Changing a report title or description in Report Builder should enable the "Save" button. This change makes the title and description observables to do this.

More context: [FB 265740](https://manage.dimagi.com/default.asp?265740)

@snopoke cc @biyeun 