### PR TITLE
Loosen validation for custom user data properties

### DIFF
--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -59,7 +59,7 @@ class XmlSlugField(forms.SlugField):
     default_validators = [
         validate_slug,
         validate_reserved_words,
-        RegexValidator(r'^[a-zA-Z]', ''),
+        RegexValidator(r'\D', ''),
     ]
 
 

--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -59,7 +59,7 @@ class XmlSlugField(forms.SlugField):
     default_validators = [
         validate_slug,
         validate_reserved_words,
-        RegexValidator(r'\D', ''),
+        RegexValidator(r'\D', ''),  # disallow property names that are just numbers, which breaks
     ]
 
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?270666

https://github.com/dimagi/commcare-hq/pull/18728/files#r154690363 ...famous last words.

Should go into today's deploy so this user gets unblocked.

@dannyroberts what do you think? I updated the validation to only check for the case that genuinely breaks (property names that are all numbers). Left the message saying 'Properties must start with a letter and consist only of letters, numbers, underscores or hyphens.' even though that's not what's being validated, because I still worry that we'll introduce code at some point that breaks if these user-entered property names aren't valid xml identifiers.

code buddy @gcapalbo 