### PR TITLE
consistent return values

### DIFF
--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -83,16 +83,16 @@ def get_version_and_app_from_build_id(domain, build_id):
 
     """
     if not build_id:
-        return None
+        return None, None
 
     try:
         build = get_app(domain, build_id)
     except (ResourceNotFound, Http404):
-        return None
+        return None, None
     if not build.copy_of:
-        return None
+        return None, None
     elif domain and build.domain != domain:
-        return None
+        return None, None
     else:
         return build.version, build.copy_of
 


### PR DESCRIPTION
```
'NoneType' object is not iterable

File "/home/cchq/www/production/current/corehq/ex-submodules/pillow_retry/tasks.py", line 59, in process_pillow_retry
pillow.process_change(change)
File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 260, in process_change
processor.process_change(self, change)
File "/home/cchq/www/production/releases/2018-03-23_20.52/corehq/pillows/synclog.py", line 61, in process_change
version, app_id = get_version_and_app_from_build_id(synclog.get('domain'), build_id)
```