### PR TITLE
Implement rollback for OpenMRS

### DIFF
--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -19,7 +19,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     create_person_attribute,
     delete_person_attribute_task,
 )
-from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, workflow_task
+from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow
 from corehq.motech.utils import pformat_json
 from dimagi.utils.parsing import string_to_utc_datetime
 

--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -20,6 +20,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     delete_person_attribute_task,
 )
 from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, workflow_task
+from corehq.motech.utils import pformat_json
 from dimagi.utils.parsing import string_to_utc_datetime
 
 
@@ -46,11 +47,10 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
 
     success, errors = execute_workflow(workflow_queue)
     if success:
-        return OpenmrsResponse(200, 'OK')
+        return OpenmrsResponse(200, 'OK', '')
     else:
         logger.error('Errors encountered sending OpenMRS data: %s', errors)
-        # TODO: Do something more useful with errors, like OpenmrsResponse.content or something
-        return OpenmrsResponse(400, 'Bad Request')
+        return OpenmrsResponse(400, 'Bad Request', pformat_json(errors))
 
 
 class SyncPersonAttrsTask(WorkflowTask):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -14,7 +14,7 @@ from corehq.apps.users.cases import get_wrapped_owner, get_owner_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
-from corehq.motech.openmrs.workflow import WorkflowTask, Task
+from corehq.motech.openmrs.workflow import WorkflowTask, task
 from corehq.motech.utils import pformat_json
 
 
@@ -110,6 +110,10 @@ class Requests(object):
     def get_url(self, uri):
         return '/'.join((self.base_url.rstrip('/'), uri.lstrip('/')))
 
+    def delete(self, uri, **kwargs):
+        return self.requests.delete(self.get_url(uri),
+                                    auth=(self.username, self.password), **kwargs)
+
     def get(self, uri, *args, **kwargs):
         return self.send_request(self.requests.get, self.get_url(uri), *args,
                                  auth=(self.username, self.password), **kwargs)
@@ -185,6 +189,13 @@ def create_person_attribute(requests, person_uuid, attribute_type_uuid, value):
     ).json()
 
 
+@task
+def delete_person_attribute_task(requests, person_uuid, attribute_uuid):
+    return requests.delete('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
+        person_uuid=person_uuid, attribute_uuid=attribute_uuid
+    )).json()
+
+
 def update_person_attribute(requests, person_uuid, attribute_uuid, attribute_type_uuid, value):
     return requests.post('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
         person_uuid=person_uuid, attribute_uuid=attribute_uuid), json={
@@ -225,17 +236,18 @@ class CreateVisitTask(WorkflowTask):
         self._subtasks.append(
             CreateEncounterTask(
                 None,
+                delete_encounter_task(requests),  # `encounter_uuid` doesn't need to be passed yet.
+                'encounter_uuid',                     # execute_workflow() sets the rollback task's kwargs later
                 requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
                 openmrs_form, visit_uuid, location_uuid,
-                rollback_task=Task(delete_encounter, requests),
-                pass_result_as='encounter_uuid',
             )
         )
 
         return visit_uuid
 
 
-def delete_visit(requests, visit_uuid):
+@task
+def delete_visit_task(requests, visit_uuid):
     return requests.delete('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
 
 
@@ -271,16 +283,17 @@ class CreateEncounterTask(WorkflowTask):
                 self._subtasks.append(
                     WorkflowTask(
                         create_obs,
+                        delete_obs_task(requests),
+                        'obs_uuid',
                         requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid,
-                        rollback_task=Task(delete_obs, requests),
-                        pass_result_as='obs_uuid'
                     )
                 )
 
         return encounter_uuid
 
 
-def delete_encounter(requests, encounter_uuid):
+@task
+def delete_encounter_task(requests, encounter_uuid):
     return requests.delete('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
 
 
@@ -298,7 +311,8 @@ def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_dateti
     return response.json()['uuid']
 
 
-def delete_obs(requests, obs_uuid):
+@task
+def delete_obs_task(requests, obs_uuid):
     return requests.delete('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
 
 
@@ -365,6 +379,27 @@ def update_person_name(requests, info, openmrs_config, person_uuid, name_uuid):
         )
 
 
+@task
+def rollback_person_name_task(requests, person, openmrs_config):
+    """
+    Reset the name changes previously set by `update_person_name()` back to their original values, which are
+    taken from the patient details that OpenMRS returned at the start of the workflow.
+    """
+    properties = {
+        property_: person['preferredName'][property_]
+        for property_ in openmrs_config.case_config.person_preferred_name.keys()
+        if property_ in NAME_PROPERTIES
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
+                person_uuid=person['uuid'],
+                name_uuid=person['preferredName']['uuid'],
+            ),
+            json=properties,
+        )
+
+
 def create_person_address(requests, info, openmrs_config, person_uuid):
     properties = {
         property_: value_source.get_value(info)
@@ -378,6 +413,16 @@ def create_person_address(requests, info, openmrs_config, person_uuid):
         )
 
 
+@task
+def delete_person_address_task(requests, person, address_uuid):
+    requests.post_with_raise(
+        '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+            person_uuid=person['uuid'],
+            address_uuid=address_uuid,
+        )
+    )
+
+
 def update_person_address(requests, info, openmrs_config, person_uuid, address_uuid):
     properties = {
         property_: value_source.get_value(info)
@@ -389,6 +434,23 @@ def update_person_address(requests, info, openmrs_config, person_uuid, address_u
             '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
                 person_uuid=person_uuid,
                 address_uuid=address_uuid,
+            ),
+            json=properties,
+        )
+
+
+@task
+def rollback_person_address_task(requests, person, openmrs_config):
+    properties = {
+        property_: person['preferredAddress'][property_]
+        for property_ in openmrs_config.case_config.person_preferred_address.keys()
+        if property_ in ADDRESS_PROPERTIES
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+                person_uuid=person['uuid'],
+                address_uuid=person['preferredAddress']['uuid'],
             ),
             json=properties,
         )
@@ -446,7 +508,12 @@ def update_person_properties(requests, info, openmrs_config, person_uuid):
         )
 
 
-def rollback_person_properties(requests, person, openmrs_config):
+@task
+def rollback_person_properties_task(requests, person, openmrs_config):
+    """
+    Reset the properties previously set by `update_person_properties()` back to their original values, which are
+    taken from the patient details that OpenMRS returned at the start of the workflow.
+    """
     properties = {
         property_: person[property_]
         for property_ in openmrs_config.case_config.person_properties.keys()

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -114,6 +114,17 @@ class Requests(object):
         return self.requests.delete(self.get_url(uri),
                                     auth=(self.username, self.password), **kwargs)
 
+    def delete_with_raise(self, uri, **kwargs):
+        response = self.delete(uri, **kwargs)
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            err_request, err_response = parse_request_exception(err)
+            logger.error('Request: ', err_request)
+            logger.error('Response: ', err_response)
+            raise
+        return response
+
     def get(self, uri, *args, **kwargs):
         return self.send_request(self.requests.get, self.get_url(uri), *args,
                                  auth=(self.username, self.password), **kwargs)
@@ -190,10 +201,12 @@ def create_person_attribute(requests, person_uuid, attribute_type_uuid, value):
 
 
 @task
-def delete_person_attribute_task(requests, person_uuid, attribute_uuid):
-    return requests.delete('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
-        person_uuid=person_uuid, attribute_uuid=attribute_uuid
-    )).json()
+def delete_person_attribute_task(requests, person_uuid, attribute_uuid=None):
+    # if attribute_uuid is not set, it would be because the workflow task to create the attribute failed
+    if attribute_uuid:
+        return requests.delete_with_raise('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
+            person_uuid=person_uuid, attribute_uuid=attribute_uuid
+        )).json()
 
 
 def update_person_attribute(requests, person_uuid, attribute_uuid, attribute_type_uuid, value):
@@ -247,8 +260,9 @@ class CreateVisitTask(WorkflowTask):
 
 
 @task
-def delete_visit_task(requests, visit_uuid):
-    return requests.delete('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
+def delete_visit_task(requests, visit_uuid=None):
+    if visit_uuid:
+        return requests.delete_with_raise('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
 
 
 class CreateEncounterTask(WorkflowTask):
@@ -293,8 +307,9 @@ class CreateEncounterTask(WorkflowTask):
 
 
 @task
-def delete_encounter_task(requests, encounter_uuid):
-    return requests.delete('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
+def delete_encounter_task(requests, encounter_uuid=None):
+    if encounter_uuid:
+        requests.delete_with_raise('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
 
 
 def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid=None):
@@ -312,8 +327,9 @@ def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_dateti
 
 
 @task
-def delete_obs_task(requests, obs_uuid):
-    return requests.delete('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
+def delete_obs_task(requests, obs_uuid=None):
+    if obs_uuid:
+        return requests.delete_with_raise('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
 
 
 def search_patients(requests, search_string):
@@ -370,13 +386,13 @@ def update_person_name(requests, info, openmrs_config, person_uuid, name_uuid):
         if property_ in NAME_PROPERTIES and value_source.get_value(info)
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
                 person_uuid=person_uuid,
                 name_uuid=name_uuid,
             ),
             json=properties,
-        )
+        ).json()
 
 
 @task
@@ -391,13 +407,13 @@ def rollback_person_name_task(requests, person, openmrs_config):
         if property_ in NAME_PROPERTIES
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
                 person_uuid=person['uuid'],
                 name_uuid=person['preferredName']['uuid'],
             ),
             json=properties,
-        )
+        ).json()
 
 
 def create_person_address(requests, info, openmrs_config, person_uuid):
@@ -407,20 +423,21 @@ def create_person_address(requests, info, openmrs_config, person_uuid):
         if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}/address/'.format(person_uuid=person_uuid),
             json=properties,
