### PR TITLE
Update redirects to include langcode for old prelogin

### DIFF
--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -71,7 +71,7 @@ domain_specific = [
     url(r'couch_doc_counts', couch_doc_counts),
 ]
 
-legacy_prelogin = [
+prelogin_root = [
     url(r'^home/$', redirect_to_dimagi('commcare/'),
         name='public_home'),
     url(r'^impact/$', redirect_to_dimagi('commcare/'),
@@ -88,5 +88,9 @@ legacy_prelogin = [
     url(r'^askdemo/$', redirect_to_dimagi('commcare/'),
         name='public_demo_cta'),
     url(r'^supply/$', redirect_to_dimagi('commcare/')),
+]
+
+legacy_prelogin = prelogin_root + [
     url(r'^google9633af922b8b0064.html$', temporary_google_verify),
+    url(r'^lang/(?P<lang_code>[\w-]+)/', include(prelogin_root)),
 ]

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -151,7 +151,10 @@ def redirect_to_default(req, domain=None):
         if domain != None:
             url = reverse('domain_login', args=[domain])
         else:
-            url = reverse('login')
+            if settings.SERVER_ENVIRONMENT == 'production':
+                url = "https://www.dimagi.com/commcare/"
+            else:
+                url = reverse('login')
     elif domain and _two_factor_needed(domain, req):
         return TemplateResponse(
             request=req,
@@ -1271,7 +1274,7 @@ class HQJSONResponseMixin(JSONResponseMixin):
 
 
 def redirect_to_dimagi(endpoint):
-    def _redirect(request):
+    def _redirect(request, lang_code=None):
         if settings.SERVER_ENVIRONMENT in [
             'production',
             'softlayer',
@@ -1280,7 +1283,10 @@ def redirect_to_dimagi(endpoint):
             'localdev',
         ]:
             return HttpResponsePermanentRedirect(
-                "https://www.dimagi.com/{}".format(endpoint)
+                "https://www.dimagi.com/{}{}".format(
+                    endpoint,
+                    "?lang={}".format(lang_code) if lang_code else "",
+                )
             )
         return redirect_to_default(request)
     return _redirect


### PR DESCRIPTION
also, on production when logged out root should redirect to dimagi.com/commcare/

@orangejenny @nickpell cc @gcapalbo 