### PR TITLE
Don't wrap buttons on mobile workers page

### DIFF
--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -35,7 +35,7 @@
     <div ng-app="mobileWorkerApp">
         <div ng-controller="MobileWorkerCreationController">
             <div class="row">
-                <div class="col-sm-8">
+                <div class="col-sm-12">
                     <p class="lead">
                         {% blocktrans %}
                             Mobile Workers can log into applications in this project space


### PR DESCRIPTION
before
<img width="690" alt="screen shot 2018-02-22 at 11 29 59 am" src="https://user-images.githubusercontent.com/1486591/36550660-ca52f8b6-17c3-11e8-9317-2467d5228a91.png">

after
<img width="840" alt="screen shot 2018-02-22 at 11 30 15 am" src="https://user-images.githubusercontent.com/1486591/36550666-cd95b0f4-17c3-11e8-89a6-510b67947bd2.png">

@gcapalbo 