### PR TITLE
dont show .0 when rounding

### DIFF
--- a/corehq/apps/userreports/transforms/custom/numeric.py
+++ b/corehq/apps/userreports/transforms/custom/numeric.py
@@ -1,5 +1,7 @@
 def get_short_decimal_display(num):
     try:
+        if num % 1 == 0:
+            return int(num)
         return round(num, 2)
     except:
         return num


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?270447#1471873

Changes the display of decimals on reports. Whenever a .0 would have been show before, it will not be shown now.