### PR TITLE
Non-admin can't edit their own reports

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -980,7 +980,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
         owner = report_instance.owner
         owner_domain = report_instance.domain
         current_user = self.request.couch_user
-        return current_user == owner or current_user.is_domain_admin(owner_domain)
+        return current_user.user_id == owner.user_id or current_user.is_domain_admin(owner_domain)
 
     @property
     @memoized


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?272237#1471517

The direct comparison of `current_user== owner` was returning false every time, hence this button not working for nonadmin users; changed it to a comparison of user_id's.