### PR TITLE
kill old product_type

### DIFF
--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -79,7 +79,6 @@ def fmt_product_rate_dict(product_name, product_rate=None):
             product_rate = SoftwareProductRate.objects.create(name=product_name, is_active=True)
     return {
         'name': product_rate.name,
-        'product_type': 'CommCare',  # TODO - kill product_type
         'rate_id': product_rate.id,
         'monthly_fee': product_rate.monthly_fee.__str__(),
     }


### PR DESCRIPTION
Wasn't able to remove this earlier, but now it works.