### PR TITLE
mobile user lockout

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -33,7 +33,6 @@ from dimagi.utils.web import json_response
 from django_otp import match_token
 
 # CCHQ imports
-from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.users.models import CouchUser
@@ -383,7 +382,7 @@ def check_lockout(fn):
             return fn(request, *args, **kwargs)
 
         user = CouchUser.get_by_username(username)
-        if user and user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
+        if user and user.is_locked_out() and user.supports_lockout():
             return json_response({_("error"): _("maximum password attempts exceeded")}, status_code=401)
         else:
             return fn(request, *args, **kwargs)

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -379,7 +379,7 @@ def check_lockout(fn):
     @wraps(fn)
     def _inner(request, *args, **kwargs):
         username, password = get_username_and_password_from_request(request)
-        if not username or username.endswith('.commcarehq.org'):
+        if not username:
             return fn(request, *args, **kwargs)
 
         user = CouchUser.get_by_username(username)

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -383,7 +383,7 @@ def check_lockout(fn):
             return fn(request, *args, **kwargs)
 
         user = CouchUser.get_by_username(username)
-        if user and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)) and user.is_locked_out():
+        if user and user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
             return json_response({_("error"): _("maximum password attempts exceeded")}, status_code=401)
         else:
             return fn(request, *args, **kwargs)

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -10,7 +10,6 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 
-from corehq import toggles
 from corehq.apps.domain.forms import NoAutocompleteMixin
 from corehq.apps.users.models import CouchUser
 
@@ -52,12 +51,12 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
             cleaned_data = super(EmailAuthenticationForm, self).clean()
         except ValidationError:
             user = CouchUser.get_by_username(username)
-            if user and user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
+            if user and user.is_locked_out() and user.supports_lockout():
                 raise ValidationError(lockout_message)
             else:
                 raise
         user = CouchUser.get_by_username(username)
-        if user and user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
+        if user and user.is_locked_out() and user.supports_lockout():
             raise ValidationError(lockout_message)
         return cleaned_data
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -52,12 +52,12 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
             cleaned_data = super(EmailAuthenticationForm, self).clean()
         except ValidationError:
             user = CouchUser.get_by_username(username)
-            if user and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)) and user.is_locked_out():
+            if user and user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
                 raise ValidationError(lockout_message)
             else:
                 raise
         user = CouchUser.get_by_username(username)
-        if user and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)) and user.is_locked_out():
+        if user and user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
             raise ValidationError(lockout_message)
         return cleaned_data
 

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -4,7 +4,6 @@ from datetime import date
 from django.contrib.auth.signals import user_logged_in, user_login_failed
 from django.dispatch import receiver
 
-from corehq import toggles
 from corehq.apps.users.models import CouchUser
 
 
@@ -25,7 +24,7 @@ def clear_failed_logins_and_unlock_account(sender, request, user, **kwargs):
 @receiver(user_login_failed)
 def add_failed_attempt(sender, credentials, **kwargs):
     user = CouchUser.get_by_username(credentials['username'])
-    if user and not user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
+    if user and not user.is_locked_out() and user.supports_lockout():
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -25,9 +25,7 @@ def clear_failed_logins_and_unlock_account(sender, request, user, **kwargs):
 @receiver(user_login_failed)
 def add_failed_attempt(sender, credentials, **kwargs):
     user = CouchUser.get_by_username(credentials['username'])
-    if user and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
-        if user.is_locked_out():
-            return
+    if user and not user.is_locked_out() and (user.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(user.domain)):
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -9,7 +9,7 @@ from corehq.apps.users.models import CouchUser
 
 
 def clear_login_attempts(user):
-    if user and user.is_web_user() and user.login_attempts > 0:
+    if user and user.login_attempts > 0:
         user.login_attempts = 0
         user.save()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -14,6 +14,7 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _, override as override_language, ugettext_noop
 from casexml.apps.phone.restore_caching import get_loadtest_factor_for_user
+from corehq import toggles
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.domain.dbaccessors import get_docs_in_domain_by_class
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
@@ -1057,6 +1058,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
     def is_web_user(self):
         return self._get_user_type() == 'web'
+
+    def supports_lockout(self):
+        return self.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(self.domain)
 
     def _get_user_type(self):
         if self.doc_type == 'WebUser':

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1473,7 +1473,8 @@ MOBILE_LOGIN_LOCKOUT = StaticToggle(
     'mobile_user_login_lockout',
     "On too many wrong password attempts, lock out mobile users",
     TAG_CUSTOM,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_DOMAIN],
+    always_disabled={'icds-cas'}
 )
 
 LINKED_DOMAINS = StaticToggle(


### PR DESCRIPTION
First commit is the only real change. Mobile user lockout check was being skipped due to a check higher up for usernames ending with `commcarehq.org`.

Remaining commits are small changes:
* reduce toggle checks by doing in memory checks first
* disable toggle DB/cache check for ICDS
* move 'supports lockout' logic to user model for readability