-        )
+        ).json()['uuid']
 
 
 @task
-def delete_person_address_task(requests, person, address_uuid):
-    requests.post_with_raise(
-        '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
-            person_uuid=person['uuid'],
-            address_uuid=address_uuid,
-        )
-    )
+def delete_person_address_task(requests, person, address_uuid=None):
+    if address_uuid:
+        return requests.delete_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+                person_uuid=person['uuid'],
+                address_uuid=address_uuid,
+            )
+        ).json()
 
 
 def update_person_address(requests, info, openmrs_config, person_uuid, address_uuid):
@@ -430,13 +447,13 @@ def update_person_address(requests, info, openmrs_config, person_uuid, address_u
         if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
                 person_uuid=person_uuid,
                 address_uuid=address_uuid,
             ),
             json=properties,
-        )
+        ).json()
 
 
 @task
@@ -447,13 +464,13 @@ def rollback_person_address_task(requests, person, openmrs_config):
         if property_ in ADDRESS_PROPERTIES
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
                 person_uuid=person['uuid'],
                 address_uuid=person['preferredAddress']['uuid'],
             ),
             json=properties,
-        )
+        ).json()
 
 
 def get_subresource_instances(requests, person_uuid, subresource):
@@ -502,10 +519,10 @@ def update_person_properties(requests, info, openmrs_config, person_uuid):
         if property_ in PERSON_PROPERTIES and value_source.get_value(info)
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person_uuid),
             json=properties
-        )
+        ).json()
 
 
 @task
@@ -520,10 +537,10 @@ def rollback_person_properties_task(requests, person, openmrs_config):
         if property_ in PERSON_PROPERTIES
     }
     if properties:
-        requests.post_with_raise(
+        return requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person['uuid']),
             json=properties
