### PR TITLE
python-modernize custom/ewsghana/ -w --future-unicode

### DIFF
--- a/custom/ewsghana/__init__.py
+++ b/custom/ewsghana/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 LOCATION_TYPES = ["country", "region", "district", "facility"]
 
 CUSTOM_DASHBOARD_VIEW_NAME = 'dashboard_page'

--- a/custom/ewsghana/alerts/__init__.py
+++ b/custom/ewsghana/alerts/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.utils.translation import ugettext as _
 
 ONGOING_NON_REPORTING = _('SMS report MISSING from these facilities over the past 3 weeks! Please follow up:\n%s')

--- a/custom/ewsghana/alerts/alert.py
+++ b/custom/ewsghana/alerts/alert.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime
 from corehq.apps.locations.dbaccessors import get_web_users_by_location
 from corehq.apps.reminders.util import get_preferred_phone_number_for_recipient

--- a/custom/ewsghana/alerts/alerts.py
+++ b/custom/ewsghana/alerts/alerts.py
@@ -1,5 +1,6 @@
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.products.models import SQLProduct
 from custom.ewsghana.alerts import COMPLETE_REPORT, \
     STOCKOUTS_MESSAGE, LOW_SUPPLY_MESSAGE, OVERSTOCKED_MESSAGE, RECEIPT_MESSAGE
@@ -40,7 +41,7 @@ class SOHAlerts(object):
 
         if stockouts or products_below:
             reorders = [
-                u'%s %s' % (code, amount)
+                '%s %s' % (code, amount)
                 for (code, amount) in report_helper.reorders()
                 if amount
             ]

--- a/custom/ewsghana/alerts/ongoing_non_reporting.py
+++ b/custom/ewsghana/alerts/ongoing_non_reporting.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import defaultdict
 from datetime import datetime, timedelta
 from django.db.models.aggregates import Max

--- a/custom/ewsghana/alerts/ongoing_stockouts.py
+++ b/custom/ewsghana/alerts/ongoing_stockouts.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime, timedelta
 from django.db.models.aggregates import Max
 from casexml.apps.stock.models import StockTransaction

--- a/custom/ewsghana/alerts/urgent_alerts.py
+++ b/custom/ewsghana/alerts/urgent_alerts.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 from collections import defaultdict
 from datetime import datetime, timedelta
 from corehq.apps.commtrack.models import StockState

--- a/custom/ewsghana/filters.py
+++ b/custom/ewsghana/filters.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import calendar
 from datetime import datetime
 from dateutil.relativedelta import relativedelta

--- a/custom/ewsghana/forms.py
+++ b/custom/ewsghana/forms.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.urls import reverse
 from corehq.apps.reminders.forms import BroadcastForm
 from corehq.apps.reminders.models import (RECIPIENT_USER_GROUP, RECIPIENT_LOCATION)

--- a/custom/ewsghana/handler.py
+++ b/custom/ewsghana/handler.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 from corehq.apps.sms.api import send_sms_to_verified_number
 from corehq.apps.sms.models import MessagingEvent

