### PR TITLE
Pv/new phone 266472

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
@@ -65,7 +65,7 @@
             Clicking below will disable your current two-factor authentication and rerun Two-Factor Authentication setup,
             so make sure you have a backup device or tokens available in case you are unable to complete the process.
         {% endblocktrans %}</p>
-        <p><a class="btn btn-default" href="{% url 'new_phone' %}">
+        <p><a class="btn btn-default" href="{% url 'reset' %}">
           {% trans "Reset Two-Factor Authentication" %}</a></p>
         <br/>
     </fieldset>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
@@ -60,14 +60,13 @@
         <br/>
     </fieldset>
     <fieldset>
-        <legend>{% trans "New Phone" %}</legend>
+        <legend>{% trans "Reset Two-Factor Authentication" %}</legend>
         <p>{% blocktrans %}
-            If you would like to enable a new phone as your primary device you can do so.
-            Clicking below will disable your current default device so make sure you have a backup device or
-            tokens available in case you are unable to complete the process.
+            Clicking below will disable your current two-factor authentication and rerun Two-Factor Authentication setup,
+            so make sure you have a backup device or tokens available in case you are unable to complete the process.
         {% endblocktrans %}</p>
         <p><a class="btn btn-default" href="{% url 'new_phone' %}">
-          {% trans "Set Up New Phone" %}</a></p>
+          {% trans "Reset Two-Factor Authentication" %}</a></p>
         <br/>
     </fieldset>
       {% else %}

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -4,7 +4,7 @@ from corehq.apps.domain.views import PublicSMSRatesView
 from corehq.apps.settings.views import (
     TwoFactorProfileView, TwoFactorSetupView, TwoFactorSetupCompleteView,
     TwoFactorBackupTokensView, TwoFactorDisableView, TwoFactorPhoneSetupView,
-    NewPhoneView
+    TwoFactorResetView
 )
 from two_factor.urls import urlpatterns as tf_urls
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
@@ -47,7 +47,7 @@ urlpatterns = [
     url(r'^account/two_factor/disable/$', TwoFactorDisableView.as_view(), name=TwoFactorDisableView.urlname),
     url(r'^account/two_factor/backup/phone/register/$', TwoFactorPhoneSetupView.as_view(), name=TwoFactorPhoneSetupView.urlname),
     url(r'', include((tf_urls + tf_twilio_urls, 'two_factor'), namespace='two_factor')),
-    url(r'^account/two_factor/new_phone/$', NewPhoneView.as_view(), name=NewPhoneView.urlname),
+    url(r'^account/two_factor/new_phone/$', TwoFactorResetView.as_view(), name=TwoFactorResetView.urlname),
     url(r'^hq/admin/session_details/$', SessionDetailsView.as_view(),
         name=SessionDetailsView.urlname),
 

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     url(r'^account/two_factor/disable/$', TwoFactorDisableView.as_view(), name=TwoFactorDisableView.urlname),
     url(r'^account/two_factor/backup/phone/register/$', TwoFactorPhoneSetupView.as_view(), name=TwoFactorPhoneSetupView.urlname),
     url(r'', include((tf_urls + tf_twilio_urls, 'two_factor'), namespace='two_factor')),
-    url(r'^account/two_factor/new_phone/$', TwoFactorResetView.as_view(), name=TwoFactorResetView.urlname),
+    url(r'^account/two_factor/reset/$', TwoFactorResetView.as_view(), name=TwoFactorResetView.urlname),
     url(r'^hq/admin/session_details/$', SessionDetailsView.as_view(),
         name=SessionDetailsView.urlname),
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -386,7 +386,7 @@ class TwoFactorPhoneSetupView(BaseMyAccountView, PhoneSetupView):
 
 
 class TwoFactorResetView(TwoFactorSetupView):
-    urlname = 'new_phone'
+    urlname = 'reset'
 
     form_list = (
         ('method', HQTwoFactorMethodForm),

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -385,7 +385,7 @@ class TwoFactorPhoneSetupView(BaseMyAccountView, PhoneSetupView):
         return super(TwoFactorPhoneSetupView, self).dispatch(request, *args, **kwargs)
 
 
-class NewPhoneView(TwoFactorSetupView):
+class TwoFactorResetView(TwoFactorSetupView):
     urlname = 'new_phone'
 
     form_list = (
@@ -398,7 +398,7 @@ class NewPhoneView(TwoFactorSetupView):
 
     def get(self, request, *args, **kwargs):
         default_device(request.user).delete()
-        return super(NewPhoneView, self).get(request, *args, **kwargs)
+        return super(TwoFactorResetView, self).get(request, *args, **kwargs)
 
 
 class BaseProjectDataView(BaseDomainView):


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?pre=preMultiSearch&pg=pgList&pgBack=pgSearch&search=2&searchFor=266472

The "Set Up New Phone" button in the 2FA page looked like a bug because it disabled 2FA and brought you back to the page to set it up again. It turns out that it was working as intended, but "Set Up New Phone" was an unclear way of describing what that button was meant to do, so I changed it to "Reset Two-Factor Authentication"