### PR TITLE
[ICDS] fix problem with the same slug column in one datasource

### DIFF
--- a/custom/icds_reports/sqldata.py
+++ b/custom/icds_reports/sqldata.py
@@ -354,9 +354,13 @@ class AggChildHealthMonthlyDataSource(ProgressReportSqlData):
                 '% Height measurement efficiency (Children <5 measured)',
                 percent_num,
                 [
-                    SumColumn('height_measured_in_month', filters=self.filters + [
-                        NOT(EQ('age_tranche', 'age_72'))
-                    ]),
+                    SumColumn(
+                        'height_measured_in_month',
+                        alias='height_measured_in_month_less_5',
+                        filters=self.filters + [
+                            NOT(EQ('age_tranche', 'age_72'))
+                        ]
+                    ),
                     SumColumn('height_eligible', alias='height_eligible', filters=self.filters + [
                         AND([
                             NOT(EQ('age_tranche', 'age_0')),
@@ -1050,7 +1054,7 @@ class ChildrenExport(ExportableMixin, SqlData):
                 'Height measurement efficiency (in month)',
                 percent,
                 [
-                    SumColumn('height_measured_in_month'),
+                    SumColumn('height_measured_in_month', alias='height_measured_in_month_all'),
                     SumColumn('height_eligible', filters=self.filters + [
                         AND([
                             NOT(EQ('age_tranche', 'age_0')),


### PR DESCRIPTION
Hi @emord 

I think I found problem described in this case: https://manage.dimagi.com/default.asp?270470#1460490
I wrote 'I think' because I tested this many times and I always get correct values.

Problem occurred because we had the same `slug` for 2 columns in one data source, and when we tried mapping data source result to dict we had the situation where one record override second.

Please let me know if you have any questions.

Regards,
Łukasz