### PR TITLE
use correct aggregation type for report builder Case Lists

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -50,7 +50,11 @@ hqDefine('userreports/js/report_config', function() {
                 if (this.newProperty()) {
                     var item = this._createListItem();
                     item.property(this.newProperty());
-                    item.calculation(item.getDefaultCalculation());
+                    if (this.reportType() === constants.REPORT_TYPE_LIST) {
+                        item.calculation(constants.GROUP_BY);
+                    } else {
+                        item.calculation(item.getDefaultCalculation());
+                    }
                     this.newProperty(null);
                     this.columns.push(item);
                     if (_.isFunction(this.addItemCallback)) {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?271526

The report builder for Case Lists inserts a data source column of type decimal when the column is aggregated as a Sum.  Aggregating as a Group By inserts a data source column of type string, which is what the report expects. 