### PR TITLE
Show All Scheduled Reports (Fix)

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -45,17 +45,8 @@ hqDefine('hqwebapp/js/multiselect_utils', function () {
         multiselectId,
         selectableHeaderTitle,
         selectedHeaderTitle,
-        searchItemTitle,
-        isOwner
+        searchItemTitle
     ) {
-        if (!isOwner) {
-            $('#' + multiselectId).hide().after(
-                $('#' + multiselectId).children().map(function () {
-                    return $("<div>").text($(this).text()).get(0);
-                })
-            );
-            return;
-        }
         var selectAllId = multiselectId + '-select-all',
             removeAllId = multiselectId + '-remove-all',
             searchSelectableId = multiselectId + '-search-selectable',

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -45,8 +45,17 @@ hqDefine('hqwebapp/js/multiselect_utils', function () {
         multiselectId,
         selectableHeaderTitle,
         selectedHeaderTitle,
-        searchItemTitle
+        searchItemTitle,
+        isOwner
     ) {
+        if (!isOwner) {
+            $('#' + multiselectId).hide().after(
+                $('#' + multiselectId).children().map(function () {
+                    return $("<div>").text($(this).text()).get(0);
+                })
+            );
+            return;
+        }
         var selectAllId = multiselectId + '-select-all',
             removeAllId = multiselectId + '-remove-all',
             searchSelectableId = multiselectId + '-search-selectable',

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -126,7 +126,7 @@ class ScheduledReportForm(forms.Form):
         choices=ReportNotification.hour_choices())
 
     send_to_owner = forms.BooleanField(
-        label='Send to me',
+        label='Send to owner',
         required=False)
 
     attach_excel = forms.BooleanField(

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -92,14 +92,22 @@ hqDefine("reports/js/edit_scheduled_report", function() {
     $("#id_config_ids").change(function(){
         updateUcrElements($(this).val());
     });
-    var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
-    multiselect_utils.createFullMultiselectWidget(
-        'id_config_ids',
-        django.gettext("Available Reports"),
-        django.gettext("Included Reports"),
-        django.gettext("Search Reports..."),
-        isOwner
-    );
+    if (!isOwner) {
+        $('#id_config_ids').hide().after(
+            $('#id_config_ids').children().map(function () {
+                return $("<div>").text($(this).text()).get(0);
+            })
+        );
+    }
+    else {
+        var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
+        multiselect_utils.createFullMultiselectWidget(
+            'id_config_ids',
+            django.gettext("Available Reports"),
+            django.gettext("Included Reports"),
+            django.gettext("Search Reports...")
+        );
+    }
     updateUcrElements($("#id_config_ids").val());
 
     var scheduled_report_form_helper = new ScheduledReportFormHelper({

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -45,6 +45,7 @@ hqDefine("reports/js/edit_scheduled_report", function() {
     var isConfigurableMap = initial_page_data('is_configurable_map');
     var languagesMap = initial_page_data('languages_map');
     var languagesForSelect = initial_page_data('languages_for_select');
+    var isOwner = initial_page_data('is_owner');
 
     var updateUcrElements = function(selectedConfigs){
         var showUcrElements = _.any(
@@ -96,7 +97,8 @@ hqDefine("reports/js/edit_scheduled_report", function() {
         'id_config_ids',
         django.gettext("Available Reports"),
         django.gettext("Included Reports"),
-        django.gettext("Search Reports...")
+        django.gettext("Search Reports..."),
+        isOwner
     );
     updateUcrElements($("#id_config_ids").val());
 

--- a/corehq/apps/reports/templates/reports/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/edit_scheduled_report.html
@@ -15,6 +15,7 @@
     {% initial_page_data 'weekly_day_options' weekly_day_options %}
     {% initial_page_data 'monthly_day_options' monthly_day_options %}
     {% initial_page_data 'day_value' day_value %}
+    {% initial_page_data 'is_owner' is_owner %}
     <div class="row">
         <div class="col-sm-12">
             {% if form %}

--- a/corehq/apps/reports/templates/reports/partials/scheduled_reports_table.html
+++ b/corehq/apps/reports/templates/reports/partials/scheduled_reports_table.html
@@ -1,0 +1,140 @@
+{% load case_tags %}
+{% load hq_shared_tags %}
+{% load i18n %}
+{% load report_tags %}
+{% load compress %}
+{% if scheduled_reports %}
+<table class="table table-striped table-bordered">
+    <thead>
+        <tr>
+            {% if not is_owner %}
+            <th>{% trans "Owner" %}</th>
+            {% endif %}
+            <th>{% trans "Saved Reports" %}</th>
+            <th>{% trans "Day and Time" %}</th>
+            <th>{% trans "Recipients" %}</th>
+            <th>{% trans "Actions" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for report in scheduled_reports %}
+        <tr>
+            {% if not is_owner %}
+            <td>
+                {{ report.owner_email }}
+            </td>
+            {% endif %}
+            <td>
+                {% if report.configs|length == 1 %}
+                {% for config in report.configs %}
+                <a href="{{ config.url }}">{{ config.full_name }}</a>
+                {% endfor %}
+                {% else %}
+                <ul style="float: left">
+                    {% for config in report.configs %}
+                    <li><a href="{{ config.url }}">{{ config.full_name }}</a></li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </td>
+            <td>{{ report.day_name }} at {{ report.hour }}:00</td>
+            <td>
+                {# handles old documents #}
+                {% if is_owner %}
+                {% if report.user_ids or report.send_to_owner %}
+                {% trans "me" %}{% if report.recipient_emails %},{% endif %}
+                {% endif %}
+                {% for email in report.recipient_emails %}
+                {{ email }}{% if email != report.recipient_emails|last %},{% endif %}
+                {% endfor %}
+                {% else %}
+                {% if not is_admin %}
+                {% trans "me (and others)" %}
+                {% else %}
+                {% if report.user_ids or report.send_to_owner %}
+                {{ report.owner_email }}{% if report.recipient_emails %},{% endif %}
+                {% endif %}
+                {% for email in report.recipient_emails %}
+                {% if user_email == email %}{% trans "me" %}{% else %}{{ email }}{% endif %}{% if email != report.recipient_emails|last %},{% endif %}
+                {% endfor %}
+                {% endif %}
+                {% endif %}
+            </td>
+
+            <td>
+                <div class="btn-toolbar">
+
+                    <div class="btn-group">
+                        {% if not report.is_editable or not is_owner and not is_admin %}
+                            <button type="button" class="btn btn-info disabled" disabled="disabled">
+                                <i class="fa fa-edit"></i> {% trans "Edit" %}
+                            </button>
+                        {% else %}
+                            <a class="btn btn-info"
+                                href="{% url "edit_scheduled_report" domain report.get_id %}">
+                                <i class="fa fa-edit"></i> {% trans "Edit" %}
+                            </a>
+                        {% endif %}
+                    </div>
+
+                    <div class="btn-group">
+                        <a class="btn btn-info" href="{% url "view_scheduled_report" domain report.get_id %}">
+                            <i class="fa fa-eye-open"></i> {% trans "View" %}
+                        </a>
+
+                        {% if not is_owner and not is_admin %}
+                            <button type="button" class="btn btn-info disabled" disabled="disabled">
+                                <i class="fa fa-envelope"></i> {% trans "Send Test" %}
+                            </button>
+                        {% else %}
+                            <a class="btn btn-info" href="{% url "send_test_scheduled_report" domain report.get_id %}">
+                                <i class="fa fa-envelope"></i> {% trans "Send Test" %}
+                            </a>
+                        {% endif %}
+                    </div>
+
+                    <div class="btn-group">
+                        {% if not is_owner and not is_admin %}
+                            <button type="button" class="btn btn-info disabled" disabled="disabled">
+                                <i class="fa fa-trash"></i> {% trans "Delete" %}
+                            </button>
+                        {% else %}
+                            <button class="btn btn-danger" data-toggle="modal" href="#delete_{{ report.get_id }}">
+                                <i class="fa fa-trash"></i> {% trans "Delete" %}
+                            </button>
+                        {% endif %}
+                    </div>
+                </div>
+                <div id="delete_{{ report.get_id }}"
+                     class="modal fade">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title">{% trans "Stop sending report?" %}</h4>
+                            </div>
+                            <form action="{% url "delete_scheduled_report" domain report.get_id %}" method="post">
+                                {% csrf_token %}
+                                <div class="modal-body">
+                                    <p>{% trans "Are you sure you want to stop sending this report?" %}</p>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</button>
+                                    <button type="submit" class="send-stopper btn btn-danger disable-on-submit">{% trans 'Stop Sending' %}</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+
+        {% endfor %}
+    </tbody>
+</table>
+{% if not is_owner and extra_reports %}
+<a href="?show_all_scheduled_reports=true">
+    {% trans "...and" %} {{ extra_reports }} {% trans "more" %}
+</a>
+{% endif %}
+{% endif %}

--- a/corehq/apps/reports/templates/reports/reports_home.html
+++ b/corehq/apps/reports/templates/reports/reports_home.html
@@ -79,104 +79,13 @@
             <i class="fa fa-plus"></i>
             {% trans "Create a New Scheduled Report" %}
         </a></p>
-        {% if scheduled_reports %}
-        <table class="table table-striped table-bordered">
-            <thead>
-                <tr>
-                    <th>{% trans "Saved Reports" %}</th>
-                    <th>{% trans "Day and Time" %}</th>
-                    <th>{% trans "Recipients" %}</th>
-                    <th>{% trans "Actions" %}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for report in scheduled_reports %}
-                <tr>
-                    <td>
-                        {% if report.configs|length == 1 %}
-                        {% for config in report.configs %}
-                        <a href="{{ config.url }}">{{ config.full_name }}</a>
-                        {% endfor %}
-                        {% else %}
-                        <ul style="float: left">
-                            {% for config in report.configs %}
-                            <li><a href="{{ config.url }}">{{ config.full_name }}</a></li>
-                            {% endfor %}
-                        </ul>
-                        {% endif %}
-                    </td>
-                    <td>{{ report.day_name }} at {{ report.hour }}:00</td>
-                    <td>
-                        {# handles old documents #}
-                        {% if report.user_ids or report.send_to_owner %}
-                        {% trans "me" %}{% if report.recipient_emails %}, {% endif %}
-                        {% endif %}
-                        {% for email in report.recipient_emails %}
-                        {{ email }},
-                        {% endfor %}
-                    </td>
-
-                    <td>
-                        <div class="btn-toolbar">
-
-                            <div class="btn-group">
-                                {% if report.is_editable %}
-                                    <a class="btn btn-info"
-                                        href="{% url "edit_scheduled_report" domain report.get_id %}">
-                                        <i class="fa fa-edit"></i> {% trans "Edit" %}
-                                    </a>
-                                {% else %}
-                                    <button type="button" class="btn btn-info disabled" disabled="disabled">
-                                        <i class="fa fa-edit"></i> {% trans "Edit" %}
-                                    </button>
-                                {% endif %}
-                            </div>
-
-                            <div class="btn-group">
-                                <a class="btn btn-info" href="{% url "view_scheduled_report" domain report.get_id %}">
-                                    <i class="fa fa-eye-open"></i> {% trans "View" %}
-                                </a>
-
-                                <a class="btn btn-info" href="{% url "send_test_scheduled_report" domain report.get_id %}">
-                                    <i class="fa fa-envelope"></i> {% trans "Send Test" %}
-                                </a>
-                            </div>
-
-                            <div class="btn-group">
-                                <button class="btn btn-danger" data-toggle="modal" href="#delete_{{ report.get_id }}">
-                                    <i class="fa fa-trash"></i> {% trans "Delete" %}
-                                </button>
-                            </div>
-                        </div>
-                        <div id="delete_{{ report.get_id }}"
-                             class="modal fade">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                                        <h4 class="modal-title">{% trans "Stop sending report?" %}</h4>
-                                    </div>
-                                    <form action="{% url "delete_scheduled_report" domain report.get_id %}" method="post">
-                                        {% csrf_token %}
-                                        <div class="modal-body">
-                                            <p>{% trans "Are you sure you want to stop sending this report?" %}</p>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="button" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</button>
-                                            <button type="submit" class="send-stopper btn btn-danger disable-on-submit">{% trans 'Stop Sending' %}</button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-
-                {% endfor %}
-            </tbody>
-        </table>
+        {% if scheduled_reports or others_scheduled_reports %}
+        {% include 'reports/partials/scheduled_reports_table.html' with is_owner=True scheduled_reports=scheduled_reports %}
+        {% if others_scheduled_reports %}
+        <h3>Other Scheduled Reports (managed by others)</h3>
+        {% include 'reports/partials/scheduled_reports_table.html' with is_owner=False scheduled_reports=others_scheduled_reports %}
+        {% endif %}
         {% else %}
-
         <div class="alert alert-info">
             {% blocktrans %}
                 You don't have any scheduled reports.  You can create a scheduled

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1482,3 +1482,11 @@ LOCATION_SEARCH = StaticToggle(
     TAG_PRODUCT,
     [NAMESPACE_DOMAIN],
 )
+
+SHOW_ALL_SCHEDULED_REPORT_EMAILS = StaticToggle(
+    'show_all_scheduled_report_emails',
+    "In the 'My Scheduled Reports' tab, show all reports the user is part of (if the user is an "
+    "admin, show all in the current project)",
+    TAG_PRODUCT,
+    [NAMESPACE_USER],
+)


### PR DESCRIPTION
Fixes pull request that allows users to see all scheduled reports in their domain if they are an admin, otherwise they see all scheduled reports they are a part of.

The issue was in multiselect_utils.js, when it was assumed that it was only used for the page when a user edits a report. The code change has been moved to not interfere with other functions.

Original PR: https://github.com/dimagi/commcare-hq/pull/19229

Revert PR: https://github.com/dimagi/commcare-hq/pull/19253

@dannyroberts