### PR TITLE
270820 Change back button behavior on "Permission Denied page"

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/otp_required.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/otp_required.html
@@ -12,7 +12,7 @@
     account. Enable two-factor authentication for enhanced account
     security.{% endblocktrans %}</p>
   <p>
-    <a href="javascript:history.go(-1)"
+    <a href="{% url "domain_select_redirect" %}"
        class="pull-right btn btn-link">{% trans "Go back" %}</a>
     <a href="{% url 'two_factor:setup' %}" class="btn btn-primary">
     {% trans "Enable Two-Factor Authentication" %}</a>

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -83,6 +83,7 @@ from corehq.motech.repeaters.views import (
 
 urlpatterns = [
     url(r'^domain/select/$', select, name='domain_select'),
+    url(r'^domain/select_redirect/$', select, {'do_not_redirect': True}, name='domain_select_redirect'),
     url(r'^domain/autocomplete/(?P<field>[\w-]+)/$', autocomplete_fields, name='domain_autocomplete_fields'),
     url(r'^domain/transfer/(?P<guid>\w+)/activate$',
         ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),


### PR DESCRIPTION
[Ticket 266361](https://manage.dimagi.com/default.asp?266361) 
On the "Permission Denied" page, there's a back button, this changes it to send users back to the "Select a project" page regardless of how many domains they have, which domain they're in, etc. 