-        )
+        ).json()
 
 
 class PatientSearchParser(object):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -83,7 +83,7 @@ ADDRESS_PROPERTIES = (
 PERSON_UUID_IDENTIFIER_TYPE_ID = 'uuid'
 
 
-OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason')
+OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason content')
 
 
 class Requests(object):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -15,7 +15,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.workflow import WorkflowTask
-from corehq.motech.utils import pformat_json, unpack_args
+from corehq.motech.utils import pformat_json
 
 PERSON_PROPERTIES = (
     'gender',
@@ -223,46 +223,38 @@ def server_datetime_to_openmrs_timestamp(dt):
     return openmrs_timestamp
 
 
-class CreateVisitTask(WorkflowTask):
+def create_visit(requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
+                 openmrs_form, visit_type, location_uuid=None):
+    subtasks = []
+    start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
+    stop_datetime = server_datetime_to_openmrs_timestamp(
+        visit_datetime + timedelta(days=1) - timedelta(seconds=1)
+    )
 
-    def run(self):
-        self.func_kwargs.setdefault('location_uuid', None)
-        (requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
-         openmrs_form, visit_type, location_uuid) = unpack_args(
-            'requests person_uuid provider_uuid visit_datetime values_for_concept encounter_type openmrs_form '
-            'visit_type location_uuid', *self.func_args, **self.func_kwargs
+    visit = {
+        'patient': person_uuid,
+        'visitType': visit_type,
+        'startDatetime': start_datetime,
+        'stopDatetime': stop_datetime,
+    }
+    if location_uuid:
+        visit['location'] = location_uuid
+    response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
+    visit_uuid = response.json()['uuid']
+
+    subtasks.append(
+        WorkflowTask(
+            func=create_encounter,
+            func_args=(requests, person_uuid, provider_uuid, start_datetime, values_for_concept,
+                       encounter_type, openmrs_form, visit_uuid, location_uuid),
+            rollback_func=delete_encounter,
+            rollback_args=(requests, ),
+            returns_result=True,
+            returns_subtasks=True
         )
+    )
 
-        subtasks = []
-        start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
-        stop_datetime = server_datetime_to_openmrs_timestamp(
-            visit_datetime + timedelta(days=1) - timedelta(seconds=1)
-        )
-
-        visit = {
-            'patient': person_uuid,
-            'visitType': visit_type,
-            'startDatetime': start_datetime,
-            'stopDatetime': stop_datetime,
-        }
-        if location_uuid:
-            visit['location'] = location_uuid
-        response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
-        visit_uuid = response.json()['uuid']
-        self.rollback_args.append(visit_uuid)
-
-        subtasks.append(
-            CreateEncounterTask(
-                func=None,
-                func_args=(requests, person_uuid, provider_uuid, start_datetime, values_for_concept,
-                           encounter_type, openmrs_form, visit_uuid, location_uuid),
-                rollback_func=delete_encounter,
-                rollback_args=(requests, ),
-                pass_result=True,
-            )
-        )
-
-        return subtasks
+    return visit_uuid, subtasks
 
 
 def delete_visit(requests, visit_uuid=None):
@@ -270,47 +262,37 @@ def delete_visit(requests, visit_uuid=None):
         return requests.delete_with_raise('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
 
 
-class CreateEncounterTask(WorkflowTask):
+def create_encounter(requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
+                     openmrs_form, visit_uuid, location_uuid=None):
+    subtasks = []
+    encounter = {
+        'encounterDatetime': start_datetime,
+        'patient': person_uuid,
+        'form': openmrs_form,
+        'encounterType': encounter_type,
+        'visit': visit_uuid,
+    }
+    if location_uuid:
+        encounter['location'] = location_uuid
+    if provider_uuid:
+        encounter['provider'] = provider_uuid
+    response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
+    encounter_uuid = response.json()['uuid']
 
-    def run(self):
-        self.func_kwargs.setdefault('location_uuid', None)
-        (requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type, openmrs_form, 
-         visit_uuid, location_uuid) = unpack_args(
-            'requests person_uuid provider_uuid start_datetime values_for_concept encounter_type openmrs_form '
-            'visit_uuid location_uuid', *self.func_args, **self.func_kwargs
-        )
-
-        subtasks = []
-        encounter = {
-            'encounterDatetime': start_datetime,
-            'patient': person_uuid,
-            'form': openmrs_form,
-            'encounterType': encounter_type,
-            'visit': visit_uuid,
-        }
-        if location_uuid:
-            encounter['location'] = location_uuid
-        if provider_uuid:
-            encounter['provider'] = provider_uuid
-        response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
-        encounter_uuid = response.json()['uuid']
-
-        self.rollback_args.append(encounter_uuid)
-
-        for concept_uuid, values in values_for_concept.items():
-            for value in values:
-                subtasks.append(
-                    WorkflowTask(
-                        func=create_obs,
-                        func_args=(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value,
-                                   location_uuid),
-                        rollback_func=delete_obs,
-                        rollback_args=(requests, ),
-                        pass_result=True,
-                    )
+    for concept_uuid, values in values_for_concept.items():
+        for value in values:
+            subtasks.append(
+                WorkflowTask(
+                    func=create_obs,
+                    func_args=(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value,
+                               location_uuid),
+                    rollback_func=delete_obs,
+                    rollback_args=(requests, ),
+                    returns_result=True,
                 )
+            )
 
-        return subtasks
+    return encounter_uuid, subtasks
 
 
 def delete_encounter(requests, encounter_uuid=None):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -392,10 +392,21 @@ def update_person_properties(requests, info, openmrs_config, person_uuid):
         if property_ in PERSON_PROPERTIES and value_source.get_value(info)
     }
     if properties:
-        for p in properties:
-            assert p in PERSON_PROPERTIES
         requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person_uuid),
+            json=properties
+        )
+
+
+def rollback_person_properties(requests, person, openmrs_config):
+    properties = {
+        property_: person[property_]
+        for property_ in openmrs_config.case_config.person_properties.keys()
+        if property_ in PERSON_PROPERTIES
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person['uuid']),
             json=properties
         )
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -14,9 +14,8 @@ from corehq.apps.users.cases import get_wrapped_owner, get_owner_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
-from corehq.motech.openmrs.workflow import WorkflowTask, task
-from corehq.motech.utils import pformat_json
-
+from corehq.motech.openmrs.workflow import WorkflowTask
+from corehq.motech.utils import pformat_json, unpack_args
 
 PERSON_PROPERTIES = (
     'gender',
@@ -200,8 +199,7 @@ def create_person_attribute(requests, person_uuid, attribute_type_uuid, value):
     ).json()
 
 
-@task
-def delete_person_attribute_task(requests, person_uuid, attribute_uuid=None):
+def delete_person_attribute(requests, person_uuid, attribute_uuid=None):
     # if attribute_uuid is not set, it would be because the workflow task to create the attribute failed
     if attribute_uuid:
         return requests.delete_with_raise('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
@@ -227,9 +225,15 @@ def server_datetime_to_openmrs_timestamp(dt):
 
 class CreateVisitTask(WorkflowTask):
 
-    def run(self, requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
-            openmrs_form, visit_type, location_uuid=None):
+    def run(self):
+        self.func_kwargs.setdefault('location_uuid', None)
+        (requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
+         openmrs_form, visit_type, location_uuid) = unpack_args(
+            'requests person_uuid provider_uuid visit_datetime values_for_concept encounter_type openmrs_form '
+            'visit_type location_uuid', *self.func_args, **self.func_kwargs
+        )
 
+        subtasks = []
         start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
         stop_datetime = server_datetime_to_openmrs_timestamp(
             visit_datetime + timedelta(days=1) - timedelta(seconds=1)
@@ -245,31 +249,38 @@ class CreateVisitTask(WorkflowTask):
             visit['location'] = location_uuid
         response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
         visit_uuid = response.json()['uuid']
+        self.rollback_args.append(visit_uuid)
 
-        self._subtasks.append(
+        subtasks.append(
             CreateEncounterTask(
-                None,
-                delete_encounter_task(requests),  # `encounter_uuid` doesn't need to be passed yet.
-                'encounter_uuid',                     # execute_workflow() sets the rollback task's kwargs later
-                requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
-                openmrs_form, visit_uuid, location_uuid,
+                func=None,
+                func_args=(requests, person_uuid, provider_uuid, start_datetime, values_for_concept,
+                           encounter_type, openmrs_form, visit_uuid, location_uuid),
+                rollback_func=delete_encounter,
+                rollback_args=(requests, ),
+                pass_result=True,
             )
         )
 
-        return visit_uuid
+        return subtasks
 
 
-@task
-def delete_visit_task(requests, visit_uuid=None):
+def delete_visit(requests, visit_uuid=None):
     if visit_uuid:
         return requests.delete_with_raise('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
 
 
 class CreateEncounterTask(WorkflowTask):
 
-    def run(self, requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
-            openmrs_form, visit_uuid, location_uuid=None):
+    def run(self):
+        self.func_kwargs.setdefault('location_uuid', None)
+        (requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type, openmrs_form, 
+         visit_uuid, location_uuid) = unpack_args(
+            'requests person_uuid provider_uuid start_datetime values_for_concept encounter_type openmrs_form '
+            'visit_uuid location_uuid', *self.func_args, **self.func_kwargs
+        )
 
+        subtasks = []
         encounter = {
             'encounterDatetime': start_datetime,
             'patient': person_uuid,
@@ -280,34 +291,29 @@ class CreateEncounterTask(WorkflowTask):
         if location_uuid:
             encounter['location'] = location_uuid
         if provider_uuid:
-            # TODO: Verify. See commented-out section below
             encounter['provider'] = provider_uuid
         response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
         encounter_uuid = response.json()['uuid']
 
-        # TODO: This is suspicious. Doesn't match docs. If it's true, add it as a subtask
-        # if provider_uuid:
-        #     encounter_provider = {'provider': provider_uuid}
-        #     uri = '/ws/rest/v1/encounter/{uuid}/encounterprovider'.format(uuid=encounter_uuid)
-        #     requests.post_with_raise(uri, json=encounter_provider)
+        self.rollback_args.append(encounter_uuid)
 
         for concept_uuid, values in values_for_concept.items():
             for value in values:
-
-                self._subtasks.append(
+                subtasks.append(
                     WorkflowTask(
-                        create_obs,
-                        delete_obs_task(requests),
-                        'obs_uuid',
-                        requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid,
+                        func=create_obs,
+                        func_args=(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value,
+                                   location_uuid),
+                        rollback_func=delete_obs,
+                        rollback_args=(requests, ),
+                        pass_result=True,
                     )
                 )
 
-        return encounter_uuid
+        return subtasks
 
 
-@task
-def delete_encounter_task(requests, encounter_uuid=None):
+def delete_encounter(requests, encounter_uuid=None):
     if encounter_uuid:
         requests.delete_with_raise('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
 
@@ -326,8 +332,7 @@ def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_dateti
     return response.json()['uuid']
 
 
-@task
-def delete_obs_task(requests, obs_uuid=None):
+def delete_obs(requests, obs_uuid=None):
     if obs_uuid:
         return requests.delete_with_raise('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
 
@@ -395,8 +400,7 @@ def update_person_name(requests, info, openmrs_config, person_uuid, name_uuid):
         ).json()
 
 
-@task
-def rollback_person_name_task(requests, person, openmrs_config):
+def rollback_person_name(requests, person, openmrs_config):
     """
     Reset the name changes previously set by `update_person_name()` back to their original values, which are
     taken from the patient details that OpenMRS returned at the start of the workflow.
@@ -429,8 +433,7 @@ def create_person_address(requests, info, openmrs_config, person_uuid):
         ).json()['uuid']
 
 
-@task
-def delete_person_address_task(requests, person, address_uuid=None):
+def delete_person_address(requests, person, address_uuid=None):
     if address_uuid:
         return requests.delete_with_raise(
             '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
@@ -456,8 +459,7 @@ def update_person_address(requests, info, openmrs_config, person_uuid, address_u
         ).json()
 
 
-@task
-def rollback_person_address_task(requests, person, openmrs_config):
+def rollback_person_address(requests, person, openmrs_config):
     properties = {
         property_: person['preferredAddress'][property_]
         for property_ in openmrs_config.case_config.person_preferred_address.keys()
@@ -525,8 +527,7 @@ def update_person_properties(requests, info, openmrs_config, person_uuid):
         ).json()
 
 
-@task
-def rollback_person_properties_task(requests, person, openmrs_config):
+def rollback_person_properties(requests, person, openmrs_config):
     """
     Reset the properties previously set by `update_person_properties()` back to their original values, which are
     taken from the patient details that OpenMRS returned at the start of the workflow.

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -14,6 +14,7 @@ from corehq.apps.users.cases import get_wrapped_owner, get_owner_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
+from corehq.motech.openmrs.workflow import WorkflowTask, Task
 from corehq.motech.utils import pformat_json
 
 
@@ -200,58 +201,105 @@ def server_datetime_to_openmrs_timestamp(dt):
     return openmrs_timestamp
 
 
-def create_visit(requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
-                 openmrs_form, visit_type, location_uuid=None, patient_uuid=None):
-    patient_uuid = patient_uuid or person_uuid
-    start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
-    stop_datetime = server_datetime_to_openmrs_timestamp(
-        visit_datetime + timedelta(days=1) - timedelta(seconds=1)
-    )
+class CreateVisitTask(WorkflowTask):
 
-    visit = {
-        'patient': patient_uuid,
-        'visitType': visit_type,
-        'startDatetime': start_datetime,
-        'stopDatetime': stop_datetime,
+    def run(self, requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
+            openmrs_form, visit_type, location_uuid=None):
+
+        start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
+        stop_datetime = server_datetime_to_openmrs_timestamp(
+            visit_datetime + timedelta(days=1) - timedelta(seconds=1)
+        )
+
+        visit = {
+            'patient': person_uuid,
+            'visitType': visit_type,
+            'startDatetime': start_datetime,
+            'stopDatetime': stop_datetime,
+        }
+        if location_uuid:
+            visit['location'] = location_uuid
+        response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
+        visit_uuid = response.json()['uuid']
+
+        self._subtasks.append(
+            CreateEncounterTask(
+                None,
+                requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
+                openmrs_form, visit_uuid, location_uuid,
+                rollback_task=Task(delete_encounter, requests),
+                pass_result_as='encounter_uuid',
+            )
+        )
+
+        return visit_uuid
+
+
+def delete_visit(requests, visit_uuid):
+    return requests.delete('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
+
+
+class CreateEncounterTask(WorkflowTask):
+
+    def run(self, requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
+            openmrs_form, visit_uuid, location_uuid=None):
+
+        encounter = {
+            'encounterDatetime': start_datetime,
+            'patient': person_uuid,
+            'form': openmrs_form,
+            'encounterType': encounter_type,
+            'visit': visit_uuid,
+        }
+        if location_uuid:
+            encounter['location'] = location_uuid
+        if provider_uuid:
+            # TODO: Verify. See commented-out section below
+            encounter['provider'] = provider_uuid
+        response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
+        encounter_uuid = response.json()['uuid']
+
+        # TODO: This is suspicious. Doesn't match docs. If it's true, add it as a subtask
+        # if provider_uuid:
+        #     encounter_provider = {'provider': provider_uuid}
+        #     uri = '/ws/rest/v1/encounter/{uuid}/encounterprovider'.format(uuid=encounter_uuid)
+        #     requests.post_with_raise(uri, json=encounter_provider)
+
+        for concept_uuid, values in values_for_concept.items():
+            for value in values:
+
+                self._subtasks.append(
+                    WorkflowTask(
+                        create_obs,
+                        requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid,
+                        rollback_task=Task(delete_obs, requests),
+                        pass_result_as='obs_uuid'
+                    )
+                )
+
+        return encounter_uuid
+
+
+def delete_encounter(requests, encounter_uuid):
+    return requests.delete('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
+
+
+def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid=None):
+    observation = {
+        'concept': concept_uuid,
+        'person': person_uuid,
+        'obsDatetime': start_datetime,
+        'encounter': encounter_uuid,
+        'value': value,
     }
     if location_uuid:
-        visit['location'] = location_uuid
-    response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
-    visit_uuid = response.json()['uuid']
+        observation['location'] = location_uuid
+    response = requests.post_with_raise('/ws/rest/v1/obs', json=observation)
+    return response.json()['uuid']
 
-    encounter = {
-        'encounterDatetime': start_datetime,
-        'patient': patient_uuid,
-        'form': openmrs_form,
-        'encounterType': encounter_type,
-        'visit': visit_uuid,
-    }
-    if location_uuid:
-        encounter['location'] = location_uuid
-    response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
-    encounter_uuid = response.json()['uuid']
-    if provider_uuid:
-        encounter_provider = {'provider': provider_uuid}
-        uri = '/ws/rest/v1/encounter/{uuid}/encounterprovider'.format(uuid=encounter_uuid)
-        requests.post_with_raise(uri, json=encounter_provider)
 
-    observation_uuids = []
-    for concept_uuid, values in values_for_concept.items():
-        for value in values:
-            observation = {
-                'concept': concept_uuid,
-                'person': person_uuid,
-                'obsDatetime': start_datetime,
-                'encounter': encounter_uuid,
-                'value': value,
-            }
-            if location_uuid:
-                observation['location'] = location_uuid
-            response = requests.post_with_raise('/ws/rest/v1/obs', json=observation)
-            observation_uuids.append(response.json()['uuid'])
-
-    logger.debug('Observations created: ', observation_uuids)
-    return OpenmrsResponse(status_code=response.status_code, reason=response.reason)
+def delete_obs(requests, obs_uuid):
+    return requests.delete('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
 
 
 def search_patients(requests, search_string):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -190,30 +190,63 @@ def get_case_location_ancestor_repeaters(case):
     return []
 
 
-def create_person_attribute(requests, person_uuid, attribute_type_uuid, value):
-    return requests.post('/ws/rest/v1/person/{person_uuid}/attribute'.format(
-        person_uuid=person_uuid), json={
-            'attributeType': attribute_type_uuid,
-            'value': value,
-        },
-    ).json()
+class CreatePersonAttributeTask(WorkflowTask):
+
+    def __init__(self, requests, person_uuid, attribute_type_uuid, value):
+        self.requests = requests
+        self.person_uuid = person_uuid
+        self.attribute_type_uuid = attribute_type_uuid
+        self.value = value
+        self.attribute_uuid = None
+
+    def run(self):
+        response = self.requests.post(
+            '/ws/rest/v1/person/{person_uuid}/attribute'.format(person_uuid=self.person_uuid),
+            json={'attributeType': self.attribute_type_uuid, 'value': self.value},
+        )
+        self.attribute_uuid = response.json()['uuid']
+
+    def rollback(self):
+        # if attribute_uuid is not set, it would be because the workflow task to create the attribute failed
+        if self.attribute_uuid:
+            self.requests.delete_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
+                    person_uuid=self.person_uuid, attribute_uuid=self.attribute_uuid
+                )
+            )
 
 
-def delete_person_attribute(requests, person_uuid, attribute_uuid=None):
-    # if attribute_uuid is not set, it would be because the workflow task to create the attribute failed
-    if attribute_uuid:
-        return requests.delete_with_raise('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
-            person_uuid=person_uuid, attribute_uuid=attribute_uuid
-        )).json()
+class UpdatePersonAttributeTask(WorkflowTask):
 
+    def __init__(self, requests, person_uuid, attribute_uuid, attribute_type_uuid, value, existing_value):
+        self.requests = requests
+        self.person_uuid = person_uuid
+        self.attribute_uuid = attribute_uuid
+        self.attribute_type_uuid = attribute_type_uuid
+        self.value = value
+        self.existing_value = existing_value
 
-def update_person_attribute(requests, person_uuid, attribute_uuid, attribute_type_uuid, value):
-    return requests.post('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
-        person_uuid=person_uuid, attribute_uuid=attribute_uuid), json={
-            'value': value,
-            'attributeType': attribute_type_uuid,
-        }
-    ).json()
+    def run(self):
+        self.requests.post(
+            '/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
+                person_uuid=self.person_uuid, attribute_uuid=self.attribute_uuid
+            ),
+            json={
+                'value': self.value,
+                'attributeType': self.attribute_type_uuid,
+            }
+        )
+
+    def rollback(self):
+        self.requests.post(
+            '/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
+                person_uuid=self.person_uuid, attribute_uuid=self.attribute_uuid
+            ),
+            json={
+                'value': self.existing_value,
+                'attributeType': self.attribute_type_uuid,
+            }
+        )
 
 
 def server_datetime_to_openmrs_timestamp(dt):
@@ -223,100 +256,126 @@ def server_datetime_to_openmrs_timestamp(dt):
     return openmrs_timestamp
 
 
-def create_visit(requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
+class CreateVisitTask(WorkflowTask):
+
+    def __init__(self, requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
                  openmrs_form, visit_type, location_uuid=None):
-    subtasks = []
-    start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
-    stop_datetime = server_datetime_to_openmrs_timestamp(
-        visit_datetime + timedelta(days=1) - timedelta(seconds=1)
-    )
+        self.requests = requests
+        self.person_uuid = person_uuid
+        self.provider_uuid = provider_uuid
+        self.visit_datetime = visit_datetime
+        self.values_for_concept = values_for_concept
+        self.encounter_type = encounter_type
+        self.openmrs_form = openmrs_form
+        self.visit_type = visit_type
+        self.location_uuid = location_uuid
+        self.visit_uuid = None
 
-    visit = {
-        'patient': person_uuid,
-        'visitType': visit_type,
-        'startDatetime': start_datetime,
-        'stopDatetime': stop_datetime,
-    }
-    if location_uuid:
-        visit['location'] = location_uuid
-    response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
-    visit_uuid = response.json()['uuid']
-
-    subtasks.append(
-        WorkflowTask(
-            func=create_encounter,
-            func_args=(requests, person_uuid, provider_uuid, start_datetime, values_for_concept,
-                       encounter_type, openmrs_form, visit_uuid, location_uuid),
-            rollback_func=delete_encounter,
-            rollback_args=(requests, ),
-            returns_result=True,
-            returns_subtasks=True
+    def run(self):
+        subtasks = []
+        start_datetime = server_datetime_to_openmrs_timestamp(self.visit_datetime)
+        stop_datetime = server_datetime_to_openmrs_timestamp(
+            self.visit_datetime + timedelta(days=1) - timedelta(seconds=1)
         )
-    )
+        visit = {
+            'patient': self.person_uuid,
+            'visitType': self.visit_type,
+            'startDatetime': start_datetime,
+            'stopDatetime': stop_datetime,
+        }
+        if self.location_uuid:
+            visit['location'] = self.location_uuid
+        response = self.requests.post_with_raise('/ws/rest/v1/visit', json=visit)
+        self.visit_uuid = response.json()['uuid']
 
-    return visit_uuid, subtasks
-
-
-def delete_visit(requests, visit_uuid=None):
-    if visit_uuid:
-        return requests.delete_with_raise('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
-
-
-def create_encounter(requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
-                     openmrs_form, visit_uuid, location_uuid=None):
-    subtasks = []
-    encounter = {
-        'encounterDatetime': start_datetime,
-        'patient': person_uuid,
-        'form': openmrs_form,
-        'encounterType': encounter_type,
-        'visit': visit_uuid,
-    }
-    if location_uuid:
-        encounter['location'] = location_uuid
-    if provider_uuid:
-        encounter['provider'] = provider_uuid
-    response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
-    encounter_uuid = response.json()['uuid']
-
-    for concept_uuid, values in values_for_concept.items():
-        for value in values:
-            subtasks.append(
-                WorkflowTask(
-                    func=create_obs,
-                    func_args=(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value,
-                               location_uuid),
-                    rollback_func=delete_obs,
-                    rollback_args=(requests, ),
-                    returns_result=True,
-                )
+        subtasks.append(
+            CreateEncounterTask(
+                self.requests, self.person_uuid, self.provider_uuid, start_datetime, self.values_for_concept,
+                self.encounter_type, self.openmrs_form, self.visit_uuid, self.location_uuid
             )
+        )
+        return subtasks
 
-    return encounter_uuid, subtasks
-
-
-def delete_encounter(requests, encounter_uuid=None):
-    if encounter_uuid:
-        requests.delete_with_raise('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
-
-
-def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid=None):
-    observation = {
-        'concept': concept_uuid,
-        'person': person_uuid,
-        'obsDatetime': start_datetime,
-        'encounter': encounter_uuid,
-        'value': value,
-    }
-    if location_uuid:
-        observation['location'] = location_uuid
-    response = requests.post_with_raise('/ws/rest/v1/obs', json=observation)
-    return response.json()['uuid']
+    def rollback(self):
+        if self.visit_uuid:
+            self.requests.delete_with_raise('/ws/rest/v1/visit/{uuid}'.format(uuid=self.visit_uuid))
 
 
-def delete_obs(requests, obs_uuid=None):
-    if obs_uuid:
-        return requests.delete_with_raise('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
+class CreateEncounterTask(WorkflowTask):
+
+    def __init__(self, requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
+                 openmrs_form, visit_uuid, location_uuid=None):
+        self.requests = requests
+        self.person_uuid = person_uuid
+        self.provider_uuid = provider_uuid
+        self.start_datetime = start_datetime
+        self.values_for_concept = values_for_concept
+        self.encounter_type = encounter_type
+        self.openmrs_form = openmrs_form
+        self.visit_uuid = visit_uuid
+        self.location_uuid = location_uuid
+        self.encounter_uuid = None
+
+    def run(self):
+        subtasks = []
+        encounter = {
+            'encounterDatetime': self.start_datetime,
+            'patient': self.person_uuid,
+            'form': self.openmrs_form,
+            'encounterType': self.encounter_type,
+            'visit': self.visit_uuid,
+        }
+        if self.location_uuid:
+            encounter['location'] = self.location_uuid
+        if self.provider_uuid:
+            encounter['provider'] = self.provider_uuid
+        response = self.requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
+        self.encounter_uuid = response.json()['uuid']
+
+        for concept_uuid, values in self.values_for_concept.items():
+            for value in values:
+                subtasks.append(
+                    CreateObsTask(
+                        self.requests, self.encounter_uuid, concept_uuid, self.person_uuid, self.start_datetime,
+                        value, self.location_uuid
+                    )
+                )
+        return subtasks
+
+    def rollback(self):
+        if self.encounter_uuid:
+            self.requests.delete_with_raise('/ws/rest/v1/encounter/{uuid}'.format(uuid=self.encounter_uuid))
+
+
+class CreateObsTask(WorkflowTask):
+
+    def __init__(self, requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value,
+                 location_uuid=None):
+        self.requests = requests
+        self.encounter_uuid = encounter_uuid
+        self.concept_uuid = concept_uuid
+        self.person_uuid = person_uuid
+        self.start_datetime = start_datetime
+        self.value = value
+        self.location_uuid = location_uuid
+        self.obs_uuid = None
+
+    def run(self):
+        observation = {
+            'concept': self.concept_uuid,
+            'person': self.person_uuid,
+            'obsDatetime': self.start_datetime,
+            'encounter': self.encounter_uuid,
+            'value': self.value,
+        }
+        if self.location_uuid:
+            observation['location'] = self.location_uuid
+        response = self.requests.post_with_raise('/ws/rest/v1/obs', json=observation)
+        self.obs_uuid = response.json()['uuid']
+
+    def rollback(self):
+        if self.obs_uuid:
+            self.requests.delete_with_raise('/ws/rest/v1/obs/{uuid}'.format(uuid=self.obs_uuid))
 
 
 def search_patients(requests, search_string):
@@ -366,95 +425,124 @@ def get_patient_by_id(requests, patient_identifier_type, patient_identifier):
             patient_identifier_type, patient_identifier)
 
 
-def update_person_name(requests, info, openmrs_config, person_uuid, name_uuid):
-    properties = {
-        property_: value_source.get_value(info)
-        for property_, value_source in openmrs_config.case_config.person_preferred_name.items()
-        if property_ in NAME_PROPERTIES and value_source.get_value(info)
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
-                person_uuid=person_uuid,
-                name_uuid=name_uuid,
-            ),
-            json=properties,
-        ).json()
+class UpdatePersonNameTask(WorkflowTask):
 
+    def __init__(self, requests, info, openmrs_config, person):
+        self.requests = requests
+        self.info = info
+        self.openmrs_config = openmrs_config
+        self.person = person
+        self.person_uuid = person['uuid']
+        self.name_uuid = person['preferredName']['uuid']
 
-def rollback_person_name(requests, person, openmrs_config):
-    """
-    Reset the name changes previously set by `update_person_name()` back to their original values, which are
-    taken from the patient details that OpenMRS returned at the start of the workflow.
-    """
-    properties = {
-        property_: person['preferredName'][property_]
-        for property_ in openmrs_config.case_config.person_preferred_name.keys()
-        if property_ in NAME_PROPERTIES
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
-                person_uuid=person['uuid'],
-                name_uuid=person['preferredName']['uuid'],
-            ),
-            json=properties,
-        ).json()
-
-
-def create_person_address(requests, info, openmrs_config, person_uuid):
-    properties = {
-        property_: value_source.get_value(info)
-        for property_, value_source in openmrs_config.case_config.person_preferred_address.items()
-        if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/address/'.format(person_uuid=person_uuid),
-            json=properties,
-        ).json()['uuid']
-
-
-def delete_person_address(requests, person, address_uuid=None):
-    if address_uuid:
-        return requests.delete_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
-                person_uuid=person['uuid'],
-                address_uuid=address_uuid,
+    def run(self):
+        properties = {
+            property_: value_source.get_value(self.info)
+            for property_, value_source in self.openmrs_config.case_config.person_preferred_name.items()
+            if property_ in NAME_PROPERTIES and value_source.get_value(self.info)
+        }
+        if properties:
+            self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
+                    person_uuid=self.person_uuid,
+                    name_uuid=self.name_uuid,
+                ),
+                json=properties,
             )
-        ).json()
+
+    def rollback(self):
+        """
+        Reset the name changes back to their original values, which are
+        taken from the patient details that OpenMRS returned at the
+        start of the workflow.
+        """
+        properties = {
+            property_: self.person['preferredName'][property_]
+            for property_ in self.openmrs_config.case_config.person_preferred_name.keys()
+            if property_ in NAME_PROPERTIES
+        }
+        if properties:
+            self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
+                    person_uuid=self.person_uuid,
+                    name_uuid=self.name_uuid,
+                ),
+                json=properties,
+            )
 
 
-def update_person_address(requests, info, openmrs_config, person_uuid, address_uuid):
-    properties = {
-        property_: value_source.get_value(info)
-        for property_, value_source in openmrs_config.case_config.person_preferred_address.items()
-        if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
-                person_uuid=person_uuid,
-                address_uuid=address_uuid,
-            ),
-            json=properties,
-        ).json()
+class CreatePersonAddressTask(WorkflowTask):
+
+    def __init__(self, requests, info, openmrs_config, person):
+        self.requests = requests
+        self.info = info
+        self.openmrs_config = openmrs_config
+        self.person = person
+        self.person_uuid = person['uuid']
+        self.address_uuid = None
+
+    def run(self):
+        properties = {
+            property_: value_source.get_value(self.info)
+            for property_, value_source in self.openmrs_config.case_config.person_preferred_address.items()
+            if property_ in ADDRESS_PROPERTIES and value_source.get_value(self.info)
+        }
+        if properties:
+            response = self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/address/'.format(person_uuid=self.person_uuid),
+                json=properties,
+            )
+            self.address_uuid = response.json()['uuid']
+
+    def rollback(self):
+        if self.address_uuid:
+            self.requests.delete_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+                    person_uuid=self.person_uuid,
+                    address_uuid=self.address_uuid,
+                )
+            )
 
 
-def rollback_person_address(requests, person, openmrs_config):
-    properties = {
-        property_: person['preferredAddress'][property_]
-        for property_ in openmrs_config.case_config.person_preferred_address.keys()
-        if property_ in ADDRESS_PROPERTIES
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
-                person_uuid=person['uuid'],
-                address_uuid=person['preferredAddress']['uuid'],
-            ),
-            json=properties,
-        ).json()
+class UpdatePersonAddressTask(WorkflowTask):
+
+    def __init__(self, requests, info, openmrs_config, person):
+        self.requests = requests
+        self.info = info
+        self.openmrs_config = openmrs_config
+        self.person = person
+        self.person_uuid = person['uuid']
+        self.address_uuid = person['preferredAddress']['uuid']
+
+    def run(self):
+        properties = {
+            property_: value_source.get_value(self.info)
+            for property_, value_source in self.openmrs_config.case_config.person_preferred_address.items()
+            if property_ in ADDRESS_PROPERTIES and value_source.get_value(self.info)
+        }
+        if properties:
+            self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+                    person_uuid=self.person_uuid,
+                    address_uuid=self.address_uuid,
+                ),
+                json=properties,
+            )
+
+    def rollback(self):
+        properties = {
+            property_: self.person['preferredAddress'][property_]
+            for property_ in self.openmrs_config.case_config.person_preferred_address.keys()
+            if property_ in ADDRESS_PROPERTIES
+        }
+        if properties:
+            self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+                    person_uuid=self.person_uuid,
+                    address_uuid=self.address_uuid,
+                ),
+                json=properties,
+            )
 
 
 def get_subresource_instances(requests, person_uuid, subresource):
