### PR TITLE
Icds no arrow on kpi for  difference below tenth of promile

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -825,6 +825,12 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                         prev_data,
                         'all_persons'
                     ),
+                    'color': 'green' if percent_diff(
+                        'person_aadhaar',
+                        data,
+                        prev_data,
+                        'all_persons'
+                    ) > 0 else 'red',
                     'value': get_value(data, 'person_aadhaar'),
                     'all': get_value(data, 'all_persons'),
                     'format': 'percent_and_div',

--- a/custom/icds_reports/templates/icds_reports/icds_app/kpi.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/kpi.directive.html
@@ -25,7 +25,8 @@
                          ng-class="{'kpi-percent': cell.redirect}">
                         <span class="white" ng-class="{'kpi-percents-text': cell.redirect}"
                               ng-show="cell.percent !== null && $ctrl.isNumber(cell.percent) && $ctrl.showPercentInfo()">
-                            <i class="fa" style="font-size: 1.5em" ng-class="{'fa-arrow-down': cell.percent < 0, 'fa-arrow-up': cell.percent > 0, 'green': cell.color === 'green', 'red': cell.color === 'red'}" ></i>&nbsp;
+                            <i class="fa" style="font-size: 1.5em" ng-show="cell.percent !== 0"
+                               ng-class="{'fa-arrow-down': cell.percent < 0, 'fa-arrow-up': cell.percent > 0, 'green': cell.color === 'green', 'red': cell.color === 'red'}" ></i>&nbsp;
                             <span class="white" ng-bind="cell.percent | number:2"></span>% from previous {$ cell.frequency $}
                         </span>
                         <span class="white" ng-class="{'kpi-percents-text': cell.redirect}"

--- a/custom/icds_reports/tests/reports/test_awc_infrastructure.py
+++ b/custom/icds_reports/tests/reports/test_awc_infrastructure.py
@@ -5,8 +5,7 @@ from custom.icds_reports.reports.awc_infrastracture import get_awc_infrastructur
 
 
 class TestAWCInfrastructure(TestCase):
-
-    def test_data(self):
+    def test_data_AWCs_reported_clean_drinking_water(self):
         self.assertDictEqual(
             get_awc_infrastructure_data(
                 'icds-cas',
@@ -15,71 +14,150 @@ class TestAWCInfrastructure(TestCase):
                     'prev_month': (2017, 4, 1),
                     'aggregation_level': 1
                 }
-            ),
+            )['records'][0][0],
             {
-                "records": [
-                    [
-                        {
-                            "redirect": "clean_water",
-                            "all": 30,
-                            "format": "percent_and_div",
-                            "color": "red",
-                            "percent": -3.3333333333333286,
-                            "value": 29,
-                            "label": "AWCs Reported Clean Drinking Water",
-                            "frequency": "month",
-                            "help_text": "Percentage of AWCs that reported having a source of clean drinking water"
-                        },
-                        {
-                            "redirect": "functional_toilet",
-                            "all": 30,
-                            "format": "percent_and_div",
-                            "color": "red",
-                            "percent": -12.499999999999995,
-                            "value": 15,
-                            "label": "AWCs Reported Functional Toilet",
-                            "frequency": "month",
-                            "help_text": "Percentage of AWCs that reported having a functional toilet"
-                        }
-                    ],
-                    [
-                        {
-                            "redirect": "infants_weight_scale",
-                            "all": 30,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": 11.999999999999996,
-                            "value": 24,
-                            "label": "AWCs Reported Weighing Scale: Infants",
-                            "frequency": "month",
-                            "help_text": "Percentage of AWCs that reported having a weighing scale for infants"
-                        },
-                        {
-                            "redirect": "adult_weight_scale",
-                            "all": 30,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": 40.00000000000001,
-                            "value": 9,
-                            "label": "AWCs Reported Weighing Scale: Mother and Child",
-                            "frequency": "month",
-                            "help_text": "Percentage of AWCs that reported having"
-                                         " a weighing scale for mother and child"
-                        }
-                    ],
-                    [
-                        {
-                            "redirect": "medicine_kit",
-                            "all": 30,
-                            "format": "percent_and_div",
-                            "color": "red",
-                            "percent": -15.15151515151516,
-                            "value": 20,
-                            "label": "AWCs Reported Medicine Kit",
-                            "frequency": "month",
-                            "help_text": "Percentage of AWCs that reported having a Medicine Kit"
-                        }
-                    ]
-                ]
+                "redirect": "clean_water",
+                "all": 30,
+                "format": "percent_and_div",
+                "color": "red",
+                "percent": -3.3333333333333286,
+                "value": 29,
+                "label": "AWCs Reported Clean Drinking Water",
+                "frequency": "month",
+                "help_text": "Percentage of AWCs that reported having a source of clean drinking water"
             }
+        )
+
+    def test_data_AWCs_reported_functional_toilet(self):
+        self.assertDictEqual(
+            get_awc_infrastructure_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][0][1],
+            {
+                "redirect": "functional_toilet",
+                "all": 30,
+                "format": "percent_and_div",
+                "color": "red",
+                "percent": -12.499999999999995,
+                "value": 15,
+                "label": "AWCs Reported Functional Toilet",
+                "frequency": "month",
+                "help_text": "Percentage of AWCs that reported having a functional toilet"
+            }
+        )
+
+    def test_data_AWCs_reported_weighing_scale_infants(self):
+        self.assertDictEqual(
+            get_awc_infrastructure_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][1][0],
+            {
+                "redirect": "infants_weight_scale",
+                "all": 30,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": 11.999999999999998,
+                "value": 24,
+                "label": "AWCs Reported Weighing Scale: Infants",
+                "frequency": "month",
+                "help_text": "Percentage of AWCs that reported having a weighing scale for infants"
+            }
+        )
+
+    def test_data_AWCs_reported_weighing_scale_mother_and_child(self):
+        self.assertDictEqual(
+            get_awc_infrastructure_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][1][1],
+            {
+                "redirect": "adult_weight_scale",
+                "all": 30,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": 40.00000000000001,
+                "value": 9,
+                "label": "AWCs Reported Weighing Scale: Mother and Child",
+                "frequency": "month",
+                "help_text": "Percentage of AWCs that reported having"
+                             " a weighing scale for mother and child"
+            }
+        )
+
+    def test_data_AWCs_reported_medicine_kit(self):
+        self.assertDictEqual(
+            get_awc_infrastructure_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][2][0],
+            {
+                "redirect": "medicine_kit",
+                "all": 30,
+                "format": "percent_and_div",
+                "color": "red",
+                "percent": -15.151515151515161,
+                "value": 20,
+                "label": "AWCs Reported Medicine Kit",
+                "frequency": "month",
+                "help_text": "Percentage of AWCs that reported having a Medicine Kit"
+            }
+        )
+
+    def test_data_records_length(self):
+        self.assertEqual(
+            len(get_awc_infrastructure_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records']),
+            3
+        )
+
+    def test_data_records_total_length(self):
+        data = get_awc_infrastructure_data(
+            'icds-cas',
+            {
+                'month': (2017, 5, 1),
+                'prev_month': (2017, 4, 1),
+                'aggregation_level': 1
+            }
+        )['records']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            5
+        )
+
+    def test_data_keys(self):
+        self.assertEqual(
+            list(get_awc_infrastructure_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            ).keys()),
+            ['records']
         )

--- a/custom/icds_reports/tests/reports/test_awc_reports.py
+++ b/custom/icds_reports/tests/reports/test_awc_reports.py
@@ -37,7 +37,7 @@ class TestAWCReport(TestCase):
         self.assertEqual(data['person_name'], 'Name 3483')
         self.assertEqual(data['mother_name'], u'रींकीकुँवर')
 
-    def test_awc_reports_system_usage(self):
+    def test_awc_reports_system_usage_AWC_days_open(self):
         self.assertDictEqual(
             get_awc_reports_system_usage(
                 'icds-cas',
@@ -52,127 +52,928 @@ class TestAWCReport(TestCase):
                 (2017, 4, 1),
                 (2017, 3, 1),
                 'aggregation_level'
-            ),
+            )['kpi'][0][0],
             {
-                "kpi": [
-                    [
-                        {
-                            "all": "",
-                            "format": "number",
-                            "percent": 100.0,
-                            "value": 18,
-                            "label": "AWC Days Open",
-                            "frequency": "month",
-                            "help_text": "The total number of days the AWC is open in the given month. "
-                                         "The AWC is expected to be open 6 days a week"
-                                         " (Not on Sundays and public holidays)"
-                        },
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percentage of eligible children (ICDS beneficiaries between 0-6 years)"
-                                     " who have been weighed in the current month",
-                            "frequency": "month",
-                            "help_text": "Percentage of AWCs with a functional toilet"
-                        }
-                    ]
-                ],
-                "charts": [
-                    [
-                        {
-                            "classed": "dashed",
-                            "values": [
-                                [
-                                    1491523200000,
-                                    1
-                                ],
-                                [
-                                    1491609600000,
-                                    1
-                                ],
-                                [
-                                    1491782400000,
-                                    1
-                                ],
-                                [
-                                    1491955200000,
-                                    1
-                                ],
-                                [
-                                    1492473600000,
-                                    1
-                                ],
-                                [
-                                    1492732800000,
-                                    1
-                                ],
-                                [
-                                    1492992000000,
-                                    1
-                                ],
-                                [
-                                    1493078400000,
-                                    1
-                                ],
-                                [
-                                    1493251200000,
-                                    1
-                                ]
-                            ],
-                            "key": "AWC Days Open Per Week"
-                        }
-                    ],
-                    [
-                        {
-                            "classed": "dashed",
-                            "values": [
-                                [
-                                    1491523200000,
-                                    0.65625
-                                ],
-                                [
-                                    1491609600000,
-                                    0.64516129
-                                ],
-                                [
-                                    1491782400000,
-                                    0.677419355
-                                ],
-                                [
-                                    1491955200000,
-                                    0.612903226
-                                ],
-                                [
-                                    1492473600000,
-                                    0.612903226
-                                ],
-                                [
-                                    1492732800000,
-                                    0.64516129
-                                ],
-                                [
-                                    1492992000000,
-                                    0.64516129
-                                ],
-                                [
-                                    1493078400000,
-                                    0.64516129
-                                ],
-                                [
-                                    1493251200000,
-                                    0.64516129
-                                ]
-                            ],
-                            "key": "PSE- Average Weekly Attendance"
-                        }
-                    ]
-                ]
+                "all": "",
+                "format": "number",
+                "percent": 100.0,
+                "value": 18,
+                "label": "AWC Days Open",
+                "frequency": "month",
+                "help_text": "The total number of days the AWC is open in the given month. "
+                             "The AWC is expected to be open 6 days a week"
+                             " (Not on Sundays and public holidays)"
             }
         )
 
