### PR TITLE
Add default content to followup form

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2695,7 +2695,7 @@ class Module(ModuleBase, ModuleDetailsMixin):
         return module
 
     def new_form(self, name, lang, attachment=Ellipsis):
-        from corehq.apps.app_manager.views.utils import get_blank_form_xml, get_default_followup_form_xml
+        from corehq.apps.app_manager.views.utils import get_blank_form_xml
         lang = lang if lang else "en"
         name = name if name else _("Untitled Form")
         form = Form(
@@ -2705,13 +2705,6 @@ class Module(ModuleBase, ModuleDetailsMixin):
         form = self.get_form(-1)
         if attachment == Ellipsis:
             attachment = get_blank_form_xml(name)
-        elif attachment == "default_followup_form":
-            msg = "This is your follow up form. Delete this label and add questions for any follow up visits."
-            context = {
-                'lang': lang,
-                'default_label': msg
-            }
-            attachment = get_default_followup_form_xml(name, context)
         form.source = attachment
         return form
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2695,7 +2695,7 @@ class Module(ModuleBase, ModuleDetailsMixin):
         return module
 
     def new_form(self, name, lang, attachment=Ellipsis):
-        from corehq.apps.app_manager.views.utils import get_blank_form_xml
+        from corehq.apps.app_manager.views.utils import get_blank_form_xml, get_default_followup_form_xml
         lang = lang if lang else "en"
         name = name if name else _("Untitled Form")
         form = Form(
@@ -2705,6 +2705,13 @@ class Module(ModuleBase, ModuleDetailsMixin):
         form = self.get_form(-1)
         if attachment == Ellipsis:
             attachment = get_blank_form_xml(name)
+        elif attachment == "default_followup_form":
+            msg = "This is your follow up form. Delete this label and add questions for any follow up visits."
+            context = {
+                'lang': lang,
+                'default_label': msg
+            }
+            attachment = get_default_followup_form_xml(name, context)
         form.source = attachment
         return form
 

--- a/corehq/apps/app_manager/templates/app_manager/default_followup_form.xml
+++ b/corehq/apps/app_manager/templates/app_manager/default_followup_form.xml
@@ -12,7 +12,7 @@
 			<itext>
 				<translation lang="{{ lang }}" default="">
 					<text id="default_label-label">
-						<value> {{ default_label }} </value>
+						<value> {{default_label}} </value>
 					</text>
 				</translation>
 			</itext>

--- a/corehq/apps/app_manager/templates/app_manager/default_followup_form.xml
+++ b/corehq/apps/app_manager/templates/app_manager/default_followup_form.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>{{ name }}</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/6E2725BB-7A7B-4CFD-A27D-BA7CD4D790DB" uiVersion="1" version="1" name="Followup Form">
+					<default_label />
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/default_label" nodeset="/data/default_label" />
+			<itext>
+				<translation lang="{{ lang }}" default="">
+					<text id="default_label-label">
+						<value> {{ default_label }} </value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<trigger vellum:ref="#form/default_label" ref="/data/default_label" appearance="minimal">
+			<label ref="jr:itext('default_label-label')" />
+		</trigger>
+	</h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.util import LatestAppInfo
 from corehq.apps.app_manager.views.utils import overwrite_app
 from corehq.apps.domain.models import Domain
+from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
 
 
 class TestGetFormData(SimpleTestCase):
@@ -29,6 +30,27 @@ class TestGetFormData(SimpleTestCase):
 
         modules, errors = util.get_form_data('domain', app)
         self.assertEqual(modules[0]['forms'][0]['action_type'], 'load (load_0)')
+
+
+class TestGetDefaultFollowupForm(SimpleTestCase):
+    def test_default_followup_form(self):
+        app = Application.new_app('domain', "Untitled Application")
+
+        parent_module = app.add_module(AdvancedModule.new_module('parent', None))
+        parent_module.case_type = 'parent'
+        parent_module.unique_id = 'id_parent_module'
+
+        context = {
+            'lang': None,
+            'default_label': "Default label message"
+        }
+        attachment = get_default_followup_form_xml(context=context)
+        followup = app.new_form(0, "Followup Form", None, attachment=attachment)
+
+        modules, _ = util.get_form_data('domain', app)
+        self.assertEqual(followup.name['en'], "Followup Form")
+        self.assertEqual(modules[0]['forms'][0]['name']['en'], "Followup Form")
+        self.assertEqual(modules[0]['forms'][0]['questions'][0]['label'], " Default label message ")
 
 
 class TestLatestAppInfo(TestCase):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -925,6 +925,7 @@ def validate_module_for_build(request, domain, app_id, module_unique_id, ajax=Tr
 @no_conflict_require_POST
 @require_can_edit_apps
 def new_module(request, domain, app_id):
+    from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
     "Adds a module to an app"
     app = get_app(domain, app_id)
     lang = request.COOKIES.get('lang', app.langs[0])
@@ -953,7 +954,9 @@ def new_module(request, domain, app_id):
                     condition=FormActionCondition(type='always'))
 
                 # one followup form
-                followup = app.new_form(module_id, _("Followup Form"), lang, attachment="default_followup_form")
+                msg = "This is your follow up form. Delete this label and add questions for any follow up visits."
+                attachment = get_default_followup_form_xml("", context={'lang': lang, 'default_label': msg})
+                followup = app.new_form(module_id, _("Followup Form"), lang, attachment=attachment)
                 followup.requires = "case"
                 followup.actions.update_case = UpdateCaseAction(condition=FormActionCondition(type='always'))
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -925,9 +925,9 @@ def validate_module_for_build(request, domain, app_id, module_unique_id, ajax=Tr
 @no_conflict_require_POST
 @require_can_edit_apps
 def new_module(request, domain, app_id):
-    from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
     "Adds a module to an app"
     app = get_app(domain, app_id)
+    from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
     lang = request.COOKIES.get('lang', app.langs[0])
     name = request.POST.get('name')
     module_type = request.POST.get('module_type', 'case')
@@ -954,7 +954,8 @@ def new_module(request, domain, app_id):
                     condition=FormActionCondition(type='always'))
 
                 # one followup form
-                msg = "This is your follow up form. Delete this label and add questions for any follow up visits."
+                msg = _("This is your follow up form. "
+                        "Delete this label and add questions for any follow up visits.")
                 attachment = get_default_followup_form_xml("", context={'lang': lang, 'default_label': msg})
                 followup = app.new_form(module_id, _("Followup Form"), lang, attachment=attachment)
                 followup.requires = "case"

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -953,7 +953,7 @@ def new_module(request, domain, app_id):
                     condition=FormActionCondition(type='always'))
 
                 # one followup form
-                followup = app.new_form(module_id, _("Followup Form"), lang)
+                followup = app.new_form(module_id, _("Followup Form"), lang, attachment="default_followup_form")
                 followup.requires = "case"
                 followup.actions.update_case = UpdateCaseAction(condition=FormActionCondition(type='always'))
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -956,7 +956,7 @@ def new_module(request, domain, app_id):
                 # one followup form
                 msg = _("This is your follow up form. "
                         "Delete this label and add questions for any follow up visits.")
-                attachment = get_default_followup_form_xml("", context={'lang': lang, 'default_label': msg})
+                attachment = get_default_followup_form_xml(context={'lang': lang, 'default_label': msg})
                 followup = app.new_form(module_id, _("Followup Form"), lang, attachment=attachment)
                 followup.requires = "case"
                 followup.actions.update_case = UpdateCaseAction(condition=FormActionCondition(type='always'))

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -150,10 +150,9 @@ def get_blank_form_xml(form_name):
     })
 
 
