### PR TITLE
Minor renaming

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -168,7 +168,6 @@ class ComposeMessageView(BaseMessagingSectionView):
         page_context.update(get_sms_autocomplete_context(self.request, self.domain))
         return page_context
 
-    @method_decorator(requires_old_reminder_framework())
     @method_decorator(require_permission(Permissions.edit_data))
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_typeahead

--- a/corehq/messaging/scheduling/templates/scheduling/broadcasts_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/broadcasts_list.html
@@ -20,10 +20,10 @@
     <div class="btn-group">
         <a href="{% url 'create_schedule' domain %}" class="btn btn-success">
             <i class="fa fa-plus"></i>
-            {% trans 'Schedule a Message' %}
+            {% trans 'New Broadcast' %}
         </a>
     </div>
-    <h4>{% trans 'Scheduled Messages' %}</h4>
+    <h4>{% trans 'Scheduled Broadcasts' %}</h4>
     <div>
         <table id="scheduled-table" class="table table-striped table-bordered">
             <thead>
@@ -37,7 +37,7 @@
             </thead>
         </table>
     </div>
-    <h4 style="clear: both">{% trans 'Immediate Messages' %}</h4>
+    <h4 style="clear: both">{% trans 'Immediate Broadcasts' %}</h4>
     <div>
         <table id="immediate-table" class="table table-striped table-bordered">
             <thead>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -21,10 +21,10 @@
     <div class="btn-group">
         <a href="{% url 'create_conditional_alert' domain %}" class="btn btn-success">
             <i class="fa fa-plus"></i>
-            {% trans "New Conditional Message" %}
+            {% trans "New Conditional Alert" %}
         </a>
     </div>
-    <h4>{% trans 'Conditional Messages' %}</h4>
+    <h4>{% trans 'Conditional Alerts' %}</h4>
     <div>
         <table id="conditional-alert-list" class="table table-striped table-bordered">
             <thead>

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -76,7 +76,7 @@ def _requires_new_reminder_framework():
 class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin):
     template_name = 'scheduling/broadcasts_list.html'
     urlname = 'new_list_broadcasts'
-    page_title = ugettext_lazy('Schedule a Message')
+    page_title = ugettext_lazy('Broadcasts')
 
     LIST_SCHEDULED = 'list_scheduled'
     LIST_IMMEDIATE = 'list_immediate'
@@ -195,7 +195,7 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
 
 class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
     urlname = 'create_schedule'
-    page_title = ugettext_lazy('Schedule a Message')
+    page_title = ugettext_lazy('New Broadcast')
     template_name = 'scheduling/create_schedule.html'
     async_handlers = [MessagingRecipientHandler]
     read_only_mode = False
@@ -269,7 +269,7 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
 
 class EditScheduleView(CreateScheduleView):
     urlname = 'edit_schedule'
-    page_title = ugettext_lazy('Edit Scheduled Message')
+    page_title = ugettext_lazy('Edit Broadcast')
 
     IMMEDIATE_BROADCAST = 'immediate'
     SCHEDULED_BROADCAST = 'scheduled'
@@ -336,7 +336,7 @@ class EditScheduleView(CreateScheduleView):
 class ConditionalAlertListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin):
     template_name = 'scheduling/conditional_alert_list.html'
     urlname = 'conditional_alert_list'
-    page_title = ugettext_lazy('Schedule a Conditional Message')
+    page_title = ugettext_lazy('Conditional Alerts')
 
     LIST_CONDITIONAL_ALERTS = 'list_conditional_alerts'
     ACTION_ACTIVATE = 'activate'
@@ -444,7 +444,7 @@ class ConditionalAlertListView(BaseMessagingSectionView, DataTablesAJAXPaginatio
 
 class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
     urlname = 'create_conditional_alert'
-    page_title = ugettext_lazy('New Conditional Message')
+    page_title = ugettext_lazy('New Conditional Alert')
     template_name = 'scheduling/conditional_alert.html'
     async_handlers = [ConditionalAlertAsyncHandler]
     read_only_mode = False
@@ -575,7 +575,7 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
 
 class EditConditionalAlertView(CreateConditionalAlertView):
     urlname = 'edit_conditional_alert'
-    page_title = ugettext_lazy('Edit Conditional Message')
+    page_title = ugettext_lazy('Edit Conditional Alert')
 
     @property
     def page_url(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1019,7 +1019,7 @@ class MessagingTab(UITab):
                 )
                 messages_urls.extend([
                     {
-                        'title': _("Schedule a Message"),
+                        'title': _("Broadcasts"),
                         'url': reverse(NewBroadcastListView.urlname, args=[self.domain]),
                         'subpages': [
                             {
@@ -1034,7 +1034,7 @@ class MessagingTab(UITab):
                         'show_in_dropdown': True,
                     },
                     {
-                        'title': _("Schedule a Conditional Message"),
+                        'title': _("Conditional Alerts"),
                         'url': reverse(ConditionalAlertListView.urlname, args=[self.domain]),
                         'subpages': [
                             {

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -999,7 +999,7 @@ class MessagingTab(UITab):
     def messages_urls(self):
         messages_urls = []
 
-        if self.can_use_outbound_sms and self.show_old_reminders_pages:
+        if self.can_use_outbound_sms:
             messages_urls.extend([
                 {
                     'title': _('Compose SMS Message'),


### PR DESCRIPTION
Make some names consistent and enables the sms compose interface when the new reminders framework is enabled for a project.

@millerdev @kaapstorm 