### PR TITLE
Update casing for analytics js models

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/logging.js
+++ b/corehq/apps/analytics/static/analytix/js/logging.js
@@ -32,24 +32,24 @@ hqDefine('analytix/js/logging', [
         } else if (_.isArguments(message.value)) {
             _title = "Arguments (" + message.value.length + ")    " + _.map(Array.from(message.value), JSON.stringify).join('    ');
             _value = Array.from(message.value);
-            _group = Group(_title, Message(_value, message.level));
+            _group = groupModel(_title, messageModel(_value, message.level));
             _group.isCollapsed = true;
             _group.print();
         } else if (_.isArray(message.value)) {
             _.each(message.value, function (msg) {
-                _printPretty(Message(msg, message.level));
+                _printPretty(messageModel(msg, message.level));
             });
         } else if (_.isObject(message.value) && _.has(message.value, 0) && _.isElement(message.value[0])) {
             // DOM element
             _title = "#" + message.value.get(0).id + " ." + message.value.get(0).className.split(' ').join('.');
             _value = message.value.get(0).outerHTML;
-            _group = Group(_title, Message(_value, message.level));
+            _group = groupModel(_title, messageModel(_value, message.level));
             _group.isCollapsed = true;
             _group.print();
         } else if (!_.isString(message.value) && !_.isUndefined(message.value)) {
             _title = JSON.stringify(message.value);
             _value = message.value;
-            _group = Group(_title, Message(_value, message.level));
+            _group = groupModel(_title, messageModel(_value, message.level));
             _group.isCollapsed = true;
             _group.isRaw = true;
             _group.print();
@@ -63,7 +63,7 @@ hqDefine('analytix/js/logging', [
         return (levelOptions) ? levelOptions.style : "";
     };
 
-    var Message = function (value, level) {
+    var messageModel = function (value, level) {
         var msg = {};
         msg.level = level;
         msg.value = value;
@@ -78,7 +78,7 @@ hqDefine('analytix/js/logging', [
      * groups so that it's easier to skim data vs info text on the console output
      * and improve readability.
      */
-    var Group = function (title, message) {
+    var groupModel = function (title, message) {
         var grp = {};
         grp.title = title;
         grp.level = message.level;
@@ -95,7 +95,7 @@ hqDefine('analytix/js/logging', [
         return grp;
     };
 
-    var Log = function(level, logger) {
+    var logModel = function(level, logger) {
         var _log = {};
         _log.level = level.slug;
         _log.isVisible = level.isVisible;
@@ -113,7 +113,7 @@ hqDefine('analytix/js/logging', [
             getPrint: function () {
                 return function (messageValue, messagePrefix) {
                     if (_log.isVisible) {
-                        var group = Group(_log.getPrefix(messagePrefix), Message(messageValue, _log.level));
+                        var group = groupModel(_log.getPrefix(messagePrefix), messageModel(messageValue, _log.level));
                         group.print();
                     }
                 };
@@ -136,7 +136,7 @@ hqDefine('analytix/js/logging', [
             level = {};
         level.addCategory = function (slug, category) {
             if (_.isUndefined(level[slug])) {
-                var _log = Log(_levelData, _logger);
+                var _log = logModel(_levelData, _logger);
                 _log.setCategory(category);
                 level[slug] = _log.getPrint();
             }
@@ -145,7 +145,7 @@ hqDefine('analytix/js/logging', [
         return level;
     };
 
-    var Logger = function (_prefix) {
+    var loggerModel = function (_prefix) {
         var logger = {};
         logger.prefix = _prefix;
         logger.createLevel = function (slug, name) {
@@ -156,7 +156,7 @@ hqDefine('analytix/js/logging', [
         });
         logger.fmt = {};
         logger.fmt.groupMsg = function (title, message) {
-            return Group(title, Message(message));
+            return groupModel(title, messageModel(message));
         };
         /**
          * Outputs a list of group messages that maps argument labels to their values.
@@ -175,7 +175,7 @@ hqDefine('analytix/js/logging', [
 
     return {
         getLoggerForApi: function (apiName) {
-            return Logger(apiName);
+            return loggerModel(apiName);
         },
     };
 });


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/19895#pullrequestreview-106915955

Looking at the analytics and accounting apps, it's relatively common for us to define an object `Thing` and then later instantiate it and assign it to a variable `thing` (mostly when dealing with knockout models, which are typically only instantiated once). There's something of a convention of adding `Model` to the end of class definitions (again thanks to knockout) so I'm going with that.

@millerdev / @czue 