### PR TITLE
Disable save button in report builder while trying to save

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -502,6 +502,10 @@ hqDefine('userreports/js/report_config', function() {
 
 
                 $("#btnSaveView").click(function () {
+                    var thisButton = $(this);
+                    self.saveButton.setState('saving');
+                    thisButton.disableButton();
+
                     var isValid = self.validate();
                     if (isValid) {
                         _ga_track_config_change('Save and View Report');
@@ -517,6 +521,10 @@ hqDefine('userreports/js/report_config', function() {
                                 // Redirect to the newly-saved report
                                 self.saveButton.setState('saved');
                                 window.location.href = data['report_url'];
+                            },
+                            error: function () {
+                                self.saveButton.setState('retry');
+                                thisButton.enableButton();
                             },
                             dataType: 'json',
                         });


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?270364

@dimagi/product This disables the report builder's save button after you click it. If the save fails, it changes the save button to be a retry button (uses the same save button as the rest of HQ). 

Something weird is that we have two save buttons on the report builder. It feels like it would be better to have one save button and it can either default to redirecting to the report, or separating it into a separate save and view report buttons.

![report_builder_save_buttons](https://user-images.githubusercontent.com/1471773/38210392-4a53eb4e-3685-11e8-8a37-4ee7ecf93bc6.png)


buddy @proteusvacuum 
report builder: @kaapstorm 