### PR TITLE
Add close button to app preview's data preview

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -11,6 +11,7 @@
         ">
         <!-- Tab title -->
         <div class="debugger-tab-title" data-bind="click: toggleState">
+            <i class="fa fa-close pull-right"></i>
             <i class="fa fa-table"></i>
             <span class="debugger-title">{% trans "Data Preview" %}</span>
         </div>

--- a/corehq/apps/hqwebapp/static/preview_app/less/preview_app/debugger.less
+++ b/corehq/apps/hqwebapp/static/preview_app/less/preview_app/debugger.less
@@ -24,7 +24,7 @@
 
   .debugger-tab-title {
     text-align: center;
-    .debugger-title {
+    .debugger-title, .fa-close {
       display: none;
     }
   }


### PR DESCRIPTION
As Kai suggested in product team slack.

It still closes if you click anywhere in the header, not just on the x, because that was the path of least resistance. I think this is still an improvement but am open to objections. This doesn't affect data preview in web apps.

@czue 

<img width="295" alt="screen shot 2018-03-30 at 12 00 17 pm" src="https://user-images.githubusercontent.com/1486591/38144287-1763790e-3412-11e8-9390-2f87b09c0ca4.png">
