### PR TITLE
Icds change adolescent age range

### DIFF
--- a/custom/icds_reports/reports/adolescent_girls.py
+++ b/custom/icds_reports/reports/adolescent_girls.py
@@ -25,8 +25,8 @@ def get_adolescent_girls_data_map(domain, config, loc_level, show_test=False):
         ).values(
             '%s_name' % loc_level, '%s_map_location_name' % loc_level
         ).annotate(
-            valid=Sum('cases_person_adolescent_girls_11_14') + Sum('cases_person_adolescent_girls_15_18'),
-            all=Sum('cases_person_adolescent_girls_11_14_all') + Sum('cases_person_adolescent_girls_15_18_all'),
+            valid=Sum('cases_person_adolescent_girls_11_14'),
+            all=Sum('cases_person_adolescent_girls_11_14_all'),
         ).order_by('%s_name' % loc_level, '%s_map_location_name' % loc_level)
         if not show_test:
             queryset = apply_exclude(domain, queryset)
@@ -73,19 +73,19 @@ def get_adolescent_girls_data_map(domain, config, loc_level, show_test=False):
             "extended_info": [
                 {
                     'indicator': (
-                        'Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services:'
+                        'Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services:'
                     ),
                     'value': indian_formatted_number(total_valid)
                 },
                 {
                     'indicator': (
-                        'Total number of adolescent girls (11 - 18 years) who are registered:'
+                        'Total number of adolescent girls (11 - 14 years) who are registered:'
                     ),
                     'value': indian_formatted_number(total)
                 },
                 {
                     'indicator': (
-                        'Percentage of registered adolescent girls (11 - 18 years) '
+                        'Percentage of registered adolescent girls (11 - 14 years) '
                         'who are enrolled for Anganwadi Services:'
                     ),
                     'value': '%.2f%%' % (total_valid * 100 / float(total or 1))
@@ -106,8 +106,8 @@ def get_adolescent_girls_sector_data(domain, config, loc_level, location_id, sho
     ).values(
         *group_by
     ).annotate(
-        valid=Sum('cases_person_adolescent_girls_11_14') + Sum('cases_person_adolescent_girls_15_18'),
-        all=Sum('cases_person_adolescent_girls_11_14_all') + Sum('cases_person_adolescent_girls_15_18_all'),
+        valid=Sum('cases_person_adolescent_girls_11_14'),
+        all=Sum('cases_person_adolescent_girls_11_14_all'),
     ).order_by('%s_name' % loc_level)
 
     if not show_test:
@@ -180,8 +180,8 @@ def get_adolescent_girls_data_chart(domain, config, loc_level, show_test=False):
     ).values(
         'month', '%s_name' % loc_level
     ).annotate(
-        valid=Sum('cases_person_adolescent_girls_11_14') + Sum('cases_person_adolescent_girls_15_18'),
-        all=Sum('cases_person_adolescent_girls_11_14_all') + Sum('cases_person_adolescent_girls_15_18_all'),
+        valid=Sum('cases_person_adolescent_girls_11_14'),
+        all=Sum('cases_person_adolescent_girls_11_14_all'),
     ).order_by('month')
 
     if not show_test:

--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -757,14 +757,8 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
             ccs_pregnant_all=Sum('cases_ccs_pregnant_all'),
             css_lactating=Sum('cases_ccs_lactating'),
             css_lactating_all=Sum('cases_ccs_lactating_all'),
-            person_adolescent=(
-                Sum('cases_person_adolescent_girls_11_14') +
-                Sum('cases_person_adolescent_girls_15_18')
-            ),
-            person_adolescent_all=(
-                Sum('cases_person_adolescent_girls_11_14_all') +
-                Sum('cases_person_adolescent_girls_15_18_all')
-            ),
+            person_adolescent=Sum('cases_person_adolescent_girls_11_14'),
+            person_adolescent_all=Sum('cases_person_adolescent_girls_11_14_all'),
             person_aadhaar=Sum(person_has_aadhaar_column(beta)),
             all_persons=Sum(person_is_beneficiary_column(beta))
         )
