### PR TITLE
Remove migration data when no longer needed

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -76,6 +76,7 @@ from corehq.const import USER_DATE_FORMAT, USER_TIME_FORMAT
 from corehq.apps.analytics.tasks import track_workflow, send_hubspot_form, HUBSPOT_SAVED_APP_FORM_ID
 from corehq.apps.app_manager.feature_support import CommCareFeatureSupportMixin
 from corehq.util.quickcache import quickcache
+from corehq.util.soft_assert import soft_assert
 from corehq.util.timezones.conversions import ServerTime
 from dimagi.utils.couch import CriticalSection
 from django_prbac.exceptions import PermissionDenied

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1486,12 +1486,21 @@ class NavMenuItemMediaMixin(DocumentSchema):
     @property
     def default_media_image(self):
         # For older apps that were migrated: just return the first available item
+        self._assert_unexpected_default_media_call('media_image')
         return self.icon_by_language('')
 
     @property
     def default_media_audio(self):
         # For older apps that were migrated: just return the first available item
+        self._assert_unexpected_default_media_call('media_audio')
         return self.audio_by_language('')
+
+    def _assert_unexpected_default_media_call(self, media_attr):
+        assert media_attr in ('media_image', 'media_audio')
+        media = getattr(self, media_attr)
+        if isinstance(media, dict) and media.keys() == ['default']:
+            _assert = soft_assert(['jschweers' + '@' + 'dimagi.com'])
+            _assert(False, 'Called default_media_image on app with localized media')
 
     def icon_by_language(self, lang, strict=False):
         return self._get_media_by_language('media_image', lang, strict=strict)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1486,12 +1486,12 @@ class NavMenuItemMediaMixin(DocumentSchema):
     @property
     def default_media_image(self):
         # For older apps that were migrated: just return the first available item
-        return self.icon_by_language(strict=False)
+        return self.icon_by_language('')
 
     @property
     def default_media_audio(self):
         # For older apps that were migrated: just return the first available item
-        return self.audio_by_language(strict=False)
+        return self.audio_by_language('')
 
     def icon_by_language(self, lang, strict=False):
         return self._get_media_by_language('media_image', lang, strict=strict)

--- a/corehq/apps/app_manager/tests/data/bulk_app_translation/download/app.json
+++ b/corehq/apps/app_manager/tests/data/bulk_app_translation/download/app.json
@@ -120,7 +120,7 @@
         },
         "show": false
       },
-      "media_image": {"default": "jr://file/commcare/image/module0.png"},
+      "media_image": {"en": "jr://file/commcare/image/module0.png"},
       "parent_select": {
         "active": false,
         "module_id": null,
@@ -248,7 +248,7 @@
           },
           "version": null,
           "no_vellum": false,
-          "media_image": {"default": "jr://file/commcare/image/module0_form0.png"},
+          "media_image": {"en": "jr://file/commcare/image/module0_form0.png"},
           "form_links": [
           ],
           "post_form_workflow": "default",

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/subcase-parent-ref.json
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/subcase-parent-ref.json
@@ -311,7 +311,7 @@
                        }
                    },
                    "version": null,
-                   "media_image": {"default": "jr://file/commcare/image/form_name.png"},
+                   "media_image": {"en": "jr://file/commcare/image/form_name.png"},
                    "show_count": false,
                    "requires": "none",
                    "unique_id": "6d9c76584578567983755edfe9c0bf520f96cfb2"

--- a/corehq/apps/app_manager/tests/data/yesno.json
+++ b/corehq/apps/app_manager/tests/data/yesno.json
@@ -273,7 +273,9 @@
                 }
             ],
             "media_audio": null,
-            "media_image": {"default": "jr://file/commcare_media/image/image.jpeg"},
+            "media_image": {
+                "en": "jr://file/commcare_media/image/image.jpeg"
+            },
             "name": {
                 "en": "Untitled Module"
             },


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?271477

The app in question had media in a state like this, with both a `default` key and regular language keys:
```
In [25]: app.modules[0].media_audio
Out[25]:
{'en': u'',
'som': u'jr://file/commcare/audio/some_path.mp3',
'default': u'jr://file/commcare/audio/some_path.mp3'}
```
The user had deleted the English file, but the path defaulting logic would keep re-inserting the old path and keep the file popping up. I played with changing around the code that generates the default and custom paths, but it's rather intricate; I think it's less risky to just get rid of the `default` key once it's no longer needed. The `default` key can also be problematic if you delete all real multimedia and just have a dict with a value for `default` (HQ sees there's a value, so it generates a suite.xml that expects audio, but the strings files don't contain paths, so you end up with a Localizer error).

It's a bit disconcerting that I don't know how the app got into this state - only old apps (pre- https://github.com/dimagi/commcare-hq/pull/7041, which was 2015 and CC2.21) should be hitting this migration and getting the `default` key. Haven't been able to reproduce locally.

I think this will also fix http://manage.dimagi.com/default.asp?246808

@mkangia / @dannyroberts / @sravfeyn 