### PR TITLE
Add LinkedApplication to view.

### DIFF
--- a/corehq/apps/app_manager/_design/views/xforms_index/map.js
+++ b/corehq/apps/app_manager/_design/views/xforms_index/map.js
@@ -6,14 +6,19 @@ function (doc) {
             "unique_id": form.unique_id
         });
     }
-    if (doc.doc_type === 'Application' && !doc.copy_of) {
-        if (doc.user_registration) {
-            doEmit(doc.user_registration);
-        }
-        for (m in doc.modules) {
-            for (f in doc.modules[m].forms) {
-                doEmit(doc.modules[m].forms[f]);
-            }
+    if (['Application', 'LinkedApplication'].indexOf(doc.doc_type) === -1) {
+      return;
+    }
+    if (doc.copy_of) {
+      return;
+    }
+
+    if (doc.user_registration) {
+        doEmit(doc.user_registration);
+    }
+    for (m in doc.modules) {
+        for (f in doc.modules[m].forms) {
+            doEmit(doc.modules[m].forms[f]);
         }
     }
 }


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?273668
https://sentry.io/dimagi/commcarehq/issues/512593578/?query=domain:vectorlink-uganda

This is [used in UCRs](https://github.com/dimagi/commcare-hq/blob/je/linked-app-data-source/corehq/apps/userreports/views.py?utf8=%E2%9C%93#L937) when building a data source in the app. Was there any reason that Linked Apps weren't added to this view?

@snopoke @calellowitz guessing you guys are the best to answer