@@ -888,9 +882,9 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                     'frequency': frequency
                 },
                 {
-                    'label': _('Percent adolescent girls (11-18 years) enrolled for Anganwadi Services'),
+                    'label': _('Percent adolescent girls (11-14 years) enrolled for Anganwadi Services'),
                     'help_text': _((
-                        "Percentage of adolescent girls registered between 11-18 years"
+                        "Percentage of adolescent girls registered between 11-14 years"
                         " old who are enrolled for Anganwadi Services"
                     )),
                     'percent': percent_diff(

--- a/custom/icds_reports/reports/demographics_data.py
+++ b/custom/icds_reports/reports/demographics_data.py
@@ -36,14 +36,8 @@ def get_demographics_data(domain, now_date, config, show_test=False, beta=False)
             ccs_pregnant_all=Sum('cases_ccs_pregnant_all'),
             css_lactating=Sum('cases_ccs_lactating'),
             css_lactating_all=Sum('cases_ccs_lactating_all'),
-            person_adolescent=(
-                Sum('cases_person_adolescent_girls_11_14') +
-                Sum('cases_person_adolescent_girls_15_18')
-            ),
-            person_adolescent_all=(
-                Sum('cases_person_adolescent_girls_11_14_all') +
-                Sum('cases_person_adolescent_girls_15_18_all')
-            ),
+            person_adolescent=Sum('cases_person_adolescent_girls_11_14'),
+            person_adolescent_all=Sum('cases_person_adolescent_girls_11_14_all'),
             person_aadhaar=Sum(person_has_aadhaar_column(beta)),
             all_persons=Sum(person_is_beneficiary_column(beta))
         )
@@ -162,9 +156,9 @@ def get_demographics_data(domain, now_date, config, show_test=False, beta=False)
                     'redirect': 'lactating_enrolled_women'
                 },
                 {
-                    'label': _('Percent adolescent girls (11-18 years) enrolled for Anganwadi Services'),
+                    'label': _('Percent adolescent girls (11-14 years) enrolled for Anganwadi Services'),
                     'help_text': _((
-                        "Percentage of adolescent girls registered between 11-18 years"
+                        "Percentage of adolescent girls registered between 11-14 years"
                         " old who are enrolled for Anganwadi Services"
                     )),
                     'percent': percent_diff(

--- a/custom/icds_reports/static/icds_reports/js/spec/adolescent-girls.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/adolescent-girls.directive.spec.js
@@ -94,9 +94,9 @@ describe('Adolescent Girls Directive', function () {
         var result = controller.templatePopup({properties: {name: 'test'}}, {valid: 14, all: 28});
         var expected = '<div class="hoverinfo" style="max-width: 200px !important; white-space: normal;">' +
             '<p>test</p>' +
-            '<div>Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>14</strong>' +
-            '<div>Total number of adolescent girls (11 - 18 years) who are registered: <strong>28</strong>' +
-            '<div>Percentage of registered adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>50.00%</strong>' +
+            '<div>Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>14</strong>' +
+            '<div>Total number of adolescent girls (11 - 14 years) who are registered: <strong>28</strong>' +
+            '<div>Percentage of registered adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>50.00%</strong>' +
             '</div>';
         assert.equal(result, expected);
     });
@@ -181,9 +181,9 @@ describe('Adolescent Girls Directive', function () {
         var month = {value: "Jul 2017", series: []};
 
         var expected = "<p><strong>Jul 2017</strong></p><br/>"
-            + "<p>Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>60</strong></p>"
-            + "<p>Total number of adolescent girls (11 - 18 years) who are registered: <strong>120</strong></p>"
-            + "<p>Percentage of registered adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>50.00%</strong></p>";
+            + "<p>Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>60</strong></p>"
+            + "<p>Total number of adolescent girls (11 - 14 years) who are registered: <strong>120</strong></p>"
+            + "<p>Percentage of registered adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>50.00%</strong></p>";
 
         var result = controller.tooltipContent(month.value, {y: 60, all: 120});
         assert.equal(expected, result);

--- a/custom/icds_reports/static/js/directives/adolescent-girls/adolescent-girls.directive.js
+++ b/custom/icds_reports/static/js/directives/adolescent-girls/adolescent-girls.directive.js
@@ -11,7 +11,7 @@ function AdolescentWomenController($scope, $routeParams, $location, $filter, dem
     }
     vm.userLocationId = userLocationId;
     vm.filtersData = $location.search();
-    vm.label = "Adolescent Girls (11-18 years)";
+    vm.label = "Adolescent Girls (11-14 years)";
     vm.step = $routeParams.step;
     vm.steps = {
         'map': {route: '/adolescent_girls/map', label: 'Map View'},
@@ -74,9 +74,9 @@ function AdolescentWomenController($scope, $routeParams, $location, $filter, dem
         var percent = row ? d3.format('.2%')(row.valid / (row.all || 1)) : "N/A";
         return '<div class="hoverinfo" style="max-width: 200px !important; white-space: normal;">' +
             '<p>' + loc.properties.name + '</p>' +
-            '<div>Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>' + valid + '</strong>' +
-            '<div>Total number of adolescent girls (11 - 18 years) who are registered: <strong>' + all + '</strong>' +
-            '<div>Percentage of registered adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>' + percent + '</strong>' +
+            '<div>Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>' + valid + '</strong>' +
+            '<div>Total number of adolescent girls (11 - 14 years) who are registered: <strong>' + all + '</strong>' +
+            '<div>Percentage of registered adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>' + percent + '</strong>' +
             '</div>';
     };
 
@@ -223,9 +223,9 @@ function AdolescentWomenController($scope, $routeParams, $location, $filter, dem
 
     vm.tooltipContent = function (monthName, day) {
         return "<p><strong>" + monthName + "</strong></p><br/>"
-            + "<p>Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>" + $filter('indiaNumbers')(day.y) + "</strong></p>"
-            + "<p>Total number of adolescent girls (11 - 18 years) who are registered: <strong>" + $filter('indiaNumbers')(day.all) + "</strong></p>"
-            + "<p>Percentage of registered adolescent girls (11 - 18 years) who are enrolled for Anganwadi Services: <strong>" + d3.format('.2%')(day.y / (day.all || 1)) + "</strong></p>";
+            + "<p>Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>" + $filter('indiaNumbers')(day.y) + "</strong></p>"
+            + "<p>Total number of adolescent girls (11 - 14 years) who are registered: <strong>" + $filter('indiaNumbers')(day.all) + "</strong></p>"
+            + "<p>Percentage of registered adolescent girls (11 - 14 years) who are enrolled for Anganwadi Services: <strong>" + d3.format('.2%')(day.y / (day.all || 1)) + "</strong></p>";
     };
 
     vm.showAllLocations = function () {

--- a/custom/icds_reports/templates/icds_reports/icds_app/navigation.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/navigation.directive.html
@@ -92,7 +92,7 @@
                         </a>
                     </li>
                     <li ng-class="{'active': $location.path().indexOf('/adolescent_girls') !== -1}">
-                        <a href="{$ goToStep('adolescent_girls', $location.search()) $}" >{% trans "Adolescent Girls (11-18 Years) enrolled for Anganwadi Services" %}
+                        <a href="{$ goToStep('adolescent_girls', $location.search()) $}" >{% trans "Adolescent Girls (11-14 Years) enrolled for Anganwadi Services" %}
                         </a>
                     </li>
                     <li ng-class="{'active': $location.path().indexOf('/adhaar') !== -1}">

--- a/custom/icds_reports/tests/reports/test_adolescent_girls.py
+++ b/custom/icds_reports/tests/reports/test_adolescent_girls.py
@@ -23,23 +23,23 @@ class TestAdolescentGirls(TestCase):
             {
                 "rightLegend": {
                     "info": "Total number of adolescent girls who are enrolled for Anganwadi Services",
-                    "average": 23.5,
+                    "average": 17.0,
                     "average_format": "number",
                     'extended_info': [
                         {
                             'indicator': (
-                                'Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi '
+                                'Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi '
                                 'Services:'
                             ),
-                            'value': "47"
+                            'value': "34"
                         },
                         {
-                            'indicator': 'Total number of adolescent girls (11 - 18 years) who are registered:',
-                            'value': "47"
+                            'indicator': 'Total number of adolescent girls (11 - 14 years) who are registered:',
+                            'value': "34"
                         },
                         {
                             'indicator': (
-                                'Percentage of registered adolescent girls (11 - 18 years) '
+                                'Percentage of registered adolescent girls (11 - 14 years) '
                                 'who are enrolled for Anganwadi Services:'
                             ),
                             'value': '100.00%'
@@ -52,14 +52,14 @@ class TestAdolescentGirls(TestCase):
                 },
                 "data": {
                     "st1": {
-                        "valid": 22,
-                        "all": 22,
+                        "valid": 17,
+                        "all": 17,
                         'original_name': ["st1"],
                         "fillKey": "Adolescent Girls"
                     },
                     "st2": {
-                        "valid": 25,
-                        "all": 25,
+                        "valid": 17,
+                        "all": 17,
                         'original_name': ["st2"],
                         "fillKey": "Adolescent Girls"
                     }
@@ -84,23 +84,23 @@ class TestAdolescentGirls(TestCase):
             {
                 "rightLegend": {
                     "info": "Total number of adolescent girls who are enrolled for Anganwadi Services",
-                    "average": 11.0,
+                    "average": 8.5,
                     "average_format": "number",
                     'extended_info': [
                         {
                             'indicator': (
-                                'Number of adolescent girls (11 - 18 years) who are enrolled for Anganwadi '
+                                'Number of adolescent girls (11 - 14 years) who are enrolled for Anganwadi '
                                 'Services:'
                             ),
-                            'value': "22"
+                            'value': "17"
                         },
                         {
-                            'indicator': 'Total number of adolescent girls (11 - 18 years) who are registered:',
-                            'value': "22"
+                            'indicator': 'Total number of adolescent girls (11 - 14 years) who are registered:',
+                            'value': "17"
                         },
                         {
                             'indicator': (
-                                'Percentage of registered adolescent girls (11 - 18 years) '
+                                'Percentage of registered adolescent girls (11 - 14 years) '
                                 'who are enrolled for Anganwadi Services:'
                             ),
                             'value': '100.00%'
@@ -113,8 +113,8 @@ class TestAdolescentGirls(TestCase):
                 },
                 "data": {
                     'block_map': {
-                        'valid': 22,
-                        'all': 22,
+                        'valid': 17,
+                        'all': 17,
                         'original_name': ['b1', 'b2'],
                         'fillKey': 'Adolescent Girls'}
                 },
@@ -137,22 +137,22 @@ class TestAdolescentGirls(TestCase):
                 "location_type": "State",
                 "bottom_five": [
                     {
-                        "loc_name": "st2",
-                        "value": 25
+                        "loc_name": "st1",
+                        "value": 17.0
                     },
                     {
-                        "loc_name": "st1",
-                        "value": 22
+                        "loc_name": "st2",
+                        "value": 17.0
                     }
                 ],
                 "top_five": [
                     {
-                        "loc_name": "st2",
-                        "value": 25
+                        "loc_name": "st1",
+                        "value": 17.0
                     },
                     {
-                        "loc_name": "st1",
-                        "value": 22
+                        "loc_name": "st2",
+                        "value": 17.0
                     }
                 ],
                 "chart_data": [
@@ -172,14 +172,14 @@ class TestAdolescentGirls(TestCase):
                                 "all": 0
                             },
                             {
-                                "y": 57,
+                                "y": 38,
                                 "x": 1491004800000,
-                                "all": 57
+                                "all": 38
                             },
                             {
-                                "y": 47,
+                                "y": 34,
                                 "x": 1493596800000,
-                                "all": 47
+                                "all": 34
                             }
                         ],
                         "key": "Total number of adolescent girls who are enrolled for Anganwadi Services"
@@ -187,12 +187,12 @@ class TestAdolescentGirls(TestCase):
                 ],
                 "all_locations": [
                     {
-                        "loc_name": "st2",
-                        "value": 25
+                        "loc_name": "st1",
+                        "value": 17.0
                     },
                     {
-                        "loc_name": "st1",
-                        "value": 22
+                        "loc_name": "st2",
+                        "value": 17.0
                     }
                 ]
             }
@@ -216,12 +216,12 @@ class TestAdolescentGirls(TestCase):
                 "info": "Total number of adolescent girls who are enrolled for Anganwadi Services",
                 "tooltips_data": {
                     "s2": {
-                        "all": 6,
-                        "valid": 6
+                        "all": 5,
+                        "valid": 5
                     },
                     "s1": {
-                        "valid": 5,
-                        "all": 5
+                        "valid": 3,
+                        "all": 3
                     },
                 },
                 "chart_data": [
@@ -232,11 +232,11 @@ class TestAdolescentGirls(TestCase):
                         "values": [
                             [
                                 "s1",
-                                5
+                                3
                             ],
                             [
                                 "s2",
-                                6
+                                5
                             ]
                         ],
                         "key": "Number Of Girls"

--- a/custom/icds_reports/tests/reports/test_awc_reports.py
+++ b/custom/icds_reports/tests/reports/test_awc_reports.py
@@ -832,10 +832,10 @@ class TestAWCReport(TestCase):
                             "color": "red",
                             "percent": -100.0,
                             "value": 0,
-                            "label": "Percent adolescent girls (11-18 years) enrolled for Anganwadi Services",
+                            "label": "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services",
                             "frequency": "month",
                             "help_text": "Percentage of adolescent girls registered between"
-                                         " 11-18 years old who are enrolled for Anganwadi Services"
+                                         " 11-14 years old who are enrolled for Anganwadi Services"
                         }
                     ]
                 ],
@@ -956,11 +956,11 @@ class TestAWCReport(TestCase):
                             "percent": "Data in the previous reporting period was 0",
                             "value": 0,
                             "label": (
-                                "Percent adolescent girls (11-18 years) enrolled for Anganwadi Services"
+                                "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services"
                             ),
                             "frequency": "day",
                             "help_text": (
-                                "Percentage of adolescent girls registered between 11-18 years old who "
+                                "Percentage of adolescent girls registered between 11-14 years old who "
                                 "are enrolled for Anganwadi Services"
                             )
                         }
@@ -1067,11 +1067,11 @@ class TestAWCReport(TestCase):
                             "percent": "Data in the previous reporting period was 0",
                             "value": 0,
                             "label": (
-                                "Percent adolescent girls (11-18 years) enrolled for Anganwadi Services"
+                                "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services"
                             ),
                             "frequency": "day",
                             "help_text": (
-                                "Percentage of adolescent girls registered between 11-18 years old who "
+                                "Percentage of adolescent girls registered between 11-14 years old who "
                                 "are enrolled for Anganwadi Services"
                             )
                         }

--- a/custom/icds_reports/tests/reports/test_demographics.py
+++ b/custom/icds_reports/tests/reports/test_demographics.py
@@ -86,15 +86,15 @@ class TestDemographics(TestCase):
                         },
                         {
                             "redirect": "adolescent_girls",
-                            "all": 47,
+                            "all": 34,
                             "format": "percent_and_div",
                             "color": "red",
                             "percent": 0.0,
-                            "value": 47,
-                            "label": "Percent adolescent girls (11-18 years) enrolled for Anganwadi Services",
+                            "value": 34,
+                            "label": "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services",
                             "frequency": "month",
                             "help_text": "Percentage of adolescent girls registered"
-                                         " between 11-18 years old who are enrolled for Anganwadi Services"
+                                         " between 11-14 years old who are enrolled for Anganwadi Services"
                         }
                     ]
                 ]
@@ -185,15 +185,15 @@ class TestDemographics(TestCase):
                         },
                         {
                             "redirect": "adolescent_girls",
-                            "all": 47,
+                            "all": 34,
                             "format": "percent_and_div",
                             "color": "green",
                             "percent": "Data in the previous reporting period was 0",
-                            "value": 47,
-                            "label": "Percent adolescent girls (11-18 years) enrolled for Anganwadi Services",
+                            "value": 34,
+                            "label": "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services",
                             "frequency": "day",
                             "help_text": (
-                                "Percentage of adolescent girls registered between 11-18 years old who "
+                                "Percentage of adolescent girls registered between 11-14 years old who "
                                 "are enrolled for Anganwadi Services"
                             )
                         }
@@ -286,15 +286,15 @@ class TestDemographics(TestCase):
                         },
                         {
                             "redirect": "adolescent_girls",
-                            "all": 47,
+                            "all": 34,
                             "format": "percent_and_div",
                             "color": "green",
                             "percent": "Data in the previous reporting period was 0",
-                            "value": 47,
-                            "label": "Percent adolescent girls (11-18 years) enrolled for Anganwadi Services",
+                            "value": 34,
+                            "label": "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services",
                             "frequency": "day",
                             "help_text": (
-                                "Percentage of adolescent girls registered between 11-18 years old who "
+                                "Percentage of adolescent girls registered between 11-14 years old who "
                                 "are enrolled for Anganwadi Services"
                             )
                         }


### PR DESCRIPTION
Hi @emord,
This PR consists of 3 changes:
1st is Fix for AwcReportsView where the variable 'month' was used as datetime when it was an integer.
2nd is the change of adolescent girls age range shown in program summary and map/ chart view.
And the 3rd one is switch on how we prevent tooltip content from overflowing to wrap content itself rather than adjust tooltip width. Thanks to which tooltips that contain a bigger amount of data will be long rather than wide.

So as you can see 2nd commit is the change mentioned in name and other two are adjustments for previous changes.

Let me know if you have any questions or comments.