### PR TITLE
Sk/missing xml

### DIFF
--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -88,6 +88,9 @@ class FormAccessorCouch(AbstractFormAccessor):
                         content_type=meta.content_type,
                         content_length=meta.content_length,
                     )
+        else:
+            # xforms are expected to at least have the XML attachment
+            raise ResourceNotFound(msg="XForm attachment missing: {}".format(form_id))
         return doc
 
     @staticmethod

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -173,7 +173,6 @@ def _handle_duplicate(new_doc):
         # Original form processing failed but left behind a form doc with no
         # attachments. It's safe to delete this now since we're going to re-process
         # the form anyway.
-        # https://sentry.io/dimagi/commcarehq/issues/261297321
         from couchforms.models import XFormInstance
         XFormInstance.get_db().delete_doc(conflict_id)
         return FormProcessingResult(new_doc)


### PR DESCRIPTION
buddies @dannyroberts @esoergel 

The docs here are 'XFormError' docs that have somehow gotten into a bad state due to some other outage (couchdb in this case). The original submission failed and now the phone is trying to re-submit but can't because of this error. Raising a `ResourceNotFound` here will cause the error form to be deleted and the incoming to be processed.
 
https://sentry.io/dimagi/commcarehq/issues/388519588/