### PR TITLE
Change add backup phone prompt to generate backup tokens

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -11,14 +11,12 @@
     <p><a href="{% url 'two_factor:profile' %}"
         class="btn btn-block btn-default">{% trans "Back to Profile" %}</a></p>
   {% else %}
-    <p>{% blocktrans %}However, it might happen that you don't have access to
-      your primary token device. To enable account recovery, add a phone 
-      number.{% endblocktrans %}</p>
+    <p>{% blocktrans %}To enable account recovery, generate backup tokens.{% endblocktrans %}</p>
 
     <a href="{% url 'two_factor:profile' %}"
         class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>
-    <p><a href="{% url 'two_factor:phone_create' %}"
-        class="btn btn-success">{% trans "Add Phone Number" %}</a></p>
+    <p><a href="{% url 'two_factor:backup_tokens' %}"
+        class="btn btn-success">{% trans "Generate Backup Tokens" %}</a></p>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?273841#1479721

When 2fa is set up, don't prompt a user to add a backup phone, prompt them to generate backup tokens