### PR TITLE
Removed unnecessary strformat.

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -829,7 +829,7 @@ def send_prepaid_credits_export():
         ])
 
     date_string = datetime.datetime.utcnow().strftime(SERVER_DATE_FORMAT)
-    filename = datetime.datetime.utcnow().strftime('prepaid-credits-export_%s.csv' % date_string)
+    filename = 'prepaid-credits-export_%s.csv' % date_string
     send_HTML_email(
         'Prepaid Credits Export - %s' % date_string, settings.ACCOUNTS_EMAIL, 'See attached file.',
         file_attachments=[{'file_obj': file_obj, 'title': filename, 'mimetype': 'text/csv'}],


### PR DESCRIPTION
@nickpell noticed this in the accounting code when I was looking for examples of sending emails. Pretty sure this strftime was not doing anything