@@ -496,34 +584,42 @@ def get_patient(requests, domain, info, openmrs_config):
     return patient
 
 
-def update_person_properties(requests, info, openmrs_config, person_uuid):
-    properties = {
-        property_: value_source.get_value(info)
-        for property_, value_source in openmrs_config.case_config.person_properties.items()
-        if property_ in PERSON_PROPERTIES and value_source.get_value(info)
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person_uuid),
-            json=properties
-        ).json()
+class UpdatePersonPropertiesTask(WorkflowTask):
 
+    def __init__(self, requests, info, openmrs_config, person):
+        self.requests = requests
+        self.info = info
+        self.openmrs_config = openmrs_config
+        self.person = person
 
-def rollback_person_properties(requests, person, openmrs_config):
-    """
-    Reset the properties previously set by `update_person_properties()` back to their original values, which are
-    taken from the patient details that OpenMRS returned at the start of the workflow.
-    """
-    properties = {
-        property_: person[property_]
-        for property_ in openmrs_config.case_config.person_properties.keys()
-        if property_ in PERSON_PROPERTIES
-    }
-    if properties:
-        return requests.post_with_raise(
-            '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person['uuid']),
-            json=properties
-        ).json()
+    def run(self):
+        properties = {
+            property_: value_source.get_value(self.info)
+            for property_, value_source in self.openmrs_config.case_config.person_properties.items()
+            if property_ in PERSON_PROPERTIES and value_source.get_value(self.info)
+        }
+        if properties:
+            self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=self.person['uuid']),
+                json=properties
+            )
+
+    def rollback(self):
+        """
+        Reset person properties back to their original values, which
+        are taken from the patient details that OpenMRS returned at the
+        start of the workflow.
+        """
+        properties = {
+            property_: self.person[property_]
+            for property_ in self.openmrs_config.case_config.person_properties.keys()
+            if property_ in PERSON_PROPERTIES
+        }
+        if properties:
+            self.requests.post_with_raise(
+                '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=self.person['uuid']),
+                json=properties
+            )
 
 
 class PatientSearchParser(object):

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,0 +1,162 @@
+from django.test import SimpleTestCase
+from mock import Mock
+
+from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, task, workflow_task
+
+
+class TaskTests(SimpleTestCase):
+
+    def test_task_run_func_args_kwargs(self):
+        sing = Mock()
+        func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
+
+        self.assertEqual(func_task.func, sing)
+        self.assertEqual(func_task.args, ('Brave Sir Robin',))
+        self.assertEqual(func_task.kwargs, {'what': 'ran', 'where': 'away'})
+        sing.assert_not_called()
+
+        func_task.run_func()
+        sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
+
+
+    def test_task_run(self):
+        class SirRobin(Task):
+            def run(self):
+                pass
+
+        sir_robin = SirRobin(None, 'fled', tail='turned', where='away')
+        sir_robin.run = Mock()
+
+        sir_robin.run_func()
+        sir_robin.run.assert_called_with('fled', tail='turned', where='away')
+
+
+class WorkflowTests(SimpleTestCase):
+
+    def test_workflow_runs(self):
+        func1 = Mock()
+        func2 = Mock()
+        workflow_queue = [
+            WorkflowTask(None, None, func1),
+            WorkflowTask(None, None, func2),
+        ]
+
+        success, errors = execute_workflow(workflow_queue)
+        self.assertTrue(success)
+        self.assertEqual(errors, [])
+        func1.assert_called()
+        func2.assert_called()
+        self.assertEqual(workflow_queue, [])
+
+    def test_rollback_runs(self):
+        func1 = Mock()
+        black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
+        func3 = Mock()
+
+        rollback_func1 = Mock()
+        rollback_black_knight = Mock(side_effect=ValueError("Come back here and take what's comin' ta ya!"))
+        rollback_func3 = Mock()
+
+        workflow_queue = [
+            WorkflowTask(Task(rollback_func1), None, func1),
+            WorkflowTask(Task(rollback_black_knight), None, black_knight),
+            WorkflowTask(Task(rollback_func3), None, func3),
+        ]
+
+        success, errors = execute_workflow(workflow_queue)
+        self.assertFalse(success)
+        self.assertEqual(errors, [
+            "Workflow failed: ValueError: 'Tis but a flesh wound",
+            "Rollback error: ValueError: Come back here and take what's comin' ta ya!",
+        ])
+
+        # Check workflow halted on failure
+        func1.assert_called()
+        black_knight.assert_called()
+        func3.assert_not_called()
+
+        # Check rollback continued after error
+        rollback_black_knight.assert_called()
+        rollback_func1.assert_called()
+
+        # Last task should still be languishing in the workflow queue
+        self.assertEqual(len(workflow_queue), 1)
+        self.assertEqual(workflow_queue[0].func, func3)
+
+    def test_pass_result_as(self):
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        workflow_queue = [
+            WorkflowTask(Task(delete_foo), 'foo_id', create_foo),
+            WorkflowTask(None, None, fail),
+        ]
+        success, errors = execute_workflow(workflow_queue)
+
+        self.assertFalse(success)
+        create_foo.assert_called()
+        delete_foo.assert_called_with(foo_id=5)
+
+
+class DecoratorTests(SimpleTestCase):
+
+    def test_task_decorator(self):
+        do_something = Mock()
+
+        @task
+        def get_foo_task(param1, param2):
+            do_something(param1, where=param2)
+
+        foo_task = get_foo_task('ran', param2='away')
+
+        self.assertIsInstance(foo_task, Task)
+        self.assertEqual(foo_task.args, ('ran',))
+        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
+        do_something.assert_not_called()
+
+        foo_task.run_func()
+        do_something.assert_called_with('ran', where='away')
+
+    def test_workflow_task_decorator(self):
+        do_something = Mock()
+
+        @workflow_task()
+        def get_foo_task(param1, param2):
+            do_something(param1, where=param2)
+
+        foo_task = get_foo_task('ran', param2='away')
+
+        self.assertIsInstance(foo_task, WorkflowTask)
+        self.assertIsNone(foo_task.rollback_task)
+        self.assertIsNone(foo_task.pass_result_as)
+        self.assertEqual(foo_task.args, ('ran',))
+        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
+        do_something.assert_not_called()
+
+        foo_task.run_func()
+        do_something.assert_called_with('ran', where='away')
+
+    def test_workflow_task_decorator_with_rollback(self):
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        @task
+        def get_delete_foo_task(foo_id):
+            delete_foo(foo_id)
+
+        @workflow_task(rollback_task=get_delete_foo_task(), pass_result_as='foo_id')
+        def get_create_foo_task(foo_name):
+            foo_id = create_foo(foo_name)
+            return foo_id
+
+        workflow_queue = [
+            get_create_foo_task('FOO'),
+            workflow_task()(fail),
+        ]
+        success, errors = execute_workflow(workflow_queue)
+
+        self.assertFalse(success)
+        create_foo.assert_called_with('FOO')
+        delete_foo.assert_called_with(5)

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.test import SimpleTestCase
 from mock import Mock
 
