### PR TITLE
Reduce checkpoint frequency for groups.

### DIFF
--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -32,7 +32,7 @@ def get_group_pillow(pillow_id='GroupPillow', num_processes=1, process_num=0, **
         change_feed=change_feed,
         processor=processor,
         change_processed_event_handler=KafkaCheckpointEventHandler(
-            checkpoint=checkpoint, checkpoint_frequency=100, change_feed=change_feed
+            checkpoint=checkpoint, checkpoint_frequency=10, change_feed=change_feed
         ),
     )
 

--- a/corehq/pillows/groups_to_user.py
+++ b/corehq/pillows/groups_to_user.py
@@ -39,7 +39,7 @@ def get_group_to_user_pillow(pillow_id='GroupToUserPillow', num_processes=1, pro
         change_feed=change_feed,
         processor=processor,
         change_processed_event_handler=KafkaCheckpointEventHandler(
-            checkpoint=checkpoint, checkpoint_frequency=100, change_feed=change_feed
+            checkpoint=checkpoint, checkpoint_frequency=10, change_feed=change_feed
         ),
     )
 


### PR DESCRIPTION
> I'm leaving it for now because it just gave me the same advice to run with `--set ignore_kafka_checkpoint_warning=true`

>fwiw, the underlying error:
```Exception: Problem with checkpoint for GroupPillow: First available topic offset for group:0 is 9909 but needed 9908.```
npellegrino [18:08]
I think @emord mentioned this type of error before


@nickpell @millerdev this happens on seldomly used environments. This means that fewer than 100 group changes had happened in the past month (we keep changes in kafka for a month) This should fix it for groups at least