### PR TITLE
Fix due list dates indicator

### DIFF
--- a/corehq/apps/userreports/indicators/__init__.py
+++ b/corehq/apps/userreports/indicators/__init__.py
@@ -119,6 +119,7 @@ class CompoundIndicator(ConfigurableIndicator):
 
 class LedgerBalancesIndicator(ConfigurableIndicator):
     column_datatype = TYPE_INTEGER
+    default_value = 0
 
     def __init__(self, spec):
         self.product_codes = spec.product_codes
@@ -142,13 +143,14 @@ class LedgerBalancesIndicator(ConfigurableIndicator):
         domain = context.root_doc['domain']
         values = self._get_values_by_product(domain, case_id)
         return [
-            ColumnValue(self._make_column(product_code), values[product_code])
+            ColumnValue(self._make_column(product_code), values.get(product_code, self.default_value))
             for product_code in self.product_codes
         ]
 
 
 class DueListDateIndicator(LedgerBalancesIndicator):
     column_datatype = TYPE_DATE
+    default_value = date(1970, 1, 1)
 
     def _get_values_by_product(self, domain, case_id):
         unix_epoch = date(1970, 1, 1)

--- a/corehq/apps/userreports/indicators/utils.py
+++ b/corehq/apps/userreports/indicators/utils.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, unicode_literals
-
-from collections import defaultdict
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from corehq.apps.products.models import SQLProduct
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
@@ -18,10 +17,9 @@ def get_values_by_product(domain, case_id, ledger_section, product_codes):
         for product in products
     }
 
-    ledger_values = defaultdict(lambda: 0)
-    for ledger in ledgers:
-        if ledger.section_id == ledger_section and ledger.entry_id in entry_id_to_code:
-            product_code = entry_id_to_code[ledger.entry_id]
-            ledger_values[product_code] = ledger.stock_on_hand
-
-    return ledger_values
+    return {
+        entry_id_to_code[ledger.entry_id]: ledger.stock_on_hand
+        for ledger in ledgers
+        if (ledger.section_id == ledger_section
+            and ledger.entry_id in entry_id_to_code)
+    }

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -572,7 +572,7 @@ class DueListDateIndicatorTest(SimpleTestCase):
             "column_id": "immun_dates",
             "display_name": "Immunization date",
             "ledger_section": "immuns",
-            "product_codes": ["tt_1", "tt_2", "hpv"],
+            "product_codes": ["tt_1", "tt_2", "hpv", "non_exist"],
             "case_id_expression": {
                 "type": "property_name",
                 "property_name": "_id"
@@ -592,7 +592,8 @@ class DueListDateIndicatorTest(SimpleTestCase):
             [
                 ('immun_dates_tt_1', date(2016, 7, 18)),
                 ('immun_dates_tt_2', date(2016, 8, 7)),
-                ('immun_dates_hpv', date(2019, 4, 14))
+                ('immun_dates_hpv', date(2019, 4, 14)),
+                ('immun_dates_non_exist', date(1970, 1, 1))
             ]
         )
 
@@ -679,15 +680,15 @@ class TestGetValuesByProduct(TestCase):
         values = get_values_by_product(
             self.domain_name, self.case_id, 'soh', ['coke', 'surge', 'new_coke']
         )
-        self.assertEqual(values['coke'], 32)
-        self.assertEqual(values['surge'], 85)
-        self.assertEqual(values['new_coke'], 0)
+        self.assertEqual(values.get('coke'), 32)
+        self.assertEqual(values.get('surge'), 85)
+        self.assertEqual(values.get('new_coke'), None)
 
     @run_with_all_backends
     def test_get_consumption_by_product(self):
         values = get_values_by_product(
             self.domain_name, self.case_id, 'consumption', ['coke', 'surge', 'new_coke']
         )
-        self.assertEqual(values['coke'], 63)
-        self.assertEqual(values['surge'], 0)
-        self.assertEqual(values['new_coke'], 0)
+        self.assertEqual(values.get('coke'), 63)
+        self.assertEqual(values.get('surge'), None)
+        self.assertEqual(values.get('new_coke'), None)


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/511402373/?referrer=slack

When I implemented due lists I returned a dictionary instead of a default dict. This changes the helper method to always return a dict

@proteusvacuum 