### PR TITLE
Render outer table for Excel

### DIFF
--- a/corehq/ex-submodules/couchexport/templates/couchexport/html_export.html
+++ b/corehq/ex-submodules/couchexport/templates/couchexport/html_export.html
@@ -8,6 +8,13 @@
 <body>
 {% endif %}
 
+{% if section == "outer_table_begin" %}
+    <table>
+        <tbody>
+        <tr>
+            <td>
+{% endif %}
+
 {% if section == "table_begin" %}
     <table>
 {% endif %}
@@ -39,6 +46,13 @@
 {% if section == "table_end" %}
 </tbody>
 </table>
+{% endif %}
+
+{% if section == "outer_table_end" %}
+            </td>
+        </tr>
+        </tbody>
+    </table>
 {% endif %}
 
 {% if section == "doc_end" %}

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -503,13 +503,18 @@ class HtmlExportWriter(OnDiskExportWriter):
                 ).encode("utf-8")
             )
 
+        multiple_tables = len(self.table_names) > 1
         write({"section": "doc_begin"})
+        if multiple_tables:
+            write({"section": "outer_table_begin"})
         for index, name in self.table_names.items():
             table_writer = self.tables[index]
             write({"section": "table_begin", "name": name})
             for line in table_writer.get_file():
                 self.file.write(line)
             write({"section": "table_end"})
+        if multiple_tables:
+            write({"section": "outer_table_end"})
         write({"section": "doc_end"})
 
         self.file.seek(0)


### PR DESCRIPTION
Context: [FB 268720](https://manage.dimagi.com/default.asp?268720)

If an Excel dashboard has multiple tables, some (all? one?) versions of Excel do not allow the user to choose only the first table. Rather it lets them choose all of them, or individual tables from the second one onwards.

By wrapping the tables in an outer table, Excel lets the user choose the outer table or any of the inner tables, including the first one.

I chose to create an outer table instead of an empty first table because I hoped this approach would be better supported by existing and future versions of Excel.

Labelling "Hold off on merge" because we don't yet know whether this change will affect existing (if any) projects that have Excel dashboards with multiple tables.
