### PR TITLE
Basic workflow management for OpenMRS

### DIFF
--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,0 +1,162 @@
+from django.test import SimpleTestCase
+from mock import Mock
+
+from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, task, workflow_task
+
+
+class TaskTests(SimpleTestCase):
+
+    def test_task_run_func_args_kwargs(self):
+        sing = Mock()
+        func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
+
+        self.assertEqual(func_task.func, sing)
+        self.assertEqual(func_task.args, ('Brave Sir Robin',))
+        self.assertEqual(func_task.kwargs, {'what': 'ran', 'where': 'away'})
+        sing.assert_not_called()
+
+        func_task.run_func()
+        sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
+
+
+    def test_task_run(self):
+        class SirRobin(Task):
+            def run(self):
+                pass
+
+        sir_robin = SirRobin(None, 'fled', tail='turned', where='away')
+        sir_robin.run = Mock()
+
+        sir_robin.run_func()
+        sir_robin.run.assert_called_with('fled', tail='turned', where='away')
+
+
+class WorkflowTests(SimpleTestCase):
+
+    def test_workflow_runs(self):
+        func1 = Mock()
+        func2 = Mock()
+        workflow_queue = [
+            WorkflowTask(None, None, func1),
+            WorkflowTask(None, None, func2),
+        ]
+
+        success, errors = execute_workflow(workflow_queue)
+        self.assertTrue(success)
+        self.assertEqual(errors, [])
+        func1.assert_called()
+        func2.assert_called()
+        self.assertEqual(workflow_queue, [])
+
+    def test_rollback_runs(self):
+        func1 = Mock()
+        black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
+        func3 = Mock()
+
+        rollback_func1 = Mock()
+        rollback_black_knight = Mock(side_effect=ValueError("Come back here and take what's comin' ta ya!"))
+        rollback_func3 = Mock()
+
+        workflow_queue = [
+            WorkflowTask(Task(rollback_func1), None, func1),
+            WorkflowTask(Task(rollback_black_knight), None, black_knight),
+            WorkflowTask(Task(rollback_func3), None, func3),
+        ]
+
+        success, errors = execute_workflow(workflow_queue)
+        self.assertFalse(success)
+        self.assertEqual(errors, [
+            "Workflow failed: ValueError: 'Tis but a flesh wound",
+            "Rollback error: ValueError: Come back here and take what's comin' ta ya!",
+        ])
+
+        # Check workflow halted on failure
+        func1.assert_called()
+        black_knight.assert_called()
+        func3.assert_not_called()
+
+        # Check rollback continued after error
+        rollback_black_knight.assert_called()
+        rollback_func1.assert_called()
+
+        # Last task should still be languishing in the workflow queue
+        self.assertEqual(len(workflow_queue), 1)
+        self.assertEqual(workflow_queue[0].func, func3)
+
+    def test_pass_result_as(self):
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        workflow_queue = [
+            WorkflowTask(Task(delete_foo), 'foo_id', create_foo),
+            WorkflowTask(None, None, fail),
+        ]
+        success, errors = execute_workflow(workflow_queue)
+
+        self.assertFalse(success)
+        create_foo.assert_called()
+        delete_foo.assert_called_with(foo_id=5)
+
+
+class DecoratorTests(SimpleTestCase):
+
+    def test_task_decorator(self):
+        do_something = Mock()
+
+        @task
+        def get_foo_task(param1, param2):
+            do_something(param1, where=param2)
+
+        foo_task = get_foo_task('ran', param2='away')
+
+        self.assertIsInstance(foo_task, Task)
+        self.assertEqual(foo_task.args, ('ran',))
+        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
+        do_something.assert_not_called()
+
+        foo_task.run_func()
+        do_something.assert_called_with('ran', where='away')
+
+    def test_workflow_task_decorator(self):
+        do_something = Mock()
+
+        @workflow_task()
+        def get_foo_task(param1, param2):
+            do_something(param1, where=param2)
+
+        foo_task = get_foo_task('ran', param2='away')
+
+        self.assertIsInstance(foo_task, WorkflowTask)
+        self.assertIsNone(foo_task.rollback_task)
+        self.assertIsNone(foo_task.pass_result_as)
+        self.assertEqual(foo_task.args, ('ran',))
+        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
+        do_something.assert_not_called()
+
+        foo_task.run_func()
+        do_something.assert_called_with('ran', where='away')
+
+    def test_workflow_task_decorator_with_rollback(self):
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        @task
+        def get_delete_foo_task(foo_id):
+            delete_foo(foo_id)
+
+        @workflow_task(rollback_task=get_delete_foo_task(), pass_result_as='foo_id')
+        def get_create_foo_task(foo_name):
+            foo_id = create_foo(foo_name)
+            return foo_id
+
+        workflow_queue = [
+            get_create_foo_task('FOO'),
+            workflow_task()(fail),
+        ]
+        success, errors = execute_workflow(workflow_queue)
+
+        self.assertFalse(success)
+        create_foo.assert_called_with('FOO')
+        delete_foo.assert_called_with(5)

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.test import SimpleTestCase
 from mock import Mock
 
