### PR TITLE
Revert "Nevermind adding requirejs_main to pages that can inherit it"

### DIFF
--- a/corehq/apps/accounting/templates/accounting/accounting_admins.html
+++ b/corehq/apps/accounting/templates/accounting/accounting_admins.html
@@ -3,6 +3,8 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
+{% requirejs_main "hqwebapp/js/crud_paginated_list_init" %}
+
 {% block pagination_header %}
     <h2>{% trans 'Manage Accounting Admins' %}</h2>
     <p class="lead">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
+{% requirejs_main "hqwebapp/js/crud_paginated_list_init" %}
+
 {% block pagination_templates %}
     <script type="text/html" id="existing-group-template">
         <td class="col-sm-6">

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
+{% requirejs_main "hqwebapp/js/crud_paginated_list_init" %}
+
 {% block pagination_header %}
     <h2>{% trans 'Manage Keywords' %}</h2>
     <p class="lead">

--- a/corehq/apps/sms/templates/sms/gateway_list.html
+++ b/corehq/apps/sms/templates/sms/gateway_list.html
@@ -3,6 +3,8 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
+{% requirejs_main "hqwebapp/js/crud_paginated_list_init" %}
+
 {% block pagination_footer %}
     <div>
         {% blocktrans %}

--- a/corehq/apps/sms/templates/sms/global_gateway_list.html
+++ b/corehq/apps/sms/templates/sms/global_gateway_list.html
@@ -3,6 +3,8 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
+{% requirejs_main "hqwebapp/js/crud_paginated_list_init" %}
+
 {% block pagination_footer %}
     <div>
         {% blocktrans %}


### PR DESCRIPTION
7df24bdb56bd4c559bb16b967c8d636e9d255f8b inadvertently turned RequireJS back off for these pages, which I didn't notice, since they still "worked". The pages then broke when https://github.com/dimagi/commcare-hq/pull/19376/ was released.

@gcapalbo / @millerdev 

Also reported in http://manage.dimagi.com/default.asp?270481