### PR TITLE
Sync case with first Repeater in location ancestry

### DIFF
--- a/corehq/motech/openmrs/dbaccessors.py
+++ b/corehq/motech/openmrs/dbaccessors.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from corehq.motech.openmrs.models import OpenmrsImporter
+from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.util.quickcache import quickcache
 
 
@@ -9,6 +10,16 @@ def get_openmrs_importers_by_domain(domain_name):
     return OpenmrsImporter.view(
         'by_domain_doc_type_date/view',
         key=[domain_name, 'OpenmrsImporter', None],
+        include_docs=True,
+        reduce=False,
+    ).all()
+
+
+@quickcache(['domain_name'])
+def get_openmrs_repeaters_by_domain(domain_name):
+    return OpenmrsRepeater.view(
+        'by_domain_doc_type_date/view',
+        key=[domain_name, 'OpenmrsRepeater', None],
         include_docs=True,
         reduce=False,
     ).all()

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -145,9 +145,9 @@ def get_case_location_ancestor_repeaters(case):
     for repeater in get_openmrs_repeaters_by_domain(case.domain):
         if repeater.location_id:
             location_repeaters[repeater.location_id].append(repeater)
-    for location in case_location.get_ancestors(include_self=True):
-        if location.location_id in location_repeaters:
-            return location_repeaters[location.location_id]
+    for location_id in reversed(case_location.path):
+        if location_id in location_repeaters:
+            return location_repeaters[location_id]
     return []
 
 

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -64,14 +64,6 @@ class OpenmrsRepeater(CaseRepeater):
         from corehq.motech.repeaters.views.repeaters import AddOpenmrsRepeaterView
         return reverse(AddOpenmrsRepeaterView.urlname, args=[domain])
 
-    def get_location(self):
-        if self.location_id:
-            try:
-                return SQLLocation.objects.get(location_id=self.location_id)
-            except SQLLocation.DoesNotExist:
-                pass
-        return None
-
     def allowed_to_forward(self, case):
         """
         Forward if superclass rules say it's OK, and if the last case

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -6,6 +6,7 @@ from couchdbkit.ext.django.schema import *
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 
+from corehq.apps.locations.models import SQLLocation
 from corehq.motech.repeaters.models import CaseRepeater
 from corehq.motech.repeaters.repeater_generators import FormRepeaterJsonPayloadGenerator
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
@@ -19,6 +20,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     Requests,
     get_form_question_values,
     get_relevant_case_updates_from_form_json,
+    get_case_location_ancestor_repeaters,
 )
 from memoized import memoized
 
@@ -33,7 +35,14 @@ class OpenmrsRepeater(CaseRepeater):
     friendly_name = _("Forward to OpenMRS")
     payload_generator_classes = (FormRepeaterJsonPayloadGenerator,)
 
+    location_id = StringProperty(default='')
     openmrs_config = SchemaProperty(OpenmrsConfig)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.get_id == other.get_id
+        )
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -55,16 +64,31 @@ class OpenmrsRepeater(CaseRepeater):
         from corehq.motech.repeaters.views.repeaters import AddOpenmrsRepeaterView
         return reverse(AddOpenmrsRepeaterView.urlname, args=[domain])
 
+    def get_location(self):
+        if self.location_id:
+            try:
+                return SQLLocation.objects.get(location_id=self.location_id)
+            except SQLLocation.DoesNotExist:
+                pass
+        return None
+
     def allowed_to_forward(self, case):
         """
