### PR TITLE
Mark case updates from OpenMRS using XMLNS

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -13,7 +13,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_wrapped_owner, get_owner_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.motech.openmrs.const import LOCATION_OPENMRS_UUID, PERSON_UUID_IDENTIFIER_TYPE_ID
+from corehq.motech.openmrs.const import LOCATION_OPENMRS_UUID, PERSON_UUID_IDENTIFIER_TYPE_ID, XMLNS_OPENMRS
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.workflow import WorkflowTask
@@ -561,7 +561,7 @@ def save_match_ids(case, case_config, patient):
         create=False,
         update=case_update,
     )
-    submit_case_blocks([case_block.as_string()], case.domain)
+    submit_case_blocks([case_block.as_string()], case.domain, xmlns=XMLNS_OPENMRS)
 
 
 def find_patient(requests, domain, case_id, openmrs_config):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -7,7 +7,9 @@ import re
 
 from six.moves import zip
 
+from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xform import extract_case_blocks
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_wrapped_owner, get_owner_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -536,13 +538,43 @@ def get_subresource_instances(requests, person_uuid, subresource):
     )).json()['results']
 
 
+def save_match_ids(case, case_config, patient):
+    """
+    If we are confident of the patient matched to a case, save
+    the patient's identifiers to the case.
+    """
+    case_config_ids = case_config['patient_identifiers']
+    case_update = {}
+    id_type_uuid = PERSON_UUID_IDENTIFIER_TYPE_ID
+    if id_type_uuid in case_config_ids:
+        case_property = case_config_ids[id_type_uuid]['case_property']
+        value = patient['uuid']
+        case_update[case_property] = value
+    for identifier in patient['identifiers']:
+        id_type_uuid = identifier['identifierType']['uuid']
+        if id_type_uuid in case_config_ids:
+            case_property = case_config_ids[id_type_uuid]['case_property']
+            value = identifier['identifier']
+            case_update[case_property] = value
+    case_block = CaseBlock(
+        case_id=case.get_id,
+        create=False,
+        update=case_update,
+    )
+    submit_case_blocks([case_block.as_string()], case.domain)
+
+
 def find_patient(requests, domain, case_id, openmrs_config):
     case = CaseAccessors(domain).get_case(case_id)
     patient_finder = PatientFinder.wrap(openmrs_config.case_config.patient_finder)
     patients = patient_finder.find_patients(requests, case, openmrs_config.case_config)
+    if len(patients) == 1:
+        patient, = patients
+        save_match_ids(case, openmrs_config.case_config, patient)
+        return patient
     # If PatientFinder can't narrow down the number of candidate
     # patients, don't guess. Just admit that we don't know.
-    return patients[0] if len(patients) == 1 else None
+    return None
 
 
 def get_patient(requests, domain, info, openmrs_config):


### PR DESCRIPTION
When MOTECH finds an OpenMRS patient, it updates the corresponding CommCare case with the patient's identifiers so that it doesn't need to search OpenMRS next time the case is updated.

This change moves that out of the PatientFinder (sub)class, which I think should only be finding patients, not updating cases. It also marks the case update as being from OpenMRS so that the update isn't forwarded back to OpenMRS.

@sravfeyn @nickpell cc @dannyroberts 