### PR TITLE
Appcues: don't use event properties

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -1,22 +1,22 @@
 /* globals hqDefine, hqImport, define, require, form_tour_start, WS4Redis, django */
 hqDefine("app_manager/js/forms/form_designer", function() {
     var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
+        appcues = hqImport('analytix/js/appcues'),
         FORM_TYPES = {
             REGISTRATION: "registration",
             SURVEY: "survey",
             FOLLOWUP: "followup",
         },
-        formType = function () {
+        trackFormEvent = function (eventType) {
+            var formType = FORM_TYPES.FOLLOWUP;
             if (initial_page_data("is_registration_form")) {
-                return FORM_TYPES.REGISTRATION;
+                formType = FORM_TYPES.REGISTRATION;
             }
             if (initial_page_data("is_survey")) {
-                return FORM_TYPES.SURVEY;
+                formType = FORM_TYPES.SURVEY;
             }
-            return FORM_TYPES.FOLLOWUP;
+            appcues.trackEvent(eventType + " (" + formType + ")");
         };
-
-    var appcues = hqImport('analytix/js/appcues');
 
     $(function() {
         var VELLUM_OPTIONS = _.extend({}, initial_page_data("vellum_options"), {
@@ -66,12 +66,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
                 if (initial_page_data("days_since_created") === 0) {
                     hqImport('analytix/js/kissmetrix').track.event('Saved the Form Builder within first 24 hours');
                 }
-                appcues.trackEvent(
-                    appcues.EVENT_TYPES.FORM_SAVE, {
-                        formType: formType(),
-                        previewOpen: hqImport("app_manager/js/preview_app").isOpen(),
-                    }
-                );
+                trackFormEvent(appcues.EVENT_TYPES.FORM_SAVE);
             },
             onReady: function() {
                 if (initial_page_data('vellum_debug') === 'dev') {
@@ -94,17 +89,10 @@ hqDefine("app_manager/js/forms/form_designer", function() {
                 }
                 $("#formdesigner").vellum("get").data.core.form.on("question-create", function() {
                     kissmetrixTrack();
-                    var appcues = hqImport('analytix/js/appcues');
-                    appcues.trackEvent(
-                        appcues.EVENT_TYPES.QUESTION_CREATE, { formType: formType() }
-                    );
+                    trackFormEvent(appcues.EVENT_TYPES.QUESTION_CREATE);
                 });
 
-                appcues.trackEvent(
-                    appcues.EVENT_TYPES.FORM_LOADED, {
-                        formType: formType(),
-                    }
-                );
+                trackFormEvent(appcues.EVENT_TYPES.FORM_LOADED);
             },
         });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -11,8 +11,7 @@ hqDefine("app_manager/js/forms/form_designer", function() {
             var formType = FORM_TYPES.FOLLOWUP;
             if (initial_page_data("is_registration_form")) {
                 formType = FORM_TYPES.REGISTRATION;
-            }
-            if (initial_page_data("is_survey")) {
+            } else if (initial_page_data("is_survey")) {
                 formType = FORM_TYPES.SURVEY;
             }
             appcues.trackEvent(eventType + " (" + formType + ")");


### PR DESCRIPTION
Discovered that https://docs.appcues.com/article/156-event-targeting says "Targeting based on event attribute values **may** be added in a future version of Appcues." (emphasis mine) ...so we can't base flows on properties and need to instead do separate events.

Talked with Marshall and agreed to get rid of the app preview open/close property altogether rather than have even more unique events.

@jmtroth0 can you review? I'd like to get this in today's deploy if possible.