@@ -7,6 +8,9 @@ from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow,
 class TaskTests(SimpleTestCase):
 
     def test_task_run_func_args_kwargs(self):
+        """
+        Task.run_func should call func with the args and kwargs that the task was instantiated with.
+        """
         sing = Mock()
         func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
 
@@ -18,8 +22,10 @@ class TaskTests(SimpleTestCase):
         func_task.run_func()
         sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
 
-
     def test_task_run(self):
+        """
+        Task.run should be called if the task was not instantiated with func
+        """
         class SirRobin(Task):
             def run(self):
                 pass
@@ -34,6 +40,9 @@ class TaskTests(SimpleTestCase):
 class WorkflowTests(SimpleTestCase):
 
     def test_workflow_runs(self):
+        """
+        If no errors occur, a workflow should be executed to completion
+        """
         func1 = Mock()
         func2 = Mock()
         workflow_queue = [
@@ -49,6 +58,9 @@ class WorkflowTests(SimpleTestCase):
         self.assertEqual(workflow_queue, [])
 
     def test_rollback_runs(self):
+        """
+        If an error is encountered, the workflow should stop, and the rollback should run to completion
+        """
         func1 = Mock()
         black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
         func3 = Mock()
@@ -84,6 +96,10 @@ class WorkflowTests(SimpleTestCase):
         self.assertEqual(workflow_queue[0].func, func3)
 
     def test_pass_result_as(self):
+        """
+        WorkflowTask.pass_result_as should pass the result of run_func to its rollback task using the given
+        parameter name.
+        """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))
@@ -102,6 +118,9 @@ class WorkflowTests(SimpleTestCase):
 class DecoratorTests(SimpleTestCase):
 
     def test_task_decorator(self):