-    def test_awc_reports_pse(self):
+    def test_awc_reports_system_usage_percentage_of_eligible_children_ICDS_beneficiaries_between_0_6_years(self):
+        self.assertDictEqual(
+            get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            )['kpi'][0][1],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percentage of eligible children (ICDS beneficiaries between 0-6 years)"
+                         " who have been weighed in the current month",
+                "frequency": "month",
+                "help_text": "Percentage of AWCs with a functional toilet"
+            }
+        )
+
+    def test_awc_reports_system_usage_kpi_length(self):
+        self.assertEqual(
+            len(get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            )['kpi']),
+            1
+        )
+
+    def test_awc_reports_system_usage_kpi_total_length(self):
+        data = get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            )['kpi']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            2
+        )
+
+    def test_awc_reports_system_usage_AWC_days_open_per_week_chart(self):
+        self.assertEqual(
+            get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            )['charts'][0],
+            [
+                {
+                    "classed": "dashed",
+                    "values": [
+                        [
+                            1491523200000,
+                            1
+                        ],
+                        [
+                            1491609600000,
+                            1
+                        ],
+                        [
+                            1491782400000,
+                            1
+                        ],
+                        [
+                            1491955200000,
+                            1
+                        ],
+                        [
+                            1492473600000,
+                            1
+                        ],
+                        [
+                            1492732800000,
+                            1
+                        ],
+                        [
+                            1492992000000,
+                            1
+                        ],
+                        [
+                            1493078400000,
+                            1
+                        ],
+                        [
+                            1493251200000,
+                            1
+                        ]
+                    ],
+                    "key": "AWC Days Open Per Week"
+                }
+            ]
+        )
+
+    def test_awc_reports_system_usage_PSE_average_weekly_attendance(self):
+        self.assertEqual(
+            get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            )['charts'][1],
+            [
+                {
+                    "classed": "dashed",
+                    "values": [
+                        [
+                            1491523200000,
+                            0.65625
+                        ],
+                        [
+                            1491609600000,
+                            0.64516129
+                        ],
+                        [
+                            1491782400000,
+                            0.677419355
+                        ],
+                        [
+                            1491955200000,
+                            0.612903226
+                        ],
+                        [
+                            1492473600000,
+                            0.612903226
+                        ],
+                        [
+                            1492732800000,
+                            0.64516129
+                        ],
+                        [
+                            1492992000000,
+                            0.64516129
+                        ],
+                        [
+                            1493078400000,
+                            0.64516129
+                        ],
+                        [
+                            1493251200000,
+                            0.64516129
+                        ]
+                    ],
+                    "key": "PSE- Average Weekly Attendance"
+                }
+            ]
+        )
+
+    def test_awc_reports_system_usage_length(self):
+        self.assertEqual(
+            len(get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            )['charts']),
+            2
+        )
+
+    def test_awc_reports_system_usage_keys(self):
+        self.assertEqual(
+            list(get_awc_reports_system_usage(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 1),
+                (2017, 4, 1),
+                (2017, 3, 1),
+                'aggregation_level'
+            ).keys()),
+            ['kpi', 'charts']
+        )
+
+    def test_awc_reports_pse_images_0(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][0],
+            [
+                {
+                    "date": "01/05/2017",
+                    "image": None,
+                    "id": 0
+                },
+                {
+                    "date": "02/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "00a368e6-e88f-41ee-96aa-25a8ec5ab3d6/1493703284010.jpg",
+                    "id": 1
+                },
+                {
+                    "date": "03/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "ef336dda-12a1-42a4-9bee-405d17c2aba8/1493790538044.jpg",
+                    "id": 2
+                },
+                {
+                    "date": "04/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "00ec149e-c1a9-4083-a73c-cdc39df17137/1493876634200.jpg",
+                    "id": 3
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_1(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][1],
+            [
+                {
+                    "date": "05/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "ebb1f3c8-34c7-4ed1-9f35-0b209cb4d683/1493959451474.jpg",
+                    "id": 4
+                },
+                {
+                    "date": "06/05/2017",
+                    "image": None,
+                    "id": 5
+                },
+                {
+                    "date": "07/05/2017",
+                    "image": None,
+                    "id": 6
+                },
+                {
+                    "date": "08/05/2017",
+                    "image": None,
+                    "id": 7
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_2(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][2],
+            [
+                {
+                    "date": "09/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "eb20b019-97ef-45e0-9698-fda3d964a096/1494308187855.jpg",
+                    "id": 8
+                },
+                {
+                    "date": "10/05/2017",
+                    "image": None,
+                    "id": 9
+                },
+                {
+                    "date": "11/05/2017",
+                    "image": None,
+                    "id": 10
+                },
+                {
+                    "date": "12/05/2017",
+                    "image": None,
+                    "id": 11
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_3(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][3],
+            [
+                {
+                    "date": "13/05/2017",
+                    "image": None,
+                    "id": 12
+                },
+                {
+                    "date": "14/05/2017",
+                    "image": None,
+                    "id": 13
+                },
+                {
+                    "date": "15/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "036ab123-0a1e-43b6-8e7d-4bcf9abcdfa2/1494826363729.jpg",
+                    "id": 14
+                },
+                {
+                    "date": "16/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "dda9c427-4ba7-4f90-9c5b-d2a02cff9e31/1494911839185.jpg",
+                    "id": 15
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_4(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][4],
+            [
+                {
+                    "date": "17/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "1be8a49b-c63c-4288-bcb2-9e5bf132834f/1494997946602.jpg",
+                    "id": 16
+                },
+                {
+                    "date": "18/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "c7f6d174-1218-4f8e-ab84-f80e17b1ebdb/1495084707730.jpg",
+                    "id": 17
+                },
+                {
+                    "date": "19/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "416990d9-f354-457f-8c52-1866e98840f5/1495173038810.jpg",
+                    "id": 18
+                },
+                {
+                    "date": "20/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "3fea99f8-c6f4-48c9-9386-152639fe1b17/1495259635314.jpg",
+                    "id": 19
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_5(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][5],
+            [
+                {
+                    "date": "21/05/2017",
+                    "image": None,
+                    "id": 20
+                },
+                {
+                    "date": "22/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "ce528857-f34e-4785-913f-41d221fbeed8/1495432106324.jpg",
+                    "id": 21
+                },
+                {
+                    "date": "23/05/2017",
+                    "image": None,
+                    "id": 22
+                },
+                {
+                    "date": "24/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "5d0f2aa4-6d5b-424f-91d1-c4afb2d0555b/1495605536823.jpg",
+                    "id": 23
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_6(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][6],
+            [
+                {
+                    "date": "25/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "20e4d641-a85a-4927-96ab-994fa46a8ea0/1495690578649.jpg",
+                    "id": 24
+                },
+                {
+                    "date": "26/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "f86e701b-1531-469f-8996-705e297bf498/1495776461721.jpg",
+                    "id": 25
+                },
+                {
+                    "date": "27/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "6701b39d-4b6f-4ae3-8a88-eadb61b1a105/1495865744995.jpg",
+                    "id": 26
+                },
+                {
+                    "date": "28/05/2017",
+                    "image": None,
+                    "id": 27
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_7(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['images'][7],
+            [
+                {
+                    "date": "29/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "6376d77d-bb2a-48ac-9042-7892dda97bba/1496036503892.jpg",
+                    "id": 28
+                },
+                {
+                    "date": "30/05/2017",
+                    "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
+                             "c0d002ca-f7b0-4bd2-a531-881b46610c2f/1496120210768.jpg",
+                    "id": 29
+                },
+                {
+                    "date": "31/05/2017",
+                    "image": None,
+                    "id": 30
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_images_length(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            len(data['images']),
+            8
+        )
+
+    def test_awc_reports_pse_kpi(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['kpi'],
+            [
+                [
+                    {
+                        "color": "green",
+                        "all": "",
+                        "frequency": "month",
+                        "format": "number",
+                        "percent": 100.0,
+                        "value": 18,
+                        "label": "AWC Days Open"
+                    }
+                ]
+            ]
+        )
+
+    def test_awc_reports_pse_charts_0(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['charts'][0],
+            [
+                {
+                    "color": "#006fdf",
+                    "classed": "dashed",
+                    "strokeWidth": 2,
+                    "values": [
+                        {
+                            "y": 4,
+                            "x": 1493596800000
+                        },
+                        {
+                            "y": 1,
+                            "x": 1494201600000
+                        },
+                        {
+                            "y": 6,
+                            "x": 1494806400000
+                        },
+                        {
+                            "y": 5,
+                            "x": 1495411200000
+                        },
+                        {
+                            "y": 2,
+                            "x": 1496016000000
+                        }
+                    ],
+                    "key": "AWC Days Open per week"
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_charts_1(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            data['charts'][1],
+            [
+                {
+                    "color": "#006fdf",
+                    "classed": "dashed",
+                    "strokeWidth": 2,
+                    "values": [
+                        {
+                            "y": 0,
+                            "x": 1493596800000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0.741935484,
+                            "x": 1493683200000,
+                            "attended": 23,
+                            "eligible": 31
+                        },
+                        {
+                            "y": 0.806451613,
+                            "x": 1493769600000,
+                            "attended": 25,
+                            "eligible": 31
+                        },
+                        {
+                            "y": 0.8,
+                            "x": 1493856000000,
+                            "attended": 24,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.8,
+                            "x": 1493942400000,
+                            "attended": 24,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494028800000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494115200000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494201600000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0.8,
+                            "x": 1494288000000,
+                            "attended": 24,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494374400000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494460800000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494547200000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494633600000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0,
+                            "x": 1494720000000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 1.0,
+                            "x": 1494806400000,
+                            "attended": 30,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1494892800000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.733333333,
+                            "x": 1494979200000,
+                            "attended": 22,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.766666667,
+                            "x": 1495065600000,
+                            "attended": 23,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1495152000000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.633333333,
+                            "x": 1495238400000,
+                            "attended": 19,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0,
+                            "x": 1495324800000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1495411200000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0,
+                            "x": 1495497600000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1495584000000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1495670400000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1495756800000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0.666666667,
+                            "x": 1495843200000,
+                            "attended": 20,
+                            "eligible": 30
+                        },
+                        {
+                            "y": 0,
+                            "x": 1495929600000,
+                            "attended": 0,
+                            "eligible": 0
+                        },
+                        {
+                            "y": 0.655172414,
+                            "x": 1496016000000,
+                            "attended": 19,
+                            "eligible": 29
+                        },
+                        {
+                            "y": 1.0,
+                            "x": 1496102400000,
+                            "attended": 29,
+                            "eligible": 29
+                        },
+                        {
+                            "y": 0,
+                            "x": 1496188800000,
+                            "attended": 0,
+                            "eligible": 0
+                        }
+                    ],
+                    "key": "PSE - Daily Attendance"
+                }
+            ]
+        )
+
+    def test_awc_reports_pse_charts_length(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            len(data['charts']),
+            2
+        )
+
+    def test_awc_reports_pse_map(self):
         data = get_awc_reports_pse(
             {
                 'state_id': 'st1',
@@ -188,447 +989,33 @@ class TestAWCReport(TestCase):
             for el in kpi:
                 del el['help_text']
         self.assertDictEqual(
-            data,
+            data['map'],
             {
-                "images": [
-                    [
-                        {
-                            "date": "01/05/2017",
-                            "image": None,
-                            "id": 0
-                        },
-                        {
-                            "date": "02/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "00a368e6-e88f-41ee-96aa-25a8ec5ab3d6/1493703284010.jpg",
-                            "id": 1
-                        },
-                        {
-                            "date": "03/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "ef336dda-12a1-42a4-9bee-405d17c2aba8/1493790538044.jpg",
-                            "id": 2
-                        },
-                        {
-                            "date": "04/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "00ec149e-c1a9-4083-a73c-cdc39df17137/1493876634200.jpg",
-                            "id": 3
-                        }
-                    ],
-                    [
-                        {
-                            "date": "05/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "ebb1f3c8-34c7-4ed1-9f35-0b209cb4d683/1493959451474.jpg",
-                            "id": 4
-                        },
-                        {
-                            "date": "06/05/2017",
-                            "image": None,
-                            "id": 5
-                        },
-                        {
-                            "date": "07/05/2017",
-                            "image": None,
-                            "id": 6
-                        },
-                        {
-                            "date": "08/05/2017",
-                            "image": None,
-                            "id": 7
-                        }
-                    ],
-                    [
-                        {
-                            "date": "09/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "eb20b019-97ef-45e0-9698-fda3d964a096/1494308187855.jpg",
-                            "id": 8
-                        },
-                        {
-                            "date": "10/05/2017",
-                            "image": None,
-                            "id": 9
-                        },
-                        {
-                            "date": "11/05/2017",
-                            "image": None,
-                            "id": 10
-                        },
-                        {
-                            "date": "12/05/2017",
-                            "image": None,
-                            "id": 11
-                        }
-                    ],
-                    [
-                        {
-                            "date": "13/05/2017",
-                            "image": None,
-                            "id": 12
-                        },
-                        {
-                            "date": "14/05/2017",
-                            "image": None,
-                            "id": 13
-                        },
-                        {
-                            "date": "15/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "036ab123-0a1e-43b6-8e7d-4bcf9abcdfa2/1494826363729.jpg",
-                            "id": 14
-                        },
-                        {
-                            "date": "16/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "dda9c427-4ba7-4f90-9c5b-d2a02cff9e31/1494911839185.jpg",
-                            "id": 15
-                        }
-                    ],
-                    [
-                        {
-                            "date": "17/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "1be8a49b-c63c-4288-bcb2-9e5bf132834f/1494997946602.jpg",
-                            "id": 16
-                        },
-                        {
-                            "date": "18/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "c7f6d174-1218-4f8e-ab84-f80e17b1ebdb/1495084707730.jpg",
-                            "id": 17
-                        },
-                        {
-                            "date": "19/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "416990d9-f354-457f-8c52-1866e98840f5/1495173038810.jpg",
-                            "id": 18
-                        },
-                        {
-                            "date": "20/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "3fea99f8-c6f4-48c9-9386-152639fe1b17/1495259635314.jpg",
-                            "id": 19
-                        }
-                    ],
-                    [
-                        {
-                            "date": "21/05/2017",
-                            "image": None,
-                            "id": 20
-                        },
-                        {
-                            "date": "22/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "ce528857-f34e-4785-913f-41d221fbeed8/1495432106324.jpg",
-                            "id": 21
-                        },
-                        {
-                            "date": "23/05/2017",
-                            "image": None,
-                            "id": 22
-                        },
-                        {
-                            "date": "24/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "5d0f2aa4-6d5b-424f-91d1-c4afb2d0555b/1495605536823.jpg",
-                            "id": 23
-                        }
-                    ],
-                    [
-                        {
-                            "date": "25/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "20e4d641-a85a-4927-96ab-994fa46a8ea0/1495690578649.jpg",
-                            "id": 24
-                        },
-                        {
-                            "date": "26/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "f86e701b-1531-469f-8996-705e297bf498/1495776461721.jpg",
-                            "id": 25
-                        },
-                        {
-                            "date": "27/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "6701b39d-4b6f-4ae3-8a88-eadb61b1a105/1495865744995.jpg",
-                            "id": 26
-                        },
-                        {
-                            "date": "28/05/2017",
-                            "image": None,
-                            "id": 27
-                        }
-                    ],
-                    [
-                        {
-                            "date": "29/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "6376d77d-bb2a-48ac-9042-7892dda97bba/1496036503892.jpg",
-                            "id": 28
-                        },
-                        {
-                            "date": "30/05/2017",
-                            "image": "http://localhost:8000/a/icds-cas/api/form/attachment/"
-                                     "c0d002ca-f7b0-4bd2-a531-881b46610c2f/1496120210768.jpg",
-                            "id": 29
-                        },
-                        {
-                            "date": "31/05/2017",
-                            "image": None,
-                            "id": 30
-                        }
-                    ]
-                ],
-                "kpi": [
-                    [
-                        {
-                            "color": "green",
-                            "all": "",
-                            "frequency": "month",
-                            "format": "number",
-                            "percent": 100.0,
-                            "value": 18,
-                            "label": "AWC Days Open"
-                        }
-                    ]
-                ],
-                "charts": [
-                    [
-                        {
-                            "color": "#006fdf",
-                            "classed": "dashed",
-                            "strokeWidth": 2,
-                            "values": [
-                                {
-                                    "y": 4,
-                                    "x": 1493596800000
-                                },
-                                {
-                                    "y": 1,
-                                    "x": 1494201600000
-                                },
-                                {
-                                    "y": 6,
-                                    "x": 1494806400000
-                                },
-                                {
-                                    "y": 5,
-                                    "x": 1495411200000
-                                },
-                                {
-                                    "y": 2,
-                                    "x": 1496016000000
-                                }
-                            ],
-                            "key": "AWC Days Open per week"
-                        }
-                    ],
-                    [
-                        {
-                            "color": "#006fdf",
-                            "classed": "dashed",
-                            "strokeWidth": 2,
-                            "values": [
-                                {
-                                    "y": 0,
-                                    "x": 1493596800000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0.741935484,
-                                    "x": 1493683200000,
-                                    "attended": 23,
-                                    "eligible": 31
-                                },
-                                {
-                                    "y": 0.806451613,
-                                    "x": 1493769600000,
-                                    "attended": 25,
-                                    "eligible": 31
-                                },
-                                {
-                                    "y": 0.8,
-                                    "x": 1493856000000,
-                                    "attended": 24,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.8,
-                                    "x": 1493942400000,
-                                    "attended": 24,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494028800000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494115200000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494201600000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0.8,
-                                    "x": 1494288000000,
-                                    "attended": 24,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494374400000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494460800000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494547200000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494633600000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1494720000000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 1.0,
-                                    "x": 1494806400000,
-                                    "attended": 30,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1494892800000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.733333333,
-                                    "x": 1494979200000,
-                                    "attended": 22,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.766666667,
-                                    "x": 1495065600000,
-                                    "attended": 23,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1495152000000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.633333333,
-                                    "x": 1495238400000,
-                                    "attended": 19,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1495324800000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1495411200000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1495497600000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1495584000000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1495670400000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1495756800000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0.666666667,
-                                    "x": 1495843200000,
-                                    "attended": 20,
-                                    "eligible": 30
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1495929600000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                },
-                                {
-                                    "y": 0.655172414,
-                                    "x": 1496016000000,
-                                    "attended": 19,
-                                    "eligible": 29
-                                },
-                                {
-                                    "y": 1.0,
-                                    "x": 1496102400000,
-                                    "attended": 29,
-                                    "eligible": 29
-                                },
-                                {
-                                    "y": 0,
-                                    "x": 1496188800000,
-                                    "attended": 0,
-                                    "eligible": 0
-                                }
-                            ],
-                            "key": "PSE - Daily Attendance"
-                        }
-                    ]
-                ],
-                "map": {
-                    "markers": {}
-                }
+                "markers": {}
             }
         )
 
-    def test_awc_reports_maternal_child(self):
+    def test_awc_reports_pse_keys(self):
+        data = get_awc_reports_pse(
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            'icds-cas'
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            list(data.keys()),
+            ["images", "kpi", "charts", "map"]
+        )
+
+    def test_awc_reports_maternal_child_underweight_weight_for_age(self):
         data = get_awc_reports_maternal_child(
             'icds-cas',
             {
@@ -645,114 +1032,341 @@ class TestAWCReport(TestCase):
             for el in kpi:
                 del el['help_text']
         self.assertDictEqual(
-            data,
+            data['kpi'][0][0],
             {
-                "kpi": [
-                    [
-                        {
-                            "color": "red",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Underweight (Weight-for-Age)"
-                        },
-                        {
-                            "color": "red",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Wasting (Weight-for-Height)"
-                        }
-                    ],
-                    [
-                        {
-                            "color": "red",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Stunting (Height-for-Age)"
-                        },
-                        {
-                            "color": "green",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Weighing Efficiency"
-                        }
-                    ],
-                    [
-                        {
-                            "color": "red",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Newborns with Low Birth Weight"
-                        },
-                        {
-                            "color": "green",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Early Initiation of Breastfeeding"
-                        }
-                    ],
-                    [
-                        {
-                            "color": "green",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Exclusive breastfeeding"
-                        },
-                        {
-                            "color": "green",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Children initiated appropriate Complementary Feeding"
-                        }
-                    ],
-                    [
-                        {
-                            "color": "green",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Immunization Coverage (at age 1 year)"
-                        },
-                        {
-                            "color": "green",
-                            "all": 0,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Institutional Deliveries"
-                        }
-                    ]
-                ]
+                "color": "red",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Underweight (Weight-for-Age)"
             }
         )
 
-    def test_awc_reports_demographics_monthly(self):
+    def test_awc_reports_maternal_child_wasting_weight_for_height(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][0][1],
+            {
+                "color": "red",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Wasting (Weight-for-Height)"
+            }
+        )
+
+    def test_awc_reports_maternal_child_stunting_height_for_age(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][1][0],
+            {
+                "color": "red",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Stunting (Height-for-Age)"
+            }
+        )
+
+    def test_awc_reports_maternal_child_weighing_efficiency(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][1][1],
+            {
+                "color": "green",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Weighing Efficiency"
+            }
+        )
+
+    def test_awc_reports_maternal_child_newborns_with_low_birth_weight(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][2][0],
+            {
+                "color": "red",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Newborns with Low Birth Weight"
+            }
+        )
+
+    def test_awc_reports_maternal_child_early_initiation_of_breastfeeding(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][2][1],
+            {
+                "color": "green",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Early Initiation of Breastfeeding"
+            }
+        )
+
+    def test_awc_reports_maternal_child_exclusive_breastfeeding(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][3][0],
+            {
+                "color": "green",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Exclusive breastfeeding"
+            }
+        )
+
+    def test_awc_reports_maternal_child_children_initiated_appropriate_complementary_feeding(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][3][1],
+            {
+                "color": "green",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Children initiated appropriate Complementary Feeding"
+            }
+        )
+
+    def test_awc_reports_maternal_child_immunization_coverage_at_age_1_year(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][4][0],
+            {
+                "color": "green",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Immunization Coverage (at age 1 year)"
+            }
+        )
+
+    def test_awc_reports_maternal_child_institutional_deliveries(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertDictEqual(
+            data['kpi'][4][1],
+            {
+                "color": "green",
+                "all": 0,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Institutional Deliveries"
+            }
+        )
+
+    def test_awc_reports_maternal_child_kpi_length(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            len(data['kpi']),
+            5
+        )
+
+    def test_awc_reports_maternal_child_kpi_total_length(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )['kpi']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            10
+        )
+
+    def test_awc_reports_maternal_child_keys(self):
+        data = get_awc_reports_maternal_child(
+            'icds-cas',
+            {
+                'state_id': 'st1',
+                'district_id': 'd1',
+                'block_id': 'b1',
+                'awc_id': 'a1',
+                'aggregation_level': 5
+            },
+            (2017, 5, 1),
+            (2017, 4, 1),
+        )
+        for kpi in data['kpi']:
+            for el in kpi:
+                del el['help_text']
+        self.assertEqual(
+            list(data.keys()),
+            ['kpi']
+        )
+
+    def test_awc_reports_demographics_monthly_registered_households(self):
         self.assertDictEqual(
             get_awc_report_demographics(
                 'icds-cas',
@@ -765,112 +1379,252 @@ class TestAWCReport(TestCase):
                 },
                 (2017, 6, 1),
                 (2017, 5, 1),
-            ),
+            )['kpi'][0][0],
             {
-                "kpi": [
-                    [
-                        {
-                            "all": "",
-                            "format": "number",
-                            "color": "red",
-                            "percent": 0.0,
-                            "value": 139,
-                            "label": "Registered Households",
-                            "frequency": "month",
-                            "help_text": "Total number of households registered"
-                        },
-                        {
-                            "all": 1,
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percent Aadhaar-seeded Beneficiaries",
-                            "frequency": "month",
-                            "help_text": "Percentage of ICDS beneficiaries whose Aadhaar"
-                                         " identification has been captured"
-                        }
-                    ],
-                    [
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percent children (0-6 years) enrolled for Anganwadi Services",
-                            "frequency": "month",
-                            "help_text": "Percentage of children registered between 0-6 years old "
-                                         "who are enrolled for Anganwadi Services"
-                        },
-                        {
-                            "all": 2,
-                            "format": "percent_and_div",
-                            "color": "red",
-                            "percent": 0.0,
-                            "value": 2,
-                            "label": "Percent pregnant women enrolled for Anganwadi Services",
-                            "frequency": "month",
-                            "help_text": "Percentage of pregnant women registered "
-                                         "who are enrolled for Anganwadi Services"
-                        }
-                    ],
-                    [
-                        {
-                            "all": 3,
-                            "format": "percent_and_div",
-                            "color": "red",
-                            "percent": 0.0,
-                            "value": 3,
-                            "label": "Percent lactating women enrolled for Anganwadi Services",
-                            "frequency": "month",
-                            "help_text": "Percentage of lactating women registered "
-                                         "who are enrolled for Anganwadi Services"
-                        },
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "color": "red",
-                            "percent": -100.0,
-                            "value": 0,
-                            "label": "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services",
-                            "frequency": "month",
-                            "help_text": "Percentage of adolescent girls registered between"
-                                         " 11-14 years old who are enrolled for Anganwadi Services"
-                        }
-                    ]
-                ],
-                "chart": [
-                    {
-                        "values": [
-                            [
-                                "0-1 month",
-                                0
-                            ],
-                            [
-                                "1-6 months",
-                                0
-                            ],
-                            [
-                                "6-12 months",
-                                0
-                            ],
-                            [
-                                "1-3 years",
-                                0
-                            ],
-                            [
-                                "3-6 years",
-                                0
-                            ]
-                        ],
-                        "classed": "dashed",
-                        "key": "Children (0-6 years)"
-                    }
-                ]
+                "all": "",
+                "format": "number",
+                "color": "red",
+                "percent": 0,
+                "value": 139,
+                "label": "Registered Households",
+                "frequency": "month",
+                "help_text": "Total number of households registered"
             }
         )
 
-    def test_awc_reports_demographics_daily(self):
+    def test_awc_reports_demographics_monthly_percent_aadhaar_seeded_beneficiaries(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi'][0][1],
+            {
+                "all": 1,
+                'color': 'green',
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percent Aadhaar-seeded Beneficiaries",
+                "frequency": "month",
+                "help_text": "Percentage of ICDS beneficiaries whose Aadhaar"
+                             " identification has been captured"
+            }
+        )
+
+    def test_awc_reports_demographics_monthly_percent_children_0_6_years_enrolled_for_anganwadi_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi'][1][0],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percent children (0-6 years) enrolled for Anganwadi Services",
+                "frequency": "month",
+                "help_text": "Percentage of children registered between 0-6 years old "
+                             "who are enrolled for Anganwadi Services"
+            }
+        )
+
+    def test_awc_reports_demographics_monthly_percent_pregnant_women_enrolled_for_anganwadi_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi'][1][1],
+            {
+                "all": 2,
+                "format": "percent_and_div",
+                "color": "red",
+                "percent": 0,
+                "value": 2,
+                "label": "Percent pregnant women enrolled for Anganwadi Services",
+                "frequency": "month",
+                "help_text": "Percentage of pregnant women registered "
+                             "who are enrolled for Anganwadi Services"
+            }
+        )
+
+    def test_awc_reports_demographics_monthly_percent_lactating_women_enrolled_for_anganwadi_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi'][2][0],
+            {
+                "all": 3,
+                "format": "percent_and_div",
+                "color": "red",
+                "percent": 0,
+                "value": 3,
+                "label": "Percent lactating women enrolled for Anganwadi Services",
+                "frequency": "month",
+                "help_text": "Percentage of lactating women registered "
+                             "who are enrolled for Anganwadi Services"
+            }
+        )
+
+    def test_awc_reports_demographics_monthly_percent_adolescent_girls_11_14_years_enrolled_for_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi'][2][1],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "color": "red",
+                "percent": -100.0,
+                "value": 0,
+                "label": "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services",
+                "frequency": "month",
+                "help_text": "Percentage of adolescent girls registered between"
+                             " 11-14 years old who are enrolled for Anganwadi Services"
+            }
+        )
+
+    def test_awc_reports_demographics_monthly_kpi_length(self):
+        self.assertEqual(
+            len(get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi']),
+            3
+        )
+
+    def test_awc_reports_demographics_monthly_kpi_total_length(self):
+        data = get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['kpi']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            6
+        )
+
+    def test_awc_reports_demographics_monthly_chart(self):
+        self.assertEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            )['chart'],
+            [
+                {
+                    "values": [
+                        [
+                            "0-1 month",
+                            0
+                        ],
+                        [
+                            "1-6 months",
+                            0
+                        ],
+                        [
+                            "6-12 months",
+                            0
+                        ],
+                        [
+                            "1-3 years",
+                            0
+                        ],
+                        [
+                            "3-6 years",
+                            0
+                        ]
+                    ],
+                    "classed": "dashed",
+                    "key": "Children (0-6 years)"
+                }
+            ]
+        )
+
+    def test_awc_reports_demographics_monthly_keys(self):
+        self.assertEqual(
+            list(get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 6, 1),
+                (2017, 5, 1),
+            ).keys()),
+            ['kpi', 'chart']
+        )
+
+    def test_awc_reports_demographics_daily_registered_households(self):
         self.assertDictEqual(
             get_awc_report_demographics(
                 'icds-cas',
@@ -883,105 +1637,244 @@ class TestAWCReport(TestCase):
                 },
                 (2017, 5, 29),
                 (2017, 5, 1),
-            ),
+            )['kpi'][0][0],
             {
-                "kpi": [
-                    [
-                        {
-                            "all": "",
-                            "format": "number",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 139,
-                            "label": "Registered Households",
-                            "frequency": "day",
-                            "help_text": "Total number of households registered"
-                        },
-                        {
-                            "all": 1,
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percent Aadhaar-seeded Beneficiaries",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of ICDS beneficiaries whose Aadhaar identification has been captured"
-                            )
-                        }
-                    ],
-                    [
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percent children (0-6 years) enrolled for Anganwadi Services",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of children registered between 0-6 years old "
-                                "who are enrolled for Anganwadi Services"
-                            )
-                        },
-                        {
-                            "all": 2,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 2,
-                            "label": "Percent pregnant women enrolled for Anganwadi Services",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of pregnant women registered who are enrolled for Anganwadi Services"
-                            )
-                        }
-                    ],
-                    [
-                        {
-                            "all": 3,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 3,
-                            "label": "Percent lactating women enrolled for Anganwadi Services",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of lactating women registered who are enrolled for Anganwadi Services"
-                            )
-                        },
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": (
-                                "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services"
-                            ),
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of adolescent girls registered between 11-14 years old who "
-                                "are enrolled for Anganwadi Services"
-                            )
-                        }
-                    ]
-                ],
-                "chart": [{
-                    "values": [
-                        ["0-1 month", 0],
-                        ["1-6 months", 0],
-                        ["6-12 months", 0],
-                        ["1-3 years", 0],
-                        ["3-6 years", 0]
-                    ],
-                    "classed": "dashed",
-                    "key": "Children (0-6 years)"
-                }]
+                "all": "",
+                "format": "number",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 139,
+                "label": "Registered Households",
+                "frequency": "day",
+                "help_text": "Total number of households registered"
             }
