### PR TITLE
hide select2 func inside each block

### DIFF
--- a/corehq/apps/reports/static/reports/js/filters.js
+++ b/corehq/apps/reports/static/reports/js/filters.js
@@ -201,9 +201,11 @@ hqDefine("reports/js/filters", [
             var model = new SMSPhoneNumberFilterViewModel(data.initialValue, data.groups);
             $el.koApplyBindings(model);
         });
-        $('[name=selected_group]').select2({
-            allowClear: true,
-            placeholder: gettext("Select a group"),
+        $('[name=selected_group]').each(function(i, el) {
+            $(el).select2({
+                allowClear: true,
+                placeholder: gettext("Select a group"),
+            });
         });
     };
 


### PR DESCRIPTION
Noticed this started throwing errors on filter pages without that tag. It shouldn't have affected anything, since it's at the end of it's block, but this should fix it for the future