### PR TITLE
Add datadog metric for seconds since last checkpoint update.

### DIFF
--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -31,6 +31,11 @@ def pillow_datadog_metrics():
             'feed_type:{}'.format('couch' if _is_couch(pillow) else 'kafka')
         ]
 
+        datadog_gauge(
+            'commcare.change_feed.seconds_since_last_update',
+            pillow['seconds_since_last_update'], tags=tags
+        )
+
         for topic_name, offset in pillow['offsets'].items():
             if _is_couch(pillow):
                 if not isinstance(pillow['seq'], int) or len(pillow['offsets']) != 1:

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -158,16 +158,18 @@ def get_pillow_json(pillow_config):
     timestamp = checkpoint.timestamp
     if timestamp:
         time_since_last = datetime.utcnow() - timestamp
-        hours_since_last = time_since_last.total_seconds() // 3600
+        seconds_since_last = time_since_last.total_seconds()
+        hours_since_last = seconds_since_last // 3600
 
         try:
             # remove microsecond portion
-            time_since_last = str(time_since_last)
-            time_since_last = time_since_last[0:time_since_last.index('.')]
+            prettified_time_since_last = str(time_since_last)
+            prettified_time_since_last = prettified_time_since_last[0:prettified_time_since_last.index('.')]
         except ValueError:
             pass
     else:
-        time_since_last = ''
+        seconds_since_last = 0
+        prettified_time_since_last = ''
         hours_since_last = None
     offsets = pillow.get_change_feed().get_latest_offsets_json()
 
@@ -183,7 +185,8 @@ def get_pillow_json(pillow_config):
         'seq_format': checkpoint.sequence_format,
         'seq': _seq_to_int(checkpoint, checkpoint.wrapped_sequence),
         'offsets': offsets,
-        'time_since_last': time_since_last,
+        'seconds_since_last': seconds_since_last,
+        'time_since_last': prettified_time_since_last,
         'hours_since_last': hours_since_last
     }
 


### PR DESCRIPTION
From the retro. Going to make a datadog alert based of this to alert us if a checkpoint hasn't been updated after x hours. I'll likely only enable it for prod/icds couch pillows as for kafka pillows the existing alerts should be sufficient and other environments will likely not have enough activity and the alerts will be noisy.

@millerdev 