### PR TITLE
change number of AWCs opened yesterday when current month not selecte…

### DIFF
--- a/custom/icds_reports/tests/reports/test_icds_cas_reach.py
+++ b/custom/icds_reports/tests/reports/test_icds_cas_reach.py
@@ -34,17 +34,15 @@ class TestICDSCASReach(TestCase):
                             )
                         },
                         {
-                            "redirect": "awc_daily_status",
                             "all": 0,
                             "format": "div",
                             "color": "green",
                             "percent": "Data in the previous reporting period was 0",
                             "value": 0,
-                            "label": "Number of AWCs Open yesterday",
+                            "label": "Number of AWCs open for at least one day in month",
                             "frequency": "day",
                             "help_text": (
-                                "Total Number of Angwanwadi Centers that were open yesterday by "
-                                "the AWW or the AWW helper"
+                                "Total Number of AWCs open for at least one day in month"
                             )
                         }
                     ],


### PR DESCRIPTION
…d to last day of selected month
Hi @emord,
In this PR I have changed the behaviour of a number of "awcs opened yesterday" when the selected month is different than a current month to show values from last day of the selected month rather than the day before current today.