--- a/custom/ewsghana/handlers/__init__.py
+++ b/custom/ewsghana/handlers/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.utils.translation import ugettext_lazy as _
 
 INVALID_MESSAGE = _('Sorry, I could not understand your message.'

--- a/custom/ewsghana/handlers/help.py
+++ b/custom/ewsghana/handlers/help.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.products.models import SQLProduct
 from custom.ewsghana.handlers import HELP_TEXT, DEACTIVATE_REMINDERS, REACTIVATE_REMINDERS
 from custom.ewsghana.handlers.keyword import KeywordHandler

--- a/custom/ewsghana/handlers/helpers/formatter.py
+++ b/custom/ewsghana/handlers/helpers/formatter.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 from collections import OrderedDict
 

--- a/custom/ewsghana/handlers/helpers/stock_and_receipt_parser.py
+++ b/custom/ewsghana/handlers/helpers/stock_and_receipt_parser.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 from decimal import Decimal
 

--- a/custom/ewsghana/handlers/keyword.py
+++ b/custom/ewsghana/handlers/keyword.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.sms.api import send_sms_to_verified_number

--- a/custom/ewsghana/handlers/receipts.py
+++ b/custom/ewsghana/handlers/receipts.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.conf import settings
 
 from corehq.apps.domain.models import Domain

--- a/custom/ewsghana/handlers/reminder.py
+++ b/custom/ewsghana/handlers/reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from custom.ewsghana.handlers import DEACTIVATE_REMINDERS, REACTIVATE_REMINDERS, START_MESSAGE, STOP_MESSAGE
 from custom.ewsghana.handlers.keyword import KeywordHandler
 from custom.ewsghana.utils import user_needs_reminders

--- a/custom/ewsghana/handlers/requisition.py
+++ b/custom/ewsghana/handlers/requisition.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.locations.models import SQLLocation
 from custom.ewsghana.handlers.keyword import KeywordHandler
 from custom.ewsghana.reminders import NO_SUPPLY_POINT_MESSAGE, REQ_SUBMITTED, \

--- a/custom/ewsghana/handlers/soh.py
+++ b/custom/ewsghana/handlers/soh.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import defaultdict
 
 from django.conf import settings

--- a/custom/ewsghana/handlers/undo.py
+++ b/custom/ewsghana/handlers/undo.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import defaultdict
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from casexml.apps.stock.models import StockReport

--- a/custom/ewsghana/handlers/web_submission_handler.py
+++ b/custom/ewsghana/handlers/web_submission_handler.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import namedtuple
 
 from corehq.apps.reminders.util import get_preferred_phone_number_for_recipient

--- a/custom/ewsghana/models.py
+++ b/custom/ewsghana/models.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.dispatch import receiver
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.signals import commcare_domain_pre_delete

--- a/custom/ewsghana/reminders/__init__.py
+++ b/custom/ewsghana/reminders/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.utils.translation import ugettext_lazy as _
 
 REGISTER_HELP = _("Sorry, I didn't understand. To register, send register <name> <facility code>. "

--- a/custom/ewsghana/reminders/const.py
+++ b/custom/ewsghana/reminders/const.py
@@ -1,2 +1,3 @@
+from __future__ import unicode_literals
 IN_CHARGE_ROLE = 'In Charge'
 DAYS_UNTIL_LATE = 5

--- a/custom/ewsghana/reminders/first_soh_reminder.py
+++ b/custom/ewsghana/reminders/first_soh_reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from custom.ewsghana.reminders import STOCK_ON_HAND_REMINDER
 from custom.ewsghana.reminders.const import IN_CHARGE_ROLE
 from custom.ewsghana.reminders.reminder import Reminder

--- a/custom/ewsghana/reminders/rrirv_reminder.py
+++ b/custom/ewsghana/reminders/rrirv_reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from custom.ewsghana.reminders import RRIRV_REMINDER
 from custom.ewsghana.reminders.const import IN_CHARGE_ROLE
 from custom.ewsghana.reminders.reminder import Reminder

--- a/custom/ewsghana/reminders/second_soh_reminder.py
+++ b/custom/ewsghana/reminders/second_soh_reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.reminders.util import get_two_way_number_for_recipient
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from custom.ewsghana.reminders import SECOND_STOCK_ON_HAND_REMINDER, SECOND_INCOMPLETE_SOH_REMINDER

--- a/custom/ewsghana/reminders/stockout_reminder.py
+++ b/custom/ewsghana/reminders/stockout_reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import WebUser

--- a/custom/ewsghana/reminders/third_soh_reminder.py
+++ b/custom/ewsghana/reminders/third_soh_reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.locations.dbaccessors import get_web_users_by_location
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reminders.util import get_preferred_phone_number_for_recipient

--- a/custom/ewsghana/reminders/visit_website_reminder.py
+++ b/custom/ewsghana/reminders/visit_website_reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import datetime
 from corehq.apps.users.models import WebUser
 from custom.ewsghana.reminders import WEB_REMINDER

--- a/custom/ewsghana/reports/__init__.py
+++ b/custom/ewsghana/reports/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 from datetime import datetime
 from django.urls import reverse
 from django.db.models import Q

--- a/custom/ewsghana/reports/email_reports.py
+++ b/custom/ewsghana/reports/email_reports.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 from collections import defaultdict
 
 from casexml.apps.stock.models import StockTransaction

--- a/custom/ewsghana/reports/maps.py
+++ b/custom/ewsghana/reports/maps.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_noop
 from corehq.apps.commtrack.models import StockState, CommtrackConfig

--- a/custom/ewsghana/reports/specific_reports/dashboard_report.py
+++ b/custom/ewsghana/reports/specific_reports/dashboard_report.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import defaultdict
 from django.http import HttpResponse
 from corehq.apps.locations.models import SQLLocation

--- a/custom/ewsghana/reports/specific_reports/reporting_rates.py
+++ b/custom/ewsghana/reports/specific_reports/reporting_rates.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 from datetime import datetime, timedelta
 
 from django.db.models import Q

--- a/custom/ewsghana/reports/specific_reports/stock_status_report.py
+++ b/custom/ewsghana/reports/specific_reports/stock_status_report.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 from collections import defaultdict
 from datetime import timedelta
 from django.db.models.aggregates import Count
@@ -156,7 +157,7 @@ class MonthOfStockProduct(EWSData):
             if not self.config['export']:
                 headers.add_column(DataTablesColumn(product.code))
             else:
-                headers.add_column(DataTablesColumn(u'{} ({})'.format(product.name, product.code)))
+                headers.add_column(DataTablesColumn('{} ({})'.format(product.name, product.code)))
         return headers
 
     @property

--- a/custom/ewsghana/reports/stock_levels_report.py
+++ b/custom/ewsghana/reports/stock_levels_report.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 import collections
 from collections import OrderedDict
 from datetime import timedelta
@@ -271,12 +272,12 @@ class InputStock(EWSData):
         if has_input_stock_permissions(self.config['user'],
                                        SQLLocation.objects.get(location_id=self.config['location_id']),
                                        self.domain):
-            rows.append([u"<a href='{}'>INPUT STOCK for {}</a>".format(link, self.location.name)])
+            rows.append(["<a href='{}'>INPUT STOCK for {}</a>".format(link, self.location.name)])
 
         try:
             rows.append(
                 [
-                    u'The last report received was at <b>{}.</b>'.format(
+                    'The last report received was at <b>{}.</b>'.format(
                         StockState.objects.filter(case_id=self.location.supply_point_id)
                         .values('last_modified_date')
                         .latest('last_modified_date')['last_modified_date']

--- a/custom/ewsghana/reports/stock_transaction.py
+++ b/custom/ewsghana/reports/stock_transaction.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import OrderedDict
 from casexml.apps.stock.models import StockTransaction
 from corehq.apps.locations.models import SQLLocation

--- a/custom/ewsghana/resources/v0_1.py
+++ b/custom/ewsghana/resources/v0_1.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 
 from corehq.apps.api.resources.auth import LoginAndDomainAuthentication

--- a/custom/ewsghana/tasks.py
+++ b/custom/ewsghana/tasks.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from celery.schedules import crontab
 from celery.task import task, periodic_task
 from custom.ewsghana.alerts.ongoing_non_reporting import OnGoingNonReporting

--- a/custom/ewsghana/tests/ews_test_reminders.py
+++ b/custom/ewsghana/tests/ews_test_reminders.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.products.models import Product, SQLProduct
 from corehq.apps.sms.tests.util import setup_default_sms_test_backend
 from custom.ewsghana.tests.handlers.utils import EWSTestCase

--- a/custom/ewsghana/tests/handlers/default.py
+++ b/custom/ewsghana/tests/handlers/default.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from custom.ewsghana.handlers import INVALID_MESSAGE, NO_SUPPLY_POINT_MESSAGE
 from custom.ewsghana.tests.handlers.utils import EWSScriptTest
 import six

--- a/custom/ewsghana/tests/handlers/formatter.py
+++ b/custom/ewsghana/tests/handlers/formatter.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.test.testcases import SimpleTestCase
 
 from custom.ewsghana.handlers.helpers.formatter import EWSFormatter

--- a/custom/ewsghana/tests/handlers/handler.py
+++ b/custom/ewsghana/tests/handlers/handler.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.commtrack.tests.util import bootstrap_domain, make_loc
 from corehq.apps.domain.models import Domain
 from corehq.apps.sms.api import incoming

--- a/custom/ewsghana/tests/handlers/receipt.py
+++ b/custom/ewsghana/tests/handlers/receipt.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from custom.ewsghana.tests.handlers.utils import EWSScriptTest
 
 

--- a/custom/ewsghana/tests/handlers/reminder.py
+++ b/custom/ewsghana/tests/handlers/reminder.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from corehq.apps.users.models import CommCareUser
 from custom.ewsghana.handlers import (STOP_MESSAGE, START_MESSAGE,
     DEACTIVATE_REMINDERS, REACTIVATE_REMINDERS)

--- a/custom/ewsghana/tests/handlers/requisition_status.py
+++ b/custom/ewsghana/tests/handlers/requisition_status.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from custom.ewsghana.reminders import REQ_SUBMITTED
 from custom.ewsghana.tests.handlers.utils import EWSScriptTest
 import six

--- a/custom/ewsghana/tests/handlers/stock_on_hand.py
+++ b/custom/ewsghana/tests/handlers/stock_on_hand.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from casexml.apps.stock.models import StockTransaction
 from corehq.toggles import EWS_INVALID_REPORT_RESPONSE, NAMESPACE_DOMAIN
 from custom.ewsghana.handlers import INVALID_MESSAGE, MS_STOCKOUT

--- a/custom/ewsghana/tests/handlers/undo.py
+++ b/custom/ewsghana/tests/handlers/undo.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from casexml.apps.stock.models import StockTransaction, StockReport
 from corehq.apps.commtrack.models import StockState
 from corehq.form_processor.tests.utils import FormProcessorTestUtils

--- a/custom/ewsghana/tests/handlers/utils.py
+++ b/custom/ewsghana/tests/handlers/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import datetime
 
 from django.test.testcases import TestCase

--- a/custom/ewsghana/tests/test_alerts.py
+++ b/custom/ewsghana/tests/test_alerts.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime
 
 from casexml.apps.stock.models import StockReport

--- a/custom/ewsghana/tests/test_delete_domain.py
+++ b/custom/ewsghana/tests/test_delete_domain.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.test import TestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import LocationType, make_location

--- a/custom/ewsghana/tests/test_input_stock_view.py
+++ b/custom/ewsghana/tests/test_input_stock_view.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from decimal import Decimal
 from django.urls import reverse
 from django.test import TestCase

--- a/custom/ewsghana/tests/test_notifications.py
+++ b/custom/ewsghana/tests/test_notifications.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime, timedelta
 import mock
 

--- a/custom/ewsghana/tests/test_reminders.py
+++ b/custom/ewsghana/tests/test_reminders.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime, timedelta
 from decimal import Decimal
 

--- a/custom/ewsghana/tests/test_urgent_alerts.py
+++ b/custom/ewsghana/tests/test_urgent_alerts.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime
 
 from casexml.apps.stock.models import StockReport

--- a/custom/ewsghana/tests/test_utils.py
+++ b/custom/ewsghana/tests/test_utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from nose.tools import nottest
 
 from corehq.apps.commtrack.models import CommtrackConfig

--- a/custom/ewsghana/urls.py
+++ b/custom/ewsghana/urls.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.conf.urls import url, include
 from corehq.apps.api.urls import CommCareHqApi
 from custom.ewsghana.resources.v0_1 import EWSLocationResource

--- a/custom/ewsghana/utils.py
+++ b/custom/ewsghana/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import namedtuple
 from datetime import timedelta, datetime
 from decimal import Decimal

--- a/custom/ewsghana/views.py
+++ b/custom/ewsghana/views.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied


### PR DESCRIPTION
Only changes in PRs with the ```--future-unicode``` fixer should be additions of ```from __future__ import unicode_literals``` and removing ```u``` prefixes on unicode string literals.  (Plus any changes for stickler).  This doesn't fix all py3 unicode compatibility issues, but will reduce the number of things that change when switching to py3.

My plan is to apply this fixer to a small number of django apps per day.