@@ -7,6 +8,9 @@ from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow,
 class TaskTests(SimpleTestCase):
 
     def test_task_run_func_args_kwargs(self):
+        """
+        Task.run_func should call func with the args and kwargs that the task was instantiated with.
+        """
         sing = Mock()
         func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
 
@@ -18,8 +22,10 @@ class TaskTests(SimpleTestCase):
         func_task.run_func()
         sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
 
-
     def test_task_run(self):
+        """
+        Task.run should be called if the task was not instantiated with func
+        """
         class SirRobin(Task):
             def run(self):
                 pass
@@ -34,6 +40,9 @@ class TaskTests(SimpleTestCase):
 class WorkflowTests(SimpleTestCase):
 
     def test_workflow_runs(self):
+        """
+        If no errors occur, a workflow should be executed to completion
+        """
         func1 = Mock()
         func2 = Mock()
         workflow_queue = [
@@ -49,6 +58,9 @@ class WorkflowTests(SimpleTestCase):
         self.assertEqual(workflow_queue, [])
 
     def test_rollback_runs(self):
+        """
+        If an error is encountered, the workflow should stop, and the rollback should run to completion
+        """
         func1 = Mock()
         black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
         func3 = Mock()
@@ -84,6 +96,10 @@ class WorkflowTests(SimpleTestCase):
         self.assertEqual(workflow_queue[0].func, func3)
 
     def test_pass_result_as(self):
+        """
+        WorkflowTask.pass_result_as should pass the result of run_func to its rollback task using the given
+        parameter name.
+        """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))
@@ -102,6 +118,9 @@ class WorkflowTests(SimpleTestCase):
 class DecoratorTests(SimpleTestCase):
 
     def test_task_decorator(self):
+        """
+        The `@task` decorator should return a function that creates a Task instance when it is executed
+        """
         do_something = Mock()
 
         @task
@@ -119,6 +138,9 @@ class DecoratorTests(SimpleTestCase):
         do_something.assert_called_with('ran', where='away')
 
     def test_workflow_task_decorator(self):
+        """
+        The `@workflow_task` decorator should return a function that creates a WorkflowTask instance
+        """
         do_something = Mock()
 
         @workflow_task()
@@ -138,6 +160,9 @@ class DecoratorTests(SimpleTestCase):
         do_something.assert_called_with('ran', where='away')
 
     def test_workflow_task_decorator_with_rollback(self):
+        """
+        The @workflow_task decorator should be able to set `rollback_task` and `pass_result_as`
+        """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -59,6 +59,7 @@ class WorkflowTask(Task):
 
 
 def task(func):
