### PR TITLE
[ICDS] PDF - Added restriction to block level location and added new message

### DIFF
--- a/custom/icds_reports/static/icds_reports/js/spec/download.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/download.directive.spec.js
@@ -195,6 +195,43 @@ describe('Download Directive', function () {
 
             assert.equal(expected, result);
         });
+
+        it('tests isDistrictOrBelowSelected - state selected', function () {
+            controller.selectedLocations = ['state', 'all'];
+            var result = controller.isDistrictOrBelowSelected();
+            assert.isFalse(result);
+        });
+
+        it('tests isDistrictOrBelowSelected - district selected', function () {
+            controller.selectedLocations = ['state', 'district'];
+            var result = controller.isDistrictOrBelowSelected();
+            assert.isTrue(result);
+        });
+
+        it('tests isBlockOrBelowSelected - district selected', function () {
+            controller.selectedLocations = ['state', 'district', 'all'];
+            var result = controller.isBlockOrBelowSelected();
+            assert.isFalse(result);
+        });
+
+        it('tests isBlockOrBelowSelected - block selected', function () {
+            controller.selectedLocations = ['state', 'district', 'block'];
+            var result = controller.isBlockOrBelowSelected();
+            assert.isTrue(result);
+        });
+
+        it('tests isAWCsSelected - AWC not selected', function () {
+            controller.selectedAWCs = [];
+            var result = controller.isAWCsSelected();
+            assert.isFalse(result);
+        });
+
+        it('tests isAWCsSelected - AWC selected', function () {
+            controller.selectedAWCs = ['awc_1', 'awc_@'];
+            var result = controller.isAWCsSelected();
+            assert.isTrue(result);
+        });
+
     });
 
     describe('Download Directive have access to features', function() {

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -421,7 +421,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         if (vm.selectedPDFFormat === 'one') {
             return vm.isISSNIPMonthlyRegisterSelected() && !vm.isBlockOrBelowSelected();
         }
-        return vm.isISSNIPMonthlyRegisterSelected() && (!vm.isDistrictOrBelowSelected() || !vm.isAWCsSelected());
+        return vm.isISSNIPMonthlyRegisterSelected() && (!vm.isBlockOrBelowSelected() || !vm.isAWCsSelected());
     };
 
     vm.isVisible = function(level) {

--- a/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
@@ -18,8 +18,8 @@
         <div class="alert alert-info col-md-12" ng-if="$ctrl.isISSNIPMonthlyRegisterSelected() && $ctrl.hasErrorsISSNIPExport()">
             <strong>Please make the following selections before you can export:</strong>
             <ul>
-                <li ng-if="$ctrl.isCombinedPDFSelected() && !$ctrl.isBlockOrBelowSelected()" style="padding: 5px;">Select at least a block-level location</li>
-                <li ng-if="!$ctrl.isCombinedPDFSelected() && !$ctrl.isDistrictOrBelowSelected()" style="padding: 5px;">Select at least a district-level location</li>
+                <li ng-if="!$ctrl.isBlockOrBelowSelected()" style="padding: 5px;">Select at least a block-level location</li>
+                <li ng-if="!$ctrl.isAWCsSelected()" style="padding: 5px;">Select at least the one option in the AWCs location filter</li>
             </ul>
         </div>
         <div class="form-horizontal black">
@@ -167,7 +167,7 @@
                            popover-placement="top-right"
                            popover-trigger="'mouseenter'"></i></label>
                     <div style="margin-bottom: 15px;" class="col-sm-6">
-                        <ui-select multiple ng-disabled="!$ctrl.isDistrictOrBelowSelected()" ng-model="$ctrl.selectedAWCs" on-select="$ctrl.onSelectAWCs($item)" close-on-select="false" theme="bootstrap">
+                        <ui-select multiple ng-disabled="!$ctrl.isBlockOrBelowSelected()" ng-model="$ctrl.selectedAWCs" on-select="$ctrl.onSelectAWCs($item)" close-on-select="false" theme="bootstrap">
                             <ui-select-match placeholder="Please select AWCs"><span ng-bind="$item.name"></span></ui-select-match>
                               <ui-select-choices repeat="location.location_id as location in $ctrl.awcLocations | propsFilter: {name: $select.search}">
                                   <div ng-bind-html="location.name | highlight: $select.search"></div>

--- a/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
@@ -19,7 +19,7 @@
             <strong>Please make the following selections before you can export:</strong>
             <ul>
                 <li ng-if="!$ctrl.isBlockOrBelowSelected()" style="padding: 5px;">Select at least a block-level location</li>
-                <li ng-if="!$ctrl.isAWCsSelected()" style="padding: 5px;">Select at least the one option in the AWCs location filter</li>
+                <li ng-if="!$ctrl.isAWCsSelected()" style="padding: 5px;">Select at least one AWC</li>
             </ul>
         </div>
         <div class="form-horizontal black">


### PR DESCRIPTION
Hi @emord,

I added a restriction to the PDF report. Now the user must choose block level in both options. Also, I added a new warning message when we have 'One PDF per AWC' selected: Select at least the one option in the AWCs location filter.

Please let me know if you have any questions.

Regards,
Łukasz