### PR TITLE
wrap in doc ready handler

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -132,30 +132,32 @@ var CaseManagement = function (o) {
     };
 };
 
-ko.bindingHandlers.caseReassignmentForm = {
-    update: function(element, valueAccessor) {
-        var value = valueAccessor()();
-        var $element = $(element);
-        if (value.length > 0) {
-            $element.slideDown();
-        } else {
-            $element.find("[type='submit']").enableButton();
-            $element.slideUp();
-        }
-    },
-};
+$(function() {
+    ko.bindingHandlers.caseReassignmentForm = {
+        update: function(element, valueAccessor) {
+            var value = valueAccessor()();
+            var $element = $(element);
+            if (value.length > 0) {
+                $element.slideDown();
+            } else {
+                $element.find("[type='submit']").enableButton();
+                $element.slideUp();
+            }
+        },
+    };
 
-ko.bindingHandlers.grabUniqueDefault = {
-    update: function(element, valueAccessor) {
-        var value = valueAccessor()();
-        var unique = _.unique(value);
-        if (unique.length === 1) {
-            $(element).val(unique[0]);
-        } else {
-            // okay, so ideally this should deselect the select and combobox. unfortunately I think this requires
-            // some reworking of the combobox, so just have it set at whatever value is set by default for now is fine.
-            // bleh.
-        }
-        $(element).trigger('change');
-    },
-};
+    ko.bindingHandlers.grabUniqueDefault = {
+        update: function(element, valueAccessor) {
+            var value = valueAccessor()();
+            var unique = _.unique(value);
+            if (unique.length === 1) {
+                $(element).val(unique[0]);
+            } else {
+                // okay, so ideally this should deselect the select and combobox. unfortunately I think this requires
+                // some reworking of the combobox, so just have it set at whatever value is set by default for now is fine.
+                // bleh.
+            }
+            $(element).trigger('change');
+        },
+    };
+});


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?272891

I can't get this to happen locally (if someone wants to explain how data interfaces work to me, that would be great), but this should fix it and doesn't seem too dangerous.

This is a good example page that is having the problem. It just seems to not have access to ko yet. https://www.commcarehq.org/a/jmtr-test/data/edit/case_groups/b6669edfc620c0290c8e8a88b8074f0a/

@orangejenny, let me know if this solution seems reasonable or if this might have something to do with requirejs hiding ko in some way.
buddy @snopoke 