### PR TITLE
Reset get_sql_locations cache after changing assigned_location_ids

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2350,6 +2350,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
             if location.location_id in membership.assigned_location_ids:
                 return
             membership.assigned_location_ids.append(location.location_id)
+            self.get_sql_locations.reset_cache(self)
             self.save()
         else:
             self.set_location(domain, location)
@@ -2368,6 +2369,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         membership.location_id = location_id
         if self.location_id not in membership.assigned_location_ids:
             membership.assigned_location_ids.append(location_id)
+            self.get_sql_locations.reset_cache(self)
         self.get_sql_location.reset_cache(self)
         self.save()
 
@@ -2380,6 +2382,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         old_location_id = membership.location_id
         if old_location_id:
             membership.assigned_location_ids.remove(old_location_id)
+            self.get_sql_locations.reset_cache(self)
         if membership.assigned_location_ids and fall_back_to_next:
             membership.location_id = membership.assigned_location_ids[0]
         else:
@@ -2398,6 +2401,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
             self.unset_location(domain, fall_back_to_next)
         else:
             membership.assigned_location_ids.remove(location_id)
+            self.get_sql_locations.reset_cache(self)
             self.save()
 
     def reset_locations(self, domain, location_ids):
@@ -2409,6 +2413,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         membership.assigned_location_ids = location_ids
         if not membership.location_id and location_ids:
             membership.location_id = location_ids[0]
+        self.get_sql_locations.reset_cache(self)
         self.save()
 
     @memoized


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?256939#1451359

I haven't been able to repro that issue locally... But:
- `WebUser.get_sql_locations` is memoized. This method accesses `assigned_location_ids`.
- `assigned_location_ids` is updated when we change the primary location. This happens in 2 steps. 
    - First, the new location is _added_ into the `assigned_location_ids` list: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/models.py#L2370-L2371. At this point, the list contains the previous and the current locations. If you called `get_sql_locations` at this moment, it would give you back the old and the new location, and cache this.
    - Then, the `assigned_location_ids` list is reset: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/forms.py#L977-L979. However, the memoized cache is never cleared.
- I don't know when `get_sql_locations` is called in between to have it be cached, however, so I don't know if this is actually the solution. 