### PR TITLE
writing to file, not logging

### DIFF
--- a/corehq/form_processor/management/commands/check_forms_have_xml.py
+++ b/corehq/form_processor/management/commands/check_forms_have_xml.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import datetime
 from django.core.management.base import BaseCommand
 from corehq.blobs import get_blob_db
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors

--- a/corehq/form_processor/management/commands/check_forms_have_xml.py
+++ b/corehq/form_processor/management/commands/check_forms_have_xml.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import datetime
 from django.core.management.base import BaseCommand
 from corehq.blobs import get_blob_db
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
@@ -7,10 +8,6 @@ from corehq.form_processor.models import XFormInstanceSQL
 from corehq.util.log import with_progress_bar
 from couchforms.const import ATTACHMENT_NAME
 from couchforms.models import XFormInstance as CouchForm
-import datetime
-import logging
-
-_logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -18,21 +15,22 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain', help='Domain to check.')
+        parser.add_argument('file_name', help='Location to put the output.')
 
-    def handle(self, domain, **options):
+    def handle(self, domain, file_name, **options):
         blob_db = get_blob_db()
         form_db = FormAccessors(domain)
         form_ids = form_db.get_all_form_ids_in_domain()
-        bad_form_id_string = "%s %s: %%s" % (domain, datetime.datetime.utcnow())
-        for form in with_progress_bar(form_db.iter_forms(form_ids), len(form_ids)):
-            if isinstance(form, CouchForm):
-                meta = form.blobs.get(ATTACHMENT_NAME)
-                if not meta or not blob_db.exists(
-                        meta.id, form._blobdb_bucket()):  # pylint: disable=protected-access
-                    _logger.info(bad_form_id_string, form.form_id)
-            elif isinstance(form, XFormInstanceSQL):
-                meta = form.get_attachment_meta(ATTACHMENT_NAME)
-                if not meta or not blob_db.exists(meta.blob_id, meta.blobdb_bucket()):
-                    _logger.info(bad_form_id_string, form.form_id)
-            else:
-                raise Exception("not sure how we got here")
+        with open(file_name, 'w') as open_file:
+            for form in with_progress_bar(form_db.iter_forms(form_ids), len(form_ids)):
+                if isinstance(form, CouchForm):
+                    meta = form.blobs.get(ATTACHMENT_NAME)
+                    if not meta or not blob_db.exists(
+                            meta.id, form._blobdb_bucket()):  # pylint: disable=protected-access
+                        open_file.write(form.form_id)
+                elif isinstance(form, XFormInstanceSQL):
+                    meta = form.get_attachment_meta(ATTACHMENT_NAME)
+                    if not meta or not blob_db.exists(meta.blob_id, meta.blobdb_bucket()):
+                        open_file.write(form.form_id)
+                else:
+                    raise Exception("not sure how we got here")

--- a/corehq/form_processor/management/commands/check_forms_have_xml.py
+++ b/corehq/form_processor/management/commands/check_forms_have_xml.py
@@ -21,16 +21,17 @@ class Command(BaseCommand):
         blob_db = get_blob_db()
         form_db = FormAccessors(domain)
         form_ids = form_db.get_all_form_ids_in_domain()
+
         with open(file_name, 'w') as open_file:
             for form in with_progress_bar(form_db.iter_forms(form_ids), len(form_ids)):
                 if isinstance(form, CouchForm):
                     meta = form.blobs.get(ATTACHMENT_NAME)
                     if not meta or not blob_db.exists(
                             meta.id, form._blobdb_bucket()):  # pylint: disable=protected-access
-                        open_file.write(form.form_id)
+                        open_file.write(form.form_id + "\n")
                 elif isinstance(form, XFormInstanceSQL):
                     meta = form.get_attachment_meta(ATTACHMENT_NAME)
                     if not meta or not blob_db.exists(meta.blob_id, meta.blobdb_bucket()):
-                        open_file.write(form.form_id)
+                        open_file.write(form.form_id + "\n")
                 else:
                     raise Exception("not sure how we got here")


### PR DESCRIPTION
Apparently logging takes a bit more boilerplate than I thought. This seems easier to just get the form_ids.

When we want to hit more domains, it'll be easy to convert this to a csvwriter and add some headers

@emord
@mkangia 