### PR TITLE
upgrade to py3 compatible ethiopian-date-converter

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -96,7 +96,7 @@ dnspython==1.15.0
 raven==6.1.0
 quickcache==0.1.0
 zeep==1.6.0
-git+git://github.com/dimagi/ethiopian-date-converter@v0.1.2#egg=ethiopian-date-converter
+git+git://github.com/dimagi/ethiopian-date-converter@v0.1.3
 git+git://github.com/dimagi/architect@v0.5.7a2#egg=architect
 contextlib2==0.5.4
 hiredis==0.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -96,7 +96,7 @@ dnspython==1.15.0
 raven==6.1.0
 quickcache==0.1.0
 zeep==1.6.0
-git+git://github.com/dimagi/ethiopian-date-converter@v0.1.3
+ethiopian-date-converter==0.1.3
 git+git://github.com/dimagi/architect@v0.5.7a2#egg=architect
 contextlib2==0.5.4
 hiredis==0.2.0


### PR DESCRIPTION
I had to remove the ```#egg=ethiopian-date-converter``` to get ```pip install``` to work for me locally.  @pr33thi is there any particular reason it's needed?