### PR TITLE
Prevent doubling data from previous month info box in fact sheet and …

### DIFF
--- a/custom/icds_reports/static/js/icds_app.js
+++ b/custom/icds_reports/static/js/icds_app.js
@@ -12,12 +12,16 @@ function MainController($scope, $route, $routeParams, $location, $uibModal, $win
     var current_month = new Date().getMonth() + 1;
     var current_year = new Date().getFullYear();
 
-    if (selected_month === current_month && selected_year === current_year &&
-        (new Date().getDate() === 1 || new Date().getDate() === 2)) {
-        $scope.showInfoMessage = true;
-        $scope.lastDayOfPreviousMonth = moment().set('date', 1).subtract(1, 'days').format('Do MMMM, YYYY');
-        $scope.currentMonth = moment().format("MMMM");
-    }
+    $scope.showInfoMessage = function() {
+        if (!$location.path().startsWith("/fact_sheets") && !$location.path().startsWith("/download") &&
+            selected_month === current_month && selected_year === current_year &&
+            (new Date().getDate() === 1 || new Date().getDate() === 2)) {
+            $scope.lastDayOfPreviousMonth = moment().set('date', 1).subtract(1, 'days').format('Do MMMM, YYYY');
+            $scope.currentMonth = moment().format("MMMM");
+            return true;
+        }
+        return false;
+    };
 
     $scope.reportAnIssue = function() {
         if (reportAnIssueUrl) {

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -213,7 +213,7 @@
                 </div>
                 <div class="row no-margin">
                     <div class="alert-container">
-                        <div class="alert alert-info" ng-if="showInfoMessage">
+                        <div class="alert alert-info" ng-if="showInfoMessage()">
                             <strong>Info!</strong> Data shown is for {$ lastDayOfPreviousMonth $}. Data for {$ currentMonth $} will be displayed beginning 3rd {$ currentMonth $}.
                         </div>
                     </div>


### PR DESCRIPTION
…tabular reports

Hi @emord,
As fact sheet reports and tabular reports have their own infobox for from when data is being generated, I removed generic "Data shown is for..." on these reports by changing $scope.showInfoMessage to function that is evaluated during each page generation, rather than during first creation of MainController.