+        """
+        The `@task` decorator should return a function that creates a Task instance when it is executed
+        """
         do_something = Mock()
 
         @task
@@ -119,6 +138,9 @@ class DecoratorTests(SimpleTestCase):
         do_something.assert_called_with('ran', where='away')
 
     def test_workflow_task_decorator(self):
+        """
+        The `@workflow_task` decorator should return a function that creates a WorkflowTask instance
+        """
         do_something = Mock()
 
         @workflow_task()
@@ -138,6 +160,9 @@ class DecoratorTests(SimpleTestCase):
         do_something.assert_called_with('ran', where='away')
 
     def test_workflow_task_decorator_with_rollback(self):
+        """
+        The @workflow_task decorator should be able to set `rollback_task` and `pass_result_as`
+        """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
-from django.test import SimpleTestCase
+
+from unittest import TestCase
+
 from mock import Mock
 
 from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, task, workflow_task
 
 
-class TaskTests(SimpleTestCase):
+class TaskTests(TestCase):
 
     def test_task_run_func_args_kwargs(self):
         """
@@ -37,7 +39,7 @@ class TaskTests(SimpleTestCase):
         sir_robin.run.assert_called_with('fled', tail='turned', where='away')
 
 
-class WorkflowTests(SimpleTestCase):
+class WorkflowTests(TestCase):
 
     def test_workflow_runs(self):
         """
@@ -115,7 +117,7 @@ class WorkflowTests(SimpleTestCase):
         delete_foo.assert_called_with(foo_id=5)
 
 
-class DecoratorTests(SimpleTestCase):
+class DecoratorTests(TestCase):
 
     def test_task_decorator(self):
         """

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -4,42 +4,24 @@ from unittest import TestCase
 
 from mock import Mock
 
-from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, task, workflow_task
-
-
-class TaskTests(TestCase):
-
-    def test_task_run_func_args_kwargs(self):
-        """
-        Task.run_func should call func with the args and kwargs that the task was instantiated with.
-        """
-        sing = Mock()
-        func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
-
-        self.assertEqual(func_task.func, sing)
-        self.assertEqual(func_task.args, ('Brave Sir Robin',))
-        self.assertEqual(func_task.kwargs, {'what': 'ran', 'where': 'away'})
-        sing.assert_not_called()
-
-        func_task.run_func()
-        sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
-
-    def test_task_run(self):
-        """
-        Task.run should be called if the task was not instantiated with func
-        """
-        class SirRobin(Task):
-            def run(self):
-                pass
-
-        sir_robin = SirRobin(None, 'fled', tail='turned', where='away')
-        sir_robin.run = Mock()
-
-        sir_robin.run_func()
-        sir_robin.run.assert_called_with('fled', tail='turned', where='away')
+from corehq.motech.openmrs.workflow import WorkflowTask, WorkflowError, execute_workflow
 
 
 class WorkflowTests(TestCase):
+
+    def test_workflow_func_str(self):
+        def run_away():
+            pass
+
+        task = WorkflowTask(func=run_away)
+        self.assertEqual(str(task), 'run_away')
+
+    def test_workflow_class_str(self):
+        class RunAwayTask(WorkflowTask):
+            pass
+
+        task = RunAwayTask(func=None)
+        self.assertEqual(str(task), 'RunAwayTask')
 
     def test_workflow_runs(self):
         """
