### PR TITLE
Fix case migrations endpoint

### DIFF
--- a/corehq/apps/case_migrations/tests/test_restore.py
+++ b/corehq/apps/case_migrations/tests/test_restore.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from casexml.apps.case.const import CASE_INDEX_CHILD
 
-from ..views import get_related_case_ids
+from ..views import get_case_and_descendants
 
 
 class TestRelatedCases(TestCase):
@@ -51,10 +51,10 @@ class TestRelatedCases(TestCase):
         )
 
     def test_get_related_case_ids(self):
-        related_ids = get_related_case_ids(self.domain, self.dad.case_id)
+        related_cases = get_case_and_descendants(self.domain, self.dad.case_id)
         # cases "above" this one should not be included
         self.assertItemsEqual(
-            related_ids,
+            [c.case_id for c in related_cases],
             [self.dad.case_id, self.kid.case_id, self.kid2.case_id,
              self.grandkid.case_id]
         )

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -9,7 +9,7 @@ from django.views.generic import FormView
 
 from casexml.apps.phone.restore import RestoreContent, RestoreResponse
 from casexml.apps.phone.xml import get_registration_element, get_casedb_element
-from corehq.apps.domain.decorators import domain_admin_required
+from corehq.apps.domain.decorators import domain_admin_required, mobile_auth
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import BaseDomainView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -53,7 +53,7 @@ def get_case_and_descendants(domain, case_id):
     return get_case_hierarchy(case, {})['case_list']
 
 
-@domain_admin_required
+@mobile_auth
 @WEBAPPS_CASE_MIGRATION.required_decorator()
 def migration_restore(request, domain, case_id):
     """Restore endpoint used in bulk case migrations

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -7,10 +7,10 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import FormView
 
+from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreContent, RestoreResponse
-from casexml.apps.phone.xml import get_registration_element, get_casedb_element
+from casexml.apps.phone.xml import get_registration_element, get_case_element
 from corehq.apps.domain.decorators import domain_admin_required, mobile_auth
-from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import BaseDomainView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.toggles import WEBAPPS_CASE_MIGRATION
@@ -50,7 +50,8 @@ class MigrationView(BaseMigrationView, FormView):
 def get_case_and_descendants(domain, case_id):
     from casexml.apps.case.templatetags.case_tags import get_case_hierarchy
     case = CaseAccessors(domain).get_case(case_id)
-    return get_case_hierarchy(case, {})['case_list']
+    return [c for c in get_case_hierarchy(case, {})['case_list']
+            if not c.closed]
 
 
 @mobile_auth
@@ -62,13 +63,14 @@ def migration_restore(request, domain, case_id):
     * Registration block
     * The passed in case and its full network of cases
     """
-    domain_obj = Domain.get_by_name(domain)
     restore_user = request.couch_user
 
     with RestoreContent(restore_user.username) as content:
         content.append(get_registration_element(restore_user))
         for case in get_case_and_descendants(domain, case_id):
-            content.append(get_casedb_element(case))
+            # Formplayer will be creating these cases for the first time, so
+            # include create blocks
+            content.append(get_case_element(case, ('create', 'update'), V2))
         payload = content.get_fileobj()
 
     return RestoreResponse(payload).get_http_response()

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -7,16 +7,13 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import FormView
 
-from casexml.apps.case.xml import V2
-from casexml.apps.phone.data_providers.case.clean_owners import CleanOwnerSyncPayload
-from casexml.apps.phone.restore import RestoreContent, RestoreResponse, RestoreState, RestoreParams
-from casexml.apps.phone.xml import get_registration_element
+from casexml.apps.phone.restore import RestoreContent, RestoreResponse
+from casexml.apps.phone.xml import get_registration_element, get_casedb_element
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import BaseDomainView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.toggles import WEBAPPS_CASE_MIGRATION
-from corehq.util.timer import TimingContext
 from corehq.util import reverse
 
 from .forms import MigrationForm
@@ -50,11 +47,10 @@ class MigrationView(BaseMigrationView, FormView):
         return HttpResponseRedirect(self.page_url)
 
 
-def get_related_case_ids(domain, case_id):
+def get_case_and_descendants(domain, case_id):
     from casexml.apps.case.templatetags.case_tags import get_case_hierarchy
     case = CaseAccessors(domain).get_case(case_id)
-    child_cases = {c.case_id for c in get_case_hierarchy(case, {})['case_list']}
-    return child_cases
+    return get_case_hierarchy(case, {})['case_list']
 
 
 @domain_admin_required
@@ -68,18 +64,11 @@ def migration_restore(request, domain, case_id):
     """
     domain_obj = Domain.get_by_name(domain)
     restore_user = request.couch_user
-    restore_params = RestoreParams(device_id="case_migration", version=V2)
-    restore_state = RestoreState(domain_obj, restore_user.to_ota_restore_user(domain), restore_params)
-    restore_state.start_sync()
-    timing_context = TimingContext('migration-restore-{}-{}'.format(domain, restore_user.username))
-    case_ids = get_related_case_ids(domain, case_id)
+
     with RestoreContent(restore_user.username) as content:
         content.append(get_registration_element(restore_user))
-
-        sync_payload = CleanOwnerSyncPayload(timing_context, case_ids, restore_state)
-        sync_payload.extend_response(content)
-
+        for case in get_case_and_descendants(domain, case_id):
+            content.append(get_casedb_element(case))
         payload = content.get_fileobj()
 
-    restore_state.finish_sync()
     return RestoreResponse(payload).get_http_response()


### PR DESCRIPTION
As requested by @wpride.
~~First~~Third commit makes the restore actually include the IDs specified, second commit switches auth.
@czue @proteusvacuum 