### PR TITLE
Fix field spacing in SMS settings form

### DIFF
--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -327,7 +327,6 @@ class SettingsForm(Form):
                               "}",
                 ),
                 data_bind="visible: showRestrictedSMSTimes",
-                field_class='col-md-10 col-lg-10'
             ),
             hqcrispy.FieldWithHelpBubble(
                 "send_to_duplicated_case_numbers",
@@ -542,7 +541,7 @@ class SettingsForm(Form):
         self.helper = FormHelper()
         self.helper.form_class = "form form-horizontal"
         self.helper.label_class = 'col-sm-2 col-md-2 col-lg-2'
-        self.helper.field_class = 'col-sm-2 col-md-3 col-lg-3'
+        self.helper.field_class = 'col-sm-10 col-lg-8'
         self.helper.layout = crispy.Layout(
             self.section_general,
             self.section_registration,

--- a/corehq/apps/sms/templates/sms/partials/day_time_windows.html
+++ b/corehq/apps/sms/templates/sms/partials/day_time_windows.html
@@ -4,12 +4,12 @@
     <p>
         <i class="fa fa-info-circle"></i> {{ context.explanation_text }}
     </p>
-    <table class="table table-bordered table-striped col-md-10 col-lg-10">
+    <table class="table table-bordered table-striped">
         <thead>
             <tr>
-                <th>{% trans "When the day is..." %}</th>
-                <th>{% trans "And the time is..." %}</th>
-                <th>{% trans "Action" %}</th>
+                <th class="col-sm-1">{% trans "When the day is..." %}</th>
+                <th class="col-sm-10">{% trans "And the time is..." %}</th>
+                <th class="col-sm-1">{% trans "Action" %}</th>
             </tr>
         </thead>
         <tbody data-bind="foreach: {{ context.ko_array_name }}">
@@ -31,18 +31,21 @@
                 </td>
                 <td>
                     <div class="row">
-                        <div class="controls col-lg-3" data-bind="css: { 'col-md-3': time_input_relationship() === 'BETWEEN', 'col-md-4': time_input_relationship() !== 'BETWEEN' }" style="width: auto; max-width: 150px">
+                        <div class="controls col-sm-3">
                             <select class="form-control" data-bind="value: time_input_relationship">
                                 <option value="BEFORE">{% trans "Before" %}</option>
                                 <option value="AFTER">{% trans "After" %}</option>
                                 <option value="BETWEEN">{% trans "Between" %}</option>
                             </select>
                         </div>
-                        {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'BEFORE'" input_data_bind="value: start_time" only %}
-                        <div class="col-md-1 col-lg-1 text-center" data-bind="visible: time_input_relationship() === 'BETWEEN'"><span>{% trans "and" %}</span></div>
-                        {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'AFTER'" input_data_bind="value: end_time" only %}
+                        <div class="col-sm-4" data-bind="visible: time_input_relationship() !== 'BEFORE'">
+                            {% include "sms/partials/time_picker.html" with input_data_bind="value: start_time" only %}
+                        </div>
+                        <div class="text-center col-sm-1" data-bind="visible: time_input_relationship() === 'BETWEEN'"><span>{% trans "and" %}</span></div>
+                        <div class="col-sm-4" data-bind="visible: time_input_relationship() !== 'AFTER'">
+                            {% include "sms/partials/time_picker.html" with input_data_bind="value: end_time" only %}
+                        </div>
                     </div>
-
                 </td>
                 <td><button type="button"
                             class="btn btn-danger"

--- a/corehq/apps/sms/templates/sms/partials/time_picker.html
+++ b/corehq/apps/sms/templates/sms/partials/time_picker.html
@@ -1,7 +1,6 @@
-<div class="col-md-4 col-lg-4 controls" data-bind="{{ div_data_bind|default:'' }}" style="max-width: 160px">
-    <div class="input-group bootstrap-timepicker" style="width: 100%">
+<div class="controls">
+    <div class="input-group bootstrap-timepicker">
         <input type="text" data-bind="{{ input_data_bind|default:'' }}" data-timeset="true" class="form-control" />
         <span class="input-group-addon"><i class="fa fa-clock-o"></i></span>
     </div>
 </div>
-

--- a/corehq/apps/sms/templates/sms/settings.html
+++ b/corehq/apps/sms/templates/sms/settings.html
@@ -23,6 +23,12 @@
             margin-left: 0;
             margin-right: 0;
         }
+        .form-horizontal .form-group > div .row select {
+            margin-left: 0px;
+        }
+        .controls-multiple .row div {
+            padding-left: 0px;
+        }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
The fields in the SMS settings form were a bit scrunched to the point where you couldn't read the values in the inputs. This fixes that.

@orangejenny 