### PR TITLE
allow empty context variables in eval expression

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -336,7 +336,7 @@ class DictExpressionSpec(JsonObject):
 class EvalExpressionSpec(JsonObject):
     type = TypeProperty('evaluator')
     statement = StringProperty(required=True)
-    context_variables = DictProperty(required=True)
+    context_variables = DictProperty()
     datatype = DataTypeProperty(required=False)
 
     def configure(self, context_variables):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -982,6 +982,7 @@ def test_add_days_to_date_expression(self, source_doc, count_expression, expecte
     ),
     ({}, "a + b", {"a": Decimal(2), "b": Decimal(3)}, Decimal(5)),
     ({}, "a + b", {"a": Decimal(2.2), "b": Decimal(3.1)}, Decimal(5.3)),
+    ({}, "range(3)", {}, [0, 1, 2]),
 ])
 def test_valid_eval_expression(self, source_doc, statement, context, expected_value):
     expression = ExpressionFactory.from_spec({

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -995,9 +995,10 @@ def test_valid_eval_expression(self, source_doc, statement, context, expected_va
 
 
 @generate_cases([
-    # context must be non-empty dict
+    # context must be a dict
     ({}, "2 + 3", "text context"),
-    ({}, "2 + 3", {}),
+    ({}, "2 + 3", 42),
+    ({}, "2 + 3", []),
     # statement must be string
     ({}, 2 + 3, {"a": 2, "b": 3})
 ])


### PR DESCRIPTION
another small ucr thing I ran into. some expressions may not actually have/require variables, but we were disallowing this. cc @orangejenny 