### PR TITLE
simplify bootstrap_test_plans

### DIFF
--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -20,12 +20,8 @@ from corehq.apps.accounting.models import (
     BillingContactInfo,
     Currency,
     DefaultProductPlan,
-    Feature,
-    FeatureRate,
-    SoftwarePlan,
     SoftwarePlanEdition,
     SoftwarePlanVersion,
-    SoftwareProductRate,
     Subscriber,
     Subscription,
     SubscriptionType,
@@ -39,13 +35,9 @@ from six.moves import range
 
 @unit_testing_only
 @nottest
-def bootstrap_test_plans():
+def bootstrap_test_software_plan_versions():
     DefaultProductPlan.objects.all().delete()
     SoftwarePlanVersion.objects.all().delete()
-    SoftwarePlan.objects.all().delete()
-    SoftwareProductRate.objects.all().delete()
-    FeatureRate.objects.all().delete()
-    Feature.objects.all().delete()
     ensure_plans(BOOTSTRAP_CONFIG_TESTING, verbose=False, apps=apps)
 
 

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -19,7 +19,7 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
     @classmethod
     def setUpClass(cls):
         super(TestDomainInvoiceFactory, cls).setUpClass()
-        generator.bootstrap_test_plans()
+        generator.bootstrap_test_software_plan_versions()
 
     def setUp(self):
         super(TestDomainInvoiceFactory, self).setUp()

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -44,7 +44,10 @@ class BaseInvoiceTestCase(BaseAccountingTest):
     @classmethod
     def setUpClass(cls):
         super(BaseInvoiceTestCase, cls).setUpClass()
-        generator.bootstrap_test_plans()  # TODO - only call for subclasses that actually need the test plans
+
+        # TODO - only call for subclasses that actually need the test plans
+        generator.bootstrap_test_software_plan_versions()
+
         cls.billing_contact = generator.create_arbitrary_web_user_name()
         cls.dimagi_user = generator.create_arbitrary_web_user_name(is_dimagi=True)
         cls.currency = generator.init_default_currency()

--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -11,7 +11,7 @@ class DomainSubscriptionMixin(object):
 
     @classmethod
     def setup_subscription(cls, domain_name, software_plan):
-        generator.bootstrap_test_plans()
+        generator.bootstrap_test_software_plan_versions()
 
         plan = DefaultProductPlan.get_default_plan_version(edition=software_plan)
         cls.account = BillingAccount.get_or_create_account_by_domain(


### PR DESCRIPTION
We only need to reset DefaultProductPlan and SoftwarePlanVersion to the test configuration, so no need to delete the other models.