### PR TITLE
Replace alert-error with alert-danger

### DIFF
--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -97,7 +97,7 @@
 </script>
 
 <script type="text/html" id="new-stripe-card-ko-template">
-    <p class="alert alert-error" data-bind="visible: showErrors">
+    <p class="alert alert-danger" data-bind="visible: showErrors">
         <i class="fa fa-exclamation-triangle"></i>
         <span data-bind="text: errorMsg"></span>
     </p>

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -65,7 +65,7 @@ hqDefine("groups/js/group_members", function() {
                     message = django.gettext('Failed to save ') + name.toLowerCase() + '.';
                 }
                 $(id).find(':button').enableButton();
-                $('#save-alert').removeClass('alert-error alert-success alert-info').addClass(alertClass);
+                $('#save-alert').removeClass('alert-danger alert-success alert-info').addClass(alertClass);
                 $('#save-alert').html(message).show();
                 $('#editGroupSettings').modal('hide');
 

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -33,7 +33,7 @@
     <div class="alert alert-info">{% blocktrans %}This application currently does not contain any multimedia references.{% endblocktrans %}</div>
 {% endif %}
 {% if multimedia_state.has_form_errors %}
-    <div class="alert alert-error"><i class="fa fa-exclamation-triangle"></i> {% blocktrans %}<strong>Warning:</strong>
+    <div class="alert alert-danger"><i class="fa fa-exclamation-triangle"></i> {% blocktrans %}<strong>Warning:</strong>
         This application contains forms with errors&mdash;we cannot pull any multimedia references from those forms.
     {% endblocktrans %}</div>
 {% endif %}

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/errors.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/errors.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <% if (errors.length > 0) { %>
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
         <h5>{% trans 'Errors found' %}</h5>
         <% for (var e = 0; e < errors.length; e++) {
             var error = errors[e]; %>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -287,7 +287,7 @@
             {% endif %}
 
             <!--[if IE]>
-                <div id="unsupported-browser" class="alert alert-error alert-block alert-full">
+                <div id="unsupported-browser" class="alert alert-danger alert-block alert-full">
                     <p><i class="fa fa-warning-sign"></i><strong>{% trans 'CommCare HQ does not work well with Internet Explorer.'%}</strong></p>
                     <p>
                         {% blocktrans %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/field/errors_only_field.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/field/errors_only_field.html
@@ -1,5 +1,5 @@
 {% if field.errors %}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
         {{ field.errors }}
     </div>
 {% endif %}

--- a/corehq/apps/reports/static/reports/js/export.manager.js
+++ b/corehq/apps/reports/static/reports/js/export.manager.js
@@ -82,7 +82,7 @@ var ExportManager = function(o) {
                             },
                             error: function() {
                                 self.$modal.find(self.exportModalLoading).addClass('hide');
-                                self.$modal.find(self.exportModalLoadedData).html('<p class="alert alert-error">' +
+                                self.$modal.find(self.exportModalLoadedData).html('<p class="alert alert-danger">' +
                                     gettext('Oh no! Your download was unable to be completed. ' +
                                         'We have been notified and are already hard at work solving this issue.') +
                                     '</p>');
@@ -100,7 +100,7 @@ var ExportManager = function(o) {
                 pollDownloader();
             },
             displayModalError = function(error_text) {
-                var $error = $('<p class="alert alert-error" />');
+                var $error = $('<p class="alert alert-danger" />');
                 $error.text(error_text);
                 self.$modal.find(self.exportModalLoadedData).html($error);
                 self.$modal.find(self.exportModalLoading).addClass('hide');

--- a/corehq/apps/reports/templates/reports/reportdata/form_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/form_data.html
@@ -13,8 +13,11 @@
 
 {% block page_content %}
     {% if not instance.initial_processing_complete and request|toggle_enabled:'SUPPORT' %}
-    <div class="alert alert-error">
-        This form's case changes were not processed because of errors that occurred during case processing: <strong>{{ instance.problem }}</strong>.
+    <div class="alert alert-danger">
+        {% blocktrans %}
+            This form's case changes were not processed because of errors that occurred during case processing:
+        {% endblocktrans %}
+        <strong>{{ instance.problem }}</strong>
     </div>
     {% endif %}
     {% render_form instance domain form_render_options %}

--- a/settings.py
+++ b/settings.py
@@ -1538,8 +1538,8 @@ MESSAGE_TAGS = {
     messages.INFO: 'alert-info',
     messages.DEBUG: '',
     messages.SUCCESS: 'alert-success',
-    messages.WARNING: 'alert-error alert-warning',
-    messages.ERROR: 'alert-error alert-danger',
+    messages.WARNING: 'alert-warning',
+    messages.ERROR: 'alert-danger',
 }
 
 COMMCARE_USER_TERM = "Mobile Worker"


### PR DESCRIPTION
Noticed media upload errors were unstyled, we must have missed a few `alert-error` class when upgrading to bootstrap 3.

Product: this just fixes a couple of error messages that were missing the normal pink box error style.

@czue / @biyeun 