### PR TITLE
Disable destructive rebuilds for ICDS

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -117,6 +117,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     asynchronous = BooleanProperty(default=False)
     sql_column_indexes = SchemaListProperty(SQLColumnIndexes)
     icds_rebuild_related_docs = BooleanProperty(default=False)
+    disable_destructive_rebuild = BooleanProperty(default=False)
 
     class Meta(object):
         # prevent JsonObject from auto-converting dates etc.

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -10,6 +10,11 @@
     {% endif %}
     {% crispy form %}
 {% if data_source.get_id %}
+    {% if data_source.disable_destructive_rebuild %}
+    <div class="alert alert-info">
+       {% trans "Fully rebuilding has been disabled for this data source, please use the in place rebuild if necessary" %}</p>
+    </div>
+    {% endif %}
   <hr />
   {% if not read_only %}
   <form method='post' action="{% url 'delete_configurable_data_source' domain data_source.get_id %}" >
@@ -19,9 +24,11 @@
   {% endif %}
   <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
     {% csrf_token %}
+    {% if not data_source.disable_destructive_rebuild %}
     <button type="submit" class="btn btn-default disable-on-submit pull-right">
       {% trans 'Rebuild Data Source'%}
     </button>
+    {% endif %}
     <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview data' %}</a>
     <a href="{% url 'summary_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Data Source Summary' %}</a>
     <a href="{% url 'configurable_data_source_json' domain data_source.get_id %}" class="btn btn-default">{% trans 'Data Source Source (Advanced)' %}</a>

--- a/custom/icds_reports/ucr/data_sources/awc_locations.json
+++ b/custom/icds_reports/ucr/data_sources/awc_locations.json
@@ -523,6 +523,7 @@
       }
     },
     "referenced_doc_type": "Location",
-    "table_id": "static-awc_location"
+    "table_id": "static-awc_location",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
+++ b/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
@@ -427,6 +427,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -1835,6 +1835,7 @@
           "owner_id"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -3119,6 +3119,7 @@
           "inserted_at"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableaunov17.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableaunov17.json
@@ -3116,6 +3116,7 @@
           "inserted_at"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
@@ -2746,6 +2746,7 @@
           "inserted_at"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
@@ -3313,6 +3313,7 @@
           "inserted_at"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
@@ -904,6 +904,7 @@
         ]
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -1593,6 +1593,7 @@
           "modified_on"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -4041,6 +4041,7 @@
           "inserted_at"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableaunov17.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableaunov17.json
@@ -4038,6 +4038,7 @@
           "inserted_at"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -1105,6 +1105,7 @@
           "submitted_on"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -648,6 +648,7 @@
           "last_date_gmp"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/hardware_cases.json
+++ b/custom/icds_reports/ucr/data_sources/hardware_cases.json
@@ -533,6 +533,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/home_visit_forms.json
+++ b/custom/icds_reports/ucr/data_sources/home_visit_forms.json
@@ -182,6 +182,7 @@
     "engine_id": "icds-ucr",
     "sql_column_indexes": [
       {"column_ids": ["supervisor_id", "submitted_on"]}
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -192,6 +192,7 @@
           "owner_id"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -1355,6 +1355,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/it_report_follow_issue.json
+++ b/custom/icds_reports/ucr/data_sources/it_report_follow_issue.json
@@ -212,6 +212,7 @@
         ],
         "named_expressions": {},
         "named_filters": {},
-        "sql_column_indexes": []
+        "sql_column_indexes": [],
+        "disable_destructive_rebuild": true
     }
 }

--- a/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
+++ b/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
@@ -141,6 +141,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/person_cases.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases.json
@@ -2551,6 +2551,7 @@
       }
     },
     "asynchronous": true,
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2800,6 +2800,7 @@
           "opened_on"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -348,6 +348,7 @@
           "dob"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
@@ -419,6 +419,7 @@
         "property_value": "ls"
       }
     },
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms.json
@@ -131,6 +131,7 @@
           "submitted_on"
         ]
       }
-    ]
+    ],
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/usage_forms.json
+++ b/custom/icds_reports/ucr/data_sources/usage_forms.json
@@ -953,6 +953,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/vhnd_form.json
@@ -711,6 +711,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
+++ b/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
@@ -328,6 +328,7 @@
     ],
     "named_expressions": {},
     "named_filters": {},
-    "engine_id": "icds-ucr"
+    "engine_id": "icds-ucr",
+    "disable_destructive_rebuild": true
   }
 }


### PR DESCRIPTION
I've wanted this for a while. I get really nervous every time I look at these data sources on ICDS and I'm sure others do as well. Rebuilding the tables would take a while with that amount of data...