### PR TITLE
Fix missing trendline in chart view and location search bug

### DIFF
--- a/custom/icds_reports/static/js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js
+++ b/custom/icds_reports/static/js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js
@@ -113,8 +113,9 @@ function AdhaarController($scope, $routeParams, $location, $filter, demographics
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/adult-weight-scale/adult-weight-scale.directive.js
+++ b/custom/icds_reports/static/js/directives/adult-weight-scale/adult-weight-scale.directive.js
@@ -113,8 +113,9 @@ function AdultWeightScaleController($scope, $routeParams, $location, $filter, in
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/awc-daily-status/awc-daily-status.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-daily-status/awc-daily-status.directive.js
@@ -114,7 +114,7 @@ function AWCDailyStatusController($scope, $routeParams, $location, $filter, icds
                     });
                 }));
                 var range = max - min;
-                vm.chartOptions.chart.forceY = [0, (max + range/10).toFixed(2)];
+                vm.chartOptions.chart.forceY = [0, parseInt((max + range/10).toFixed(0))];
             }
         });
     };

--- a/custom/icds_reports/static/js/directives/awcs-covered/awcs-covered.directive.js
+++ b/custom/icds_reports/static/js/directives/awcs-covered/awcs-covered.directive.js
@@ -114,8 +114,8 @@ function AWCSCoveredController($scope, $routeParams, $location, $filter, icdsCas
                 }));
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    (min - range/10).toFixed(2) < 0 ? 0 : (min - range/10).toFixed(2),
-                    (max + range/10).toFixed(2),
+                    parseInt((min - range/10).toFixed(0)) < 0 ? 0 : parseInt((min - range/10).toFixed(0)),
+                    parseInt((max + range/10).toFixed(0)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/children-initiated/children-initiated.directive.js
+++ b/custom/icds_reports/static/js/directives/children-initiated/children-initiated.directive.js
@@ -124,8 +124,9 @@ function ChildrenInitiatedController($scope, $routeParams, $location, $filter, m
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/clean-water/clean-water.directive.js
+++ b/custom/icds_reports/static/js/directives/clean-water/clean-water.directive.js
@@ -113,8 +113,9 @@ function CleanWaterController($scope, $routeParams, $location, $filter, infrastr
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js
+++ b/custom/icds_reports/static/js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js
@@ -126,8 +126,9 @@ function EarlyInitiationBreastfeedingController($scope, $routeParams, $location,
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/enrolled-children/enrolled-children.directive.js
+++ b/custom/icds_reports/static/js/directives/enrolled-children/enrolled-children.directive.js
@@ -142,7 +142,7 @@ function EnrolledChildrenController($scope, $routeParams, $location, $filter, de
                     });
                 }));
                 var range = max - min;
-                vm.chartOptions.chart.forceY = [0, (max + range/10).toFixed(2)];
+                vm.chartOptions.chart.forceY = [0, parseInt((max + range/10).toFixed(0))];
             }
         });
     };

