### PR TITLE
Clearer use of lambda for skip_arg

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2261,7 +2261,7 @@ def update_fixture_status_for_users(user_ids, fixture_type):
         get_fixture_statuses.clear(user_id)
 
 
-@quickcache(['user_id'], lambda _: settings.UNIT_TESTING)
+@quickcache(['user_id'], skip_arg=lambda user_id: settings.UNIT_TESTING)
 def get_fixture_statuses(user_id):
     from corehq.apps.fixtures.models import UserFixtureType, UserFixtureStatus
     last_modifieds = {choice[0]: UserFixtureStatus.DEFAULT_LAST_MODIFIED


### PR DESCRIPTION
This PR just changes the syntax used for `@quickcache` line when getting fixture status from a user. The anonymous function is passed as a argument and the `user_id` variable is specified to avoid confusion: https://github.com/dimagi/commcare-hq/pull/19964#pullrequestreview-108574090