-
         )
 
-    def test_awc_reports_demographics_daily_if_aggregation_script_fail(self):
+    def test_awc_reports_demographics_daily_percent_aadhaar_seeded_beneficiaries(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi'][0][1],
+            {
+                "all": 1,
+                'color': 'green',
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percent Aadhaar-seeded Beneficiaries",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of ICDS beneficiaries whose Aadhaar identification has been captured"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_percent_children_0_6_years_enrolled_for_anganwadi_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi'][1][0],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percent children (0-6 years) enrolled for Anganwadi Services",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of children registered between 0-6 years old "
+                    "who are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_percent_pregnant_women_enrolled_for_anganwadi_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi'][1][1],
+            {
+                "all": 2,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 2,
+                "label": "Percent pregnant women enrolled for Anganwadi Services",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of pregnant women registered who are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_percent_lactating_women_enrolled_for_anganwadi_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi'][2][0],
+            {
+                "all": 3,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 3,
+                "label": "Percent lactating women enrolled for Anganwadi Services",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of lactating women registered who are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_percent_adolescent_girls_11_14_years_enrolled_for_services(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi'][2][1],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": (
+                    "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services"
+                ),
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of adolescent girls registered between 11-14 years old who "
+                    "are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_kpi_length(self):
+        self.assertEqual(
+            len(get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi']),
+            3
+        )
+
+    def test_awc_reports_demographics_daily_kpi_total_length(self):
+        data = get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['kpi']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            6
+        )
+
+    def test_awc_reports_demographics_daily_chart(self):
+        self.assertEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            )['chart'],
+            [{
+                "values": [
+                    ["0-1 month", 0],
+                    ["1-6 months", 0],
+                    ["6-12 months", 0],
+                    ["1-3 years", 0],
+                    ["3-6 years", 0]
+                ],
+                "classed": "dashed",
+                "key": "Children (0-6 years)"
+            }]
+        )
+
+    def test_awc_reports_demographics_daily_keys(self):
+        self.assertEqual(
+            list(get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 29),
+                (2017, 5, 1),
+            ).keys()),
+            ['kpi', 'chart']
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_registered_households(self):
         self.assertDictEqual(
             get_awc_report_demographics(
                 'icds-cas',
@@ -994,107 +1887,22 @@ class TestAWCReport(TestCase):
                 },
                 (2017, 5, 30),
                 (2017, 5, 1),
-            ),
+            )['kpi'][0][0],
             {
-                "kpi": [
-                    [
-                        {
-                            "all": "",
-                            "format": "number",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 139,
-                            "label": "Registered Households",
-                            "frequency": "day",
-                            "help_text": "Total number of households registered"
-                        },
-                        {
-                            "all": 1,
-                            "format": "percent_and_div",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percent Aadhaar-seeded Beneficiaries",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of ICDS beneficiaries whose Aadhaar identification has been captured"
-                            )
-                        }
-                    ],
-                    [
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": "Percent children (0-6 years) enrolled for Anganwadi Services",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of children registered between 0-6 years old "
-                                "who are enrolled for Anganwadi Services"
-                            )
-                        },
-                        {
-                            "all": 2,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 2,
-                            "label": "Percent pregnant women enrolled for Anganwadi Services",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of pregnant women registered who are enrolled for Anganwadi Services"
-                            )
-                        }
-                    ],
-                    [
-                        {
-                            "all": 3,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 3,
-                            "label": "Percent lactating women enrolled for Anganwadi Services",
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of lactating women registered who are enrolled for Anganwadi Services"
-                            )
-                        },
-                        {
-                            "all": 0,
-                            "format": "percent_and_div",
-                            "color": "green",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 0,
-                            "label": (
-                                "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services"
-                            ),
-                            "frequency": "day",
-                            "help_text": (
-                                "Percentage of adolescent girls registered between 11-14 years old who "
-                                "are enrolled for Anganwadi Services"
-                            )
-                        }
-                    ]
-                ],
-                "chart": [{
-                    "values": [
-                        ["0-1 month", 0],
-                        ["1-6 months", 0],
-                        ["6-12 months", 0],
-                        ["1-3 years", 0],
-                        ["3-6 years", 0]
-                    ],
-                    "classed": "dashed",
-                    "key": "Children (0-6 years)"
-                }]
+                "all": "",
+                "format": "number",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 139,
+                "label": "Registered Households",
+                "frequency": "day",
+                "help_text": "Total number of households registered"
             }
