### PR TITLE
add episode ids to notification reports

### DIFF
--- a/custom/enikshay/ucr/reports/tb_notification_register_2b.json
+++ b/custom/enikshay/ucr/reports/tb_notification_register_2b.json
@@ -858,6 +858,17 @@
                 "calculate_total": false,
                 "type": "field",
                 "display": "Treatment Supporter Details - Designation"
+            },
+            {
+                "sortable": false,
+                "description": null,
+                "format": "default",
+                "transform": {},
+                "aggregation": "simple",
+                "field": "doc_id",
+                "calculate_total": false,
+                "type": "field",
+                "display": "source_doc_id"
             }
         ]
     }

--- a/custom/enikshay/ucr/reports/tb_notification_register_private.json
+++ b/custom/enikshay/ucr/reports/tb_notification_register_private.json
@@ -739,6 +739,17 @@
                 "calculate_total": false,
                 "type": "field",
                 "display": "eNikshay External ID"
+            },
+            {
+                "sortable": false,
+                "description": null,
+                "format": "default",
+                "transform": {},
+                "aggregation": "simple",
+                "field": "doc_id",
+                "calculate_total": false,
+                "type": "field",
+                "display": "source_doc_id"
             }
         ]
     }


### PR DESCRIPTION
add episode ids which is the source doc id to reports to map the episode belonging to each record in that report. Useful for tracking/retriggering notifications