### PR TITLE
Track ICDS tasks cases

### DIFF
--- a/corehq/apps/locations/tests/test_location_expressions.py
+++ b/corehq/apps/locations/tests/test_location_expressions.py
@@ -227,3 +227,19 @@ class TestAncestorLocationExpression(LocationHierarchyTest):
 
         ancestor_location = expression({}, context)
         self.assertIsNone(ancestor_location)
+
+    def test_ancestor_location_property(self):
+        context = EvaluationContext({'domain': self.domain})
+        expression = ExpressionFactory.from_spec({
+            'type': 'ancestor_location',
+            'location_id': self.city.location_id,
+            'location_type': "continent",
+            'location_property': "_id"
+        }, context)
+
+        ancestor_location_property = expression({}, context)
+        self.assertIsNotNone(ancestor_location_property)
+        self.assertEqual(
+            ancestor_location_property,
+            self.continent.location_id
+        )

--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from jsonobject import DefaultProperty
+from jsonobject import DefaultProperty, StringProperty
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.userreports.decorators import ucr_context_cache
@@ -76,6 +76,7 @@ class AncestorLocationExpression(JsonObject):
     type = TypeProperty("ancestor_location")
     location_id = DefaultProperty(required=True)
     location_type = DefaultProperty(required=True)
+    location_property = StringProperty(required=False)
 
     def configure(self, location_id_expression, location_type_expression):
         self._location_id_expression = location_id_expression
@@ -84,7 +85,12 @@ class AncestorLocationExpression(JsonObject):
     def __call__(self, item, context=None):
         location_id = self._location_id_expression(item, context)
         location_type = self._location_type_expression(item, context)
-        return self._get_ancestors_by_type(location_id, context).get(location_type)
+        location = self._get_ancestors_by_type(location_id, context).get(location_type)
+
+        if self.location_property:
+            return location.get(self.location_property)
+
+        return location
 
     @staticmethod
     @ucr_context_cache(vary_on=('location_id',))

--- a/corehq/apps/userreports/const.py
+++ b/corehq/apps/userreports/const.py
@@ -35,6 +35,11 @@ KAFKA_TOPICS = (
     topics.COMMCARE_USER,
 )
 
