### PR TITLE
show Report an Issue on 500 page selectively

### DIFF
--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -44,6 +44,7 @@
                     </fieldset>
                 </form>
             </div>
+            {% if allow_report_an_issue %}
             <form class="form form-horizontal" action="{% url "bug_report" %}" method="post">
                 {% csrf_token %}
                 <input type="hidden" id="bug-report-500-url" name="url" value="{{ request.build_absolute_uri }}"/>
@@ -86,6 +87,7 @@
                     </div>
                 </div>
             </form>
+            {% endif %}
             <br />
         </div>
     </div>


### PR DESCRIPTION
using same logic as used in Report an Issue item in dropdown menu

Fixes https://manage.dimagi.com/default.asp?270840 @kishansampat

We were originally leaning toward the following because it's more explicit

<img width="1196" alt="screen shot 2018-02-21 at 5 07 01 pm" src="https://user-images.githubusercontent.com/137212/36478402-8ed355fe-172a-11e8-8454-729072d94f4a.png">

but ended up going with

<img width="1196" alt="screen shot 2018-02-21 at 5 07 21 pm" src="https://user-images.githubusercontent.com/137212/36478413-9aa4d0e2-172a-11e8-8dba-c54749e70bcd.png">

because it's a bit cleaner.

(Ignore weird highlighting in the diff; that's just the JS syntax highlighter going awry because of a single quote inside a translation above.)