### PR TITLE
use strings with __import__

### DIFF
--- a/corehq/ex-submodules/auditcare/signals.py
+++ b/corehq/ex-submodules/auditcare/signals.py
@@ -89,7 +89,7 @@ for full_str in settings.AUDIT_MODEL_SAVE:
     comps = full_str.split('.')
     model_class = comps[-1]
     mod_str = '.'.join(comps[0:-1])
-    mod = __import__(mod_str, {}, {}, [model_class])
+    mod = __import__(mod_str, {}, {}, [str(model_class)])
     if hasattr(mod, model_class):
         audit_model = getattr(mod, model_class)
         if issubclass(audit_model, models.Model):


### PR DESCRIPTION
@nickpell another one of the same error. Please watch out for them in future.

FYI: https://stackoverflow.com/questions/27477880/portable-code-import-parameter-string-type-between-python-2-and-python-3