### PR TITLE
Clarify various 'parents' in app manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -31,7 +31,7 @@ hqDefine("app_manager/js/modules/module_view", function() {
                     lang: moduleBrief.lang,
                     langs: moduleBrief.langs,
                     saveUrl: hqImport('hqwebapp/js/initial_page_data').reverse('edit_module_detail_screens'),
-                    parentModules: initial_page_data('parent_modules'),
+                    parentModules: initial_page_data('parent_case_modules'),
                     childCaseTypes: detail.subcase_types,
                     fixture_columns_by_type: options.fixture_columns_by_type || {},
                     parentSelect: detail.parent_select,

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -68,7 +68,7 @@
   {% initial_page_data 'case_list_form_not_allowed_reasons' case_list_form_not_allowed_reasons %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
-  {% initial_page_data 'parent_modules' parent_modules %}
+  {% initial_page_data 'parent_case_modules' parent_case_modules %}
   {% initial_page_data 'print_media_info' print_media_info %}
   {% initial_page_data 'print_ref' print_ref %}
   {% initial_page_data 'print_uploader_js' print_uploader_js %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_view_settings.html
@@ -61,7 +61,7 @@
                     <div class="col-sm-4">
                         <select type="text" name="root_module_id" class="form-control">
                             <option value="">{% trans "No Parent" %}</option>
-                            {% for mod in valid_parent_modules %}
+                            {% for mod in valid_parents_for_child_module %}
                                 <option value="{{mod.unique_id}}"{% if mod.unique_id == module.root_module_id %} selected{% endif %}>
                                     {{ mod.name|trans:langs }}
                                 </option>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -122,7 +122,7 @@ def _get_shared_module_view_context(app, module, case_property_builder, lang=Non
     context = {
         'details': _get_module_details_context(app, module, case_property_builder, case_type),
         'case_list_form_options': _case_list_form_options(app, module, case_type, lang),
-        'valid_parent_modules': _get_valid_parent_modules(app, module),
+        'valid_parents_for_child_module': _get_valid_parents_for_child_module(app, module),
         'js_options': {
             'fixture_columns_by_type': _get_fixture_columns_by_type(app.domain),
             'is_search_enabled': case_search_enabled_for_domain(app.domain),
@@ -180,7 +180,8 @@ def _get_advanced_module_view_context(app, module):
 
 def _get_basic_module_view_context(app, module, case_property_builder):
     return {
-        'parent_modules': _get_parent_modules(app, module, case_property_builder, module.case_type),
+        'parent_case_modules': _get_modules_with_parent_case_type(
+            app, module, case_property_builder, module.case_type),
         'case_list_form_not_allowed_reasons': _case_list_form_not_allowed_reasons(module),
         'child_module_enabled': (
             toggles.BASIC_CHILD_MODULE.enabled(app.domain)
@@ -282,7 +283,8 @@ def _setup_case_property_builder(app):
     return builder
 
 
-def _get_parent_modules(app, module, case_property_builder, case_type_):
+# Parent case selection in case list: get modules whose case type is the parent of the given module's case type
+def _get_modules_with_parent_case_type(app, module, case_property_builder, case_type_):
         parent_types = case_property_builder.get_parent_types(case_type_)
         modules = app.modules
         parent_module_ids = [mod.unique_id for mod in modules
@@ -294,7 +296,8 @@ def _get_parent_modules(app, module, case_property_builder, case_type_):
         } for mod in app.modules if mod.case_type != case_type_ and mod.unique_id != module.unique_id]
 
 
-def _get_valid_parent_modules(app, module):
+# Parent/child modules: get modules that may be used as parents of the given module
+def _get_valid_parents_for_child_module(app, module):
     # If this module already has a child, it can't also have a parent
     for m in app.modules:
         if module.unique_id == getattr(m, 'root_module_id', None):


### PR DESCRIPTION
Minor, just thought it was confusing to have a `_get_parent_modules` and a `_get_valid_parent_modules` that don't have anything to do with each other.

@nickpell / @calellowitz 