-
         )
 
-    def test_awc_reports_infrastructure(self):
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_percent_aadhaar_seeded_beneficiaries(self):
         self.assertDictEqual(
-            get_awc_report_infrastructure(
+            get_awc_report_demographics(
                 'icds-cas',
                 {
                     'state_id': 'st1',
@@ -1103,67 +1911,569 @@ class TestAWCReport(TestCase):
                     'awc_id': 'a1',
                     'aggregation_level': 5
                 },
+                (2017, 5, 30),
                 (2017, 5, 1),
-            ),
+            )['kpi'][0][1],
             {
-                "kpi": [
-                    [
-                        {
-                            "all": "",
-                            "format": "string",
-                            "show_percent": False,
-                            "value": "Available",
-                            "label": "Clean Drinking Water",
-                            "frequency": "month",
-                            "help_text": None
-                        },
-                        {
-                            "all": "",
-                            "format": "string",
-                            "show_percent": False,
-                            "value": "Available",
-                            "label": "Functional Toilet",
-                            "frequency": "month",
-                            "help_text": None
-                        }
-                    ],
-                    [
-                        {
-                            "all": "",
-                            "format": "string",
-                            "show_percent": False,
-                            "value": "Data not Entered",
-                            "label": "Weighing Scale: Infants",
-                            "frequency": "month",
-                            "help_text": None
-                        },
-                        {
-                            "all": "",
-                            "format": "string",
-                            "show_percent": False,
-                            "value": "Data not Entered",
-                            "label": "AWCs with Weighing Scale: Mother and Child",
-                            "frequency": "month",
-                            "help_text": None
-                        }
-                    ],
-                    [
-                        {
-                            "all": "",
-                            "format": "string",
-                            "show_percent": False,
-                            "value": "Data not Entered",
-                            "label": "Medicine Kit",
-                            "frequency": "month",
-                            "help_text": None
-                        }
-                    ]
-                ]
+                "all": 1,
+                'color': 'green',
+                "format": "percent_and_div",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percent Aadhaar-seeded Beneficiaries",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of ICDS beneficiaries whose Aadhaar identification has been captured"
+                )
             }
         )
 
