### PR TITLE
Delete data from UCR documents when they no longer produce data

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -140,9 +140,6 @@ class IndicatorSqlAdapter(IndicatorAdapter):
             self.handle_exception(doc, e)
 
     def _save_rows(self, rows, doc):
-        if not rows:
-            return
-
         table = self.get_table()
         with self.engine.begin() as connection:
             # delete all existing rows for this doc to ensure we aren't left with stale data


### PR DESCRIPTION
@czue get ready for a blast from the past. https://github.com/dimagi/commcare-hq/commit/ecdd8437022593f039e2de44ae2e87e43c9a1829#diff-6b3d8d59b5382c8600c6fb61366d72e2R28  2014 (sometime between when [everyone was happy and before we all shook it off](https://en.wikipedia.org/wiki/List_of_Billboard_Hot_100_number-one_singles_of_2014#Chart_history)) had to go through several refactors to figure out when this behavior was introduced.

Do you know why this condition is here? At the moment this means that even if a case no longer outputs a row to be put in the database, it's old rows will not be deleted. For most projects this likely means nothing as case types and xmlns don't really change, but once your project gets [complex logic in repeat iterations](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json#L18-L140) there can be rows that no longer have an effect. 

I found this trying to debug why our "recalculate stagnant cases" task on ICDS always picks up millions of ccs record cases. There are several million rows on some of these icds monthly UCRs which haven't been recalculated for several months, but also never deleted due to this. I manually deleted quite a few, so there should be fewer of these next time it runs (monday or tuesday).

Thoughts on proactively deleting here?