### PR TITLE
Resolve UCR aggregation types vs Report Builder UI aggregation types

### DIFF
--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -60,8 +60,9 @@ class ColumnOption(object):
 
     def _get_aggregation_config(self, agg):
         """
-        Convert an aggregation value selected in the UI to and aggregation value to be used in the UCR
+        Convert an aggregation value selected in the UI to an aggregation value to be used in the UCR
         configuration.
+
         :param agg: UI aggregation value
         :return: UCR config aggregation value
         """
@@ -123,6 +124,9 @@ class QuestionColumnOption(ColumnOption):
         return ret
 
     def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+        """
+        Return the report config snippet for the data source indicator for this form question column option
+        """
         if aggregation in (UI_AGG_SUM, UI_AGG_AVERAGE):
             data_type = "decimal"
         elif aggregation in ("sum", "avg"):
@@ -216,9 +220,19 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         return make_multiselect_question_indicator(self._question_source, column_id)
 
     def get_indicators(self, aggregation, is_multiselect_chart_report=False):
+        """
+        Return the report config snippets that specify the data source indicator that will be used for
+        aggregating this question, and the data source indicator for the multi-select question's choices.
+        """
         return [self._get_filter_and_agg_indicator(), self._get_choice_indicator()]
 
     def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+        """
+        Validate that this is being called with aggregation == "Group By" (i.e. not actually aggregating).
+
+        (Aggregations of MultiselectQuestionColumnOption can aggregate either of two indicators; its value or its
+        choices, so self.get_indicators() must be used instead.)
+        """
         if aggregation == UI_AGG_GROUP_BY:
             return super(MultiselectQuestionColumnOption, self).get_indicator(
                 aggregation, is_multiselect_chart_report)

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -96,12 +96,14 @@ class ColumnOption(object):
         :param display_text: The label for this column
         :param aggregation: What sort of aggregation the user selected for this column in the UI
         :param is_aggregated_on: True if the user chose to "group by" this column
-        :return:
         """
+        # Use get_indicators() instead of get_indicator() to find column_id because otherwise this will break
+        # for MultiselectQuestionColumnOption instances when aggregation != "Group By"
+        column_id = self.get_indicators(aggregation)[0]['column_id']
         return [{
             "format": "default",
             "aggregation": self._get_aggregation_config(aggregation),
-            "field": self.get_indicator(aggregation)['column_id'],
+            "field": column_id,
             "column_id": "column_{}".format(index),
             "type": "field",
             "display": display_text,
@@ -216,7 +218,8 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         Return the data source indicator that will be used for displaying this question in the report (but not
         filtering or aggregation)
         """
-        # TODO: Is it a problem that this is the same as the filter/agg indicator id?
+        # column_id must match that used in _get_filter_and_agg_indicator() because the data will come from the
+        # same data source column
         column_id = get_column_name(self._property.strip("/"))
         return make_multiselect_question_indicator(self._question_source, column_id)
 

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -127,10 +127,11 @@ class QuestionColumnOption(ColumnOption):
         """
         Return the report config snippet for the data source indicator for this form question column option
         """
+        assert aggregation in UI_AGGREGATIONS, (
+            '"{}" is not an aggregation recognised by the Report Builder interface.'.format(aggregation)
+        )
         if aggregation in (UI_AGG_SUM, UI_AGG_AVERAGE):
             data_type = "decimal"
-        elif aggregation in ("sum", "avg"):
-            raise Exception("I think this should be Sum or Avg, where did you find this?...")
         else:
             data_type = None  # use the default
 
@@ -233,14 +234,12 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         (Aggregations of MultiselectQuestionColumnOption can aggregate either of two indicators; its value or its
         choices, so self.get_indicators() must be used instead.)
         """
-        if aggregation == UI_AGG_GROUP_BY:
-            return super(MultiselectQuestionColumnOption, self).get_indicator(
-                aggregation, is_multiselect_chart_report)
-        else:
-            raise Exception(
-                "This column option is represented by multiple indicators when not being aggreated by, "
-                "use get_indicators() instead (aggregation was {})".format(aggregation)
-            )
+        assert aggregation == UI_AGG_GROUP_BY, (
+            'Column options for multi-select questions have multiple indicators for all aggregations except '
+            '"group by". For "{}" aggregation you need to use get_indicators() instead.'.format(aggregation)
+        )
+        return super(MultiselectQuestionColumnOption, self).get_indicator(
+            aggregation, is_multiselect_chart_report)
 
 
 class CasePropertyColumnOption(ColumnOption):

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -66,12 +66,14 @@ class ColumnOption(object):
         :param ui_aggregation: UI aggregation value
         :return: UCR config aggregation value
         """