-    def test_awc_report_beneficiary(self):
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_percent_children_0_6_years_enrolled(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['kpi'][1][0],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": "Percent children (0-6 years) enrolled for Anganwadi Services",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of children registered between 0-6 years old "
+                    "who are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_percent_pregnant_women_enrolled(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['kpi'][1][1],
+            {
+                "all": 2,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 2,
+                "label": "Percent pregnant women enrolled for Anganwadi Services",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of pregnant women registered who are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_percent_lactating_women_enrolled(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['kpi'][2][0],
+            {
+                "all": 3,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 3,
+                "label": "Percent lactating women enrolled for Anganwadi Services",
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of lactating women registered who are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_percent_adolescent_girls_enrolled(self):
+        self.assertDictEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['kpi'][2][1],
+            {
+                "all": 0,
+                "format": "percent_and_div",
+                "color": "green",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 0,
+                "label": (
+                    "Percent adolescent girls (11-14 years) enrolled for Anganwadi Services"
+                ),
+                "frequency": "day",
+                "help_text": (
+                    "Percentage of adolescent girls registered between 11-14 years old who "
+                    "are enrolled for Anganwadi Services"
+                )
+            }
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_kpi_length(self):
+        self.assertEqual(
+            len(get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['kpi']),
+            3
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_kpi_total_length(self):
+        data = get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['kpi']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            6
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_chart(self):
+        self.assertEqual(
+            get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            )['chart'],
+            [{
+                "values": [
+                    ["0-1 month", 0],
+                    ["1-6 months", 0],
+                    ["6-12 months", 0],
+                    ["1-3 years", 0],
+                    ["3-6 years", 0]
+                ],
+                "classed": "dashed",
+                "key": "Children (0-6 years)"
+            }]
+        )
+
+    def test_awc_reports_demographics_daily_if_aggregation_script_fail_keys(self):
+        self.assertEqual(
+            list(get_awc_report_demographics(
+                'icds-cas',
+                {
+                    'state_id': 'st1',
+                    'district_id': 'd1',
+                    'block_id': 'b1',
+                    'awc_id': 'a1',
+                    'aggregation_level': 5
+                },
+                (2017, 5, 30),
+                (2017, 5, 1),
+            ).keys()),
+            ['kpi', 'chart']
+        )
+
+    def test_awc_report_beneficiary_ca040875_2e42_4ce4_acf7_f96695b370f1(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][0]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "12.8000000000000000",
+                    "age_in_months": 59,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Moderately stunted"
+                    },
+                    "pse_days_attended": 14,
+                    "dob": "2012-06-03",
+                    "age": "4 years 11 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Normal weight for height"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Moderately underweight"
+                    },
+                    "case_id": "ca040875-2e42-4ce4-acf7-f96695b370f1",
+                    "recorded_height": "95.0000000000000000",
+                    "fully_immunized": "No",
+                    "person_name": "Name 4416",
+                    "sex": "F",
+                    "mother_name": "रामकन्या"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_82f33fa1_2aec_45ba_8d6c_d3ca9f50ab73(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][1]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "14.3000000000000000",
+                    "age_in_months": 59,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 14,
+                    "dob": "2012-06-23",
+                    "age": "4 years 11 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "82f33fa1-2aec-45ba-8d6c-d3ca9f50ab73",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4445",
+                    "sex": "F",
+                    "mother_name": "किरणबाई"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_b954eb28_75de_43c8_9ec0_d38b7d246ead(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][2]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "19.0000000000000000",
+                    "age_in_months": 59,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 1,
+                    "dob": "2012-06-26",
+                    "age": "4 years 11 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "b954eb28-75de-43c8-9ec0-d38b7d246ead",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 2617",
+                    "sex": "M",
+                    "mother_name": "ताराकुँवर पति राजेन्द्रसिंह"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_519720be_4343_41e7_a9f6_cdfad6ecf8d8(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][3]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "14.6000000000000000",
+                    "age_in_months": 58,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 14,
+                    "dob": "2012-07-05",
+                    "age": "4 years 10 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "519720be-4343-41e7-a9f6-cdfad6ecf8d8",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4412",
+                    "sex": "M",
+                    "mother_name": "जशोदा"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_80099a73_b7ec_4de9_a402_459ed15f6641(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][4]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "14.8000000000000000",
+                    "age_in_months": 58,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 16,
+                    "dob": "2012-07-18",
+                    "age": "4 years 10 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "80099a73-b7ec-4de9-a402-459ed15f6641",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4411",
+                    "sex": "F",
+                    "mother_name": "लक्ष्मी बाई"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_532f3754_e231_40ec_a861_abbb2a06dff5(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][5]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "13.5000000000000000",
+                    "age_in_months": 58,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 10,
+                    "dob": "2012-07-19",
+                    "age": "4 years 10 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Moderately underweight"
+                    },
+                    "case_id": "532f3754-e231-40ec-a861-abbb2a06dff5",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4408",
+                    "sex": "F",
+                    "mother_name": "छनुकुवर पति चोकसिंह"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_4cd07ebf_abce_4345_a930_f6db7ede8996(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][6]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "14.5000000000000000",
+                    "age_in_months": 57,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 9,
+                    "dob": "2012-08-24",
+                    "age": "4 years 9 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "4cd07ebf-abce-4345-a930-f6db7ede8996",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4399",
+                    "sex": "F",
+                    "mother_name": "संगीताबाई पति धनसिंह"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_c9ee2435_d7fc_4307_9c18_9d5d83d2a691(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][7]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "11.0000000000000000",
+                    "age_in_months": 52,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Moderately stunted"
+                    },
+                    "pse_days_attended": 17,
+                    "dob": "2013-01-02",
+                    "age": "4 years 4 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Moderately wasted"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "red",
+                        "value": "Severely underweight"
+                    },
+                    "case_id": "c9ee2435-d7fc-4307-9c18-9d5d83d2a691",
+                    "recorded_height": "94.0000000000000000",
+                    "fully_immunized": "No",
+                    "person_name": "Name 4402",
+                    "sex": "M",
+                    "mother_name": "पोपा बाई"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_d44f7902_83d4_4f1d_a913_4176cf41094e(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][8]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "14.8000000000000000",
+                    "age_in_months": 51,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 13,
+                    "dob": "2013-02-07",
+                    "age": "4 years 3 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "d44f7902-83d4-4f1d-a913-4176cf41094e",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4414",
+                    "sex": "M",
+                    "mother_name": "भूराकुवर पति धर्मेन्द्रसिंह"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_71230690_c828_4863_b2c1_f61a75aed9d7(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))['data'][9]
+        self.assertJSONEqual(
+            json.dumps(data, cls=DjangoJSONEncoder),
+            json.dumps(
+                {
+                    "recorded_weight": "12.6000000000000000",
+                    "age_in_months": 51,
+                    "current_month_stunting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "pse_days_attended": 9,
+                    "dob": "2013-02-11",
+                    "age": "4 years 3 months ",
+                    "current_month_wasting": {
+                        "color": "black",
+                        "value": "Data Not Entered"
+                    },
+                    "current_month_nutrition_status": {
+                        "color": "black",
+                        "value": "Normal weight for age"
+                    },
+                    "case_id": "71230690-c828-4863-b2c1-f61a75aed9d7",
+                    "recorded_height": 0,
+                    "fully_immunized": "No",
+                    "person_name": "Name 4407",
+                    "sex": "M",
+                    "mother_name": "ममता बाई"
+                },
+                cls=DjangoJSONEncoder
+            )
+        )
+
+    def test_awc_report_beneficiary_data_length(self):
         data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))
