### PR TITLE
Allows CommCare to create and update identifiers

### DIFF
--- a/corehq/motech/openmrs/README.md
+++ b/corehq/motech/openmrs/README.md
@@ -255,6 +255,12 @@ This is sufficient for projects that import their patient cases from
 OpenMRS, because each CommCare case will have a corresponding OpenMRS
 patient, and its ID, or IDs, will have been set by OpenMRS.
 
+**NOTE**: MOTECH has the ability to create or update the values of
+patient identifiers. If an app offers this ability to users, then that
+identifier should not be included in `match_on_ids`. If the case was
+originally matched using only that identifier and its value changes,
+MOTECH may be unable to match that patient again.
+
 For projects where patient cases can be registered in CommCare, there
 needs to be a way of finding a corresponding patient, if one exists.
 

--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from corehq.motech.openmrs.const import PERSON_UUID_IDENTIFIER_TYPE_ID
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.repeater_helpers import (
     CaseTriggerInfo,
@@ -137,6 +138,10 @@ class SyncPatientIdentifiersTask(WorkflowTask):
             for identifier in self.patient['identifiers']
         }
         for patient_identifier_type, value_source in self.openmrs_config.case_config.patient_identifiers.items():
+            if patient_identifier_type == PERSON_UUID_IDENTIFIER_TYPE_ID:
+                # Don't try to sync the OpenMRS person UUID; It's not a
+                # user-defined identifier and it can't be changed.
+                continue
             identifier = value_source.get_value(self.info)
             if patient_identifier_type in existing_patient_identifiers:
                 identifier_uuid, existing_identifier = existing_patient_identifiers[patient_identifier_type]

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -200,6 +200,66 @@ class UpdatePersonAttributeTask(WorkflowTask):
         )
 
 
+class CreatePatientIdentifierTask(WorkflowTask):
+
+    def __init__(self, requests, patient_uuid, identifier_type_uuid, identifier):
+        self.requests = requests
+        self.patient_uuid = patient_uuid
+        self.identifier_type_uuid = identifier_type_uuid
+        self.identifier = identifier
+        self.identifier_uuid = None
+
+    def run(self):
+        response = self.requests.post(
+            '/ws/rest/v1/patient/{patient_uuid}/identifier'.format(patient_uuid=self.patient_uuid),
+            json={'identifierType': self.identifier_type_uuid, 'identifier': self.identifier},
+        )
+        self.identifier_uuid = response.json()['uuid']
+
+    def rollback(self):
+        if self.identifier_uuid:
+            self.requests.delete(
+                '/ws/rest/v1/patient/{patient_uuid}/identifier/{identifier_uuid}'.format(
+                    patient_uuid=self.patient_uuid, identifier_uuid=self.identifier_uuid
+                ),
+                raise_for_status=True,
+            )
+
+
+class UpdatePatientIdentifierTask(WorkflowTask):
+
+    def __init__(self, requests, patient_uuid, identifier_uuid, identifier_type_uuid, identifier,
+                 existing_identifier):
+        self.requests = requests
+        self.patient_uuid = patient_uuid
+        self.identifier_uuid = identifier_uuid
+        self.identifier_type_uuid = identifier_type_uuid
+        self.identifier = identifier
+        self.existing_identifier = existing_identifier
+
+    def run(self):
+        self.requests.post(
+            '/ws/rest/v1/patient/{patient_uuid}/identifier/{identifier_uuid}'.format(
+                patient_uuid=self.patient_uuid, identifier_uuid=self.identifier_uuid
+            ),
+            json={
+                'identifier': self.identifier,
+                'identifierType': self.identifier_type_uuid,
+            }
+        )
+
+    def rollback(self):
+        self.requests.post(
+            '/ws/rest/v1/patient/{patient_uuid}/identifier/{identifier_uuid}'.format(
+                patient_uuid=self.patient_uuid, identifier_uuid=self.identifier_uuid
+            ),
+            json={
+                'identifier': self.existing_identifier,
+                'identifierType': self.identifier_type_uuid,
+            }
+        )
+
+
 class CreateVisitTask(WorkflowTask):
 
     def __init__(self, requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,


### PR DESCRIPTION
OpenMRS identifiers are user-defined ways to identify patients. This change allows CommCare apps to update their values.

@nickpell @sravfeyn cc @dannyroberts 
