### PR TITLE
Serialize dates and names to be acceptable for OpenMRS

### DIFF
--- a/corehq/motech/openmrs/const.py
+++ b/corehq/motech/openmrs/const.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import logging
+
 from django.utils.translation import ugettext_lazy as _
+
+from corehq.motech.openmrs.serializers import to_timestamp, to_name
 
 
 LOG_LEVEL_CHOICES = (
@@ -46,3 +50,43 @@ LOCATION_OPENMRS_UUID = 'openmrs_uuid'
 #     }
 #
 PERSON_UUID_IDENTIFIER_TYPE_ID = 'uuid'
+
+
+# Standard OpenMRS property names, and serializers
+PERSON_PROPERTIES = {
+    'gender': None,
+    'age': None,
+    'birthdate': to_timestamp,
+    'birthdateEstimated': None,
+    'dead': None,
+    'deathDate': to_timestamp,
+    'deathdateEstimated': None,
+    'causeOfDeath': None,
+}
+NAME_PROPERTIES = {
+    'givenName': to_name,
+    'familyName': to_name,
+    'middleName': to_name,
+    'familyName2': to_name,
+    'prefix': None,
+    'familyNamePrefix': None,
+    'familyNameSuffix': None,
+    'degree': None,
+}
+ADDRESS_PROPERTIES = {
+    'address1': None,
+    'address2': None,
+    'cityVillage': None,
+    'stateProvince': None,
+    'country': None,
+    'postalCode': None,
+    'latitude': None,
+    'longitude': None,
+    'countyDistrict': None,
+    'address3': None,
+    'address4': None,
+    'address5': None,
+    'address6': None,
+    'startDate': to_timestamp,
+    'endDate': to_timestamp,
+}

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -8,7 +8,7 @@ from corehq.apps.userreports.ui.fields import JsonField
 from corehq.motech.openmrs.const import LOG_LEVEL_CHOICES, IMPORT_FREQUENCY_CHOICES
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.models import OpenmrsImporter, ColumnMapping
-from corehq.motech.openmrs.repeater_helpers import PERSON_PROPERTIES, NAME_PROPERTIES, ADDRESS_PROPERTIES
+from corehq.motech.openmrs.const import PERSON_PROPERTIES, NAME_PROPERTIES, ADDRESS_PROPERTIES
 from corehq.motech.utils import b64_aes_encrypt
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
-
 from __future__ import unicode_literals
+
 from collections import namedtuple, defaultdict
 from datetime import timedelta
+from itertools import chain
 import re
 
 from six.moves import zip
@@ -91,11 +92,9 @@ def serialize(data):
     {'birthdate': '2017-06-27T00:00:00.000+0000'}
 
     """
-    serializers = dict(zip(
-        # We can get away with not worrying about namespaces because these property names are fixed and unique
-        ADDRESS_PROPERTIES.keys() + NAME_PROPERTIES.keys() + PERSON_PROPERTIES.keys(),
-        ADDRESS_PROPERTIES.values() + NAME_PROPERTIES.values() + PERSON_PROPERTIES.values()
-    ))
+    # We can get away with not worrying about namespaces because these
+    # property names are fixed and unique.
+    serializers = dict(chain(ADDRESS_PROPERTIES.items(), NAME_PROPERTIES.items(), PERSON_PROPERTIES.items()))
     return {p: serializers[p](v) if serializers[p] else v for p, v in data.items()}
 
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -83,6 +83,22 @@ def parse_request_exception(err):
     return err_request, err_response
 
 
+def serialize(data):
+    """
+    Convert values in data to a format OpenMRS will accept.
+
+    >>> serialize({'birthdate': '2017-06-27'})
+    {'birthdate': '2017-06-27T00:00:00.000+0000'}
+
+    """
+    serializers = dict(zip(
+        # We can get away with not worrying about namespaces because these property names are fixed and unique
+        ADDRESS_PROPERTIES.keys() + NAME_PROPERTIES.keys() + PERSON_PROPERTIES.keys(),
+        ADDRESS_PROPERTIES.values() + NAME_PROPERTIES.values() + PERSON_PROPERTIES.values()
+    ))
+    return {p: serializers[p](v) if serializers[p] else v for p, v in data.items()}
+
+
 def get_case_location(case):
     """
     If the owner of the case is a location, return it. Otherwise return
@@ -388,7 +404,7 @@ class UpdatePersonNameTask(WorkflowTask):
                     person_uuid=self.person_uuid,
                     name_uuid=self.name_uuid,
                 ),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
 
