### PR TITLE
remove is mobile from invitation form

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -308,7 +308,6 @@ class WebUserInvitationForm(NoAutocompleteMixin, DomainRegistrationForm):
                                help_text=mark_safe("""
                                <span data-bind="text: passwordHelp, css: color">
                                """))
-    is_mobile = forms.BooleanField(widget=forms.HiddenInput())
     if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
         captcha = CaptchaField(_("Type the letters in the box"))
     create_domain = forms.BooleanField(widget=forms.HiddenInput(), required=False, initial=False)


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?272331#1471405

It appears that I erroneously added this field to this form as well. Eventually we should definitely add this experience (the alternative mobile signups) for this segment as well, but now is likely not the time to add it, and there will be plenty of time when the ab test has concluded