### PR TITLE
execute run_case_update_rules_for_domain on CELERY_CASE_UPDATE_RULE_Q…

### DIFF
--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -113,7 +113,7 @@ def check_data_migration_in_progress(domain, last_migration_check_time):
     '{domain}',
     timeout=36 * 60 * 60,
     max_retries=0,
-    queue='background_queue',
+    queue=settings.CELERY_CASE_UPDATE_RULE_QUEUE,
 )
 def run_case_update_rules_for_domain(domain, now=None):
     now = now or datetime.utcnow()

--- a/settings.py
+++ b/settings.py
@@ -585,6 +585,10 @@ CELERY_REMINDER_RULE_QUEUE = CELERY_MAIN_QUEUE
 # on its own queue.
 CELERY_REMINDER_CASE_UPDATE_QUEUE = CELERY_MAIN_QUEUE
 
+# This is the celery queue to use for running automatic update rules.
+# It's set to the background queue here and can be overriden to put it
+# on its own queue.
+CELERY_CASE_UPDATE_RULE_QUEUE = 'background_queue'
 
 # This is the celery queue to use for sending repeat records.
 # It's set to the main queue here and can be overridden to put it


### PR DESCRIPTION
…UEUE

@emord had a hypothesis that https://manage.dimagi.com/default.asp?270029 is being caused by the background_queue deadlocking due to an issue with the autoscaling.  From watching the queue in flower it looks like ```run_case_update_rules_for_domain``` is taking a long time to run.  I'm hoping that putting this task into a separate queue will resolve the recurring issue every Tuesday.  If not, it may require separating out other tasks until we identify the problematic one.