### PR TITLE
Fix 'My Timezone' page

### DIFF
--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -26,7 +26,9 @@ class BootstrapCheckboxInput(CheckboxInput):
         self.inline_label = inline_label
 
     def render(self, name, value, attrs=None):
-        final_attrs = self.build_attrs(attrs, extra_attrs={'type': 'checkbox', 'name': name})
+        extra_attrs={'type': 'checkbox', 'name': name}
+        extra_attrs.update(self.attrs)
+        final_attrs = self.build_attrs(attrs, extra_attrs=extra_attrs)
         try:
             result = self.check_test(value)
         except: # Silently catch exceptions

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -26,7 +26,7 @@ class BootstrapCheckboxInput(CheckboxInput):
         self.inline_label = inline_label
 
     def render(self, name, value, attrs=None):
-        extra_attrs={'type': 'checkbox', 'name': name}
+        extra_attrs = {'type': 'checkbox', 'name': name}
         extra_attrs.update(self.attrs)
         final_attrs = self.build_attrs(attrs, extra_attrs=extra_attrs)
         try:


### PR DESCRIPTION
The Project Settings > My Timezone page doesn't have its javascript working. This appears to be caused by the django 1.11 upgrade and in particular https://github.com/dimagi/commcare-hq/commit/594d814b86650200da73a9c78ad1f7e07eee796f - the `data-bind` attributes for the override checkbox weren't being correctly passed through and added to the HTML.

@nickpell Any idea why exactly this broke?

code buddy @gcapalbo 