### PR TITLE
Clean up after PatientFinders and rollback

### DIFF
--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -19,7 +19,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     create_person_attribute,
     delete_person_attribute_task,
 )
-from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, workflow_task
+from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow
 from corehq.motech.utils import pformat_json
 from dimagi.utils.parsing import string_to_utc_datetime
 

--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -20,6 +20,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     delete_person_attribute_task,
 )
 from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, workflow_task
+from corehq.motech.utils import pformat_json
 from dimagi.utils.parsing import string_to_utc_datetime
 
 
@@ -46,11 +47,10 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
 
     success, errors = execute_workflow(workflow_queue)
     if success:
-        return OpenmrsResponse(200, 'OK')
+        return OpenmrsResponse(200, 'OK', '')
     else:
         logger.error('Errors encountered sending OpenMRS data: %s', errors)
-        # TODO: Do something more useful with errors, like OpenmrsResponse.content or something
-        return OpenmrsResponse(400, 'Bad Request')
+        return OpenmrsResponse(400, 'Bad Request', pformat_json(errors))
 
 
 class SyncPersonAttrsTask(WorkflowTask):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -61,7 +61,7 @@ ADDRESS_PROPERTIES = (
 PERSON_UUID_IDENTIFIER_TYPE_ID = 'uuid'
 
 
-OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason')
+OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason content')
 
 
 class Requests(object):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -12,7 +12,7 @@ from casexml.apps.case.xform import extract_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
-from corehq.motech.openmrs.workflow import WorkflowTask, Task
+from corehq.motech.openmrs.workflow import WorkflowTask, task
 from corehq.motech.utils import pformat_json
 
 
@@ -75,6 +75,10 @@ class Requests(object):
     def get_url(self, uri):
         return '/'.join((self.base_url.rstrip('/'), uri.lstrip('/')))
 
+    def delete(self, uri, **kwargs):
+        return self.requests.delete(self.get_url(uri),
+                                    auth=(self.username, self.password), **kwargs)
+
     def get(self, uri, *args, **kwargs):
         return self.requests.get(self.get_url(uri), *args,
                                  auth=(self.username, self.password), **kwargs)
@@ -123,6 +127,13 @@ def create_person_attribute(requests, person_uuid, attribute_type_uuid, value):
     ).json()
 
 
