### PR TITLE
update DOMAIN_MODULE_MAP with prod's DOMAIN_MODULE_CONFIG

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2246,7 +2246,25 @@ DOMAIN_MODULE_MAP = {
     'care-macf-bangladesh': 'custom.care_pathways',
     'care-macf-ghana': 'custom.care_pathways',
     'pnlppgi': 'custom.pnlppgi',
-    'champ-cameroon': 'custom.champ'
+    'champ-cameroon': 'custom.champ',
+
+    # From DOMAIN_MODULE_CONFIG on production
+    'dca-malawi': 'dca',
+    'eagles-fahu': 'dca',
+    'ews-ghana': 'custom.ewsghana',
+    'ews-ghana-1': 'custom.ewsghana',
+    'ewsghana-6': 'custom.ewsghana',
+    'ewsghana-september': 'custom.ewsghana',
+    'ewsghana-test-4': 'custom.ewsghana',
+    'ewsghana-test-5': 'custom.ewsghana',
+    'ewsghana-test3': 'custom.ewsghana',
+    'ils-gateway': 'custom.ilsgateway',
+    'ils-gateway-training': 'custom.ilsgateway',
+    'ilsgateway-full-test': 'custom.ilsgateway',
+    'ilsgateway-test-2': 'custom.ilsgateway',
+    'ilsgateway-test3': 'custom.ilsgateway',
+    'mvp-mayange': 'mvp',
+    'psi-unicef': 'psi',
 }
 
 CASEXML_FORCE_DOMAIN_CHECK = True


### PR DESCRIPTION
Currently we use a [roundabout process](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/utils.py#L45-L53) to map a domain to it's custom module.  This change moves the values in production's [```DOMAIN_MODULE_CONFIG```](https://www.commcarehq.org/hq/admin/raw_doc/?id=DOMAIN_MODULE_CONFIG) to ```settings.py```.  I'm assuming that collisions with domains with the same name on other environments is unlikely, which we already assume with the domains listed in ```DOMAIN_MODULE_MAP```.

I've confirmed that there are no domains to include from [softlayer](https://india.commcarehq.org/hq/admin/raw_doc/?id=DOMAIN_MODULE_CONFIG), [swiss](https://swiss.commcarehq.org/hq/admin/raw_doc/?id=DOMAIN_MODULE_CONFIG), or [staging](https://staging.commcarehq.org/hq/admin/raw_doc/?id=DOMAIN_MODULE_CONFIG).

After this change gets deployed to prod, I'll delete [```DOMAIN_MODULE_CONFIG```](https://www.commcarehq.org/hq/admin/raw_doc/?id=DOMAIN_MODULE_CONFIG) and simplify ```get_domain_module_map```.