### PR TITLE
Unify fsdb and s3db blob overwrite behavior

### DIFF
--- a/corehq/blobs/management/commands/import_blob_zip.py
+++ b/corehq/blobs/management/commands/import_blob_zip.py
@@ -5,7 +5,6 @@ import zipfile
 from django.core.management.base import BaseCommand
 
 from corehq.blobs import BlobInfo, get_blob_db
-from corehq.blobs.fsdb import FileExists
 
 USAGE = "Usage: ./manage.py import_blob_zip <zipname>"
 
@@ -27,7 +26,4 @@ class Command(BaseCommand):
             blob = io.BytesIO(from_zip.read(filename))
             # copy_blob only needs the identifier
             blob_info = BlobInfo(identifier=identifier, length="", digest="")
-            try:
-                to_db.copy_blob(blob, blob_info, bucket)
-            except FileExists:
-                continue
+            to_db.copy_blob(blob, blob_info, bucket)

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -149,6 +149,13 @@ class _BlobDBTests(object):
         self.assertNotIn(".", info.identifier)
         return info
 
+    def test_put_with_colliding_blob_id(self):
+        ident = get_id()
+        self.db.put(BytesIO(b"bing"), ident)
+        self.db.put(BytesIO(b"bang"), ident)
+        with self.db.get(ident) as fh:
+            self.assertEqual(fh.read(), b"bang")
+
 
 @generate_cases([
     ("test.1", "\u4500.1"),
@@ -179,14 +186,6 @@ class TestFilesystemBlobDB(TestCase, _BlobDBTests):
         rmtree(cls.rootdir)
         cls.rootdir = None
         super(TestFilesystemBlobDB, cls).tearDownClass()
-
-    def test_put_with_colliding_blob_id(self):
-        # unfortunately can't do this on S3 because there is no way to
-        # reliably check if an object exists before putting it.
-        ident = get_id()
-        self.db.put(BytesIO(b"bing"), ident)
-        with self.assertRaises(mod.FileExists):
-            self.db.put(BytesIO(b"bang"), ident)
 
     def test_delete(self):
         info, bucket = super(TestFilesystemBlobDB, self).test_delete()


### PR DESCRIPTION
Doing this now because a case came up where it makes sense to overwrite when putting a blob with an existing identifier. Also, this makes fsdb and s3db handle overwrites in the same way, which is a good thing.

@pr33thi @calellowitz 