### PR TITLE
Set max open files for couch in docker

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -45,6 +45,12 @@ postgres:
 couch:
   image: klaemo/couchdb:2.0-dev
   command: ["--with-haproxy", "--with-admin-party-please", "-n", "1"]
+  ulimits:
+    # fix high CPU usage (1048576 is the default, tried 65536, 1024 fixed it)
+    # https://groups.google.com/forum/#!topic/rabbitmq-users/hO06SB-QBqc
+    nofile:
+      soft: 1024
+      hard: 1048576
   expose:
     - "5984"
   volumes:


### PR DESCRIPTION
CouchDB was returning various unhelpful errors when I attempted to run tests:

* `RequestFailed: {"error":"unknown_error","reason":"undefined"}`
* `ResourceNotFound: missing`

It also had very high CPU usage in docker, like near 100%.

@emord @esoergel 