### PR TITLE
Add migration and availing services columns

### DIFF
--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -280,11 +280,10 @@
 			  "type": "related_doc", 
 			  "related_doc_type": "CommCareCase", 
 			  "doc_id_expression": {
-				"type": "named", 
-				"name": "parent_id"
+				"type": "icds_parent_parent_id"
 			  }
 			}, 
-			"property_value": "yes"
+			"property_value": "migrated"
 		  }, 
 		  "expression_if_true": {
 			"constant": 1, 

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -314,8 +314,7 @@
 			  "type": "related_doc", 
 			  "related_doc_type": "CommCareCase", 
 			  "doc_id_expression": {
-				"type": "named", 
-				"name": "parent_id"
+				"type": "icds_parent_parent_id"
 			  }
 			}, 
 			"property_value": "not_registered"

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -262,7 +262,77 @@
         "type": "boolean",
         "display_name": null,
         "column_id": "open_child_count"
-      }
+      },
+	  {
+	    "datatype": "integer", 
+		"type": "expression", 
+		"is_nullable": true, 
+		"expression": {
+		  "test": {
+			"operator": "eq", 
+			"type": "boolean_expression", 
+			"expression": {
+			  "value_expression": {
+				"datatype": null, 
+				"type": "property_name", 
+				"property_name": "migration_status"
+			  }, 
+			  "type": "related_doc", 
+			  "related_doc_type": "CommCareCase", 
+			  "doc_id_expression": {
+				"type": "named", 
+				"name": "parent_id"
+			  }
+			}, 
+			"property_value": "yes"
+		  }, 
+		  "expression_if_true": {
+			"constant": 1, 
+			"type": "constant"
+		  }, 
+		  "type": "conditional", 
+		  "expression_if_false": {
+			"constant": 0, 
+			"type": "constant"
+		  }
+		}, 
+		"column_id": "is_migrated"
+	  },
+	  {
+	  "datatype": "integer", 
+		"type": "expression", 
+		"is_nullable": true, 
+		"expression": {
+		  "test": {
+			"operator": "not_eq", 
+			"type": "boolean_expression", 
+			"expression": {
+			  "value_expression": {
+				"datatype": null, 
+				"type": "property_name", 
+				"property_name": "registered_status"
+			  }, 
+			  "type": "related_doc", 
+			  "related_doc_type": "CommCareCase", 
+			  "doc_id_expression": {
+				"type": "named", 
+				"name": "parent_id"
+			  }
+			}, 
+			"property_value": "not_registered"
+		  }, 
+		  "expression_if_true": {
+			"constant": 1, 
+			"type": "constant"
+		  }, 
+		  "type": "conditional", 
+		  "expression_if_false": {
+			"constant": 0, 
+			"type": "constant"
+		  }
+		}, 
+		"column_id": "is_availing"
+		}
     ],
     "named_expressions": {
       "parent_id": {


### PR DESCRIPTION
@emord @calellowitz 

Hey Cal and Emord, I'm not sure if the related doc expressions for the person case are accurate here. I wasn't able to find a straightforward example of a reference to the person case from another task case indicator so I used parent_id to start with. Could you check if that's the right way to reference the related person case from the task case? Thanks!