### PR TITLE
 Allow overriding daily auto case update rule limits by domain

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -1435,11 +1435,11 @@ class CaseRuleEndToEndTests(BaseCaseRuleTest):
 
     def setUpClass(cls):
         super(CaseRuleEndToEndTests, cls).setUpClass()
-        self.domain_object = Domain(name=self.domain)
-        self.domain_object.save()
+        cls.domain_object = Domain(name=cls.domain)
+        cls.domain_object.save()
 
     def tearDownClass(cls):
-        self.domain_object.delete()
+        cls.domain_object.delete()
         super(CaseRuleEndToEndTests, cls).tearDownClass()
 
     def test_get_rules_from_domain(self):

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -1433,11 +1433,13 @@ class CaseRuleOnSaveTests(BaseCaseRuleTest):
 
 class CaseRuleEndToEndTests(BaseCaseRuleTest):
 
+    @classmethod
     def setUpClass(cls):
         super(CaseRuleEndToEndTests, cls).setUpClass()
         cls.domain_object = Domain(name=cls.domain)
         cls.domain_object.save()
 
+    @classmethod
     def tearDownClass(cls):
         cls.domain_object.delete()
         super(CaseRuleEndToEndTests, cls).tearDownClass()

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -21,6 +21,7 @@ from corehq.apps.data_interfaces.models import (
     CaseRuleUndoer,
 )
 from corehq.apps.data_interfaces.tasks import run_case_update_rules_for_domain
+from corehq.apps.domain.models import Domain
 from datetime import datetime, date
 
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
@@ -45,6 +46,8 @@ class AutomaticCaseUpdateTest(TestCase):
     def setUp(self):
         super(AutomaticCaseUpdateTest, self).setUp()
         self.domain = 'auto-update-test'
+        self.domain_object = Domain(name=self.domain)
+        self.domain_object.save()
         update_toggle_cache(AUTO_CASE_UPDATE_ENHANCEMENTS.slug, self.domain, True, NAMESPACE_DOMAIN)
         update_toggle_cache(RUN_AUTO_CASE_UPDATES_ON_SAVE.slug, self.domain, True, NAMESPACE_DOMAIN)
         self.case_db = CaseAccessors(self.domain)
@@ -167,6 +170,7 @@ class AutomaticCaseUpdateTest(TestCase):
         UpdateCaseDefinition.objects.all().delete()
         AutomaticUpdateRule.objects.all().delete()
         FormProcessorTestUtils.delete_all_cases(self.domain)
+        self.domain_object.delete()
         super(AutomaticCaseUpdateTest, self).tearDown()
 
     def _get_case(self):
@@ -1428,6 +1432,15 @@ class CaseRuleOnSaveTests(BaseCaseRuleTest):
 
 
 class CaseRuleEndToEndTests(BaseCaseRuleTest):
+
+    def setUpClass(cls):
+        super(CaseRuleEndToEndTests, cls).setUpClass()
+        self.domain_object = Domain(name=self.domain)
+        self.domain_object.save()
+
+    def tearDownClass(cls):
+        self.domain_object.delete()
+        super(CaseRuleEndToEndTests, cls).tearDownClass()
 
     def test_get_rules_from_domain(self):
         rule1 = _create_empty_rule(self.domain, case_type='person-1')

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1049,6 +1049,19 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
             "Check this box to trigger a hand-off email to the partner when this form is submitted."
         ),
     )
+    use_custom_auto_case_update_limit = forms.ChoiceField(
+        label=ugettext_lazy("Set custom auto case update rule limits"),
+        required=True,
+        choices=(
+            ('N', ugettext_lazy("No")),
+            ('Y', ugettext_lazy("Yes")),
+        ),
+    )
+    auto_case_update_limit = forms.IntegerField(
+        label=ugettext_lazy("Max allowed updates in a daily run"),
+        required=False,
+        min_value=1000,
+    )
 
     def __init__(self, domain, can_edit_eula, *args, **kwargs):
         super(DomainInternalForm, self).__init__(*args, **kwargs)
