### PR TITLE
require superuser status in addition to accounting admin to access ac…

### DIFF
--- a/corehq/apps/accounting/dispatcher.py
+++ b/corehq/apps/accounting/dispatcher.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.utils.decorators import method_decorator
 from corehq import privileges
+from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.reports.dispatcher import ReportDispatcher
 from django_prbac.decorators import requires_privilege_raise404
 
@@ -10,6 +11,7 @@ class AccountingAdminInterfaceDispatcher(ReportDispatcher):
     prefix = 'accounting_admin_interface'
     map_name = "ACCOUNTING_ADMIN_INTERFACES"
 
+    @method_decorator(require_superuser)
     @method_decorator(requires_privilege_raise404(privileges.ACCOUNTING_ADMIN))
     def dispatch(self, request, *args, **kwargs):
         return super(AccountingAdminInterfaceDispatcher, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -16,6 +16,8 @@ from django.http import (
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_noop
 from django.views.generic import View
+
+from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
     use_select2,
@@ -74,6 +76,7 @@ from django_prbac.models import Role, Grant
 from six.moves.urllib.parse import urlencode
 
 
+@require_superuser
 @requires_privilege_raise404(privileges.ACCOUNTING_ADMIN)
 def accounting_default(request):
     return HttpResponseRedirect(AccountingInterface.get_url())
@@ -86,6 +89,7 @@ class AccountingSectionView(BaseSectionPageView):
     def section_url(self):
         return reverse('accounting_default')
 
+    @method_decorator(require_superuser)
     @method_decorator(requires_privilege_raise404(privileges.ACCOUNTING_ADMIN))
     @use_select2
     def dispatch(self, request, *args, **kwargs):
@@ -967,6 +971,7 @@ class AccountingSingleOptionResponseView(View, AsyncHandlerMixin):
         SoftwarePlanAsyncHandler,
     ]
 
+    @method_decorator(require_superuser)
     @method_decorator(requires_privilege_raise404(privileges.ACCOUNTING_ADMIN))
     def dispatch(self, request, *args, **kwargs):
         return super(AccountingSingleOptionResponseView, self).dispatch(request, *args, **kwargs)


### PR DESCRIPTION
…counting admin pages

If somebody forgets to remove the accounting admin status during offboarding, a former employee might be able to access accounting admin pages.  This fixes that by also requiring superuser status.