### PR TITLE
Revert "Use search string query for case searches"

### DIFF
--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -80,7 +80,8 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             query = query.OR(self.scope_filter())
 
         search_string = CaseSearchFilter.get_value(self.request, self.domain)
-        query = query.search_string_query(search_string)
+        if search_string:
+            query = query.set_query({"query_string": {"query": search_string}})
 
         return query
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#19266
This breaks existing functionality of the search. See https://manage.dimagi.com/default.asp?269331