@@ -1110,6 +1123,17 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
                 'dimagi_contact',
             ),
             crispy.Fieldset(
+                _("Project Limits"),
+                crispy.Field(
+                    'use_custom_auto_case_update_limit',
+                    data_bind='value: use_custom_auto_case_update_limit',
+                ),
+                crispy.Div(
+                    crispy.Field('auto_case_update_limit'),
+                    data_bind="visible: use_custom_auto_case_update_limit() === 'Y'",
+                ),
+            ),
+            crispy.Fieldset(
                 _("Salesforce Details"),
                 'sf_contract_id',
                 'sf_account_id',
@@ -1123,6 +1147,12 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
             ),
         )
 
+    @property
+    def current_values(self):
+        return {
+            'use_custom_auto_case_update_limit': self['use_custom_auto_case_update_limit'].value(),
+        }
+
     def _get_user_or_fail(self, field):
         username = self.cleaned_data[field]
         if not username:
@@ -1135,6 +1165,16 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
             msg = "'{username}' is not the username of a web user in '{domain}'"
             self.add_error(field, msg.format(username=username, domain=self.domain))
         return user
+
+    def clean_auto_case_update_limit(self):
+        if self.cleaned_data.get('use_custom_auto_case_update_limit') != 'Y':
+            return None
+
+        value = self.cleaned_data.get('auto_case_update_limit')
+        if not value:
+            raise forms.ValidationError(_("This field is required"))
+
+        return value
 
     def clean(self):
         send_handoff_email = self.cleaned_data['send_handoff_email']
@@ -1166,6 +1206,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
             countries=self.cleaned_data['countries'],
         )
         domain.is_test = self.cleaned_data['is_test']
+        domain.auto_case_update_limit = self.cleaned_data['auto_case_update_limit']
         domain.update_internal(
             sf_contract_id=self.cleaned_data['sf_contract_id'],
             sf_account_id=self.cleaned_data['sf_account_id'],

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -327,6 +327,10 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
     # Allowed outbound SMS per day
     daily_outbound_sms_limit = IntegerProperty(default=5000)
 
+    # Allowed number of case updates or closes from automatic update rules in the daily rule run.
+    # If this value is None, the value in settings.MAX_RULE_UPDATES_IN_ONE_RUN is used.
+    auto_case_update_limit = IntegerProperty()
+
     # exchange/domain copying stuff
     is_snapshot = BooleanProperty(default=False)
     is_approved = BooleanProperty(default=False)

--- a/corehq/apps/domain/static/domain/js/internal_settings.js
+++ b/corehq/apps/domain/static/domain/js/internal_settings.js
@@ -2,6 +2,11 @@
 hqDefine("domain/js/internal_settings", function() {
     var areas = hqImport('hqwebapp/js/initial_page_data').get('areas');
 
+    var InternalSettingsViewModel = function(initial_values) {
+        var self = this;
+        self.use_custom_auto_case_update_limit = ko.observable(initial_values.use_custom_auto_case_update_limit);
+    };
+
     function update_subareas() {
         var $subarea = $subarea || $('[name="sub_area"]');
         var chosen_sub_area = $subarea.val();
@@ -40,6 +45,10 @@ hqDefine("domain/js/internal_settings", function() {
             update_workshop_region();
         });
 
+        var internalSettingsViewModel = new InternalSettingsViewModel(
+            hqImport("hqwebapp/js/initial_page_data").get("current_values")
+        );
+        $('#update-project-info').koApplyBindings(internalSettingsViewModel);
     });
 
     $(function() {

--- a/corehq/apps/domain/templates/domain/internal_settings.html
+++ b/corehq/apps/domain/templates/domain/internal_settings.html
@@ -16,6 +16,7 @@
 
 {% block page_content %}
     {% initial_page_data 'areas' areas %}
+    {% initial_page_data 'current_values' form.current_values %}
     <form id="update-project-info" class="form-horizontal disable-on-submit" method="post">
         {% crispy form %}
     </form>

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2242,6 +2242,8 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
         initial = {
             'countries': self.domain_object.deployment.countries,
             'is_test': self.domain_object.is_test,
+            'use_custom_auto_case_update_limit': 'Y' if self.domain_object.auto_case_update_limit else 'N',
+            'auto_case_update_limit': self.domain_object.auto_case_update_limit,
         }
         internal_attrs = [
             'sf_contract_id',


### PR DESCRIPTION
Lets the limit for case updates be specified on a per-domain basis.  If no limit is specified, the default in settings is used.

@orangejenny 