### PR TITLE
force date to date object in the icds_data_validation task

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -33,6 +33,7 @@ from custom.icds_reports.models import AggChildHealthMonthly
 from custom.icds_reports.reports.issnip_monthly_register import ISSNIPMonthlyReport
 from custom.icds_reports.utils import zip_folder, create_pdf_file
 from dimagi.utils.chunked import chunked
+from dimagi.utils.dates import force_to_date
 from dimagi.utils.logging import notify_exception
 from six.moves import range
 
@@ -300,7 +301,7 @@ def icds_data_validation(day):
     """
 
     # agg tables store the month like YYYY-MM-01
-    month = day
+    month = force_to_date(day)
     month.replace(day=1)
     return_values = ('state_name', 'district_name', 'block_name', 'supervisor_name', 'awc_name')
 


### PR DESCRIPTION
Hi @emord 

I added a small change to your validatio task. When I tried run aggregation script today I get an error:
```
Traceback (most recent call last):
  File "/home/user/.virtualenvs/commcare-hq/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/user/.virtualenvs/commcare-hq/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/user/projects/hq/custom/icds_reports/tasks.py", line 304, in icds_data_validation
    month.replace(day=1)
TypeError: replace() takes no keyword arguments
```
I debug this and I noticed that the date parameter is a string, so I force it to the date object.

Please let me know if you have any questions.

Regards,
Łukasz