### PR TITLE
Change "View Report" button text to "Save and View Report"

### DIFF
--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -46,7 +46,7 @@
       {% endif %}
       {% if has_report_builder_access %}
         {% if not at_report_limit or existing_report %}
-          <button id="btnSaveView" class="btn btn-info">{% trans 'View Report' %}</button>
+          <button id="btnSaveView" class="btn btn-info">{% trans 'Save and View Report' %}</button>
         {% endif %}
       {% endif %}
       &nbsp;<span id="saveButtonHolder"></span>


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?270644
Some users have found the “View Report” button confusing because it isn’t clear that the Report Builder will save the report before letting the user view it.

I’ve changed the text on this button back to “Save and View Report” to minimize confusion.