+FILTER_INTERPOLATION_DOC_TYPES = {
+    "CommCareCase": "type",
+    "XFormInstance": "xmlns",
+}
+
 VALID_REFERENCED_DOC_TYPES = [
     'CommCareCase',
     'CommCareUser',

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -80,7 +80,7 @@ class SQLPartition(DocumentSchema):
     http://architect.readthedocs.io/features/partition/index.html
     """
     column = StringProperty()
-    subtype = StringProperty(choices=['date', 'string_firstchars'])
+    subtype = StringProperty(choices=['date', 'string_firstchars', 'string_lastchars'])
     constraint = StringProperty()
 
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -377,7 +377,8 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         """Returns a list of case types or xmlns from the filter of this data source.
 
         If this can't figure out the case types or xmlns's that filter, then returns [None]
-        Currently returns [None] due to a loop in _iteratively_build_table
+        Currently always returns a list because it is called by a loop in _iteratively_build_table
+        Could be reworked to return [] to be more pythonic
         """
         if self.referenced_doc_type not in FILTER_INTERPOLATION_DOC_TYPES:
             return [None]

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -100,6 +100,150 @@ class DataSourceConfigurationTest(SimpleTestCase):
             bad_config.validate()
 
 
+class DataSourceFilterInterpolationTest(SimpleTestCase):
+    def _setup_config(self, doc_type, filter_):
+        return DataSourceConfiguration(
+            domain='test',
+            referenced_doc_type=doc_type,
+            table_id='blah',
+            configured_filter=filter_
+        )
+
+    def _case_config(self, filter_):
+        return self._setup_config('CommCareCase', filter_)
+
+    def _form_config(self, filter_):
+        return self._setup_config('XFormInstance', filter_)
+
+    def _test_helper(self, data_source, expected_filter):
+        self.assertEqual(
+            data_source.get_case_type_or_xmlns_filter(),
+            expected_filter
+        )
+
+    def test_one_case_type(self):
+        self._test_helper(
+            self._case_config({
+                "type": "boolean_expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "type"
+                },
+                "operator": "eq",
+                "property_value": "ticket"
+            }),
+            ['ticket']
+        )
+
+    def test_multiple_case_type(self):
+        self._test_helper(
+            self._case_config({
+                "type": "boolean_expression",
+                "operator": "in",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "type"
+                },
+                "property_value": ["ticket", "task"]
+            }),
+            ["ticket", "task"]
+        )
+
+    def test_one_xmlns(self):
+        self._test_helper(
+            self._form_config({
+                "type": "boolean_expression",
+                "operator": "eq",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "xmlns"
+                },
+                "property_value": "xmlns"
+            }),
+            ['xmlns']
+        )
+
+    def test_multiple_xmlns(self):
+        self._test_helper(
+            self._form_config({
+                "type": "boolean_expression",
+                "operator": "in",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "xmlns"
+                },
+                "property_value": ["xmlns1", "xmlns2"]
+            }),
+            ["xmlns1", "xmlns2"]
+        )
+
+    def test_xmlns_with_and(self):
+        self._test_helper(
+            self._form_config({
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "type": "property_name",
+                            "property_name": "xmlns"
+                        },
+                        "property_value": "xmlns"
+                    }
+                ]
+            }),
+            ["xmlns"]
+        )
+
+    def test_case_type_with_and(self):
+        self._test_helper(
+            self._case_config({
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "type": "property_name",
+                            "property_name": "type"
+                        },
+                        "property_value": "ticket"
+                    }
+                ]
+            }),
+            ["ticket"]
+        )
+
+    def test_case_type_with_and_other_filter(self):
+        self._test_helper(
+            self._case_config({
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "type": "property_name",
+                            "property_name": "type"
+                        },
+                        "property_value": "ticket"
+                    },
+                    {
+                        "type": "boolean_expression",
+                        "operator": "eq",
+                        "expression": {
+                            "type": "property_name",
+                            "property_name": "other_property"
+                        },
+                        "property_value": "not_ticket"
+                    }
+                ]
+            }),
+            ["ticket"]
+        )
+
+
 class DataSourceConfigurationDbTest(TestCase):
 
     @classmethod

--- a/corehq/apps/userreports/tests/test_data_source_partitioning.py
+++ b/corehq/apps/userreports/tests/test_data_source_partitioning.py
@@ -160,7 +160,7 @@ class DataSourcePartitionByOwnerLastChars(DataSourceConfigurationPartitionTest):
 
         # ensure docs are in separate databases
         result = self.adapter.engine.execute(
-            'SELECT COUNT(*) FROM "{}fhijklmnop";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
+            'SELECT COUNT(*) FROM "{}ghijklmnop";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
 
         self.assertEqual(2, result)

--- a/corehq/apps/userreports/tests/test_data_source_partitioning.py
+++ b/corehq/apps/userreports/tests/test_data_source_partitioning.py
@@ -136,3 +136,35 @@ class DataSourcePartitionByOwner(DataSourceConfigurationPartitionTest):
             'SELECT COUNT(*) FROM "{}abcdefhijk";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
         result = result.fetchone()[0]
         self.assertEqual(1, result)
+
+
+class DataSourcePartitionByOwnerLastChars(DataSourceConfigurationPartitionTest):
+    column = "owner"
+    subtype = "string_lastchars"
+    constraint = "10"
+
+    def test_partitioned_by_date(self):
+        # two docs from separate days
+        sample_doc1, _ = get_sample_doc_and_indicators()
+        sample_doc1['owner_id'] = "abcdefghijklmnop"
+        sample_doc2, _ = get_sample_doc_and_indicators()
+        sample_doc2['owner_id'] = "abcdefghijklmnop"
+
+        # drop g
+        sample_doc3, _ = get_sample_doc_and_indicators()
+        sample_doc3['owner_id'] = "abcdefhijklmnop"
+
+        self._process_docs([sample_doc1, sample_doc2, sample_doc3])
+
+        self.assertEqual(3, self.adapter.get_query_object().count())
+
+        # ensure docs are in separate databases
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM "{}fhijklmnop";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
+        result = result.fetchone()[0]
+
+        self.assertEqual(2, result)
+        result = self.adapter.engine.execute(
+            'SELECT COUNT(*) FROM "{}fhijklmnop";'.format(EXPECTED_UCR_CHILD_TABLE_PREFIX))
+        result = result.fetchone()[0]
+        self.assertEqual(1, result)

--- a/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
@@ -1,0 +1,189 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new"
+  ],
+  "config": {
+    "table_id": "static-child_tasks_cases",
+    "display_name": "Cases - Child Tasks (Static)",
+    "referenced_doc_type": "CommCareCase",
+    "description": "",
+    "base_item_expression": {},
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "type"
+          },
+          "property_value": "tasks"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "tasks_type"
+          },
+          "property_value": "child"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "column_id": "state_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "ancestor_location",
+          "location_id": {
+            "type": "property_name",
+            "name": "owner_id"
+          },
+          "location_type": "state",
+          "location_property": "_id"
+        }
+      },
+      {
+        "column_id": "awc_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "name": "owner_id"
+        }
+      },
+      {
+        "column_id": "child_health_case_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "named",
+          "name": "parent_id"
+        },
+        "create_index": true
+      },
+      {
+        "column_id": "tasks_type",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "tasks_type"
+        }
+      },
+      {
+        "column_id": "immun_one_year_date",
+        "datatype": "date",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "immun_one_year_date"
+        }
+      },
+      {
+        "column_id": "due_list_date",
+        "type": "due_list_date",
+        "case_id_expression": {
+          "type": "property_name",
+          "property_name": "_id"
+        },
+        "ledger_section": "immuns",
+        "product_codes": [
+          "1g_dpt_1",
+          "2g_dpt_2",
+          "3g_dpt_3",
+          "5g_dpt_booster",
+          "5g_dpt_booster1",
+          "7gdpt_booster_2",
+          "0g_hep_b_0",
+          "1g_hep_b_1",
+          "2g_hep_b_2",
+          "3g_hep_b_3",
+          "3g_ipv",
+          "4g_je_1",
+          "5g_je_2",
+          "5g_measles_booster",
+          "4g_measles",
+          "0g_opv_0",
+          "1g_opv_1",
+          "2g_opv_2",
+          "3g_opv_3",
+          "5g_opv_booster",
+          "1g_penta_1",
+          "2g_penta_2",
+          "3g_penta_3",
+          "1g_rv_1",
+          "2g_rv_2",
+          "3g_rv_3",
+          "4g_vit_a_1",
+          "5g_vit_a_2",
+          "6g_vit_a_3",
+          "6g_vit_a_4",
+          "6g_vit_a_5",
+          "6g_vit_a_6",
+          "6g_vit_a_7",
+          "6g_vit_a_8",
+          "7g_vit_a_9"
+        ]
+      }
+    ],
+    "named_expressions": {
+      "parent_id": {
+        "value_expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "referenced_id"
+        },
+        "type": "nested",
+        "argument_expression": {
+          "type": "array_index",
+          "array_expression": {
+            "filter_expression": {
+              "operator": "eq",
+              "type": "boolean_expression",
+              "expression": {
+                "datatype": null,
+                "type": "property_name",
+                "property_name": "identifier"
+              },
+              "property_value": "parent"
+            },
+            "type": "filter_items",
+            "items_expression": {
+              "type": "root_doc",
+              "expression": {
+                "datatype": "array",
+                "type": "property_name",
+                "property_name": "indices"
+              }
+            }
+          },
+          "index_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
+      }
+    },
+    "named_filters": {},
+    "engine_id": "icds-ucr",
+    "sql_settings": {
+      "partition_config": [
+        {
+          "column": "state_id",
+          "subtype": "string_lastchars",
+          "constraint": "5"
+        }
+      ]
+    },
+    "disable_destructive_rebuild": true
+  }
+}

--- a/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
@@ -45,7 +45,7 @@
           "type": "ancestor_location",
           "location_id": {
             "type": "property_name",
-            "name": "owner_id"
+            "property_name": "owner_id"
           },
           "location_type": "state",
           "location_property": "_id"
@@ -57,7 +57,7 @@
         "type": "expression",
         "expression": {
           "type": "property_name",
-          "name": "owner_id"
+          "property_name": "owner_id"
         }
       },
       {

--- a/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
@@ -1,0 +1,169 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new"
+  ],
+  "config": {
+    "table_id": "static-pregnant-tasks_cases",
+    "display_name": "Cases - Pregnant Tasks (Static)",
+    "referenced_doc_type": "CommCareCase",
+    "description": "",
+    "base_item_expression": {},
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "type"
+          },
+          "property_value": "tasks"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "tasks_type"
+          },
+          "property_value": "pregnant"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "column_id": "state_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "ancestor_location",
+          "location_id": {
+            "type": "property_name",
+            "name": "owner_id"
+          },
+          "location_type": "state",
+          "location_property": "_id"
+        }
+      },
+      {
+        "column_id": "awc_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "name": "owner_id"
+        }
+      },
+      {
+        "column_id": "ccs_record_case_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "named",
+          "name": "parent_id"
+        },
+        "create_index": true
+      },
+      {
+        "column_id": "tasks_type",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "tasks_type"
+        }
+      },
+      {
+        "column_id": "num_anc_complete",
+        "datatype": "date",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "num_anc_complete"
+        }
+      },
+      {
+        "column_id": "tt_complete_date",
+        "datatype": "date",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "tt_complete_date"
+        }
+      },
+      {
+        "column_id": "due_list_date",
+        "type": "due_list_date",
+        "case_id_expression": {
+          "type": "property_name",
+          "property_name": "_id"
+        },
+        "ledger_section": "immuns",
+        "product_codes": [
+          "anc_1",
+          "anc_2",
+          "anc_3",
+          "anc_4",
+          "tt_1",
+          "tt_2"
+        ]
+      }
+    ],
+    "named_expressions": {
+      "parent_id": {
+        "type": "nested",
+        "value_expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "referenced_id"
+        },
+        "argument_expression": {
+          "type": "array_index",
+          "array_expression": {
+            "filter_expression": {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "datatype": null,
+                "type": "property_name",
+                "property_name": "identifier"
+              },
+              "property_value": "parent"
+            },
+            "type": "filter_items",
+            "items_expression": {
+              "type": "root_doc",
+              "expression": {
+                "datatype": "array",
+                "type": "property_name",
+                "property_name": "indices"
+              }
+            }
+          },
+          "index_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
+      }
+    },
+    "named_filters": {},
+    "engine_id": "icds-ucr",
+    "sql_settings": {
+      "partition_config": [
+        {
+          "column": "state_id",
+          "subtype": "string_lastchars",
+          "constraint": "5"
+        }
+      ]
+    },
+    "disable_destructive_rebuild": true
+  }
+}

--- a/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
@@ -45,7 +45,7 @@
           "type": "ancestor_location",
           "location_id": {
             "type": "property_name",
-            "name": "owner_id"
+            "property_name": "owner_id"
           },
           "location_type": "state",
           "location_property": "_id"
@@ -57,7 +57,7 @@
         "type": "expression",
         "expression": {
           "type": "property_name",
-          "name": "owner_id"
+          "property_name": "owner_id"
         }
       },
       {

--- a/settings.py
+++ b/settings.py
@@ -2030,6 +2030,8 @@ STATIC_DATA_SOURCES = [
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'dashboard', 'usage_forms_v2.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'dashboard', 'commcare_user_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'dashboard', 'delivery_forms.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'dashboard', 'pregnant_tasks.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'dashboard', 'child_tasks.json'),
 
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'adherence.json'),
     os.path.join('custom', 'enikshay', 'ucr', 'data_sources', 'episode_for_cc_outbound.json'),


### PR DESCRIPTION
:blowfish: / :blowfish: 

Added some nice to have things as well

Adds a shortcut to get a property from ancestor locations,
Also supports interpolating case and xmlns filters when they're inside an and filter. 