### PR TITLE
prevent duplicate device log entries

### DIFF
--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -51,8 +51,9 @@ def process_device_log(domain, xform):
 
 
 def _process_user_subreport(xform):
+    if UserEntry.objects.filter(xform_id=xform.form_id).exists():
+        return
     userlogs = _get_logs(xform.form_data, 'user_subreport', 'user')
-    UserEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for i, log in enumerate(userlogs):
         to_save.append(UserEntry(
@@ -67,9 +68,10 @@ def _process_user_subreport(xform):
 
 
 def _process_log_subreport(domain, xform):
+    if DeviceReportEntry.objects.filter(xform_id=xform.form_id).exists():
+        return
     form_data = xform.form_data
     logs = _get_logs(form_data, 'log_subreport', 'log')
-    DeviceReportEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for i, log in enumerate(logs):
         if not log:
@@ -110,8 +112,9 @@ def _get_user_info_from_log(domain, log):
 
 
 def _process_user_error_subreport(domain, xform):
+    if UserErrorEntry.objects.filter(xform_id=xform.form_id).exists():
+        return
     errors = _get_logs(xform.form_data, 'user_error_subreport', 'user_error')
-    UserErrorEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for i, error in enumerate(errors):
         # beta versions have 'version', but the name should now be 'app_build'.
@@ -137,8 +140,9 @@ def _process_user_error_subreport(domain, xform):
 
 
 def _process_force_close_subreport(domain, xform):
+    if ForceCloseEntry.objects.filter(xform_id=xform.form_id).exists():
+        return
     force_closures = _get_logs(xform.form_data, 'force_close_subreport', 'force_close')
-    ForceCloseEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for force_closure in force_closures:
         # There are some testing versions going around with an outdated schema

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -111,6 +111,7 @@ def _get_user_info_from_log(domain, log):
 
 def _process_user_error_subreport(domain, xform):
     errors = _get_logs(xform.form_data, 'user_error_subreport', 'user_error')
+    UserErrorEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for i, error in enumerate(errors):
         # beta versions have 'version', but the name should now be 'app_build'.
@@ -137,6 +138,7 @@ def _process_user_error_subreport(domain, xform):
 
 def _process_force_close_subreport(domain, xform):
     force_closures = _get_logs(xform.form_data, 'force_close_subreport', 'force_close')
+    ForceCloseEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for force_closure in force_closures:
         # There are some testing versions going around with an outdated schema

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -53,7 +53,6 @@ def process_device_log(domain, xform):
 def _process_user_subreport(xform):
     userlogs = _get_logs(xform.form_data, 'user_subreport', 'user')
     UserEntry.objects.filter(xform_id=xform.form_id).delete()
-    DeviceReportEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for i, log in enumerate(userlogs):
         to_save.append(UserEntry(
@@ -70,8 +69,7 @@ def _process_user_subreport(xform):
 def _process_log_subreport(domain, xform):
     form_data = xform.form_data
     logs = _get_logs(form_data, 'log_subreport', 'log')
-    logged_in_username = None
-    logged_in_user_id = None
+    DeviceReportEntry.objects.filter(xform_id=xform.form_id).delete()
     to_save = []
     for i, log in enumerate(logs):
         if not log:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -253,11 +253,12 @@ class SubmissionPost(object):
                     submission_type = 'device_log'
                     try:
                         process_device_log(self.domain, instance)
-                    except Exception:
+                    except Exception as e:
                         notify_exception(None, "Error processing device log", details={
                             'xml': self.instance,
                             'domain': self.domain
                         })
+                        e.sentry_capture = False
                         raise
 
                 elif instance.is_duplicate:


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/468129145/

I spent a while trying to figure out how the duplicates ended up in there but didn't get anywhere. I think what might be happening is that the phone times out on the original submission so tries to re-submit but the original submission did get processed. Didn't find any proof of that in the logs though.

Also changed this to rather be a noop if logs for a form are found instead of deleting and re-adding.