### PR TITLE
send user_location_id only if one exists, otherwise will be null

### DIFF
--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -276,7 +276,7 @@
 {% block js-inline %}{% endblock js-inline %}
 <script>
     angular.module('icdsApp').constant('locationHierarchy', {{ location_hierarchy | JSON }});
-    angular.module('icdsApp').constant('userLocationId', {{ user_location_id | JSON }});
+    angular.module('icdsApp').constant('userLocationId', {% if user_location_id %}{{ user_location_id | JSON }}{% endif %});
     angular.module('icdsApp').constant('reportAnIssueUrl', {{ report_an_issue_url | JSON }});
     angular.module('icdsApp').constant('isWebUser', {{ is_web_user | JSON }});
     angular.module('icdsApp').constant('haveAccessToFeatures', {{ have_access | JSON }});


### PR DESCRIPTION
Prevent console error when selecting 'See More' on program summary at National Level and allow the map to render.