### PR TITLE
worker activity performance improvements

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -327,11 +327,11 @@ def get_group_stubs(group_ids):
 
 
 def get_user_stubs(user_ids):
-    from corehq.apps.reports.util import SimplifiedUserInfo_ES_FIELDS
+    from corehq.apps.reports.util import SimplifiedUserInfo
     return (UserES()
         .user_ids(user_ids)
         .show_inactive()
-        .values(*SimplifiedUserInfo_ES_FIELDS))
+        .values(*SimplifiedUserInfo.ES_FIELDS))
 
 
 def get_forms(domain, startdate, enddate, user_ids=None, app_ids=None, xmlnss=None, by_submission_time=True):

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -327,10 +327,11 @@ def get_group_stubs(group_ids):
 
 
 def get_user_stubs(user_ids):
+    from corehq.apps.reports.util import SimplifiedUserInfo_ES_FIELDS
     return (UserES()
         .user_ids(user_ids)
         .show_inactive()
-        .values('_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active'))
+        .values(SimplifiedUserInfo_ES_FIELDS))
 
 
 def get_forms(domain, startdate, enddate, user_ids=None, app_ids=None, xmlnss=None, by_submission_time=True):

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -96,15 +96,15 @@ def _get_case_case_counts_by_owner(domain, datespan, case_types, is_total=False,
     return case_query.run().aggregations.owner_id.counts_by_bucket()
 
 
-def get_case_counts_closed_by_user(domain, datespan, case_types=None, owner_ids=None):
-    return _get_case_counts_by_user(domain, datespan, case_types, False, owner_ids)
+def get_case_counts_closed_by_user(domain, datespan, case_types=None, user_ids=None):
+    return _get_case_counts_by_user(domain, datespan, case_types, False, user_ids)
 
 
-def get_case_counts_opened_by_user(domain, datespan, case_types=None, owner_ids=None):
-    return _get_case_counts_by_user(domain, datespan, case_types, True, owner_ids)
+def get_case_counts_opened_by_user(domain, datespan, case_types=None, user_ids=None):
+    return _get_case_counts_by_user(domain, datespan, case_types, True, user_ids)
 
 
-def _get_case_counts_by_user(domain, datespan, case_types=None, is_opened=True, owner_ids=None):
+def _get_case_counts_by_user(domain, datespan, case_types=None, is_opened=True, user_ids=None):
     date_field = 'opened_on' if is_opened else 'closed_on'
     user_field = 'opened_by' if is_opened else 'closed_by'
 
@@ -125,8 +125,8 @@ def _get_case_counts_by_user(domain, datespan, case_types=None, is_opened=True, 
     else:
         case_query = case_query.filter(filters.NOT(case_type_filter('commcare-user')))
 
-    if owner_ids:
-        case_query = case_query.filter(filters.term(user_field, owner_ids))
+    if user_ids:
+        case_query = case_query.filter(filters.term(user_field, user_ids))
 
     return case_query.run().aggregations.by_user.counts_by_bucket()
 

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -331,7 +331,7 @@ def get_user_stubs(user_ids):
     return (UserES()
         .user_ids(user_ids)
         .show_inactive()
-        .values(SimplifiedUserInfo_ES_FIELDS))
+        .values(*SimplifiedUserInfo_ES_FIELDS))
 
 
 def get_forms(domain, startdate, enddate, user_ids=None, app_ids=None, xmlnss=None, by_submission_time=True):

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT
 from corehq.apps.reports.filters.case_list import CaseListFilterUtils
-from corehq.apps.reports.util import SimplifiedUserInfo_ES_FIELDS
+from corehq.apps.reports.util import SimplifiedUserInfo
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.elastic import ESError
 from memoized import memoized
@@ -167,7 +167,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
 
     def get_users(self, query, start, size):
         users = (self.user_es_query(query)
-                 .fields(SimplifiedUserInfo_ES_FIELDS)
+                 .fields(SimplifiedUserInfo.ES_FIELDS)
                  .start(start)
                  .size(size)
                  .sort("username.exact"))

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -14,6 +14,7 @@ from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT
 from corehq.apps.reports.filters.case_list import CaseListFilterUtils
+from corehq.apps.reports.util import SimplifiedUserInfo_ES_FIELDS
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.elastic import ESError
 from memoized import memoized
@@ -166,7 +167,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
 
     def get_users(self, query, start, size):
         users = (self.user_es_query(query)
-                 .fields(self.utils.SimplifiedUserInfo_ES_FIELDS)
+                 .fields(SimplifiedUserInfo_ES_FIELDS)
                  .start(start)
                  .size(size)
                  .sort("username.exact"))

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -166,7 +166,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
 
     def get_users(self, query, start, size):
         users = (self.user_es_query(query)
-                 .fields(['_id', 'username', 'first_name', 'last_name', 'doc_type'])
+                 .fields(self.utils.SimplifiedUserInfo_ES_FIELDS)
                  .start(start)
                  .size(size)
                  .sort("username.exact"))

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -117,8 +117,6 @@ class BaseGroupedMobileWorkerFilter(BaseSingleOptionFilter):
 
 
 class EmwfUtils(object):
-    SimplifiedUserInfo_ES_FIELDS = util.SimplifiedUserInfo_ES_FIELDS
-
     def __init__(self, domain):
         self.domain = domain
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -117,6 +117,7 @@ class BaseGroupedMobileWorkerFilter(BaseSingleOptionFilter):
 
 
 class EmwfUtils(object):
+    SimplifiedUserInfo_ES_FIELDS = util.SimplifiedUserInfo_ES_FIELDS
 
     def __init__(self, domain):
         self.domain = domain

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1738,13 +1738,20 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
     def _report_data(self):
         avg_datespan = self.avg_datespan
 
+        case_owners = set()
+        user_ids = []
+        for user in self.users_to_iterate:
+            user_ids.append(user.user_id)
+            case_owners = case_owners.union((user.user_id, user.location_id))
+            case_owners = case_owners.union(user.group_ids)
+
         return WorkerActivityReportData(
-            avg_submissions_by_user=get_submission_counts_by_user(self.domain, avg_datespan),
-            submissions_by_user=get_submission_counts_by_user(self.domain, self.datespan),
-            active_cases_by_owner=get_active_case_counts_by_owner(self.domain, self.datespan, self.case_types),
-            total_cases_by_owner=get_total_case_counts_by_owner(self.domain, self.datespan, self.case_types),
-            cases_closed_by_user=get_case_counts_closed_by_user(self.domain, self.datespan, self.case_types),
-            cases_opened_by_user=get_case_counts_opened_by_user(self.domain, self.datespan, self.case_types),
+            avg_submissions_by_user=get_submission_counts_by_user(self.domain, avg_datespan, user_ids=user_ids),
+            submissions_by_user=get_submission_counts_by_user(self.domain, self.datespan, user_ids=user_ids),
+            active_cases_by_owner=get_active_case_counts_by_owner(self.domain, self.datespan, self.case_types, owner_ids=case_owners),
+            total_cases_by_owner=get_total_case_counts_by_owner(self.domain, self.datespan, self.case_types, owner_ids=case_owners),
+            cases_closed_by_user=get_case_counts_closed_by_user(self.domain, self.datespan, self.case_types, owner_ids=user_ids),
+            cases_opened_by_user=get_case_counts_opened_by_user(self.domain, self.datespan, self.case_types, owner_ids=user_ids),
         )
 
     def _total_row(self, rows, report_data):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1746,12 +1746,24 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             case_owners = case_owners.union(user.group_ids)
 
         return WorkerActivityReportData(
-            avg_submissions_by_user=get_submission_counts_by_user(self.domain, avg_datespan, user_ids=user_ids),
-            submissions_by_user=get_submission_counts_by_user(self.domain, self.datespan, user_ids=user_ids),
-            active_cases_by_owner=get_active_case_counts_by_owner(self.domain, self.datespan, self.case_types, owner_ids=case_owners),
-            total_cases_by_owner=get_total_case_counts_by_owner(self.domain, self.datespan, self.case_types, owner_ids=case_owners),
-            cases_closed_by_user=get_case_counts_closed_by_user(self.domain, self.datespan, self.case_types, owner_ids=user_ids),
-            cases_opened_by_user=get_case_counts_opened_by_user(self.domain, self.datespan, self.case_types, owner_ids=user_ids),
+            avg_submissions_by_user=get_submission_counts_by_user(
+                self.domain, avg_datespan, user_ids=user_ids
+            ),
+            submissions_by_user=get_submission_counts_by_user(
+                self.domain, self.datespan, user_ids=user_ids
+            ),
+            active_cases_by_owner=get_active_case_counts_by_owner(
+                self.domain, self.datespan, self.case_types, owner_ids=case_owners
+            ),
+            total_cases_by_owner=get_total_case_counts_by_owner(
+                self.domain, self.datespan, self.case_types, owner_ids=case_owners
+            ),
+            cases_closed_by_user=get_case_counts_closed_by_user(
+                self.domain, self.datespan, self.case_types, owner_ids=user_ids
+            ),
+            cases_opened_by_user=get_case_counts_opened_by_user(
+                self.domain, self.datespan, self.case_types, owner_ids=user_ids
+            ),
         )
 
     def _total_row(self, rows, report_data):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1759,10 +1759,10 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
                 self.domain, self.datespan, self.case_types, owner_ids=case_owners
             ),
             cases_closed_by_user=get_case_counts_closed_by_user(
-                self.domain, self.datespan, self.case_types, owner_ids=user_ids
+                self.domain, self.datespan, self.case_types, user_ids=user_ids
             ),
             cases_opened_by_user=get_case_counts_opened_by_user(
-                self.domain, self.datespan, self.case_types, owner_ids=user_ids
+                self.domain, self.datespan, self.case_types, user_ids=user_ids
             ),
         )
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1832,8 +1832,8 @@ def _get_selected_users(domain, request):
 def _get_owner_ids_from_users(users):
     owner_ids = set()
     for user in users:
-        owner_ids = owner_ids.union([user['user_id'].lower(), user['location_id']])
-        owner_ids = owner_ids.union(user['group_ids'])
+        owner_ids.update([user['user_id'].lower(), user['location_id']])
+        owner_ids.update(user['group_ids'])
 
     try:
         owner_ids.remove(None)

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1744,6 +1744,11 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             case_owners = case_owners.union((user.user_id, user.location_id))
             case_owners = case_owners.union(user.group_ids)
 
+        try:
+            case_owners.remove(None)
+        except KeyError:
+            pass
+
         return WorkerActivityReportData(
             avg_submissions_by_user=get_submission_counts_by_user(
                 self.domain, avg_datespan, user_ids=user_ids

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1455,6 +1455,7 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         ) if ufilters else []
 
     @property
+    @memoized
     def users_to_iterate(self):
         if toggles.EMWF_WORKER_ACTIVITY_REPORT.enabled(self.request.domain):
             user_query = EMWF.user_es_query(

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -943,6 +943,7 @@ class TestUserESAccessors(SimpleTestCase):
             'first_name': self.first_name,
             'last_name': self.last_name,
             'doc_type': self.doc_type,
+            'location_id': None
         })
 
     def test_inactive_user_query(self):
@@ -957,6 +958,7 @@ class TestUserESAccessors(SimpleTestCase):
             'first_name': self.first_name,
             'last_name': self.last_name,
             'doc_type': self.doc_type,