+        self.assertEqual(
+            len(data['data']),
+            10
+        )
+
+    def test_awc_report_beneficiary_data_without_data(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))
+        del data['data']
         self.assertJSONEqual(
             json.dumps(data, cls=DjangoJSONEncoder),
             json.dumps({
@@ -1176,248 +2486,15 @@ class TestAWCReport(TestCase):
                     "Mar 2017"
                 ],
                 "recordsFiltered": 27,
-                "data": [
-                    {
-                        "recorded_weight": "12.8000000000000000",
-                        "age_in_months": 59,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Moderately stunted"
-                        },
-                        "pse_days_attended": 14,
-                        "dob": "2012-06-03",
-                        "age": "4 years 11 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Normal weight for height"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Moderately underweight"
-                        },
-                        "case_id": "ca040875-2e42-4ce4-acf7-f96695b370f1",
-                        "recorded_height": "95.0000000000000000",
-                        "fully_immunized": "No",
-                        "person_name": "Name 4416",
-                        "sex": "F",
-                        "mother_name": "रामकन्या"
-                    }, {
-                        "recorded_weight": "14.3000000000000000",
-                        "age_in_months": 59,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 14,
-                        "dob": "2012-06-23",
-                        "age": "4 years 11 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "82f33fa1-2aec-45ba-8d6c-d3ca9f50ab73",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4445",
-                        "sex": "F",
-                        "mother_name": "किरणबाई"
-                    }, {
-                        "recorded_weight": "19.0000000000000000",
-                        "age_in_months": 59,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 1,
-                        "dob": "2012-06-26",
-                        "age": "4 years 11 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "b954eb28-75de-43c8-9ec0-d38b7d246ead",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 2617",
-                        "sex": "M",
-                        "mother_name": "ताराकुँवर पति राजेन्द्रसिंह"
-                    }, {
-                        "recorded_weight": "14.6000000000000000",
-                        "age_in_months": 58,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 14,
-                        "dob": "2012-07-05",
-                        "age": "4 years 10 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "519720be-4343-41e7-a9f6-cdfad6ecf8d8",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4412",
-                        "sex": "M",
-                        "mother_name": "जशोदा"
-                    }, {
-                        "recorded_weight": "14.8000000000000000",
-                        "age_in_months": 58,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 16,
-                        "dob": "2012-07-18",
-                        "age": "4 years 10 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "80099a73-b7ec-4de9-a402-459ed15f6641",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4411",
-                        "sex": "F",
-                        "mother_name": "लक्ष्मी बाई"
-                    }, {
-                        "recorded_weight": "13.5000000000000000",
-                        "age_in_months": 58,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 10,
-                        "dob": "2012-07-19",
-                        "age": "4 years 10 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Moderately underweight"
-                        },
-                        "case_id": "532f3754-e231-40ec-a861-abbb2a06dff5",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4408",
-                        "sex": "F",
-                        "mother_name": "छनुकुवर पति चोकसिंह"
-                    }, {
-                        "recorded_weight": "14.5000000000000000",
-                        "age_in_months": 57,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 9,
-                        "dob": "2012-08-24",
-                        "age": "4 years 9 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "4cd07ebf-abce-4345-a930-f6db7ede8996",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4399",
-                        "sex": "F",
-                        "mother_name": "संगीताबाई पति धनसिंह"
-                    }, {
-                        "recorded_weight": "11.0000000000000000",
-                        "age_in_months": 52,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Moderately stunted"
-                        },
-                        "pse_days_attended": 17,
-                        "dob": "2013-01-02",
-                        "age": "4 years 4 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Moderately wasted"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "red",
-                            "value": "Severely underweight"
-                        },
-                        "case_id": "c9ee2435-d7fc-4307-9c18-9d5d83d2a691",
-                        "recorded_height": "94.0000000000000000",
-                        "fully_immunized": "No",
-                        "person_name": "Name 4402",
-                        "sex": "M",
-                        "mother_name": "पोपा बाई"
-                    }, {
-                        "recorded_weight": "14.8000000000000000",
-                        "age_in_months": 51,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 13,
-                        "dob": "2013-02-07",
-                        "age": "4 years 3 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "d44f7902-83d4-4f1d-a913-4176cf41094e",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4414",
-                        "sex": "M",
-                        "mother_name": "भूराकुवर पति धर्मेन्द्रसिंह"
-                    }, {
-                        "recorded_weight": "12.6000000000000000",
-                        "age_in_months": 51,
-                        "current_month_stunting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "pse_days_attended": 9,
-                        "dob": "2013-02-11",
-                        "age": "4 years 3 months ",
-                        "current_month_wasting": {
-                            "color": "black",
-                            "value": "Data Not Entered"
-                        },
-                        "current_month_nutrition_status": {
-                            "color": "black",
-                            "value": "Normal weight for age"
-                        },
-                        "case_id": "71230690-c828-4863-b2c1-f61a75aed9d7",
-                        "recorded_height": 0,
-                        "fully_immunized": "No",
-                        "person_name": "Name 4407",
-                        "sex": "M",
-                        "mother_name": "ममता बाई"
-                    }
-                ]
             }, cls=DjangoJSONEncoder)