-        Applies superclass rules, and whether the case was last updated
-        by importing from OpenMRS. Do not forward OpenMRS updates back
-        to OpenMRS.
+        Forward if superclass rules say it's OK, and if the last case
+        update did not come from OpenMRS, and if this repeater forwards
+        to the right server for this case.
         """
-        if super(OpenmrsRepeater, self).allowed_to_forward(case):
-            last_form = FormAccessors(case.domain).get_form(case.xform_ids[-1])
-            return last_form.xmlns != XMLNS_OPENMRS
-        return False
+        if not super(OpenmrsRepeater, self).allowed_to_forward(case):
+            return False
+        last_form = FormAccessors(case.domain).get_form(case.xform_ids[-1])
+        if last_form.xmlns == XMLNS_OPENMRS:
+            # Case update came from OpenMRS. Don't send it back.
+            return False
+        repeaters = get_case_location_ancestor_repeaters(case)
+        if repeaters and self not in repeaters:
+            # self points to the wrong server for this case. Let the right repeater handle it.
+            return False
+        return True
 
     def get_payload(self, repeat_record):
         payload = super(OpenmrsRepeater, self).get_payload(repeat_record)

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
-from couchdbkit.ext.django.schema import *
 
+from couchdbkit.ext.django.schema import SchemaProperty, StringProperty
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import doctest
 import os
-from django.test import SimpleTestCase
+from collections import namedtuple
+from unittest import TestCase
 import mock
 from casexml.apps.case.models import CommCareCase
+from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.util.test_utils import TestFileMixin
 import corehq.motech.openmrs.repeater_helpers
 from corehq.motech.openmrs.repeater_helpers import (
@@ -13,14 +16,19 @@ from corehq.motech.openmrs.repeater_helpers import (
     get_relevant_case_updates_from_form_json,
     CaseTriggerInfo,
     get_form_question_values,
+    get_case_location,
+    get_case_location_ancestor_repeaters,
 )
+
+
+DOMAIN = 'test-domain'
 
 
 @mock.patch.object(CaseAccessors, 'get_cases', lambda self, case_ids, ordered=False: [{
     '65e55473-e83b-4d78-9dde-eaf949758997': CommCareCase(
         type='paciente', case_id='65e55473-e83b-4d78-9dde-eaf949758997')
 }[case_id] for case_id in case_ids])
-class OpenmrsRepeaterTest(SimpleTestCase, TestFileMixin):
+class OpenmrsRepeaterTest(TestCase, TestFileMixin):
     file_path = ('data',)
     root = os.path.dirname(__file__)
 
@@ -66,7 +74,7 @@ class OpenmrsRepeaterTest(SimpleTestCase, TestFileMixin):
         )
 
 
-class GetPatientByUuidTests(SimpleTestCase):
+class GetPatientByUuidTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -101,7 +109,7 @@ class GetPatientByUuidTests(SimpleTestCase):
         self.assertEqual(patient, self.patient)
 
 
-class GetFormQuestionValuesTests(SimpleTestCase):
+class GetFormQuestionValuesTests(TestCase):
 
     def test_unicode_answer(self):
         value = get_form_question_values({'form': {'foo': {'bar': u'b\u0105z'}}})
@@ -122,7 +130,157 @@ class GetFormQuestionValuesTests(SimpleTestCase):
         self.assertEqual(value, {u'/data/foo/b\u0105r': 'baz'})
 
 
-class DocTests(SimpleTestCase):
+joburg = SQLLocation(location_id='johannesburg')
+cape_town = SQLLocation(location_id='cape_town')
+FakeLocation = namedtuple('FakeLocation', 'location_id')
+
+
+does_not_exist_mock = mock.Mock(side_effect=SQLLocation.DoesNotExist)
+cape_town_chw_doc = {
+    'doc_type': 'CommCareUser',
+    '_id': 'cape_town_chw',
+    'domain': DOMAIN,
+    'username': 'chw@cape_town.org',
+    'user_data': {},
+    'location_id': 'cape_town',
+}
+cape_town_chw_owner = mock.Mock(return_value=mock.Mock(get=lambda owner_id: cape_town_chw_doc))
+
+nowhere_chw_doc = {
+    'doc_type': 'CommCareUser',
+    '_id': 'nowhere_chw',
+    'domain': DOMAIN,
+    'username': 'chw@nowhere.org',
+    'user_data': {},
+    'location_id': None,
+}
+nowhere_chw_owner = mock.Mock(return_value=mock.Mock(get=lambda owner_id: nowhere_chw_doc))
+
+everywhere_chw_doc = {
+    'doc_type': 'CommCareUser',
+    '_id': 'everywhere_chw',
+    'domain': DOMAIN,
+    'username': 'chw@everywhere.org',
+    'user_data': {},
+    'location_id': None,
+    'assigned_location_ids': ['cape_town', 'johannesburg']
+}
+everywhere_chw_owner = mock.Mock(return_value=mock.Mock(get=lambda owner_id: everywhere_chw_doc))
+
+class CaseLocationTests(TestCase):
+
+    @mock.patch('corehq.apps.locations.models.SQLLocation.objects.get', mock.Mock(return_value=joburg))
+    def test_owner_is_location(self):
+        """
+        get_case_location should return case owner when owner is a location
+        """
+        joburg_patient = CommCareCase(domain=DOMAIN, owner_id='johannesburg')
+        location = get_case_location(joburg_patient)
+        self.assertIsInstance(location, SQLLocation)
+        self.assertEqual(location.location_id, 'johannesburg')
+
+    @mock.patch('corehq.apps.locations.models.SQLLocation.objects.get', does_not_exist_mock)
+    @mock.patch('corehq.apps.users.models.CouchUser.get_db', cape_town_chw_owner)
+    @mock.patch('corehq.apps.users.models.DomainMembership.location_id', cape_town_chw_doc['location_id'])
+    @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
+                mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
+    def test_owner_has_primary_location(self):
+        """
+        get_case_location should return case owner's location when owner is a mobile worker
+        """
+        cape_town_patient = CommCareCase(domain=DOMAIN, owner_id='cape_town_chw')
+        location = get_case_location(cape_town_patient)
+        self.assertIsInstance(location, FakeLocation)
+        self.assertEqual(location.location_id, 'cape_town')
+
+    @mock.patch('corehq.apps.locations.models.SQLLocation.objects.get', does_not_exist_mock)
+    @mock.patch('corehq.apps.users.models.CouchUser.get_db', nowhere_chw_owner)
+    @mock.patch('corehq.apps.users.models.DomainMembership.location_id', nowhere_chw_doc['location_id'])
+    @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
+                mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
+    def test_owner_has_no_locations(self):
+        """
+        get_case_location should return None when owner has no location
+        """
+        nowhere_patient = CommCareCase(domain=DOMAIN, owner_id='nowhere_chw')
+        location = get_case_location(nowhere_patient)
+        self.assertIsNone(location)
+
+    @mock.patch('corehq.apps.locations.models.SQLLocation.objects.get', does_not_exist_mock)
+    @mock.patch('corehq.apps.users.models.CouchUser.get_db', everywhere_chw_owner)
+    @mock.patch('corehq.apps.users.models.DomainMembership.location_id', everywhere_chw_doc['location_id'])
+    @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
+                mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
+    def test_owner_has_assigned_locations(self):
+        """
+        get_case_location should return None when owner has no primary location
+        """
+        everywhere_patient = CommCareCase(domain=DOMAIN, owner_id='everywhere_chw')
+        location = get_case_location(everywhere_patient)
+        self.assertIsNone(location)
+
+
+cape_town_ancestors = [
+    FakeLocation('56_barnet_st'),
+    FakeLocation('gardens'),
+    FakeLocation('cape_town'),
+    FakeLocation('western_cape'),
+    FakeLocation('south_africa'),
+]
+joburg_ancestors = [
+    FakeLocation('johannesburg'),
+    FakeLocation('gauteng'),
+    FakeLocation('south_africa'),
+]
+cape_town_repeater = OpenmrsRepeater(
+    _id='0000',
+    location_id='cape_town'
+)
+western_cape_repeater = OpenmrsRepeater(
+    _id='1111',
+    location_id='western_cape'
+)
+joburg_repeater = OpenmrsRepeater(
+    _id='2222',
+    location_id='johannesburg'
+)
+get_repeaters_mock = mock.Mock(return_value=[cape_town_repeater, western_cape_repeater, joburg_repeater,])
+
+class AncestorRepeaterTests(TestCase):
+
+    @mock.patch('corehq.motech.openmrs.repeater_helpers.get_case_location',
+                mock.Mock(return_value=joburg))
+    @mock.patch('corehq.apps.locations.models.SQLLocation.get_ancestors',
+                mock.Mock(return_value=joburg_ancestors))
+    @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
+                mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
+    @mock.patch('corehq.motech.openmrs.dbaccessors.get_openmrs_repeaters_by_domain', get_repeaters_mock)
+    def test_get_case_location_ancestor_repeaters_self(self):
+        """
+        The repeater should be returned when it is at the same location as the case
+        """
+        joburg_patient = CommCareCase()  # because get_case_location mock returns joburg
+        repeaters = get_case_location_ancestor_repeaters(joburg_patient)
+        self.assertEqual(repeaters, [joburg_repeater])
+
+    @mock.patch('corehq.motech.openmrs.repeater_helpers.get_case_location',
+                mock.Mock(return_value=cape_town))
+    @mock.patch('corehq.apps.locations.models.SQLLocation.get_ancestors',
+                mock.Mock(return_value=cape_town_ancestors))
+    @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
+                mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
+    @mock.patch('corehq.motech.openmrs.dbaccessors.get_openmrs_repeaters_by_domain', get_repeaters_mock)
+    def test_get_case_location_ancestor_repeaters_multi(self):
+        """
+        When a case location has multiple ancestors with repeaters, the
+        repeater of the closest ancestor should be returned
+        """
+        cape_town_patient = CommCareCase()  # because get_case_location mock returns cape_town
+        repeaters = get_case_location_ancestor_repeaters(cape_town_patient)
+        self.assertEqual(repeaters, [cape_town_repeater])
+
+
+class DocTests(TestCase):
 
     def test_doctests(self):
         results = doctest.testmod(corehq.motech.openmrs.repeater_helpers)

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -167,6 +167,7 @@ everywhere_chw_doc = {
 }
 everywhere_chw_owner = mock.Mock(return_value=mock.Mock(get=lambda owner_id: everywhere_chw_doc))
 
+
 class CaseLocationTests(TestCase):
 
     @mock.patch('corehq.apps.locations.models.SQLLocation.objects.get', mock.Mock(return_value=joburg))
@@ -244,7 +245,8 @@ joburg_repeater = OpenmrsRepeater(
     _id='2222',
     location_id='johannesburg'
 )
-get_repeaters_mock = mock.Mock(return_value=[cape_town_repeater, western_cape_repeater, joburg_repeater,])
+get_repeaters_mock = mock.Mock(return_value=[cape_town_repeater, western_cape_repeater, joburg_repeater])
+
 
 class AncestorRepeaterTests(TestCase):
 

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -222,16 +222,16 @@ class CaseLocationTests(TestCase):
 
 
 cape_town_ancestors = [
-    FakeLocation('56_barnet_st'),
-    FakeLocation('gardens'),
-    FakeLocation('cape_town'),
-    FakeLocation('western_cape'),
-    FakeLocation('south_africa'),
+    'south_africa',
+    'western_cape',
+    'cape_town',
+    'gardens',
+    '56_barnet_st',
 ]
 joburg_ancestors = [
-    FakeLocation('johannesburg'),
-    FakeLocation('gauteng'),
-    FakeLocation('south_africa'),
+    'south_africa',
+    'gauteng',
+    'johannesburg',
 ]
 cape_town_repeater = OpenmrsRepeater(
     _id='0000',
@@ -252,8 +252,7 @@ class AncestorRepeaterTests(TestCase):
 
     @mock.patch('corehq.motech.openmrs.repeater_helpers.get_case_location',
                 mock.Mock(return_value=joburg))
-    @mock.patch('corehq.apps.locations.models.SQLLocation.get_ancestors',
-                mock.Mock(return_value=joburg_ancestors))
+    @mock.patch('corehq.apps.locations.models.SQLLocation.path', joburg_ancestors)
     @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
                 mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
     @mock.patch('corehq.motech.openmrs.dbaccessors.get_openmrs_repeaters_by_domain', get_repeaters_mock)
@@ -267,8 +266,7 @@ class AncestorRepeaterTests(TestCase):
 
     @mock.patch('corehq.motech.openmrs.repeater_helpers.get_case_location',
                 mock.Mock(return_value=cape_town))
-    @mock.patch('corehq.apps.locations.models.SQLLocation.get_ancestors',
-                mock.Mock(return_value=cape_town_ancestors))
+    @mock.patch('corehq.apps.locations.models.SQLLocation.path', cape_town_ancestors)
     @mock.patch('corehq.apps.locations.models.SQLLocation.by_location_id',
                 mock.Mock(side_effect=lambda loc_id: FakeLocation(loc_id) if loc_id else None))
     @mock.patch('corehq.motech.openmrs.dbaccessors.get_openmrs_repeaters_by_domain', get_repeaters_mock)

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+from corehq.apps.users.forms import SupplyPointSelectWidget
 from corehq.motech.repeaters.dbaccessors import get_repeaters_by_domain
 from corehq.motech.repeaters.repeater_generators import RegisterGenerator
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
@@ -197,6 +198,25 @@ class CaseRepeaterForm(GenericRepeaterForm):
         if not set(black_listed_users).issubset([t[0] for t in self.user_choices]):
             raise ValidationError(_('Unknown user'))
         return cleaned_data
+
+
+class OpenmrsRepeaterForm(CaseRepeaterForm):
+    location_id = forms.CharField(
+        label=_("Location"),
+        required=False,
+        help_text=_(
+            'Cases at this location and below will be forwarded. '
+            'Leave empty if this is the only OpenMRS Forwarder'
+        )
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
+        self.fields['location_id'].widget = SupplyPointSelectWidget(self.domain, id='id_location_id')
+
+    def get_ordered_crispy_form_fields(self):
+        fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()
+        return ['location_id'] + fields
 
 
 class SOAPCaseRepeaterForm(CaseRepeaterForm):

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -25,6 +25,7 @@ from corehq.motech.repeaters.forms import (
     CaseRepeaterForm,
     FormRepeaterForm,
     GenericRepeaterForm,
+    OpenmrsRepeaterForm,
     SOAPCaseRepeaterForm,
     SOAPLocationRepeaterForm,
 )
@@ -202,8 +203,14 @@ class AddCaseRepeaterView(AddRepeaterView):
 
 class AddOpenmrsRepeaterView(AddCaseRepeaterView):
     urlname = 'new_openmrs_repeater$'
+    repeater_form_class = OpenmrsRepeaterForm
     page_title = ugettext_lazy("Forward to OpenMRS")
     page_name = ugettext_lazy("Forward to OpenMRS")
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super(AddOpenmrsRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
+        repeater.location_id = self.add_repeater_form.cleaned_data['location_id']
+        return repeater
 
 
 class AddCustomSOAPCaseRepeaterView(AddCaseRepeaterView):


### PR DESCRIPTION
Project sthat have more than one OpenMRS server need patients to be synced with the OpenMRS server that is responsible for that patient's location.

This change associates an OpenmrsRepeater with a location, and only forwards cases if the repeater is the one responsible for that case's location.

(Also curious to know whether you think there is a maximum about of mocking that is reasonable for a unit test, and whether these tests cross that line. :grimacing: )

buddy @sravfeyn cc @dannyroberts, @esoergel 
