### PR TITLE
Don't use memoize_timeout by default

### DIFF
--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -11,7 +11,7 @@ quickcache_soft_assert = soft_assert(
     skip_frames=5,
 )
 
-quickcache = get_django_quickcache(timeout=5 * 60, memoize_timeout=10,
+quickcache = get_django_quickcache(timeout=5 * 60, memoize_timeout=0,
                                    assert_function=quickcache_soft_assert)
 
 


### PR DESCRIPTION
I was debugging an issue where stale rule criteria were being referenced in celery tasks despite having the cached value cleared, and tracked it down to this. Even though we call `.clear()` on a quickcached function after we save certain models, it can't clear the local memory cache used in other processes, so using a `memoize_timeout` creates a vulnerability of referencing a stale result in a celery task (or django view accessed on another machine) even though you've called `.clear()` on a quickcached function post model save from a django view, which is something we do often.

It also seems like, in most cases, you shouldn't actually need to use `memoize_timeout` because you should just be storing the result of a quickcached function in a variable and then referencing that variable thereafter, instead of calling the function multiple times. You really should only use `memoize_timeout` in special circumstances when you understand the implications.

@dannyroberts @orangejenny 