### PR TITLE
Expose module and form indices in navigation

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/form_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_link_primary.html
@@ -2,8 +2,6 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 
-{# For APP BUILDER PROTOTYPE use only #}
-
 <a id="view_form_{{ module.unique_id }}_{{ form.unique_id }}_sidebar"
    {% if form.no_vellum %}
    href="{% url "view_form" domain app.id form.unique_id %}"
@@ -38,7 +36,15 @@
         data-container="body"
         >
     </i>
-    <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
+    <span {% if form == selected_form %}class="variable-form_name"{% endif %}
+          {% if request.user.is_superuser %}
+              title="f{{ form.id }}"
+              data-toggle="tooltip"
+              data-placement="right"
+              data-container="body"
+              data-delay='{ "show": 1000, "hide": 100 }'
+          {% endif %}
+    >
         {{ form.name|html_trans_prefix:langs }}
     </span>
 </a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_link_primary.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_link_primary.html
@@ -2,8 +2,6 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 
-{# For APP BUILDER PROTOTYPE use only #}
-
 <a href="{% url "view_module" domain app.id module.unique_id %}"
    class="appnav-title{% if module.doc_type != 'ReportModule' and module.doc_type != 'ShadowModule' %} appnav-title-secondary{% endif %} appnav-responsive">
     <i class="drag_handle appnav-drag-icon js-appnav-drag-module"></i>
@@ -18,7 +16,15 @@
     {% else %}
       <i class="fa fa-folder-open appnav-primary-icon"></i>
     {% endif %}
-    <span {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}>
+    <span {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}
+        {% if request.user.is_superuser %}
+            title="m{{ module.id }}"
+            data-toggle="tooltip"
+            data-placement="right"
+            data-container="body"
+            data-delay='{ "show": 1000, "hide": 100 }'
+        {% endif %}
+     >
         {{ module.name|html_trans_prefix:langs }}
     </span>
 </a>


### PR DESCRIPTION
Adds module and form ids as tooltips when you hover over their name (superuser only) so you can find which file this corresponds to in the ccz. 
Not convinced this is the best place to put this, but thought I'd open some discussion.

@orangejenny 
@emord 

FYI @ctsims 

https://trello.com/c/ZfPJqpZI/35-reveal-internally-assigned-ids