### PR TITLE
ICDS reports tabular reports monthly register download button fix

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -421,9 +421,11 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     };
 
     vm.goToLink = function () {
-        window.open($rootScope.issnip_report_link);
-        vm.downloaded = true;
-        $rootScope.issnip_report_link = '';
+        if (vm.readyToDownload()) {
+            window.open($rootScope.issnip_report_link);
+            vm.downloaded = true;
+            $rootScope.issnip_report_link = '';
+        }
     };
 
 }


### PR DESCRIPTION
Hi @emord,
I have fixed issue on tabular reports monthly register, when during the preparation of report you were able to click download button to cancel the download.