### PR TITLE
Disable all CTE stats when disabled for env

### DIFF
--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from django.conf import settings
 from django.contrib.postgres.fields.array import ArrayField
 from django.db.models import CharField, IntegerField
 from django.db.models.aggregates import Max
@@ -210,8 +211,11 @@ class AdjListManager(TreeManager):
             cte_qs = queryset._cte_set
         with timing("mptt"):
             mptt_set = self.mptt_get_queryset_ancestors(mptt_qs, include_self)
-        with timing("cte"):
-            cte_set = self.cte_get_queryset_ancestors(cte_qs, include_self)
+        if settings.IS_LOCATION_CTE_ENABLED:
+            with timing("cte"):
+                cte_set = self.cte_get_queryset_ancestors(cte_qs, include_self)
+        else:
+            cte_set = None
         return ComparedQuerySet(mptt_set, cte_set, timing)
 
     def get_queryset_descendants(self, queryset, include_self=False):
@@ -222,8 +226,11 @@ class AdjListManager(TreeManager):
             cte_qs = queryset._cte_set
         with timing("mptt"):
             mptt_set = self.mptt_get_queryset_descendants(mptt_qs, include_self)
-        with timing("cte"):
-            cte_set = self.cte_get_queryset_descendants(cte_qs, include_self)
+        if settings.IS_LOCATION_CTE_ENABLED:
+            with timing("cte"):
+                cte_set = self.cte_get_queryset_descendants(cte_qs, include_self)
+        else:
+            cte_set = None
         return ComparedQuerySet(mptt_set, cte_set, timing)
 
 
@@ -257,8 +264,11 @@ class AdjListModel(MPTTModel):
         timing = TimingContext("get_ancestors")
         with timing("mptt"):
             mptt_set = self.mptt_get_ancestors(**kw)
-        with timing("cte"):
-            cte_set = type(self).objects.cte_get_ancestors(self, **kw)
+        if settings.IS_LOCATION_CTE_ENABLED:
+            with timing("cte"):
+                cte_set = type(self).objects.cte_get_ancestors(self, **kw)
+        else:
+            cte_set = None
         return ComparedQuerySet(mptt_set, cte_set, timing)
 
     def get_descendants(self, **kw):
@@ -268,8 +278,11 @@ class AdjListModel(MPTTModel):
         timing = TimingContext("get_descendants")
         with timing("mptt"):
             mptt_set = self.mptt_get_descendants(**kw)
-        with timing("cte"):
-            cte_set = type(self).objects.cte_get_descendants(self, **kw)
+        if settings.IS_LOCATION_CTE_ENABLED:
+            with timing("cte"):
+                cte_set = type(self).objects.cte_get_descendants(self, **kw)
+        else:
+            cte_set = None
         return ComparedQuerySet(mptt_set, cte_set, timing)
 
 

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from xml.etree.cElementTree import Element
 
 import six
+from django.conf import settings
 from django.db.models import IntegerField
 from django.contrib.postgres.fields.array import ArrayField
 from django_cte import With
@@ -222,8 +223,11 @@ def get_location_fixture_queryset(user):
     timing = TimingContext("get_location_fixture_queryset")
     with timing("mptt"):
         mptt_set = mptt_get_location_fixture_queryset(user)
-    with timing("cte"):
-        cte_set = cte_get_location_fixture_queryset(user)
+    if settings.IS_LOCATION_CTE_ENABLED:
+        with timing("cte"):
+            cte_set = cte_get_location_fixture_queryset(user)
+    else:
+        cte_set = None
     return ComparedQuerySet(mptt_set, cte_set, timing)
 
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -272,7 +272,7 @@ class LocationQueriesMixin(object):
         assert isinstance(ids_query, ComparedQuerySet), ids_query
         return ComparedQuerySet(
             self.filter(id__in=ids_query._mptt_set),
-            self.filter(id__in=ids_query._cte_set),
+            self.filter(id__in=ids_query._cte_set) if ids_query._cte_set is not None else None,
             ids_query,
         )
 

--- a/corehq/apps/locations/queryutil.py
+++ b/corehq/apps/locations/queryutil.py
@@ -22,8 +22,7 @@ class ComparedQuerySet(object):
 
     def __init__(self, mptt_set, cte_set, timing_context):
         self._mptt_set = mptt_set
-        self._cte_set = cte_set
-        self._enable_cte = settings.IS_LOCATION_CTE_ENABLED
+        self._cte_set = cte_set if settings.IS_LOCATION_CTE_ENABLED else None
         if isinstance(timing_context, ComparedQuerySet):
             timing_context = timing_context._timing.clone()
         self._timing = timing_context
@@ -31,7 +30,7 @@ class ComparedQuerySet(object):
     def __str__(self):
         return "MPTT query: {}\n\nCTE query: {}".format(
             self._mptt_set.query,
-            self._cte_set.query,
+            self._cte_set.query if self._cte_set is not None else None,
         )
 
     def __iter__(self):
