### PR TITLE
Hide help bubble on enterprise

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/global_navigation_bar.html
@@ -75,41 +75,43 @@
             </li>
         </ul>
     </li>
-    <li class="dropdown">
-        <a href="#" class="dropdown-toggle dropdown-toggle-with-icon track-usage-link"
-           data-toggle="dropdown" data-category="Nav Bar" data-action="Click Question Mark">
-            <i class="fa fa-question-circle nav-main-icon"></i> <span class="responsive-label">{% trans "Help &amp; Resources" %}</span>
-        </a>
-        <ul class="dropdown-menu dropdown-menu-right" role="menu">
-            <li class="dropdown-header nav-header">
-            {% blocktrans with cc_name=commcare_hq_names.COMMCARE_NAME %}
-            {{ cc_name }} Help
-            {% endblocktrans %}
-            </li>
-            <li>
-                <a href="{% trans 'https://wiki.commcarehq.org/display/commcarepublic/Home' %}" class="track-usage-link" target="_blank"
-                   data-category="Nav Bar" data-action="Question Mark" data-label="Visit the Help Site">
-                    <i class="fa fa-question-circle icon-question-sign dropdown-icon"></i> {% trans "Visit the Help Site" %}
-                </a>
-            </li>
-            <li>
-                <a href="{% trans 'https://forum.dimagi.com/' %}" class="track-usage-link" target="_blank"
-                   data-category="Nav Bar" data-action="Question Mark" data-label="User Forum">
-                    <i class="fa fa-comments icon-comments dropdown-icon"></i> {% trans "User Forum" %}
-                </a>
-            </li>
-            {% if not enterprise_mode or not 500traceback %}
-                {% if allow_report_an_issue %}
-                    <li>
-                        <a href="#modalReportIssue" data-toggle="modal" class="track-usage-link"
-                           data-category="Nav Bar" data-action="Question Mark" data-label="Report an Issue">
-                            <i class="fa fa-exclamation-triangle icon-warning-sign dropdown-icon"></i> {% trans "Report an Issue" %}
-                        </a>
-                    </li>
+    {% if not enterprise_mode %}
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle dropdown-toggle-with-icon track-usage-link"
+               data-toggle="dropdown" data-category="Nav Bar" data-action="Click Question Mark">
+                <i class="fa fa-question-circle nav-main-icon"></i> <span class="responsive-label">{% trans "Help &amp; Resources" %}</span>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                <li class="dropdown-header nav-header">
+                    {% blocktrans with cc_name=commcare_hq_names.COMMCARE_NAME %}
+                        {{ cc_name }} Help
+                    {% endblocktrans %}
+                </li>
+                <li>
+                    <a href="{% trans 'https://wiki.commcarehq.org/display/commcarepublic/Home' %}" class="track-usage-link" target="_blank"
+                       data-category="Nav Bar" data-action="Question Mark" data-label="Visit the Help Site">
+                        <i class="fa fa-question-circle icon-question-sign dropdown-icon"></i> {% trans "Visit the Help Site" %}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% trans 'https://forum.dimagi.com/' %}" class="track-usage-link" target="_blank"
+                       data-category="Nav Bar" data-action="Question Mark" data-label="User Forum">
+                        <i class="fa fa-comments icon-comments dropdown-icon"></i> {% trans "User Forum" %}
+                    </a>
+                </li>
+                {% if  not 500traceback %}
+                    {% if allow_report_an_issue %}
+                        <li>
+                            <a href="#modalReportIssue" data-toggle="modal" class="track-usage-link"
+                               data-category="Nav Bar" data-action="Question Mark" data-label="Report an Issue">
+                                <i class="fa fa-exclamation-triangle icon-warning-sign dropdown-icon"></i> {% trans "Report an Issue" %}
+                            </a>
+                        </li>
+                    {% endif %}
                 {% endif %}
-            {% endif %}
-        </ul>
-    </li>
+            </ul>
+        </li>
+    {% endif %}
     {% if request.couch_user and request.couch_user.is_web_user %}
     {% include 'notifications/partials/global_notifications.html' %}
     <li id="settingsmenu-project" class="dropdown">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/global_navigation_bar.html
@@ -75,13 +75,16 @@
             </li>
         </ul>
     </li>
-    {% if not enterprise_mode %}
+    {% if enterprise_mode and allow_report_an_issue and not 500traceback or not enterprise_mode %}
+        {# In enterprise mode, the bubble is only shown when the user can report an issue and this isn't from a 500 error #}
+        {# In non-enterprise mode, the bubble is always shown #}
         <li class="dropdown">
-            <a href="#" class="dropdown-toggle dropdown-toggle-with-icon track-usage-link"
-               data-toggle="dropdown" data-category="Nav Bar" data-action="Click Question Mark">
-                <i class="fa fa-question-circle nav-main-icon"></i> <span class="responsive-label">{% trans "Help &amp; Resources" %}</span>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <a href="#" class="dropdown-toggle dropdown-toggle-with-icon track-usage-link"
+           data-toggle="dropdown" data-category="Nav Bar" data-action="Click Question Mark">
+            <i class="fa fa-question-circle nav-main-icon"></i> <span class="responsive-label">{% trans "Help &amp; Resources" %}</span>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+            {% if not enterprise_mode %}
                 <li class="dropdown-header nav-header">
                     {% blocktrans with cc_name=commcare_hq_names.COMMCARE_NAME %}
                         {{ cc_name }} Help
@@ -99,17 +102,16 @@
                         <i class="fa fa-comments icon-comments dropdown-icon"></i> {% trans "User Forum" %}
                     </a>
                 </li>
-                {% if  not 500traceback %}
-                    {% if allow_report_an_issue %}
-                        <li>
-                            <a href="#modalReportIssue" data-toggle="modal" class="track-usage-link"
-                               data-category="Nav Bar" data-action="Question Mark" data-label="Report an Issue">
-                                <i class="fa fa-exclamation-triangle icon-warning-sign dropdown-icon"></i> {% trans "Report an Issue" %}
-                            </a>
-                        </li>
-                    {% endif %}
-                {% endif %}
-            </ul>
+            {% endif %}
+            {% if allow_report_an_issue and not 500traceback %}
+                <li>
+                    <a href="#modalReportIssue" data-toggle="modal" class="track-usage-link"
+                       data-category="Nav Bar" data-action="Question Mark" data-label="Report an Issue">
+                        <i class="fa fa-exclamation-triangle icon-warning-sign dropdown-icon"></i> {% trans "Report an Issue" %}
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
         </li>
     {% endif %}
     {% if request.couch_user and request.couch_user.is_web_user %}


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?273872#1480641

This might be too heavy handed? Not sure if this is relevant for all enterprise clients.
Best with https://github.com/dimagi/commcare-hq/pull/20127/files?w=1
@dimagi/product 
