### PR TITLE
Rework Appcues AB test

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/appcues.js
+++ b/corehq/apps/analytics/static/analytix/js/appcues.js
@@ -31,7 +31,7 @@ hqDefine('analytix/js/appcues', [
             _logger = logging.getLoggerForApi('Appcues');
 
         _ready = utils.initApi(_ready, apiId, scriptUrl, _logger, function () {
-            Appcues.identify(_get("username"), {
+            identify(_get("username"), {
                 firstName: _get("firstName"),
                 lastName: _get("lastName"),
                 email: _get("username"),
@@ -42,8 +42,18 @@ hqDefine('analytix/js/appcues', [
         });
     });
 
-    function trackEvent(label, data) {
+    function identify(email, properties) {
+        var originalArgs = arguments;
         _ready.done(function () {
+            _logger.debug.log(originalArgs, 'Identify');
+            Appcues.identify(email, properties);
+        });
+    }
+
+    function trackEvent(label, data) {
+        var originalArgs = arguments;
+        _ready.done(function () {
+            _logger.debug.log(originalArgs, 'RECORD EVENT');
             if (_.isObject(data)) {
                 Appcues.track(label, data);
             } else {
@@ -56,6 +66,7 @@ hqDefine('analytix/js/appcues', [
     }
 
     return {
+        identify: identify,
         trackEvent: trackEvent,
         EVENT_TYPES: EVENT_TYPES,
         then: then,

--- a/corehq/apps/analytics/static/analytix/js/appcues.js
+++ b/corehq/apps/analytics/static/analytix/js/appcues.js
@@ -17,6 +17,7 @@ hqDefine('analytix/js/appcues', [
     'use strict';
     var _get = initialAnalytics.getFn('appcues'),
         _ready = $.Deferred(),
+        _logger = logging.getLoggerForApi('Appcues'),
         EVENT_TYPES = {
             FORM_LOADED: "Form is loaded",
             FORM_SAVE: "Saved a form",
@@ -27,9 +28,9 @@ hqDefine('analytix/js/appcues', [
 
     $(function () {
         var apiId = _get('apiId'),
-            scriptUrl = "//fast.appcues.com/" + apiId + '.js',
-            _logger = logging.getLoggerForApi('Appcues');
+            scriptUrl = "//fast.appcues.com/" + apiId + '.js';
 
+        _logger = logging.getLoggerForApi('Appcues');
         _ready = utils.initApi(_ready, apiId, scriptUrl, _logger, function () {
             identify(_get("username"), {
                 firstName: _get("firstName"),

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -8,7 +8,7 @@
 {% block title %}{{ module.name|clean_trans:langs }}{% endblock %}
 
 {% block stylesheets %}{{ block.super }}
-    {% if request|toggle_enabled:"APPCUES_AB_TEST_CONTROLLER" and request|toggle_enabled:"APPCUES_AB_TEST" %}
+    {% if request|toggle_enabled:"APPCUES_AB_TEST" %}
         <style type="text/css">
             .helpbubble {
                 display: none !important;

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -7,6 +7,16 @@
 
 {% block title %}{{ module.name|clean_trans:langs }}{% endblock %}
 
+{% block stylesheets %}{{ block.super }}
+    {% if request|toggle_enabled:"APPCUES_AB_TEST_CONTROLLER" and request|toggle_enabled:"APPCUES_AB_TEST" %}
+        <style type="text/css">
+            .helpbubble {
+                display: none !important;
+            }
+        </style>
+    {% endif %}
+{% endblock stylesheets %}
+
 {% block js %}
     {{ block.super }}
     {% compress js %}

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -214,6 +214,6 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 302)
         redirect_location = response['Location']
         [app_id] = re.compile(r'[a-fA-F0-9]{32}').findall(redirect_location)
-        expected = '/apps/view/{}/'.format(app_id)
+        expected = '/apps/view/{}/?appcues=1'.format(app_id)    # Remove get param when APPCUES_AB_TEST is over
         self.assertTrue(redirect_location.endswith(expected))
         self.addCleanup(lambda: Application.get_db().delete_doc(app_id))

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -131,7 +131,8 @@ def default_new_app(request, domain):
         app.secure_submissions = True
     clear_app_cache(request, domain)
     app.save()
-    return HttpResponseRedirect(reverse('view_app', args=[domain, app._id]))
+    # GET param can be removed when APPCUES_AB_TEST is finished
+    return HttpResponseRedirect(reverse('view_app', args=[domain, app._id]) + "?appcues=1")
 
 
 def get_app_view_context(request, app):

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -54,11 +54,11 @@ hqDefine('registration/js/new_user.ko', function () {
 
             var appcuesEvent = "Assigned user to Appcues test",
                 appcuesData = {
-                'Appcues test': data.appcuesAbTest ? 'On' : 'Off',
+                'Appcues test': data.appcuesAbTest,
             };
 
             _appcues.identify(data.email, appcuesData);
-            _appcues.track.event(appcuesEvent, appcuesData);
+            _appcues.trackEvent(appcuesEvent, appcuesData);
 
             _kissmetrics.identify(data.email);
             _kissmetrics.identifyTraits(appcuesData);
@@ -387,7 +387,7 @@ hqDefine('registration/js/new_user.ko', function () {
                             self.isMobileExperience(response.is_mobile_experience);
                             _private.submitSuccessAnalytics(_.extend({}, submitData, {
                                 email: self.email(),
-                                appcuesAbTest: response.appcues_ab_test ? 'Yes' : 'No',
+                                appcuesAbTest: response.appcues_ab_test ? 'On' : 'Off',
                             }));
                         }
                     },

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -13,6 +13,7 @@ hqDefine('registration/js/new_user.ko', function () {
     var module = {};
 
     var _private = {},
+        _appcues = hqImport('analytix/js/appcues'),
         _kissmetrics = hqImport('analytix/js/kissmetrix');
 
     _private.rmiUrl = null;
@@ -50,6 +51,18 @@ hqDefine('registration/js/new_user.ko', function () {
             if (_private.isAbPhoneNumber) {
                 _kissmetrics.track.event("Phone Number Field Filled Out");
             }
+
+            var appcuesEvent = "Assigned user to Appcues test",
+                appcuesData = {
+                'Appcues test': data.appcuesAbTest ? 'On' : 'Off',
+            };
+
+            _appcues.identify(self.email(), appcuesData);
+            _appcues.track.event(appcuesEvent, appcuesData);
+
+            _kissmetrics.identify(self.email());
+            _kissmetrics.identifyTraits(appcuesData);
+            _kissmetrics.track.event(appcuesEvent, appcuesData);
         };
     });
 
@@ -372,7 +385,9 @@ hqDefine('registration/js/new_user.ko', function () {
                             self.isSubmitting(false);
                             self.isSubmitSuccess(true);
                             self.isMobileExperience(response.is_mobile_experience);
-                            _private.submitSuccessAnalytics(submitData);
+                            _private.submitSuccessAnalytics(_.extend({}, submitData, {
+                                data.appcuesAbTest: response.appcues_ab_test ? 'Yes' : 'No',
+                            }));
                         }
                     },
                     error: function () {

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -54,8 +54,8 @@ hqDefine('registration/js/new_user.ko', function () {
 
             var appcuesEvent = "Assigned user to Appcues test",
                 appcuesData = {
-                'Appcues test': data.appcuesAbTest,
-            };
+                    'Appcues test': data.appcuesAbTest,
+                };
 
             _appcues.identify(data.email, appcuesData);
             _appcues.trackEvent(appcuesEvent, appcuesData);

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -57,10 +57,10 @@ hqDefine('registration/js/new_user.ko', function () {
                 'Appcues test': data.appcuesAbTest ? 'On' : 'Off',
             };
 
-            _appcues.identify(self.email(), appcuesData);
+            _appcues.identify(data.email, appcuesData);
             _appcues.track.event(appcuesEvent, appcuesData);
 
-            _kissmetrics.identify(self.email());
+            _kissmetrics.identify(data.email);
             _kissmetrics.identifyTraits(appcuesData);
             _kissmetrics.track.event(appcuesEvent, appcuesData);
         };
@@ -386,7 +386,8 @@ hqDefine('registration/js/new_user.ko', function () {
                             self.isSubmitSuccess(true);
                             self.isMobileExperience(response.is_mobile_experience);
                             _private.submitSuccessAnalytics(_.extend({}, submitData, {
-                                data.appcuesAbTest: response.appcues_ab_test ? 'Yes' : 'No',
+                                email: self.email(),
+                                appcuesAbTest: response.appcues_ab_test ? 'Yes' : 'No',
                             }));
                         }
                     },

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -129,6 +129,7 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
         email = new_user.email
 
         properties = {}
+        toggles.APPCUES_AB_TEST_CONTROLLER.set(email, True)
         if is_mobile:
             toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.set(
                 email, True)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -161,7 +161,6 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
                     }
                 }
 
-
             couch_user = CouchUser.get_by_username(reg_form.cleaned_data['email'])
             appcues_ab_test = toggles.APPCUES_AB_TEST.enabled(reg_form.cleaned_data['email'],
                                                               toggles.NAMESPACE_USER)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -129,7 +129,6 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
         email = new_user.email
 
         properties = {}
-        toggles.APPCUES_AB_TEST_CONTROLLER.set(email, True)
         if is_mobile:
             toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.set(
                 email, True)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -168,7 +168,7 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
                                                                  toggles.NAMESPACE_USER)
             if couch_user:
                 hubspot_fields = {
-                    "Appcues test": in_appcues_ab_test ? "On": "Off",
+                    "Appcues test": "On" if in_appcues_ab_test else "Off",
                 }
                 if reg_form.cleaned_data['persona']:
                     hubspot_fields['buyer_persona'] = reg_form.cleaned_data['persona']

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -136,9 +136,7 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
             variation = toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(email, toggles.NAMESPACE_USER)
             properties = {"mobile_signups_test_march2018test": "variation" if variation else "control"}
 
-        track_workflow(email,
-                       "Requested new account",
-                       properties)
+        track_workflow(email, "Requested new account", properties)
         login(self.request, new_user)
 
     @allow_remote_invocation
@@ -164,21 +162,27 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
                     }
                 }
 
-            persona_fields = {}
-            if reg_form.cleaned_data['persona']:
-                persona_fields['buyer_persona'] = reg_form.cleaned_data['persona']
-                if reg_form.cleaned_data['persona_other']:
-                    persona_fields['buyer_persona_other'] = reg_form.cleaned_data['persona_other']
-                couch_user = CouchUser.get_by_username(reg_form.cleaned_data['email'])
-                if couch_user:
-                    update_hubspot_properties.delay(couch_user, persona_fields)
+
+            couch_user = CouchUser.get_by_username(reg_form.cleaned_data['email'])
+            in_appcues_ab_test = toggles.APPCUES_AB_TEST.enabled(reg_form.cleaned_data['email'],
+                                                                 toggles.NAMESPACE_USER)
+            if couch_user:
+                hubspot_fields = {
+                    "Appcues test": in_appcues_ab_test ? "On": "Off",
+                }
+                if reg_form.cleaned_data['persona']:
+                    hubspot_fields['buyer_persona'] = reg_form.cleaned_data['persona']
+                    if reg_form.cleaned_data['persona_other']:
+                        hubspot_fields['buyer_persona_other'] = reg_form.cleaned_data['persona_other']
+                update_hubspot_properties.delay(couch_user, hubspot_fields)
 
             return {
                 'success': True,
                 'is_mobile_experience': (
                     reg_form.cleaned_data.get('is_mobile') and
                     toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
-                        reg_form.cleaned_data['email'], toggles.NAMESPACE_USER))
+                        reg_form.cleaned_data['email'], toggles.NAMESPACE_USER)),
+                'appcues_ab_test': in_appcues_ab_test,
             }
         logging.error(
             "There was an error processing a new user registration form."

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -163,11 +163,11 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
 
 
             couch_user = CouchUser.get_by_username(reg_form.cleaned_data['email'])
-            in_appcues_ab_test = toggles.APPCUES_AB_TEST.enabled(reg_form.cleaned_data['email'],
-                                                                 toggles.NAMESPACE_USER)
+            appcues_ab_test = toggles.APPCUES_AB_TEST.enabled(reg_form.cleaned_data['email'],
+                                                              toggles.NAMESPACE_USER)
             if couch_user:
                 hubspot_fields = {
-                    "Appcues test": "On" if in_appcues_ab_test else "Off",
+                    "Appcues test": "On" if appcues_ab_test else "Off",
                 }
                 if reg_form.cleaned_data['persona']:
                     hubspot_fields['buyer_persona'] = reg_form.cleaned_data['persona']
@@ -181,7 +181,7 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
                     reg_form.cleaned_data.get('is_mobile') and
                     toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
                         reg_form.cleaned_data['email'], toggles.NAMESPACE_USER)),
-                'appcues_ab_test': in_appcues_ab_test,
+                'appcues_ab_test': appcues_ab_test,
             }
         logging.error(
             "There was an error processing a new user registration form."

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1520,14 +1520,6 @@ MOBILE_SIGNUP_REDIRECT_AB_TEST = PredictablyRandomToggle(
 )
 
 
-APPCUES_AB_TEST_CONTROLLER = StaticToggle(
-    'appcues_ab_test_controller',
-    'Enable AB test for whether or not to show Appcues to new users.',
-    TAG_PRODUCT,
-    namespaces=[NAMESPACE_USER]
-)
-
-
 APPCUES_AB_TEST = PredictablyRandomToggle(
     'appcues_ab_test',
     'True if user is in variant group for Appcues AB test. Irrelevent if user is not in test.',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1518,3 +1518,20 @@ MOBILE_SIGNUP_REDIRECT_AB_TEST = PredictablyRandomToggle(
     namespaces=[NAMESPACE_USER],
     randomness=0.5
 )
+
+
+APPCUES_AB_TEST_CONTROLLER = StaticToggle(
+    'appcues_ab_test_controller',
+    'Enable AB test for whether or not to show Appcues to new users.',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_USER]
+)
+
+
+APPCUES_AB_TEST = PredictablyRandomToggle(
+    'appcues_ab_test',
+    'True if user is in variant group for Appcues AB test. Irrelevent if user is not in test.',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_USER],
+    randomness=0.5
+)


### PR DESCRIPTION
- Assign user to test cohort in HQ rather than letting Appcues do it.
- Pass the AB test value to appcues to control the test itself, plus to kiss and hubspot for data analysis.
- Don't show the app manager v2 app help bubbles (add case list, check out app preview, add question in form builder) ever to people who are in the test.
- Flag whether or not an app is brand new so we can avoid triggering Appcues for existing apps (generally not an issue because Appcues will only display once, which will usually be on the user's first visit and will be a blank app, but invited users may have their first visit be to an existing app).

https://docs.google.com/document/d/1iW8J_GTcv26JKTUSYWK41VVkVI7GskODq_7ZLR3snow/edit

@jmtroth0 