@@ -46,7 +45,7 @@ class ComparedQuerySet(object):
                             yield item
                 finished = True
             finally:
-                if not self._enable_cte:
+                if self._cte_set is None:
                     return
                 with self._timing("cte"):
                     items2 = list(self._cte_set)
@@ -61,10 +60,10 @@ class ComparedQuerySet(object):
         with _commit_timing(self):
             with self._timing("mptt"):
                 len1 = len(self._mptt_set)
-            if self._enable_cte:
+            if self._cte_set is not None:
                 with self._timing("cte"):
                     len2 = len(self._cte_set)
-        if self._enable_cte and len1 != len2:
+        if self._cte_set is not None and len1 != len2:
             ids1 = {_identify(it) for it in self._mptt_set}
             ids2 = {_identify(it) for it in self._cte_set}
             _report_diff(self, ids1, ids2, "%s != %s" % (len1, len2))
@@ -74,14 +73,16 @@ class ComparedQuerySet(object):
         with _commit_timing(self):
             with self._timing("mptt"):
                 mptt_result = self._mptt_set.__getitem__(key)
-            if self._enable_cte or isinstance(mptt_result, QuerySet):
+            if self._cte_set is not None or isinstance(mptt_result, QuerySet):
                 with self._timing("cte"):
                     cte_result = self._cte_set.__getitem__(key)
         if isinstance(mptt_result, QuerySet):
-            if not isinstance(cte_result, QuerySet):
+            if self._cte_set is None:
+                cte_result = None
+            elif not isinstance(cte_result, QuerySet):
                 _report_diff(self, mptt_result, cte_result)
             return ComparedQuerySet(mptt_result, cte_result, self)
-        if self._enable_cte:
+        if self._cte_set is not None:
             if isinstance(mptt_result, list) and isinstance(cte_result, list):
                 ids1 = [_identify(it) for it in mptt_result]
                 ids2 = [_identify(it) for it in cte_result]
@@ -96,10 +97,10 @@ class ComparedQuerySet(object):
         with _commit_timing(self):
             with self._timing("mptt"):
                 ex1 = self._mptt_set.exists(*args, **kw)
-            if self._enable_cte:
+            if self._cte_set is not None:
                 with self._timing("cte"):
                     ex2 = self._cte_set.exists(*args, **kw)
-        if self._enable_cte and ex1 != ex2:
+        if self._cte_set is not None and ex1 != ex2:
             _report_diff(self, ex1, ex2)
         return ex1
 
@@ -110,7 +111,7 @@ class ComparedQuerySet(object):
             for qs in other_qs]
         return ComparedQuerySet(
             self._mptt_set.union(*other_mptt, **kwargs),
-            self._cte_set.union(*other_cte, **kwargs),
+            self._cte_set.union(*other_cte, **kwargs) if self._cte_set is not None else None,
             self,
         )
 
@@ -129,7 +130,7 @@ class ComparedQuerySet(object):
         assert isinstance(ids_query, ComparedQuerySet), ids_query
         result = ComparedQuerySet(
             self._mptt_set.filter(id__in=ids_query._mptt_set),
-            self._cte_set.filter(id__in=ids_query._cte_set),
+            self._cte_set.filter(id__in=ids_query._cte_set) if self._cte_set is not None else None,
             TimingContext("accessible_to_user"),
         )
         result._timing += ids_query._timing
@@ -145,10 +146,10 @@ def _make_get_method(name):
         with _commit_timing(self):
             with self._timing("mptt"):
                 obj1 = getattr(self._mptt_set, name)(*args, **kw)
-            if self._enable_cte:
+            if self._cte_set is not None:
                 with self._timing("cte"):
                     obj2 = getattr(self._cte_set, name)(*args, **kw)
-        if self._enable_cte and _identify(obj1) != _identify(obj2):
+        if self._cte_set is not None and _identify(obj1) != _identify(obj2):
             _report_diff(self, obj1, obj2)
         return obj1
     method.__name__ = str(name)  # unicode_literals: must be bytes on PY2
@@ -159,7 +160,7 @@ def _make_qs_method(name):
     def method(self, *args, **kw):
         return ComparedQuerySet(
             getattr(self._mptt_set, name)(*args, **kw),
-            getattr(self._cte_set, name)(*args, **kw),
+            getattr(self._cte_set, name)(*args, **kw) if self._cte_set is not None else None,
             self,
         )
     method.__name__ = str(name)  # unicode_literals: must be bytes on PY2


### PR DESCRIPTION
The first try was still recording timings, but only CTE query construction (not execution) time? Anyway, this should more completely eliminate those stats on envs where it is disabled.

@esoergel @calellowitz 