@@ -47,41 +29,43 @@ class WorkflowTests(TestCase):
         """
         func1 = Mock()
         func2 = Mock()
-        workflow_queue = [
-            WorkflowTask(None, None, func1),
-            WorkflowTask(None, None, func2),
+        workflow = [
+            WorkflowTask(func1),
+            WorkflowTask(func2),
         ]
 
-        success, errors = execute_workflow(workflow_queue)
-        self.assertTrue(success)
+        errors = execute_workflow(workflow)
         self.assertEqual(errors, [])
         func1.assert_called()
         func2.assert_called()
-        self.assertEqual(workflow_queue, [])
+        self.assertEqual(workflow, [])
 
     def test_rollback_runs(self):
         """
         If an error is encountered, the workflow should stop, and the rollback should run to completion
         """
         func1 = Mock()
-        black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
+        black_knight_error = ValueError("'Tis but a flesh wound")
+        black_knight = Mock(side_effect=black_knight_error)
         func3 = Mock()
 
         rollback_func1 = Mock()
-        rollback_black_knight = Mock(side_effect=ValueError("Come back here and take what's comin' ta ya!"))
+        black_knight_rollback_error = ValueError("Come back here and take what's comin' ta ya!")
+        rollback_black_knight = Mock(side_effect=black_knight_rollback_error)
         rollback_func3 = Mock()
 
-        workflow_queue = [
-            WorkflowTask(Task(rollback_func1), None, func1),
-            WorkflowTask(Task(rollback_black_knight), None, black_knight),
-            WorkflowTask(Task(rollback_func3), None, func3),
+        black_knight_task = WorkflowTask(func=black_knight, rollback_func=rollback_black_knight)
+
+        workflow = [
+            WorkflowTask(func=func1, rollback_func=rollback_func1),
+            black_knight_task,
+            WorkflowTask(func=func3, rollback_func=rollback_func3),
         ]
 
-        success, errors = execute_workflow(workflow_queue)
-        self.assertFalse(success)
+        errors = execute_workflow(workflow)
         self.assertEqual(errors, [
-            "Workflow failed: ValueError: 'Tis but a flesh wound",
-            "Rollback error: ValueError: Come back here and take what's comin' ta ya!",
+            WorkflowError(black_knight_task, black_knight_error, is_rollback_error=False),
+            WorkflowError(black_knight_task, black_knight_rollback_error, is_rollback_error=True),
         ])
 
         # Check workflow halted on failure
@@ -93,97 +77,52 @@ class WorkflowTests(TestCase):
         rollback_black_knight.assert_called()
         rollback_func1.assert_called()
 
-        # Last task should still be languishing in the workflow queue
-        self.assertEqual(len(workflow_queue), 1)
-        self.assertEqual(workflow_queue[0].func, func3)
-
-    def test_pass_result_as(self):
+    def test_pass_result(self):
         """
-        WorkflowTask.pass_result_as should pass the result of run_func to its rollback task using the given
-        parameter name.
+        WorkflowTask.pass_result should pass the result of func as an arg to rollback_func.
         """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))
 
-        workflow_queue = [
-            WorkflowTask(Task(delete_foo), 'foo_id', create_foo),
-            WorkflowTask(None, None, fail),
+        workflow = [
+            WorkflowTask(func=create_foo, rollback_func=delete_foo, pass_result=True),
+            WorkflowTask(func=fail),
         ]
-        success, errors = execute_workflow(workflow_queue)
+        errors = execute_workflow(workflow)
 
-        self.assertFalse(success)
+        self.assertTrue(errors)
+        create_foo.assert_called()
+        delete_foo.assert_called_with(5)
+
+    def test_pass_result_as(self):
+        """
+        WorkflowTask.pass_result_as should pass the result of func as a kwarg to rollback_func.
+        """
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        workflow = [
+            WorkflowTask(func=create_foo, rollback_func=delete_foo, pass_result_as='foo_id'),
+            WorkflowTask(func=fail),
+        ]
+        errors = execute_workflow(workflow)
+
+        self.assertTrue(errors)
         create_foo.assert_called()
         delete_foo.assert_called_with(foo_id=5)
 
 
-class DecoratorTests(TestCase):
+class WorkflowErrorTests(TestCase):
 
-    def test_task_decorator(self):
-        """
-        The `@task` decorator should return a function that creates a Task instance when it is executed
-        """
-        do_something = Mock()
+    def test_str(self):
+        def get_airspeed_velocity(bird, is_laden):
+            pass
 
-        @task
-        def get_foo_task(param1, param2):
-            do_something(param1, where=param2)
-
-        foo_task = get_foo_task('ran', param2='away')
-
-        self.assertIsInstance(foo_task, Task)
-        self.assertEqual(foo_task.args, ('ran',))
-        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
-        do_something.assert_not_called()
-
-        foo_task.run_func()
-        do_something.assert_called_with('ran', where='away')
-
-    def test_workflow_task_decorator(self):
-        """
-        The `@workflow_task` decorator should return a function that creates a WorkflowTask instance
-        """
-        do_something = Mock()
-
-        @workflow_task()
-        def get_foo_task(param1, param2):
-            do_something(param1, where=param2)
-
-        foo_task = get_foo_task('ran', param2='away')
-
-        self.assertIsInstance(foo_task, WorkflowTask)
-        self.assertIsNone(foo_task.rollback_task)
-        self.assertIsNone(foo_task.pass_result_as)
-        self.assertEqual(foo_task.args, ('ran',))
-        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
-        do_something.assert_not_called()
-
-        foo_task.run_func()
-        do_something.assert_called_with('ran', where='away')
-
-    def test_workflow_task_decorator_with_rollback(self):
-        """
-        The @workflow_task decorator should be able to set `rollback_task` and `pass_result_as`
-        """
-        create_foo = Mock(return_value=5)
-        delete_foo = Mock()
-        fail = Mock(side_effect=Exception('Fail'))
-
-        @task
-        def get_delete_foo_task(foo_id):
-            delete_foo(foo_id)
-
-        @workflow_task(rollback_task=get_delete_foo_task(), pass_result_as='foo_id')
-        def get_create_foo_task(foo_name):
-            foo_id = create_foo(foo_name)
-            return foo_id
-
-        workflow_queue = [
-            get_create_foo_task('FOO'),
-            workflow_task()(fail),
-        ]
-        success, errors = execute_workflow(workflow_queue)
-
-        self.assertFalse(success)
-        create_foo.assert_called_with('FOO')
-        delete_foo.assert_called_with(5)
+        task = WorkflowTask(func=get_airspeed_velocity, func_args=('swallow', ), func_kwargs={'is_laden': False})
+        error = WorkflowError(task, TypeError('Missing argument: african_or_european'), False)
+        self.assertEqual(
+            str(error),
+            'WorkflowTask "get_airspeed_velocity" failed: TypeError: Missing argument: african_or_european'
+        )

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -59,6 +59,7 @@ class WorkflowTask(Task):
 
 
 def task(func):
+    # Doesn't use `@wraps` because `call()` doesn't execute func; it returns a Task instantiated with func
     def call(*args, **kwargs):
         instance = Task(func, *args, **kwargs)
         return instance

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import
+
+
+class Task(object):
+    """
+    Tasks are instantiated with a function to run, and args and kwargs that must be passed to it.
+
+    Instances of this class are used for rollback.
+
+    If a task is not instantiated with a function, it must implement a run() method. It will be passed the args
+    and kwargs that the class was instantiated with.
+    """
+
+    def __init__(self, func=None, *args, **kwargs):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def run_func(self):
+        if self.func:
+            return self.func(*self.args, **self.kwargs)
+        else:
+            return self.run(*self.args, **self.kwargs)
+
+    def run(self, *args, **kwargs):
+        raise NotImplementedError('Task.func must be set, or Task.run() must be defined.')
+
+
+class WorkflowTask(Task):
+    """
+    Extends rollback tasks. Workflow tasks can define subtasks, which will be prepended to the workflow queue
+    after the task is run.
+
+    If a workflow task is not instantiated with a rollback task, either it must implement its own
+    get_rollback_task() method, or it will be assumed that the task does not cause a change of state (probably
+    because its subtasks do).
+    """
+
+    def __init__(self, rollback_task=None, pass_result_as=None, func=None, *args, **kwargs):
+        """
+        Instantiate WorkflowTask
+
+        :param rollback_task: A Task instance
+        :param pass_result_as: A parameter name, to be passed as a kwarg to rollback_task
+        :param func: The function this task must run
+        :param args: Arguments to pass to func or self.run()
+        :param kwargs: Keyword arguments to pass to func or self.run()
+        """
+        self.rollback_task = rollback_task
+        self.pass_result_as = pass_result_as
+        super(WorkflowTask, self).__init__(func, *args, **kwargs)
+        self._subtasks = []
+
+    def get_rollback_task(self):
+        return self.rollback_task
+
+    def get_subtasks(self):
+        return self._subtasks
+
+
+def task(func):
+    def call(*args, **kwargs):
+        instance = Task(func, *args, **kwargs)
+        return instance
+    return call
+
+
+def workflow_task(rollback_task=None, pass_result_as=None):
+    def decorate(func):
+        def call(*args, **kwargs):
+            instance = WorkflowTask(rollback_task, pass_result_as, func, *args, **kwargs)
+            return instance
+        return call
+    return decorate
+
+
+def execute_workflow(workflow_queue):
+    """
+    We use two lists to execute a workflow:
+
+    1. The (given) workflow queue, where tasks are pulled off the front and run, until an error is encountered.
+    2. A rollback stack, where each workflow task appends a reverse task to undo its action, to be run if the
+       workflow fails.
+
+    """
+    success = True
+    errors = []
+    rollback_stack = []
+
+    try:
+        while workflow_queue:
+            workflow_task = workflow_queue.pop(0)
+            rollback_task = workflow_task.get_rollback_task()
+            if rollback_task:
+                rollback_stack.append(rollback_task)
+            # Note: The rollback task is added before the workflow task is run. This offers developers an
+            # opportunity to try to fix whatever the workflow task might have broken before it failed.
+            # ...
+            # BUT if the workflow task needs to make more than one change, it should split them up into subtasks.
+            result = workflow_task.run_func()
+            if workflow_task.pass_result_as and rollback_task:
+                # Useful for rollback tasks that must delete something created by the workflow task
+                rollback_task.kwargs.update({workflow_task.pass_result_as: result})
+            for i, subtask in enumerate(workflow_task.get_subtasks()):
+                workflow_queue.insert(i, subtask)
+
+    except Exception as workflow_error:
+        success = False
+        errors.append('Workflow failed: {name}: {message}'.format(
+            name=workflow_error.__class__.__name__, message=str(workflow_error)
+        ))
+        for rollback_task in reversed(rollback_stack):
+            try:
+                rollback_task.run_func()
+            except Exception as rollback_error:
+                errors.append('Rollback error: {name}: {message}'.format(
+                    name=rollback_error.__class__.__name__, message=str(rollback_error)
+                ))
+
+    return success, errors

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -22,7 +22,7 @@ class WorkflowTask(object):
     """
     def __init__(self, func, func_args=None, func_kwargs=None,
                  rollback_func=None, rollback_args=None, rollback_kwargs=None,
-                 pass_result=False, pass_result_as=None):
+                 returns_result=False, pass_result_as=None, returns_subtasks=False):
         """
         Instantiate WorkflowTask
         """
