### PR TITLE
store calculated property in an xpath variable

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -122,7 +122,7 @@ class FormattedDetailColumn(object):
     @property
     def variables(self):
         variables = {}
-        if re.search(r'\$lang', self.column.field):
+        if re.search(r'\$lang', self.xpath_function):
             variables['lang'] = self.id_strings.current_language()
         return variables
 
@@ -133,6 +133,19 @@ class FormattedDetailColumn(object):
             form=self.template_form,
             width=self.template_width,
         )
+
+        if self.column.useXpathExpression:
+            xpath = sx.CalculatedPropertyXpath(function=self.xpath)
+            if re.search(r'\$lang', self.xpath):
+                xpath.variables.node.append(
+                    sx.CalculatedPropertyXpathVariable(
+                        name=u'lang',
+                        locale_id=self.id_strings.current_language()
+                    ).node
+                )
+            xpath_variable = sx.XpathVariable(name=u'calculated_property', xpath=xpath)
+            template.text.xpath.variables.node.append(xpath_variable.node)
+
         if self.variables:
             for key, value in sorted(self.variables.items()):
                 template.text.xpath.variables.node.append(
@@ -161,6 +174,18 @@ class FormattedDetailColumn(object):
                 type=sort_type,
             )
 
+            if self.column.useXpathExpression:
+                xpath = sx.CalculatedPropertyXpath(function=self.xpath)
+                if re.search(r'\$lang', self.xpath):
+                    xpath.variables.node.append(
+                        sx.CalculatedPropertyXpathVariable(
+                            name=u'lang',
+                            locale_id=self.id_strings.current_language()
+                        ).node
+                    )
+                xpath_variable = sx.XpathVariable(name=u'calculated_property', xpath=xpath)
+                sort.text.xpath.variables.node.append(xpath_variable.node)
+
         if self.sort_element:
             if not sort:
                 sort_type = {
@@ -179,6 +204,16 @@ class FormattedDetailColumn(object):
                     text=sx.Text(xpath_function=sort_xpath),
                     type=sort_type,
                 )
+                if not sort_calculation and self.column.useXpathExpression:
+                    xpath = sx.CalculatedPropertyXpath(function=self.xpath)
+                    if re.search(r'\$lang', self.xpath):
+                        xpath.variables.node.append(
+                            sx.CalculatedPropertyXpathVariable(
+                                name=u'lang', locale_id=self.id_strings.current_language()
+                            ).node
+                        )
+                    xpath_variable = sx.XpathVariable(name=u'calculated_property', xpath=xpath)
+                    sort.text.xpath.variables.node.append(xpath_variable.node)
 
             if self.sort_element.type == 'distance':
                 sort.text.xpath_function = self.evaluate_template(Distance.SORT_XPATH_FUNCTION)
@@ -208,7 +243,7 @@ class FormattedDetailColumn(object):
     def evaluate_template(self, template):
         if template:
             return template.format(
-                xpath=self.xpath,
+                xpath=u'$calculated_property' if self.column.useXpathExpression else self.xpath,
                 app=self.app,
                 module=self.module,
                 detail=self.detail,
@@ -345,7 +380,7 @@ class Enum(FormattedDetailColumn):
                 xpath_fragment_template.format(
                     key=item.key,
                     key_as_var=item.key_as_variable,
-                    xpath=self.xpath,
+                    xpath=u'$calculated_property' if self.column.useXpathExpression else self.xpath,
                     i=i,
                 )
             )

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -198,6 +198,8 @@ class FormattedDetailColumn(object):
 
     @property
     def xpath(self):
+        if self.column.useXpathExpression:
+            return self.column.field
         return get_column_xpath_generator(self.app, self.module, self.detail,
                                           self.column).xpath
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -172,8 +172,6 @@ class DetailContributor(SectionContributor):
                     detail_type=detail_type, *column_info
                 ).fields
                 for field in fields:
-                    if column_info.column.useXpathExpression:
-                        field.template.text.xpath_function = column_info.column.field
                     d.fields.append(field)
 
             # Add actions

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -35,11 +35,24 @@ class IdNode(XmlObject):
     id = StringField('@id')
 
 
+class CalculatedPropertyXpathVariable(XmlObject):
+    ROOT_NAME = 'variable'
+    name = StringField('@name')
+    locale_id = StringField('locale/@id')
+
+
+class CalculatedPropertyXpath(XmlObject):
+    ROOT_NAME = 'xpath'
+    function = XPathField('@function')
+    variables = NodeListField('variable', CalculatedPropertyXpathVariable)
+
+
 class XpathVariable(XmlObject):
     ROOT_NAME = 'variable'
     name = StringField('@name')
 
     locale_id = StringField('locale/@id')
