### PR TITLE
Drop unused FormQuestionConcept

### DIFF
--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -121,15 +121,6 @@ class FormQuestionMap(FormQuestion):
             return None
 
 
-class FormQuestionConcept(FormQuestionMap):
-    # This alias for FormQuestionMap allows us to easily manually
-    # migrate the OpenmrsConfig of the *two* domains that use
-    # FormQuestionConcept on prod.
-    #
-    # TODO: NH 2018-04-06: Drop after deploy and config edited.
-    pass
-
-
 class OpenmrsCaseConfig(DocumentSchema):
 
     # "patient_identifiers": {


### PR DESCRIPTION
PR #20123 was deployed, and the two domains migrated, so we can delete this unused class now.

(See #20123 for more context.)
