### PR TITLE
A semantic change to map CommCare values to OpenMRS values

### DIFF
--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -91,8 +91,8 @@ def get_caseproperty_jsonpathvaluemap(jsonpath, value_source):
         return {}
     if value_source['doc_type'] == 'CaseProperty':
         return {value_source['case_property']: JsonpathValuemap(jsonpath, {})}
-    if value_source['doc_type'] == 'CasePropertyConcept':
-        value_map = {v: k for k, v in value_source['value_concepts'].items()}
+    if value_source['doc_type'] == 'CasePropertyMap':
+        value_map = {v: k for k, v in value_source['value_map'].items()}
         return {value_source['case_property']: JsonpathValuemap(jsonpath, value_map)}
     raise ValueError(
         '"{}" is not a recognised ValueSource for setting OpenMRS patient values from CommCare case properties. '
@@ -183,9 +183,9 @@ class WeightedPropertyPatientFinder(PatientFinder):
         #                 "case_property": "caste"
         #             },
         #             "c1f455e7-3f10-11e4-adec-0800271c1b75": {
-        #                 "doc_type": "CasePropertyConcept",
+        #                 "doc_type": "CasePropertyMap",
         #                 "case_property": "class",
-        #                 "value_concepts": {
+        #                 "value_map": {
         #                     "sc": "c1fcd1c6-3f10-11e4-adec-0800271c1b75",
         #                     "general": "c1fc20ab-3f10-11e4-adec-0800271c1b75",
         #                     "obc": "c1fb51cc-3f10-11e4-adec-0800271c1b75",

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -78,45 +78,45 @@ class ConstantString(ValueSource):
         return self.value
 
 
-class CasePropertyConcept(CaseProperty):
+class CasePropertyMap(CaseProperty):
     """
-    Maps case property values to OpenMRS concepts
+    Maps case property values to OpenMRS values or concept UUIDs
     """
     # Example "person_attribute" value::
     #
     #     {
     #       "00000000-771d-0000-0000-000000000000": {
-    #         "doc_type": "CasePropertyConcept",
+    #         "doc_type": "CasePropertyMap",
     #         "case_property": "pill"
-    #         "value_concepts": {
+    #         "value_map": {
     #           "red": "00ff0000-771d-0000-0000-000000000000",
     #           "blue": "000000ff-771d-0000-0000-000000000000",
     #         }
     #       }
     #     }
     #
-    value_concepts = DictProperty()
+    value_map = DictProperty()
 
     def get_value(self, case_trigger_info):
-        value = super(CasePropertyConcept, self).get_value(case_trigger_info)
+        value = super(CasePropertyMap, self).get_value(case_trigger_info)
         try:
-            return self.value_concepts[value]
+            return self.value_map[value]
         except KeyError:
             # We don't care if some CommCare answers are not mapped to OpenMRS concepts, e.g. when only the "yes"
             # value of a yes-no question in CommCare is mapped to a concept in OpenMRS.
             return None
 
 
-class FormQuestionConcept(FormQuestion):
+class FormQuestionMap(FormQuestion):
     """
-    Maps form question values to OpenMRS concepts
+    Maps form question values to OpenMRS values or concept UUIDs
     """
-    value_concepts = DictProperty()
+    value_map = DictProperty()
 
     def get_value(self, case_trigger_info):
-        value = super(FormQuestionConcept, self).get_value(case_trigger_info)
+        value = super(FormQuestionMap, self).get_value(case_trigger_info)
         try:
-            return self.value_concepts[value]
+            return self.value_map[value]
         except KeyError:
             return None
 
@@ -202,9 +202,9 @@ class OpenmrsCaseConfig(DocumentSchema):
     #         "case_property": "caste"
     #     },
     #     "c1f455e7-3f10-11e4-adec-0800271c1b75": {
-    #         "doc_type": "CasePropertyConcept",
+    #         "doc_type": "CasePropertyMap",
     #         "case_property": "class",
-    #         "value_concepts": {
+    #         "value_map": {
     #             "sc": "c1fcd1c6-3f10-11e4-adec-0800271c1b75",
     #             "general": "c1fc20ab-3f10-11e4-adec-0800271c1b75",
     #             "obc": "c1fb51cc-3f10-11e4-adec-0800271c1b75",

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -121,6 +121,15 @@ class FormQuestionMap(FormQuestion):
             return None
 
 
+class FormQuestionConcept(FormQuestionMap):
+    # This alias for FormQuestionMap allows us to easily manually
+    # migrate the OpenmrsConfig of the *two* domains that use
+    # FormQuestionConcept on prod.
+    #
+    # TODO: NH 2018-04-06: Drop after deploy and config edited.
+    pass
+
+
 class OpenmrsCaseConfig(DocumentSchema):
 
     # "patient_identifiers": {

--- a/corehq/motech/openmrs/tests/test_finders.py
+++ b/corehq/motech/openmrs/tests/test_finders.py
@@ -89,9 +89,9 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
             'person_attributes': {
                 'c1f4239f-3f10-11e4-adec-0800271c1b75': {'doc_type': 'CaseProperty', 'case_property': 'caste'},
                 'c1f455e7-3f10-11e4-adec-0800271c1b75': {
-                    'doc_type': 'CasePropertyConcept',
+                    'doc_type': 'CasePropertyMap',
                     'case_property': 'class',
-                    'value_concepts': {
+                    'value_map': {
                         'sc': 'c1fcd1c6-3f10-11e4-adec-0800271c1b75',
                         'general': 'c1fc20ab-3f10-11e4-adec-0800271c1b75',
                         'obc': 'c1fb51cc-3f10-11e4-adec-0800271c1b75',


### PR DESCRIPTION
Rename (CaseProperty|FormQuestion)Concept to ...Map so that it's obvious from the name what it does, and to separate it from the narrower application of OpenMRS Concepts.

CasePropertyMap allows us to map CommCare case property values to OpenMRS patient values, and FormQuestionMap does the same for OpenMRS Visit, Encounter and Observation values.
