### PR TITLE
Fix back buttons in 2FA (attempt #2)

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/phone_register.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/phone_register.html
@@ -5,7 +5,7 @@
 {% block page_content %}
   <h1>{% block title %}{% trans "Add Backup Phone" %}{% endblock %}</h1>
 
-  {% if wizard.steps.current == 'setup' %}
+  {% if wizard.steps.current == 'method' %}
       <p>{% blocktrans %}Your backup phone number will be used if your primary method of
         registration is not available. Please enter a valid phone number.{% endblocktrans %}</p>
   {% elif wizard.steps.current == 'validation' %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup.html
@@ -4,8 +4,11 @@
 
 {% block page_content %}
   <h1>{% block title %}{% trans "Enable Two-Factor Authentication" %}{% endblock %}</h1>
-  {% if wizard.steps.current == 'welcome' %}
+  {% if wizard.steps.current == 'welcome_setup' %}
     <p>{% blocktrans %}Follow the steps in this wizard to enable two-factor
+        authentication.{% endblocktrans %}</p>
+  {% elif wizard.steps.current == 'welcome_reset' %}
+    <p>{% blocktrans %}Follow the steps in this wizard to reset two-factor
         authentication.{% endblocktrans %}</p>
   {% elif wizard.steps.current == 'method' %}
     <p>{% blocktrans %}Please select which authentication method you would

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -78,7 +78,7 @@ class HQPhoneNumberMethodForm(PhoneNumberMethodForm):
                              validators=[validate_international_phonenumber],
                              widget=forms.TextInput(
                                  attrs={'placeholder': _('Start with +, followed by Country Code.')}))
-    forms.CharField.run_validators = run_validators
+    number.run_validators = run_validators
 
     def __init__(self, **kwargs):
         super(HQPhoneNumberMethodForm, self).__init__(**kwargs)
@@ -216,7 +216,7 @@ class HQPhoneNumberForm(PhoneNumberForm):
                              validators=[validate_international_phonenumber],
                              widget=forms.TextInput(
                                  attrs={'placeholder': _('Start with +, followed by Country Code.')}))
-    forms.CharField.run_validators = run_validators
+    number.run_validators = run_validators
 
     def __init__(self, **kwargs):
         super(HQPhoneNumberForm, self).__init__(**kwargs)

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -119,16 +119,12 @@ class HQDeviceValidationForm(DeviceValidationForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
-<<<<<<< HEAD
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
                 ),
                 twbscrispy.StrictButton(
-                    _("Back"),
-=======
                     _('Back'),
->>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
                     css_class='btn-default',
                     type='submit',
                     value='method',
@@ -163,7 +159,6 @@ class HQTwoFactorMethodForm(MethodForm):
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
-<<<<<<< HEAD
                 ),
                 twbscrispy.StrictButton(
                     _("Back"),
@@ -172,9 +167,6 @@ class HQTwoFactorMethodForm(MethodForm):
                     value='welcome',
                     name="wizard_goto_step",
                 ),
-=======
-                )
->>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
             )
         )
 
