### PR TITLE
Externalize js: bulk archive interface

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
@@ -7,15 +7,15 @@ hqDefine("data_interfaces/js/archive_forms", function() {
     function updateFormCounts() {
         var selectedCount = $('#form-management').find('input.xform-checkbox:checked').length;
         $(".selectedCount").text(selectedCount);
-        enable_disable_button(selectedCount);
+        enableDisableButton(selectedCount);
     }
 
-    function enable_disable_button(count){
-        if (count == 0) {
-            $("#submitForms").prop('disabled', true);
+    function enableDisableButton(count){
+        if (count) {
+            $("#submitForms").prop('disabled', false);
         }
         else {
-            $("#submitForms").prop('disabled', false);
+            $("#submitForms").prop('disabled', true);
         }
     }
 
@@ -53,13 +53,13 @@ hqDefine("data_interfaces/js/archive_forms", function() {
             if (this.checked) {
                 $(checkboxesSelector).prop('checked', true).change();
                 $(indicatorSelector).hide();
-                enable_disable_button(1);
+                enableDisableButton(1);
             }
             else {
                 $(indicatorSelector).show();
                 $(".selectedCount").text(0);
                 $(managementSelector + ' a.select-none').click();
-                enable_disable_button(0);
+                enableDisableButton(0);
             }
         });
 
@@ -73,6 +73,6 @@ hqDefine("data_interfaces/js/archive_forms", function() {
             } else {
                 hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Selected Forms');
             }
-        })
+        });
     });
 });

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
@@ -1,11 +1,11 @@
 hqDefine("data_interfaces/js/archive_forms", function() {
-    var managementSelector = '#form-management',
+    var managementSelector = '#data-interfaces-archive-forms',
         allFormsButtonSelector = managementSelector + ' input[name="select_all"]',
         checkboxesSelector = managementSelector + ' input.xform-checkbox',
         indicatorSelector = '#count_indicator';
 
     function updateFormCounts() {
-        var selectedCount = $('#form-management').find('input.xform-checkbox:checked').length;
+        var selectedCount = $(managementSelector + ' input.xform-checkbox:checked').length;
         $(".selectedCount").text(selectedCount);
         enableDisableButton(selectedCount);
     }

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
@@ -7,10 +7,10 @@ hqDefine("data_interfaces/js/archive_forms", function() {
     function updateFormCounts() {
         var selectedCount = $(managementSelector + ' input.xform-checkbox:checked').length;
         $(".selectedCount").text(selectedCount);
-        enableDisableButton(selectedCount);
+        toggleButton(selectedCount);
     }
 
-    function enableDisableButton(count){
+    function toggleButton(count){
         if (count) {
             $("#submitForms").prop('disabled', false);
         }
@@ -53,13 +53,13 @@ hqDefine("data_interfaces/js/archive_forms", function() {
             if (this.checked) {
                 $(checkboxesSelector).prop('checked', true).change();
                 $(indicatorSelector).hide();
-                enableDisableButton(1);
+                toggleButton(1);
             }
             else {
                 $(indicatorSelector).show();
                 $(".selectedCount").text(0);
                 $(managementSelector + ' a.select-none').click();
-                enableDisableButton(0);
+                toggleButton(0);
             }
         });
 

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
@@ -1,0 +1,78 @@
+hqDefine("data_interfaces/js/archive_forms", function() {
+    var managementSelector = '#form-management',
+        allFormsButtonSelector = managementSelector + ' input[name="select_all"]',
+        checkboxesSelector = managementSelector + ' input.xform-checkbox',
+        indicatorSelector = '#count_indicator';
+
+    function updateFormCounts() {
+        var selectedCount = $('#form-management').find('input.xform-checkbox:checked').length;
+        $(".selectedCount").text(selectedCount);
+        enable_disable_button(selectedCount);
+    }
+
+    function enable_disable_button(count){
+        if (count == 0) {
+            $("#submitForms").prop('disabled', true);
+        }
+        else {
+            $("#submitForms").prop('disabled', false);
+        }
+    }
+
+    function selectNone() {
+        $(managementSelector + ' input.xform-checkbox:checked').prop('checked', false).change();
+        $(allFormsButtonSelector).prop('checked', false);
+    }
+
+    $(function() {
+        // bindings for 'all' button
+        $(document).on('click', managementSelector + ' a.select-visible', function() {
+            $(allFormsButtonSelector).prop('checked', false);
+            $(checkboxesSelector).prop('checked', true).change();
+            return false;
+        });
+
+        // bindings for 'none' button
+        $(document).on('click', managementSelector + ' a.select-none', function() {
+            selectNone();
+            return false;
+        });
+
+        // bindings for form checkboxes
+        $(document).on('change', checkboxesSelector, function() {
+            // updates text like '3 of 5 selected'
+            updateFormCounts();
+            $(indicatorSelector).show();
+        });
+        $(document).on('click', checkboxesSelector, function() {
+            $(allFormsButtonSelector).prop('checked', false);
+        });
+
+        // bindings for 'Select all' checkboxes
+        $(document).on('click', allFormsButtonSelector, function() {
+            if (this.checked) {
+                $(checkboxesSelector).prop('checked', true).change();
+                $(indicatorSelector).hide();
+                enable_disable_button(1);
+            }
+            else {
+                $(indicatorSelector).show();
+                $(".selectedCount").text(0);
+                $(managementSelector + ' a.select-none').click();
+                enable_disable_button(0);
+            }
+        });
+
+        // clear checkboxes when changing page
+        $(document).on('mouseup', managementSelector + ' .dataTables_paginate a', selectNone);
+        $(document).on('change', managementSelector + ' .dataTables_length select', selectNone);
+
+        $(document).on('click', '#submitForms', function() {
+            if ($(allFormsButtonSelector)[0].checked) {
+                hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Checkbox');
+            } else {
+                hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Selected Forms');
+            }
+        })
+    });
+});

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
@@ -3,87 +3,8 @@
 {% load report_tags %}
 {% load i18n %}
 
-{% block js-inline %} {{ block.super }}
-    <script>
-
-    var managementSelector = '#form-management',
-        allFormsButtonSelector = managementSelector + ' input[name="select_all"]',
-        checkboxesSelector = managementSelector + ' input.xform-checkbox',
-        indicatorSelector = '#count_indicator';
-
-    function updateFormCounts() {
-        var selectedCount = $('#form-management').find('input.xform-checkbox:checked').length;
-        $(".selectedCount").text(selectedCount);
-        enable_disable_button(selectedCount);
-    }
-
-    function enable_disable_button(count){
-        if (count == 0) {
-            $("#submitForms").prop('disabled', true);
-        }
-        else {
-            $("#submitForms").prop('disabled', false);
-        }
-    }
-
-    function selectNone() {
-        $(managementSelector + ' input.xform-checkbox:checked').prop('checked', false).change();
-        $(allFormsButtonSelector).prop('checked', false);
-    }
-
-    $(function() {
-        // bindings for 'all' button
-        $(document).on('click', managementSelector + ' a.select-visible', function() {
-            $(allFormsButtonSelector).prop('checked', false);
-            $(checkboxesSelector).prop('checked', true).change();
-            return false;
-        });
-
-        // bindings for 'none' button
-        $(document).on('click', managementSelector + ' a.select-none', function() {
-            selectNone();
-            return false;
-        });
-
-        // bindings for form checkboxes
-        $(document).on('change', checkboxesSelector, function() {
-            // updates text like '3 of 5 selected'
-            updateFormCounts();
-            $(indicatorSelector).show();
-        });
-        $(document).on('click', checkboxesSelector, function() {
-            $(allFormsButtonSelector).prop('checked', false);
-        });
-
-        // bindings for 'Select all' checkboxes
-        $(document).on('click', allFormsButtonSelector, function() {
-            if (this.checked) {
-                $(checkboxesSelector).prop('checked', true).change();
-                $(indicatorSelector).hide();
-                enable_disable_button(1);
-            }
-            else {
-                $(indicatorSelector).show();
-                $(".selectedCount").text(0);
-                $(managementSelector + ' a.select-none').click();
-                enable_disable_button(0);
-            }
-        });
-
-        // clear checkboxes when changing page
-        $(document).on('mouseup', managementSelector + ' .dataTables_paginate a', selectNone);
-        $(document).on('change', managementSelector + ' .dataTables_length select', selectNone);
-
-        $(document).on('click', '#submitForms', function() {
-            if ($(allFormsButtonSelector)[0].checked) {
-                hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Checkbox');
-            } else {
-                hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Selected Forms');
-            }
-        })
-    });
-
-    </script>
+{% block js %}{{ block.super }}
+    <script src="{% static "data_interfaces/js/archive_forms.js" %}"></script>
 {% endblock %}
 
 {% block reportcontent %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
@@ -3,12 +3,8 @@
 {% load report_tags %}
 {% load i18n %}
 
-{% block js %}{{ block.super }}
-    <script src="{% static "data_interfaces/js/archive_forms.js" %}"></script>
-{% endblock %}
-
 {% block reportcontent %}
-    <div id="form-management">
+    <div id="data-interfaces-archive-forms">
         <p class="alert fade in hide page-level-alert alert-danger" id="errorMessage">
             {% blocktrans %}
                 Something went wrong! There was an error. If you see this error repeatedly please report it as issue.

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
@@ -5,6 +5,12 @@
 
 {% block js-inline %} {{ block.super }}
     <script>
+
+    var managementSelector = '#form-management',
+        allFormsButtonSelector = managementSelector + ' input[name="select_all"]',
+        checkboxesSelector = managementSelector + ' input.xform-checkbox',
+        indicatorSelector = '#count_indicator';
+
     function updateFormCounts() {
         var selectedCount = $('#form-management').find('input.xform-checkbox:checked').length;
         $(".selectedCount").text(selectedCount);
@@ -20,76 +26,63 @@
         }
     }
 
-    (function () {
-        function applyCheckboxBindings() {
-            var $XFormManagement = $('#form-management');
-            var $allFormsButton = $XFormManagement.find('input[name="select_all"]');
-            var $checkboxes = $XFormManagement.find('input.xform-checkbox');
-            var $indicator = $('#count_indicator');
+    function selectNone() {
+        $(managementSelector + ' input.xform-checkbox:checked').prop('checked', false).change();
+        $(allFormsButtonSelector).prop('checked', false);
+    }
 
-            // bindings for 'all' button
-            $XFormManagement.find('a.select-visible').click(function () {
-                $allFormsButton.prop('checked', false);
-                $checkboxes.prop('checked', true).change();
-                return false;
-            });
+    $(function() {
+        // bindings for 'all' button
+        $(document).on('click', managementSelector + ' a.select-visible', function() {
+            $(allFormsButtonSelector).prop('checked', false);
+            $(checkboxesSelector).prop('checked', true).change();
+            return false;
+        });
 
-            // bindings for 'none' button
-            $XFormManagement.find('a.select-none').click(function(){
-                selectNone(); return false;
-            });
-            function selectNone() {
-                $XFormManagement.find('input.xform-checkbox:checked').prop('checked', false).change();
-                $allFormsButton.prop('checked', false);
+        // bindings for 'none' button
+        $(document).on('click', managementSelector + ' a.select-none', function() {
+            selectNone();
+            return false;
+        });
+
+        // bindings for form checkboxes
+        $(document).on('change', checkboxesSelector, function() {
+            // updates text like '3 of 5 selected'
+            updateFormCounts();
+            $(indicatorSelector).show();
+        });
+        $(document).on('click', checkboxesSelector, function() {
+            $(allFormsButtonSelector).prop('checked', false);
+        });
+
+        // bindings for 'Select all' checkboxes
+        $(document).on('click', allFormsButtonSelector, function() {
+            if (this.checked) {
+                $(checkboxesSelector).prop('checked', true).change();
+                $(indicatorSelector).hide();
+                enable_disable_button(1);
             }
-
-            // bindings for form checkboxes
-            $checkboxes.on('change', function(){
-                // updates text like '3 of 5 selected'
-                updateFormCounts();
-                $indicator.show();
-            });
-            $checkboxes.on('click', function(){
-                $allFormsButton.prop('checked', false);
-            });
-
-            // bindings for 'Select all' checkboxe
-            $allFormsButton.on('click', function(){
-                if (this.checked) {
-                    $checkboxes.prop('checked', true).change();
-                    $indicator.hide();
-                    enable_disable_button(1);
-                    $(".selectedCount").text({{ total_xForms }});
-                }
-                else {
-                    $indicator.show();
-                    $(".selectedCount").text(0);
-                    $XFormManagement.find('a.select-none').click();
-                    enable_disable_button(0);
-                }
-            });
-
-            $('#submitForms').click(function() {
-                if ($allFormsButton[0].checked) {
-                    hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Checkbox');
-                } else {
-                    hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Selected Forms');
-                }
-            })
-
-            $XFormManagement.find('.dataTables_paginate a').mouseup(selectNone);
-            $XFormManagement.find('.dataTables_length select').change(selectNone);
-        }
-
-        var keepTrying = setInterval(function () {
-            if (window.reportTables !== undefined) {
-                clearInterval(keepTrying);
-                applyCheckboxBindings();
-                window.reportTables.fnDrawCallback = applyCheckboxBindings;
+            else {
+                $(indicatorSelector).show();
+                $(".selectedCount").text(0);
+                $(managementSelector + ' a.select-none').click();
+                enable_disable_button(0);
             }
-        }, 1000);
+        });
 
-    }());
+        // clear checkboxes when changing page
+        $(document).on('mouseup', managementSelector + ' .dataTables_paginate a', selectNone);
+        $(document).on('change', managementSelector + ' .dataTables_length select', selectNone);
+
+        $(document).on('click', '#submitForms', function() {
+            if ($(allFormsButtonSelector)[0].checked) {
+                hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Checkbox');
+            } else {
+                hqImport('analytix/js/google').track.event('Bulk Archive', 'All', 'Selected Forms');
+            }
+        })
+    });
+
     </script>
 {% endblock %}
 

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -20,6 +20,7 @@
     <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
     <script src="{% static 'reports/js/filters.js' %}"></script>
+    <script src="{% static 'data_interfaces/js/archive_forms.js' %}"></script>
     {% endcompress %}
     {% for script in report.js_scripts %}
         <script src="{{ script|static }}"></script>


### PR DESCRIPTION
This turned out to not be a big deal, as the only django reference was `$(".selectedCount").text({{ total_xForms }});` and that could be deleted (the `selectedCount` div isn't visible at the time that line executes).

Also replaced the interesting but kind of weird "every second, check if the elements exist yet and if so add their events" approach with `on`.

@jmtroth0 / @calellowitz 