### PR TITLE
add ancestor utils and test

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -430,10 +430,23 @@ class SQLLocation(MPTTModel):
         return super(SQLLocation, self).get_descendants(**kw)
 
     def get_ancestors(self, **kw):
+        """
+        Returns list of all ancestor locations of this location
+        """
         timing = TimingContext("get_ancestors")
         with timing("mptt"):
             mptt_set = self.mptt_get_ancestors(**kw)
         return ComparedQuerySet(mptt_set, timing)
+
+    def get_ancestor_of_type(self, type_code):
+        """
+        Returns the ancestor of given location_type_code of the location
+        """
+        for loc in self.get_ancestors():
+            if loc.location_type.code == type_code:
+                return loc
+        raise SQLLocation.DoesNotExist(
+            'No ancestor of type {} could be found for this location'.format(type_code))
 
     def get_descendants(self, **kw):
         timing = TimingContext("get_descendants")

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -442,11 +442,7 @@ class SQLLocation(MPTTModel):
         """
         Returns the ancestor of given location_type_code of the location
         """
-        for loc in self.get_ancestors():
-            if loc.location_type.code == type_code:
-                return loc
-        raise SQLLocation.DoesNotExist(
-            'No ancestor of type {} could be found for this location'.format(type_code))
+        return self.get_ancestors().get(location_type__code=type_code)
 
     def get_descendants(self, **kw):
         timing = TimingContext("get_descendants")

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -50,6 +50,27 @@ class TestLocationQuerysetMethods(BaseTestLocationQuerysetMethods):
             [loc.name for loc in middlesex_locs]
         )
 
+    def test_ancestors(self):
+        boston_matches = (SQLLocation.objects
+                          .filter_by_user_input(self.domain, "Boston"))
+
+        self.assertItemsEqual(
+            [loc.name for loc in boston_matches[0].mptt_get_ancestors()],
+            ['Suffolk', 'Massachusetts']
+        )
+
+    def test_ancestor_of_type(self):
+        boston = (SQLLocation.objects
+                  .filter_by_user_input(self.domain, "Boston"))[0]
+        self.assertEqual(
+            boston.get_ancestor_of_type('county').name,
+            'Suffolk'
+        )
+        self.assertEqual(
+            boston.get_ancestor_of_type('state').name,
+            'Massachusetts'
+        )
+
 
 class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
 


### PR DESCRIPTION
@snopoke @esoergel

I will use this in an upcoming location based UCR optimization PR. Since this can without the full, I made a separate PR.