### PR TITLE
Make rebuild_stock_state smaller

### DIFF
--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -318,8 +318,8 @@ class RebuildStockStateView(BaseCommTrackManageView):
 
     @property
     def page_context(self, **kwargs):
-        stock_state_limit = 100
-        stock_transaction_limit = 10000
+        stock_state_limit = self.request.GET.get('stock_state_limit', 100)
+        stock_transaction_limit = self.request.GET.get('stock_transaction_limit', 1000)
         stock_state_limit_exceeded = False
         stock_transaction_limit_exceeded = False
 

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -316,8 +316,7 @@ class RebuildStockStateView(BaseCommTrackManageView):
         else:
             return ServerTime(server_date).ui_string()
 
-    @memoized
-    def selected_case_id(self):
+    def _get_selected_case_id(self):
         location_id = self.request.GET.get('location_id')
         if location_id:
             try:
@@ -335,8 +334,9 @@ class RebuildStockStateView(BaseCommTrackManageView):
         stock_transaction_limit_exceeded = False
 
         query = StockTransaction.objects.filter(report__domain=self.domain)
-        if self.selected_case_id:
-            query = query.filter(case_id=self.selected_case_id)
+        selected_case_id = self._get_selected_case_id()
+        if selected_case_id:
+            query = query.filter(case_id=selected_case_id)
         selected_product_id = self.request.GET.get('product_id')
         if selected_product_id:
             query = query.filter(product_id=selected_product_id)

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -337,6 +337,9 @@ class RebuildStockStateView(BaseCommTrackManageView):
         query = StockTransaction.objects.filter(report__domain=self.domain)
         if self.selected_case_id:
             query = query.filter(case_id=self.selected_case_id)
+        selected_product_id = self.request.GET.get('product_id')
+        if selected_product_id:
+            query = query.filter(product_id=selected_product_id)
 
         stock_state_keys = [
             (txn.case_id, txn.section_id, txn.product_id)

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -328,8 +328,8 @@ class RebuildStockStateView(BaseCommTrackManageView):
 
     @property
     def page_context(self, **kwargs):
-        stock_state_limit = self.request.GET.get('stock_state_limit', 100)
-        stock_transaction_limit = self.request.GET.get('stock_transaction_limit', 1000)
+        stock_state_limit = int(self.request.GET.get('stock_state_limit', 100))
+        stock_transaction_limit = int(self.request.GET.get('stock_transaction_limit', 1000))
         stock_state_limit_exceeded = False
         stock_transaction_limit_exceeded = False
 


### PR DESCRIPTION
This page can take a very long time to load, and usually times out.  This shrinks the default size and parameterizes a little so we can smartly restrict the data shown.
@snopoke @sravfeyn