+            'location_id': None
         })
 
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -192,10 +192,6 @@ def namedtupledict(name, fields):
     })
 
 
-SimplifiedUserInfo_ES_FIELDS = [
-    '_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active', 'location_id', '__group_ids'
-]
-
 class SimplifiedUserInfo(
         namedtupledict(b'SimplifiedUserInfo' if six.PY2 else 'SimplifiedUserInfo', (
             'user_id',
@@ -204,6 +200,10 @@ class SimplifiedUserInfo(
             'is_active',
             'location_id',
         ))):
+
+    ES_FIELDS = [
+        '_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active', 'location_id', '__group_ids'
+    ]
 
     @property
     @memoized
@@ -257,7 +257,7 @@ def get_simplified_users(user_es_query):
     Accepts an instance of UserES and returns SimplifiedUserInfo dicts for the
     matching users, sorted by username.
     """
-    users = user_es_query.fields(SimplifiedUserInfo_ES_FIELDS).run().hits
+    users = user_es_query.fields(SimplifiedUserInfo.ES_FIELDS).run().hits
     users = list(map(_report_user_dict, users))
     return sorted(users, key=lambda u: u['username_in_report'])
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -192,23 +192,25 @@ def namedtupledict(name, fields):
     })
 
 
+SimplifiedUserInfo_ES_FIELDS = [
+    '_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active', 'location_id', '__group_ids'
+]
+
 class SimplifiedUserInfo(
         namedtupledict(b'SimplifiedUserInfo' if six.PY2 else 'SimplifiedUserInfo', (
             'user_id',
             'username_in_report',
             'raw_username',
             'is_active',
+            'location_id',
         ))):
 
     @property
     @memoized
     def group_ids(self):
+        if hasattr(self, '__group_ids'):
+            return getattr(self, '__group_ids')
         return Group.by_user(self.user_id, False)
-
-    @property
-    @memoized
-    def location_id(self):
-        return CommCareUser.get_by_user_id(self.user_id).location_id
 
 
 def _report_user_dict(user):
@@ -218,8 +220,9 @@ def _report_user_dict(user):
     ['_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active']
     """
     if not isinstance(user, dict):
-        user_report_attrs = ['user_id', 'username_in_report', 'raw_username',
-                             'is_active']
+        user_report_attrs = [
+            'user_id', 'username_in_report', 'raw_username', 'is_active', 'location_id'
+        ]
         return SimplifiedUserInfo(**{attr: getattr(user, attr)
                                      for attr in user_report_attrs})
     else:
@@ -236,12 +239,17 @@ def _report_user_dict(user):
             if full_name:
                 yield ' "%s"' % html.escape(full_name)
         username_in_report = safestring.mark_safe(''.join(parts()))
-        return SimplifiedUserInfo(
+        info = SimplifiedUserInfo(
             user_id=user.get('_id', ''),
             username_in_report=username_in_report,
             raw_username=raw_username,
-            is_active=user.get('is_active', None)
+            is_active=user.get('is_active', None),
+            location_id=user.get('location_id', None)
         )
+        if '__group_ids' in user:
+            group_ids = user['__group_ids']
+            info.__group_ids = group_ids if isinstance(group_ids, list) else [group_ids]
+        return info
 
 
 def get_simplified_users(user_es_query):
@@ -249,8 +257,7 @@ def get_simplified_users(user_es_query):
     Accepts an instance of UserES and returns SimplifiedUserInfo dicts for the
     matching users, sorted by username.
     """
-    fields = ['_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active', 'email']
-    users = user_es_query.fields(fields).run().hits
+    users = user_es_query.fields(SimplifiedUserInfo_ES_FIELDS).run().hits
     users = list(map(_report_user_dict, users))
     return sorted(users, key=lambda u: u['username_in_report'])
 

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -78,6 +78,7 @@ class TestUserSyncToEs(SimpleTestCase):
             is_active=True,
             first_name='user1 first name',
             last_name='user1 last name',
+            location_id='location1'
         )
         user.save()
 
@@ -104,4 +105,6 @@ class TestUserSyncToEs(SimpleTestCase):
             'first_name': user.first_name,
             'last_name': user.last_name,
             'doc_type': user.doc_type,
+            'location_id': 'location1',
+            '__group_ids': []
         })


### PR DESCRIPTION
This report is basically broken on ICDS.

Apart from a few cleanups the main change is to pass in the list of `user_ids` or `owner_ids` to the ES queries so that it doesn't try to aggregate over the user space.

Can review by commit :fish: 