### PR TITLE
Ability to filter releases page by "released"

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -211,7 +211,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.savedApps = ko.observableArray();
         self.doneFetching = ko.observable(false);
         self.buildState = ko.observable('');
-        self.limitToReleased = ko.observable(false);
+        self.onlyShowReleased = ko.observable(false);
         self.fetchState = ko.observable('');
         self.nextVersionToFetch = null;
         self.fetchLimit = o.fetchLimit || 5;
@@ -321,7 +321,7 @@ hqDefine('app_manager/js/releases/releases', function () {
                 data: {
                     start_build: self.nextVersionToFetch,
                     limit: self.fetchLimit,
-                    limit_to_released: self.limitToReleased(),
+                    only_show_released: self.onlyShowReleased(),
                 },
                 success: function (savedApps) {
                     self.addSavedApps(savedApps);
@@ -371,7 +371,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         };
 
         self.toggleLimitToReleased = function() {
-            self.limitToReleased(!self.limitToReleased());
+            self.onlyShowReleased(!self.onlyShowReleased());
             self.clearSavedApps();
             self.getMoreSavedApps(false);
         };

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -308,6 +308,11 @@ hqDefine('app_manager/js/releases/releases', function () {
             }
         };
 
+        self.clearSavedApps = function() {
+            self.savedApps.splice(0);
+            self.nextVersionToFetch = null;
+        };
+
         self.getMoreSavedApps = function (scroll) {
             self.fetchState('pending');
             $.ajax({
@@ -315,7 +320,8 @@ hqDefine('app_manager/js/releases/releases', function () {
                 dataType: 'json',
                 data: {
                     start_build: self.nextVersionToFetch,
-                    limit: self.fetchLimit
+                    limit: self.fetchLimit,
+                    limit_to_released: self.limitToReleased(),
                 },
                 success: function (savedApps) {
                     self.addSavedApps(savedApps);
@@ -366,6 +372,8 @@ hqDefine('app_manager/js/releases/releases', function () {
 
         self.toggleLimitToReleased = function() {
             self.limitToReleased(!self.limitToReleased());
+            self.clearSavedApps();
+            self.getMoreSavedApps(false);
         };
 
         self.reload_message = gettext("Sorry, that didn't go through. " +

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -211,6 +211,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.savedApps = ko.observableArray();
         self.doneFetching = ko.observable(false);
         self.buildState = ko.observable('');
+        self.limitToReleased = ko.observable(false);
         self.fetchState = ko.observable('');
         self.nextVersionToFetch = null;
         self.fetchLimit = o.fetchLimit || 5;
@@ -362,6 +363,11 @@ hqDefine('app_manager/js/releases/releases', function () {
                 });
             }
         };
+
+        self.toggleLimitToReleased = function() {
+            self.limitToReleased(!self.limitToReleased());
+        };
+
         self.reload_message = gettext("Sorry, that didn't go through. " +
                 "Please reload your page and try again");
         self.deleteSavedApp = function (savedApp) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -19,12 +19,12 @@
             </small>
         </p>
     </div>
-    <p class="pull-right auto-release-notes" data-bind="visible: savedApps().length || limitToReleased()">
-        <a href="#" data-bind="click: toggleLimitToReleased"><span data-bind="visible: !limitToReleased()">{% trans 'Show only released versions' %}</span></a>
-        <span data-bind="visible: limitToReleased()">
+    <p class="pull-right auto-release-notes" data-bind="visible: savedApps().length || onlyShowReleased()">
+        <a href="#" data-bind="click: toggleLimitToReleased"><span data-bind="visible: !onlyShowReleased()">{% trans 'Show only released versions' %}</span></a>
+        <span data-bind="visible: onlyShowReleased()">
             {% trans 'Released versions only' %}
         </span>
-        <a href="#" data-bind="click: toggleLimitToReleased, visible: limitToReleased()" class="label label-info">{% trans 'show all' %}</a>
+        <a href="#" data-bind="click: toggleLimitToReleased, visible: onlyShowReleased()" class="label label-info">{% trans 'show all' %}</a>
 
         <span class="hq-help-template"
             data-title="Released Versions"

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -20,7 +20,14 @@
         </p>
     </div>
     <p class="pull-right auto-release-notes">
-        {% trans 'What are Released Versions?' %}
+        <a href="#" data-bind="click: toggleLimitToReleased">
+            <span data-bind="visible: !limitToReleased()">
+                {% trans 'Show only released versions' %}
+            </span>
+            <span data-bind="visible: limitToReleased()">
+                {% trans 'Show all versions' %}
+            </span>
+        </a>
         <span class="hq-help-template"
             data-title="Released Versions"
             data-container="body"
@@ -83,6 +90,7 @@
              data-bind="css: {
                 'build-released': is_released(),
                 'build-unreleased': !is_released(),
+                'hide': $root.limitToReleased() && !is_released(),
                 'build-latest-release': id() === $root.latestReleaseId(),
                 'error': build_broken
             }">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -19,7 +19,7 @@
             </small>
         </p>
     </div>
-    <p class="pull-right auto-release-notes">
+    <p class="pull-right auto-release-notes" data-bind="visible: savedApps().length || limitToReleased()">
         <a href="#" data-bind="click: toggleLimitToReleased">
             <span data-bind="visible: !limitToReleased()">
                 {% trans 'Show only released versions' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -90,7 +90,6 @@
              data-bind="css: {
                 'build-released': is_released(),
                 'build-unreleased': !is_released(),
-                'hide': $root.limitToReleased() && !is_released(),
                 'build-latest-release': id() === $root.latestReleaseId(),
                 'error': build_broken
             }">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -20,14 +20,12 @@
         </p>
     </div>
     <p class="pull-right auto-release-notes" data-bind="visible: savedApps().length || limitToReleased()">
-        <a href="#" data-bind="click: toggleLimitToReleased">
-            <span data-bind="visible: !limitToReleased()">
-                {% trans 'Show only released versions' %}
-            </span>
-            <span data-bind="visible: limitToReleased()">
-                {% trans 'Show all versions' %}
-            </span>
-        </a>
+        <a href="#" data-bind="click: toggleLimitToReleased"><span data-bind="visible: !limitToReleased()">{% trans 'Show only released versions' %}</span></a>
+        <span data-bind="visible: limitToReleased()">
+            {% trans 'Released versions only' %}
+        </span>
+        <a href="#" data-bind="click: toggleLimitToReleased, visible: limitToReleased()" class="label label-info">{% trans 'show all' %}</a>
+
         <span class="hq-help-template"
             data-title="Released Versions"
             data-container="body"

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -69,7 +69,7 @@ def _get_error_counts(domain, app_id, version_numbers):
 @require_deploy_apps
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit')
-    limit_to_released = json.loads(request.GET.get('limit_to_released'))
+    only_show_released = json.loads(request.GET.get('only_show_released', 'false'))
     try:
         limit = int(limit)
     except (TypeError, ValueError):
@@ -94,7 +94,7 @@ def paginate_releases(request, domain, app_id):
         ).all()
         if len(batch):
             start_build = batch[-1]['version'] - 1
-        saved_apps = saved_apps + [app for app in batch if not limit_to_released or app['is_released']]
+        saved_apps = saved_apps + [app for app in batch if not only_show_released or app['is_released']]
     saved_apps = saved_apps[:limit]
 
     j2me_enabled_configs = CommCareBuildConfig.j2me_enabled_config_labels()

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -69,6 +69,7 @@ def _get_error_counts(domain, app_id, version_numbers):
 @require_deploy_apps
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit')
+    limit_to_released = json.loads(request.GET.get('limit_to_released'))
     try:
         limit = int(limit)
     except (TypeError, ValueError):
@@ -80,13 +81,22 @@ def paginate_releases(request, domain, app_id):
     else:
         start_build = {}
     timezone = get_timezone_for_user(request.couch_user, domain)
-    saved_apps = Application.get_db().view('app_manager/saved_app',
-        startkey=[domain, app_id, start_build],
-        endkey=[domain, app_id],
-        descending=True,
-        limit=limit,
-        wrapper=lambda x: SavedAppBuild.wrap(x['value']).to_saved_build_json(timezone),
-    ).all()
+
+    saved_apps = []
+    batch = [None]
+    while len(saved_apps) < limit and len(batch):
+        batch = Application.get_db().view('app_manager/saved_app',
+            startkey=[domain, app_id, start_build],
+            endkey=[domain, app_id],
+            descending=True,
+            limit=limit,
+            wrapper=lambda x: SavedAppBuild.wrap(x['value']).to_saved_build_json(timezone),
+        ).all()
+        if len(batch):
+            start_build = batch[-1]['version'] - 1
+        saved_apps = saved_apps + [app for app in batch if not limit_to_released or app['is_released']]
+    saved_apps = saved_apps[:limit]
+
     j2me_enabled_configs = CommCareBuildConfig.j2me_enabled_config_labels()
     for app in saved_apps:
         app['include_media'] = app['doc_type'] != 'RemoteApp'


### PR DESCRIPTION
@gcapalbo / @proteusvacuum 

Before:
<img width="251" alt="screen shot 2018-02-14 at 5 38 24 pm" src="https://user-images.githubusercontent.com/1486591/36231974-15723562-11ae-11e8-8bbc-5015ce0db4c7.png">

After:
<img width="313" alt="screen shot 2018-02-14 at 5 32 06 pm" src="https://user-images.githubusercontent.com/1486591/36231983-1c247244-11ae-11e8-99cb-d77f715b83b5.png">

After clicking on the link:
<img width="320" alt="screen shot 2018-02-14 at 5 32 13 pm" src="https://user-images.githubusercontent.com/1486591/36231991-20a63d5c-11ae-11e8-9f69-ecc7c0d94d2e.png">

@dimagi/product any objections? Did some hallway testing and it went well. I'm not worried about adding clutter because the default view is so similar to the current state.