### PR TITLE
delete report configs when deleting report configuration

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -740,7 +740,9 @@ def delete_report(request, domain, report_id):
 
     report_configs = ReportConfig.by_domain_and_owner(
         domain, request.couch_user.get_id, "configurable")
-    (rc.delete() for rc in report_configs if rc.subreport_slug == config.get_id)
+    for rc in report_configs:
+        if rc.subreport_slug == config.get_id:
+            rc.delete()
 
     if did_purge_something:
         messages.warning(

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -53,6 +53,7 @@ from corehq.apps.domain.decorators import login_and_domain_required, login_or_ba
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
+from corehq.apps.reports.models import ReportConfig
 from corehq.apps.hqwebapp.decorators import (
     use_select2,
     use_daterangepicker,
@@ -736,6 +737,11 @@ def delete_report(request, domain, report_id):
         ),
         extra_tags='html'
     )
+
+    report_configs = ReportConfig.by_domain_and_owner(
+        domain, request.couch_user.get_id, "configurable")
+    (rc.delete() for rc in report_configs if rc.subreport_slug == config.get_id)
+
     if did_purge_something:
         messages.warning(
             request,


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?271943

Checks associated report configs and deletes them. This should be safe, as it just adds a deleted field to the configs and removes them from the notifications

@nickpell 
@emord --> since you had this suggestion