### PR TITLE
Add regex validation option to custom fields

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 from collections import OrderedDict
+from django.core.validators import RegexValidator
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django import forms
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Div, HTML, Field
-from corehq.apps.hqwebapp.fields import RegexField
 from corehq.apps.hqwebapp.widgets import Select2MultipleChoiceWidget
 
 from dimagi.utils.decorators.memoized import memoized
@@ -88,8 +88,9 @@ class CustomDataEditor(object):
 
     def _make_field(self, field):
         if field.regex:
-            return RegexField(field.regex, field.regex_msg, label=field.label,
-                              required=field.is_required)
+            validator = RegexValidator(field.regex, field.regex_msg)
+            return forms.CharField(label=field.label, required=field.is_required,
+                                   validators=[validator])
         elif field.choices:
             if not field.is_multiple_choice:
                 choice_field = forms.ChoiceField(

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -6,6 +6,7 @@ from django import forms
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Div, HTML, Field
+from corehq.apps.hqwebapp.fields import RegexField
 from corehq.apps.hqwebapp.widgets import Select2MultipleChoiceWidget
 
 from dimagi.utils.decorators.memoized import memoized
@@ -86,7 +87,10 @@ class CustomDataEditor(object):
         return dict(cleaned_data, **system_data)
 
     def _make_field(self, field):
-        if field.choices:
+        if field.regex:
+            return RegexField(field.regex, field.regex_msg, label=field.label,
+                              required=field.is_required)
+        elif field.choices:
             if not field.is_multiple_choice:
                 choice_field = forms.ChoiceField(
                     label=field.label,
@@ -101,7 +105,8 @@ class CustomDataEditor(object):
                     widget=Select2MultipleChoiceWidget
                 )
             return choice_field
-        return forms.CharField(label=field.label, required=field.is_required)
+        else:
+            return forms.CharField(label=field.label, required=field.is_required)
 
     @property
     @memoized

--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -4,6 +4,7 @@ import json
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, validate_slug
+from django.shortcuts import redirect
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django import forms
 from corehq.apps.hqwebapp.decorators import use_jquery_ui
@@ -193,7 +194,7 @@ class CustomDataModelMixin(object):
                 six.text_type(self.entity_string)
             )
             messages.success(request, msg)
-            return self.get(request, success=True, *args, **kwargs)
+            return redirect(self.urlname, self.domain)
         else:
             return self.get(request, *args, **kwargs)
 

--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import json
+import re
 
 from django.contrib import messages
 from django.core.exceptions import ValidationError
@@ -93,6 +94,15 @@ class CustomDataFieldForm(forms.Form):
 
     def clean_choices(self):
         return self._raw_choices
+
+    def clean_regex(self):
+        regex = self.cleaned_data.get('regex')
+        if regex:
+            try:
+                re.compile(regex)
+            except Exception:
+                raise ValidationError(_("Not a valid regular expression"))
+        return regex
 
 
 class CustomDataModelMixin(object):

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import re
 from dimagi.ext.couchdbkit import (Document, StringProperty,
     BooleanProperty, SchemaListProperty, StringListProperty)
 from dimagi.ext.jsonobject import JsonObject
@@ -92,6 +93,11 @@ class CustomDataFieldsDefinition(Document):
                     options=', '.join(field.choices),
                 )
 