@@ -409,7 +425,7 @@ class UpdatePersonNameTask(WorkflowTask):
                     person_uuid=self.person_uuid,
                     name_uuid=self.name_uuid,
                 ),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
 
@@ -433,7 +449,7 @@ class CreatePersonAddressTask(WorkflowTask):
         if properties:
             response = self.requests.post(
                 '/ws/rest/v1/person/{person_uuid}/address/'.format(person_uuid=self.person_uuid),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
             self.address_uuid = response.json()['uuid']
@@ -471,7 +487,7 @@ class UpdatePersonAddressTask(WorkflowTask):
                     person_uuid=self.person_uuid,
                     address_uuid=self.address_uuid,
                 ),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
 
@@ -487,7 +503,7 @@ class UpdatePersonAddressTask(WorkflowTask):
                     person_uuid=self.person_uuid,
                     address_uuid=self.address_uuid,
                 ),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
 
@@ -566,7 +582,7 @@ class UpdatePersonPropertiesTask(WorkflowTask):
         if properties:
             self.requests.post(
                 '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=self.person['uuid']),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
 
@@ -584,7 +600,7 @@ class UpdatePersonPropertiesTask(WorkflowTask):
         if properties:
             self.requests.post(
                 '/ws/rest/v1/person/{person_uuid}'.format(person_uuid=self.person['uuid']),
-                json=properties,
+                json=serialize(properties),
                 raise_for_status=True,
             )
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -88,8 +88,8 @@ def serialize(data):
     """
     Convert values in data to a format OpenMRS will accept.
 
-    >>> serialize({'birthdate': '2017-06-27'})
-    {'birthdate': '2017-06-27T00:00:00.000+0000'}
+    >>> serialize({'birthdate': '2017-06-27'}) == {'birthdate': '2017-06-27T00:00:00.000+0000'}
+    True
 
     """
     # We can get away with not worrying about namespaces because these

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -30,7 +30,6 @@ PERSON_PROPERTIES = (
     'deathdateEstimated',
     'causeOfDeath',
 )
-PERSON_SUBRESOURCES = ('attribute', 'address', 'name')
 NAME_PROPERTIES = (
     'givenName',
     'familyName',
@@ -522,14 +521,6 @@ class UpdatePersonAddressTask(WorkflowTask):
                 json=properties,
                 raise_for_status=True,
             )
-
-
-def get_subresource_instances(requests, person_uuid, subresource):
-    assert subresource in PERSON_SUBRESOURCES
-    return requests.get('/ws/rest/v1/person/{person_uuid}/{subresource}'.format(
-        person_uuid=person_uuid,
-        subresource=subresource,
-    )).json()['results']
 
 
 def save_match_ids(case, case_config, patient):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -13,50 +13,19 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_wrapped_owner, get_owner_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.motech.openmrs.const import LOCATION_OPENMRS_UUID, PERSON_UUID_IDENTIFIER_TYPE_ID, XMLNS_OPENMRS
+from corehq.motech.openmrs.const import (
+    ADDRESS_PROPERTIES,
+    LOCATION_OPENMRS_UUID,
+    NAME_PROPERTIES,
+    PERSON_PROPERTIES,
+    PERSON_UUID_IDENTIFIER_TYPE_ID,
+    XMLNS_OPENMRS,
+)
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.serializers import to_timestamp
 from corehq.motech.openmrs.workflow import WorkflowTask
 from corehq.motech.utils import pformat_json
-
-PERSON_PROPERTIES = (
-    'gender',
-    'age',
-    'birthdate',
-    'birthdateEstimated',
-    'dead',
-    'deathDate',
-    'deathdateEstimated',
-    'causeOfDeath',
-)
-NAME_PROPERTIES = (
-    'givenName',
-    'familyName',
-    'middleName',
-    'familyName2',
-    'prefix',
-    'familyNamePrefix',
-    'familyNameSuffix',
-    'degree',
-)
-ADDRESS_PROPERTIES = (
-    'address1',
-    'address2',
-    'cityVillage',
-    'stateProvince',
-    'country',
-    'postalCode',
-    'latitude',
-    'longitude',
-    'countyDistrict',
-    'address3',
-    'address4',
-    'address5',
-    'address6',
-    'startDate',
-    'endDate',
-)
 
 
 OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason content')

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -16,6 +16,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.openmrs.const import LOCATION_OPENMRS_UUID, PERSON_UUID_IDENTIFIER_TYPE_ID, XMLNS_OPENMRS
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.logger import logger
+from corehq.motech.openmrs.serializers import to_timestamp
 from corehq.motech.openmrs.workflow import WorkflowTask
 from corehq.motech.utils import pformat_json
 
@@ -216,13 +217,6 @@ class UpdatePersonAttributeTask(WorkflowTask):
         )
 
 
