### PR TITLE
sorting fixture data items for download

### DIFF
--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -150,7 +150,8 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
         max_groups = 0
         max_locations = 0
         max_field_prop_combos = {field_name: 0 for field_name in data_type.fields_without_attributes}
-        fixture_data = FixtureDataItem.by_data_type(domain, data_type.get_id)
+        fixture_data = sorted(FixtureDataItem.by_data_type(domain, data_type.get_id),
+                              key=lambda x: x.sort_key)
         num_rows = len(fixture_data)
         for n, item_row in enumerate(fixture_data):
             _update_progress(event_count, n, num_rows)


### PR DESCRIPTION
@mkangia @nickpell 
https://manage.dimagi.com/default.asp?269920#1458775
Lookup table upload order defines the sort order for how it appears in the app. However, we were not ordering them based on that order on download, making a download and immediate reupload not an idempotent operation, since it could change the ordering. This ensures downloaded lookup tables are sorted based on the internal sort key.