-def get_default_followup_form_xml(form_name, context):
-    context.update({
-        'xmlns': str(uuid.uuid4()).upper(),
-        'name': form_name})
+def get_default_followup_form_xml(context):
+    """Update context and apply in XML file default_followup_form"""
+    context.update({'xmlns': str(uuid.uuid4()).upper()})
     return render_to_string("app_manager/default_followup_form.xml", context=context)
 
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -149,6 +149,13 @@ def get_blank_form_xml(form_name):
         'name': form_name,
     })
 
+def get_default_followup_form_xml(form_name, context):
+    context.update({
+        'xmlns': str(uuid.uuid4()).upper(),
+        'name': form_name}
+    )
+    return render_to_string("app_manager/default_followup_form.xml", context=context)
+
 
 def overwrite_app(app, master_build, report_map=None):
     excluded_fields = set(Application._meta_fields).union([

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -149,11 +149,11 @@ def get_blank_form_xml(form_name):
         'name': form_name,
     })
 
+
 def get_default_followup_form_xml(form_name, context):
     context.update({
         'xmlns': str(uuid.uuid4()).upper(),
-        'name': form_name}
-    )
+        'name': form_name})
     return render_to_string("app_manager/default_followup_form.xml", context=context)
 
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?267085#1450594

When a user creates a new Case List, a Registration Form and a Followup Form are automatically created. This PR adds to the Followup Form a label with the text "This is your follow up form. Delete this label and add questions for any follow up visits.", to avoid unnecessary build errors.