### PR TITLE
Use makeHqHelp for report builder's help icons

### DIFF
--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -36,18 +36,14 @@ TODO:
             <th></th>
             <th>
                 <!--ko if: $data.propertyHelpText -->
-                <span class="hq-help-template" data-bind="
-                    attr: {'data-content': propertyHelpText}
-                "></span>
+                <span data-bind="makeHqHelp: {description: propertyHelpText}"></span>
                 <!--/ko-->
                 {% trans "Property" %}
             </th>
             <!--ko if: $data.hasDisplayCol -->
             <th>
                 <!--ko if: $data.displayHelpText -->
-                <span class="hq-help-template" data-bind="
-                    attr: {'data-content': displayHelpText}
-                "></span>
+                <span data-bind="makeHqHelp: {description: displayHelpText}"></span>
                 <!--/ko-->
                 {% trans "Label" %}
             </th>
@@ -55,10 +51,7 @@ TODO:
             <!--ko if: $data.hasFormatCol -->
             <th class="table-editprops-format">
                 <!--ko if: $data.formatHelpText -->
-                <span class="hq-help-template" data-bind="
-                    if: formatHelpText,
-                    attr: {'data-content': formatHelpText}
-                "></span>
+                <span data-bind="makeHqHelp: {description: formatHelpText}"></span>
                 <!--/ko-->
                 {% trans "Format" %}
             </th>
@@ -67,10 +60,7 @@ TODO:
             <th class="table-editprops-format">
                 {% trans "Format" %}
                 <!--ko if: $data.calcHelpText -->
-                <span class="hq-help-template" data-bind="
-                    if: calcHelpText,
-                    attr: {'data-content': calcHelpText}
-                "></span>
+                <span data-bind="makeHqHelp: {description: calcHelpText}"></span>
                 <!--/ko-->
             </th>
             <!--/ko-->
@@ -78,10 +68,7 @@ TODO:
             <th class="table-editprops-filterval">
                 {% trans "Filter Value" %}
                 <!--ko if: $data.filterValueHelpText -->
-                <span class="hq-help-template" data-bind="
-                    if: filterValueHelpText,
-                    attr: {'data-content': filterValueHelpText}
-                "></span>
+                <span data-bind="makeHqHelp: {description: filterValueHelpText}"></span>
                 <!--/ko-->
             </th>
             <!--/ko-->


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?256315

I don't know why, but the data bindings in were not working properly for the help icons in the Report Builder's. Replacing `hq-help-template` with a `makeHqHelp` binding fixes this.