### PR TITLE
Support translations in case detail sort elements

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -789,6 +789,10 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
         detail.long.sort_nodeset_columns = sort_nodeset_columns
 
     if sort_elements is not None:
+        # Attempt to map new elements to old so we don't lose translations
+        # Imperfect because the same field may be used multiple times, or user may change field
+        old_elements_by_field = {e['field']: e for e in detail.short.sort_elements}
+
         detail.short.sort_elements = []
         for sort_element in sort_elements:
             item = SortElement()
@@ -796,6 +800,8 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             item.type = sort_element['type']
             item.direction = sort_element['direction']
             item.blanks = sort_element['blanks']
+            if item.field in old_elements_by_field:
+                item.display = old_elements_by_field[item.field].display
             item.display[lang] = sort_element['display']
             if toggles.SORT_CALCULATION_IN_CASE_LIST.enabled(domain):
                 item.sort_calculation = sort_element['sort_calculation']


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?268607

This isn't perfect: it won't work if you change the field and the display text in the same save action, or if you have multiple sort elements that use the same field. To do that, we'd probably need to add IDs to sort elements.

On the other hand, it looks like this has always never worked (in 2+ years), so making it work at all seems like a good enough improvement for now.

@calellowitz 