### PR TITLE
Pass correct arguments to analytics logger

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -82,6 +82,7 @@ hqDefine('analytix/js/google', [
      * @param {function} eventCallback - (optional) Event callback fn
      */
     var trackEvent = function (eventCategory, eventAction, eventLabel, eventValue, eventParameters, eventCallback) {
+        var originalArgs = arguments;
         _ready.done(function() {
             var params = {
                 event_category: eventCategory,
@@ -93,7 +94,7 @@ hqDefine('analytix/js/google', [
             if (_.isObject(eventParameters)) {
                 params = _.extend(params, eventParameters);
             }
-            _logger.debug.log(_logger.fmt.labelArgs(["Category", "Action", "Label", "Value", "Parameters", "Callback"], arguments), "Event Recorded");
+            _logger.debug.log(_logger.fmt.labelArgs(["Category", "Action", "Label", "Value", "Parameters", "Callback"], originalArgs), "Event Recorded");
             _gtag('event', eventAction, params);
         }).fail(function() {
             if (_.isFunction(eventCallback)) {
@@ -115,6 +116,7 @@ hqDefine('analytix/js/google', [
      * @param {object} eventParameters - (optional) Extra event parameters
      */
     var trackClick = function (element, eventCategory, eventAction, eventLabel, eventValue, eventParameters) {
+        var originalArgs = arguments;
         _ready.done(function() {
             utils.trackClickHelper(
                 element,
@@ -122,7 +124,7 @@ hqDefine('analytix/js/google', [
                     trackEvent(eventCategory, eventAction, eventLabel, eventValue, eventParameters, callbackFn);
                 }
             );
-            _logger.debug.log(_logger.fmt.labelArgs(["Element", "Category", "Action", "Label", "Value", "Parameters"], arguments), "Added Click Tracker");
+            _logger.debug.log(_logger.fmt.labelArgs(["Element", "Category", "Action", "Label", "Value", "Parameters"], originalArgs), "Added Click Tracker");
         });
     };
 

--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -45,8 +45,9 @@ hqDefine('analytix/js/hubspot', [
      * @param {integer|float} value - This is an optional argument that can be used to track the revenue of an event.
      */
     var trackEvent = function (eventId, value) {
+        var originalArgs = arguments;
         _ready.done(function() {
-            _logger.debug.log(_logger.fmt.labelArgs(["Event ID", "Value"], arguments), 'Track Event');
+            _logger.debug.log(_logger.fmt.labelArgs(["Event ID", "Value"], originalArgs), 'Track Event');
             _hsq.push(['trackEvent', {
                 id: eventId,
                 value: value,

--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -87,8 +87,9 @@ hqDefine('analytix/js/kissmetrix', [
      * @param {string} identity - A unique ID to identify the session. Typically the user's email address.
      */
     var identify = function (identity) {
+        var originalArgs = arguments;
         _ready.done(function() {
-            _logger.debug.log(arguments, 'Identify');
+            _logger.debug.log(originalArgs, 'Identify');
             _kmqPushCommand('identify', identity);
         });
     };
@@ -100,8 +101,9 @@ hqDefine('analytix/js/kissmetrix', [
      * @param {integer} timeout - (optional) timeout in milliseconds
      */
     var identifyTraits = function (traits, callbackFn, timeout) {
+        var originalArgs = arguments;
         _ready.done(function() {
-            _logger.debug.log(_logger.fmt.labelArgs(["Traits", "Callback Function", "Timeout"], arguments), 'Identify Traits (Set)');
+            _logger.debug.log(_logger.fmt.labelArgs(["Traits", "Callback Function", "Timeout"], originalArgs), 'Identify Traits (Set)');
             callbackFn = utils.createSafeCallback(callbackFn, timeout);
             _kmqPushCommand('set', traits, callbackFn);
         }).fail(function() {
@@ -119,8 +121,9 @@ hqDefine('analytix/js/kissmetrix', [
      * @param {integer} timeout - (optional) Timeout for safe callback
      */
     var trackEvent = function (name, properties, callbackFn, timeout) {
+        var originalArgs = arguments;
         _ready.done(function() {
-            _logger.debug.log(arguments, 'RECORD EVENT');
+            _logger.debug.log(originalArgs, 'RECORD EVENT');
             callbackFn = utils.createSafeCallback(callbackFn, timeout);
             _kmqPushCommand('record', properties, callbackFn, name);
         }).fail(function() {
@@ -137,8 +140,9 @@ hqDefine('analytix/js/kissmetrix', [
      * @param {object} properties - optional Properties related to the event being recorded.
      */
     var internalClick = function (selector, name, properties) {
+        var originalArgs = arguments;
         _ready.done(function() {
-            _logger.debug.log(_logger.fmt.labelArgs(["Selector", "Name", "Properties"], arguments), 'Track Internal Click');
+            _logger.debug.log(_logger.fmt.labelArgs(["Selector", "Name", "Properties"], originalArgs), 'Track Internal Click');
             _kmqPushCommand('trackClick', properties, undefined, name);
         });
     };
@@ -150,8 +154,9 @@ hqDefine('analytix/js/kissmetrix', [
      * @param {object} properties - optional Properties related to the event being recorded.
      */
     var trackOutboundLink = function (selector, name, properties) {
+        var originalArgs = arguments;
         _ready.done(function() {
-            _logger.debug.log(_logger.fmt.labelArgs(["Selector", "Name", "Properties"], arguments), 'Track Click on Outbound Link');
+            _logger.debug.log(_logger.fmt.labelArgs(["Selector", "Name", "Properties"], originalArgs), 'Track Click on Outbound Link');
             _kmqPushCommand('trackClickOnOutboundLink', properties, undefined, name);
         });
     };


### PR DESCRIPTION
Introduced in https://github.com/dimagi/commcare-hq/pull/18834 - moving logger calls inside callbacks killed the value of `arguments`.

@gcapalbo / @biyeun 