### PR TITLE
Add collapse button and remove search bar edit/archive/delete buttons

### DIFF
--- a/corehq/apps/locations/static/locations/js/location_tree.async.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.async.js
@@ -41,8 +41,7 @@ function LocationTreeViewModel(hierarchy) {
 
     // load location hierarchy
     this.load = function(locs) {
-        this.root(new LocationModel({name: '_root', children: locs, can_edit: can_edit_root}, this));
-        this.root().expanded(true);
+        this.root(new LocationModel({name: '_root', children: locs, can_edit: can_edit_root, expanded: true}, this));
     };
 }
 

--- a/corehq/apps/locations/static/locations/js/location_tree.async.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.async.js
@@ -41,7 +41,7 @@ function LocationTreeViewModel(hierarchy) {
 
     // load location hierarchy
     this.load = function(locs) {
-        this.root(new LocationModel({name: '_root', children: locs, can_edit: can_edit_root, expanded: true}, this));
+        this.root(new LocationModel({name: '_root', children: locs, can_edit: can_edit_root, expanded: true}, this)); // eslint-disable-line no-undef
     };
 }
 

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -33,36 +33,36 @@
             $('#location_search_select').select2({
                 ajax: {
                     url: '{% url 'location_search' domain %}',
-                        dataType: 'json',
-                        data: function (params) {
-                            return {
-                                q: params.term,
-                                page_limit: 10,
-                                page: params.page,
-                                show_inactive: show_inactive,
-                            };
-                        },
-                        processResults: function (data, params) {
-                            var more = data.more || (params.page * 10) < data.total;
-                            return {results: data.results, more: more};
-                        }
+                    dataType: 'json',
+                    data: function (params) {
+                        return {
+                            q: params.term,
+                            page_limit: 10,
+                            page: params.page,
+                            show_inactive: show_inactive,
+                        };
                     },
-                });
-            };
+                    processResults: function (data, params) {
+                        var more = data.more || (params.page * 10) < data.total;
+                        return {results: data.results, more: more};
+                    }
+                },
+            });
+        };
 
-            var tree_model = new LocationTreeViewModel(hierarchy);
+        var tree_model = new LocationTreeViewModel(hierarchy);
 
-            var reloadLocationSearchSelect = function() {
-                $('#location_search_select').select2('val', null);
-                enableLocationSearchSelect();
-            };
-
-            var clearLocationSelection = function() {
-                reloadLocationSearchSelect();
-                tree_model.load(locs);
-            };
-
+        var reloadLocationSearchSelect = function() {
+            $('#location_search_select').select2('val', null);
             enableLocationSearchSelect();
+        };
+
+        var clearLocationSelection = function() {
+            reloadLocationSearchSelect();
+            tree_model.load(locs);
+        };
+
+        enableLocationSearchSelect();
 
         $(function() {
             $('#location_tree').koApplyBindings(tree_model);
@@ -165,7 +165,6 @@
 
     <div class="col-xs-7 col-md-7 col-lg-8">
 
-        <div>
         <select type="text"
             id="location_search_select"
             data-bind="value: l__selected_location_id"
@@ -174,10 +173,9 @@
             name="location_search"
             style="max-width:80%;"></select>
 
-            <div style="display:inline; cursor:pointer;" data-bind="if: selected_location_id(), click: clearLocationSelection">
-            <button type="button" class="btn btn-secondary"><i class="fa fa-times" aria-hidden="true"></i></button>
-            </div>
-        </div>
+        <button type="button" class="btn btn-secondary" style="display:inline; cursor:pointer;" data-bind="visible: selected_location_id(), click: clearLocationSelection">
+            <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
 
         <span class="help-block">
             <i class="fa fa-info-circle"></i>

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -50,15 +50,21 @@
                 });
             };
 
+            var tree_model = new LocationTreeViewModel(hierarchy);
+
             var reloadLocationSearchSelect = function() {
                 $('#location_search_select').select2('val', null);
                 enableLocationSearchSelect();
             };
 
+            var clearLocationSelection = function() {
+                reloadLocationSearchSelect();
+                tree_model.load(locs);
+            };
+
             enableLocationSearchSelect();
 
         $(function() {
-            var tree_model = new LocationTreeViewModel(hierarchy);
             $('#location_tree').koApplyBindings(tree_model);
             tree_model.load(locs);
             var model = new LocationSearchViewModel(tree_model);
@@ -159,6 +165,7 @@
 
     <div class="col-xs-7 col-md-7 col-lg-8">
 
+        <div>
         <select type="text"
             id="location_search_select"
             data-bind="value: l__selected_location_id"
@@ -167,6 +174,11 @@
             name="location_search"
             style="max-width:80%;"></select>
 
+            <div style="display:inline; cursor:pointer;" data-bind="if: selected_location_id(), click: clearLocationSelection">
+            <button type="button" class="btn btn-secondary"><i class="fa fa-times" aria-hidden="true"></i></button>
+            </div>
+        </div>
+
         <span class="help-block">
             <i class="fa fa-info-circle"></i>
             To quick search for a location, write your query as "parent"/descendant. For more info, see the <a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" target="_blank">Location Search</a> help page.
@@ -174,9 +186,6 @@
 
     </div>
 
-    <div class="button_section">
-        <div data-bind="template: { name: 'button-template', if: selected_location_id(), data: selected_location}"></div>
-    </div>
 </div>
 
 


### PR DESCRIPTION
Added an 'x' button next to the search bar to allow users to clear their selection and collapse the tree. Also removed the edit/archive/delete buttons from the search bar. If users would like to edit/archive/delete the selected location, they can do so in the tree. 
@dannyroberts 