@@ -34,20 +34,32 @@ class WorkflowTask(object):
         self.rollback_args = rollback_args or []
         self.rollback_kwargs = rollback_kwargs or {}
 
-        self.pass_result = pass_result or pass_result_as
+        self.returns_result = returns_result or pass_result_as
         self.pass_result_as = pass_result_as
+        self.returns_subtasks = returns_subtasks
 
     def __str__(self):
         return self.func.__name__ if self.func else self.__class__.__name__
 
     def run(self):
         if self.func:
-            result = self.func(*self.func_args, **self.func_kwargs)
-            if self.pass_result:
+            result_subtasks = self.func(*self.func_args, **self.func_kwargs)
+
+            if self.returns_result and self.returns_subtasks:
+                result, subtasks = result_subtasks
+            elif self.returns_result:
+                result = result_subtasks
+            elif self.returns_subtasks:
+                subtasks = result_subtasks
+
+            if self.returns_result:
                 if self.pass_result_as:
                     self.rollback_kwargs[self.pass_result_as] = result
                 else:
                     self.rollback_args.append(result)
+
+            if self.returns_subtasks:
+                return subtasks
         else:
             raise NotImplementedError('func must be set, or run() must be defined.')
 

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -20,28 +20,34 @@ class WorkflowTask(object):
     values set by `func`, then the `run()` method should add them to
     `rollback_args` or `rollback_kwargs`.
     """
-    def __init__(self, func, func_args, func_kwargs,
-                 rollback_func=None, rollback_args=None, rollback_kwargs=None):
+    def __init__(self, func, func_args=None, func_kwargs=None,
+                 rollback_func=None, rollback_args=None, rollback_kwargs=None,
+                 pass_result=False, pass_result_as=None):
         """
         Instantiate WorkflowTask
         """
         self.func = func
-        self.func_args = func_args
-        self.func_kwargs = func_kwargs
+        self.func_args = func_args or []
+        self.func_kwargs = func_kwargs or {}
 
         self.rollback_func = rollback_func
-        self.rollback_args = rollback_args
-        self.rollback_kwargs = rollback_kwargs
+        self.rollback_args = rollback_args or []
+        self.rollback_kwargs = rollback_kwargs or {}
 
-        self.subtasks = []
+        self.pass_result = pass_result or pass_result_as
+        self.pass_result_as = pass_result_as
 
     def __str__(self):
         return self.func.__name__ if self.func else self.__class__.__name__
 
     def run(self):
         if self.func:
-            self.func(*self.func_args, **self.func_kwargs)
-            return self.subtasks
+            result = self.func(*self.func_args, **self.func_kwargs)
+            if self.pass_result:
+                if self.pass_result_as:
+                    self.rollback_kwargs[self.pass_result_as] = result
+                else:
+                    self.rollback_args.append(result)
         else:
             raise NotImplementedError('Task.func must be set, or Task.run() must be defined.')
 

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -49,7 +49,7 @@ class WorkflowTask(object):
                 else:
                     self.rollback_args.append(result)
         else:
-            raise NotImplementedError('Task.func must be set, or Task.run() must be defined.')
+            raise NotImplementedError('func must be set, or run() must be defined.')
 
     def rollback(self):
         if self.rollback_func:

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -57,6 +57,9 @@ class WorkflowTask(object):
 
 
 WorkflowError = namedtuple('WorkflowError', 'task exception is_rollback_error')
+WorkflowError.__str__ = lambda self: 'WorkflowTask "{}" {}failed: {}: {}'.format(
+    self.task, 'rollback ' if self.is_rollback_error else '', self.exception.__class__.__name__, self.exception
+)
 
 
 def execute_workflow(workflow):

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -5,72 +5,30 @@ from collections import namedtuple
 
 class WorkflowTask(object):
     """
-    WorkflowTasks are instantiated with a function to run, and args and
-    kwargs that must be passed to it.
+    WorkflowTask subclasses must must implement the run() method.
 
-    If a task is not instantiated with a function, it must implement
-    its own run() method.
+    Any changes made by run() should be reversed by rollback().
 
-    `WorkflowTask.run()` can return subtasks, which will be prepended
+    run() can return subtasks, which will be prepended
     to the workflow queue. If a task needs to make more than one
     change, it should split them up into subtasks.
-
-    A WorkflowTask can accept a rollback_func when it is instantiated,
-    or its rollback() method can be overridden. If rollback_func needs
-    values set by `func`, then the `run()` method should add them to
-    `rollback_args` or `rollback_kwargs`.
     """
-    def __init__(self, func, func_args=None, func_kwargs=None,
-                 rollback_func=None, rollback_args=None, rollback_kwargs=None,
-                 returns_result=False, pass_result_as=None, returns_subtasks=False):
-        """
-        Instantiate WorkflowTask
-        """
-        self.func = func
-        self.func_args = func_args or []
-        self.func_kwargs = func_kwargs or {}
-
-        self.rollback_func = rollback_func
-        self.rollback_args = rollback_args or []
-        self.rollback_kwargs = rollback_kwargs or {}
-
-        self.returns_result = returns_result or pass_result_as
-        self.pass_result_as = pass_result_as
-        self.returns_subtasks = returns_subtasks
-
     def __str__(self):
-        return self.func.__name__ if self.func else self.__class__.__name__
+        return self.__class__.__name__
 
     def run(self):
-        if self.func:
-            result_subtasks = self.func(*self.func_args, **self.func_kwargs)
-
-            if self.returns_result and self.returns_subtasks:
-                result, subtasks = result_subtasks
-            elif self.returns_result:
-                result = result_subtasks
-            elif self.returns_subtasks:
-                subtasks = result_subtasks
-
-            if self.returns_result:
-                if self.pass_result_as:
-                    self.rollback_kwargs[self.pass_result_as] = result
-                else:
-                    self.rollback_args.append(result)
-
-            if self.returns_subtasks:
-                return subtasks
-        else:
-            raise NotImplementedError('func must be set, or run() must be defined.')
+        raise NotImplementedError
 
     def rollback(self):
-        if self.rollback_func:
-            return self.rollback_func(*self.rollback_args, **self.rollback_kwargs)
+        pass
 
 
-WorkflowError = namedtuple('WorkflowError', 'task exception is_rollback_error')
-WorkflowError.__str__ = lambda self: 'WorkflowTask "{}" {}failed: {}: {}'.format(
-    self.task, 'rollback ' if self.is_rollback_error else '', self.exception.__class__.__name__, self.exception
+WorkflowError = namedtuple('WorkflowError', 'task error is_rollback_error')
+WorkflowError.__str__ = lambda self: '{task}{is_rollback} failed: {exception}: {error}'.format(
+    task=self.task,
+    is_rollback='.rollback()' if self.is_rollback_error else '.run()',
+    exception=self.error.__class__.__name__,
+    error=self.error
 )
 
 
@@ -87,9 +45,11 @@ def execute_workflow(workflow):
         executed_tasks.append(task)
         try:
             subtasks = task.run() or []
-            assert hasattr(subtasks, '__iter__') and all(isinstance(t, WorkflowTask) for t in subtasks), \
-                'Error running WorkflowTask "{}". run() should return subtasks or None. Got {} instead'.format(
-                    task, repr(subtasks))
+            if not (hasattr(subtasks, '__iter__') and all(isinstance(t, WorkflowTask) for t in subtasks)):
+                raise ValueError(
+                    'Error running WorkflowTask "{}": '
+                    'run() should return subtasks or None. Got {} instead'.format(task, repr(subtasks))
+                )
         except Exception as err:
             errors.append(WorkflowError(task, err, False))
             for task in reversed(executed_tasks):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -98,3 +98,18 @@ def pformat_json(data):
         return json.dumps(json_data, indent=2, sort_keys=True)
     except ValueError:
         return data
+
+
+def unpack_args(names, *args, **kwargs):
+    """
+    Unpack arguments named `names` with values `args` and `kwargs`, and
+    return them as a tuple.
+
+    >>> unpack_args('foo bar baz qux', 1, 2, qux=4, baz=3)
+    (1, 2, 3, 4)
+
+    """
+    if isinstance(names, six.string_types):
+        names = names.split()
+    args_dict = dict(zip(names, args), **kwargs)
+    return tuple(args_dict[n] for n in names)

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -98,18 +98,3 @@ def pformat_json(data):
         return json.dumps(json_data, indent=2, sort_keys=True)
     except ValueError:
         return data
-
-
-def unpack_args(names, *args, **kwargs):
-    """
-    Unpack arguments named `names` with values `args` and `kwargs`, and
-    return them as a tuple.
-
-    >>> unpack_args('foo bar baz qux', 1, 2, qux=4, baz=3)
-    (1, 2, 3, 4)
-
-    """
-    if isinstance(names, six.string_types):
-        names = names.split()
-    args_dict = dict(zip(names, args), **kwargs)
-    return tuple(args_dict[n] for n in names)


### PR DESCRIPTION
Builds on PRs #19756 and #19757. 

Probably easiest to take the last 5 commits :blowfish: ... and ignoring whitespace might make it more readable.

This implements the work done in the previous 2 PRs. Please hold off on merge. I'd like to test from Staging.

@nickpell I understand that you're probably going to be a bit thin on context wrt OpenMRS API calls, but hopefully this isn't too bad -- it doesn't add any new functionality. It just wraps existing calls as Tasks, and adds a few rollback functions for the calls that need them.

@dannyroberts buddy @nickpell cc @snopoke 
