### PR TITLE
WhatsApp

### DIFF
--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -33,6 +33,7 @@ from corehq.messaging.smsbackends.tropo.models import SQLTropoBackend
 from corehq.messaging.smsbackends.twilio.models import SQLTwilioBackend
 from corehq.messaging.smsbackends.unicel.models import SQLUnicelBackend, InboundParams
 from corehq.messaging.smsbackends.vertex.models import VertexBackend
+from corehq.messaging.smsbackends.whatsapp.models import SQLWhatsAppBackend
 from corehq.messaging.smsbackends.yo.models import SQLYoBackend
 from corehq.util.test_utils import create_test_case
 from datetime import datetime
@@ -170,6 +171,16 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         )
         cls.vertext_backend.save()
 
+        cls.whatsapp_backend = SQLWhatsAppBackend(
+            name="WHATSAPP",
+            is_global=False,
+            domain=cls.domain_obj.name,
+            hq_api_id=SQLWhatsAppBackend.get_api_id(),
+            phone_number=27837596738,
+            password='secret',
+        )
+        cls.whatsapp_backend.save()
+
         cls.start_enterprise_backend = StartEnterpriseBackend(
             name="START_ENT",
             is_global=True,
@@ -204,6 +215,7 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         cls.push_backend.delete()
         cls.icds_backend.delete()
         cls.vertext_backend.delete()
+        cls.whatsapp_backend.delete()
         cls.start_enterprise_backend.delete()
         cls.ivory_coast_mtn_backend.delete()
         super(AllBackendTest, cls).tearDownClass()
@@ -295,12 +307,14 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
     @patch('corehq.messaging.smsbackends.push.models.PushBackend.send')
     @patch('corehq.messaging.smsbackends.icds_nic.models.SQLICDSBackend.send')
     @patch('corehq.messaging.smsbackends.vertex.models.VertexBackend.send')
+    @patch('corehq.messaging.smsbackends.whatsapp.models.SQLWhatsAppBackend.send')
     @patch('corehq.messaging.smsbackends.start_enterprise.models.StartEnterpriseBackend.send')
     @patch('corehq.messaging.smsbackends.ivory_coast_mtn.models.IvoryCoastMTNBackend.send')
     def test_outbound_sms(
             self,
             ivory_coast_mtn_send,
             start_ent_send,
+            whatsapp_send,
             vertex_send,
             icds_send,
             push_send,
@@ -333,6 +347,7 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._test_outbound_backend(self.push_backend, 'push test', push_send)
         self._test_outbound_backend(self.icds_backend, 'icds test', icds_send)
         self._test_outbound_backend(self.vertext_backend, 'vertex_test', vertex_send)
+        self._test_outbound_backend(self.whatsapp_backend, 'whatsapp_test', whatsapp_send)
         self._test_outbound_backend(self.start_enterprise_backend, 'start_ent_test', start_ent_send)
         self._test_outbound_backend(self.ivory_coast_mtn_backend, 'ivory_coast_mtn_test', ivory_coast_mtn_send)
 

--- a/corehq/messaging/smsbackends/whatsapp/forms.py
+++ b/corehq/messaging/smsbackends/whatsapp/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.utils.translation import ugettext_lazy as _
 
 from corehq.apps.sms.forms import BackendForm

--- a/corehq/messaging/smsbackends/whatsapp/forms.py
+++ b/corehq/messaging/smsbackends/whatsapp/forms.py
@@ -1,0 +1,23 @@
+from django.utils.translation import ugettext_lazy as _
+
+from corehq.apps.sms.forms import BackendForm
+from crispy_forms import layout as crispy
+from dimagi.utils.django.fields import TrimmedCharField
+
+
+class WhatsAppBackendForm(BackendForm):
+    phone_number = TrimmedCharField(
+        label=_("Phone Number"),
+        help_text=_('Phone number with international dialling code, excluding leading "+" or zeros.')
+    )
+    password = TrimmedCharField(
+        label=_("WhatsApp Password"),
+    )
+
+    @property
+    def gateway_specific_fields(self):
+        return crispy.Fieldset(
+            _("WhatsApp Settings"),
+            'phone_number',
+            'password',
+        )

--- a/corehq/messaging/smsbackends/whatsapp/models.py
+++ b/corehq/messaging/smsbackends/whatsapp/models.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import namedtuple
 
 from yowsup.demos.sendclient import YowsupSendStack

--- a/corehq/messaging/smsbackends/whatsapp/models.py
+++ b/corehq/messaging/smsbackends/whatsapp/models.py
@@ -1,0 +1,60 @@
+from collections import namedtuple
+
+from yowsup.demos.sendclient import YowsupSendStack
+from yowsup.layers import YowLayerEvent
+from yowsup.layers.auth import AuthError
+from yowsup.layers.network import YowNetworkLayer
+
+from corehq.apps.sms.models import SQLSMSBackend
+from corehq.apps.sms.util import clean_phone_number
+from corehq.messaging.smsbackends.whatsapp.forms import WhatsAppBackendForm
+from dimagi.utils import logging
+
+
+YowsupMessage = namedtuple('YowsupMessage', 'phone body')
+
+
+class SQLWhatsAppBackend(SQLSMSBackend):
+
+    class Meta:
+        app_label = 'sms'
+        proxy = True
+
+    @classmethod
+    def get_available_extra_fields(cls):
+        return [
+            'phone_number',
+            'password',
+        ]
+
+    @classmethod
+    def get_api_id(cls):
+        return 'WHATSAPP'
+
+    @classmethod
+    def get_generic_name(cls):
+        return "WhatsApp"
+
+    @classmethod
+    def get_form_class(cls):
+        return WhatsAppBackendForm
+
+    def get_credentials(self):
+        config = self.config
+        return (config.phone_number, config.password)
+
+    def send(self, msg, *args, **kwargs):
+        phone_number = clean_phone_number(msg.phone_number)
+        messages = [YowsupMessage(phone_number, msg.text)]  # msg.text is expected to be Unicode
+
+        stack = YowsupSendStack(self.get_credentials(), messages, encryptionEnabled=True)
+        # stack.start()  # Reimplemented below, but notify on auth failure instead of printing it
+        stack.stack.broadcastEvent(YowLayerEvent(YowNetworkLayer.EVENT_STATE_CONNECT))
+        try:
+            stack.stack.loop()  # TODO: discrete=5, count=X ?
+        except AuthError as err:
+            domain = ' for domain "{}"'.format(self.domain) if self.domain else ''
+            logging.notify_error('WhatsApp authentication failure{domain}: {err}'.format(domain=domain, err=err))
+        except KeyboardInterrupt:
+            # Raised when messages sent and acks received
+            pass

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -95,6 +95,7 @@ email_validator==1.0.2
 dnspython==1.15.0
 raven==6.1.0
 quickcache==0.1.0
+yowsup2==2.5.7
 zeep==1.6.0
 git+git://github.com/dimagi/ethiopian-date-converter@v0.1.2#egg=ethiopian-date-converter
 architect==0.5.6

--- a/settings.py
+++ b/settings.py
@@ -294,6 +294,7 @@ HQ_APPS = (
     'corehq.messaging.smsbackends.unicel',
     'corehq.messaging.smsbackends.icds_nic',
     'corehq.messaging.smsbackends.vertex',
+    'corehq.messaging.smsbackends.whatsapp',
     'corehq.messaging.smsbackends.start_enterprise',
     'corehq.messaging.smsbackends.ivory_coast_mtn',
     'corehq.apps.reports.app_config.ReportsModule',
@@ -1553,6 +1554,7 @@ SMS_LOADED_SQL_BACKENDS = [
     'corehq.messaging.smsbackends.unicel.models.SQLUnicelBackend',
     'corehq.messaging.smsbackends.yo.models.SQLYoBackend',
     'corehq.messaging.smsbackends.vertex.models.VertexBackend',
+    'corehq.messaging.smsbackends.whatsapp.models.SQLWhatsAppBackend',
     'corehq.messaging.smsbackends.start_enterprise.models.StartEnterpriseBackend',
     'corehq.messaging.smsbackends.ivory_coast_mtn.models.IvoryCoastMTNBackend',
 ]


### PR DESCRIPTION
![Here Be Dragons](https://user-images.githubusercontent.com/708421/35980912-96280bbe-0cf4-11e8-98a3-ace553eb7552.jpg)

This is a Hackathon project. It adds WhatsApp as a messaging backend. Currently outbound only.

![whatsapp_gateway](https://user-images.githubusercontent.com/708421/35980862-76a4a518-0cf4-11e8-9160-8f777f556d6e.png)

#### Still to do

- Get a new SIM card and register with WhatsApp to get a password.
- **... Then actually test this!**
- Restrict this to **Dimagi domains only**<sup>[1](#fn1)</sup>, because we can't rely on this API, or support this.
- Write a big warning somewhere that this could break without notice, and not to use it for important notifications.

@gcapalbo @snopoke buddy @czue 

<a name="fn1">1</a>: I couldn't see how to restrict this in a clean way. Open to suggestions.