+        assert ui_aggregation in UI_AGGREGATIONS, (
+            '"{}" is not recognised as a Report Builder UI aggregation'.format(ui_aggregation)
+        )
         aggregation_map = {
             UI_AGG_AVERAGE: UCR_AGG_AVG,
             UI_AGG_COUNT_PER_CHOICE: UCR_AGG_EXPAND,
             UI_AGG_GROUP_BY: UCR_AGG_SIMPLE,
             UI_AGG_SUM: UCR_AGG_SUM,
-            UCR_AGG_SIMPLE: UCR_AGG_SIMPLE,  # TODO: Why would a RB UI use a UCR agg?
             None: UCR_AGG_SIMPLE,
         }
         return aggregation_map[ui_aggregation]

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -76,7 +76,7 @@ class ColumnOption(object):
         }
         return aggregation_map[agg]
 
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         """
         Get the indicator corresponding to this column option. This function will raise an exception if more than
         one indicator corresponds to this column.
@@ -87,7 +87,7 @@ class ColumnOption(object):
         """
         Return the indicators corresponding to this column option.
         """
-        return [self.get_indicator(aggregation)]
+        return [self._get_indicator(aggregation)]
 
     def to_column_dicts(self, index, display_text, aggregation, is_aggregated_on=False):
         """
@@ -97,7 +97,7 @@ class ColumnOption(object):
         :param aggregation: What sort of aggregation the user selected for this column in the UI
         :param is_aggregated_on: True if the user chose to "group by" this column
         """
-        # Use get_indicators() instead of get_indicator() to find column_id because otherwise this will break
+        # Use get_indicators() instead of _get_indicator() to find column_id because otherwise this will break
         # for MultiselectQuestionColumnOption instances when aggregation != "Group By"
         column_id = self.get_indicators(aggregation)[0]['column_id']
         return [{
@@ -125,7 +125,7 @@ class QuestionColumnOption(ColumnOption):
         ret['question_source'] = self._question_source
         return ret
 
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         """
         Return the report config snippet for the data source indicator for this form question column option
         """
@@ -153,7 +153,7 @@ class FormMetaColumnOption(ColumnOption):
         super(FormMetaColumnOption, self).__init__(property, data_types, default_display)
         self._meta_property_spec = meta_property_spec
 
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         # aggregation parameter is never used because we need not infer the data type
         # self._question_source is a tuple of (identifier, datatype)
         identifier = self._meta_property_spec[0]
@@ -230,7 +230,7 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         """
         return [self._get_filter_and_agg_indicator(), self._get_choice_indicator()]
 
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         """
         Validate that this is being called with aggregation == "Group By" (i.e. not actually aggregating).
 
@@ -241,7 +241,7 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
             'Column options for multi-select questions have multiple indicators for all aggregations except '
             '"group by". For "{}" aggregation you need to use get_indicators() instead.'.format(aggregation)
         )
-        return super(MultiselectQuestionColumnOption, self).get_indicator(
+        return super(MultiselectQuestionColumnOption, self)._get_indicator(
             aggregation, is_multiselect_chart_report)
 
 
@@ -260,13 +260,13 @@ class CasePropertyColumnOption(ColumnOption):
         }
         return map[self._get_aggregation_config(aggregation)]
 
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         column_id = get_column_name(self._property, suffix=self._get_datatype(aggregation))
         return make_case_property_indicator(self._property, column_id, datatype=self._get_datatype(aggregation))
 
 
 class UsernameComputedCasePropertyOption(ColumnOption):
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         column_id = get_column_name(self._property)
         expression = {
             'type': 'property_name',
@@ -294,7 +294,7 @@ class UsernameComputedCasePropertyOption(ColumnOption):
 
 
 class OwnernameComputedCasePropertyOption(ColumnOption):
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         column_id = get_column_name(self._property)
         expression = {
             'type': 'property_name',
@@ -334,7 +334,7 @@ class CountColumn(ColumnOption):
         """
         return UCR_AGG_SUM
 
