### PR TITLE
Optimize cte_get_descendants query

### DIFF
--- a/corehq/apps/hqadmin/tests/test_clone_domain.py
+++ b/corehq/apps/hqadmin/tests/test_clone_domain.py
@@ -99,11 +99,13 @@ class TestCloneDomain(TestCase):
                 # exclude here instead of at end (on union queryset) because
                 # django discards filters on union queries?? (django bug?)
                 .exclude(domain=domain)
+                .values("name")
                 .order_by()  # discard ORDER BY
                 .union(
                     SQLLocation.objects
                     .get_queryset_descendants(locs_in_domain)
                     .exclude(domain=domain)  # exclude here instead of at end...
+                    .values("name")
                     .order_by(),  # discard ORDER BY
                     all=True,
                 )

--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -125,7 +125,6 @@ class AdjListManager(TreeManager):
         def make_cte_query(cte):
             return self.filter(where).order_by().values(
                 "id",
-                parent_col,
                 _cte_ordering=StrArray(ordering_col),
             ).union(
                 cte.join(
@@ -138,7 +137,6 @@ class AdjListManager(TreeManager):
                     )
                 ).values(
                     "id",
-                    parent_col,
                     "_cte_ordering",
                 ),
                 all=True,
@@ -171,7 +169,6 @@ class AdjListManager(TreeManager):
                 ).values(
                     id=cte.col.id,
                     _cte_ordering=cte.col._cte_ordering,
-                    **{parent_col: getattr(cte.col, parent_col)}
                 ),
                 name="xdups",
             )


### PR DESCRIPTION
Noticed really slow times in datadog for the CTE version of `get_descendants`.

@esoergel @calellowitz 