### PR TITLE
 only pass necessary cookies to celery

### DIFF
--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -163,4 +163,4 @@ def track_user_login(sender, request, user, **kwargs):
                 return
 
         meta = get_meta(request)
-        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES, meta, request.path)
+        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta, request.path)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -323,12 +323,6 @@ def track_job_candidate_on_hubspot(user_email):
 
 
 @analytics_task()
-def track_saved_app_on_hubspot(couchuser, hubspot_cookie, meta):
-    if couchuser.is_web_user():
-        _send_form_to_hubspot(HUBSPOT_SAVED_APP_FORM_ID, couchuser, hubspot_cookie, meta)
-
-
-@analytics_task()
 def track_clicked_signup_on_hubspot(email, hubspot_cookie, meta):
     data = {'lifecyclestage': 'subscriber'}
     number = deterministic_random(email + 'a_b_test_variable_newsletter')

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -199,7 +199,7 @@ def _get_client_ip(meta):
     return ip
 
 
-def _send_form_to_hubspot(form_id, webuser, cookies, meta, extra_fields=None, email=False):
+def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=None, email=False):
     """
     This sends hubspot the user's first and last names and tracks everything they did
     up until the point they signed up.
@@ -210,7 +210,6 @@ def _send_form_to_hubspot(form_id, webuser, cookies, meta, extra_fields=None, em
         return
 
     hubspot_id = settings.ANALYTICS_IDS.get('HUBSPOT_API_ID')
-    hubspot_cookie = cookies.get(HUBSPOT_COOKIE)
     if hubspot_id and hubspot_cookie:
         url = u"https://forms.hubspot.com/uploads/form/v2/{hubspot_id}/{form_id}".format(
             hubspot_id=hubspot_id,
@@ -245,7 +244,7 @@ def update_hubspot_properties(webuser, properties):
 
 
 @analytics_task()
-def track_user_sign_in_on_hubspot(webuser, cookies, meta, path):
+def track_user_sign_in_on_hubspot(webuser, hubspot_cookie, meta, path):
     from corehq.apps.registration.views import ProcessRegistrationView
     if path.startswith(reverse(ProcessRegistrationView.urlname)):
         tracking_dict = {
@@ -263,8 +262,8 @@ def track_user_sign_in_on_hubspot(webuser, cookies, meta, path):
             })
         tracking_dict.update(get_ab_test_properties(webuser))
         _track_on_hubspot(webuser, tracking_dict)
-        _send_form_to_hubspot(HUBSPOT_SIGNUP_FORM_ID, webuser, cookies, meta)
-    _send_form_to_hubspot(HUBSPOT_SIGNIN_FORM_ID, webuser, cookies, meta)
+        _send_form_to_hubspot(HUBSPOT_SIGNUP_FORM_ID, webuser, hubspot_cookie, meta)
+    _send_form_to_hubspot(HUBSPOT_SIGNIN_FORM_ID, webuser, hubspot_cookie, meta)
 
 
 @analytics_task()
@@ -300,19 +299,19 @@ def send_hubspot_form(form_id, request, user=None):
         user = getattr(request, 'couch_user', None)
     if request and user and user.is_web_user():
         meta = get_meta(request)
-        send_hubspot_form_task.delay(form_id, user, request.COOKIES, meta)
+        send_hubspot_form_task.delay(form_id, user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
 
 
 @analytics_task()
-def send_hubspot_form_task(form_id, web_user, cookies, meta):
-    _send_form_to_hubspot(form_id, web_user, cookies, meta)
+def send_hubspot_form_task(form_id, web_user, hubspot_cookie, meta):
+    _send_form_to_hubspot(form_id, web_user, hubspot_cookie, meta)
 
 @analytics_task()
-def track_clicked_deploy_on_hubspot(webuser, cookies, meta):
+def track_clicked_deploy_on_hubspot(webuser, hubspot_cookie, meta):
     ab = {
         'a_b_variable_deploy': 'A' if deterministic_random(webuser.username + 'a_b_variable_deploy') > 0.5 else 'B',
     }
-    _send_form_to_hubspot(HUBSPOT_CLICKED_DEPLOY_FORM_ID, webuser, cookies, meta, extra_fields=ab)
+    _send_form_to_hubspot(HUBSPOT_CLICKED_DEPLOY_FORM_ID, webuser, hubspot_cookie, meta, extra_fields=ab)
 
 
 @analytics_task()
@@ -324,13 +323,13 @@ def track_job_candidate_on_hubspot(user_email):
 
 
 @analytics_task()
-def track_saved_app_on_hubspot(couchuser, cookies, meta):
+def track_saved_app_on_hubspot(couchuser, hubspot_cookie, meta):
     if couchuser.is_web_user():
-        _send_form_to_hubspot(HUBSPOT_SAVED_APP_FORM_ID, couchuser, cookies, meta)
+        _send_form_to_hubspot(HUBSPOT_SAVED_APP_FORM_ID, couchuser, hubspot_cookie, meta)
 
 
 @analytics_task()
-def track_clicked_signup_on_hubspot(email, cookies, meta):
+def track_clicked_signup_on_hubspot(email, hubspot_cookie, meta):
     data = {'lifecyclestage': 'subscriber'}
     number = deterministic_random(email + 'a_b_test_variable_newsletter')
     if number < 0.33:
@@ -340,7 +339,7 @@ def track_clicked_signup_on_hubspot(email, cookies, meta):
     else:
         data['a_b_test_variable_newsletter'] = 'C'
     if email:
-        _send_form_to_hubspot(HUBSPOT_CLICKED_SIGNUP_FORM, None, cookies, meta, extra_fields=data, email=email)
+        _send_form_to_hubspot(HUBSPOT_CLICKED_SIGNUP_FORM, None, hubspot_cookie, meta, extra_fields=data, email=email)
 
 
 def track_workflow(email, event, properties=None):

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -339,7 +339,10 @@ def track_clicked_signup_on_hubspot(email, hubspot_cookie, meta):
     else:
         data['a_b_test_variable_newsletter'] = 'C'
     if email:
-        _send_form_to_hubspot(HUBSPOT_CLICKED_SIGNUP_FORM, None, hubspot_cookie, meta, extra_fields=data, email=email)
+        _send_form_to_hubspot(
+            HUBSPOT_CLICKED_SIGNUP_FORM, None, hubspot_cookie,
+            meta, extra_fields=data, email=email
+        )
 
 
 def track_workflow(email, event, properties=None):

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -8,7 +8,9 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.conf import settings
 
-from corehq.apps.analytics.tasks import track_clicked_deploy_on_hubspot, track_job_candidate_on_hubspot
+from corehq.apps.analytics.tasks import (
+    track_clicked_deploy_on_hubspot, track_job_candidate_on_hubspot, HUBSPOT_COOKIE
+)
 from corehq.apps.analytics.utils import get_meta
 
 
@@ -17,7 +19,7 @@ class HubspotClickDeployView(View):
 
     def post(self, request, *args, **kwargs):
         meta = get_meta(request)
-        track_clicked_deploy_on_hubspot.delay(request.couch_user, request.COOKIES, meta)
+        track_clicked_deploy_on_hubspot.delay(request.couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
         return HttpResponse()
 
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -22,7 +22,7 @@ from corehq.apps.analytics.tasks import (
     track_confirmed_account_on_hubspot,
     track_clicked_signup_on_hubspot,
     update_hubspot_properties,
-)
+    HUBSPOT_COOKIE)
 from corehq.apps.analytics.utils import get_meta
 from corehq.apps.app_manager.dbaccessors import domain_has_apps
 from corehq.apps.domain.decorators import login_required
@@ -222,7 +222,7 @@ class UserRegistrationView(NewUserNumberAbTestMixin, BasePageView):
     def post(self, request, *args, **kwargs):
         if self.prefilled_email:
             meta = get_meta(request)
-            track_clicked_signup_on_hubspot.delay(self.prefilled_email, request.COOKIES, meta)
+            track_clicked_signup_on_hubspot.delay(self.prefilled_email, request.COOKIES.get(HUBSPOT_COOKIE), meta)
         return super(UserRegistrationView, self).get(request, *args, **kwargs)
 
     @property


### PR DESCRIPTION
When looking at this I noticed that we're passing the entire cookie dictionary to celery when we only need one value: https://sentry.io/dimagi/commcarehq/issues/489618039/

Its somewhat of a security risk to have all of those appear in Sentry, especially session ID.