### PR TITLE
Fix js tests for notifications

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -416,7 +416,7 @@
                     'jquery.cookie/jquery.cookie',
                     'hqwebapp/js/layout',
                     'hqwebapp/js/hq-bug-report',
-                    'notifications/js/notifications_service',
+                    'notifications/js/notifications_service_main',
                     'analytix/js/appcues',
                     'analytix/js/drift',
                     'analytix/js/google',
@@ -445,7 +445,8 @@
         {# JavaScript Display Logic Libaries #}
 
         {% if request.couch_user and not requirejs_main %}
-        <script src="{% static 'notifications/js/notifications_service.js' %}"></script>
+            <script src="{% static 'notifications/js/notifications_service.js' %}"></script>
+            <script src="{% static 'notifications/js/notifications_service_main.js' %}"></script>
         {% endif %}
 
         {% if request.use_angular_js and not requirejs_main %}

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -41,17 +41,6 @@
       {% block fixtures %}{% endblock %}
       </div>
 
-      <div class="initial-page-data" class="hide">
-      {% block initial_page_data %}
-          {# do not override this block, use initial_page_data template tag to populate #}
-      {% endblock %}
-      </div>
-      <div class="commcarehq-urls" class="hide">
-      {% block registered_urls %}
-          {# do not override this block, use registerurl template tag to populate #}
-      {% endblock %}
-      </div>
-
       {% block mocha_tests %}{% endblock %}
       <script charset="utf-8">
   	      // Only tests run in real browser, injected script run if options.run == true

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -40,12 +40,24 @@
       <div id="mocha-fixtures" style="display:none">
       {% block fixtures %}{% endblock %}
       </div>
+
+      <div class="initial-page-data" class="hide">
+      {% block initial_page_data %}
+          {# do not override this block, use initial_page_data template tag to populate #}
+      {% endblock %}
+      </div>
+      <div class="commcarehq-urls" class="hide">
+      {% block registered_urls %}
+          {# do not override this block, use registerurl template tag to populate #}
+      {% endblock %}
+      </div>
+
       {% block mocha_tests %}{% endblock %}
       <script charset="utf-8">
-	// Only tests run in real browser, injected script run if options.run == true
-	if (navigator.userAgent.indexOf('PhantomJS') < 0) {
-	  mocha.run();
-	}
+  	      // Only tests run in real browser, injected script run if options.run == true
+	      if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+	          mocha.run();
+	      }
       </script>
   </body>
 </html>

--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -153,18 +153,5 @@ hqDefine('notifications/js/notifications_service', [
         }
     };
 
-    $(function () {
-        var csrfToken = $("#csrfTokenContainer").val();
-        module.setRMI(initialPageData.reverse('notifications_service'), csrfToken);
-        module.initService('#js-settingsmenu-notifications');
-        module.relativelyPositionUINotify('.alert-ui-notify-relative');
-        module.initUINotify('.alert-ui-notify');
-
-        $(document).on('click', '.notification-link', function() {
-            googleAnalytics.track.event('Notification', 'Opened Message', this.href);
-        });
-        googleAnalytics.track.click($('#notification-icon'), 'Notification', 'Clicked Bell Icon');
-    });
-
     return module;
 });

--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -8,17 +8,13 @@ hqDefine('notifications/js/notifications_service', [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/initial_page_data',
     'jquery.rmi/jquery.rmi',
-    'analytix/js/google',
     'hqwebapp/js/hq.helpers',
 ], function (
     $,
     ko,
     _,
-    initialPageData,
-    RMI,
-    googleAnalytics
+    RMI
 ) {
     'use strict';
 

--- a/corehq/apps/notifications/static/notifications/js/notifications_service_main.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service_main.js
@@ -1,0 +1,28 @@
+/**
+ * Document ready handling for pages that use notifications/js/notifications_service.js
+ */
+
+hqDefine('notifications/js/notifications_service_main', [
+    'jquery',
+    'hqwebapp/js/initial_page_data',
+    'notifications/js/notifications_service',
+    'analytix/js/google',
+], function (
+    $,
+    initialPageData,
+    notificationsService,
+    googleAnalytics
+) {
+    $(function () {
+        var csrfToken = $("#csrfTokenContainer").val();
+        notificationsService.setRMI(initialPageData.reverse('notifications_service'), csrfToken);
+        notificationsService.initService('#js-settingsmenu-notifications');
+        notificationsService.relativelyPositionUINotify('.alert-ui-notify-relative');
+        notificationsService.initUINotify('.alert-ui-notify');
+
+        $(document).on('click', '.notification-link', function() {
+            googleAnalytics.track.event('Notification', 'Opened Message', this.href);
+        });
+        googleAnalytics.track.click($('#notification-icon'), 'Notification', 'Clicked Bell Icon');
+    });
+});

--- a/corehq/apps/notifications/templates/notifications/spec/mocha.html
+++ b/corehq/apps/notifications/templates/notifications/spec/mocha.html
@@ -6,6 +6,7 @@
 {% endblock %}
 
 {% block fixtures %}
+{% registerurl 'notifications_service' %}
 <ul>
     {% include 'notifications/partials/global_notifications.html' %}
 </ul>

--- a/corehq/apps/notifications/templates/notifications/spec/mocha.html
+++ b/corehq/apps/notifications/templates/notifications/spec/mocha.html
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block fixtures %}
-{% registerurl 'notifications_service' %}
 <ul>
     {% include 'notifications/partials/global_notifications.html' %}
 </ul>


### PR DESCRIPTION
While looking into js testing for data corrections, found the tests for notifications were throwing js errors: one because initial page data wasn't set up for mocha, and another because the document ready logic in notifications_service.js isn't meant to be run in a test environment. Somewhat counterintuitively, said js errors weren't causing tests themselves to fail.

@czue 