### PR TITLE
Validate that "match_on_ids" only refers to identifiers that have been configured

### DIFF
--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -51,6 +51,14 @@ class OpenmrsConfigForm(forms.Form):
                     params={'key': key}
                 )
 
+        for id_ in self.cleaned_data['case_config']['match_on_ids']:
+            if id_ not in self.cleaned_data['case_config']['patient_identifiers']:
+                raise ValidationError(
+                    _('ID "%(id_)s" used in "match_on_ids" is missing from "patient_identifiers".'),
+                    code='invalid',
+                    params={'id_': id_}
+                )
+
         return self.cleaned_data['case_config']
 
 


### PR DESCRIPTION
"patient_identifiers" maps CommCare case properties to OpenMRS patient identifiers.

"match_on_ids" tells MOTECH which identifiers to use for matching CommCare cases to OpenMRS patients (because some will be reliable, but some may not).

This PR adds validation that we aren't trying to match on an identifier that isn't mapped to a case property.