### PR TITLE
Swap button order so the Enter key triggers 'Next' instead of Back

### DIFF
--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -108,6 +108,7 @@ class HQDeviceValidationForm(DeviceValidationForm):
         self.helper.form_class = 'form form-horizontal'
         self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        # Next button is defined first so the enter key triggers it
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 '',
@@ -115,16 +116,16 @@ class HQDeviceValidationForm(DeviceValidationForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+                    _('Next'),
+                    css_class='btn-primary',
+                    type='submit',
+                ),
+                twbscrispy.StrictButton(
                     _("Back"),
                     css_class='btn-default',
                     type='submit',
                     value='method',
                     name="wizard_goto_step",
-                ),
-                twbscrispy.StrictButton(
-                    _('Next'),
-                    css_class='btn-primary',
-                    type='submit',
                 ),
             )
         )
@@ -138,6 +139,7 @@ class HQTwoFactorMethodForm(MethodForm):
         self.helper.form_class = 'form form-horizontal'
         self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        # Next button is defined first so the enter key triggers it
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 '',
@@ -145,17 +147,17 @@ class HQTwoFactorMethodForm(MethodForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+                    _('Next'),
+                    css_class='btn-primary',
+                    type='submit',
+                ),
+                twbscrispy.StrictButton(
                     _("Back"),
                     css_class='btn-default',
                     type='submit',
                     value='welcome',
                     name="wizard_goto_step",
                 ),
-                twbscrispy.StrictButton(
-                    _('Next'),
-                    css_class='btn-primary',
-                    type='submit',
-                )
             )
         )
 
@@ -168,6 +170,7 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
         self.helper.form_class = 'form form-horizontal'
         self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        # Next button is defined first so the enter key triggers it
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 '',
@@ -175,17 +178,17 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+                    _('Next'),
+                    css_class='btn-primary',
+                    type='submit',
+                ),
+                twbscrispy.StrictButton(
                     _("Back"),
                     css_class='btn-default',
                     type='submit',
                     value='method',
                     name="wizard_goto_step",
                 ),
-                twbscrispy.StrictButton(
-                    _('Next'),
-                    css_class='btn-primary',
-                    type='submit',
-                )
             )
         )
 
@@ -205,6 +208,7 @@ class HQPhoneNumberForm(PhoneNumberForm):
         self.helper.form_class = 'form form-horizontal'
         self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        # Next button is defined first so the enter key triggers it
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 '',
@@ -212,17 +216,17 @@ class HQPhoneNumberForm(PhoneNumberForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+                    _('Next'),
+                    css_class='btn-primary',
+                    type='submit',
+                ),
+                twbscrispy.StrictButton(
                     _("Back"),
                     css_class='btn-default',
                     type='submit',
                     value='method',
                     name="wizard_goto_step",
                 ),
-                twbscrispy.StrictButton(
-                    _('Next'),
-                    css_class='btn-primary',
-                    type='submit',
-                )
             )
         )
 


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?270569
The enter button was triggering 'Back' instead of 'Next' because it was defined first, so I swapped the order of the buttons because, by default, the first button gets triggered on Enter. 
Verified with @Ben-Talbot that this was an acceptable fix UI-wise.