+        )
+
+    def test_awc_report_beneficiary_keys(self):
+        data = get_awc_report_beneficiary(0, 10, 1, 'dob', 'a18', (2017, 5, 1), (2017, 3, 1))
+        self.assertJSONEqual(
+            json.dumps(list(data.keys()), cls=DjangoJSONEncoder),
+            json.dumps(
+                ['draw', 'last_month', 'recordsTotal', 'months', 'recordsFiltered', 'data'],
+                cls=DjangoJSONEncoder
+            )
         )

--- a/custom/icds_reports/tests/reports/test_maternal_child_data.py
+++ b/custom/icds_reports/tests/reports/test_maternal_child_data.py
@@ -5,9 +5,7 @@ from custom.icds_reports.reports.maternal_child import get_maternal_child_data
 
 
 class TestMaternalChildData(TestCase):
-    maxDiff = None
-
-    def test_data(self):
+    def test_data_underweight_weight_for_age(self):
         self.assertDictEqual(
             get_maternal_child_data(
                 'icds-cas',
@@ -16,132 +14,245 @@ class TestMaternalChildData(TestCase):
                     'prev_month': (2017, 4, 1),
                     'aggregation_level': 1
                 }
-            ),
+            )['records'][0][0],
             {
-                "records": [
-                    [
-                        {
-                            "redirect": "underweight_children",
-                            "color": "green",
-                            "all": 696,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of children between 0-5 years enrolled for Anganwadi Services"
-                                         " with weight-for-age less than -2 standard deviations"
-                                         " of the WHO Child Growth Standards median. "
-                                         "Children who are moderately or severely underweight"
-                                         " have a higher risk of mortality.",
-                            "percent": -14.901477832512326,
-                            "value": 150,
-                            "label": "Underweight (Weight-for-Age)"
-                        },
-                        {
-                            "redirect": "wasting",
-                            "color": "red",
-                            "all": 31,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of children (6-60 months) with weight-for-height below"
-                                         " -3 standard deviations of the WHO Child Growth Standards median. "
-                                         "Severe Acute Malnutrition (SAM) or wasting in children is a symptom of"
-                                         " acute undernutrition usually as a consequence of insufficient "
-                                         "food intake or a high incidence of infectious diseases.",
-                            "percent": 41.93548387096772,
-                            "value": 8,
-                            "label": "Wasting (Weight-for-Height)"
-                        }
-                    ],
-                    [
-                        {
-                            "redirect": "stunting",
-                            "color": "green",
-                            "all": 32,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of children (6-60 months) with height-for-age below -2Z"
-                                         " standard deviations of the WHO Child Growth Standards median. "
-                                         "Stunting is a sign of chronic undernutrition and has "
-                                         "long lasting harmful consequences on the growth of a child",
-                            "percent": -27.430555555555564,
-                            "value": 19,
-                            "label": "Stunting (Height-for-Age)"
-                        },
-                        {
-                            "redirect": "low_birth",
-                            "color": "red",
-                            "all": 4,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of newborns born with birth weight less than 2500 grams."
-                                         " Newborns with Low Birth Weight are closely associated "
-                                         "with foetal and neonatal mortality and morbidity,"
-                                         " inhibited growth and cognitive development,"
-                                         " and chronic diseases later in life",
-                            "percent": "Data in the previous reporting period was 0",
-                            "value": 2,
-                            "label": "Newborns with Low Birth Weight"
-                        }
-                    ],
-                    [
-                        {
-                            "redirect": "early_initiation",
-                            "color": "green",
-                            "all": 7,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of children breastfed within an hour of birth. "
-                                         "Early initiation of breastfeeding ensure the newborn "
-                                         "recieves the 'first milk' rich in nutrients "
-                                         "and encourages exclusive breastfeeding practice",
-                            "percent": 128.57142857142856,
-                            "value": 4,
-                            "label": "Early Initiation of Breastfeeding"
-                        },
-                        {
-                            "redirect": "exclusive_breastfeeding",
-                            "color": "green",
-                            "all": 50,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of children between 0 - 6 months exclusively breastfed. "
-                                         "An infant is exclusively breastfed if they recieve only breastmilk "
-                                         "with no additional food, liquids (even water) ensuring "
-                                         "optimal nutrition and growth between 0 - 6 months",
-                            "percent": 149.84615384615384,
-                            "value": 28,
-                            "label": "Exclusive Breastfeeding"
-                        }
-                    ],
-                    [
-                        {
-                            "redirect": "children_initiated",
-                            "color": "green",
-                            "all": 40,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of children between 6 - 8 months given timely "
-                                         "introduction to solid or semi-solid food. Timely intiation"
-                                         " of complementary feeding in addition to breastmilk "
-                                         "at 6 months of age is a key feeding practice to reduce malnutrition",
-                            "percent": 147.27272727272725,
-                            "value": 34,
-                            "label": "Children initiated appropriate Complementary Feeding"
-                        },
-                        {
-                            "redirect": "institutional_deliveries",
-                            "color": "green",
-                            "all": 26,
-                            "frequency": "month",
-                            "format": "percent_and_div",
-                            "help_text": "Percentage of pregnant women who delivered in a public "
-                                         "or private medical facility in the last month. "
-                                         "Delivery in medical instituitions is associated "
-                                         "with a decrease in maternal mortality rate",
-                            "percent": 156.41025641025647,
-                            "value": 20,
-                            "label": "Institutional Deliveries"
-                        }
-                    ]
-                ]
+                "redirect": "underweight_children",
+                "color": "green",
+                "all": 696,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of children between 0-5 years enrolled for Anganwadi Services"
+                             " with weight-for-age less than -2 standard deviations"
+                             " of the WHO Child Growth Standards median. "
+                             "Children who are moderately or severely underweight"
+                             " have a higher risk of mortality.",
+                "percent": -14.901477832512326,
+                "value": 150,
+                "label": "Underweight (Weight-for-Age)"
             }
