### PR TITLE
Clear date filter

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -38,6 +38,7 @@
             locale: {
                 format: 'YYYY-MM-DD',
                 separator: separator,
+                cancelLabel: gettext('Clear'),
             },
         };
         var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
@@ -47,6 +48,22 @@
         }
 
         $(this).daterangepicker(config);
+
+        var $el = $(this);
+        $el.daterangepicker(config);
+        $el.on('cancel.daterangepicker', function() {
+
+            // Clear startdate and enddate filters
+            var filter_id = $(this)[0].getAttribute("name");
+            var filter_id_start = filter_id + "-start";
+            var filter_id_end = filter_id + "-end";
+            if (document.getElementById(filter_id_start) && document.getElementById(filter_id_end)) {
+                document.getElementById(filter_id_start).setAttribute("value", "");
+                document.getElementById(filter_id_end).setAttribute("value", "");
+            }
+
+            $el.val(gettext("Show All"));
+        });
 
         if (! hasStartAndEndDate){
             $(this).val("");

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -47,15 +47,15 @@
 
         $(this).daterangepicker(config);
 
-        var $el = $(this);
-
         // UCRs
-        var ucr = "userreports/js/configurable_report";
-        if (typeof COMMCAREHQ_MODULES[ucr] !== 'undefined') {
+        var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get;
+        if (initial_page_data('daterangepicker-show-clear')) {
             // Change 'Cancel' button text to 'Clear'
+            var $el = $(this);
             config.locale.cancelLabel = gettext('Clear');
-
             $el.daterangepicker(config);
+
+            // Add clearing functionality
             $el.on('cancel.daterangepicker', function() {
                 $el.val(gettext("Show All Dates"));
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -17,7 +17,6 @@
     $.fn.createDateRangePicker = function(
         range_labels, separator, startdate, enddate
     ) {
-        var now = moment();
         var ranges = {};
         ranges[range_labels.last_7_days] = [
             moment().subtract('7', 'days').startOf('days'),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -52,6 +52,7 @@
         var $el = $(this);
         $el.daterangepicker(config);
         $el.on('cancel.daterangepicker', function() {
+            $el.val(gettext("Show All Dates"));
 
             // Clear startdate and enddate filters
             var filter_id = $(this)[0].getAttribute("name");
@@ -61,8 +62,6 @@
                 document.getElementById(filter_id_start).setAttribute("value", "");
                 document.getElementById(filter_id_end).setAttribute("value", "");
             }
-
-            $el.val(gettext("Show All"));
         });
 
         if (! hasStartAndEndDate){

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -37,7 +37,6 @@
             locale: {
                 format: 'YYYY-MM-DD',
                 separator: separator,
-                cancelLabel: gettext('Clear'),
             },
         };
         var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
@@ -49,19 +48,27 @@
         $(this).daterangepicker(config);
 
         var $el = $(this);
-        $el.daterangepicker(config);
-        $el.on('cancel.daterangepicker', function() {
-            $el.val(gettext("Show All Dates"));
 
-            // Clear startdate and enddate filters
-            var filter_id = $(this)[0].getAttribute("name");
-            var filter_id_start = filter_id + "-start";
-            var filter_id_end = filter_id + "-end";
-            if (document.getElementById(filter_id_start) && document.getElementById(filter_id_end)) {
-                document.getElementById(filter_id_start).setAttribute("value", "");
-                document.getElementById(filter_id_end).setAttribute("value", "");
-            }
-        });
+        // UCRs
+        var ucr = "userreports/js/configurable_report";
+        if (typeof COMMCAREHQ_MODULES[ucr] !== 'undefined') {
+            // Change 'Cancel' button text to 'Clear'
+            config.locale.cancelLabel = gettext('Clear');
+
+            $el.daterangepicker(config);
+            $el.on('cancel.daterangepicker', function() {
+                $el.val(gettext("Show All Dates"));
+
+                // Clear startdate and enddate filters
+                var filter_id = $(this)[0].getAttribute("name");
+                var filter_id_start = filter_id + "-start";
+                var filter_id_end = filter_id + "-end";
+                if (document.getElementById(filter_id_start) && document.getElementById(filter_id_end)) {
+                    document.getElementById(filter_id_start).setAttribute("value", "");
+                    document.getElementById(filter_id_end).setAttribute("value", "");
+                }
+            });
+        }
 
         if (! hasStartAndEndDate){
             $(this).val("");

--- a/corehq/apps/reports/templates/reports/filters/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/datespan.html
@@ -8,6 +8,7 @@
                    id="filter_range"
                    class="date-range-picker form-control report-filter-datespan"
                    value="{{ datespan.startdate|date:'Y-m-d' }} to {{ datespan.enddate|date:'Y-m-d' }}"
+                   placeholder="{% trans "Show All Dates"|escapejs %}"
                    data-init="{% block init_filter %}{% if slug == 'datespan' %}1{% endif %}{% endblock %}"
                    data-separator="{% html_attr separator %}" 
                    data-report-labels="{% html_attr report_labels %}"

--- a/corehq/apps/reports/templates/reports/filters/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/datespan.html
@@ -8,7 +8,6 @@
                    id="filter_range"
                    class="date-range-picker form-control report-filter-datespan"
                    value="{{ datespan.startdate|date:'Y-m-d' }} to {{ datespan.enddate|date:'Y-m-d' }}"
-                   placeholder="{% trans "Show All Dates"|escapejs %}"
                    data-init="{% block init_filter %}{% if slug == 'datespan' %}1{% endif %}{% endblock %}"
                    data-separator="{% html_attr separator %}" 
                    data-report-labels="{% html_attr report_labels %}"

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -35,6 +35,7 @@
     {% initial_page_data 'report_configs' report_configs %}
     {% initial_page_data 'has_datespan' report.has_datespan %}
     {% initial_page_data 'datespan_filters' datespan_filters %}
+    {% initial_page_data 'daterangepicker-show-clear' 'true'%}
     {% if request.datespan %}
         {% initial_page_data 'startdate' datespan.startdate|date:"Y-m-d" %}
         {% initial_page_data 'enddate' datespan.enddate|date:"Y-m-d" %}


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?266238#1446837

Took some of the changes @orangejenny originally made in this PR: https://github.com/dimagi/commcare-hq/pull/18711

This PR changes "Cancel" to "Clear" and adds the ability to clear date filters that have been set.