### PR TITLE
Tabular report percent adhaar seeded beneficiaries value fix

### DIFF
--- a/custom/icds_reports/sqldata.py
+++ b/custom/icds_reports/sqldata.py
@@ -1680,8 +1680,10 @@ class DemographicsExport(ExportableMixin):
         return columns
 
     def get_data(self):
-        awc_monthly = DemographicsAWCMonthly(self.config, self.loc_level).get_data()
-        child_health = DemographicsChildHealth(self.config, self.loc_level).get_data()
+        awc_monthly = DemographicsAWCMonthly(
+            self.config, self.loc_level, show_test=self.show_test, beta=self.beta).get_data()
+        child_health = DemographicsChildHealth(
+            self.config, self.loc_level, show_test=self.show_test, beta=self.beta).get_data()
         connect_column = 'state_name'
         if self.loc_level == 2:
             connect_column = 'district_name'

--- a/custom/icds_reports/tests/__init__.py
+++ b/custom/icds_reports/tests/__init__.py
@@ -56,6 +56,17 @@ def setUpModule():
         location_type=location_type
     )
 
+    state_location_type = LocationType.objects.create(
+        domain=domain.name,
+        name='state',
+    )
+    SQLLocation.objects.create(
+        domain=domain.name,
+        name='st1',
+        location_id='st1',
+        location_type=state_location_type
+    )
+
     awc_location_type = LocationType.objects.create(
         domain=domain.name,
         name='awc',

--- a/custom/icds_reports/tests/test_export_data.py
+++ b/custom/icds_reports/tests/test_export_data.py
@@ -888,6 +888,255 @@ class TestExportData(TestCase):
             ]
         )
 
+    def test_demographics_export_flags_being_passed(self):
+        self.assertListEqual(
+            DemographicsExport(
+                config={
+                    'domain': 'icds-cas'
+                },
+                beta=True
+            ).get_excel_data('st1'),
+            [
+                [
+                    'Demographics',
+                    [
+                        [
+                            'State', 'Number of households',
+                            'Total number of beneficiaries (under 6 years old and women between 11 and 49 years '
+                            'old, alive and seeking services) who have an aadhaar ID',
+                            'Total number of beneficiaries (under 6 years old and women between 11 and 49 years '
+                            'old, alive and seeking services)',
+                            'Percent Aadhaar-seeded beneficaries', 'Number of pregnant women',
+                            'Number of pregnant women enrolled for services', 'Number of lactating women',
+                            'Number of lactating women enrolled for services',
+                            'Number of children 0-6 years old',
+                            'Number of children 0-6 years old enrolled for services',
+                            'Number of children 0-6 months old enrolled for services',
+                            'Number of children 6 months to 3 years old enrolled for services',
+                            'Number of children 3 to 6 years old enrolled for services',
+                            'Number of adolescent girls 11 to 14 years old',
+                            'Number of adolescent girls 15 to 18 years old',
+                            'Number of adolescent girls 11 to 14 years old that are enrolled for services',
+                            'Number of adolescent girls 15 to 18 years old that are enrolled for services'
+                        ],
+                        [
+                            u'st1',
+                            7266,
+                            365,
+                            1493,
+                            '24.45 %',
+                            120,
+                            120,
+                            171,
+                            171,
+                            1227,
+                            1227,
+                            56,
+                            244,
+                            927,
+                            36,
+                            12,
+                            36,
+                            12
+                        ],
+                        [
+                            u'st1',
+                            7266,
+                            365,
+                            1493,
+                            '24.45 %',
+                            120,
+                            120,
+                            171,
+                            171,
+                            1227,
+                            1227,
+                            56,
+                            244,
+                            927,
+                            36,
+                            12,
+                            36,
+                            12
+                        ],
+                        [
+                            u'st1',
+                            7266,
+                            365,
+                            1493,
+                            '24.45 %',
+                            120,
+                            120,
+                            171,
+                            171,
+                            1227,
+                            1227,
+                            56,
+                            244,
+                            927,
+                            36,
+                            12,
+                            36,
+                            12
+                        ],
+                        [
+                            u'st1',
+                            7266,
+                            365,
+                            1493,
+                            '24.45 %',
+                            120,
+                            120,
+                            171,
+                            171,
+                            1227,
+                            1227,
+                            56,
+                            244,
+                            927,
+                            36,
+                            12,
+                            36,
+                            12
+                        ],
+                        [
+                            u'st1',
+                            7266,
+                            365,
+                            1493,
+                            '24.45 %',
+                            120,
+                            120,
+                            171,
+                            171,
+                            1227,
+                            1227,
+                            56,
+                            244,
+                            927,
+                            36,
+                            12,
+                            36,
+                            12
+                        ],
+                        [
+                            u'st2',
+                            6662,
+                            269,
+                            1590,
+                            '16.92 %',
+                            139,
+                            139,
+                            154,
+                            154,
+                            1322,
+                            1322,
+                            52,
+                            301,
+                            969,
+                            36,
+                            20,
+                            36,
+                            20
+                        ],
+                        [
+                            u'st2',
+                            6662,
+                            269,
+                            1590,
+                            '16.92 %',
+                            139,
+                            139,
+                            154,
+                            154,
+                            1322,
+                            1322,
+                            52,
+                            301,
+                            969,
+                            36,
+                            20,
+                            36,
+                            20
+                        ],
+                        [
+                            u'st2',
+                            6662,
+                            269,
+                            1590,
+                            '16.92 %',
+                            139,
+                            139,
+                            154,
+                            154,
+                            1322,
+                            1322,
+                            52,
+                            301,
+                            969,
+                            36,
+                            20,
+                            36,
+                            20
+                        ],
+                        [
+                            u'st2',
+                            6662,
+                            269,
+                            1590,
+                            '16.92 %',
+                            139,
+                            139,
+                            154,
+                            154,
+                            1322,
+                            1322,
+                            52,
+                            301,
+                            969,
+                            36,
+                            20,
+                            36,
+                            20
+                        ],
+                        [
+                            u'st2',
+                            6662,
+                            269,
+                            1590,
+                            '16.92 %',
+                            139,
+                            139,
+                            154,
+                            154,
+                            1322,
+                            1322,
+                            52,
+                            301,
+                            969,
+                            36,
+                            20,
+                            36,
+                            20
+                        ]
+                    ]
+                ],
+                [
+                    'Export Info',
+                    [
+                        [
+                            'Generated at',
+                            '16:21:11 15 November 2017'
+                        ],
+                        [
+                            u'State',
+                            u'st1'
+                        ]
+                    ]
+                ]
+            ]
+        )
+
     def test_system_usage_export(self):
         self.assertListEqual(
             SystemUsageExport(


### PR DESCRIPTION
Hi @emord,
This commit fixes incorrect Percent Adhaar-seeded beneficiaries on the Tabular Reports page.
The issue was caused by fact that view ExportIndicatorView returns values from DemographicsExport.get_excel_data which uses DemographicsExport.get_data which on the other hand uses DemographicsAWCMonthly.get_data and DemographicsChildHealth.get_data combined information, where both DemographicsAWCMonthly and DemographicsChildHealth didn't get arguments passed from DemographicsExport that invoked them.