### PR TITLE
pass id to app linking helper

### DIFF
--- a/corehq/apps/app_manager/management/commands/link_apps.py
+++ b/corehq/apps/app_manager/management/commands/link_apps.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.core.management import BaseCommand, CommandError
 
 from corehq.apps.app_manager.dbaccessors import get_latest_released_app_version
-from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.models import Application, LinkedApplication
 from corehq.apps.app_manager.views.utils import update_linked_app
 from corehq.apps.linked_domain.applications import link_app
 
@@ -30,7 +30,7 @@ class Command(BaseCommand):
                 " Make sure you have at least one released build."
             )
 
-        linked_app = Application.get(linked_id)
+        linked_app = LinkedApplication.get(linked_id)
 
         link_app(linked_app, master_app.domain, master_id)
         update_linked_app(linked_app, 'system')

--- a/corehq/apps/app_manager/management/commands/link_apps.py
+++ b/corehq/apps/app_manager/management/commands/link_apps.py
@@ -32,5 +32,5 @@ class Command(BaseCommand):
 
         linked_app = Application.get(linked_id)
 
-        link_app(linked_app, master_app.domain, master_app.domain)
+        link_app(linked_app, master_app.domain, master_id)
         update_linked_app(linked_app, 'system')


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/blob/d4f9ed6f23a472a9c63dae109f03424ada2de211/corehq/apps/linked_domain/applications.py#L35

This was pretty confusing. I think https://confluence.dimagi.com/display/ccinternal/Linked+Applications could probably be shown some love. I think I ended up with linked domains, but I ended up doing a couple of things manually since i didn't understand these bugs for a bit