-    def get_indicator(self, aggregation, is_multiselect_chart_report=False):
+    def _get_indicator(self, aggregation, is_multiselect_chart_report=False):
         return {
             "column_id": "count",
             "display_name": "Count",

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -92,6 +92,7 @@ class ColumnOption(object):
     def to_column_dicts(self, index, display_text, ui_aggregation, is_aggregated_on=False):
         """
         Return a UCR report column configuration dictionary
+
         :param index: The index of the column in the list of columns, e.g. 0, 1, 2, etc.
         :param display_text: The label for this column
         :param ui_aggregation: What sort of aggregation the user selected for this column in the UI
@@ -102,7 +103,7 @@ class ColumnOption(object):
         column_id = self.get_indicators(ui_aggregation)[0]['column_id']
         return [{
             "format": "default",
-            "aggregation": self._get_ucr_aggregation(ui_aggregation),
+            "aggregation": self._get_ucr_aggregation(ui_aggregation),  # NOTE: "aggregation" is a UCR aggregation
             "field": column_id,
             "column_id": "column_{}".format(index),
             "type": "field",
@@ -179,7 +180,7 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         )
 
     def to_column_dicts(self, index, display_text, ui_aggregation, is_aggregated_on=False):
-        assert ui_aggregation in (UI_AGG_COUNT_PER_CHOICE, UCR_AGG_SIMPLE)  # TODO: Why UCR_AGG_SIMPLE and not UI_AGG_GROUP_BY?
+        assert ui_aggregation in (UI_AGG_COUNT_PER_CHOICE, UI_AGG_GROUP_BY)
 
         if is_aggregated_on:
             return [{

--- a/corehq/apps/userreports/reports/builder/const.py
+++ b/corehq/apps/userreports/reports/builder/const.py
@@ -2,7 +2,27 @@ from __future__ import unicode_literals
 COMPUTED_USER_NAME_PROPERTY_ID = "computed/user_name"
 COMPUTED_OWNER_NAME_PROPERTY_ID = "computed/owner_name"
 
-COUNT_PER_CHOICE = "Count per Choice"
+UI_AGG_AVERAGE = "Average"
+UI_AGG_COUNT_PER_CHOICE = "Count per Choice"
+UI_AGG_GROUP_BY = "Group By"
+UI_AGG_SUM = "Sum"
+UI_AGGREGATIONS = (
+    UI_AGG_AVERAGE,
+    UI_AGG_COUNT_PER_CHOICE,
+    UI_AGG_GROUP_BY,
+    UI_AGG_SUM,
+)
+
+UCR_AGG_AVG = 'avg'
+UCR_AGG_EXPAND = 'expand'
+UCR_AGG_SIMPLE = "simple"
+UCR_AGG_SUM = 'sum'
+UCR_AGGREGATIONS = (
+    UCR_AGG_AVG,
+    UCR_AGG_EXPAND,
+    UCR_AGG_SIMPLE,
+    UCR_AGG_SUM,
+)
 
 PROPERTY_TYPE_META = "meta"
 PROPERTY_TYPE_CASE_PROP = "case_property"

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -261,7 +261,7 @@ class DataSourceProperty(object):
         if filter_format == "numeric":
             return UI_AGG_SUM  # This could also be UI_AGG_AVERAGE, just needs to force numeric
         else:
-            return "simple"
+            return UI_AGG_GROUP_BY
 
     def to_report_filter(self, configuration, index):
         """

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -259,7 +259,7 @@ class DataSourceProperty(object):
         create the correct type of indicator.
         """
         if filter_format == "numeric":
-            return "Sum"  # This could also be "Avg", just needs to force numeric
+            return UI_AGG_SUM  # This could also be UI_AGG_AVERAGE, just needs to force numeric
         else:
             return "simple"
 
@@ -1384,7 +1384,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
                     index=i,
                     display_text=conf['display_text'],
                     ui_aggregation=conf['calculation'],
-                    is_aggregated_on=conf.get('calculation') == "Group By",
+                    is_aggregated_on=conf.get('calculation') == UI_AGG_GROUP_BY,
                 ))
         return columns
 
@@ -1392,8 +1392,8 @@ class ConfigureTableReportForm(ConfigureListReportForm):
     @memoized
     def _report_aggregation_cols(self):
         return [
-            self.ds_builder.report_column_options[conf['property']].get_indicators("Group By")[0]['column_id']
-            for conf in self.cleaned_data['columns'] if conf['calculation'] == "Group By"
+            self.ds_builder.report_column_options[conf['property']].get_indicators(UI_AGG_GROUP_BY)[0]['column_id']
+            for conf in self.cleaned_data['columns'] if conf['calculation'] == UI_AGG_GROUP_BY
         ]
 
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -252,11 +252,11 @@ class DataSourceProperty(object):
             filter_format = REPORT_BUILDER_FILTER_TYPE_MAP[selected_filter_type]
         return filter_format
 
-    def _get_agg_type_for_filter_format(self, filter_format):
+    def _get_ui_aggregation_for_filter_format(self, filter_format):
         """
-        ColumnOption._get_indicator(aggregation) uses the aggregation type to determine what data type the indicator
-        should be. Therefore, we need to convert filter formats to aggregation types so that we can create the
-        correct type of indicator.
+        ColumnOption._get_indicator(aggregation) uses the aggregation type to determine what data type the
+        indicator should be. Therefore, we need to convert filter formats to aggregation types so that we can
+        create the correct type of indicator.
         """
         if filter_format == "numeric":
             return "Sum"  # This could also be "Avg", just needs to force numeric
@@ -271,8 +271,8 @@ class DataSourceProperty(object):
         :return:
         """
         filter_format = self._get_filter_format(configuration)
-        agg = self._get_agg_type_for_filter_format(filter_format)
-        column_id = self.to_report_column_option().get_indicators(agg)[0]['column_id']
+        ui_aggregation = self._get_ui_aggregation_for_filter_format(filter_format)
+        column_id = self.to_report_column_option().get_indicators(ui_aggregation)[0]['column_id']
 
         filter = {
             "field": column_id,
@@ -299,8 +299,8 @@ class DataSourceProperty(object):
         Return the indicator that would correspond to the given filter configuration
         """
         filter_format = self._get_filter_format(configuration)
-        agg = self._get_agg_type_for_filter_format(filter_format)
-        return self.to_report_column_option()._get_indicator(agg)
+        ui_aggregation = self._get_ui_aggregation_for_filter_format(filter_format)
+        return self.to_report_column_option()._get_indicator(ui_aggregation)
 
 
 class DataSourceBuilder(object):
@@ -1383,7 +1383,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
                 column.to_column_dicts(
                     index=i,
                     display_text=conf['display_text'],
-                    aggregation=conf['calculation'],
+                    ui_aggregation=conf['calculation'],
                     is_aggregated_on=conf.get('calculation') == "Group By",
                 ))
         return columns

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -254,7 +254,7 @@ class DataSourceProperty(object):
 
     def _get_agg_type_for_filter_format(self, filter_format):
         """
-        ColumnOption.get_indicator(aggregation) uses the aggregation type to determine what data type the indicator
+        ColumnOption._get_indicator(aggregation) uses the aggregation type to determine what data type the indicator
         should be. Therefore, we need to convert filter formats to aggregation types so that we can create the
         correct type of indicator.
         """
@@ -300,7 +300,7 @@ class DataSourceProperty(object):
         """
         filter_format = self._get_filter_format(configuration)
         agg = self._get_agg_type_for_filter_format(filter_format)
-        return self.to_report_column_option().get_indicator(agg)
+        return self.to_report_column_option()._get_indicator(agg)
 
 
 class DataSourceBuilder(object):

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1322,7 +1322,9 @@ class ConfigureListReportForm(ConfigureNewReportBase):
         for i, conf in enumerate(self.cleaned_data['columns']):
             columns.extend(
                 self.ds_builder.report_column_options[conf['property']].to_column_dicts(
-                    i, conf.get('display_text', conf['property']), UCR_AGG_SIMPLE
+                    index=i,
+                    display_text=conf.get('display_text', conf['property']),
+                    ui_aggregation=UI_AGG_GROUP_BY
                 )
             )
         return columns

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -420,8 +420,7 @@ class DataSourceBuilder(object):
             # Property is only set if the column exists in report_column_options
             if column['property']:
                 column_option = self.report_column_options[column['property']]
-                for indicator in column_option.get_indicators(column['calculation'],
-                                                              is_multiselect_chart_report):
+                for indicator in column_option.get_indicators(column['calculation'], is_multiselect_chart_report):
                     indicators.setdefault(str(indicator), indicator)
 
         for filter_ in filters:
@@ -816,7 +815,7 @@ class ConfigureNewReportBase(forms.Form):
         if location:
             configured_columns += [{
                 "property": location,
-                "calculation": "simple"  # Not aggregated
+                "calculation": UI_AGG_GROUP_BY  # Not aggregated
             }]
         return configured_columns
 
@@ -1145,6 +1144,9 @@ class ConfigureNewReportBase(forms.Form):
 
     @property
     def _report_columns(self):
+        """
+        Returns column dicts for columns posted from the UI
+        """
         return []
 
     @property
@@ -1440,7 +1442,7 @@ class ConfigureMapReportForm(ConfigureListReportForm):
 
         if self.location_field:
             loc_column = self.data_source_properties[self.location_field].to_report_column_option()
-            loc_field_id = loc_column.get_indicators("simple")[0]['column_id']
+            loc_field_id = loc_column.get_indicators(UI_AGG_GROUP_BY)[0]['column_id']
             loc_field_text = loc_column.get_default_display()
 
             displaying_loc_column = False

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -272,7 +272,7 @@ class DataSourceProperty(object):
         """
         filter_format = self._get_filter_format(configuration)
         agg = self._get_agg_type_for_filter_format(filter_format)
-        column_id = self.to_report_column_option().get_indicator(agg)['column_id']
+        column_id = self.to_report_column_option().get_indicators(agg)[0]['column_id']
 
         filter = {
             "field": column_id,
@@ -1256,7 +1256,7 @@ class ConfigureListReportForm(ConfigureNewReportBase):
             data_source_field=(
                 self.data_source_properties['name']
                     .to_report_column_option()
-                    .get_indicator(UI_AGG_COUNT_PER_CHOICE)['column_id']),
+                    .get_indicators(UI_AGG_COUNT_PER_CHOICE)[0]['column_id']),
             calculation=UI_AGG_COUNT_PER_CHOICE
         ))
         cols.append(ColumnViewModel(
@@ -1266,7 +1266,7 @@ class ConfigureListReportForm(ConfigureNewReportBase):
             data_source_field=(
                 self.data_source_properties[COMPUTED_OWNER_NAME_PROPERTY_ID]
                     .to_report_column_option()
-                    .get_indicator(UI_AGG_COUNT_PER_CHOICE)['column_id']),
+                    .get_indicators(UI_AGG_COUNT_PER_CHOICE)[0]['column_id']),
             calculation=UI_AGG_COUNT_PER_CHOICE
         ))
         case_props_found = 0
@@ -1279,7 +1279,9 @@ class ConfigureListReportForm(ConfigureNewReportBase):
                     display_text=prop.get_text(),
                     exists_in_current_version=True,
                     property=prop.get_id(),
-                    data_source_field=prop.to_report_column_option().get_indicator(UI_AGG_COUNT_PER_CHOICE)['column_id'],
+                    data_source_field=(
+                        prop.to_report_column_option()
+                            .get_indicators(UI_AGG_COUNT_PER_CHOICE)[0]['column_id']),
                     calculation=UI_AGG_COUNT_PER_CHOICE,
                 ))
                 if case_props_found == 3:
@@ -1293,7 +1295,9 @@ class ConfigureListReportForm(ConfigureNewReportBase):
             display_text=prop.get_text(),
             exists_in_current_version=True,
             property=prop.get_id(),
-            data_source_field=prop.to_report_column_option().get_indicator(UI_AGG_COUNT_PER_CHOICE)['column_id'],
+            data_source_field=(
+                prop.to_report_column_option()
+                    .get_indicators(UI_AGG_COUNT_PER_CHOICE)[0]['column_id']),
             calculation=UI_AGG_COUNT_PER_CHOICE
         ))
         questions = [p for p in self.data_source_properties.values()
@@ -1388,7 +1392,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
     @memoized
     def _report_aggregation_cols(self):
         return [
-            self.ds_builder.report_column_options[conf['property']].get_indicator("Group By")['column_id']
+            self.ds_builder.report_column_options[conf['property']].get_indicators("Group By")[0]['column_id']
             for conf in self.cleaned_data['columns'] if conf['calculation'] == "Group By"
         ]
 
@@ -1436,8 +1440,7 @@ class ConfigureMapReportForm(ConfigureListReportForm):
 
         if self.location_field:
             loc_column = self.data_source_properties[self.location_field].to_report_column_option()
-            loc_indicator = loc_column.get_indicator("simple")
-            loc_field_id = loc_indicator['column_id']
+            loc_field_id = loc_column.get_indicators("simple")[0]['column_id']
             loc_field_text = loc_column.get_default_display()
 
             displaying_loc_column = False


### PR DESCRIPTION
Context: [FB 265033](https://manage.dimagi.com/default.asp?265033)

Resolved ambiguities between UCR aggregations ("avg", "expand", "simple", "sum") and Report Builder UI aggregations ("Average", "Count per Choice", "Group By" and "Sum"). And found why multi-select questions break Report Builder. (See commit 514209a)

Tested, but still needs unit tests. 

@gbova @biyeun buddy @mkangia 