### PR TITLE
Bump Django to 1.11.10

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ jsonobject-couchdbkit==0.9.0.0
 celery==3.1.18
 # required by django-digest
 decorator==4.0.11
-django==1.11.9
+django==1.11.10
 django-braces==1.8.1
 django-celery==3.2.1
 django-crispy-forms==1.7.0


### PR DESCRIPTION
https://www.djangoproject.com/weblog/2018/feb/01/security-releases/

@nickpell 