### PR TITLE
Externalize JavaScript: some easy files

### DIFF
--- a/corehq/apps/export/templates/export/download_data_files.html
+++ b/corehq/apps/export/templates/export/download_data_files.html
@@ -7,10 +7,6 @@
 
 {% block js %}{{ block.super }}
     <script src="{% static 'export/js/download_data_files.js' %}"></script>
-    <script>
-        var copyDataFileUrl = hqImport('export/js/download_data_files').copyDataFileUrl;
-        var deleteDataFile = hqImport('export/js/download_data_files').deleteDataFile;
-    </script>
 {% endblock %}
 
 {% block page_content %}
@@ -36,7 +32,7 @@
                 </td>
                 <td style="width: 6em; text-align: right;">
                     <a href="#"
-                       onclick="copyDataFileUrl(
+                       onclick="hqImport('export/js/download_data_files').copyDataFileUrl(
                                     '{{ url_base }}{% url 'download_data_file' domain data_file.id data_file.filename %}',
                                     $('#url_{{ data_file.id }}')
                                 )">
@@ -49,7 +45,7 @@
 
                     {% if is_admin %}
                     <a href="#"
-                       onclick="deleteDataFile(
+                       onclick="hqImport('export/js/download_data_files').deleteDataFile(
                                     '{% url 'download_data_file' domain data_file.id data_file.filename %}',
                                     $('#row_{{ data_file.id }}')
                                 )">

--- a/corehq/apps/export/templates/export/partial/daily_export_move_notifier.html
+++ b/corehq/apps/export/templates/export/partial/daily_export_move_notifier.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
-<div class="modal fade" id="dailySavedExportNotifier">
+<div class="modal" id="dailySavedExportNotifier">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -21,10 +21,3 @@
         </div>
     </div>
 </div>
-{% addtoblock js-inline %}
-<script>
-    $(window).on('load', function(){
-        $('#dailySavedExportNotifier').modal('show');
-    });
-</script>
-{% endaddtoblock %}

--- a/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/single.js
+++ b/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/single.js
@@ -1,0 +1,20 @@
+hqDefine("hqpillow_retry/js/single", function() {
+    function performAction(action) {
+        if (action === 'delete') {
+            var r=confirm("Are you sure you want to delete this error log?");
+            if (!r) {
+                return;
+            }
+        }
+        $("input[name=action]").val(action);
+        $("#actionform").submit();
+    }
+    $(function(){
+        $.each(['reset','delete','send'], function(index, id){
+            $('#'+id).click(function() {
+                performAction(id);
+                return false;
+            });
+        });
+    });
+});

--- a/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
+++ b/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
@@ -2,27 +2,9 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load compress %}
-{% block js-inline %}{{ block.super }}
-    <script>
-     function performAction(action) {
-         if (action === 'delete') {
-             var r=confirm("Are you sure you want to delete this error log?");
-             if (!r) {
-                 return;
-             }
-         }
-         $("input[name=action]").val(action);
-         $("#actionform").submit();
-     }
-     $(function(){
-         $.each(['reset','delete','send'], function(index, id){
-             $('#'+id).click(function() {
-                 performAction(id);
-                 return false;
-             });
-         });
-     })
-    </script>
+
+{% block js %}{{ block.super }}
+    <script src="{% static "hqpillow_retry/js/single.js" %}"></script>
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
@@ -1,0 +1,11 @@
+hqDefine("hqwebapp/js/500", function() {
+    $(function () {
+        $('#sad-danny').popover({
+            title: gettext("This is Danny, one of our best developers."),
+            content: gettext("Danny is pretty sad that you had to encounter this issue. He's making sure it gets fixed as soon as possible."),
+        });
+        $('#refresh').click(function() {
+            window.location.reload(true);
+        });
+    });
+});

--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -4,18 +4,8 @@
 {% block title %}
     {% trans "500 Error" %}
 {% endblock %}
-{% block js-inline %}
-    <script>
-        $(function () {
-            $('#sad-danny').popover({
-                title: "{% trans "This is Danny, one of our best developers." %}",
-                content: "{% trans "Danny is pretty sad that you had to encounter this issue. He's making sure it gets fixed as soon as possible." %}"
-            });
-            $('#refresh').click(function() {
-                window.location.reload(true);
-            });
-        });
-    </script>
+{% block js %}
+    <script src="{% static 'hqwebapp/js/500.js' %}"></script>
 {% endblock %}
 {% block page_name %}<h2>{% trans "Oh no, something unexpected just happened!" %}</h2>{% endblock %}
 {% block page_content %}

--- a/corehq/apps/reports/templates/reports/async/print_report.html
+++ b/corehq/apps/reports/templates/reports/async/print_report.html
@@ -7,9 +7,10 @@
 {% block js-inline %}
     {{ block.super }}
     <script>
+        // This is fine as an inline script; it's independent of all HQ code and all third-party libraries
         $(function() {
             setTimeout(function() {
-                $('.hq-loading').hide();
+                document.querySelector('.hq-loading').style.display = 'none';
                 window.print();
             }, 2000);
         })

--- a/corehq/apps/userreports/static/userreports/js/data_source_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_evaluator.js
@@ -1,7 +1,7 @@
 /* globals hqDefine */
 hqDefine('userreports/js/data_source_evaluator', function () {
-    var DataSourceModel = function (submitUrl) {
-        var self = this;
+    var dataSourceModel = function (submitUrl) {
+        var self = {};
         self.submitUrl = submitUrl;
         self.documentsId = ko.observable();
         self.dataSourceId = ko.observable();
@@ -43,6 +43,15 @@ hqDefine('userreports/js/data_source_evaluator', function () {
                 });
             }
         };
+
+        return self;
     };
-    return {DataSourceModel: DataSourceModel};
+
+    $(function () {
+        var submitUrl = hqImport("hqwebapp/js/initial_page_data").reverse("data_source_evaluator");
+        ko.applyBindings(
+            dataSourceModel(submitUrl),
+            document.getElementById('data-source-debugger')
+        );
+    });
 });

--- a/corehq/apps/userreports/templates/userreports/data_source_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/data_source_debugger.html
@@ -3,17 +3,6 @@
 {% load hq_shared_tags %}
 {% block js %}{{ block.super }}
     <script src="{% static 'userreports/js/data_source_evaluator.js' %}"></script>
-    <script>
-        $(function () {
-            var DataSourceModel = hqImport('userreports/js/data_source_evaluator').DataSourceModel;
-            var submitUrl = hqImport("hqwebapp/js/initial_page_data").reverse("data_source_evaluator");
-
-            ko.applyBindings(
-                new DataSourceModel(submitUrl),
-                document.getElementById('data-source-debugger')
-            );
-        });
-    </script>
 {% endblock %}
 {% block page_content %}
     {% registerurl "data_source_evaluator" domain %}


### PR DESCRIPTION
```
$ ./scripts/codechecks/hqDefine.sh

90%     (717/798) of HTML files are free of inline scripts
52%     (225/437) of JS files use hqDefine
11%     (45/437) of JS files specify their dependencies
```

90% of the way there...

@czue / @jmtroth0 