### PR TITLE
Bump ipdb version

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -11,12 +11,13 @@ sniffer==0.4.0
 psutil==5.1.3  # for memory profiling
 django-extensions==1.7.7
 ipython==5.2.2
-ipdb==0.9.4
+ipdb==0.11
 wheel==0.29.0
 graphviz==0.7
 git+git://github.com/nickpell/django-package-monitor@np/handle-no-semver
 transifex-client==0.12.4
 modernize==0.6
 Fabric==1.14.0
+readline==6.2.4.1
 
 --requirement=test-requirements.txt


### PR DESCRIPTION
Also adds readline dependency

This allows for autocomplete in `ipdb`.
If you are on ubuntu, you might need to install ncurses:
`sudo apt-get install libncurses5-dev`

![screenshot from 2018-03-12 16-19-34](https://user-images.githubusercontent.com/146896/37307558-b6ceb742-2611-11e8-90c2-ddfef256265c.png)
