### PR TITLE
Use case_id as uuid instead of user id

### DIFF
--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -9,7 +9,7 @@ from django.views.generic import FormView
 
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreContent, RestoreResponse
-from casexml.apps.phone.xml import get_registration_element, get_case_element
+from casexml.apps.phone.xml import get_case_element, get_registration_element_for_case
 from corehq.apps.domain.decorators import domain_admin_required, mobile_auth
 from corehq.apps.domain.views import BaseDomainView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -65,7 +65,7 @@ def migration_restore(request, domain, case_id):
     restore_user = request.couch_user
 
     with RestoreContent(restore_user.username) as content:
-        content.append(get_registration_element(restore_user))
+        content.append(get_registration_element_for_case(restore_user, case_id))
         for case in get_case_and_descendants(domain, case_id):
             # Formplayer will be creating these cases for the first time, so
             # include create blocks

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -121,6 +121,17 @@ def get_registration_element(restore_user):
     return root
 
 
+def get_registration_element_for_case(restore_user, case_id):
+    root = safe_element("Registration")
+    root.attrib = {"xmlns": USER_REGISTRATION_XMLNS}
+    root.append(safe_element("username", restore_user.username))
+    root.append(safe_element("password", restore_user.password))
+    root.append(safe_element("uuid", case_id))
+    root.append(safe_element("date", date_to_xml_string(restore_user.date_joined)))
+    root.append(get_data_element('user_data', restore_user.user_session_data))
+    return root
+
+
 def get_data_element(name, dict):
     elem = safe_element(name)
     for k, v in dict.items():


### PR DESCRIPTION
Touchforms expects the `user_id` of forms submitted using this restore endpoint to be the `case_id` rather than the touchforms dedicated web user's ID. I expect for migrations we'll want all the submission to show up under a single migration user ID and we can parameterize this when necessary, but until then this is necessary.

@esoergel I promise I will take a PID on implementing case migrations next week.