### PR TITLE
Externalize js: faceted_report.html

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
@@ -15,10 +15,6 @@
 {% block js-inline %}{{ block.super }}
     <script src="{% static 'appstore/js/facet_sidebar.js' %}"></script>
     <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
-    <script>
-        var standardHQReport = hqImport("reports/js/standard_hq_report").getStandardHQReport(),
-            asyncHQReport = hqImport("reports/js/standard_hq_report").getAsyncHQReport();
-    </script>
 {% endblock %}
 
 {% block page_navigation %}


### PR DESCRIPTION
This code doesn't seem to do anything, guessing it's something I introduced or overlooked in https://github.com/dimagi/commcare-hq/pull/15897/ or https://github.com/dimagi/commcare-hq/pull/16866

Verified that admin reports still load fine and that there aren't any templates that extend this, override the `js-inline` block, and then use `standardHQReport` or `asyncHQReport`.

@calellowitz / @jmtroth0 
or @emord didn't you work on admin reports (or maybe write them in the first place) at some point?