### PR TITLE
Remove softlayer from location cte test

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2339,5 +2339,4 @@ IS_LOCATION_CTE_ENABLED = UNIT_TESTING or SERVER_ENVIRONMENT in [
     'localdev',
     'changeme',  # default value in localsettings.example.py
     'staging',
-    'softlayer',
 ]


### PR DESCRIPTION
@millerdev Going to remove this because of that dashboard ticket and https://manage.dimagi.com/default.asp?272980

Although I won't be deploying today so if your fix gets in by tomorrow we can just close this.

Any reason this isn't a localsetting? It seems like that would be way better to use and more inline with how we usually do these types of changes