### PR TITLE
Fix styling of file input in case importer

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -21,8 +21,9 @@
                 <label class="control-label col-sm-3" for="file">
                     {% trans "Select a file to upload" %}
                 </label>
-                <div class="col-sm-6">
-                    <input class="form-control" name="file" id="file" type="file" />
+                <!-- unorthodox use of .control-label to vertically align the file input with the actual label -->
+                <div class="col-sm-6 control-label">
+                    <input name="file" id="file" type="file" />
                 </div>
             </div>
         </fieldset>


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?273381

Apparently `.form-control` isn't meant for file inputs. It looks a little weird in chrome and really bad in firefox.

after:
<img width="509" alt="screen shot 2018-03-30 at 11 22 21 am" src="https://user-images.githubusercontent.com/1486591/38143067-e5e76ad4-340c-11e8-8cc6-c4bc6f0d389b.png">

@czue / @biyeun 