### PR TITLE
Add more debugging info to the form page when processing failed

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/form_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/form_data.html
@@ -14,7 +14,7 @@
 {% block page_content %}
     {% if not instance.initial_processing_complete and request|toggle_enabled:'SUPPORT' %}
     <div class="alert alert-error">
-        {% trans "This form's case changes were not processed because of errors that occurred during case processing." %}
+        This form's case changes were not processed because of errors that occurred during case processing: <strong>{{ instance.problem }}</strong>.
     </div>
     {% endif %}
     {% render_form instance domain form_render_options %}


### PR DESCRIPTION
This is only relevant for support (i.e. internal)
