### PR TITLE
fix icds image deletion task

### DIFF
--- a/custom/icds/tasks.py
+++ b/custom/icds/tasks.py
@@ -155,27 +155,27 @@ if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
         start = datetime.utcnow()
         max_age = start - timedelta(days=90)
         db = get_blob_db()
-        paths = []
-        deleted_attachments = []
 
-        def _get_query(db_name, max_age):
+        def _get_query(db_name, max_age=max_age):
             return XFormAttachmentSQL.objects.using(db_name).filter(
                 content_type='image/jpeg',
                 form__domain='icds-cas',
                 form__received_on__lt=max_age
             )
 
+        run_again = False
         for db_name in get_db_aliases_for_partitioned_query():
-            attachments = _get_query(db_name, max_age)
-            while attachments.exists():
-                for attachment in attachments[:10000]:
-                    paths.append(db.get_path(attachment.blob_id, attachment.blobdb_bucket()))
-                    deleted_attachments.append(attachment.pk)
+            paths = []
+            deleted_attachments = []
+            attachments = _get_query(db_name)
+            for attachment in attachments[:1000]:
+                paths.append(db.get_path(attachment.blob_id, attachment.blobdb_bucket()))
+                deleted_attachments.append(attachment.pk)
 
-                if paths:
-                    db.bulk_delete(paths)
-                    XFormAttachmentSQL.objects.using(db_name).filter(pk__in=deleted_attachments).delete()
-                    paths = []
-                    deleted_attachments = []
+            if paths:
+                db.bulk_delete(paths)
+                XFormAttachmentSQL.objects.using(db_name).filter(pk__in=deleted_attachments).delete()
+                run_again = True
 
-                attachments = _get_query(db_name, max_age)
+        if run_again:
+            delete_old_images.delay()


### PR DESCRIPTION
This task was failing with a error from Boto:
```
ClientError: An error occurred (MalformedXML) when calling the DeleteObjects operation: The XML you provided was not well-formed or did not validate against our published schema
```

After some testing I think it was because the payload was too big. Running with a batch size of 1000 is fine.