### PR TITLE
Remove flag required for case restore endpoint

### DIFF
--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -55,7 +55,6 @@ def get_case_and_descendants(domain, case_id):
 
 
 @mobile_auth
-@WEBAPPS_CASE_MIGRATION.required_decorator()
 def migration_restore(request, domain, case_id):
     """Restore endpoint used in bulk case migrations
 


### PR DESCRIPTION
This restore endpoint is needed for the SMS mode where you fill out a form as a case; this allows you to create a proper restore for the case. Don't believe that there will be high usage for this endpoint. 

cross-request: https://github.com/dimagi/commcare-hq/pull/19319

Ringing endorsement:
Will Pride [10:17 AM]
do you think that’s safe?
Ethan Soergel [10:18 AM]
yeah, safe enough

cc @gcapalbo 