### PR TITLE
Fix spacing on chat contacts button

### DIFF
--- a/corehq/apps/sms/static/sms/js/chat_contacts.js
+++ b/corehq/apps/sms/static/sms/js/chat_contacts.js
@@ -28,7 +28,7 @@ hqDefine('sms/js/chat_contacts', function() {
                             '<a target="_blank" href="<%= href %>"><%= content %></a>' +
                             '<span class="btn btn-primary pull-right" ' +
                                   'onClick="window.open(\'<%= url %>\', \'_blank\', \'location=no,menubar=no,scrollbars=no,status=no,toolbar=no,height=400,width=400\');">' +
-                            '<%= chat %><i class="fa fa-share"></i></span>'
+                            '<%= chat %> <i class="fa fa-share"></i></span>'
                         )({
                             href: row[4],
                             content: row[0],


### PR DESCRIPTION
Tiny. Fixes this:
<img width="467" alt="screen shot 2018-04-03 at 8 28 03 am" src="https://user-images.githubusercontent.com/1486591/38249294-31a20cf4-3719-11e8-9c05-bbaec6d9eb49.png">

@jmtroth0 / @czue 