### PR TITLE
THR UCR Form partitioning

### DIFF
--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -1,0 +1,136 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "icds-sql",
+    "icds-test",
+    "icds-cas",
+    "icds-cas-sandbox"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new"
+  ],
+  "config": {
+    "table_id": "static-thr_forms_v2",
+    "display_name": "Forms - Take Home Ration (Partitioned by day) (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "description": "",
+    "base_item_expression": {},
+    "configured_filter": {
+      "operator": "eq",
+      "expression": {
+        "datatype": null,
+        "type": "property_name",
+        "property_name": "xmlns"
+      },
+      "type": "boolean_expression",
+      "property_value": "http://openrosa.org/formdesigner/F1B73934-8B70-4CEE-B462-3E4C81F80E4A"
+    },
+    "configured_indicators": [
+      {
+        "display_name": "AWC ID",
+        "datatype": "string",
+        "type": "expression",
+        "transform": {},
+        "is_nullable": true,
+        "is_primary_key": false,
+        "column_id": "awc_id",
+        "expression": {
+          "value_expression": {
+            "datatype": null,
+            "type": "property_path",
+            "property_path": [
+              "user_data",
+              "commcare_location_id"
+            ]
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareUser",
+          "doc_id_expression": {
+            "type": "root_doc",
+            "expression": {
+              "datatype": null,
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "meta",
+                "userID"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "display_name": "Supervisor ID",
+        "datatype": "string",
+        "type": "expression",
+        "transform": {},
+        "is_nullable": true,
+        "is_primary_key": false,
+        "column_id": "supervisor_id",
+        "expression": {
+          "location_id_expression": {
+            "value_expression": {
+              "datatype": null,
+              "type": "property_path",
+              "property_path": [
+                "user_data",
+                "commcare_location_id"
+              ]
+            },
+            "type": "related_doc",
+            "related_doc_type": "CommCareUser",
+            "doc_id_expression": {
+              "type": "root_doc",
+              "expression": {
+                "datatype": null,
+                "type": "property_path",
+                "property_path": [
+                  "form",
+                  "meta",
+                  "userID"
+                ]
+              }
+            }
+          },
+          "type": "location_parent_id"
+        }
+      },
+      {
+        "display_name": "Submission Date",
+        "datatype": "date",
+        "type": "expression",
+        "transform": {},
+        "is_nullable": true,
+        "is_primary_key": false,
+        "column_id": "submitted_on",
+        "expression": {
+          "datatype": "date",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
+        }
+      },
+      {
+        "display_name": "Count",
+        "type": "count",
+        "column_id": "count"
+      }
+    ],
+    "named_expressions": {},
+    "named_filters": {},
+    "engine_id": "icds-ucr",
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "submitted_on"
+        ]
+      }
+    ],
+    "disable_destructive_rebuild": true
+  }
+}

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -1,10 +1,7 @@
 {
   "domains": [
     "icds-dashboard-qa",
-    "icds-sql",
-    "icds-test",
-    "icds-cas",
-    "icds-cas-sandbox"
+    "icds-cas"
   ],
   "server_environment": [
     "softlayer",

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -67,6 +67,7 @@
         "transform": {},
         "is_nullable": true,
         "is_primary_key": false,
+        "create_index": true,
         "column_id": "supervisor_id",
         "expression": {
           "location_id_expression": {
@@ -128,14 +129,6 @@
     "named_expressions": {},
     "named_filters": {},
     "engine_id": "icds-ucr",
-    "sql_column_indexes": [
-      {
-        "column_ids": [
-          "supervisor_id",
-          "submitted_on"
-        ]
-      }
-    ],
     "sql_settings": {
       "partition_config": [
         {

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -136,6 +136,15 @@
         ]
       }
     ],
+    "sql_settings": {
+      "partition_config": [
+        {
+          "column": "submitted_on",
+          "subtype": "date",
+          "constraint": "day"
+        }
+      ]
+    },
     "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -116,8 +116,18 @@
       },
       {
         "display_name": "Count",
-        "type": "count",
-        "column_id": "count"
+        "column_id": "count",
+        "type": "boolean",
+        "filter": {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "constant",
+            "constant": 1
+          },
+          "property_value": 1
+        }
+
       }
     ],
     "named_expressions": {},

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -117,17 +117,12 @@
       {
         "display_name": "Count",
         "column_id": "count",
-        "type": "boolean",
-        "filter": {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "constant",
-            "constant": 1
-          },
-          "property_value": 1
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "constant",
+          "constant": 1
         }
-
       }
     ],
     "named_expressions": {},

--- a/settings.py
+++ b/settings.py
@@ -1991,6 +1991,7 @@ STATIC_DATA_SOURCES = [
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'tasks_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'tech_issue_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'thr_forms.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'thr_forms_v2.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'usage_forms.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'vhnd_form.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'visitorbook_forms.json'),


### PR DESCRIPTION
This is only used in one report and it always has a filter on submitted_on so partitioning by that. 

I'm pretty sure this should help memory usage on our UCR Databases because forms from < 30 days ago will never be loaded again and the index on supervisor_id will be much smaller (since they are on the child tables).

Will also want to do similar things for the other UCRs (especially forms)

@nickpell 