### PR TITLE
Remove unused ICDS_LIVEQUERY toggle

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -27,7 +27,7 @@ from casexml.apps.phone.exceptions import (
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.utils import get_cached_items_with_count
-from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC, ICDS_LIVEQUERY, NAMESPACE_USER
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC
 from corehq.util.datadog.utils import bucket_value
 from corehq.util.timer import TimingContext
 from corehq.util.datadog.gauges import datadog_counter
@@ -338,10 +338,7 @@ class RestoreState(object):
         self._last_sync_log = Ellipsis
 
         if case_sync is None:
-            username = self.restore_user.username
             if LIVEQUERY_SYNC.enabled(self.domain):
-                case_sync = LIVEQUERY
-            elif self.domain == 'icds-cas' and ICDS_LIVEQUERY.enabled(username, namespace=NAMESPACE_USER):
                 case_sync = LIVEQUERY
             else:
                 case_sync = DEFAULT_CASE_SYNC

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1433,14 +1433,6 @@ REGEX_FIELD_VALIDATION = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-ICDS_LIVEQUERY = PredictablyRandomToggle(
-    'icds_livequery',
-    'ICDS: Enable livequery case sync for a random subset of ICDS users',
-    TAG_CUSTOM,
-    [NAMESPACE_USER],
-    randomness=0.0,
-)
-
 REMOTE_REQUEST_QUESTION_TYPE = StaticToggle(
     'remote_request_quetion_type',
     'Enikshay: Enable remote request question type in the form builder',


### PR DESCRIPTION
LiveQuery is enabled on ICDS now, so no more need for the random toggle.

@snopoke @calellowitz 