### PR TITLE
disable type coercion

### DIFF
--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -330,14 +330,14 @@ class ExpressionFactory(object):
         try:
             return cls.spec_map[spec['type']](spec, context)
         except KeyError:
-            raise BadSpecError(_('Invalid or missing getter type: {} for expression: {}. '
+            raise BadSpecError(_('Invalid or missing expression type: {} for expression: {}. '
                                  'Valid options are: {}').format(
                 spec.get('type', '[missing]'),
                 spec,
                 ', '.join(cls.spec_map),
             ))
         except (TypeError, BadValueError) as e:
-            raise BadSpecError(_('Problem creating getter: {}. Message is: {}').format(
+            raise BadSpecError(_('Problem creating expression: {}. Message is: {}').format(
                 json.dumps(spec, indent=2, default=json_handler),
                 str(e),
             ))

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import itertools
 from django.utils.translation import ugettext as _
+
+from corehq.apps.userreports.mixins import NoPropertyTypeCoersionMixIn
 from dimagi.ext.jsonobject import JsonObject, DictProperty, StringProperty
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.specs import TypeProperty
@@ -18,7 +20,7 @@ def _evaluate_items_expression(itemx_ex, doc, context):
         return result
 
 
-class FilterItemsExpressionSpec(JsonObject):
+class FilterItemsExpressionSpec(NoPropertyTypeCoersionMixIn, JsonObject):
     type = TypeProperty('filter_items')
     items_expression = DefaultProperty(required=True)
     filter_expression = DictProperty(required=True)

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -85,7 +85,7 @@ class ReduceItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
                                                   items=add_tabbed_text(str(self._items_expression)))
 
 
-class FlattenExpressionSpec(JsonObject):
+class FlattenExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     type = TypeProperty('flatten')
     items_expression = DefaultProperty(required=True)
 

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import itertools
 from django.utils.translation import ugettext as _
 
-from corehq.apps.userreports.mixins import NoPropertyTypeCoersionMixIn
+from corehq.apps.userreports.mixins import NoPropertyTypeCoercionMixIn
 from dimagi.ext.jsonobject import JsonObject, DictProperty, StringProperty
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.specs import TypeProperty
@@ -20,7 +20,7 @@ def _evaluate_items_expression(itemx_ex, doc, context):
         return result
 
 
-class FilterItemsExpressionSpec(NoPropertyTypeCoersionMixIn, JsonObject):
+class FilterItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     type = TypeProperty('filter_items')
     items_expression = DefaultProperty(required=True)
     filter_expression = DictProperty(required=True)

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -47,7 +47,7 @@ class FilterItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
 class MapItemsExpressionSpec(JsonObject):
     type = TypeProperty('map_items')
     items_expression = DefaultProperty(required=True)
-    map_expression = DictProperty(required=True)
+    map_expression = DefaultProperty(required=True)
 
     def configure(self, items_expression, map_expression):
         self._items_expression = items_expression

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -107,7 +107,7 @@ class FlattenExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
         return "flatten:\n{items}\n".format(items=add_tabbed_text(str(self._items_expression)))
 
 
-class SortItemsExpressionSpec(JsonObject):
+class SortItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     ASC, DESC = "ASC", "DESC"
     type = TypeProperty('sort_items')
     items_expression = DefaultProperty(required=True)

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -44,7 +44,7 @@ class FilterItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
                                                           filter=add_tabbed_text(str(self._filter_expression)))
 
 
-class MapItemsExpressionSpec(JsonObject):
+class MapItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     type = TypeProperty('map_items')
     items_expression = DefaultProperty(required=True)
     map_expression = DefaultProperty(required=True)

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -63,7 +63,7 @@ class MapItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
                                                     map=add_tabbed_text(str(self._map_expression)))
 
 
-class ReduceItemsExpressionSpec(JsonObject):
+class ReduceItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     type = TypeProperty('reduce_items')
     items_expression = DefaultProperty(required=True)
     aggregation_fn = StringProperty(required=True)

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -14,7 +14,7 @@ from corehq.apps.userreports.const import XFORM_CACHE_KEY_PREFIX, NAMED_EXPRESSI
 from corehq.apps.userreports.decorators import ucr_context_cache
 from corehq.apps.userreports.document_stores import get_document_store
 from corehq.apps.userreports.exceptions import BadSpecError
-from corehq.apps.userreports.mixins import NoPropertyTypeCoersionMixIn
+from corehq.apps.userreports.mixins import NoPropertyTypeCoercionMixIn
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.couch import get_db_by_doc_type
@@ -206,7 +206,7 @@ class SwitchExpressionSpec(JsonObject):
             default=add_tabbed_text((str(self._default_expression))))
 
 