+    xpath = NodeField('xpath', CalculatedPropertyXpath)
 
 
 class Xpath(XmlObject):
@@ -783,6 +796,10 @@ class Detail(OrderedXmlObject, IdNode):
             else:
                 result.add(field.header.text.xpath_function)
                 result.add(field.template.text.xpath_function)
+                if field.template.text.xpath:
+                    for variable in field.template.text.xpath.variables:
+                        if variable.xpath:
+                            result.add(six.text_type(variable.xpath.function))
 
         for detail in self.details:
             result.update(detail.get_all_xpaths())

--- a/corehq/apps/app_manager/tests/data/suite/normal-suite.xml
+++ b/corehq/apps/app_manager/tests/data/suite/normal-suite.xml
@@ -286,7 +286,11 @@
         </header>
         <template>
             <text>
-                <xpath function="concat(plain, plain)"/>
+                <xpath function="$calculated_property">
+                    <variable name="calculated_property">
+                        <xpath function="concat(plain, plain)"/>
+                    </variable>
+                </xpath>
             </text>
         </template>
     </field>
@@ -298,9 +302,13 @@
         </header>
         <template>
             <text>
-                <xpath function="if($lang = 'en', plain, 'nope')">
-                    <variable name="lang">
-                        <locale id="lang.current"/>
+                <xpath function="$calculated_property">
+                    <variable name="calculated_property">
+                        <xpath function="if($lang = 'en', plain, 'nope')">
+                            <variable name="lang">
+                                <locale id="lang.current"/>
+                            </variable>
+                        </xpath>
                     </variable>
                 </xpath>
             </text>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -25,7 +25,11 @@
       </header>
       <template>
         <text>
-          <xpath function="instance('reports')/report[1]/name"/>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="instance('reports')/report[1]/name"/>
+            </variable>
+          </xpath>
         </text>
       </template>
     </field>
@@ -69,7 +73,11 @@
       </header>
       <template>
         <text>
-          <xpath function="instance('ledgerdb')/ledgers/name/name"/>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="instance('ledgerdb')/ledgers/name/name"/>
+            </variable>
+          </xpath>
         </text>
       </template>
     </field>
@@ -100,7 +108,11 @@
       </header>
       <template>
         <text>
-          <xpath function="instance('reports')/report[1]/name"/>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="instance('reports')/report[1]/name"/>
+            </variable>
+          </xpath>
         </text>
       </template>
     </field>

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-detail-instances.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-detail-instances.xml
@@ -67,7 +67,11 @@
       </header>
       <template>
         <text>
-          <xpath function="count(instance('item-list:short')/short_list/short)"/>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="count(instance('item-list:short')/short_list/short)"/>
+            </variable>
+          </xpath>
         </text>
       </template>
     </field>
@@ -98,7 +102,11 @@
       </header>
       <template>
         <text>
-          <xpath function="count(instance('item-list:long')/long_list/long)"/>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="count(instance('item-list:long')/long_list/long)"/>
+            </variable>
+          </xpath>
         </text>
       </template>
     </field>
@@ -271,7 +279,11 @@
       </header>
       <template>
         <text>
-          <xpath function="count(instance('item-list:inline')/inline_list/inline)"/>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="count(instance('item-list:inline')/inline_list/inline)"/>
+            </variable>
+          </xpath>
         </text>
       </template>
     </field>

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-detail-tabs-with-nodesets.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-detail-tabs-with-nodesets.xml
@@ -113,7 +113,11 @@
         </header>
         <template>
           <text>
-            <xpath function="column"/>
+            <xpath function="$calculated_property">
+              <variable name="calculated_property">
+                <xpath function="column"/>
+              </variable>
+            </xpath>
           </text>
         </template>
       </field>
@@ -132,7 +136,11 @@
         </header>
         <template>
           <text>
-            <xpath function="column"/>
+            <xpath function="$calculated_property">
+              <variable name="calculated_property">
+                <xpath function="column"/>
+              </variable>
+            </xpath>
           </text>
         </template>
       </field>


### PR DESCRIPTION
This eliminates a theoretical performance issue where a calculated property could be computed multiple times.  This also has the side effect of enabling using calculated properties in ID mappings which wasn't working before.