### PR TITLE
Bump Datatables version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,7 @@
     "less": "1.7.3",
     "xpath": "dimagi/js-xpath#f4f0c78",
     "blazy": "1.6.2",
-    "datatables": "1.10.9",
+    "datatables": "1.10.16",
     "datatables-bootstrap3": "*",
     "datatables-fixedcolumns": "3.2.0",
     "datatables-fixedheader": "^3.1.3",


### PR DESCRIPTION
Scrolling to the side sometimes makes the header not aligned with the body of the table..
https://manage.dimagi.com/default.asp?269448

I don't know if this is the right solution as it doesn't seem like this change actually updates the datatables version that is used in admin reports, but opening this for discussion.

@biyeun @orangejenny 



