### PR TITLE
prevent indicator text being overlapped by see more link

### DIFF
--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -386,10 +386,19 @@ h4 {
     text-align: center;
 }
 
+@media (min-width: 992px) {
+    .see-more-content {
+        min-height: 145px;
+    }
+}
+
+.see-more-content {
+    padding-left: 0;
+}
+
 .see-more {
-    margin-right: 20px;
-    flex: 0 1 auto;
-    margin-left: auto;
+    position: absolute;
+    bottom: 0;
 }
 
 .see-more > a {
@@ -485,7 +494,7 @@ h4 {
 }
 
 .kpi {
-    height: 170px;
+    min-height: 170px;
 }
 
 .kpi-content {
@@ -510,7 +519,6 @@ h4 {
 
 .kpi-percents-text {
     display: flex;
-    position: absolute;
     align-items: center;
 }
 

--- a/custom/icds_reports/templates/icds_reports/icds_app/kpi.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/kpi.directive.html
@@ -2,13 +2,13 @@
     <div class="col-md-6" ng-repeat="cell in section track by $index">
         <div class="report-cell kpi">
             <div class="row">
-                <div class="col-md-1"
+                <div class="col-md-2"
                      uib-popover-html="cell.help_text"
                      popover-placement="right"
                      popover-trigger="'mouseenter'">
                     <i ng-show="cell.help_text !== null" class="fa fa-info-circle fa-2x" ></i>
                 </div>
-                <div class="col-md-11 kpi-content">
+                <div class="col-md-8 kpi-content">
                     <div class="kpi-justify-center">
                         <span class="title white" ng-bind="cell.label"></span>
                     </div>
@@ -32,8 +32,10 @@
                               ng-show="cell.percent !== null && !$ctrl.isNumber(cell.percent) && $ctrl.showPercentInfo()">
                             <span class="white" ng-bind="cell.percent"></span>
                         </span>
-                        <span ng-show="cell.redirect" class="see-more" aria-hidden="true"><a href="{$ $ctrl.goToStep(cell.redirect) $}" class="fa">See more</a></span>
                     </div>
+                </div>
+                <div class="col-md-2 see-more-content">
+                    <span ng-show="cell.redirect" class="see-more" aria-hidden="true"><a href="{$ $ctrl.goToStep(cell.redirect) $}" class="fa">See more</a></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Hi @emord,
I have made a change that prevents indicator text from being overlapped by 'see more' link.
Changes are applicable to any size.