### PR TITLE
fix and refactor DB routers

### DIFF
--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -55,9 +55,11 @@ def allow_migrate(db, app_label):
         return bool(db_alias and db_alias == db)
     elif app_label == SYNCLOGS_APP:
         return db == settings.SYNCLOGS_SQL_DB_ALIAS
+    elif app_label == WAREHOUSE_APP:
+        return db == settings.WAREHOUSE_DATABASE_ALIAS
 
     if not settings.USE_PARTITIONED_DATABASE:
-        return app_label != PROXY_APP
+        return app_label != PROXY_APP and db in ('default', None)
 
     if app_label == PROXY_APP:
         return db == partition_config.get_proxy_db()
@@ -68,8 +70,6 @@ def allow_migrate(db, app_label):
         )
     elif app_label == SQL_ACCESSORS_APP:
         return db in partition_config.get_form_processing_dbs()
-    elif app_label == WAREHOUSE_APP:
-        return db == settings.WAREHOUSE_DATABASE_ALIAS
     else:
         return db == partition_config.get_main_db()
 

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -87,6 +87,11 @@ def db_for_read_write(model, write=True):
     """
     app_label = model._meta.app_label
 
+    if app_label == WAREHOUSE_APP:
+        return settings.WAREHOUSE_DATABASE_ALIAS
+    elif app_label == SYNCLOGS_APP:
+        return settings.SYNCLOGS_SQL_DB_ALIAS
+
     if not settings.USE_PARTITIONED_DATABASE:
         return 'default'
 
@@ -97,9 +102,5 @@ def db_for_read_write(model, write=True):
         if not write:
             engine_id = connection_manager.get_load_balanced_read_engine_id(ICDS_UCR_ENGINE_ID)
         return connection_manager.get_django_db_alias(engine_id)
-    elif app_label == WAREHOUSE_APP:
-        return settings.WAREHOUSE_DATABASE_ALIAS
-    elif app_label == SYNCLOGS_APP:
-        return settings.SYNCLOGS_SQL_DB_ALIAS
     else:
         return partition_config.get_main_db()

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -14,7 +14,7 @@ WAREHOUSE_APP = 'warehouse'
 SYNCLOGS_APP = 'phone'
 
 
-class PartitionRouter(object):
+class MultiDBRouter(object):
 
     def db_for_read(self, model, **hints):
         return db_for_read_write(model, write=False)

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -48,6 +48,11 @@ class MonolithRouter(object):
 
 def allow_migrate(db, app_label):
     """
+    Return ``True`` if a app's migrations should be applied to the specified database otherwise
+    return ``False``.
+
+    Note: returning ``None`` is tantamount to returning ``True``
+
     :return: Must return a boolean value, not None.
     """
     if app_label == ICDS_REPORTS_APP:

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -40,12 +40,6 @@ class PartitionRouter(object):
         return False
 
 
-class MonolithRouter(object):
-
-    def allow_migrate(self, db, app_label, model=None, **hints):
-        return app_label != PROXY_APP
-
-
 def allow_migrate(db, app_label):
     """
     Return ``True`` if a app's migrations should be applied to the specified database otherwise

--- a/corehq/sql_db/tests/test_routers.py
+++ b/corehq/sql_db/tests/test_routers.py
@@ -65,3 +65,8 @@ class AllowMigrateTest(SimpleTestCase):
         mock.return_value = 'icds'
         self.assertIs(False, allow_migrate('default', ICDS_REPORTS_APP))
         self.assertIs(True, allow_migrate('icds', ICDS_REPORTS_APP))
+
+    def test_synclogs_non_partitioned(self):
+        self.assertIs(False, allow_migrate('synclogs', 'accounting'))
+        self.assertIs(True, allow_migrate(None, 'accounting'))
+        self.assertIs(True, allow_migrate('default', 'accounting'))

--- a/settings.py
+++ b/settings.py
@@ -1354,10 +1354,7 @@ else:
 if helper.is_testing():
     helper.assign_test_db_names(DATABASES)
 
-if USE_PARTITIONED_DATABASE:
-    DATABASE_ROUTERS = ['corehq.sql_db.routers.PartitionRouter']
-else:
-    DATABASE_ROUTERS = ['corehq.sql_db.routers.MonolithRouter']
+DATABASE_ROUTERS = ['corehq.sql_db.routers.PartitionRouter']
 
 MVP_INDICATOR_DB = 'mvp-indicators'
 

--- a/settings.py
+++ b/settings.py
@@ -1354,7 +1354,7 @@ else:
 if helper.is_testing():
     helper.assign_test_db_names(DATABASES)
 
-DATABASE_ROUTERS = ['corehq.sql_db.routers.PartitionRouter']
+DATABASE_ROUTERS = ['corehq.sql_db.routers.MultiDBRouter']
 
 MVP_INDICATOR_DB = 'mvp-indicators'
 


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/493048674/

This is a bit of a bigger change now since I've removed the `MonolithRouter` which was broken since the addition on the warehouse DB and the synclog DB.

Now all envs use the `MultiDBRouter` which support partitioned and non-partitioned environments.