### PR TITLE
avoid data source error when moving from Case Summary to Case List

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -126,6 +126,11 @@ hqDefine('userreports/js/report_config', function() {
                     var wasAggregationEnabled = self.isAggregationEnabled();
                     self.isAggregationEnabled(newValue === constants.REPORT_TYPE_TABLE);
                     self.previewChart(newValue === constants.REPORT_TYPE_TABLE && self.selectedChart() !== "none");
+                    if (self.reportType() === constants.REPORT_TYPE_LIST) {
+                        self.columnList.columns().forEach(function(val, index) {
+                            val.calculation(constants.GROUP_BY);
+                        });
+                    }
                     if (self.isAggregationEnabled() && !wasAggregationEnabled) {
                         self.columnList.columns().forEach(function(val, index) {
                             if (index === 0) {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?270364

Issue was that the column formats applied in the Case Summary report were being carried over to the Case List, which should only use Group By.

@kaapstorm @gbova 