### PR TITLE
patch time and select

### DIFF
--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from gevent import monkey
 import six
-monkey.patch_all(time=False, select=False)
+monkey.patch_all()
 
 import os
 import jsonobject


### PR DESCRIPTION
Script hang without these since 'sh' uses time and select

Note this conflicts with @dannyroberts comment on this commit (though it was 4 years ago): https://github.com/dimagi/commcare-hq/commit/4b0a0a03940091250b266ca7625b067933e2dd7e