-def server_datetime_to_openmrs_timestamp(dt):
-    openmrs_timestamp = dt.isoformat()[:-3] + '+0000'
-    # todo: replace this with tests
-    assert len(openmrs_timestamp) == len('2017-06-27T09:36:47.000-0400'), openmrs_timestamp
-    return openmrs_timestamp
-
-
 class CreateVisitTask(WorkflowTask):
 
     def __init__(self, requests, person_uuid, provider_uuid, visit_datetime, values_for_concept, encounter_type,
@@ -240,8 +234,8 @@ class CreateVisitTask(WorkflowTask):
 
     def run(self):
         subtasks = []
-        start_datetime = server_datetime_to_openmrs_timestamp(self.visit_datetime)
-        stop_datetime = server_datetime_to_openmrs_timestamp(
+        start_datetime = to_timestamp(self.visit_datetime)
+        stop_datetime = to_timestamp(
             self.visit_datetime + timedelta(days=1) - timedelta(seconds=1)
         )
         visit = {

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import datetime
+import re
+
+import six
+from dateutil import parser as dateutil_parser
+
+
+def to_timestamp(value):
+    """
+    OpenMRS accepts strings in the same format for both dates and datetimes.
+
+    >>> to_timestamp('2017-06-27')
+    '2017-06-27T00:00:00.000+0000'
+
+    """
+    if isinstance(value, six.string_types):
+        value = dateutil_parser.parse(value)
+    if isinstance(value, datetime.datetime):
+        micros = value.strftime('%f')[:3]  # Only 3 digits for OpenMRS
+        tz = value.strftime('%z') or '+0000'  # If we don't know, lie
+        return value.strftime('%Y-%m-%dT%H:%M:%S.{f}{z}'.format(f=micros, z=tz))
+
+
+def to_name(value):
+    """
+    OpenMRS does not accept names that have numbers in them
+
+    >>> to_name('5dbbabc66c12730b')
+    u'-dbbabc--c-----b'
+
+    """
+    # Replace non-alphanumeric, digits and underscores with "-", but allow spaces and apostrophes
+    def usually_hyphen(match):
+        m = match.group()
+        return m if m in (' ', "'", "ʼ") else '-'
+
+    nonalpha = re.compile(r'[\W\d_]', re.UNICODE)
+    return nonalpha.sub(usually_hyphen, value)

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -19,7 +19,7 @@ def to_timestamp(value):
     """
     if isinstance(value, six.string_types):
         value = dateutil_parser.parse(value)
-    if isinstance(value, datetime.datetime):
+    if isinstance(value, (datetime.date, datetime.datetime)):
         micros = value.strftime('%f')[:3]  # Only 3 digits for OpenMRS
         tz = value.strftime('%z') or '+0000'  # If we don't know, lie
         return value.strftime('%Y-%m-%dT%H:%M:%S.{f}{z}'.format(f=micros, z=tz))

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -18,6 +18,8 @@ def to_timestamp(value):
 
     """
     if isinstance(value, six.string_types):
+        if not re.match('\d{4}-\d{2}-\d{2}', value):
+            raise ValueError('"{}" is not recognised as a date or a datetime'.format(value))
         value = dateutil_parser.parse(value)
     if isinstance(value, (datetime.date, datetime.datetime)):
         micros = value.strftime('%f')[:3]  # Only 3 digits for OpenMRS

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -13,8 +13,8 @@ def to_timestamp(value):
     """
     OpenMRS accepts strings in the same format for both dates and datetimes.
 
-    >>> to_timestamp('2017-06-27')
-    '2017-06-27T00:00:00.000+0000'
+    >>> to_timestamp('2017-06-27') == '2017-06-27T00:00:00.000+0000'
+    True
 
     """
     if isinstance(value, six.string_types):
@@ -29,8 +29,8 @@ def to_name(value):
     """
     OpenMRS does not accept names that have numbers in them
 
-    >>> to_name('5dbbabc66c12730b')
-    u'-dbbabc--c-----b'
+    >>> to_name('5dbbabc66c12730b') == '-dbbabc--c-----b'
+    True
 
     """
     # Replace non-alphanumeric, digits and underscores with "-", but allow spaces and apostrophes

--- a/corehq/motech/openmrs/tests/test_serializers.py
+++ b/corehq/motech/openmrs/tests/test_serializers.py
@@ -32,6 +32,11 @@ class SerializerTests(SimpleTestCase):
         openmrs_timestamp = to_timestamp(datetime_str)
         self.assertEqual(openmrs_timestamp, '2017-06-27T09:36:47.396+0000')
 
+    def test_to_timestamp_date(self):
+        date = datetime.date(2017, 6, 27)
+        openmrs_timestamp = to_timestamp(date)
+        self.assertEqual(openmrs_timestamp, '2017-06-27T00:00:00.000+0000')
+
     def test_to_name_numeric(self):
         commcare_name = 'Bush 2'
         openmrs_name = to_name(commcare_name)

--- a/corehq/motech/openmrs/tests/test_serializers.py
+++ b/corehq/motech/openmrs/tests/test_serializers.py
@@ -1,0 +1,70 @@
+# coding=utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import datetime
+import doctest
+
+from django.test import SimpleTestCase
+
+import corehq.motech.openmrs.serializers
+from corehq.motech.openmrs.serializers import to_name, to_timestamp
+
+
+class SerializerTests(SimpleTestCase):
+
+    def test_to_timestamp_datetime(self):
+
+        class CAT(datetime.tzinfo):
+            def utcoffset(self, dt):
+                return datetime.timedelta(hours=2)
+            def tzname(self, dt):
+                return "CAT"
+            def dst(self, dt):
+                return datetime.timedelta(0)
+
+        dt = datetime.datetime(2017, 6, 27, 9, 36, 47, tzinfo=CAT())
+        openmrs_timestamp = to_timestamp(dt)
+        self.assertEqual(openmrs_timestamp, '2017-06-27T09:36:47.000+0200')
+
+    def test_to_timestamp_datetime_str(self):
+        datetime_str = '2017-06-27T09:36:47.396000Z'
+        openmrs_timestamp = to_timestamp(datetime_str)
+        self.assertEqual(openmrs_timestamp, '2017-06-27T09:36:47.396+0000')
+
+    def test_to_name_numeric(self):
+        commcare_name = 'Bush 2'
+        openmrs_name = to_name(commcare_name)
+        self.assertEqual(openmrs_name, 'Bush -')
+
+    def test_to_name_hyphen(self):
+        commcare_name = 'Jean-Paul'
+        openmrs_name = to_name(commcare_name)
+        self.assertEqual(openmrs_name, commcare_name)
+
+    def test_to_name_spaces(self):
+        commcare_name = 'van der Merwe'
+        openmrs_name = to_name(commcare_name)
+        self.assertEqual(openmrs_name, commcare_name)
+
+    def test_to_name_extendedlatin(self):
+        commcare_name = 'Müller'
+        openmrs_name = to_name(commcare_name)
+        self.assertEqual(openmrs_name, commcare_name)
+
+    def test_to_name_ascii_apostrophe(self):
+        commcare_name = "D'Urban"
+        openmrs_name = to_name(commcare_name)
+        self.assertEqual(openmrs_name, commcare_name)
+
+    def test_to_name_unicode_apostrophe(self):
+        commcare_name = "DʼUrban"  # i.e. 'D\u02bcUrban'
+        openmrs_name = to_name(commcare_name)
+        self.assertEqual(openmrs_name, commcare_name)
+
+
+class DocTests(SimpleTestCase):
+
+    def test_doctests(self):
+        results = doctest.testmod(corehq.motech.openmrs.serializers)
+        self.assertEqual(results.failed, 0)

--- a/corehq/motech/openmrs/tests/test_serializers.py
+++ b/corehq/motech/openmrs/tests/test_serializers.py
@@ -37,6 +37,16 @@ class SerializerTests(SimpleTestCase):
         openmrs_timestamp = to_timestamp(date)
         self.assertEqual(openmrs_timestamp, '2017-06-27T00:00:00.000+0000')
 
+    def test_to_timestamp_day_str(self):
+        day_str = 'Wednesday'
+        with self.assertRaisesMessage(ValueError, '"Wednesday" is not recognised as a date or a datetime'):
+            to_timestamp(day_str)
+
+    def test_to_timestamp_day_num(self):
+        day_str = '1'
+        with self.assertRaisesMessage(ValueError, '"1" is not recognised as a date or a datetime'):
+            to_timestamp(day_str)
+
     def test_to_name_numeric(self):
         commcare_name = 'Bush 2'
         openmrs_name = to_name(commcare_name)


### PR DESCRIPTION
This helps to satisfy OpenMRS API validation.

(Sanitising names is necessary because OpenMRS can have patients with names that don't meet its own validation ... and if a name is invalid, it will reject requests that don't fix the name! So we have to clean the patient's name first, before we can submit other data.)

@gcapalbo cc @dannyroberts 
