### PR TITLE
New Redirect URLs for old Prelogin pages to Dimagi.com

### DIFF
--- a/corehq/apps/hqwebapp/templates/google9633af922b8b0064.html
+++ b/corehq/apps/hqwebapp/templates/google9633af922b8b0064.html
@@ -1,0 +1,1 @@
+google-site-verification: google9633af922b8b0064.html

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -17,6 +17,7 @@ from corehq.apps.hqwebapp.views import (
     assert_initial_page_data, retrieve_download, toggles_js, couch_doc_counts,
     server_up, BugReportView,
     redirect_to_dimagi,
+    temporary_google_verify,
 )
 from corehq.apps.hqwebapp.session_details_endpoint.views import SessionDetailsView
 
@@ -87,4 +88,5 @@ legacy_prelogin = [
     url(r'^askdemo/$', redirect_to_dimagi('commcare/'),
         name='public_demo_cta'),
     url(r'^supply/$', redirect_to_dimagi('commcare/')),
+    url(r'^google9633af922b8b0064.html$', temporary_google_verify),
 ]

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -10,9 +10,14 @@ from two_factor.urls import urlpatterns as tf_urls
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from corehq.apps.hqwebapp.views import (
     MaintenanceAlertsView, redirect_to_default,
-    yui_crossdomain, password_change, no_permissions, login, logout, debug_notify,
-    quick_find, osdd, create_alert, activate_alert, deactivate_alert, jserror, dropbox_upload, domain_login,
-    assert_initial_page_data, retrieve_download, toggles_js, couch_doc_counts, server_up, BugReportView)
+    yui_crossdomain, password_change, no_permissions, login, logout,
+    debug_notify,
+    quick_find, osdd, create_alert, activate_alert, deactivate_alert, jserror,
+    dropbox_upload, domain_login,
+    assert_initial_page_data, retrieve_download, toggles_js, couch_doc_counts,
+    server_up, BugReportView,
+    redirect_to_dimagi,
+)
 from corehq.apps.hqwebapp.session_details_endpoint.views import SessionDetailsView
 
 urlpatterns = [
@@ -63,4 +68,23 @@ domain_specific = [
         name='hq_soil_download'),
     url(r'toggles.js$', toggles_js, name='toggles_js'),
     url(r'couch_doc_counts', couch_doc_counts),
+]
+
+legacy_prelogin = [
+    url(r'^home/$', redirect_to_dimagi('commcare/'),
+        name='public_home'),
+    url(r'^impact/$', redirect_to_dimagi('commcare/'),
+        name='public_impact'),
+    url(r'^pricing/$', redirect_to_dimagi('commcare/pricing/'),
+        name='public_software_services'),
+    url(r'^software_services/$', redirect_to_dimagi('commcare/pricing/')),
+    url(r'^services/$', redirect_to_dimagi('services/'),
+        name='public_services'),
+    url(r'^software/$', redirect_to_dimagi('commcare/pricing/'),
+        name='public_pricing'),
+    url(r'^solutions/$', redirect_to_dimagi('services/'),
+        name='public_services'),
+    url(r'^askdemo/$', redirect_to_dimagi('commcare/'),
+        name='public_demo_cta'),
+    url(r'^supply/$', redirect_to_dimagi('commcare/')),
 ]

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -19,9 +19,9 @@ from django.contrib.auth.models import User
 from django.contrib.auth.views import logout as django_logout
 from django.core import cache
 from django.core.mail.message import EmailMessage
-from django.http import HttpResponseRedirect, HttpResponse, Http404,\
-    HttpResponseServerError, HttpResponseNotFound, HttpResponseBadRequest,\
-    HttpResponseForbidden
+from django.http import HttpResponseRedirect, HttpResponse, Http404, \
+    HttpResponseServerError, HttpResponseNotFound, HttpResponseBadRequest, \
+    HttpResponseForbidden, HttpResponsePermanentRedirect
 from django.shortcuts import redirect, render
 from django.template import loader
 from django.template.loader import render_to_string
@@ -151,15 +151,7 @@ def redirect_to_default(req, domain=None):
         if domain != None:
             url = reverse('domain_login', args=[domain])
         else:
-            if settings.ENABLE_PRELOGIN_SITE:
-                try:
-                    from corehq.apps.prelogin.views import HomePublicView
-                    url = reverse(HomePublicView.urlname)
-                except ImportError:
-                    # this happens when the prelogin app is not included.
-                    url = reverse('login')
-            else:
-                url = reverse('login')
+            url = reverse('login')
     elif domain and _two_factor_needed(domain, req):
         return TemplateResponse(
             request=req,
@@ -1276,3 +1268,19 @@ class HQJSONResponseMixin(JSONResponseMixin):
         from djangular.templatetags.djangular_tags import djng_current_rmi
         context['djng_current_rmi'] = json.loads(djng_current_rmi(context))
         return context
+
+
+def redirect_to_dimagi(endpoint):
+    def _redirect(request):
+        if settings.SERVER_ENVIRONMENT in [
+            'production',
+            'softlayer',
+            'staging',
+            'changeme',
+            'localdev',
+        ]:
+            return HttpResponsePermanentRedirect(
+                "https://www.dimagi.com/{}".format(endpoint)
+            )
+        return redirect_to_default(request)
+    return _redirect

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1284,3 +1284,9 @@ def redirect_to_dimagi(endpoint):
             )
         return redirect_to_default(request)
     return _redirect
