### PR TITLE
Allow GET and POST to call raise_for_status()

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -94,27 +94,35 @@ class Requests(object):
         self.username = username
         self.password = password
 
-    def get_url(self, uri):
-        return '/'.join((self.base_url.rstrip('/'), uri.lstrip('/')))
-
-    def get(self, uri, *args, **kwargs):
-        return self.requests.get(self.get_url(uri), *args,
-                                 auth=(self.username, self.password), **kwargs)
-
-    def post(self, uri, *args, **kwargs):
-        return self.requests.post(self.get_url(uri), *args,
-                                  auth=(self.username, self.password), **kwargs)
-
-    def post_with_raise(self, uri, *args, **kwargs):
-        response = self.post(uri, *args, **kwargs)
+    def send_request(self, method_func, *args, **kwargs):
+        raise_for_status = kwargs.pop('raise_for_status', False)
         try:
-            response.raise_for_status()
-        except HTTPError as err:
+            response = method_func(*args, **kwargs)
+            if raise_for_status:
+                response.raise_for_status()
+        except self.requests.RequestException as err:
             err_request, err_response = parse_request_exception(err)
             logger.error('Request: ', err_request)
             logger.error('Response: ', err_response)
             raise
         return response
+
+    def get_url(self, uri):
+        return '/'.join((self.base_url.rstrip('/'), uri.lstrip('/')))
+
+    def get(self, uri, *args, **kwargs):
+        return self.send_request(self.requests.get, self.get_url(uri), *args,
+                                 auth=(self.username, self.password), **kwargs)
+
+    def post(self, uri, *args, **kwargs):
+        return self.send_request(self.requests.post, self.get_url(uri), *args,
+                                 auth=(self.username, self.password), **kwargs)
+
+    def post_with_raise(self, uri, *args, **kwargs):
+        # When nh/omrs/rollback is merged TODO: drop this method
+        # and pass raise_for_status=True to get()/post()/delete() calls instead
+        return self.send_request(self.requests.post, self.get_url(uri), *args,
+                                 auth=(self.username, self.password), raise_for_status=True, **kwargs)
 
 
 def parse_request_exception(err):


### PR DESCRIPTION
Small refactor to allow both GET and POST requests to raise an exception for non-2XX-status API responses. (DELETE coming soon.)

Use 
```python
    my_requests_instance.get(some_url, raise_for_status=True)
```

This PR implements part of PR #19898 but doesn't depend on other PRs and preserves the current interface of the Requests class.

buddies @nickpell @sravfeyn cc @dannyroberts