-class IteratorExpressionSpec(NoPropertyTypeCoersionMixIn, JsonObject):
+class IteratorExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     type = TypeProperty('iterator')
     expressions = ListProperty(required=True)
     # an optional filter to test the values on - if they don't match they won't be included in the iteration

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -14,6 +14,7 @@ from corehq.apps.userreports.const import XFORM_CACHE_KEY_PREFIX, NAMED_EXPRESSI
 from corehq.apps.userreports.decorators import ucr_context_cache
 from corehq.apps.userreports.document_stores import get_document_store
 from corehq.apps.userreports.exceptions import BadSpecError
+from corehq.apps.userreports.mixins import NoPropertyTypeCoersionMixIn
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.couch import get_db_by_doc_type
@@ -205,7 +206,7 @@ class SwitchExpressionSpec(JsonObject):
             default=add_tabbed_text((str(self._default_expression))))
 
 
-class IteratorExpressionSpec(JsonObject):
+class IteratorExpressionSpec(NoPropertyTypeCoersionMixIn, JsonObject):
     type = TypeProperty('iterator')
     expressions = ListProperty(required=True)
     # an optional filter to test the values on - if they don't match they won't be included in the iteration

--- a/corehq/apps/userreports/filters/specs.py
+++ b/corehq/apps/userreports/filters/specs.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from corehq.apps.userreports.mixins import NoPropertyTypeCoersionMixIn
 from dimagi.ext.jsonobject import JsonObject, StringProperty, ListProperty, DictProperty
 from jsonobject.base import DefaultProperty
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -14,7 +16,7 @@ class BaseFilterSpec(JsonObject):
     comment = StringProperty()
 
 
-class BooleanExpressionFilterSpec(BaseFilterSpec):
+class BooleanExpressionFilterSpec(NoPropertyTypeCoersionMixIn, BaseFilterSpec):
     type = TypeProperty('boolean_expression')
     operator = StringProperty(choices=list(OPERATORS), required=True)
     property_value = DefaultProperty()

--- a/corehq/apps/userreports/filters/specs.py
+++ b/corehq/apps/userreports/filters/specs.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from corehq.apps.userreports.mixins import NoPropertyTypeCoersionMixIn
+from corehq.apps.userreports.mixins import NoPropertyTypeCoercionMixIn
 from dimagi.ext.jsonobject import JsonObject, StringProperty, ListProperty, DictProperty
 from jsonobject.base import DefaultProperty
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -16,7 +16,7 @@ class BaseFilterSpec(JsonObject):
     comment = StringProperty()
 
 
-class BooleanExpressionFilterSpec(NoPropertyTypeCoersionMixIn, BaseFilterSpec):
+class BooleanExpressionFilterSpec(NoPropertyTypeCoercionMixIn, BaseFilterSpec):
     type = TypeProperty('boolean_expression')
     operator = StringProperty(choices=list(OPERATORS), required=True)
     property_value = DefaultProperty()

--- a/corehq/apps/userreports/mixins.py
+++ b/corehq/apps/userreports/mixins.py
@@ -122,7 +122,7 @@ class ConfigurableReportDataSourceMixin(object):
             return [column_id]
 
 
