### PR TITLE
Show error message even if response fails

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
@@ -65,7 +65,7 @@ hqDefine('userreports/js/expression_evaluator', function () {
                         self.updateUrl();
                     },
                     error: function (data) {
-                        self.uiFeedback("<strong>Failure!:</strong> " + data.responseJSON.error);
+                        self.uiFeedback("<strong>Failure!:</strong> " + data.responseJSON ? data.responseJSON.error : "Unknown error");
                     },
                 });
             }


### PR DESCRIPTION
If you use the datasource debugger and the response 500s, you don't get an error message since `data.responseJSON` is undefined. 