### PR TITLE
Update phone location

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -767,8 +767,13 @@ def _unassign_users_from_location(domain, location_id):
     """
     Unset location for all users assigned to that location.
     """
-    from corehq.apps.locations.dbaccessors import get_all_users_by_location
-    for user in get_all_users_by_location(domain, location_id):
+    from corehq.apps.locations.dbaccessors import user_ids_at_locations
+    from corehq.apps.users.models import CommCareUser
+    from dimagi.utils.couch.database import iter_docs
+
+    user_ids = user_ids_at_locations([location_id])
+    for doc in iter_docs(CommCareUser.get_db(), user_ids):
+        user = CommCareUser.wrap(doc)
         if user.is_web_user():
             user.unset_location_by_id(domain, location_id, fall_back_to_next=True)
         elif user.is_commcare_user():

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -21,6 +21,8 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.app_manager.tests.util import TestXmlMixin, extract_xml_partial
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
+from corehq.elastic import refresh_elasticsearch_index
+
 from .util import (
     setup_location_types_with_structure,
     setup_locations_with_structure,
@@ -740,13 +742,32 @@ class ShouldSyncLocationFixturesTest(TestCase):
             should_sync_locations(SyncLog(date=after_save), locations_queryset, self.user.to_ota_restore_user())
         )
 
+        # Set the user's location
+        self.user.set_location(location)
+        after_assign = datetime.utcnow()
+
+        # Should resync if last sync was before location was assigned
+        self.assertTrue(
+            should_sync_locations(SyncLog(date=after_save), locations_queryset, self.user.to_ota_restore_user())
+        )
+        # Should not resync if last sync was after location was assigned
+        self.assertFalse(
+            should_sync_locations(SyncLog(date=after_assign), locations_queryset, self.user.to_ota_restore_user())
+        )
+
         # Delete the location
+        refresh_elasticsearch_index('users')
         location.full_delete()
         after_delete = datetime.utcnow()
 
-        # TODO: Should resync if last sync was after location was saved but before location was deleted
-
-        # TODO: Should not resync if last sync was after location was deleted
+        # Should resync if last sync was before location was deleted
+        self.assertTrue(
+            should_sync_locations(SyncLog(date=after_assign), locations_queryset, self.user.to_ota_restore_user())
+        )
+        # Should not resync if last sync was after location was deleted
+        self.assertFalse(
+            should_sync_locations(SyncLog(date=after_delete), locations_queryset, self.user.to_ota_restore_user())
+        )
 
 
 @mock.patch('corehq.apps.domain.models.Domain.uses_locations', lambda: True)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2019,8 +2019,10 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             self.save()
 
     def _remove_location_from_user(self, location_id):
+        from corehq.apps.fixtures.models import UserFixtureType
         try:
             self.assigned_location_ids.remove(location_id)
+            self.update_fixture_status(UserFixtureType.LOCATION)
         except ValueError:
             notify_exception(None, "Location missing from user", {
                 'user_id': self._id,

--- a/corehq/apps/users/tests/test_location_assignment.py
+++ b/corehq/apps/users/tests/test_location_assignment.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from corehq.apps.commtrack.tests.util import make_loc
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.elastic import refresh_elasticsearch_index
 from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.users.management.commands import add_multi_location_property
@@ -99,6 +100,7 @@ class CCUserLocationAssignmentTest(TestCase):
 
     def test_deleting_location_updates_user(self):
         self.user.reset_locations(self.loc_ids)
+        refresh_elasticsearch_index('users')
         self.loc1.sql_location.full_delete()
         self.loc2.sql_location.full_delete()
         self.assertAssignedLocations([])


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?269773

The first commit fetches and removes all user IDs from the location that is being deleted.

The second commit updates UserFixtureType.LOCATION to ensure the change is reflected in locations fixture on the next sync.