+        )
+
+    def test_data_wasting_weight_for_height(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][0][1],
+            {
+                "redirect": "wasting",
+                "color": "red",
+                "all": 31,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of children (6-60 months) with weight-for-height below"
+                             " -3 standard deviations of the WHO Child Growth Standards median. "
+                             "Severe Acute Malnutrition (SAM) or wasting in children is a symptom of"
+                             " acute undernutrition usually as a consequence of insufficient "
+                             "food intake or a high incidence of infectious diseases.",
+                "percent": 41.935483870967715,
+                "value": 8,
+                "label": "Wasting (Weight-for-Height)"
+            }
+        )
+
+    def test_data_stunting_height_for_age(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][1][0],
+            {
+                "redirect": "stunting",
+                "color": "green",
+                "all": 32,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of children (6-60 months) with height-for-age below -2Z"
+                             " standard deviations of the WHO Child Growth Standards median. "
+                             "Stunting is a sign of chronic undernutrition and has "
+                             "long lasting harmful consequences on the growth of a child",
+                "percent": -27.43055555555556,
+                "value": 19,
+                "label": "Stunting (Height-for-Age)"
+            }
+        )
+
+    def test_data_newborns_with_low_birth_weight(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][1][1],
+            {
+                "redirect": "low_birth",
+                "color": "red",
+                "all": 4,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of newborns born with birth weight less than 2500 grams."
+                             " Newborns with Low Birth Weight are closely associated "
+                             "with foetal and neonatal mortality and morbidity,"
+                             " inhibited growth and cognitive development,"
+                             " and chronic diseases later in life",
+                "percent": "Data in the previous reporting period was 0",
+                "value": 2,
+                "label": "Newborns with Low Birth Weight"
+            }
+        )
+
+    def test_data_early_initiation_of_breastfeeding(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][2][0],
+            {
+                "redirect": "early_initiation",
+                "color": "green",
+                "all": 7,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of children breastfed within an hour of birth. "
+                             "Early initiation of breastfeeding ensure the newborn "
+                             "recieves the 'first milk' rich in nutrients "
+                             "and encourages exclusive breastfeeding practice",
+                "percent": 128.57142857142856,
+                "value": 4,
+                "label": "Early Initiation of Breastfeeding"
+            }
+        )
+
+    def test_data_exclusive_breastfeeding(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][2][1],
+            {
+                "redirect": "exclusive_breastfeeding",
+                "color": "green",
+                "all": 50,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of children between 0 - 6 months exclusively breastfed. "
+                             "An infant is exclusively breastfed if they recieve only breastmilk "
+                             "with no additional food, liquids (even water) ensuring "
+                             "optimal nutrition and growth between 0 - 6 months",
+                "percent": 149.84615384615384,
+                "value": 28,
+                "label": "Exclusive Breastfeeding"
+            }
+        )
+
+    def test_data_children_initiated_appropriate_complementary_feeding(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][3][0],
+            {
+                "redirect": "children_initiated",
+                "color": "green",
+                "all": 40,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of children between 6 - 8 months given timely "
+                             "introduction to solid or semi-solid food. Timely intiation"
+                             " of complementary feeding in addition to breastmilk "
+                             "at 6 months of age is a key feeding practice to reduce malnutrition",
+                "percent": 147.27272727272728,
+                "value": 34,
+                "label": "Children initiated appropriate Complementary Feeding"
+            }
+        )
+
+    def test_data_institutional_deliveries(self):
+        self.assertDictEqual(
+            get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records'][3][1],
+            {
+                "redirect": "institutional_deliveries",
+                "color": "green",
+                "all": 26,
+                "frequency": "month",
+                "format": "percent_and_div",
+                "help_text": "Percentage of pregnant women who delivered in a public "
+                             "or private medical facility in the last month. "
+                             "Delivery in medical instituitions is associated "
+                             "with a decrease in maternal mortality rate",
+                "percent": 156.41025641025647,
+                "value": 20,
+                "label": "Institutional Deliveries"
+            }
+        )
+
+    def test_data_records_length(self):
+        self.assertEqual(
+            len(get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            )['records']),
+            4
+        )
+
+    def test_data_records_total_length(self):
+        data = get_maternal_child_data(
+            'icds-cas',
+            {
+                'month': (2017, 5, 1),
+                'prev_month': (2017, 4, 1),
+                'aggregation_level': 1
+            }
+        )['records']
+
+        self.assertEqual(
+            sum([len(record_row) for record_row in data]),
+            8
+        )
+
+    def test_data_keys(self):
+        self.assertEqual(
+            list(get_maternal_child_data(
+                'icds-cas',
+                {
+                    'month': (2017, 5, 1),
+                    'prev_month': (2017, 4, 1),
+                    'aggregation_level': 1
+                }
+            ).keys()),
+            ['records']
         )

--- a/custom/icds_reports/utils.py
+++ b/custom/icds_reports/utils.py
@@ -220,8 +220,8 @@ def percent_increase(prop, data, prev_data):
         previous = prev_data[0][prop]
 
     if previous:
-        tenths_of_promils = ((current or 0) - (previous or 0)) / float(previous or 1) * 10000
-        return tenths_of_promils * 100 if int(tenths_of_promils) else 0
+        tenths_of_promils = (((current or 0) - (previous or 0)) * 10000) / float(previous or 1)
+        return tenths_of_promils / 100 if (tenths_of_promils < -1 or 1 < tenths_of_promils) else 0
     else:
         return "Data in the previous reporting period was 0"
 
@@ -243,8 +243,8 @@ def percent_diff(property, current_data, prev_data, all):
     prev_percent = prev / float(prev_all) * 100
 
     if prev_percent:
-        tenths_of_promils = ((current_percent - prev_percent) / (prev_percent or 1.0)) * 10000
-        return tenths_of_promils * 100 if int(tenths_of_promils) else 0
+        tenths_of_promils = ((current_percent - prev_percent) * 10000) / (prev_percent or 1.0)
+        return tenths_of_promils / 100 if (tenths_of_promils < -1 or 1 < tenths_of_promils) else 0
     else:
         return "Data in the previous reporting period was 0"
 

--- a/custom/icds_reports/utils.py
+++ b/custom/icds_reports/utils.py
@@ -220,7 +220,8 @@ def percent_increase(prop, data, prev_data):
         previous = prev_data[0][prop]
 
     if previous:
-        return ((current or 0) - (previous or 0)) / float(previous or 1) * 100
+        tenths_of_promils = ((current or 0) - (previous or 0)) / float(previous or 1) * 10000
+        return tenths_of_promils * 100 if int(tenths_of_promils) else 0
     else:
         return "Data in the previous reporting period was 0"
 
@@ -242,7 +243,8 @@ def percent_diff(property, current_data, prev_data, all):
     prev_percent = prev / float(prev_all) * 100
 
     if prev_percent:
-        return ((current_percent - prev_percent) / (prev_percent or 1.0)) * 100
+        tenths_of_promils = ((current_percent - prev_percent) / (prev_percent or 1.0)) * 10000
+        return tenths_of_promils * 100 if int(tenths_of_promils) else 0
     else:
         return "Data in the previous reporting period was 0"
 


### PR DESCRIPTION
Hi @emord,
I have made fixes to UI.
First changes the returned difference to 0 if it is < 0.01%. As we show the difference with precision up to second place after the dot this can and it does produce a situation in which nominator and denominator have changed but the difference is <0.01% and is shown as growth/ decline of 0.00%.
Second change colours arrow for Aadhaar-Seeded Beneficiaries.