### PR TITLE
Handle reminder template context for system user

### DIFF
--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -27,7 +27,7 @@ from corehq.apps.sms.models import (
 from django.conf import settings
 from corehq.apps.app_manager.models import Form
 from corehq.form_processor.utils import is_commcarecase
-from corehq.messaging.templating import _get_obj_template_info
+from corehq.messaging.templating import _get_obj_template_info, _get_system_user_template_info
 from dimagi.utils.couch import CriticalSection
 from django.utils.translation import ugettext_noop
 from dimagi.utils.modules import to_function
@@ -107,6 +107,10 @@ def _add_owner_to_template_params(case, result):
 
 
 def _add_modified_by_to_template_params(case, result):
+    if case.modified_by == 'system':
+        result['case']['last_modified_by'] = _get_system_user_template_info()
+        return
+
     try:
         modified_by = CouchUser.get_by_user_id(case.modified_by)
     except KeyError:

--- a/corehq/apps/reminders/tests/test_message_formatting.py
+++ b/corehq/apps/reminders/tests/test_message_formatting.py
@@ -211,7 +211,8 @@ class MessageTestCase(TestCase):
             expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_web()
             self.assertEqual(get_message_template_params(case), expected_result)
 
-        with create_test_case(self.domain, 'person', 'Joe', owner_id=self.location.location_id, user_id='system') as case:
+        with create_test_case(self.domain, 'person', 'Joe', owner_id=self.location.location_id,
+                user_id='system') as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_location()
             expected_result['case']['last_modified_by'] = _get_system_user_template_info()

--- a/corehq/apps/reminders/tests/test_message_formatting.py
+++ b/corehq/apps/reminders/tests/test_message_formatting.py
@@ -7,6 +7,7 @@ from corehq.apps.reminders.models import Message
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.messaging.templating import _get_system_user_template_info
 from corehq.util.test_utils import create_test_case, set_parent_case
 from datetime import datetime, timedelta
 from django.test import TestCase
@@ -208,6 +209,12 @@ class MessageTestCase(TestCase):
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_location()
             expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_web()
+            self.assertEqual(get_message_template_params(case), expected_result)
+
+        with create_test_case(self.domain, 'person', 'Joe', owner_id=self.location.location_id, user_id='system') as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_location()
+            expected_result['case']['last_modified_by'] = _get_system_user_template_info()
             self.assertEqual(get_message_template_params(case), expected_result)
 
     def test_unicode_template_params(self):

--- a/corehq/messaging/scheduling/tests/test_templating.py
+++ b/corehq/messaging/scheduling/tests/test_templating.py
@@ -235,3 +235,12 @@ class TemplatingTestCase(TestCase):
             self.assertEqual(r.render("Phone: {case.last_modified_by.phone_number}"), "Phone: 999456")
             self.assertEqual(r.render("Unknown: {case.last_modified_by.unknown}"), "Unknown: (?)")
             self.assertEqual(r.render("Unknown: {case.last_modified_by.unknown.unknown}"), "Unknown: (?)")
+
+        with create_test_case(self.domain, 'person', 'Joe', user_id='system') as case:
+            r.set_context_param('case', CaseMessagingTemplateParam(case))
+            self.assertEqual(r.render("Name: {case.last_modified_by.name}"), "Name: System")
+            self.assertEqual(r.render("First Name: {case.last_modified_by.first_name}"), "First Name: System")
+            self.assertEqual(r.render("Last Name: {case.last_modified_by.last_name}"), "Last Name: ")
+            self.assertEqual(r.render("Phone: {case.last_modified_by.phone_number}"), "Phone: ")
+            self.assertEqual(r.render("Unknown: {case.last_modified_by.unknown}"), "Unknown: (?)")
+            self.assertEqual(r.render("Unknown: {case.last_modified_by.unknown.unknown}"), "Unknown: (?)")

--- a/corehq/messaging/templating.py
+++ b/corehq/messaging/templating.py
@@ -34,6 +34,15 @@ def _get_mobile_user_template_info(user):
     }
 
 
+def _get_system_user_template_info():
+    return {
+        'name': 'System',
+        'first_name': 'System',
+        'last_name': '',
+        'phone_number': '',
+    }
+
+
 def _get_group_template_info(group):
     return {
         'name': group.name,
@@ -207,6 +216,10 @@ class CaseMessagingTemplateParam(SimpleDictTemplateParam):
         so we cache the result using a private attribute.
         """
         if self.__last_modified_by_result:
+            return self.__last_modified_by_result
+
+        if self.__case.modified_by == 'system':
+            self.__last_modified_by_result = SimpleDictTemplateParam(_get_system_user_template_info())
             return self.__last_modified_by_result
 
         try:


### PR DESCRIPTION
Currently when referencing `{case.last_modified_by.name}` in a reminder message, it renders as "(?)" if the system was the case's last submitting user because it can't find the user with the system user id. This handles the system user in the template context so that we have values to render.

@millerdev 