### PR TITLE
Improve query plan for CTE get_descendants

### DIFF
--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -171,7 +171,8 @@ class AdjListManager(TreeManager):
             .order_by(self.tree_id_attr, self.left_attr)
         )
 
-    cte_get_queryset_descendants = cte_get_descendants
+    def cte_get_queryset_descendants(self, *args, **kw):
+        return self.cte_get_descendants(*args, **kw)
 
     def mptt_get_queryset_ancestors(self, node, *args, **kw):
         if isinstance(node, Q):

--- a/corehq/apps/locations/queryutil.py
+++ b/corehq/apps/locations/queryutil.py
@@ -52,8 +52,6 @@ class ComparedQuerySet(object):
                 ids2 = [_identify(it) for it in items2]
                 if (finished and ids1 != ids2) or not ids1 == ids2[:len(ids1)]:
                     _report_diff(self, ids1, ids2, "" if finished else "incomplete iteration")
-                if finished:
-                    self.__len__()  # compares lengths -> reports diff if necessary
 
     def __len__(self):
         with _commit_timing(self):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -67,7 +67,7 @@ django-compressor==2.1
 django-angular==0.7.16
 Pycco==0.5.1
 django-mptt==0.8.7
-django-cte==0.1.4
+django-cte==1.0.0
 jsonpath-rw==1.4.0
 pip>=6.1.1
 django-transfer==0.4

--- a/settings.py
+++ b/settings.py
@@ -429,6 +429,8 @@ INSTALLED_APPS = ('hqscripts',) + DEFAULT_APPS + HQ_APPS + ENIKSHAY_APPS
 # rather than the default 'accounts/profile'
 LOGIN_REDIRECT_URL = 'homepage'
 
+# set to True or False in localsettings to override the value set way down below
+IS_LOCATION_CTE_ENABLED = None
 
 REPORT_CACHE = 'default'  # or e.g. 'redis'
 
@@ -2345,8 +2347,10 @@ if RESTRICT_USED_PASSWORDS_FOR_NIC_COMPLIANCE:
 
 PACKAGE_MONITOR_REQUIREMENTS_FILE = os.path.join(FILEPATH, 'requirements', 'requirements.txt')
 
-IS_LOCATION_CTE_ENABLED = UNIT_TESTING or SERVER_ENVIRONMENT in [
-    'localdev',
-    'changeme',  # default value in localsettings.example.py
-    'staging',
-]
+if IS_LOCATION_CTE_ENABLED is None:
+    IS_LOCATION_CTE_ENABLED = UNIT_TESTING or SERVER_ENVIRONMENT in [
+        'localdev',
+        'changeme',  # default value in localsettings.example.py
+        'staging',
+        'softlayer',
+    ]


### PR DESCRIPTION
A substantial [refactor of django-cte](https://github.com/dimagi/django-cte/compare/v0.1.4...v1.0.0) eliminates the JOIN imposed on every CTE query (https://github.com/dimagi/django-cte/commit/db4f11e3bb41ef35b7cf3b9d8e752fd2fec7a9a7). This is a major improvement to the way django-cte works and allows much more flexibility in query construction.

With these new capabilities I was able to rework both `get_descendants` and `get_ancestors` to exploit more efficient query planning.

This PR also re-enables CTE query execution and timing on softlayer (@emord, see https://github.com/dimagi/commcare-hq/commit/9d1cd9dcebf41f251ff4d660c766f56de2e1fbff).

@esoergel cc @biyeun 