### PR TITLE
remove from requirejs

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/manage_case_groups.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/manage_case_groups.js
@@ -1,25 +1,16 @@
-hqDefine("data_interfaces/js/manage_case_groups", [
-    "jquery",
-    "underscore",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/crud_paginated_list_init",
-    "hqwebapp/js/bulk_upload_file",
-], function(
-    $,
-    _,
-    initialPagedata
-) {
+hqDefine("data_interfaces/js/manage_case_groups", function() {
+    var initialPagedata = hqImport('hqwebapp/js/initial_page_data');
     $(function() {
         var bulkUploadId = initialPagedata.get("bulk_upload_id");
         if (bulkUploadId) {
             var isPollingActive = true,
                 attempts = 0;
-    
+
             var retry = function () {
                 attempts += 1;
                 setTimeout(pollStatus, 2000);
             };
-    
+
             var pollStatus = function () {
                 if (isPollingActive && attempts < 10) {
                     $.ajax({

--- a/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
@@ -3,7 +3,11 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "data_interfaces/js/manage_case_groups" %}
+{% block js %}{{ block.super }}
+    <script src="{% static 'hqwebapp/js/crud_paginated_list_init.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bulk_upload_file.js' %}"></script>
+    <script src="{% static 'data_interfaces/js/manage_case_groups.js' %}"></script>
+{% endblock js %}
 
 {% block pagination_header %}
     <h3>


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?272891
Again --> 

I can't get this to happen locally (if someone wants to explain how data interfaces work to me, that would be great), but this should fix it and doesn't seem too dangerous.

This is a good example page that is having the problem. It just seems to not have access to ko yet. https://www.commcarehq.org/a/jmtr-test/data/edit/case_groups/b6669edfc620c0290c8e8a88b8074f0a/

taking @orangejenny's suggestion in #19944
buddy @snopoke