@@ -196,16 +188,12 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
-<<<<<<< HEAD
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
                 ),
                 twbscrispy.StrictButton(
-                    _("Back"),
-=======
                     _('Back'),
->>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
                     css_class='btn-default',
                     type='submit',
                     value='method',
@@ -244,16 +232,12 @@ class HQPhoneNumberForm(PhoneNumberForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
-<<<<<<< HEAD
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
                 ),
                 twbscrispy.StrictButton(
-                    _("Back"),
-=======
                     _('Back'),
->>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
                     css_class='btn-default',
                     type='submit',
                     value='method',

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -6,7 +6,7 @@ from two_factor.forms import (
     PhoneNumberMethodForm, DeviceValidationForm, MethodForm,
     TOTPDeviceForm, PhoneNumberForm
 )
-from corehq.apps.settings.validators import validate_international_phonenumber, run_validators
+from corehq.apps.settings.validators import validate_international_phonenumber
 from two_factor.utils import totp_digits
 
 from crispy_forms.helper import FormHelper
@@ -75,10 +75,9 @@ class HQPasswordChangeForm(EncodedPasswordChangeFormMixin, PasswordChangeForm):
 class HQPhoneNumberMethodForm(PhoneNumberMethodForm):
     number = forms.CharField(required=False,
                              label=_('Phone Number'),
-                             validators=[validate_international_phonenumber],
                              widget=forms.TextInput(
                                  attrs={'placeholder': _('Start with +, followed by Country Code.')}))
-    number.run_validators = run_validators
+    number.run_validators = validate_international_phonenumber
 
     def __init__(self, **kwargs):
         super(HQPhoneNumberMethodForm, self).__init__(**kwargs)
@@ -216,7 +215,7 @@ class HQPhoneNumberForm(PhoneNumberForm):
                              validators=[validate_international_phonenumber],
                              widget=forms.TextInput(
                                  attrs={'placeholder': _('Start with +, followed by Country Code.')}))
-    number.run_validators = run_validators
+    number.run_validators = validate_international_phonenumber
 
     def __init__(self, **kwargs):
         super(HQPhoneNumberForm, self).__init__(**kwargs)

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -164,7 +164,7 @@ class HQTwoFactorMethodForm(MethodForm):
                     _("Back"),
                     css_class='btn-default',
                     type='submit',
-                    value='welcome',
+                    value='welcome_setup',
                     name="wizard_goto_step",
                 ),
             )

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -6,7 +6,8 @@ from two_factor.forms import (
     PhoneNumberMethodForm, DeviceValidationForm, MethodForm,
     TOTPDeviceForm, PhoneNumberForm
 )
-from two_factor.validators import validate_international_phonenumber
+from corehq.apps.settings.validators import validate_international_phonenumber, run_validators
+from two_factor.utils import totp_digits
 
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
@@ -24,7 +25,7 @@ from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
 
 class HQPasswordChangeForm(EncodedPasswordChangeFormMixin, PasswordChangeForm):
 
