### PR TITLE
Migrate boolean columns to integer columns in infrastructure form UCR.

### DIFF
--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -501,21 +501,55 @@
         "column_id": "medicine_kits_available"
       },
       {
-        "filter": {
-          "operator": "eq",
-          "expression": {
-            "datatype": "string",
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "supply_position_available_1",
-              "preschool_kit"
-            ]
+        "expression": {
+          "type": "conditional",
+          "test": {
+            "operator": "eq",
+            "expression": {
+              "datatype": "string",
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "supply_position_available_1",
+                "preschool_kit"
+              ]
+            },
+            "type": "boolean_expression",
+            "property_value": "yes"
           },
-          "type": "boolean_expression",
-          "property_value": "yes"
+          "expression_if_true": {
+            "type": "constant",
+            "constant": 1
+          },
+          "expression_if_false": {
+            "type": "conditional",
+            "test": {
+              "operator": "eq",
+              "expression": {
+                "datatype": "string",
+                "type": "property_path",
+                "property_path": [
+                  "form",
+                  "supply_position_available_1",
+                  "preschool_kit"
+                ]
+              },
+              "type": "boolean_expression",
+              "property_value": "no"
+            },
+            "expression_if_true": {
+              "type": "constant",
+              "constant": 0
+            },
+            "expression_if_false": {
+              "type": "constant",
+              "constant": null
+            }
+          }
         },
-        "type": "boolean",
+        "type": "expression",
+        "datatype": "integer",
+        "is_nullable": true,
         "display_name": null,
         "column_id": "preschool_kit_available"
       },
@@ -823,22 +857,57 @@
         "display_name": null,
         "column_id": "medicine_kits_usable"
       },
+
       {
-        "filter": {
-          "operator": "eq",
-          "expression": {
-            "datatype": "string",
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "supply_position_usable_1",
-              "preschool_kit"
-            ]
+        "expression": {
+          "type": "conditional",
+          "test": {
+            "operator": "eq",
+            "expression": {
+              "datatype": "string",
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "supply_position_usable_1",
+                "preschool_kit"
+              ]
+            },
+            "type": "boolean_expression",
+            "property_value": "yes"
           },
-          "type": "boolean_expression",
-          "property_value": "yes"
+          "expression_if_true": {
+            "type": "constant",
+            "constant": 1
+          },
+          "expression_if_false": {
+            "type": "conditional",
+            "test": {
+              "operator": "eq",
+              "expression": {
+                "datatype": "string",
+                "type": "property_path",
+                "property_path": [
+                  "form",
+                  "supply_position_usable_1",
+                  "preschool_kit"
+                ]
+              },
+              "type": "boolean_expression",
+              "property_value": "no"
+            },
+            "expression_if_true": {
+              "type": "constant",
+              "constant": 0
+            },
+            "expression_if_false": {
+              "type": "constant",
+              "constant": null
+            }
+          }
         },
-        "type": "boolean",
+        "type": "expression",
+        "datatype": "integer",
+        "is_nullable": true,
         "display_name": null,
         "column_id": "preschool_kit_usable"
       },


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?270315

Allows a preschool kit columns to be null when the question is skipped in the app.

These are "boolean" datatype. In UCR "boolean" is actually a (4 byte, nullable) integer that is forced to 0 or 1. I'm not sure on the origins of that. This change changes it to be a nullable integer column that can be 0, 1, or null. This will not change the underlying postgres table's definition so it won't wipe any data once deployed.

I'll do a "rebuild in place" once this is deployed which will recalculate all the indicators so that these can be null when they were skipped in the app. Should be pretty quick as it's only ~200k forms

buddy @millerdev 