-class NoPropertyTypeCoersionMixIn(object):
+class NoPropertyTypeCoercionMixIn(object):
     """
     This disables automatic type conversion on a JsonObject
     So, for example, nested date-like things don't get automatically converted to dates.

--- a/corehq/apps/userreports/mixins.py
+++ b/corehq/apps/userreports/mixins.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from collections import OrderedDict
 
-from corehq.apps.userreports.models import DataSourceConfiguration, get_datasource_config
-from corehq.apps.userreports.reports.specs import ReportColumn, ExpressionColumn
 from corehq.apps.userreports.util import get_table_name
 import six
 
 
 class ConfigurableReportDataSourceMixin(object):
     def __init__(self, domain, config_or_config_id, filters, aggregation_columns, columns, order_by):
+        from corehq.apps.userreports.models import DataSourceConfiguration
         self.lang = None
         self.domain = domain
         if isinstance(config_or_config_id, DataSourceConfiguration):
@@ -42,6 +41,7 @@ class ConfigurableReportDataSourceMixin(object):
 
     @property
     def config(self):
+        from corehq.apps.userreports.models import get_datasource_config
         if self._config is None:
             self._config, _ = get_datasource_config(self._config_id, self.domain)
         return self._config
@@ -68,10 +68,13 @@ class ConfigurableReportDataSourceMixin(object):
 
     @property
     def top_level_db_columns(self):
+        from corehq.apps.userreports.reports.specs import ReportColumn
+
         return [col for col in self.top_level_columns if isinstance(col, ReportColumn)]
 
     @property
     def top_level_computed_columns(self):
+        from corehq.apps.userreports.reports.specs import ExpressionColumn
         return [col for col in self.top_level_columns if isinstance(col, ExpressionColumn)]
 
     @property
@@ -117,3 +120,14 @@ class ConfigurableReportDataSourceMixin(object):
         else:
             # if the column isn't found just treat it as a normal field
             return [column_id]
+
+
+class NoPropertyTypeCoersionMixIn(object):
+    """
+    This disables automatic type conversion on a JsonObject
+    So, for example, nested date-like things don't get automatically converted to dates.
+
+    Used by many of the spec classes.
+    """
+    class Meta(object):
+        string_conversions = ()

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -659,6 +659,19 @@ class IteratorExpressionTest(SimpleTestCase):
         expression = ExpressionFactory.from_spec(spec)
         self.assertEqual([1], expression({'p1': 1, 'p2': ''}))
 
+    def test_type_coercion(self):
+        spec = copy.copy(self.spec)
+        spec['expressions'] = [
+            '2018-01-01',
+            {
+                'type': 'constant',
+                'constant': '2018-01-01',
+                'datatype': 'date',
+            },
+        ]
+        expression = ExpressionFactory.from_spec(spec)
+        self.assertEqual([date(2018, 1, 1), date(2018, 1, 1)], expression({}))
+
 
 class RootDocExpressionTest(SimpleTestCase):
 

--- a/corehq/apps/userreports/tests/test_filters.py
+++ b/corehq/apps/userreports/tests/test_filters.py
@@ -218,6 +218,24 @@ class BooleanExpressionFilterTest(SimpleTestCase):
         self.assertFalse(filter_with_date({'visit_date': '2015-05-04'}))
         self.assertTrue(filter_with_date({'visit_date': '2015-05-06'}))
 
+    def test_date_conversion_nested(self):
+        filter_with_date = FilterFactory.from_spec({
+            "type": "boolean_expression",
+            "expression": {
+                "datatype": "date",
+                "property_name": "visit_date",
+                "type": "property_name"
+            },
+            "operator": "gt",
+            "property_value": {
+                "type": "constant",
+                "datatype": "date",
+                "constant": "2015-05-05",
+            }
+        })
+        self.assertFalse(filter_with_date({'visit_date': '2015-05-04'}))
+        self.assertTrue(filter_with_date({'visit_date': '2015-05-06'}))
+
     def test_literal_in_expression(self):
         filter_with_literal = FilterFactory.from_spec({
             'type': 'boolean_expression',

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -99,7 +99,6 @@ def test_filter_items_basic(self, doc, items_ex, filter_ex, expected):
     self.assertEqual(expression(doc), expected)
 
 
-
 @generate_cases([
     ([{'key': 'v1'}, {'key': 'v2'}], None),
     ([{'key': 'v1'}, {'key': 'v2'}], {}),

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -574,7 +574,6 @@ class NestedExpressionTest(SimpleTestCase):
             self.assertEqual(self.DATE, val)
 
 
-
 class ListExpressionTest(SimpleTestCase):
     """
     Test filter, map, reduce, sort and flatten together for few expected use cases

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -99,6 +99,7 @@ def test_filter_items_basic(self, doc, items_ex, filter_ex, expected):
     self.assertEqual(expression(doc), expected)
 
 
+
 @generate_cases([
     ([{'key': 'v1'}, {'key': 'v2'}], None),
     ([{'key': 'v1'}, {'key': 'v2'}], {}),
@@ -484,6 +485,48 @@ def test_sort_items_basic(self, doc, items_ex, sort_ex, expected):
         'sort_expression': sort_ex
     })
     self.assertEqual(expression(doc), expected)