-    new_password1 = forms.CharField(label=_("New password"),
+    new_password1 = forms.CharField(label=_('New password'),
                                     widget=forms.PasswordInput(),
                                     help_text=mark_safe("""
                                     <span data-bind="text: passwordHelp, css: color">
@@ -46,7 +47,7 @@ class HQPasswordChangeForm(EncodedPasswordChangeFormMixin, PasswordChangeForm):
                     data_bind="value: password, valueUpdate: 'input'",
                 ),
                 'new_password2',
-                css_class="check-password",
+                css_class='check-password',
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
@@ -72,14 +73,14 @@ class HQPasswordChangeForm(EncodedPasswordChangeFormMixin, PasswordChangeForm):
 
 
 class HQPhoneNumberMethodForm(PhoneNumberMethodForm):
-    number = forms.CharField(label=_("Phone Number"),
+    number = forms.CharField(required=False,
+                             label=_('Phone Number'),
                              validators=[validate_international_phonenumber],
                              widget=forms.TextInput(
                                  attrs={'placeholder': _('Start with +, followed by Country Code.')}))
+    forms.CharField.run_validators = run_validators
 
     def __init__(self, **kwargs):
-        validate_international_phonenumber.message = _("Make sure to enter a valid phone number "
-                                                       "starting with a +, followed by your country code.")
         super(HQPhoneNumberMethodForm, self).__init__(**kwargs)
         self.helper = FormHelper()
         self.helper.form_class = 'form form-horizontal'
@@ -102,6 +103,7 @@ class HQPhoneNumberMethodForm(PhoneNumberMethodForm):
 
 
 class HQDeviceValidationForm(DeviceValidationForm):
+    token = forms.IntegerField(required=False, label=_("Token"), min_value=1, max_value=int('9' * totp_digits()))
 
     def __init__(self, **kwargs):
         super(HQDeviceValidationForm, self).__init__(**kwargs)
@@ -117,19 +119,29 @@ class HQDeviceValidationForm(DeviceValidationForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+<<<<<<< HEAD
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
                 ),
                 twbscrispy.StrictButton(
                     _("Back"),
+=======
+                    _('Back'),
+>>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
                     css_class='btn-default',
                     type='submit',
                     value='method',
-                    name="wizard_goto_step",
+                    name='wizard_goto_step',
                 ),
             )
         )
+
+    def clean_token(self):
+        token = self.cleaned_data['token']
+        if not token or not self.device.verify_token(token):
+            raise forms.ValidationError(self.error_messages['invalid_token'])
+        return token
 
 
 class HQTwoFactorMethodForm(MethodForm):
@@ -151,6 +163,7 @@ class HQTwoFactorMethodForm(MethodForm):
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
+<<<<<<< HEAD
                 ),
                 twbscrispy.StrictButton(
                     _("Back"),
@@ -159,11 +172,15 @@ class HQTwoFactorMethodForm(MethodForm):
                     value='welcome',
                     name="wizard_goto_step",
                 ),
+=======
+                )
+>>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
             )
         )
 
 
 class HQTOTPDeviceForm(TOTPDeviceForm):
+    token = forms.IntegerField(required=False, label=_("Token"), min_value=1, max_value=int('9' * totp_digits()))
 
     def __init__(self, **kwargs):
         super(HQTOTPDeviceForm, self).__init__(**kwargs)
@@ -179,16 +196,20 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+<<<<<<< HEAD
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
                 ),
                 twbscrispy.StrictButton(
                     _("Back"),
+=======
+                    _('Back'),
+>>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
                     css_class='btn-default',
                     type='submit',
                     value='method',
-                    name="wizard_goto_step",
+                    name='wizard_goto_step',
                 ),
             )
         )
@@ -202,6 +223,12 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
 
 
 class HQPhoneNumberForm(PhoneNumberForm):
+    number = forms.CharField(required=False,
+                             label=_('Phone Number'),
+                             validators=[validate_international_phonenumber],
+                             widget=forms.TextInput(
+                                 attrs={'placeholder': _('Start with +, followed by Country Code.')}))
+    forms.CharField.run_validators = run_validators
 
     def __init__(self, **kwargs):
         super(HQPhoneNumberForm, self).__init__(**kwargs)
@@ -217,16 +244,20 @@ class HQPhoneNumberForm(PhoneNumberForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
+<<<<<<< HEAD
                     _('Next'),
                     css_class='btn-primary',
                     type='submit',
                 ),
                 twbscrispy.StrictButton(
                     _("Back"),
+=======
+                    _('Back'),
+>>>>>>> parent of ce9f3f003c... Revert "Pv/back btns 268514"
                     css_class='btn-default',
                     type='submit',
                     value='method',
-                    name="wizard_goto_step",
+                    name='wizard_goto_step',
                 ),
             )
         )

--- a/corehq/apps/settings/validators.py
+++ b/corehq/apps/settings/validators.py
@@ -14,17 +14,4 @@ def validate_international_phonenumber(value):
 validate_international_phonenumber.message = \
     _('Make sure to enter a valid phone number '
       'starting with a +, followed by your country code.')
-
-
-def run_validators(self, value):
-    # Validator that doesn't ignore none's
-    errors = []
-    for v in self.validators:
-        try:
-            v(value)
-        except ValidationError as e:
-            if hasattr(e, 'code') and e.code in self.error_messages:
-                e.message = self.error_messages[e.code]
-            errors.extend(e.error_list)
-    if errors:
-        raise ValidationError(errors)
+validators = [validate_international_phonenumber]

--- a/corehq/apps/settings/validators.py
+++ b/corehq/apps/settings/validators.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+from phonenumber_field.phonenumber import to_python
+
+
+def validate_international_phonenumber(value):
+    phone_number = to_python(value)
+    if not phone_number or not phone_number.is_valid():
+        raise ValidationError(validate_international_phonenumber.message,
+                              code='invalid')
+
+
+validate_international_phonenumber.message = \
+    _('Make sure to enter a valid phone number '
+      'starting with a +, followed by your country code.')
+
+
+def run_validators(self, value):
+    # Validator that doesn't ignore none's
+    errors = []
+    for v in self.validators:
+        try:
+            v(value)
+        except ValidationError as e:
+            if hasattr(e, 'code') and e.code in self.error_messages:
+                e.message = self.error_messages[e.code]
+            errors.extend(e.error_list)
+    if errors:
+        raise ValidationError(errors)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -37,6 +37,7 @@ from dimagi.utils.couch import CriticalSection
 from django.shortcuts import redirect
 
 from tastypie.models import ApiKey
+from two_factor.models import PhoneDevice
 from two_factor.utils import default_device
 from two_factor.views import (
     ProfileView, SetupView, SetupCompleteView,
@@ -321,7 +322,7 @@ class TwoFactorSetupView(BaseMyAccountView, SetupView):
     page_title = ugettext_lazy("Two Factor Authentication Setup")
 
     form_list = (
-        ('welcome', HQEmptyForm),
+        ('welcome_setup', HQEmptyForm),
         ('method', HQTwoFactorMethodForm),
         ('generator', HQTOTPDeviceForm),
         ('sms', HQPhoneNumberForm),
@@ -377,7 +378,7 @@ class TwoFactorPhoneSetupView(BaseMyAccountView, PhoneSetupView):
     page_title = ugettext_lazy("Two Factor Authentication Phone Setup")
 
     form_list = (
-        ('setup', HQPhoneNumberMethodForm),
+        ('method', HQPhoneNumberMethodForm),
         ('validation', HQDeviceValidationForm),
     )
 
@@ -394,6 +395,14 @@ class TwoFactorPhoneSetupView(BaseMyAccountView, PhoneSetupView):
         messages.add_message(self.request, messages.SUCCESS, _("Phone number added."))
         return redirect(reverse(TwoFactorProfileView.urlname))
 
+    def get_device(self, **kwargs):
+        """
+        Uses the data from the setup step and generated key to recreate device, gets the 'method' step
+        in the form_list.
+        """
+        kwargs = kwargs or {}
+        kwargs.update(self.storage.validated_step_data.get('method', {}))
+        return PhoneDevice(key=self.get_key(), **kwargs)
 
 class TwoFactorPhoneDeleteView(BaseMyAccountView, PhoneDeleteView):
 
@@ -411,6 +420,7 @@ class TwoFactorResetView(TwoFactorSetupView):
     urlname = 'reset'
 
     form_list = (
+        ('welcome_reset', HQEmptyForm),
         ('method', HQTwoFactorMethodForm),
         ('generator', HQTOTPDeviceForm),
         ('sms', HQPhoneNumberForm),


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?268514

Note, I PR'd this previously but reverted it because it had unexpected errors: https://github.com/dimagi/commcare-hq/pull/19617

The errors were caused by the fact that I overwrote the validators for **every** charfield by no longer allowing nulls (not just the charfield I wanted to overwrite), which was fixed by using `number.run_validators = validate_international_phonenumber` in forms.py, as opposed to `forms.CharField = validate_international_phonenumber`

And here's the description I have on the previous PR for this:

------------

Several back buttons in 2FA setup weren't working.
Reason: The back button uses logic from django's form wizard.
How it works: in corehq/apps/settings/views.py, the different steps of the setup process are defined as a tuple of tuples called form_list, which are defined in three different places for three different workflows:


- Setup  2fa for the first time (TwoFactorSetupView)
- Reset 2fa (TwoFactorResetView)
- Add a backup phone (TwoFactorPhoneSetupView). The back button logic (in corehq/apps/settings/forms.py) defines the page to redirect to as it's value property.
=====
Problems that are fixed here:
The back button is a post request, but the validators didn't allow post requests of empty forms so I overwrote the validators, and added a lot of 'required=False's to the forms. I also changed the validators so that you get an error message if you click 'next' on an empty form
To allow the form sections to be recycled, I made the sections of different forms have more uniform naming (which is why setup was changed to method in the TwoFactorPhoneSetupView form_list). This means that a back button can always be programmed to go back to the method page, but the method page has a different meaning depending on what view you're in.
Add a welcome page for the reset 2fa view, and distinguish between welcome_reset and welcome_setup (they have different text)
Get rid of unneeded back button in the method selection page (verified this with @Ben-Talbot )