### PR TITLE
Don't load map for district and blocks view

### DIFF
--- a/custom/icds_reports/static/js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js
+++ b/custom/icds_reports/static/js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js
@@ -123,7 +123,7 @@ function AdhaarController($scope, $routeParams, $location, $filter, demographics
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/adult-weight-scale/adult-weight-scale.directive.js
+++ b/custom/icds_reports/static/js/directives/adult-weight-scale/adult-weight-scale.directive.js
@@ -123,7 +123,7 @@ function AdultWeightScaleController($scope, $routeParams, $location, $filter, in
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/awc-daily-status/awc-daily-status.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-daily-status/awc-daily-status.directive.js
@@ -121,7 +121,7 @@ function AWCDailyStatusController($scope, $routeParams, $location, $filter, icds
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/children-initiated/children-initiated.directive.js
+++ b/custom/icds_reports/static/js/directives/children-initiated/children-initiated.directive.js
@@ -134,7 +134,7 @@ function ChildrenInitiatedController($scope, $routeParams, $location, $filter, m
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/clean-water/clean-water.directive.js
+++ b/custom/icds_reports/static/js/directives/clean-water/clean-water.directive.js
@@ -123,7 +123,7 @@ function CleanWaterController($scope, $routeParams, $location, $filter, infrastr
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js
+++ b/custom/icds_reports/static/js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js
@@ -136,7 +136,7 @@ function EarlyInitiationBreastfeedingController($scope, $routeParams, $location,
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/enrolled-children/enrolled-children.directive.js
+++ b/custom/icds_reports/static/js/directives/enrolled-children/enrolled-children.directive.js
@@ -149,7 +149,7 @@ function EnrolledChildrenController($scope, $routeParams, $location, $filter, de
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/enrolled-women/enrolled-women.directive.js
+++ b/custom/icds_reports/static/js/directives/enrolled-women/enrolled-women.directive.js
@@ -127,7 +127,7 @@ function EnrolledWomenController($scope, $routeParams, $location, $filter, demog
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js
+++ b/custom/icds_reports/static/js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js
@@ -135,7 +135,7 @@ function ExclusiveBreasfeedingController($scope, $routeParams, $location, $filte
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/functional-toilet/functional-toilet.directive.js
+++ b/custom/icds_reports/static/js/directives/functional-toilet/functional-toilet.directive.js
@@ -123,7 +123,7 @@ function FunctionalToiletController($scope, $routeParams, $location, $filter, in
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/immunization_coverage/immunization_coverage.directive.js
+++ b/custom/icds_reports/static/js/directives/immunization_coverage/immunization_coverage.directive.js
@@ -135,7 +135,7 @@ function ImmunizationCoverageController($scope, $routeParams, $location, $filter
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/infants-weight-scale/infants-weight-scale.directive.js
+++ b/custom/icds_reports/static/js/directives/infants-weight-scale/infants-weight-scale.directive.js
@@ -123,7 +123,7 @@ function InfantsWeightScaleController($scope, $routeParams, $location, $filter, 
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/institutional-deliveries/institutional-deliveries.directive.js
+++ b/custom/icds_reports/static/js/directives/institutional-deliveries/institutional-deliveries.directive.js
@@ -125,7 +125,7 @@ function InstitutionalDeliveriesController($scope, $routeParams, $location, $fil
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/lactating-enrolled-women/lactating-enrolled-women.directive.js
+++ b/custom/icds_reports/static/js/directives/lactating-enrolled-women/lactating-enrolled-women.directive.js
@@ -127,7 +127,7 @@ function LactatingEnrolledWomenController($scope, $routeParams, $location, $filt
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/medicine-kit/medicine-kit.directive.js
+++ b/custom/icds_reports/static/js/directives/medicine-kit/medicine-kit.directive.js
@@ -123,7 +123,7 @@ function MedicineKitController($scope, $routeParams, $location, $filter, infrast
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
+++ b/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
@@ -138,7 +138,7 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js
+++ b/custom/icds_reports/static/js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js
@@ -155,7 +155,7 @@ function PrevalenceOfSevereReportController($scope, $routeParams, $location, $fi
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js
+++ b/custom/icds_reports/static/js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js
@@ -156,7 +156,7 @@ function PrevalenceOfStuntingReportController($scope, $routeParams, $location, $
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/registered-household/registered-household.directive.js
+++ b/custom/icds_reports/static/js/directives/registered-household/registered-household.directive.js
@@ -120,7 +120,7 @@ function RegisteredHouseholdController($scope, $routeParams, $location, $filter,
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;

--- a/custom/icds_reports/static/js/directives/underweight-children-report/underweight-children-report.directive.js
+++ b/custom/icds_reports/static/js/directives/underweight-children-report/underweight-children-report.directive.js
@@ -152,7 +152,7 @@ function UnderweightChildrenReportController($scope, $routeParams, $location, $f
 
     vm.init = function() {
         var locationId = vm.filtersData.location_id || vm.userLocationId;
-        if (!vm.userLocationId || !locationId || locationId === 'all' || locationId === 'null') {
+        if (!locationId || ["all", "null", "undefined"].indexOf(locationId) >= 0) {
             vm.loadData();
             vm.loaded = true;
             return;


### PR DESCRIPTION
Hi @emord,
This is a fix for bugged district and blocks view where the map was trying to get rendered, while at the same time keeping all necessary changes to close all holes in country view to render the map.
The issue comes from fact that angular is not willing to put into url argument empty value and uses stringified versions instead, that's why there were two ways to ultimately fix issue on country view: either check vm.userLocationId which is the value that is put into the url argument 'locationId' or to compare locationId to all unwanted values.
At the same time vm.userLocationId is not existing in district and blocks view which caused the issue.