### PR TITLE
fix lazy migration with non-case property name

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2090,8 +2090,7 @@ class DetailColumn(IndexedSchema):
 
         # Lazy migration: xpath expressions from format to first-class property
         if data.get('format') == 'calculate':
-            property_xpath = PropertyXpathGenerator(None, None, None, super(DetailColumn, cls).wrap(data)).xpath
-            data['field'] = dot_interpolate(data.get('calc_xpath', '.'), property_xpath)
+            data['field'] = dot_interpolate(data.get('calc_xpath', '.'), data['field'])
             data['useXpathExpression'] = True
             data['hasAutocomplete'] = False
             data['format'] = 'plain'

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2090,7 +2090,13 @@ class DetailColumn(IndexedSchema):
 
         # Lazy migration: xpath expressions from format to first-class property
         if data.get('format') == 'calculate':
-            data['field'] = dot_interpolate(data.get('calc_xpath', '.'), data['field'])
+            if data.get('model') == 'case':
+                property_xpath = PropertyXpathGenerator(
+                    None, None, None, super(DetailColumn, cls).wrap(data)
+                ).xpath
+                data['field'] = dot_interpolate(data.get('calc_xpath', '.'), property_xpath)
+            else:
+                data['field'] = dot_interpolate(data.get('calc_xpath', '.'), data['field'])
             data['useXpathExpression'] = True
             data['hasAutocomplete'] = False
             data['format'] = 'plain'


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?269071

Previous behavior: When the property is "name", replace with "case_name" when doing dot interpolation.

New behavior: Use "name" instead of "case_name" when doing dot interpolation for non-case models. 
 Continue using "case_name" for cases.  This way calculated properties still work with locations etc.