### PR TITLE
override built-in zip

### DIFF
--- a/corehq/apps/locations/tests/test_export.py
+++ b/corehq/apps/locations/tests/test_export.py
@@ -6,6 +6,7 @@ from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition, Cu
 from ..util import LocationExporter
 from ..views import LocationFieldsView
 from .util import LocationHierarchyTestCase
+from six.moves import zip
 
 
 class MockExportWriter(object):


### PR DESCRIPTION
Looks like this is not caught by py3k: https://github.com/dimagi/commcare-hq/pull/19428