### PR TITLE
Refactor to use SQLLocation.objects.get_or_None

### DIFF
--- a/corehq/apps/reports/commtrack/util.py
+++ b/corehq/apps/reports/commtrack/util.py
@@ -43,12 +43,8 @@ class StockLedgerValueWrapper(jsonobject.JsonObject):
     @property
     def sql_location(self):
         if self.location_id and not self._sql_location:
-            try:
-                self._sql_location = SQLLocation.objects.get(domain=self.domain, location_id=self.location_id)
-            except ObjectDoesNotExist:
-                # todo: cache this result so multiple failing calls don't keep hitting the DB
-                return None
-
+            self._sql_location = SQLLocation.objects.get_or_None(domain=self.domain, location_id=self.location_id)
+            # todo: cache this result so multiple failing calls don't keep hitting the DB
         return self._sql_location
 
     @classmethod

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -99,10 +99,7 @@ class CaseInfo(object):
     @property
     @memoized
     def location(self):
-        try:
-            return SQLLocation.objects.get(location_id=self.owner_id)
-        except SQLLocation.DoesNotExist:
-            return None
+        return SQLLocation.objects.get_or_None(location_id=self.owner_id)
 
     @property
     def owner(self):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1893,10 +1893,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
     def sql_location(self):
         from corehq.apps.locations.models import SQLLocation
         if self.location_id:
-            try:
-                return SQLLocation.objects.get(location_id=self.location_id)
-            except SQLLocation.DoesNotExist:
-                pass
+            return SQLLocation.objects.get_or_None(location_id=self.location_id)
         return None
 
     def get_location_ids(self, domain):

--- a/corehq/ex-submodules/casexml/apps/stock/signals.py
+++ b/corehq/ex-submodules/casexml/apps/stock/signals.py
@@ -81,10 +81,7 @@ def get_stock_state_for_transaction(transaction):
     except AttributeError:
         domain_name = sql_product.domain
 
-    try:
-        sql_location = SQLLocation.objects.get(supply_point_id=transaction.case_id)
-    except SQLLocation.DoesNotExist:
-        sql_location = None
+    sql_location = SQLLocation.objects.get_or_None(supply_point_id=transaction.case_id)
 
     try:
         state = StockState.include_archived.get(

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1434,10 +1434,7 @@ class LedgerValue(PartitionedModel, SaveStateMixin, models.Model, TrackRelatedCh
     @memoized
     def location(self):
         from corehq.apps.locations.models import SQLLocation
-        try:
-            return SQLLocation.objects.get(supply_point_id=self.case_id)
-        except SQLLocation.DoesNotExist:
-            return None
+        return SQLLocation.objects.get_or_None(supply_point_id=self.case_id)
 
     @property
     def location_id(self):


### PR DESCRIPTION
Small refactor to use `SQLLocation.objects.get_or_None()` instead of variations of
```python
try:
    location = SQLLocation.objects.get()
except SQLLocation.DoesNotExist:
    location = None
```
... just because I noticed both being used, and it was a slow Saturday. :upside_down_face: 

@esoergel cc buddy @sravfeyn 