### PR TITLE
Fix the Undo button on app deletion

### DIFF
--- a/corehq/apps/app_manager/templates/undo_delete_app.html
+++ b/corehq/apps/app_manager/templates/undo_delete_app.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+
+<form action="{% url 'undo_delete_app' domain record_id %}" method="post">
+    {% csrf_token %}
+    {% trans "You have deleted an application." %}
+    <input type="submit" class="btn btn-default" value="Undo" />
+</form>

--- a/corehq/apps/app_manager/templates/undo_delete_app.html
+++ b/corehq/apps/app_manager/templates/undo_delete_app.html
@@ -3,5 +3,5 @@
 <form action="{% url 'undo_delete_app' domain record_id %}" method="post">
     {% csrf_token %}
     {% trans "You have deleted an application." %}
-    <input type="submit" class="btn btn-default" value="Undo" />
+    <input type="submit" class="btn btn-default" value={% trans "Undo" %}/>
 </form>

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -8,18 +8,14 @@ import zipfile
 from collections import defaultdict
 from wsgiref.util import FileWrapper
 
-from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
+from couchdbkit.exceptions import ResourceConflict
 from django.contrib import messages
 from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseRedirect
-from django.http.request import QueryDict
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.decorators import method_decorator
 from django.utils.http import urlencode as django_urlencode
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
-from django.views import View
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 from django_prbac.utils import has_privilege
 
@@ -34,7 +30,7 @@ from corehq.apps.app_manager.const import (
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_current_app, get_latest_released_app_version
 from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
-    require_can_edit_apps, require_deploy_apps, no_conflict
+    require_can_edit_apps, require_deploy_apps
 from corehq.apps.app_manager.exceptions import IncompatibleFormTypeException, RearrangeError, AppLinkError
 from corehq.apps.app_manager.forms import CopyApplicationForm
 from corehq.apps.app_manager.models import (
@@ -42,10 +38,9 @@ from corehq.apps.app_manager.models import (
     ApplicationBase,
     DeleteApplicationRecord,
     Form,
-    FormNotFoundException,
     Module,
     ModuleNotFoundException,
-    ReportModule, LinkedApplication)
+    ReportModule)
 from corehq.apps.app_manager.models import import_app as import_app_util
 from corehq.apps.app_manager.util import (
     get_settings_values,


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?271883#1468765
Problem: The `undo_delete_app` function has a `@no_conflict_require_POST` decorator, which requires a post request. Before, the undo was an `href` (which will always be a link), so I changed it to a form containing a button that makes a post request.