+        def validate_regex(field, value):
+            if field.regex and value and not re.search(field.regex, value):
+                return _("'{value}' is not a valid match for {slug}").format(
+                    value=value, slug=field.slug)
+
         def validate_required(field, value):
             if field.is_required and not value:
                 return _(
@@ -108,6 +114,7 @@ class CustomDataFieldsDefinition(Document):
                 value = custom_fields.get(field.slug, None)
                 errors.append(validate_required(field, value))
                 errors.append(validate_choices(field, value))
+                errors.append(validate_regex(field, value))
             return ' '.join(filter(None, errors))
 
         return validate_custom_fields

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -42,6 +42,8 @@ class CustomDataField(JsonObject):
     is_required = BooleanProperty()
     label = StringProperty()
     choices = StringListProperty()
+    regex = StringProperty()
+    regex_msg = StringProperty()
     is_multiple_choice = BooleanProperty(default=False)
     # Currently only relevant for location fields
     index_in_fixture = BooleanProperty(default=False)

--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -17,25 +17,11 @@ function CustomDataField () {
     self.index_in_fixture = ko.observable();
 
     self.addChoice = function () {
-        self.validationMode('choice');
         self.choices.unshift(new Choice());
     };
 
     self.removeChoice = function (choice) {
         self.choices.remove(choice);
-        if (self.choices().length === 0) {
-            self.validationMode(undefined);
-        }
-    };
-
-    self.addRegex = function () {
-        self.validationMode('regex');
-    };
-
-    self.removeRegex = function () {
-        self.validationMode(undefined);
-        self.regex(undefined);
-        self.regex_msg(undefined);
     };
 
     self.init = function (field) {

--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -16,6 +16,11 @@ function CustomDataField () {
     self.regex_msg = ko.observable();
     self.index_in_fixture = ko.observable();
 
+    if (!hqImport('hqwebapp/js/toggles').toggleEnabled('REGEX_FIELD_VALIDATION')) {
+        // if toggle isn't enabled - always show "choice" option
+        self.validationMode('choice');
+    }
+
     self.addChoice = function () {
         self.choices.unshift(new Choice());
     };

--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -10,25 +10,49 @@ function CustomDataField () {
     self.label = ko.observable();
     self.is_required = ko.observable();
     self.choices = ko.observableArray();
-    self.multipleChoice = ko.observable();
+    self.validationMode = ko.observable(); // 'choice' or 'regex'
+    self.multiple_choice = ko.observable();
+    self.regex = ko.observable();
+    self.regex_msg = ko.observable();
     self.index_in_fixture = ko.observable();
 
     self.addChoice = function () {
+        self.validationMode('choice');
         self.choices.unshift(new Choice());
     };
 
     self.removeChoice = function (choice) {
         self.choices.remove(choice);
+        if (self.choices().length === 0) {
+            self.validationMode(undefined);
+        }
+    };
+
+    self.addRegex = function () {
+        self.validationMode('regex');
+    };
+
+    self.removeRegex = function () {
+        self.validationMode(undefined);
+        self.regex(undefined);
+        self.regex_msg(undefined);
     };
 
     self.init = function (field) {
         self.slug(field.slug);
         self.label(field.label);
         self.is_required(field.is_required);
-        self.choices(field.choices.map(function (choice) {
-            return new Choice(choice);
-        }));
-        self.multipleChoice(field.is_multiple_choice);
+        if (field.choices.length > 0) {
+            self.validationMode('choice');
+            self.choices(field.choices.map(function (choice) {
+                return new Choice(choice);
+            }));
+        } else if (field.regex) {
+            self.validationMode('regex');
+            self.regex(field.regex);
+            self.regex_msg(field.regex_msg);
+        }
+        self.multiple_choice(field.is_multiple_choice);
         self.index_in_fixture(field.index_in_fixture);
     };
 
@@ -45,13 +69,18 @@ function CustomDataField () {
         _.each(choicesToRemove, function (choice) {
             self.removeChoice(choice);
         });
+        if (!self.regex()) {
+            self.removeRegex();
+        }
 
         return {
             'slug': self.slug(),
             'label': self.label(),
             'is_required': self.is_required(),
             'choices': choices,
-            'is_multiple_choice': self.multipleChoice(),
+            'regex': self.regex(),
+            'regex_msg': self.regex_msg(),
+            'is_multiple_choice': self.multiple_choice(),
             'index_in_fixture': self.index_in_fixture(),
         };
     };

--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -43,20 +43,26 @@ function CustomDataField () {
     };
 
     self.serialize = function () {
-        var choices = [];
-        var choicesToRemove = [];
-        _.each(self.choices(), function (choice) {
-            if (choice.value()) {
-                choices.push(choice.value());
-            } else {
-                choicesToRemove.push(choice);
-            }
-        });
-        _.each(choicesToRemove, function (choice) {
-            self.removeChoice(choice);
-        });
-        if (!self.regex()) {
-            self.removeRegex();
+        var choices = [],
+            is_multiple_choice = null,
+            regex = null,
+            regex_msg = null;
+        if (self.validationMode() === 'choice') {
+            var choicesToRemove = [];
+            _.each(self.choices(), function (choice) {
+                if (choice.value()) {
+                    choices.push(choice.value());
+                } else {
+                    choicesToRemove.push(choice);
+                }
+            });
+            _.each(choicesToRemove, function (choice) {
+                self.removeChoice(choice);
+            });
+            is_multiple_choice = self.multiple_choice();
+        } else if (self.validationMode() === 'regex') {
+            regex = self.regex();
+            regex_msg = self.regex_msg();
         }
 
         return {
@@ -64,9 +70,9 @@ function CustomDataField () {
             'label': self.label(),
             'is_required': self.is_required(),
             'choices': choices,
-            'regex': self.regex(),
-            'regex_msg': self.regex_msg(),
-            'is_multiple_choice': self.multiple_choice(),
+            'regex': regex,
+            'regex_msg': regex_msg,
+            'is_multiple_choice': is_multiple_choice,
             'index_in_fixture': self.index_in_fixture(),
         };
     };

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -34,8 +34,11 @@
 {% block stylesheets %}
 {{ block.super }}
     <style>
-        ul.choices-list > li {
+        ul.validation-list > li {
             padding-top: 5px;
+        }
+        .validation-options {
+            padding-bottom: 5px;
         }
     </style>
 {% endblock %}
@@ -191,8 +194,8 @@
                                                         <input class="form-control" type="text" data-bind="value: value"/>
                                                         <div class="input-group-btn">
                                                             <a type="button"
-                                                                class="btn btn-danger"
-                                                                data-bind="click: $parent.removeChoice">
+                                                               class="btn btn-danger"
+                                                               data-bind="click: $parent.removeChoice">
                                                                 <i class="fa fa-times"></i>
                                                             </a>
                                                         </div>

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -156,9 +156,20 @@
                                         <input type="checkbox" data-bind="checked: is_required"/>
                                     </td>
                                     <td>
-                                        <a data-bind="click: addChoice" type="button" class="btn btn-primary" >
+
+                                        <button data-bind="enable: !validationMode() || validationMode() === 'choice',
+                                                           click: addChoice"
+                                                type="button" class="btn btn-primary" >
                                             <i class="fa fa-plus"></i> {% trans "Add Choice" %}
-                                        </a>
+                                        </button>
+
+                                        {% if request|toggle_enabled:"REGEX_FIELD_VALIDATION" %}
+                                        <button data-bind="enable: !validationMode(), click: addRegex"
+                                                type="button" class="btn btn-primary" >
+                                            <i class="fa fa-plus"></i> {% trans "Add Regex" %}
+                                        </button>
+                                        {% endif %}
+
                                         <ul data-bind="sortable: choices" class="list-unstyled choices-list">
                                             <li data-bind="attr: {'data-order': _sortableOrder}">
                                                 <div class="input-group">
@@ -168,16 +179,29 @@
                                                         <a type="button"
                                                            class="btn btn-danger"
                                                            data-bind="click: $parent.removeChoice">
-                                                            &times;
+                                                            <i class="fa fa-times"></i>
                                                         </a>
                                                     </div>
                                                  </div>
                                             </li>
                                         </ul>
+
+                                        {% if request|toggle_enabled:"REGEX_FIELD_VALIDATION" %}
+                                        <div data-bind="visible: validationMode() === 'regex'">
+                                            <input data-bind="value: regex" class="form-control" type="text"
+                                                   placeholder="{% trans "Regular Expression" %}"/>
+                                            <input data-bind="value: regex_msg" class="form-control" type="text"
+                                                   placeholder="{% trans "Validation Message" %}"/>
+                                            <a data-bind="click: removeRegex" type="button" class="btn btn-danger">
+                                                <i class="fa fa-times"></i> {% trans "Remove Regex" %}
+                                            </a>
+                                        </div>
+                                        {% endif %}
+
                                         {% if request|toggle_enabled:"MULTIPLE_CHOICE_CUSTOM_FIELD" %}
                                             <span data-bind="visible: choices().length !== 0">
                                                 <label style="display: inline" for="multipleChoice">{% trans 'Multiple choice' %}: </label>
-                                                <input data-bind="checked: multipleChoice" id="multipleChoice" type="checkbox"/>
+                                                <input data-bind="checked: multiple_choice" id="multipleChoice" type="checkbox"/>
                                             </span>
                                         {% endif %}
                                     </td>

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -113,9 +113,9 @@
                                         </span>
                                     </th>
                                     <th class="col-sm-3">
-                                        {% trans "Choices" %}
+                                        {% trans "Validation" %}
                                         <span class="hq-help-template"
-                                              data-title="{% trans "Choices" %}"
+                                              data-title="{% trans "Validation" %}"
                                               data-content="{% blocktrans %}
                                                   Provides a drop-down list of choices for this field
                                                   instead of free text entry.
@@ -157,45 +157,59 @@
                                     </td>
                                     <td>
 
-                                        <button data-bind="enable: !validationMode() || validationMode() === 'choice',
-                                                           click: addChoice"
-                                                type="button" class="btn btn-primary" >
-                                            <i class="fa fa-plus"></i> {% trans "Add Choice" %}
-                                        </button>
-
                                         {% if request|toggle_enabled:"REGEX_FIELD_VALIDATION" %}
-                                        <button data-bind="enable: !validationMode(), click: addRegex"
-                                                type="button" class="btn btn-primary" >
-                                            <i class="fa fa-plus"></i> {% trans "Add Regex" %}
-                                        </button>
+                                        <div class="btn-group validation-options">
+                                            <div data-bind="css: {active: !validationMode()},
+                                                            click: function () {validationMode(undefined)}"
+                                                 class="btn btn-default">
+                                                {% trans "None" %}
+                                            </div>
+                                            <div data-bind="css: {active: validationMode() === 'choice'},
+                                                            click: function () {validationMode('choice')}"
+                                                 class="btn btn-default">
+                                                {% trans "Choices" %}
+                                            </div>
+                                            <div data-bind="css: {active: validationMode() === 'regex'},
+                                                            click: function () {validationMode('regex')}"
+                                                 class="btn btn-default">
+                                                {% trans "Regex" %}
+                                            </div>
+                                        </div>
                                         {% endif %}
 
-                                        <ul data-bind="sortable: choices" class="list-unstyled choices-list">
-                                            <li data-bind="attr: {'data-order': _sortableOrder}">
-                                                <div class="input-group">
-                                                    <span class="input-group-addon"><i class="fa fa-sort sortable-handle"></i></span>
-                                                    <input class="form-control" type="text" data-bind="value: value"/>
-                                                    <div class="input-group-btn">
-                                                        <a type="button"
-                                                           class="btn btn-danger"
-                                                           data-bind="click: $parent.removeChoice">
-                                                            <i class="fa fa-times"></i>
-                                                        </a>
+                                        <div data-bind="visible: validationMode() === 'choice'">
+
+                                            <button data-bind="click: addChoice"
+                                                    type="button" class="btn btn-primary" >
+                                                <i class="fa fa-plus"></i> {% trans "Add Choice" %}
+                                            </button>
+
+                                            <ul data-bind="sortable: choices" class="list-unstyled validation-list">
+                                                <li data-bind="attr: {'data-order': _sortableOrder}">
+                                                    <div class="input-group">
+                                                        <span class="input-group-addon"><i class="fa fa-sort sortable-handle"></i></span>
+                                                        <input class="form-control" type="text" data-bind="value: value"/>
+                                                        <div class="input-group-btn">
+                                                            <a type="button"
+                                                                class="btn btn-danger"
+                                                                data-bind="click: $parent.removeChoice">
+                                                                <i class="fa fa-times"></i>
+                                                            </a>
+                                                        </div>
                                                     </div>
-                                                 </div>
-                                            </li>
-                                        </ul>
+                                                </li>
+                                            </ul>
+
+                                        </div>
 
                                         {% if request|toggle_enabled:"REGEX_FIELD_VALIDATION" %}
-                                        <div data-bind="visible: validationMode() === 'regex'">
-                                            <input data-bind="value: regex" class="form-control" type="text"
-                                                   placeholder="{% trans "Regular Expression" %}"/>
-                                            <input data-bind="value: regex_msg" class="form-control" type="text"
-                                                   placeholder="{% trans "Validation Message" %}"/>
-                                            <a data-bind="click: removeRegex" type="button" class="btn btn-danger">
-                                                <i class="fa fa-times"></i> {% trans "Remove Regex" %}
-                                            </a>
-                                        </div>
+                                        <ul data-bind="visible: validationMode() === 'regex'"
+                                            class="list-unstyled validation-list">
+                                            <li><input data-bind="value: regex" class="form-control" type="text"
+                                                       placeholder="{% trans "Regular Expression" %}"/></li>
+                                            <li><input data-bind="value: regex_msg" class="form-control" type="text"
+                                                       placeholder="{% trans "Validation Message" %}"/></li>
+                                        </ul>
                                         {% endif %}
 
                                         {% if request|toggle_enabled:"MULTIPLE_CHOICE_CUSTOM_FIELD" %}

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -116,14 +116,28 @@
                                         </span>
                                     </th>
                                     <th class="col-sm-3">
-                                        {% trans "Validation" %}
-                                        <span class="hq-help-template"
-                                              data-title="{% trans "Validation" %}"
-                                              data-content="{% blocktrans %}
-                                                  Provides a drop-down list of choices for this field
-                                                  instead of free text entry.
-                                              {% endblocktrans %}">
-                                        </span>
+                                        {% if request|toggle_enabled:"REGEX_FIELD_VALIDATION" %}
+                                            {% trans "Validation" %}
+                                            <span class="hq-help-template"
+                                                data-title="{% trans "Validation" %}"
+                                                data-content="{% blocktrans %}
+                                                    Specify a means of validating user input to this field.
+                                                    You can provide a drop-down list of choices or specify
+                                                    a regular expression to be applied to the input. For
+                                                    example, ^[1-9]{10}$ will match only 10 character
+                                                    numeric input.
+                                                {% endblocktrans %}">
+                                            </span>
+                                        {% else %}
+                                            {% trans "Choices" %}
+                                            <span class="hq-help-template"
+                                                data-title="{% trans "Choices" %}"
+                                                data-content="{% blocktrans %}
+                                                    Provides a drop-down list of choices for this field
+                                                    instead of free text entry.
+                                                {% endblocktrans %}">
+                                            </span>
+                                        {% endif %}
                                     </th>
                                     {% if show_index_in_fixture %}
                                     <th class="col-sm-1">

--- a/corehq/apps/hqwebapp/fields.py
+++ b/corehq/apps/hqwebapp/fields.py
@@ -72,3 +72,16 @@ class MultiEmailField(MultiCharField):
     default_error_messages = {
         'invalid': 'Please enter only valid email addresses.'
     }
+
+
+class RegexField(fields.RegexField):
+    def __init__(self, regex, message, *args, **kwargs):
+        self.raw_regex = regex
+        self.message = message
+        super(RegexField, self).__init__(regex, *args, **kwargs)
+
+    def widget_attrs(self, widget):
+        attrs = super(RegexField, self).widget_attrs(widget)
+        attrs['pattern'] = self.raw_regex
+        attrs['title'] = self.message
+        return attrs

--- a/corehq/apps/hqwebapp/fields.py
+++ b/corehq/apps/hqwebapp/fields.py
@@ -72,16 +72,3 @@ class MultiEmailField(MultiCharField):
     default_error_messages = {
         'invalid': 'Please enter only valid email addresses.'
     }
-
-
-class RegexField(fields.RegexField):
-    def __init__(self, regex, message, *args, **kwargs):
-        self.raw_regex = regex
-        self.message = message
-        super(RegexField, self).__init__(regex, *args, **kwargs)
-
-    def widget_attrs(self, widget):
-        attrs = super(RegexField, self).widget_attrs(widget)
-        attrs['pattern'] = self.raw_regex
-        attrs['title'] = self.message
-        return attrs

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1426,6 +1426,13 @@ BULK_UPLOAD_DATE_OPENED = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+REGEX_FIELD_VALIDATION = StaticToggle(
+    'regex_field_validation',
+    'Enable regex validation for custom data fields',
+    TAG_SOLUTIONS,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 ICDS_LIVEQUERY = PredictablyRandomToggle(
     'icds_livequery',
     'ICDS: Enable livequery case sync for a random subset of ICDS users',


### PR DESCRIPTION
@czue @proteusvacuum
https://trello.com/c/Q6G5pVSI/291-validate-phone-numbers-in-user-details

![image](https://user-images.githubusercontent.com/2367539/35542026-e79a73cc-052b-11e8-90e1-419340ac83e4.png)

edit: after soliciting input from @orangejenny , I switched the UI to look like this:
![image](https://user-images.githubusercontent.com/2367539/35595365-795db18a-05e4-11e8-83bb-dd4139a8c647.png)