### PR TITLE
Data source missing required columns

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -421,14 +421,18 @@ class DataSourceBuilder(object):
             if column['property']:
                 column_option = self.report_column_options[column['property']]
                 for indicator in column_option.get_indicators(column['calculation'], is_multiselect_chart_report):
-                    indicators.setdefault(str(indicator), indicator)
+                    # A column may have multiple indicators. e.g. "Group By" and "Count Per Choice" aggregations
+                    # will use one indicator for the field's string value, and "Sum" and "Average" aggregations
+                    # will use a second indicator for the field's numerical value. "column_id" includes the
+                    # indicator's data type, so it is unique per indicator.
+                    indicators.setdefault(indicator['column_id'], indicator)
 
         for filter_ in filters:
             # Property is only set if the filter exists in report_column_options
             if filter_['property']:
                 property_ = self.data_source_properties[filter_['property']]
                 indicator = property_.to_report_filter_indicator(filter_)
-                indicators.setdefault(str(indicator), indicator)
+                indicators.setdefault(indicator['column_id'], indicator)
 
         if as_dict:
             return indicators
@@ -445,7 +449,7 @@ class DataSourceBuilder(object):
         for column_option in self.report_column_options.values():
             for agg in column_option.aggregation_options:
                 for indicator in column_option.get_indicators(agg):
-                    indicators.setdefault(str(indicator), indicator)
+                    indicators.setdefault(indicator['column_id'], indicator)
 
         return list(indicators.values())[:MAX_COLUMNS]
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -424,7 +424,10 @@ class DataSourceBuilder(object):
                     # A column may have multiple indicators. e.g. "Group By" and "Count Per Choice" aggregations
                     # will use one indicator for the field's string value, and "Sum" and "Average" aggregations
                     # will use a second indicator for the field's numerical value. "column_id" includes the
-                    # indicator's data type, so it is unique per indicator.
+                    # indicator's data type, so it is unique per indicator ... except for choice list indicators,
+                    # because they get expanded to one column per choice. The column_id of choice columns will end
+                    # up unique because they will include a slug of the choice value. Here "column_id + type" is
+                    # unique.
                     indicator_key = (indicator['column_id'], indicator['type'])
                     indicators.setdefault(indicator_key, indicator)
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -406,7 +406,7 @@ class DataSourceBuilder(object):
                 "map_expression": sub_doc(path)
             }
 
-    def indicators(self, columns, filters, is_multiselect_chart_report=False):
+    def indicators(self, columns, filters, is_multiselect_chart_report=False, as_dict=False):
         """
         Return a list of indicators to be used in a data source configuration that supports the given columns and
         indicators.
@@ -430,6 +430,9 @@ class DataSourceBuilder(object):
                 indicator = property_.to_report_filter_indicator(filter_)
                 indicators.setdefault(str(indicator), indicator)
 
+        if as_dict:
+            return indicators
+
         return list(indicators.values())
 
     def all_possible_indicators(self, required_columns, required_filters):
@@ -437,9 +440,7 @@ class DataSourceBuilder(object):
         Will generate a set of possible indicators for the datasource making sure to include the
         provided columns and filters
         """
-        indicators = OrderedDict()
-        for i in self.indicators(required_columns, required_filters):
-            indicators.setdefault(str(i), i)
+        indicators = self.indicators(required_columns, required_filters, as_dict=True)
 
         for column_option in self.report_column_options.values():
             for agg in column_option.aggregation_options:

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -980,10 +980,11 @@ class ConfigureNewReportBase(forms.Form):
         data_source_config = DataSourceConfiguration.get(data_source_config_id)
 
         filters = self.cleaned_data['user_filters'] + self.cleaned_data['default_filters']
-        required_column_set = set([c["column_id"]
-                                   for c in self.ds_builder.indicators(self._configured_columns, filters)])
-        current_column_set = set([c["column_id"] for c in data_source_config.configured_indicators])
-        missing_columns = [c for c in required_column_set if c not in current_column_set]
+        # The data source needs indicators for all possible calculations, not just the ones currently in use
+        required_columns = {c["column_id"]
+                            for c in self.ds_builder.all_possible_indicators(self._configured_columns, filters)}
+        current_columns = {c["column_id"] for c in data_source_config.configured_indicators}
+        missing_columns = required_columns - current_columns
 
         # rebuild the table
         if missing_columns:

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -425,14 +425,16 @@ class DataSourceBuilder(object):
                     # will use one indicator for the field's string value, and "Sum" and "Average" aggregations
                     # will use a second indicator for the field's numerical value. "column_id" includes the
                     # indicator's data type, so it is unique per indicator.
-                    indicators.setdefault(indicator['column_id'], indicator)
+                    indicator_key = (indicator['column_id'], indicator['type'])
+                    indicators.setdefault(indicator_key, indicator)
 
         for filter_ in filters:
             # Property is only set if the filter exists in report_column_options
             if filter_['property']:
                 property_ = self.data_source_properties[filter_['property']]
                 indicator = property_.to_report_filter_indicator(filter_)
-                indicators.setdefault(indicator['column_id'], indicator)
+                indicator_key = (indicator['column_id'], indicator['type'])
+                indicators.setdefault(indicator_key, indicator)
 
         if as_dict:
             return indicators
@@ -449,7 +451,8 @@ class DataSourceBuilder(object):
         for column_option in self.report_column_options.values():
             for agg in column_option.aggregation_options:
                 for indicator in column_option.get_indicators(agg):
-                    indicators.setdefault(indicator['column_id'], indicator)
+                    indicator_key = (indicator['column_id'], indicator['type'])
+                    indicators.setdefault(indicator_key, indicator)
 
         return list(indicators.values())[:MAX_COLUMNS]
 


### PR DESCRIPTION
Context: [FB 268655](https://manage.dimagi.com/default.asp?268655)

Report Builder was not checking that the data source included columns for all possible aggregations. When the user switched from one report type to another (e.g. Case List to Case Summary, or vice versa) it was only checking columns for indicators that were in use when the user switched. As a result, switching from a Case Summary to a Case List report would break the Case List report if the Case Summary report aggregated a numerical field. (Editing the report again (or refreshing Report Builder) and saving after an arbitrary change would recreate the data source and fix the error.)

This change checks that all required columns are included when switching report types, and if not, rebuilds the data source for all possible indicators (which is what refreshing the Report Builder would do).

(The last commit addresses the bug. The first two are refactors.)

@czue @biyeun @gbova 