+@task
+def delete_person_attribute_task(requests, person_uuid, attribute_uuid):
+    return requests.delete('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
+        person_uuid=person_uuid, attribute_uuid=attribute_uuid
+    )).json()
+
+
 def update_person_attribute(requests, person_uuid, attribute_uuid, attribute_type_uuid, value):
     return requests.post('/ws/rest/v1/person/{person_uuid}/attribute/{attribute_uuid}'.format(
         person_uuid=person_uuid, attribute_uuid=attribute_uuid), json={
@@ -163,17 +174,18 @@ class CreateVisitTask(WorkflowTask):
         self._subtasks.append(
             CreateEncounterTask(
                 None,
+                delete_encounter_task(requests),  # `encounter_uuid` doesn't need to be passed yet.
+                'encounter_uuid',                     # execute_workflow() sets the rollback task's kwargs later
                 requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
                 openmrs_form, visit_uuid, location_uuid,
-                rollback_task=Task(delete_encounter, requests),
-                pass_result_as='encounter_uuid',
             )
         )
 
         return visit_uuid
 
 
-def delete_visit(requests, visit_uuid):
+@task
+def delete_visit_task(requests, visit_uuid):
     return requests.delete('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
 
 
@@ -209,16 +221,17 @@ class CreateEncounterTask(WorkflowTask):
                 self._subtasks.append(
                     WorkflowTask(
                         create_obs,
+                        delete_obs_task(requests),
+                        'obs_uuid',
                         requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid,
-                        rollback_task=Task(delete_obs, requests),
-                        pass_result_as='obs_uuid'
                     )
                 )
 
         return encounter_uuid
 
 
-def delete_encounter(requests, encounter_uuid):
+@task
+def delete_encounter_task(requests, encounter_uuid):
     return requests.delete('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
 
 
@@ -236,7 +249,8 @@ def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_dateti
     return response.json()['uuid']
 
 
-def delete_obs(requests, obs_uuid):
+@task
+def delete_obs_task(requests, obs_uuid):
     return requests.delete('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
 
 
@@ -303,6 +317,27 @@ def update_person_name(requests, info, openmrs_config, person_uuid, name_uuid):
         )
 
 
+@task
+def rollback_person_name_task(requests, person, openmrs_config):
+    """
+    Reset the name changes previously set by `update_person_name()` back to their original values, which are
+    taken from the patient details that OpenMRS returned at the start of the workflow.
+    """
+    properties = {
+        property_: person['preferredName'][property_]
+        for property_ in openmrs_config.case_config.person_preferred_name.keys()
+        if property_ in NAME_PROPERTIES
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/name/{name_uuid}'.format(
+                person_uuid=person['uuid'],
+                name_uuid=person['preferredName']['uuid'],
+            ),
+            json=properties,
+        )
+
+
 def create_person_address(requests, info, openmrs_config, person_uuid):
     properties = {
         property_: value_source.get_value(info)
@@ -316,6 +351,16 @@ def create_person_address(requests, info, openmrs_config, person_uuid):
         )
 
 
+@task
+def delete_person_address_task(requests, person, address_uuid):
+    requests.post_with_raise(
+        '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+            person_uuid=person['uuid'],
+            address_uuid=address_uuid,
+        )
+    )
+
+
 def update_person_address(requests, info, openmrs_config, person_uuid, address_uuid):
     properties = {
         property_: value_source.get_value(info)
@@ -327,6 +372,23 @@ def update_person_address(requests, info, openmrs_config, person_uuid, address_u
             '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
                 person_uuid=person_uuid,
                 address_uuid=address_uuid,
+            ),
+            json=properties,
+        )
+
+
+@task
+def rollback_person_address_task(requests, person, openmrs_config):
+    properties = {
+        property_: person['preferredAddress'][property_]
+        for property_ in openmrs_config.case_config.person_preferred_address.keys()
+        if property_ in ADDRESS_PROPERTIES
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}/address/{address_uuid}'.format(
+                person_uuid=person['uuid'],
+                address_uuid=person['preferredAddress']['uuid'],
             ),
             json=properties,
         )
@@ -384,7 +446,12 @@ def update_person_properties(requests, info, openmrs_config, person_uuid):
         )
 
 
