### PR TITLE
Fix bug that shows conflicting password strength messages

### DIFF
--- a/corehq/apps/registration/static/registration/js/password.js
+++ b/corehq/apps/registration/static/registration/js/password.js
@@ -23,11 +23,14 @@
                 return '';
             } else if (self.strength() < 1) {
                 return gettext("Your password is too weak! Try adding numbers or symbols!");
-            } else if (self.strength() == 1) {
+            } else if (self.strength() === 1) {
                 return gettext("Your password is almost strong enough!");
             } else {
                 return gettext("Good Job! Your password is strong!");
             }
+        });
+        self.passwordSufficient = ko.computed(function () {
+            return self.strength() > 1;
         });
     };
 

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -89,12 +89,12 @@
                         <div class="hide">
                           {{ form.errors }}
                         </div>
-                    </fieldset>
-                    <div class="form-actions">
+                        <div class="form-actions">
                         <div class="col-sm-offset-4 col-sm-4">
-                            <button type="submit" class="btn btn-primary">{% trans 'Create Account' %}</button>
+                            <button type="submit" class="btn btn-primary" data-bind="enable: passwordSufficient">{% trans 'Create Account' %}</button>
                         </div>
-                    </div>
+                        </div>
+                    </fieldset>
                 </form>
             </div>
             <div class="col-sm-4">


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?268357#1450113

There was a bug in server-side password validation, so that an error message would appear when a user typed in a weak password, but it would not disappear when they typed in a strong password.

Now, the JavaScript validator should block that message when the user types in a strong password.