### PR TITLE
Use get_case_property() instead of to_json()

### DIFF
--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -230,10 +230,26 @@ class AbstractCommCareCase(CaseToXMLMixin):
                 host._resolve_case_property(property_name[5:], result)
             return
 
-        result.append(CasePropertyResult(
-            self,
-            self.to_json().get(property_name)
-        ))
+        from corehq.form_processor.models import CommCareCaseSQL
+        if isinstance(self, CommCareCaseSQL):
+            if property_name == '_id':
+                property_name = 'case_id'
+
+            # Use .get_case_property() for the CommCareCaseSQL because
+            # using .to_json() makes a lot of unnecessary db calls to find
+            # things like case indices and case actions which we don't need here
+            result.append(CasePropertyResult(
+                self,
+                self.get_case_property(property_name)
+            ))
+        else:
+            # Use .to_json() for the couch CommCareCase because if we used
+            # get_case_property() then dynamic case properties might end
+            # up being coerced into data types other than string
+            result.append(CasePropertyResult(
+                self,
+                self.to_json().get(property_name)
+            ))
 
     def resolve_case_property(self, property_name):
         """


### PR DESCRIPTION
A small change which should boost performance on running rules in domains with the sql form processing backend.

@millerdev cc @biyeun 