### PR TITLE
UCR Small boolean

### DIFF
--- a/corehq/apps/userreports/indicators/__init__.py
+++ b/corehq/apps/userreports/indicators/__init__.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from corehq.apps.userreports.util import truncate_value
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
-from fluff import TYPE_INTEGER
+from fluff import TYPE_INTEGER, TYPE_SMALL_INTEGER
 
 
 class Column(object):
@@ -68,16 +68,21 @@ class BooleanIndicator(SingleColumnIndicator):
     A boolean indicator leverages the filter logic and returns "1" if
     the filter is true, or "0" if it is false.
     """
+    column_datatype = TYPE_INTEGER
 
     def __init__(self, display_name, column_id, filter, wrapped_spec):
         super(BooleanIndicator, self).__init__(display_name,
-                                               Column(column_id, datatype=TYPE_INTEGER),
+                                               Column(column_id, datatype=self.column_datatype),
                                                wrapped_spec)
         self.filter = filter
 
     def get_values(self, item, context=None):
         value = 1 if self.filter(item, context) else 0
         return [ColumnValue(self.column, value)]
+
+
+class SmallBooleanIndicator(BooleanIndicator):
+    column_datatype = TYPE_SMALL_INTEGER
 
 
 class RawIndicator(SingleColumnIndicator):

--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -12,6 +12,7 @@ from corehq.apps.userreports.indicators import (
     CompoundIndicator,
     LedgerBalancesIndicator,
     RawIndicator,
+    SmallBooleanIndicator,
 )
 from corehq.apps.userreports.indicators.specs import (
     BooleanIndicatorSpec,
@@ -20,6 +21,7 @@ from corehq.apps.userreports.indicators.specs import (
     IndicatorSpecBase,
     LedgerBalancesIndicatorSpec,
     RawIndicatorSpec,
+    SmallBooleanIndicatorSpec,
 )
 
 
@@ -63,6 +65,16 @@ def _build_expression_indicator(spec, context):
         wrapped.display_name,
         column,
         getter=wrapped.parsed_expression(context),
+        wrapped_spec=wrapped,
+    )
+
+
+def _build_small_boolean_indicator(spec, context):
+    wrapped = SmallBooleanIndicatorSpec.wrap(spec)
+    return SmallBooleanIndicator(
+        wrapped.display_name,
+        wrapped.column_id,
+        FilterFactory.from_spec(wrapped.filter, context),
         wrapped_spec=wrapped,
     )
 
@@ -137,6 +149,7 @@ def _build_inserted_at(spec, context):
 
 class IndicatorFactory(object):
     constructor_map = {
+        'small_boolean': _build_small_boolean_indicator,
         'boolean': _build_boolean_indicator,
         'choice_list': _build_choice_list_indicator,
         'count': _build_count_indicator,

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -73,6 +73,10 @@ class BooleanIndicatorSpec(IndicatorSpecBase):
         return str(filter_object)
 
 
+class SmallBooleanIndicatorSpec(BooleanIndicatorSpec):
+    type = TypeProperty('small_boolean')
+
+
 class RawIndicatorSpec(PropertyReferenceIndicatorSpecBase):
     type = TypeProperty('raw')
     datatype = DataTypeProperty(required=True)


### PR DESCRIPTION
Ideally booleans would be actual boolean types, but historically booleans in UCR are backed by integers. I think that mostly because that's what it was in fluff and custom pillows and may have been that way due to numbers having better support for aggregations (like SUM), but I'm not sure.

I don't want to have to rewrite any of the reports/reporting framework to support booleans, so I'm not going to try to move these to boolean types, but we can move them to small integers which take up half the space without a ton of hassle. If I were to change the current boolean type to small integer it would trigger rebuilds on every data source in HQ, so I'm just adding a new type for now.

As an example for ICDS on the person cases UCR there are 59 columns with a boolean type. By cutting the storage in half we'll be saving 59 columns * 2 bytes * 67,000,000 / 1024**3 => **7.4 GB** somewhat overnight

We'll also be saving a lot on some other UCRs as well (those changes will be coming in the coming week or so and will need a somewhat manual migration)

@nickpell 