### PR TITLE
Clear translations when deleting a language

### DIFF
--- a/corehq/apps/app_manager/app_translations/__init__.py
+++ b/corehq/apps/app_manager/app_translations/__init__.py
@@ -5,4 +5,5 @@ from .app_translations import (
     expected_bulk_app_sheet_rows,
     update_form_translations,
     escape_output_value,
+    raw_bulk_app_sheet,
 )

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -162,7 +162,7 @@ def process_bulk_app_translation_upload(app, f):
         # This could be added if we want though
         #      (it is not that bad if a user leaves out a row)
 
-        if sheet.worksheet.title == "Modules_and_forms":
+        if re.search(r'modules.and.forms', sheet.worksheet.title, re.I):
             # It's the first sheet
             ms = _process_modules_and_forms_sheet(rows, app)
             msgs.extend(ms)

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import
 from collections import defaultdict, OrderedDict
+import io
 
 import itertools
 from django.utils.encoding import force_text
@@ -20,6 +21,8 @@ from corehq.apps.app_manager.util import save_xform
 from corehq.apps.app_manager.xform import namespaces, WrappedNode, ItextValue, ItextOutput
 from corehq.util.workbook_json.excel import HeaderValueError, WorkbookJSONReader, JSONReaderError, \
     InvalidExcelFileException
+
+from couchexport.export import export_raw
 
 from django.contrib import messages
 from django.utils.translation import ugettext as _
@@ -64,6 +67,11 @@ def process_bulk_app_translation_upload(app, f):
     expected_sheets = {h[0]: h[1] for h in headers}
     processed_sheets = set()
 
+    # The first sheet might be marked with "Modules_and_forms" or
+    # "Modules and Forms" depending on where it comes from
+    def _is_first_sheet(sheet_title):
+        return re.search(r'modules.and.forms', sheet_title, re.I)
+
     try:
         workbook = WorkbookJSONReader(f)
     # todo: HeaderValueError does not belong here
@@ -105,7 +113,7 @@ def process_bulk_app_translation_upload(app, f):
             continue
 
         # CHECK FOR MISSING KEY COLUMN
-        if sheet.worksheet.title == "Modules and Forms":
+        if _is_first_sheet(sheet.worksheet.title):
             # Several columns on this sheet could be used to uniquely identify
             # rows. Using sheet_name for now, but unique_id could also be used.
             if expected_columns[1] not in sheet.headers:
@@ -162,7 +170,7 @@ def process_bulk_app_translation_upload(app, f):
         # This could be added if we want though
         #      (it is not that bad if a user leaves out a row)
 
-        if re.search(r'modules.and.forms', sheet.worksheet.title, re.I):
+        if _is_first_sheet(sheet.worksheet.title):
             # It's the first sheet
             ms = _process_modules_and_forms_sheet(rows, app)
             msgs.extend(ms)
@@ -201,6 +209,15 @@ def _make_modules_and_forms_row(row_type, sheet_name, languages,
     return [item if item is not None else ""
             for item in ([row_type, sheet_name] + languages
                          + media_image + media_audio + [unique_id])]
+
+
+def raw_bulk_app_sheet(app):
+    headers = expected_bulk_app_sheet_headers(app)
+    rows = expected_bulk_app_sheet_rows(app)
+    temp = io.BytesIO()
+    data = [(k, v) for k, v in six.iteritems(rows)]
+    export_raw(headers, data, temp)
+    return temp
 
 
 def expected_bulk_app_sheet_headers(app):

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -557,7 +557,7 @@ def edit_app_langs(request, domain, app_id):
         if old != new:
             app.rename_lang(old, new)
 
-    #remove deleted languages from build profiles
+    # remove deleted languages from build profiles
     new_langs = set(langs)
     deleted = [lang for lang in app.langs if lang not in new_langs]
     for id in app.build_profiles:
@@ -575,6 +575,15 @@ def edit_app_langs(request, domain, app_id):
     replace_all(app.langs, langs)
 
     app.save()
+
+    # Clear out old translations
+    if deleted:
+        from corehq.apps.app_manager.views.translations import jls_download, jls_upload
+        filename = jls_download(request, domain, app_id)
+        jls_upload(domain, app_id, filename)
+        # Get current translations, which won't include deleted languages
+        # Re-apply
+
     return json_response(langs)
 
 

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -88,6 +88,28 @@ def download_bulk_app_translations(request, domain, app_id):
     return export_response(temp, Format.XLS_2007, "bulk_app_translations")
 
 
+@require_can_edit_apps
+def jls_download(request, domain, app_id):
+    app = get_app(domain, app_id)
+    headers = expected_bulk_app_sheet_headers(app)
+    rows = expected_bulk_app_sheet_rows(app)
+    temp = io.BytesIO()
+    data = [(k, v) for k, v in six.iteritems(rows)]
+    export_raw(headers, data, temp)
+    import tempfile
+    fd, path = tempfile.mkstemp()
+    with open(path,'wb') as out:
+        out.write(temp.getvalue())
+    return path
+
+
+def jls_upload(domain, app_id, filename):
+    app = get_app(domain, app_id)
+    with open(filename) as f:
+        msgs = process_bulk_app_translation_upload(app, f)
+    app.save()
+
+
 @no_conflict_require_POST
 @require_can_edit_apps
 @get_file("bulk_upload_file")


### PR DESCRIPTION
Opening for discussion.

https://github.com/dimagi/commcare-hq/pull/18395 made the bulk translation upload clear out translations for languages that have been deleted. This PR adds an automatic download & re-upload when you delete a language. It's not really necessary to create the excel file, but it made the code simpler.

@emord / @mkangia does this sound reasonable? If it does, I'll take a look at making it also clear out multimedia for deleted languages, which is the real reason this came up (ghost multimedia references were causing errors in app preview - see https://github.com/dimagi/commcare-hq/pull/19685).
