### PR TITLE
Fix pillow datadog metrics.

### DIFF
--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -33,7 +33,7 @@ def pillow_datadog_metrics():
 
         datadog_gauge(
             'commcare.change_feed.seconds_since_last_update',
-            pillow['seconds_since_last_update'], tags=tags
+            pillow['seconds_since_last'], tags=tags
         )
 
         for topic_name, offset in pillow['offsets'].items():


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/462492268/?referrer=slack

Typo broke pillow metrics :/ Are there any good ways to test metrics that are sent to datadog?

@nickpell @millerdev 