+
+
+class NestedExpressionTest(SimpleTestCase):
+    DATE_LITERAL = '2018-01-01'
+    DATE_CONSTANT_EXPRESSION = {
+        'type': 'constant',
+        'constant': '2018-01-01',
+        'datatype': 'date',
+    }
+    DATE_LITERAL_FILTER = {
+        'type': 'boolean_expression',
+        'operator': 'eq',
+        'expression': {
+            'type': 'identity',
+        },
+        'property_value': DATE_LITERAL,
+    }
+    DATE_CONSTANT_FILTER = {
+        'type': 'boolean_expression',
+        'operator': 'eq',
+        'expression': {
+            'type': 'identity',
+        },
+        'property_value': DATE_CONSTANT_EXPRESSION,
+    }
+    ITEMS_EXPRESSION = {
+        'type': 'iterator',
+        "expressions": [
+            DATE_LITERAL,
+            DATE_CONSTANT_EXPRESSION,
+            'not a date',
+        ],
+    }
+
+    def test_filter_items_with_nested_dates(self):
+        for filter_spec in [self.DATE_LITERAL_FILTER, self.DATE_CONSTANT_FILTER]:
+            expression = ExpressionFactory.from_spec({
+                "type": "filter_items",
+                "items_expression": self.ITEMS_EXPRESSION,
+                "filter_expression": filter_spec,
+            })
+            self.assertEqual(2, len(expression({})))
 
 
 class ListExpressionTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import datetime
+from copy import copy
+
 from django.test import SimpleTestCase
 
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -557,6 +559,20 @@ class NestedExpressionTest(SimpleTestCase):
         # in this case the expression fails and defaults to an empty list because the inner dates aren't iterable
         # this is fine as the bug was actually in the generation of the expression from the factory
         self.assertEqual([], expression({}))
+
+    def test_sort_items_with_nested_dates(self):
+        items_expression = copy(self.ITEMS_EXPRESSION)
+        items_expression['expressions'] = items_expression['expressions'][:2]
+        expression = ExpressionFactory.from_spec({
+            "type": "sort_items",
+            "items_expression": items_expression,
+            "sort_expression": {'type': 'identity'}
+        })
+        result = expression({})
+        self.assertEqual(2, len(result))
+        for val in result:
+            self.assertEqual(self.DATE, val)
+
 
 
 class ListExpressionTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
+from corehq.apps.userreports.expressions.utils import COUNT
 from corehq.util.test_utils import generate_cases
 
 
@@ -539,6 +540,14 @@ class NestedExpressionTest(SimpleTestCase):
             self.assertEqual(3, len(result))
             for val in result:
                 self.assertEqual(self.DATE, val)
+
+    def test_reduce_items_with_nested_dates(self):
+        expression = ExpressionFactory.from_spec({
+            "type": "reduce_items",
+            "items_expression": self.ITEMS_EXPRESSION,
+            "aggregation_fn": COUNT,
+        })
+        self.assertEqual(3, expression({}))
 
 
 class ListExpressionTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -487,6 +487,7 @@ def test_sort_items_basic(self, doc, items_ex, sort_ex, expected):
 
 
 class NestedExpressionTest(SimpleTestCase):
+    DATE = datetime.date(2018, 1, 1)
     DATE_LITERAL = '2018-01-01'
     DATE_CONSTANT_EXPRESSION = {
         'type': 'constant',
@@ -526,6 +527,18 @@ class NestedExpressionTest(SimpleTestCase):
                 "filter_expression": filter_spec,
             })
             self.assertEqual(2, len(expression({})))
+
+    def test_map_items_with_nested_dates(self):
+        for inner_expression_spec in [self.DATE_LITERAL, self.DATE_CONSTANT_EXPRESSION]:
+            expression = ExpressionFactory.from_spec({
+                "type": "map_items",
+                "items_expression": self.ITEMS_EXPRESSION,
+                "map_expression": inner_expression_spec,
+            })
+            result = expression({})
+            self.assertEqual(3, len(result))
+            for val in result:
+                self.assertEqual(self.DATE, val)
 
 
 class ListExpressionTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_list_expressions.py
+++ b/corehq/apps/userreports/tests/test_list_expressions.py
@@ -549,6 +549,15 @@ class NestedExpressionTest(SimpleTestCase):
         })
         self.assertEqual(3, expression({}))
 
+    def test_flatten_items_with_nested_dates(self):
+        expression = ExpressionFactory.from_spec({
+            "type": "flatten",
+            "items_expression": self.ITEMS_EXPRESSION,
+        })
+        # in this case the expression fails and defaults to an empty list because the inner dates aren't iterable
+        # this is fine as the bug was actually in the generation of the expression from the factory
+        self.assertEqual([], expression({}))
+
 
 class ListExpressionTest(SimpleTestCase):
     """


### PR DESCRIPTION
not quite ready for merge yet but wanted to get feedback before going any further on this.

basically i noticed that certain categories of expressions failed unexpectedly due to `JsonObject`'s automatic type detection/coercion. this is an issue for anything that references an expression.

wrote a few tests and fixes for some classes as a PoC, just wanted to confirm this seems like a reasonable change?

i went with github's suggested reviewers. cc @orangejenny buddy