### PR TITLE
Limit beneficiary requests to one and if possible retrieve limited qu…

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -1009,6 +1009,7 @@ def get_awc_report_beneficiary(start, length, draw, order, awc_id, month, two_be
         age_in_months__lte=60
     )
 
+    data_count = data.count()
     if 'current_month_nutrition_status' in order:
         sort_order = {
             'Severely underweight': 1,
@@ -1031,7 +1032,6 @@ def get_awc_report_beneficiary(start, length, draw, order, awc_id, month, two_be
     else:
         data = data.order_by('-month', order)
 
-    data_count = len(data)
     data = data[start:(start + length)]
 
     config = {

--- a/custom/icds_reports/static/icds_reports/js/spec/awc-reports.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/awc-reports.directive.spec.js
@@ -213,26 +213,6 @@ describe('AWC Reports Directive', function () {
         assert.equal(expected, result);
     });
 
-    it('tests get data for step', function () {
-        controller.filtersData.location_id = 'test-id';
-        controller.selectedLocationLevel = 4;
-        var step = 'beneficiary';
-        var mockBeneficiaryDetails = {
-            "age_in_months": 43, "weight": [50], "wfl": [], "dob": "2014-03-15",
-            "age": "3 years 8 months ", "height": [150], "person_name": "child1HH1-05",
-            "sex": "M", "mother_name": "motherHH1",
-        };
-
-        $httpBackend.expectGET('beneficiary_details?location_id=test-id').respond(200, mockBeneficiaryDetails);
-        controller.getDataForStep(step);
-        $httpBackend.flush();
-
-        var centerExpected = {"lat": 22.1, "lng": 78.22, "zoom": 5};
-        assert.deepEqual(controller.center, centerExpected);
-        assert.equal(controller.message, false);
-        assert.notEqual(controller.markers, null);
-    });
-
     it('tests show beneficiary details', function () {
         this.timeout(500);
         controller.filtersData.location_id = 'test-id';

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -1819,7 +1819,7 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
         }
 
         var get_url = url('awc_reports', step);
-        if (parseInt(vm.selectedLocationLevel && step !== 'beneficiary') === 4) {
+        if (parseInt(vm.selectedLocationLevel) === 4 && step !== 'beneficiary') {
             vm.myPromise = $http({
                 method: "GET",
                 url: get_url,

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -1703,13 +1703,11 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
     vm.label = "AWC Report";
     vm.tooltipPlacement = "right";
     vm.step = $routeParams.step;
-    vm.data = null;
     vm.filters = ['gender', 'age'];
     vm.prevDay = moment().subtract(1, 'days').format('Do MMMM, YYYY');
     vm.lastDayOfPreviousMonth = moment().set('date', 1).subtract(1, 'days').format('Do MMMM, YYYY');
     vm.currentMonth = moment().format("MMMM");
     vm.userLocationId = userLocationId;
-
 
     vm.dtOptions = DTOptionsBuilder.newOptions()
         .withOption('ajax', {
@@ -1821,7 +1819,7 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
         }
 
         var get_url = url('awc_reports', step);
-        if (parseInt(vm.selectedLocationLevel) === 4) {
+        if (parseInt(vm.selectedLocationLevel && step !== 'beneficiary') === 4) {
             vm.myPromise = $http({
                 method: "GET",
                 url: get_url,

--- a/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
@@ -73,7 +73,7 @@
                 </div>
             </div>
             <div class="row black" ng-if="$ctrl.step === 'beneficiary'">
-                <div ng-if="$ctrl.data.months && $ctrl.showTable" class="col-md-12">
+                <div ng-if="$ctrl.showTable" class="col-md-12">
                     <table id="beneficiariesTable" datatable="" dt-options="$ctrl.dtOptions" dt-columns="$ctrl.dtColumns" class="table table-striped table-bordered">
                     </table>
                 </div>


### PR DESCRIPTION
…eryset
Hi @emord,
This change is designed to fix the 500 error when trying to load the child beneficiary detail page.
These changes are repealing first always very expensive request on beneficiary view.
This part is done in directive and template where we are using datatables library to show data in tables. 
Second part is changing len(QuerySet) to QuerySet.count() which in case:
1013 if 'current_month_nutrition_status' in order:
doesn't make a difference as the database is doing count rather than python,
but when this statement is false executes SQL query with LIMIT which makes the request that falls into this category lightweight.

In the end, only place where things still could go somewhat slow would be sorting by "Weight-for-Age Status (in Month)" (case when line 1013 is True), as we need to execute sorting in Python due to the fact that this column gives us values that we are soring like that: {
            'Severely underweight': 1,
            'Moderately underweight': 2,
            'Normal weight for age': 3,
            'Data Not Entered': 4
        }.