### PR TITLE
Fix custom ICDS expression

### DIFF
--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from jsonobject.base_properties import DefaultProperty
 from six.moves import filter
-from six.moves import map
 
 from casexml.apps.case.xform import extract_case_blocks
 from corehq.apps.receiverwrapper.util import get_version_from_appversion_text
@@ -95,15 +94,15 @@ class GetCaseHistorySpec(JsonObject):
         for f in forms:
             case_blocks = extract_case_blocks(f)
             if case_blocks:
-                case_history.append(
-                    next(case_block for case_block in case_blocks
-                         if case_block['@case_id'] == case_id))
+                for case_block in case_blocks:
+                    if case_block['@case_id'] == case_id:
+                        case_history.append(case_block)
+
         context.set_cache_value(cache_key, case_history)
         return case_history
 
     def __str__(self):
         return "case_history(\n{cases}\n)".format(cases=add_tabbed_text(str(self._case_forms_expression)))
-
 
 
 class GetCaseHistoryByDateSpec(JsonObject):

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -87,7 +87,7 @@ class GetCaseHistorySpec(JsonObject):
         if context.get_cache_value(cache_key) is not None:
             return context.get_cache_value(cache_key)
 
-        # TODO(Sheel/Emord) looks like this is only used when getting the last
+        # TODO(Emord) looks like this is only used when getting the last
         # property update. maybe this could be optimized sort by received_on
         # and stop looking at forms once it finds the update
         case_history = []


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/348510784/

@snopoke I think this may be related to the UUID clash. This looked pretty weird, but not sure if I'm missing something.

case 298dffa9-39c1-4b2b-a0ad-5bfed7f3a66d has form f18ffc2f-7576-4cb9-9e65-5bd481be16ed in its case history, but that form doesn't actually modify that case.

Howevery the form id from before it was edited ( 9cabe9be-ee80-4ee7-9b5e-c0b09ea2596b ) does edit this case. 

Not sure if this is expected or not