+    # Doesn't use `@wraps` because `call()` doesn't execute func; it returns a Task instantiated with func
     def call(*args, **kwargs):
         instance = Task(func, *args, **kwargs)
         return instance

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import
+
+
+class Task(object):
+    """
+    Tasks are instantiated with a function to run, and args and kwargs that must be passed to it.
+
+    Instances of this class are used for rollback.
+
+    If a task is not instantiated with a function, it must implement a run() method. It will be passed the args
+    and kwargs that the class was instantiated with.
+    """
+
+    def __init__(self, func=None, *args, **kwargs):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def run_func(self):
+        if self.func:
+            return self.func(*self.args, **self.kwargs)
+        else:
+            return self.run(*self.args, **self.kwargs)
+
+    def run(self, *args, **kwargs):
+        raise NotImplementedError('Task.func must be set, or Task.run() must be defined.')
+
+
+class WorkflowTask(Task):
+    """
+    Extends rollback tasks. Workflow tasks can define subtasks, which will be prepended to the workflow queue
+    after the task is run.
+
+    If a workflow task is not instantiated with a rollback task, either it must implement its own
+    get_rollback_task() method, or it will be assumed that the task does not cause a change of state (probably
+    because its subtasks do).
+    """
+
+    def __init__(self, rollback_task=None, pass_result_as=None, func=None, *args, **kwargs):
+        """
+        Instantiate WorkflowTask
+
+        :param rollback_task: A Task instance
+        :param pass_result_as: A parameter name, to be passed as a kwarg to rollback_task
+        :param func: The function this task must run
+        :param args: Arguments to pass to func or self.run()
+        :param kwargs: Keyword arguments to pass to func or self.run()
+        """
+        self.rollback_task = rollback_task
+        self.pass_result_as = pass_result_as
+        super(WorkflowTask, self).__init__(func, *args, **kwargs)
+        self._subtasks = []
+
+    def get_rollback_task(self):
+        return self.rollback_task
+
+    def get_subtasks(self):
+        return self._subtasks
+
+
+def task(func):
+    def call(*args, **kwargs):
+        instance = Task(func, *args, **kwargs)
+        return instance
+    return call
+
+
+def workflow_task(rollback_task=None, pass_result_as=None):
+    def decorate(func):
+        def call(*args, **kwargs):
+            instance = WorkflowTask(rollback_task, pass_result_as, func, *args, **kwargs)
+            return instance
+        return call
+    return decorate
+
+
+def execute_workflow(workflow_queue):
+    """
+    We use two lists to execute a workflow:
+
+    1. The (given) workflow queue, where tasks are pulled off the front and run, until an error is encountered.
+    2. A rollback stack, where each workflow task appends a reverse task to undo its action, to be run if the
+       workflow fails.
+
+    """
+    success = True
+    errors = []
+    rollback_stack = []
+
+    try:
+        while workflow_queue:
+            workflow_task = workflow_queue.pop(0)
+            rollback_task = workflow_task.get_rollback_task()
+            if rollback_task:
+                rollback_stack.append(rollback_task)
+            # Note: The rollback task is added before the workflow task is run. This offers developers an
+            # opportunity to try to fix whatever the workflow task might have broken before it failed.
+            # ...
+            # BUT if the workflow task needs to make more than one change, it should split them up into subtasks.
+            result = workflow_task.run_func()
+            if workflow_task.pass_result_as and rollback_task:
+                # Useful for rollback tasks that must delete something created by the workflow task
+                rollback_task.kwargs.update({workflow_task.pass_result_as: result})
+            for i, subtask in enumerate(workflow_task.get_subtasks()):
+                workflow_queue.insert(i, subtask)
+
+    except Exception as workflow_error:
+        success = False
+        errors.append('Workflow failed: {name}: {message}'.format(
+            name=workflow_error.__class__.__name__, message=str(workflow_error)
+        ))
+        for rollback_task in reversed(rollback_stack):
+            try:
+                rollback_task.run_func()
+            except Exception as rollback_error:
+                errors.append('Rollback error: {name}: {message}'.format(
+                    name=rollback_error.__class__.__name__, message=str(rollback_error)
+                ))
+
+    return success, errors


### PR DESCRIPTION
This PR builds on PR #19756 -- only the last two commits are added.

A **workflow queue** is a list of **workflow tasks**. Each workflow task is instantiated with a function. For our usecase the function is generally an API call that makes a change to OpenMRS.

The workflow task can also have an opposite task -- a rollback function to delete whatever the original function created, or reset whatever the original function updated.

Workflow tasks can prepend subtasks to the queue. This offers a way to break big tasks down into smaller tasks.

The workflow queue is run with `execute_workflow()`.

Before each task is executed, its corresponding rollback is added to a rollback stack. If the task fails, the workflow is halted, and then each rollback task is picked off the stack. Unlike workflow tasks, if a rollback task fails rollback will continue until all rollback tasks have been run.

The module also has decorators to make it easier to turn a function into a Task.

@dannyroberts buddy @nickpell cc @snopoke 
