### PR TITLE
Update ethiopian conversion to expect datetime

### DIFF
--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -77,6 +77,8 @@ def test_ethiopian_to_gregorian(self, date_string, expected_result):
     (date(2017, 5, 19), '2009-09-11'),
     (date(2017, 9, 10), '2009-13-05'),
     (None, ''),
+    ('2017-05-19 ', '2009-09-11'),
+    ('2017-5-19', '2009-09-11')
 ), TestEthiopianConversion)
 def test_gregorian_to_ethiopian(self, date_string, expected_result):
     transform = TransformFactory.get_transform({

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -74,10 +74,8 @@ def test_ethiopian_to_gregorian(self, date_string, expected_result):
 
 
 @generate_cases((
-    ('2017-05-19 ', '2009-09-11'),
-    ('2017-09-10 ', '2009-13-05'),
-    ('2009_13_11 ', ''),
-    ('abc-13-11', ''),
+    (date(2017, 5, 19), '2009-09-11'),
+    (date(2017, 9, 10), '2009-13-05'),
     (None, ''),
 ), TestEthiopianConversion)
 def test_gregorian_to_ethiopian(self, date_string, expected_result):

--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import calendar
-from datetime import datetime
+from datetime import datetime, date
 from ethiopian_date import EthiopianDateConverter
 from dimagi.utils.dates import force_to_datetime
 
@@ -52,20 +52,21 @@ def get_ethiopian_to_gregorian(date_string):
         return ''
 
 
-def get_gregorian_to_ethiopian(datetime_input):
+def get_gregorian_to_ethiopian(date_input):
     '''
-    Takes a string gregorian date and converts it to
+    Takes a gregorian date string or datetime and converts it to
     the equivalent ethiopian date
 
-    :param datetime_input: A datetime
+    :param date_input: A datetime or date string
     :returns: An ethiopian date string or ''
     '''
-    if not datetime_input:
+    if not date_input:
         return ''
 
     try:
-        date_string = datetime_input.strftime('%Y-%m-%d')
-        year, month, day = split_date_string(date_string)
+        if isinstance(date_input, date):
+            date_input = date_input.strftime('%Y-%m-%d')
+        year, month, day = split_date_string(date_input)
     except ValueError:
         return ''
 

--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -52,18 +52,19 @@ def get_ethiopian_to_gregorian(date_string):
         return ''
 
 
-def get_gregorian_to_ethiopian(date_string):
+def get_gregorian_to_ethiopian(datetime_input):
     '''
     Takes a string gregorian date and converts it to
     the equivalent ethiopian date
 
-    :param date_string: A date string that is in the format YYYY-MM-DD
-    :returns: An ethiopian datetime or ''
+    :param datetime_input: A datetime
+    :returns: An ethiopian date string or ''
     '''
-    if not date_string:
+    if not datetime_input:
         return ''
 
     try:
+        date_string = datetime_input.strftime('%Y-%m-%d')
         year, month, day = split_date_string(date_string)
     except ValueError:
         return ''

--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -71,6 +71,6 @@ def get_gregorian_to_ethiopian(datetime_input):
 
     try:
         ethiopian_year, ethiopian_month, ethiopian_day = EthiopianDateConverter.to_ethiopian(year, month, day)
-        return '{:02d}-{:02d}-{:02d}'.format(ethiopian_year, ethiopian_month, ethiopian_day)
+        return '{}-{:02d}-{:02d}'.format(ethiopian_year, ethiopian_month, ethiopian_day)
     except Exception:
         return ''


### PR DESCRIPTION
Working on this ticket: https://manage.dimagi.com/default.asp?pre=preMultiSearch&pg=pgList&pgBack=pgSearch&search=2&searchFor=268877

Issue: This is what's currently happening https://sentry.io/dimagi/commcarehq/issues/457550602/
Because the conversion code is expecting a string containing the date, but it's getting a python datetime.

Also removed the zero padding on the year, the year will always return a 4 digit number so it wasn't necessary