### PR TITLE
Fix form view page 500s

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -664,6 +664,9 @@ class LatestAppInfo(object):
 def get_form_source_download_url(xform):
     """Returns the download url for the form source for a submitted XForm
     """
+    if not xform.build_id:
+        return None
+
     from corehq.apps.app_manager.models import Application
     app = Application.get(xform.build_id)
     try:


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/19998/

@proteusvacuum Pretty sure that `build_id` is `None` when there's no build associated, like if the form was submitted via web apps and there wasn't a "real" saved build. I'm seeing forms breaking locally and on staging.