--- a/custom/icds_reports/static/js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js
+++ b/custom/icds_reports/static/js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js
@@ -125,8 +125,9 @@ function ExclusiveBreasfeedingController($scope, $routeParams, $location, $filte
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/functional-toilet/functional-toilet.directive.js
+++ b/custom/icds_reports/static/js/directives/functional-toilet/functional-toilet.directive.js
@@ -113,8 +113,9 @@ function FunctionalToiletController($scope, $routeParams, $location, $filter, in
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/immunization_coverage/immunization_coverage.directive.js
+++ b/custom/icds_reports/static/js/directives/immunization_coverage/immunization_coverage.directive.js
@@ -125,8 +125,9 @@ function ImmunizationCoverageController($scope, $routeParams, $location, $filter
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/infants-weight-scale/infants-weight-scale.directive.js
+++ b/custom/icds_reports/static/js/directives/infants-weight-scale/infants-weight-scale.directive.js
@@ -113,8 +113,9 @@ function InfantsWeightScaleController($scope, $routeParams, $location, $filter, 
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/institutional-deliveries/institutional-deliveries.directive.js
+++ b/custom/icds_reports/static/js/directives/institutional-deliveries/institutional-deliveries.directive.js
@@ -115,8 +115,9 @@ function InstitutionalDeliveriesController($scope, $routeParams, $location, $fil
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
@@ -119,13 +119,15 @@ function LocationFilterController($scope, $location, $uibModal, locationHierarch
 
     vm.userLocationId = userLocationId;
     vm.animationsEnabled = true;
-    vm.selectedLocationId = $location.search()['location_id'] || vm.userLocationId;
+    vm.selectedLocationId = $location.search()['location_id'] !== 'undefined' &&
+        $location.search()['location_id'] !== 'null' ? $location.search()['location_id'] : vm.userLocationId;
     vm.locationsCache = {};
     vm.selectedLocations = [];
     vm.hierarchy = [];
     vm.currentLevel = 0;
     vm.maxLevel = 0;
-    vm.location_id = $location.search()['location_id'] || vm.selectedLocationId;
+    vm.location_id = $location.search()['location_id'] !== 'undefined' &&
+        $location.search()['location_id'] !== 'null' ? $location.search()['location_id'] : vm.selectedLocationId;
 
     var ALL_OPTION = {name: 'All', location_id: 'all'};
 

--- a/custom/icds_reports/static/js/directives/medicine-kit/medicine-kit.directive.js
+++ b/custom/icds_reports/static/js/directives/medicine-kit/medicine-kit.directive.js
@@ -113,8 +113,9 @@ function MedicineKitController($scope, $routeParams, $location, $filter, infrast
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
+++ b/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
@@ -128,8 +128,9 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js
+++ b/custom/icds_reports/static/js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js
@@ -142,8 +142,9 @@ function PrevalenceOfSevereReportController($scope, $routeParams, $location, $fi
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js
+++ b/custom/icds_reports/static/js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js
@@ -143,8 +143,9 @@ function PrevalenceOfStuntingReportController($scope, $routeParams, $location, $
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/registered-household/registered-household.directive.js
+++ b/custom/icds_reports/static/js/directives/registered-household/registered-household.directive.js
@@ -111,8 +111,8 @@ function RegisteredHouseholdController($scope, $routeParams, $location, $filter,
                 }));
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    (min - range/10).toFixed(2) < 0 ? 0 : (min - range/10).toFixed(2),
-                    (max + range/10).toFixed(2),
+                    parseInt((min - range/10).toFixed(0)) < 0 ? 0 : parseInt((min - range/10).toFixed(0)),
+                    parseInt((max + range/10).toFixed(0)),
                 ];
             }
         });

--- a/custom/icds_reports/static/js/directives/underweight-children-report/underweight-children-report.directive.js
+++ b/custom/icds_reports/static/js/directives/underweight-children-report/underweight-children-report.directive.js
@@ -139,8 +139,9 @@ function UnderweightChildrenReportController($scope, $routeParams, $location, $f
                 }) * 100);
                 var range = max - min;
                 vm.chartOptions.chart.forceY = [
-                    ((min - range/10)/100).toFixed(2) < 0 ? 0 : ((min - range/10)/100).toFixed(2),
-                    ((max + range/10)/100).toFixed(2),
+                    parseInt(((min - range/10)/100).toFixed(2)) < 0 ?
+                        0 : parseInt(((min - range/10)/100).toFixed(2)),
+                    parseInt(((max + range/10)/100).toFixed(2)),
                 ];
             }
         });

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -285,7 +285,9 @@ class BaseReportView(View):
         domain = self.kwargs['domain']
         current_month = datetime(year, month, 1)
         prev_month = current_month - relativedelta(months=1)
-        location = request.GET.get('location_id', '')
+        location = request.GET.get('location_id')
+        if location == 'null' or location == 'undefined':
+            location = None
         selected_month = current_month
 
         return step, now, month, year, include_test, domain, current_month, prev_month, location, selected_month
@@ -375,8 +377,10 @@ class PrevalenceOfUndernutritionView(BaseReportView):
 class LocationView(View):
 
     def get(self, request, *args, **kwargs):
-        if 'location_id' in request.GET and request.GET['location_id'] and request.GET['location_id'] != 'null':
-            location_id = request.GET['location_id']
+        location_id = request.GET.get('location_id')
+        if location_id == 'null' or location_id == 'undefined':
+            location_id = None
+        if location_id:
             if not user_can_access_location_id(self.kwargs['domain'], request.couch_user, location_id):
                 return JsonResponse({})
             location = get_object_or_404(
@@ -429,6 +433,8 @@ class LocationView(View):
 class LocationAncestorsView(View):
     def get(self, request, *args, **kwargs):
         location_id = request.GET.get('location_id')
+        if location_id == 'null' or location_id == 'undefined':
+            location_id = None
         show_test = request.GET.get('include_test', False)
         selected_location = get_object_or_404(SQLLocation, location_id=location_id, domain=self.kwargs['domain'])
         parents = list(SQLLocation.objects.get_queryset_ancestors(
@@ -465,6 +471,8 @@ class LocationAncestorsView(View):
 class AWCLocationView(View):
     def get(self, request, *args, **kwargs):
         location_id = request.GET.get('location_id')
+        if location_id == 'null' or location_id == 'undefined':
+            location_id = None
         selected_location = get_object_or_404(SQLLocation, location_id=location_id, domain=self.kwargs['domain'])
         awcs = selected_location.get_descendants().filter(
             location_type__code=AWC_LOCATION_TYPE_CODE
@@ -488,7 +496,9 @@ class AwcReportsView(BaseReportView):
             self.get_settings(request, *args, **kwargs)
 
         two_before = current_month - relativedelta(months=2)
-        location = request.GET.get('location_id', None)
+        location = request.GET.get('location_id')
+        if location == 'null' or location == 'undefined':
+            location = None
         aggregation_level = 5
 
         config = {
@@ -1029,6 +1039,8 @@ class AWCDailyStatusView(View):
             'aggregation_level': 1,
         }
         location = request.GET.get('location_id', '')
+        if location == 'null' or location == 'undefined':
+            location = None
         config.update(get_location_filter(location, self.kwargs['domain']))
         loc_level = get_location_level(config.get('aggregation_level'))
 


### PR DESCRIPTION
Hi @emord,
I've added fix for missing trendline on registered households chart view as well as I set minimal and maximal values on the chart to be fixed to a precision of 2 digits after dot if the value is shown as a percentage or to be shown as an integer.
There is also change in views that will catch all nasty values in location_id parameter during requests.
