### PR TITLE
Bump SQLAlchemy to 1.2.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -77,7 +77,7 @@ django-two-factor-auth==1.6.2
 datadog==0.15.0
 django-websocket-redis==0.5.1
 django-redis-sessions==0.5.6
-SQLAlchemy==1.1.9
+SQLAlchemy==1.2.2
 alembic==0.8.6
 pyzxcvbn==0.8.0
 django-statici18n==1.3.0


### PR DESCRIPTION
Trying this out. Otherwise will go with 1.1.15

@millerdev 