### PR TITLE
correctly encode accented e

### DIFF
--- a/custom/intrahealth/filters.py
+++ b/custom/intrahealth/filters.py
@@ -66,7 +66,7 @@ class RecapPassageLocationFilter(LocationFilter):
 
 
 class FRYearFilter(YearFilter):
-    label = ugettext_noop("Ann\xe9e")
+    label = ugettext_noop("Année")
 
 
 class FRMonthFilter(MonthFilter):


### PR DESCRIPTION
```"Ann\xe9e"``` worked with translations, but ```u"Ann\xe9e"``` does not.  Switching to future unicode in this file broke translations.