+
+
+def temporary_google_verify(request):
+    # will remove once google search console verify process completes
+    # BMB 4/20/18
+    return render(request, "google9633af922b8b0064.html")

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -279,7 +279,7 @@ class ReportBuilderView(BaseDomainView):
             ),
             'report_limit': allowed_num_reports,
             'paywall_url': paywall_home(self.domain),
-            'pricing_page_url': reverse('public_pricing') if settings.ENABLE_PRELOGIN_SITE else "",
+            'pricing_page_url': settings.PRICING_PAGE_URL,
             'support_email': settings.SUPPORT_EMAIL,
         })
         return main_context
@@ -346,7 +346,7 @@ class ReportBuilderPaywallPricing(ReportBuilderPaywallBase):
             'at_report_limit': num_builder_reports >= max_allowed_reports and max_allowed_reports is not None,
             'max_allowed_reports': max_allowed_reports if max_allowed_reports is not None else 0,
             'support_email': settings.SUPPORT_EMAIL,
-            'pricing_page_url': reverse('public_pricing') if settings.ENABLE_PRELOGIN_SITE else "",
+            'pricing_page_url': settings.PRICING_PAGE_URL,
         })
         return context
 

--- a/settings.py
+++ b/settings.py
@@ -760,6 +760,9 @@ PRELOGIN_APPS = (
     'corehq.apps.prelogin',
 )
 
+# dimagi.com urls
+PRICING_PAGE_URL = "https://www.dimagi.com/commcare/pricing/"
+
 # our production logstash aggregation
 LOGSTASH_DEVICELOG_PORT = 10777
 LOGSTASH_AUDITCARE_PORT = 10999

--- a/urls.py
+++ b/urls.py
@@ -25,12 +25,6 @@ try:
 except ImportError:
     LOCAL_APP_URLS = []
 
-try:
-    from localsettings import PRELOGIN_APP_URLS
-except ImportError:
-    PRELOGIN_APP_URLS = [
-        url(r'', include('corehq.apps.prelogin.urls')),
-    ]
 admin.autodiscover()
 
 handler500 = 'corehq.apps.hqwebapp.views.server_error'
@@ -38,6 +32,7 @@ handler404 = 'corehq.apps.hqwebapp.views.not_found'
 handler403 = 'corehq.apps.hqwebapp.views.no_permissions'
 
 from corehq.apps.hqwebapp.urls import domain_specific as hqwebapp_domain_specific
+from corehq.apps.hqwebapp.urls import legacy_prelogin
 from corehq.apps.settings.urls import domain_specific as settings_domain_specific
 from corehq.apps.settings.urls import users_redirect, domain_redirect
 from corehq.apps.sms.urls import sms_admin_interface_urls
@@ -162,7 +157,10 @@ urlpatterns = [
 ] + LOCAL_APP_URLS
 
 if settings.ENABLE_PRELOGIN_SITE:
-    urlpatterns += PRELOGIN_APP_URLS
+    # handle redirects from old prelogin
+    urlpatterns += [
+        url(r'', include(legacy_prelogin)),
+    ]
 
 if settings.DEBUG:
     try:

--- a/urls.py
+++ b/urls.py
@@ -19,6 +19,7 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import static
 from corehq.apps.reports.urls import report_urls
 from corehq.apps.registration.utils import PRICING_LINK
 from corehq.apps.sms.views import sms_in
+from corehq.apps.hqwebapp.urls import legacy_prelogin
 
 try:
     from localsettings import LOCAL_APP_URLS
@@ -32,7 +33,6 @@ handler404 = 'corehq.apps.hqwebapp.views.not_found'
 handler403 = 'corehq.apps.hqwebapp.views.no_permissions'
 
 from corehq.apps.hqwebapp.urls import domain_specific as hqwebapp_domain_specific
-from corehq.apps.hqwebapp.urls import legacy_prelogin
 from corehq.apps.settings.urls import domain_specific as settings_domain_specific
 from corehq.apps.settings.urls import users_redirect, domain_redirect
 from corehq.apps.sms.urls import sms_admin_interface_urls


### PR DESCRIPTION
todos are to remove prelogin

also adds the google search console verification code (on an endpoint only available if ENABLE_PRELOGIN is set to true)

@orangejenny // @nickpell 