### PR TITLE
Partition UCR tables

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -70,6 +70,20 @@ class SQLColumnIndexes(DocumentSchema):
     column_ids = StringListProperty()
 
 
+class SQLPartition(DocumentSchema):
+    """Uses architect library to partition
+
+    http://architect.readthedocs.io/features/partition/index.html
+    """
+    column = StringProperty()
+    subtype = StringProperty(choices=['date', 'string_firstchars'])
+    constraint = StringProperty()
+
+
+class SQLSettings(DocumentSchema):
+    partition_config = SchemaListProperty(SQLPartition)
+
+
 class DataSourceBuildInformation(DocumentSchema):
     """
     A class to encapsulate meta information about the process through which
@@ -119,6 +133,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     sql_column_indexes = SchemaListProperty(SQLColumnIndexes)
     icds_rebuild_related_docs = BooleanProperty(default=False)
     disable_destructive_rebuild = BooleanProperty(default=False)
+    sql_settings = SchemaProperty(SQLSettings)
 
     class Meta(object):
         # prevent JsonObject from auto-converting dates etc.

--- a/corehq/apps/userreports/tests/test_data_source_partitioning.py
+++ b/corehq/apps/userreports/tests/test_data_source_partitioning.py
@@ -125,11 +125,11 @@ class DataSourcePartitionByOwner(DataSourceConfigurationPartitionTest):
 
         # ensure docs are in separate databases
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM """config_report_user-reports_sample_7554612a_abcdefghij""";')
+            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_abcdefghij";')
         result = result.fetchone()[0]
 
         self.assertEqual(2, result)
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM """config_report_user-reports_sample_7554612a_abcdefhijk""";')
+            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_abcdefhijk";')
         result = result.fetchone()[0]
         self.assertEqual(1, result)

--- a/corehq/apps/userreports/tests/test_data_source_partitioning.py
+++ b/corehq/apps/userreports/tests/test_data_source_partitioning.py
@@ -15,6 +15,9 @@ from corehq.apps.userreports.tests.utils import (
 from corehq.apps.userreports.util import get_indicator_adapter
 
 
+EXPECTED_UCR_CHILD_TABLE_PREFIX = 'tbl_80f005a0bdc2f0d0ff6f8293daee8f33_'
+
+
 class DataSourceConfigurationPartitionTest(TestCase):
     column = None
     subtype = None
@@ -64,11 +67,11 @@ class DataSourcePartitionByDay(DataSourceConfigurationPartitionTest):
 
         # ensure docs are in separate databases
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018d001";')
+            'SELECT COUNT(*) FROM "{}y2018d001";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
         self.assertEqual(1, result)
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018d002";')
+            'SELECT COUNT(*) FROM "{}y2018d002";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
         self.assertEqual(1, result)
 
@@ -93,12 +96,12 @@ class DataSourcePartitionByMonth(DataSourceConfigurationPartitionTest):
 
         # ensure docs are in separate databases
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018m01";')
+            'SELECT COUNT(*) FROM "{}y2018m01";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
 
         self.assertEqual(1, result)
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018m02";')
+            'SELECT COUNT(*) FROM "{}y2018m02";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
         self.assertEqual(2, result)
 
@@ -125,11 +128,11 @@ class DataSourcePartitionByOwner(DataSourceConfigurationPartitionTest):
 
         # ensure docs are in separate databases
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_abcdefghij";')
+            'SELECT COUNT(*) FROM "{}abcdefghij";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
 
         self.assertEqual(2, result)
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_abcdefhijk";')
+            'SELECT COUNT(*) FROM "{}abcdefhijk";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
         self.assertEqual(1, result)

--- a/corehq/apps/userreports/tests/test_data_source_partitioning.py
+++ b/corehq/apps/userreports/tests/test_data_source_partitioning.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+from django.test import TestCase
+
+from corehq.apps.userreports.models import SQLPartition
+from corehq.apps.userreports.pillow import get_kafka_ucr_pillow
+from corehq.apps.userreports.tests.utils import (
+    doc_to_change,
+    get_sample_data_source,
+    get_sample_doc_and_indicators,
+)
+from corehq.apps.userreports.util import get_indicator_adapter
+
+
+class DataSourceConfigurationPartitionTest(TestCase):
+    column = None
+    subtype = None
+    constraint = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(DataSourceConfigurationPartitionTest, cls).setUpClass()
+        cls.data_source = get_sample_data_source()
+        cls.data_source.sql_settings.partition_config = [
+            SQLPartition(column=cls.column, subtype=cls.subtype, constraint=cls.constraint)
+        ]
+        cls.data_source.save()
+        cls.adapter = get_indicator_adapter(cls.data_source)
+        cls.adapter.build_table()
+
+    def tearDown(self):
+        self.adapter.session_helper.Session.remove()
+        table = self.adapter.get_table()
+        self.adapter.engine.execute("DROP TABLE \"%s\" CASCADE;" % table.name)
+        self.data_source.delete()
+        super(DataSourceConfigurationPartitionTest, self).tearDown()
+
+    def _process_docs(self, docs):
+        pillow = get_kafka_ucr_pillow()
+        pillow.bootstrap(configs=[self.data_source])
+
+        for doc in docs:
+            pillow.process_change(doc_to_change(doc))
+
+
+class DataSourcePartitionByDay(DataSourceConfigurationPartitionTest):
+    column = "date"
+    subtype = "date"
+    constraint = "day"
+
+    def test_partitioned_by_date(self):
+        # two docs from separate days
+        sample_doc1, _ = get_sample_doc_and_indicators()
+        sample_doc1['opened_on'] = datetime(2018, 1, 1)
+        sample_doc2, _ = get_sample_doc_and_indicators()
+        sample_doc2['opened_on'] = datetime(2018, 1, 2)
+
+        self._process_docs([sample_doc1, sample_doc2])
+
+        self.assertEqual(2, self.adapter.get_query_object().count())
+
+        # ensure docs are in separate databases
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018d001";')
+        result = result.fetchone()[0]
+        self.assertEqual(1, result)
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018d002";')
+        result = result.fetchone()[0]
+        self.assertEqual(1, result)
+
+
+class DataSourcePartitionByMonth(DataSourceConfigurationPartitionTest):
+    column = "date"
+    subtype = "date"
+    constraint = "month"
+
+    def test_partitioned_by_date(self):
+        # two docs from separate days
+        sample_doc1, _ = get_sample_doc_and_indicators()
+        sample_doc1['opened_on'] = datetime(2018, 1, 1)
+        sample_doc2, _ = get_sample_doc_and_indicators()
+        sample_doc2['opened_on'] = datetime(2018, 2, 2)
+        sample_doc3, _ = get_sample_doc_and_indicators()
+        sample_doc3['opened_on'] = datetime(2018, 2, 3)
+
+        self._process_docs([sample_doc1, sample_doc2, sample_doc3])
+
+        self.assertEqual(3, self.adapter.get_query_object().count())
+
+        # ensure docs are in separate databases
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018m01";')
+        result = result.fetchone()[0]
+
+        self.assertEqual(1, result)
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM "config_report_user-reports_sample_7554612a_y2018m02";')
+        result = result.fetchone()[0]
+        self.assertEqual(2, result)
+
+
+class DataSourcePartitionByOwner(DataSourceConfigurationPartitionTest):
+    column = "owner"
+    subtype = "string_firstchars"
+    constraint = "10"
+
+    def test_partitioned_by_date(self):
+        # two docs from separate days
+        sample_doc1, _ = get_sample_doc_and_indicators()
+        sample_doc1['owner_id'] = "abcdefghijklmnop"
+        sample_doc2, _ = get_sample_doc_and_indicators()
+        sample_doc2['owner_id'] = "abcdefghijklmnop"
+
+        # drop g
+        sample_doc3, _ = get_sample_doc_and_indicators()
+        sample_doc3['owner_id'] = "abcdefhijklmnop"
+
+        self._process_docs([sample_doc1, sample_doc2, sample_doc3])
+
+        self.assertEqual(3, self.adapter.get_query_object().count())
+
+        # ensure docs are in separate databases
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM """config_report_user-reports_sample_7554612a_abcdefghij""";')
+        result = result.fetchone()[0]
+
+        self.assertEqual(2, result)
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM """config_report_user-reports_sample_7554612a_abcdefhijk""";')
+        result = result.fetchone()[0]
+        self.assertEqual(1, result)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -97,7 +97,7 @@ raven==6.1.0
 quickcache==0.1.0
 zeep==1.6.0
 git+git://github.com/dimagi/ethiopian-date-converter@v0.1.2#egg=ethiopian-date-converter
-architect==0.5.6
+git+git://github.com/dimagi/architect@v0.5.7a2#egg=architect
 contextlib2==0.5.4
 hiredis==0.2.0
 xlwt==1.3.0

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -3,3 +3,4 @@ xlutils
 github3.py
 mocker
 ethiopian-date
+architect


### PR DESCRIPTION
This depends on a PR I made to architect. Currently in review right now https://github.com/maxtepkeev/architect/pull/51

It's currently impossible to rebuild this tables as sqlalchemy doesn't have a function to DROP ... CASCADE, but I think that's fine as the tables that use this are going to be big enough that a rebuild shouldn't happen often.

buddy @nickpell 