### PR TITLE
limit the number of columns in case imports

### DIFF
--- a/corehq/apps/case_importer/const.py
+++ b/corehq/apps/case_importer/const.py
@@ -3,6 +3,14 @@ from django.utils.translation import ugettext_noop
 from six.moves import range
 
 
+# Each column results in 3 form fields so this must be true:
+#   num_columns * 3 < DATA_UPLOAD_MAX_NUMBER_FIELDS
+#
+# DATA_UPLOAD_MAX_NUMBER_FIELDS defaults to 1000 but there are
+# a few other fields as well. Also 300 is a nice round number.
+MAX_CASE_IMPORTER_COLUMNS = 300
+
+
 class LookupErrors:
     NotFound, MultipleResults = list(range(2))
 

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -5,6 +5,7 @@ from django.utils.datastructures import MultiValueDictKeyError
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.case_importer import base
 from corehq.apps.case_importer import util as importer_util
+from corehq.apps.case_importer.const import MAX_CASE_IMPORTER_COLUMNS
 from corehq.apps.case_importer.exceptions import ImporterError
 from django.views.decorators.http import require_POST
 from corehq.apps.case_importer.suggested_fields import get_suggested_case_fields
@@ -76,6 +77,13 @@ def excel_config(request, domain):
         return render_error(request, domain,
                             'Your spreadsheet is empty. '
                             'Please try again with a different spreadsheet.')
+
+    if len(columns) > MAX_CASE_IMPORTER_COLUMNS:
+        return render_error(request, domain,
+                            'Your spreadsheet has too many columns. '
+                            'A maximum of %(max_columns)s is supported.' % {
+                                'max_columns': MAX_CASE_IMPORTER_COLUMNS
+                            })
 
     case_types_from_apps = get_case_types_from_apps(domain)
     unrecognized_case_types = [t for t in get_case_types_for_domain_es(domain)

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -54,10 +54,11 @@ def excel_config(request, domain):
     # using the soil framework.
 
     if extension not in importer_util.ALLOWED_EXTENSIONS:
-        return render_error(request, domain,
-                            'The file you chose could not be processed. '
-                            'Please check that it is saved as a Microsoft '
-                            'Excel file.')
+        return render_error(request, domain, _(
+            'The file you chose could not be processed. '
+            'Please check that it is saved as a Microsoft '
+            'Excel file.'
+        ))
 
     # stash content in the default storage for subsequent views
     case_upload = CaseUpload.create(uploaded_file_handle,
@@ -74,29 +75,26 @@ def excel_config(request, domain):
         row_count = spreadsheet.max_row
 
     if row_count == 0:
-        return render_error(request, domain,
-                            'Your spreadsheet is empty. '
-                            'Please try again with a different spreadsheet.')
+        return render_error(request, domain, _(
+            'Your spreadsheet is empty. Please try again with a different spreadsheet.'
+        ))
 
     if len(columns) > MAX_CASE_IMPORTER_COLUMNS:
-        return render_error(request, domain,
-                            'Your spreadsheet has too many columns. '
-                            'A maximum of %(max_columns)s is supported.' % {
-                                'max_columns': MAX_CASE_IMPORTER_COLUMNS
-                            })
+        return render_error(request, domain, _(
+            'Your spreadsheet has too many columns. '
+            'A maximum of %(max_columns)s is supported.'
+        ) % {'max_columns': MAX_CASE_IMPORTER_COLUMNS})
 
     case_types_from_apps = get_case_types_from_apps(domain)
     unrecognized_case_types = [t for t in get_case_types_for_domain_es(domain)
                                if t not in case_types_from_apps]
 
     if len(case_types_from_apps) == 0 and len(unrecognized_case_types) == 0:
-        return render_error(
-            request,
-            domain,
+        return render_error(request, domain, _(
             'No cases have been submitted to this domain and there are no '
             'applications yet. You cannot import case details from an Excel '
             'file until you have existing cases or applications.'
-        )
+        ))
 
     return render(
         request,


### PR DESCRIPTION
Product Note: this limits the number of columns you can have in a case export to 300. This is linked to a [Django security setting](https://docs.djangoproject.com/en/2.0/ref/settings/#data-upload-max-number-fields). We can change this if necessary though having this many does make the UI slower and hard to work with.

https://manage.dimagi.com/default.asp?269117#1450407