-def rollback_person_properties(requests, person, openmrs_config):
+@task
+def rollback_person_properties_task(requests, person, openmrs_config):
+    """
+    Reset the properties previously set by `update_person_properties()` back to their original values, which are
+    taken from the patient details that OpenMRS returned at the start of the workflow.
+    """
     properties = {
         property_: person[property_]
         for property_ in openmrs_config.case_config.person_properties.keys()

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -16,7 +16,6 @@ from corehq.motech.openmrs.workflow import WorkflowTask, task
 from corehq.motech.utils import pformat_json
 
 
-Should = namedtuple('Should', ['method', 'url', 'parser'])
 PERSON_PROPERTIES = (
     'gender',
     'age',

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -330,10 +330,21 @@ def update_person_properties(requests, info, openmrs_config, person_uuid):
         if property_ in PERSON_PROPERTIES and value_source.get_value(info)
     }
     if properties:
-        for p in properties:
-            assert p in PERSON_PROPERTIES
         requests.post_with_raise(
             '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person_uuid),
+            json=properties
+        )
+
+
+def rollback_person_properties(requests, person, openmrs_config):
+    properties = {
+        property_: person[property_]
+        for property_ in openmrs_config.case_config.person_properties.keys()
+        if property_ in PERSON_PROPERTIES
+    }
+    if properties:
+        requests.post_with_raise(
+            '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=person['uuid']),
             json=properties
         )
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -124,10 +124,6 @@ def parse_request_exception(err):
     return err_request, err_response
 
 
-def url(url_format_string, **kwargs):
-    return url_format_string.format(**kwargs)
-
-
 def create_person_attribute(requests, person_uuid, attribute_type_uuid, value):
     return requests.post('/ws/rest/v1/person/{person_uuid}/attribute'.format(
         person_uuid=person_uuid), json={

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -12,6 +12,7 @@ from casexml.apps.case.xform import extract_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
+from corehq.motech.openmrs.workflow import WorkflowTask, Task
 from corehq.motech.utils import pformat_json
 
 
@@ -138,58 +139,105 @@ def server_datetime_to_openmrs_timestamp(dt):
     return openmrs_timestamp
 
 
-def create_visit(requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
-                 openmrs_form, visit_type, location_uuid=None, patient_uuid=None):
-    patient_uuid = patient_uuid or person_uuid
-    start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
-    stop_datetime = server_datetime_to_openmrs_timestamp(
-        visit_datetime + timedelta(days=1) - timedelta(seconds=1)
-    )
+class CreateVisitTask(WorkflowTask):
 
-    visit = {
-        'patient': patient_uuid,
-        'visitType': visit_type,
-        'startDatetime': start_datetime,
-        'stopDatetime': stop_datetime,
+    def run(self, requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
+            openmrs_form, visit_type, location_uuid=None):
+
+        start_datetime = server_datetime_to_openmrs_timestamp(visit_datetime)
+        stop_datetime = server_datetime_to_openmrs_timestamp(
+            visit_datetime + timedelta(days=1) - timedelta(seconds=1)
+        )
+
+        visit = {
+            'patient': person_uuid,
+            'visitType': visit_type,
+            'startDatetime': start_datetime,
+            'stopDatetime': stop_datetime,
+        }
+        if location_uuid:
+            visit['location'] = location_uuid
+        response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
+        visit_uuid = response.json()['uuid']
+
+        self._subtasks.append(
+            CreateEncounterTask(
+                None,
+                requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
+                openmrs_form, visit_uuid, location_uuid,
+                rollback_task=Task(delete_encounter, requests),
+                pass_result_as='encounter_uuid',
+            )
+        )
+
+        return visit_uuid
+
+
+def delete_visit(requests, visit_uuid):
+    return requests.delete('/ws/rest/v1/visit/{uuid}'.format(uuid=visit_uuid)).json()
+
+
+class CreateEncounterTask(WorkflowTask):
+
+    def run(self, requests, person_uuid, provider_uuid, start_datetime, values_for_concept, encounter_type,
+            openmrs_form, visit_uuid, location_uuid=None):
+
+        encounter = {
+            'encounterDatetime': start_datetime,
+            'patient': person_uuid,
+            'form': openmrs_form,
+            'encounterType': encounter_type,
+            'visit': visit_uuid,
+        }
+        if location_uuid:
+            encounter['location'] = location_uuid
+        if provider_uuid:
+            # TODO: Verify. See commented-out section below
+            encounter['provider'] = provider_uuid
+        response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
+        encounter_uuid = response.json()['uuid']
+
+        # TODO: This is suspicious. Doesn't match docs. If it's true, add it as a subtask
+        # if provider_uuid:
+        #     encounter_provider = {'provider': provider_uuid}
+        #     uri = '/ws/rest/v1/encounter/{uuid}/encounterprovider'.format(uuid=encounter_uuid)
+        #     requests.post_with_raise(uri, json=encounter_provider)
+
+        for concept_uuid, values in values_for_concept.items():
+            for value in values:
+
+                self._subtasks.append(
+                    WorkflowTask(
+                        create_obs,
+                        requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid,
+                        rollback_task=Task(delete_obs, requests),
+                        pass_result_as='obs_uuid'
+                    )
+                )
+
+        return encounter_uuid
+
+
+def delete_encounter(requests, encounter_uuid):
+    return requests.delete('/ws/rest/v1/encounter/{uuid}'.format(uuid=encounter_uuid)).json()
+
+
+def create_obs(requests, encounter_uuid, concept_uuid, person_uuid, start_datetime, value, location_uuid=None):
+    observation = {
+        'concept': concept_uuid,
+        'person': person_uuid,
+        'obsDatetime': start_datetime,
+        'encounter': encounter_uuid,
+        'value': value,
     }
     if location_uuid:
-        visit['location'] = location_uuid
-    response = requests.post_with_raise('/ws/rest/v1/visit', json=visit)
-    visit_uuid = response.json()['uuid']
+        observation['location'] = location_uuid
+    response = requests.post_with_raise('/ws/rest/v1/obs', json=observation)
+    return response.json()['uuid']
 
-    encounter = {
-        'encounterDatetime': start_datetime,
-        'patient': patient_uuid,
-        'form': openmrs_form,
-        'encounterType': encounter_type,
-        'visit': visit_uuid,
-    }
-    if location_uuid:
-        encounter['location'] = location_uuid
-    response = requests.post_with_raise('/ws/rest/v1/encounter', json=encounter)
-    encounter_uuid = response.json()['uuid']
-    if provider_uuid:
-        encounter_provider = {'provider': provider_uuid}
-        uri = '/ws/rest/v1/encounter/{uuid}/encounterprovider'.format(uuid=encounter_uuid)
-        requests.post_with_raise(uri, json=encounter_provider)
 
-    observation_uuids = []
-    for concept_uuid, values in values_for_concept.items():
-        for value in values:
-            observation = {
-                'concept': concept_uuid,
-                'person': person_uuid,
-                'obsDatetime': start_datetime,
-                'encounter': encounter_uuid,
-                'value': value,
-            }
-            if location_uuid:
-                observation['location'] = location_uuid
-            response = requests.post_with_raise('/ws/rest/v1/obs', json=observation)
-            observation_uuids.append(response.json()['uuid'])
-
-    logger.debug('Observations created: ', observation_uuids)
-    return OpenmrsResponse(status_code=response.status_code, reason=response.reason)
+def delete_obs(requests, obs_uuid):
+    return requests.delete('/ws/rest/v1/obs/{uuid}'.format(uuid=obs_uuid)).json()
 
 
 def search_patients(requests, search_string):

--- a/corehq/motech/openmrs/tests/test_parsers.py
+++ b/corehq/motech/openmrs/tests/test_parsers.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
-from django.test import SimpleTestCase
-from corehq.motech.openmrs.repeater_helpers import PatientSearchParser
+from unittest import TestCase
+
+from mock import Mock
+
+from corehq.motech.openmrs.repeater_helpers import get_patient_by_identifier
 
 
 PATIENT_SEARCH_RESPONSE = json.loads("""{
@@ -63,8 +66,13 @@ PATIENT_SEARCH_RESPONSE = json.loads("""{
 }""")
 
 
-class PatientSearchParserTest(SimpleTestCase):
-    def test_patient_search_parser(self):
-        patient = PatientSearchParser(PATIENT_SEARCH_RESPONSE).get_patient_matching_identifiers(
-            'e2b966d0-1d5f-11e0-b929-000c29ad1d07', '11111111/11/1111')
+class GetPatientTest(TestCase):
+    def test_get_patient_by_identifier(self):
+        response_mock = Mock()
+        response_mock.json.return_value = PATIENT_SEARCH_RESPONSE
+        requests_mock = Mock()
+        requests_mock.get.return_value = response_mock
+
+        patient = get_patient_by_identifier(
+            requests_mock, 'e2b966d0-1d5f-11e0-b929-000c29ad1d07', '11111111/11/1111')
         self.assertEqual(patient['uuid'], '5ba94fa2-9cb3-4ae6-b400-7bf45783dcbf')

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,0 +1,162 @@
+from django.test import SimpleTestCase
+from mock import Mock
+
+from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, task, workflow_task
+
+
+class TaskTests(SimpleTestCase):
+
+    def test_task_run_func_args_kwargs(self):
+        sing = Mock()
+        func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
+
+        self.assertEqual(func_task.func, sing)
+        self.assertEqual(func_task.args, ('Brave Sir Robin',))
+        self.assertEqual(func_task.kwargs, {'what': 'ran', 'where': 'away'})
+        sing.assert_not_called()
+
+        func_task.run_func()
+        sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
+
+
+    def test_task_run(self):
+        class SirRobin(Task):
+            def run(self):
+                pass
+
+        sir_robin = SirRobin(None, 'fled', tail='turned', where='away')
+        sir_robin.run = Mock()
+
+        sir_robin.run_func()
+        sir_robin.run.assert_called_with('fled', tail='turned', where='away')
+
+
+class WorkflowTests(SimpleTestCase):
+
+    def test_workflow_runs(self):
+        func1 = Mock()
+        func2 = Mock()
+        workflow_queue = [
+            WorkflowTask(None, None, func1),
+            WorkflowTask(None, None, func2),
+        ]
+
+        success, errors = execute_workflow(workflow_queue)
+        self.assertTrue(success)
+        self.assertEqual(errors, [])
+        func1.assert_called()
+        func2.assert_called()
+        self.assertEqual(workflow_queue, [])
+
+    def test_rollback_runs(self):
+        func1 = Mock()
+        black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
+        func3 = Mock()
+
+        rollback_func1 = Mock()
+        rollback_black_knight = Mock(side_effect=ValueError("Come back here and take what's comin' ta ya!"))
+        rollback_func3 = Mock()
+
+        workflow_queue = [
+            WorkflowTask(Task(rollback_func1), None, func1),
+            WorkflowTask(Task(rollback_black_knight), None, black_knight),
+            WorkflowTask(Task(rollback_func3), None, func3),
+        ]
+
+        success, errors = execute_workflow(workflow_queue)
+        self.assertFalse(success)
+        self.assertEqual(errors, [
+            "Workflow failed: ValueError: 'Tis but a flesh wound",
+            "Rollback error: ValueError: Come back here and take what's comin' ta ya!",
+        ])
+
+        # Check workflow halted on failure
+        func1.assert_called()
+        black_knight.assert_called()
+        func3.assert_not_called()
+
+        # Check rollback continued after error
+        rollback_black_knight.assert_called()
+        rollback_func1.assert_called()
+
+        # Last task should still be languishing in the workflow queue
+        self.assertEqual(len(workflow_queue), 1)
+        self.assertEqual(workflow_queue[0].func, func3)
+
+    def test_pass_result_as(self):
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        workflow_queue = [
+            WorkflowTask(Task(delete_foo), 'foo_id', create_foo),
+            WorkflowTask(None, None, fail),
+        ]
+        success, errors = execute_workflow(workflow_queue)
+
+        self.assertFalse(success)
+        create_foo.assert_called()
+        delete_foo.assert_called_with(foo_id=5)
+
+
+class DecoratorTests(SimpleTestCase):
+
+    def test_task_decorator(self):
+        do_something = Mock()
+
+        @task
+        def get_foo_task(param1, param2):
+            do_something(param1, where=param2)
+
+        foo_task = get_foo_task('ran', param2='away')
+
+        self.assertIsInstance(foo_task, Task)
+        self.assertEqual(foo_task.args, ('ran',))
+        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
+        do_something.assert_not_called()
+
+        foo_task.run_func()
+        do_something.assert_called_with('ran', where='away')
+
+    def test_workflow_task_decorator(self):
+        do_something = Mock()
+
+        @workflow_task()
+        def get_foo_task(param1, param2):
+            do_something(param1, where=param2)
+
+        foo_task = get_foo_task('ran', param2='away')
+
+        self.assertIsInstance(foo_task, WorkflowTask)
+        self.assertIsNone(foo_task.rollback_task)
+        self.assertIsNone(foo_task.pass_result_as)
+        self.assertEqual(foo_task.args, ('ran',))
+        self.assertEqual(foo_task.kwargs, {'param2': 'away'})
+        do_something.assert_not_called()
+
+        foo_task.run_func()
+        do_something.assert_called_with('ran', where='away')
+
+    def test_workflow_task_decorator_with_rollback(self):
+        create_foo = Mock(return_value=5)
+        delete_foo = Mock()
+        fail = Mock(side_effect=Exception('Fail'))
+
+        @task
+        def get_delete_foo_task(foo_id):
+            delete_foo(foo_id)
+
+        @workflow_task(rollback_task=get_delete_foo_task(), pass_result_as='foo_id')
+        def get_create_foo_task(foo_name):
+            foo_id = create_foo(foo_name)
+            return foo_id
+
+        workflow_queue = [
+            get_create_foo_task('FOO'),
+            workflow_task()(fail),
+        ]
+        success, errors = execute_workflow(workflow_queue)
+
+        self.assertFalse(success)
+        create_foo.assert_called_with('FOO')
+        delete_foo.assert_called_with(5)

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.test import SimpleTestCase
 from mock import Mock
 
@@ -7,6 +8,9 @@ from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow,
 class TaskTests(SimpleTestCase):
 
     def test_task_run_func_args_kwargs(self):
+        """
+        Task.run_func should call func with the args and kwargs that the task was instantiated with.
+        """
         sing = Mock()
         func_task = Task(sing, 'Brave Sir Robin', what='ran', where='away')
 
@@ -18,8 +22,10 @@ class TaskTests(SimpleTestCase):
         func_task.run_func()
         sing.assert_called_with('Brave Sir Robin', what='ran', where='away')
 
-
     def test_task_run(self):
+        """
+        Task.run should be called if the task was not instantiated with func
+        """
         class SirRobin(Task):
             def run(self):
                 pass
@@ -34,6 +40,9 @@ class TaskTests(SimpleTestCase):
 class WorkflowTests(SimpleTestCase):
 
     def test_workflow_runs(self):
+        """
+        If no errors occur, a workflow should be executed to completion
+        """
         func1 = Mock()
         func2 = Mock()
         workflow_queue = [
@@ -49,6 +58,9 @@ class WorkflowTests(SimpleTestCase):
         self.assertEqual(workflow_queue, [])
 
     def test_rollback_runs(self):
+        """
+        If an error is encountered, the workflow should stop, and the rollback should run to completion
+        """
         func1 = Mock()
         black_knight = Mock(side_effect=ValueError("'Tis but a flesh wound"))
         func3 = Mock()
@@ -84,6 +96,10 @@ class WorkflowTests(SimpleTestCase):
         self.assertEqual(workflow_queue[0].func, func3)
 
     def test_pass_result_as(self):
+        """
+        WorkflowTask.pass_result_as should pass the result of run_func to its rollback task using the given
+        parameter name.
+        """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))
@@ -102,6 +118,9 @@ class WorkflowTests(SimpleTestCase):
 class DecoratorTests(SimpleTestCase):
 
     def test_task_decorator(self):
+        """
+        The `@task` decorator should return a function that creates a Task instance when it is executed
+        """
         do_something = Mock()
 
         @task
@@ -119,6 +138,9 @@ class DecoratorTests(SimpleTestCase):
         do_something.assert_called_with('ran', where='away')
 
     def test_workflow_task_decorator(self):
+        """
+        The `@workflow_task` decorator should return a function that creates a WorkflowTask instance
+        """
         do_something = Mock()
 
         @workflow_task()
@@ -138,6 +160,9 @@ class DecoratorTests(SimpleTestCase):
         do_something.assert_called_with('ran', where='away')
 
     def test_workflow_task_decorator_with_rollback(self):
+        """
+        The @workflow_task decorator should be able to set `rollback_task` and `pass_result_as`
+        """
         create_foo = Mock(return_value=5)
         delete_foo = Mock()
         fail = Mock(side_effect=Exception('Fail'))

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
-from django.test import SimpleTestCase
+
+from unittest import TestCase
+
 from mock import Mock
 
 from corehq.motech.openmrs.workflow import Task, WorkflowTask, execute_workflow, task, workflow_task
 
 
-class TaskTests(SimpleTestCase):
+class TaskTests(TestCase):
 
     def test_task_run_func_args_kwargs(self):
         """
@@ -37,7 +39,7 @@ class TaskTests(SimpleTestCase):
         sir_robin.run.assert_called_with('fled', tail='turned', where='away')
 
 
-class WorkflowTests(SimpleTestCase):
+class WorkflowTests(TestCase):
 
     def test_workflow_runs(self):
         """
@@ -115,7 +117,7 @@ class WorkflowTests(SimpleTestCase):
         delete_foo.assert_called_with(foo_id=5)
 
 
-class DecoratorTests(SimpleTestCase):
+class DecoratorTests(TestCase):
 
     def test_task_decorator(self):
         """

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -59,6 +59,7 @@ class WorkflowTask(Task):
 
 
 def task(func):
+    # Doesn't use `@wraps` because `call()` doesn't execute func; it returns a Task instantiated with func
     def call(*args, **kwargs):
         instance = Task(func, *args, **kwargs)
         return instance

--- a/corehq/motech/openmrs/workflow.py
+++ b/corehq/motech/openmrs/workflow.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import
+
+
+class Task(object):
+    """
+    Tasks are instantiated with a function to run, and args and kwargs that must be passed to it.
+
+    Instances of this class are used for rollback.
+
+    If a task is not instantiated with a function, it must implement a run() method. It will be passed the args
+    and kwargs that the class was instantiated with.
+    """
+
+    def __init__(self, func=None, *args, **kwargs):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def run_func(self):
+        if self.func:
+            return self.func(*self.args, **self.kwargs)
+        else:
+            return self.run(*self.args, **self.kwargs)
+
+    def run(self, *args, **kwargs):
+        raise NotImplementedError('Task.func must be set, or Task.run() must be defined.')
+
+
+class WorkflowTask(Task):
+    """
+    Extends rollback tasks. Workflow tasks can define subtasks, which will be prepended to the workflow queue
+    after the task is run.
+
+    If a workflow task is not instantiated with a rollback task, either it must implement its own
+    get_rollback_task() method, or it will be assumed that the task does not cause a change of state (probably
+    because its subtasks do).
+    """
+
+    def __init__(self, rollback_task=None, pass_result_as=None, func=None, *args, **kwargs):
+        """
+        Instantiate WorkflowTask
+
+        :param rollback_task: A Task instance
+        :param pass_result_as: A parameter name, to be passed as a kwarg to rollback_task
+        :param func: The function this task must run
+        :param args: Arguments to pass to func or self.run()
+        :param kwargs: Keyword arguments to pass to func or self.run()
+        """
+        self.rollback_task = rollback_task
+        self.pass_result_as = pass_result_as
+        super(WorkflowTask, self).__init__(func, *args, **kwargs)
+        self._subtasks = []
+
+    def get_rollback_task(self):
+        return self.rollback_task
+
+    def get_subtasks(self):
+        return self._subtasks
+
+
+def task(func):
+    def call(*args, **kwargs):
+        instance = Task(func, *args, **kwargs)
+        return instance
+    return call
+
+
+def workflow_task(rollback_task=None, pass_result_as=None):
+    def decorate(func):
+        def call(*args, **kwargs):
+            instance = WorkflowTask(rollback_task, pass_result_as, func, *args, **kwargs)
+            return instance
+        return call
+    return decorate
+
+
+def execute_workflow(workflow_queue):
+    """
+    We use two lists to execute a workflow:
+
+    1. The (given) workflow queue, where tasks are pulled off the front and run, until an error is encountered.
+    2. A rollback stack, where each workflow task appends a reverse task to undo its action, to be run if the
+       workflow fails.
+
+    """
+    success = True
+    errors = []
+    rollback_stack = []
+
+    try:
+        while workflow_queue:
+            workflow_task = workflow_queue.pop(0)
+            rollback_task = workflow_task.get_rollback_task()
+            if rollback_task:
+                rollback_stack.append(rollback_task)
+            # Note: The rollback task is added before the workflow task is run. This offers developers an
+            # opportunity to try to fix whatever the workflow task might have broken before it failed.
+            # ...
+            # BUT if the workflow task needs to make more than one change, it should split them up into subtasks.
+            result = workflow_task.run_func()
+            if workflow_task.pass_result_as and rollback_task:
+                # Useful for rollback tasks that must delete something created by the workflow task
+                rollback_task.kwargs.update({workflow_task.pass_result_as: result})
+            for i, subtask in enumerate(workflow_task.get_subtasks()):
+                workflow_queue.insert(i, subtask)
+
+    except Exception as workflow_error:
+        success = False
+        errors.append('Workflow failed: {name}: {message}'.format(
+            name=workflow_error.__class__.__name__, message=str(workflow_error)
+        ))
+        for rollback_task in reversed(rollback_stack):
+            try:
+                rollback_task.run_func()
+            except Exception as rollback_error:
+                errors.append('Rollback error: {name}: {message}'.format(
+                    name=rollback_error.__class__.__name__, message=str(rollback_error)
+                ))
+
+    return success, errors


### PR DESCRIPTION
:blowfish: commits from [\`Should\` unused](https://github.com/dimagi/commcare-hq/commit/5a66ebd4d8448329527e3b99504d3a38e7fadb1a) onwards. (Previous commits appear in PRs #19757 and #19758)

This removes a few unused things. It refactors Requests so that it can catch and log errors in a DRYer way. And it turns PatientSearchParser into a function. 

I think PatientSearchParser was going to be what PatientFinders turned into. Using a function to fetch patients by their identifiers simplifies things a bit. The function names are awkward though: `get_patient_by_id` which calls `get_patient_by_uuid` when the ID is a UUID and `get_patient_by_identifier` when the ID is an OpenMRS Identifier.

I'll move the tests in *test_parsers.py* into *test_repeaters.py* and maybe split up *test_repeaters.py*. But I'll wait for more stuff to get merged because otherwise resolving merge conflict will be a pain.

In a future PR I'll move Requests into its own module, and merge it with the equivalent in `motech.dhis2` (which I think is a bit of a mess, and could benefit from the relative simplicity of the `openmrs` version).

@dannyroberts, buddy @sravfeyn 
