### PR TITLE
Add icons for form edit and settings pages

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -49,7 +49,7 @@
     {% if request.guided_tour %}{% include request.guided_tour.template %}{% endif %}
 {% endblock %}
 
-{% block title %}{{ form.name|clean_trans:langs }} - {% trans 'Edit Form' %}{% endblock %}
+{% block title %}✎ {{ form.name|clean_trans:langs }} - {% trans 'Edit Form' %}{% endblock %}
 
 {% block form-view %}
     {% initial_page_data 'CKEDITOR_BASEPATH' CKEDITOR_BASEPATH|static %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -4,7 +4,7 @@
 {% load compress %}
 {% load i18n %}
 
-{% block title %}{{ form.name|clean_trans:langs }} - {% trans 'Form Settings' %}{% endblock %}
+{% block title %}⚙ {{ form.name|clean_trans:langs }} - {% trans 'Form Settings' %}{% endblock %}
 
 {% block stylesheets %}{{ block.super }}
     <link rel="stylesheet" href="{% static 'syntaxhighlighter/styles/shCoreDefault.css' %}"/>


### PR DESCRIPTION
@biyeun @orangejenny 
Curious what you think of this change. When you have multiple CCHQ tabs open, it is hard to remember which one is which, which is pretty frustrating. Ideally, I think this would happen in the favicon (like github does it), but wanted to open this for conversation first.

![screenshot from 2018-02-16 15-08-46](https://user-images.githubusercontent.com/146896/36327076-62556326-132b-11e8-827f-a40845f265c1.png)


