### PR TITLE
stop setting the val

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -146,18 +146,3 @@ ko.bindingHandlers.caseReassignmentForm = {
         }
     },
 };
-
-ko.bindingHandlers.grabUniqueDefault = {
-    update: function(element, valueAccessor) {
-        var value = valueAccessor()();
-        var unique = _.unique(value);
-        if (unique.length === 1) {
-            $(element).val(unique[0]);
-        } else {
-            // okay, so ideally this should deselect the select and combobox. unfortunately I think this requires
-            // some reworking of the combobox, so just have it set at whatever value is set by default for now is fine.
-            // bleh.
-        }
-        $(element).trigger('change');
-    },
-};

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -80,17 +80,16 @@
     <div id="case-management">
         <div class="row">
             <form class="well form-inline" style="margin: 1em; display: none;" data-bind="submit: updateCaseOwners, caseReassignmentForm: selected_cases">
-                    <label for="reassign_owner_select" class="inline">{% trans 'Reassign selected cases to' %} </label>
-                    <span data-bind="visible: should_show_owners">
-                        <input type="hidden" name="reassign_owner"
-                            id="reassign_owner_select"
-                            style="width: 300px;"
-                            data-bind="grabUniqueDefault: selected_owners,
-                                       optionsText: 'name',
-                                       optionsValue: 'ownerid',
-                                       optionsCaption: '{% trans 'Select New Owner...' %}',
-                                       event: {change: changeNewOwner}, ic"></select>
-                    </span>
+                <label for="reassign_owner_select" class="inline">{% trans 'Reassign selected cases to' %} </label>
+                <span data-bind="visible: should_show_owners">
+                    <input type="hidden" name="reassign_owner"
+                        id="reassign_owner_select"
+                        style="width: 300px;"
+                        data-bind="optionsText: 'name',
+                                   optionsValue: 'ownerid',
+                                   optionsCaption: '{% trans 'Select New Owner...' %}',
+                                   event: {change: changeNewOwner}, ic" />
+                </span>
                 <button type="submit"
                         data-bind="hqbSubmitReady: is_submit_enabled, visible: is_submit_enabled"
                         class="btn btn-default disabled">{% trans 'Reassign' %}</button>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -88,7 +88,7 @@
                         data-bind="optionsText: 'name',
                                    optionsValue: 'ownerid',
                                    optionsCaption: '{% trans 'Select New Owner...' %}',
-                                   event: {change: changeNewOwner}, ic" />
+                                   event: {change: changeNewOwner}" />
                 </span>
                 <button type="submit"
                         data-bind="hqbSubmitReady: is_submit_enabled, visible: is_submit_enabled"


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?273328#1477056

The behavior seems to originally have been that it would set the current owner as the default selection, but select2's (especially ajax ones) aren't so simple. It seems the options are generated dynamically on the select2 request. 

Because switching the owner is the intent anyway, it seemed reasonable to just remove that behavior.

@emord, it looks like you might know a bit more about select2 than I do from my brief googling, so if you have any recommendations about how to change it back to it's previous behavior let me know.