### PR TITLE
Download form source from form page

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -658,3 +658,20 @@ class LatestAppInfo(object):
             "latest_apk_version": self.get_latest_apk_version(),
             "latest_ccz_version": self.get_latest_app_version(),
         }
+
+
+def get_form_source_download_url(xform):
+    """Returns the download url for the form source for a submitted XForm
+    """
+    from corehq.apps.app_manager.models import Application
+    app = Application.get(xform.build_id)
+    try:
+        form = app.get_forms_by_xmlns(xform.xmlns)[0]
+    except KeyError:
+        return None
+
+    return reverse("app_download_file", args=[
+        xform.domain,
+        xform.build_id,
+        app.get_form_filename(module=form.get_module(), form=form),
+    ])

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -238,6 +238,9 @@ def download_file(request, domain, app_id, path):
         content_type = None
     response = HttpResponse(content_type=content_type)
 
+    if request.GET.get('download') == 'true':
+        response['Content-Disposition'] = "attachment; filename={}".format(path)
+
     build_profile = request.GET.get('profile')
     build_profile_access = domain_has_privilege(domain, privileges.BUILD_PROFILES)
     if path in ('CommCare.jad', 'CommCare.jar'):

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -171,7 +171,8 @@ requires proptable.css to be included in the main template
         <ul class="list-inline">
             {% if instance.app_id %}<li><a href="{% url "view_app" domain instance.app_id %}">{% trans "View app" %}</a></li>{% endif %}
             {% if instance.build_id and request.user.is_superuser %}
-                <a href="{% url "download_index" domain instance.build_id %}">{% trans "View build" %}</a>
+                <li><a href="{% url "download_index" domain instance.build_id %}">{% trans "View build" %}</a></li>
+                <li><a href="{{ download_url }}?download=true">{% trans "Download Form Source" %} <i class='fa fa-download'></i></a></li>
             {% endif %}
         </ul>
     </div>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -170,9 +170,13 @@ requires proptable.css to be included in the main template
         <br/>
         <ul class="list-inline">
             {% if instance.app_id %}<li><a href="{% url "view_app" domain instance.app_id %}">{% trans "View app" %}</a></li>{% endif %}
-            {% if instance.build_id and request.user.is_superuser %}
-                <li><a href="{% url "download_index" domain instance.build_id %}">{% trans "View build" %}</a></li>
-                <li><a href="{{ download_url }}?download=true">{% trans "Download Form Source" %} <i class='fa fa-download'></i></a></li>
+            {% if request.user.is_superuser %}
+                {% if instance.build_id %}
+                    <li><a href="{% url "download_index" domain instance.build_id %}">{% trans "View build" %}</a></li>
+                {% endif %}
+                {% if form_source_download_url %}
+                    <li><a href="{{ form_source_download_url }}?download=true">{% trans "Download Form Source" %} <i class='fa fa-download'></i></a></li>
+                {% endif %}
             {% endif %}
         </ul>
     </div>

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -15,6 +15,7 @@ from corehq import privileges
 from corehq.apps.cloudcare import CLOUDCARE_DEVICE_ID
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 
+from corehq.apps.app_manager.util import get_form_source_download_url
 from corehq.apps.receiverwrapper.auth import AuthContext
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id, DocInfo
 from corehq.apps.locations.permissions import can_edit_form_location
@@ -99,6 +100,7 @@ def render_form(form, domain, options):
         "context_case_id": case_id,
         "instance": form,
         "is_archived": form.is_archived,
+        "download_url": get_form_source_download_url(form),
         "edit_info": _get_edit_info(form),
         "domain": domain,
         'question_list_not_found': question_list_not_found,

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -100,7 +100,7 @@ def render_form(form, domain, options):
         "context_case_id": case_id,
         "instance": form,
         "is_archived": form.is_archived,
-        "download_url": get_form_source_download_url(form),
+        "form_source_download_url": get_form_source_download_url(form),
         "edit_info": _get_edit_info(form),
         "domain": domain,
         'question_list_not_found': question_list_not_found,


### PR DESCRIPTION
Button to allow you to download the form source for a particular XForm submission. 
Superuser only since that's the only people who can see source files elsewhere in our UI.

![screenshot from 2018-03-30 15-30-32](https://user-images.githubusercontent.com/146896/38151029-90211c08-342f-11e8-99b6-dd7b3cebac9d.png)

https://trello.com/c/d5S2T2a2/40-improve-ease-of-seeing-form-definition

@emord 
FYI @ctsims 