### PR TITLE
Messaging Summary Page

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1510,7 +1510,6 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
             )
             return [CountTuple(*row) for row in cursor.fetchall()]
 
-
     @classmethod
     def get_counts_of_errors(cls, domain, start_date, end_date, time_zone):
         """

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -305,7 +305,7 @@ class SMS(SMSBase):
         :return: A list of (date, direction, count) named tuples
         """
 
-        CountTuple = namedtuple('CountTuple', ['date', 'direction', 'count'])
+        CountTuple = namedtuple('CountTuple', ['date', 'direction', 'sms_count'])
 
         query = """
         SELECT  (date AT TIME ZONE %s)::DATE AS date,

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -290,8 +290,8 @@ class SMS(SMSBase):
             self.delete()
             queued_sms.save()
 
-    @classmethod
-    def get_counts_by_date(cls, domain, start_date, end_date, time_zone):
+    @staticmethod
+    def get_counts_by_date(domain, start_date, end_date, time_zone):
         """
         Retrieves counts of SMS sent and received over the given date range
         for the given domain.
@@ -1465,8 +1465,8 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         )
         return qs.order_by('-date')[0] if qs.count() > 0 else None
 
-    @classmethod
-    def get_counts_by_date(cls, domain, start_date, end_date, time_zone):
+    @staticmethod
+    def get_counts_by_date(domain, start_date, end_date, time_zone):
         """
         Retrieves counts of messaging events at the subevent level over the
         given date range for the given domain.

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -251,6 +251,10 @@ class OutboundDailyCounter(object):
         return self.client.decr(self.key)
 
     @property
+    def current_usage(self):
+        return self.client.get(self.key) or 0
+
+    @property
     def daily_limit(self):
         if self.domain_object:
             return self.domain_object.daily_outbound_sms_limit

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -226,10 +226,15 @@ class OutboundDailyCounter(object):
 
     def __init__(self, domain_object=None):
         self.domain_object = domain_object
-        self.utc_date = datetime.utcnow().date()
+
+        if domain_object:
+            self.date = ServerTime(datetime.utcnow()).user_time(domain_object.get_default_timezone()).done().date()
+        else:
+            self.date = datetime.utcnow().date()
+
         self.key = 'outbound-daily-count-for-%s-%s' % (
             domain_object.name if domain_object else '',
-            self.utc_date.strftime('%Y-%m-%d')
+            self.date.strftime('%Y-%m-%d')
         )
 
         # We need access to the raw redis client because calling incr on
@@ -280,7 +285,7 @@ class OutboundDailyCounter(object):
             # Log the fact that we reached this limit
             DailyOutboundSMSLimitReached.create_for_domain_and_date(
                 self.domain_object.name if self.domain_object else '',
-                self.utc_date
+                self.date
             )
             return False
 

--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -36,6 +36,15 @@ hqDefine("scheduling/js/dashboard", function() {
                 .showControls(false)
                 .groupSpacing(0.1);
             self.sms_count_chart.yAxis.tickFormat(d3.format(',f'));
+
+            self.event_count_chart = nv.models.multiBarChart()
+                .color(['#ed1c24', '#008000'])
+                .transitionDuration(500)
+                .reduceXTicks(true)
+                .rotateLabels(0)
+                .showControls(false)
+                .groupSpacing(0.1);
+            self.event_count_chart.yAxis.tickFormat(d3.format(',f'));
         };
 
         self.update = function(values) {
@@ -56,8 +65,14 @@ hqDefine("scheduling/js/dashboard", function() {
                 .transition()
                 .duration(500)
                 .call(self.sms_count_chart);
-
             nv.utils.windowResize(self.sms_count_chart.update);
+
+            d3.select('#event_count_chart svg')
+                .datum(values.event_count_data)
+                .transition()
+                .duration(500)
+                .call(self.event_count_chart);
+            nv.utils.windowResize(self.event_count_chart.update);
         }
     };
 

--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -13,6 +13,7 @@ hqDefine("scheduling/js/dashboard", function() {
         self.project_timezone = ko.observable();
         self.outbound_sms_sent_today = ko.observable();
         self.daily_outbound_sms_limit = ko.observable();
+        self.events_pending = ko.observable();
 
         self.percentage_daily_outbound_sms_used = ko.computed(function() {
             return Math.round(100.0 * self.outbound_sms_sent_today() / self.daily_outbound_sms_limit());
@@ -35,6 +36,7 @@ hqDefine("scheduling/js/dashboard", function() {
             self.project_timezone(values.project_timezone);
             self.outbound_sms_sent_today(values.outbound_sms_sent_today);
             self.daily_outbound_sms_limit(values.daily_outbound_sms_limit);
+            self.events_pending(values.events_pending);
         }
     };
 

--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -72,7 +72,7 @@ hqDefine("scheduling/js/dashboard", function() {
             self.outbound_sms_sent_today(values.outbound_sms_sent_today);
             self.daily_outbound_sms_limit(values.daily_outbound_sms_limit);
             self.events_pending(values.events_pending);
-        }
+        };
 
         self.update_charts = function(values) {
             d3.select('#sms_count_chart svg')
@@ -95,7 +95,7 @@ hqDefine("scheduling/js/dashboard", function() {
                 .duration(500)
                 .call(self.error_count_chart);
             nv.utils.windowResize(self.error_count_chart.update);
-        }
+        };
     };
 
     var dashboardViewModel = new DashboardViewModel();
@@ -114,7 +114,7 @@ hqDefine("scheduling/js/dashboard", function() {
             dashboardViewModel.update_charts(json);
         });
         setTimeout(updateDashboard, 30000);
-    }
+    };
 
     $(function() {
         updateDashboard();

--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -1,0 +1,59 @@
+/* globals d3, nv, ko */
+hqDefine("scheduling/js/dashboard", function() {
+    var dashboardUrl = hqImport("hqwebapp/js/initial_page_data").reverse("messaging_dashboard");
+
+    var DashboardViewModel = function() {
+        var self = this;
+        self.bindingApplied = ko.observable(false);
+        self.last_refresh_time = ko.observable();
+        self.queued_sms_count = ko.observable();
+        self.uses_restricted_time_windows = ko.observable();
+        self.within_allowed_sms_times = ko.observable();
+        self.sms_resume_time = ko.observable();
+        self.project_timezone = ko.observable();
+        self.outbound_sms_sent_today = ko.observable();
+        self.daily_outbound_sms_limit = ko.observable();
+
+        self.percentage_daily_outbound_sms_used = ko.computed(function() {
+            return Math.round(100.0 * self.outbound_sms_sent_today() / self.daily_outbound_sms_limit());
+        });
+
+        self.is_daily_usage_ok = ko.computed(function() {
+            return self.outbound_sms_sent_today() < self.daily_outbound_sms_limit();
+        });
+
+        self.is_sms_currently_allowed = ko.computed(function() {
+            return self.is_daily_usage_ok() && self.within_allowed_sms_times();
+        });
+
+        self.update = function(values) {
+            self.last_refresh_time(values.last_refresh_time);
+            self.queued_sms_count(values.queued_sms_count);
+            self.uses_restricted_time_windows(values.uses_restricted_time_windows);
+            self.within_allowed_sms_times(values.within_allowed_sms_times);
+            self.sms_resume_time(values.sms_resume_time);
+            self.project_timezone(values.project_timezone);
+            self.outbound_sms_sent_today(values.outbound_sms_sent_today);
+            self.daily_outbound_sms_limit(values.daily_outbound_sms_limit);
+        }
+    };
+
+    var dashboardViewModel = new DashboardViewModel();
+
+    var updateDashboard = function() {
+        $.getJSON(dashboardUrl, {action: 'raw'}).done(function(json) {
+            dashboardViewModel.update(json);
+            if(!dashboardViewModel.bindingApplied()) {
+                // We have to do this on the async ajax thread otherwise there
+                // still might be a flicker on the page.
+                $('#messaging_dashboard').koApplyBindings(dashboardViewModel);
+                dashboardViewModel.bindingApplied(true);
+            }
+        });
+        setTimeout(updateDashboard, 30000);
+    }
+
+    $(function() {
+        updateDashboard();
+    });
+});

--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -34,7 +34,8 @@ hqDefine("scheduling/js/dashboard", function() {
                 .reduceXTicks(true)
                 .rotateLabels(0)
                 .showControls(false)
-                .groupSpacing(0.1);
+                .groupSpacing(0.3)
+                .forceY([0, 10]);
             self.sms_count_chart.yAxis.tickFormat(d3.format(',f'));
 
             self.event_count_chart = nv.models.multiBarChart()
@@ -43,8 +44,22 @@ hqDefine("scheduling/js/dashboard", function() {
                 .reduceXTicks(true)
                 .rotateLabels(0)
                 .showControls(false)
-                .groupSpacing(0.1);
+                .groupSpacing(0.3)
+                .forceY([0, 10]);
             self.event_count_chart.yAxis.tickFormat(d3.format(',f'));
+
+            self.error_count_chart = nv.models.discreteBarChart()
+                .x(function(d) { return d.label; })
+                .y(function(d) { return d.value; })
+                .tooltips(true)
+                .showValues(true)
+                .color(['#ed1c24'])
+                .transitionDuration(500)
+                .showXAxis(false)
+                .valueFormat(d3.format(',f'))
+                .forceY([0, 10])
+                .noData(gettext("(no errors over the given date range)"));
+            self.error_count_chart.yAxis.tickFormat(d3.format(',f'));
         };
 
         self.update = function(values) {
@@ -73,6 +88,13 @@ hqDefine("scheduling/js/dashboard", function() {
                 .duration(500)
                 .call(self.event_count_chart);
             nv.utils.windowResize(self.event_count_chart.update);
+
+            d3.select('#error_count_chart svg')
+                .datum(values.error_count_data)
+                .transition()
+                .duration(500)
+                .call(self.error_count_chart);
+            nv.utils.windowResize(self.error_count_chart.update);
         }
     };
 

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -122,9 +122,28 @@
                 </h3>
             </div>
             <div class="panel-body">
-                {% blocktrans %}
-                View <a target="_blank" href="{{ scheduled_events_url }}">scheduled events</a>
-                {% endblocktrans %}
+                <p>
+                    {% blocktrans %}
+                    View <a target="_blank" href="{{ scheduled_events_url }}">scheduled events</a>
+                    {% endblocktrans %}
+                </p>
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    <strong>{% trans "SMS Received, Sent" %}</strong>
+                </h3>
+            </div>
+            <div class="panel-body">
+                <p>
+                    {% blocktrans %}
+                    View <a target="_blank" href="{{ message_log_url }}">SMS activity</a>
+                    {% endblocktrans %}
+                </p>
+                <div class="row">
+                    <div id="sms_count_chart"><svg height="300px"></svg></div>
+                </div>
             </div>
         </div>
         <div>

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -19,158 +19,164 @@
 
 {% block page_content %}
     {% registerurl 'messaging_dashboard' domain %}
-    {# Prevent flicker by hiding and using bindingApplied to make visible #}
-    <div id="messaging_dashboard" class="container-fluid" style="display: none;" data-bind="visible: bindingApplied">
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">
-                    <strong>{% trans "SMS Status:" %}</strong>
-                    <strong class="text-success" data-bind="visible: is_sms_currently_allowed() && queued_sms_count() === 0">{% trans "All Caught Up" %}</strong>
-                    <strong class="text-warning" data-bind="visible: is_sms_currently_allowed() && queued_sms_count() > 0">{% trans "Working" %}</strong>
-                    <strong class="text-danger" data-bind="visible: !is_sms_currently_allowed()">{% trans "Paused" %}</strong>
-                    <span data-bind="visible: queued_sms_count() > 0 || !is_sms_currently_allowed()">
-                        (<span data-bind="text: queued_sms_count"></span>
-                        {% trans "SMS queued" %})
-                    </span>
-                    <span data-bind="visible: !is_sms_currently_allowed()">
-                        <span class="hq-help-template"
-                              data-title="{% trans 'SMS Paused' %}"
-                              data-container="body"
-                              data-content="{% trans 'Messages will remain queued until the below conditions are cleared.' %}"
-                              data-placement="left">
+    <div id="messaging_dashboard" class="container-fluid">
+        <div data-bind="visible: !bindingApplied()">
+            <img src="/static/hqwebapp/images/ajax-loader.gif" />
+            <span>{% trans "Loading..." %}</span>
+        </div>
+        {# Prevent flicker by hiding and using bindingApplied to make visible #}
+        <div style="display: none;" data-bind="visible: bindingApplied">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <strong>{% trans "SMS Status:" %}</strong>
+                        <strong class="text-success" data-bind="visible: is_sms_currently_allowed() && queued_sms_count() === 0">{% trans "All Caught Up" %}</strong>
+                        <strong class="text-warning" data-bind="visible: is_sms_currently_allowed() && queued_sms_count() > 0">{% trans "Working" %}</strong>
+                        <strong class="text-danger" data-bind="visible: !is_sms_currently_allowed()">{% trans "Paused" %}</strong>
+                        <span data-bind="visible: queued_sms_count() > 0 || !is_sms_currently_allowed()">
+                            (<span data-bind="text: queued_sms_count"></span>
+                            {% trans "SMS queued" %})
                         </span>
-                    </span>
-                </h3>
-            </div>
-            <div class="panel-body">
-                <div class="row">
-                    <div class="col-xs-2 col-lg-1">
-                        <span>{% trans "Daily Usage" %}</span>
-                    </div>
-                    <div class="col-xs-1 text-center">
-                       <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: is_daily_usage_ok"></span>
-                       <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !is_daily_usage_ok()"></span>
-                    </div>
-                    <div class="col-xs-4">
-                        <div class="progress">
-                            <div class="progress-bar"
-                                 role="progressbar"
-                                 aria-valuemin="0"
-                                 aria-valuemax="100"
-                                 data-bind="
-                                    style: {width: percentage_daily_outbound_sms_used() + '%'},
-                                    css: {'progress-bar-success': outbound_sms_sent_today() < daily_outbound_sms_limit(),
-                                          'progress-bar-danger': outbound_sms_sent_today() >= daily_outbound_sms_limit()}
-                                 ">
+                        <span data-bind="visible: !is_sms_currently_allowed()">
+                            <span class="hq-help-template"
+                                  data-title="{% trans 'SMS Paused' %}"
+                                  data-container="body"
+                                  data-content="{% trans 'Messages will remain queued until the below conditions are cleared.' %}"
+                                  data-placement="left">
+                            </span>
+                        </span>
+                    </h3>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-xs-2 col-lg-1">
+                            <span>{% trans "Daily Usage" %}</span>
+                        </div>
+                        <div class="col-xs-1 text-center">
+                           <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: is_daily_usage_ok"></span>
+                           <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !is_daily_usage_ok()"></span>
+                        </div>
+                        <div class="col-xs-4">
+                            <div class="progress">
+                                <div class="progress-bar"
+                                     role="progressbar"
+                                     aria-valuemin="0"
+                                     aria-valuemax="100"
+                                     data-bind="
+                                        style: {width: percentage_daily_outbound_sms_used() + '%'},
+                                        css: {'progress-bar-success': outbound_sms_sent_today() < daily_outbound_sms_limit(),
+                                              'progress-bar-danger': outbound_sms_sent_today() >= daily_outbound_sms_limit()}
+                                     ">
+                                </div>
                             </div>
                         </div>
+                        <div class="col-xs-4">
+                            <span data-bind="text: outbound_sms_sent_today"></span>
+                            <span>/</span>
+                            <span data-bind="text: daily_outbound_sms_limit"></span>
+                            <span class="hq-help-template"
+                                  data-title="{% trans 'Daily Usage' %}"
+                                  data-container="body"
+                                  data-content="{% trans 'The number of SMS sent today out of the total daily limit for your project.' %}"
+                                  data-placement="left">
+                            </span>
+                        </div>
                     </div>
-                    <div class="col-xs-4">
-                        <span data-bind="text: outbound_sms_sent_today"></span>
-                        <span>/</span>
-                        <span data-bind="text: daily_outbound_sms_limit"></span>
-                        <span class="hq-help-template"
-                              data-title="{% trans 'Daily Usage' %}"
-                              data-container="body"
-                              data-content="{% trans 'The number of SMS sent today out of the total daily limit for your project.' %}"
-                              data-placement="left">
-                        </span>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-xs-2 col-lg-1">
-                        <span>{% trans "Restricted Times" %}</span>
-                    </div>
-                    <div class="col-xs-1 text-center">
-                       <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: within_allowed_sms_times"></span>
-                       <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !within_allowed_sms_times()"></span>
-                    </div>
-                    <div class="col-xs-9">
-                        <span data-bind="visible: !uses_restricted_time_windows()">
-                            {% blocktrans %}
-                            Your project currently does not restrict the times of day at which SMS can be sent.
-                            {% endblocktrans %}
-                        </span>
-                        <span data-bind="visible: uses_restricted_time_windows() && !within_allowed_sms_times()">
-                            {% blocktrans %}
-                            Your project restricts the times of day at which SMS can be sent. SMS will resume sending at
-                            <span data-bind="text: sms_resume_time"></span> (<span data-bind="text: project_timezone"></span>).
-                            {% endblocktrans %}
-                        </span>
-                        <span data-bind="visible: uses_restricted_time_windows() && within_allowed_sms_times()">
-                            {% blocktrans %}
-                            Your project restricts the times of day at which SMS can be sent, but no restrictions are currently active.
-                            {% endblocktrans %}
-                        </span>
-                        {% if request.couch_user.is_domain_admin %}
-                            <a target="_blank" href="{% url 'sms_settings' domain %}">{% trans "Update" %}</a>
-                        {% endif %}
+                    <div class="row">
+                        <div class="col-xs-2 col-lg-1">
+                            <span>{% trans "Restricted Times" %}</span>
+                        </div>
+                        <div class="col-xs-1 text-center">
+                           <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: within_allowed_sms_times"></span>
+                           <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !within_allowed_sms_times()"></span>
+                        </div>
+                        <div class="col-xs-9">
+                            <span data-bind="visible: !uses_restricted_time_windows()">
+                                {% blocktrans %}
+                                Your project currently does not restrict the times of day at which SMS can be sent.
+                                {% endblocktrans %}
+                            </span>
+                            <span data-bind="visible: uses_restricted_time_windows() && !within_allowed_sms_times()">
+                                {% blocktrans %}
+                                Your project restricts the times of day at which SMS can be sent. SMS will resume sending at
+                                <span data-bind="text: sms_resume_time"></span> (<span data-bind="text: project_timezone"></span>).
+                                {% endblocktrans %}
+                            </span>
+                            <span data-bind="visible: uses_restricted_time_windows() && within_allowed_sms_times()">
+                                {% blocktrans %}
+                                Your project restricts the times of day at which SMS can be sent, but no restrictions are currently active.
+                                {% endblocktrans %}
+                            </span>
+                            {% if request.couch_user.is_domain_admin %}
+                                <a target="_blank" href="{% url 'sms_settings' domain %}">{% trans "Update" %}</a>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">
-                    <strong>{% trans "Reminder Status:" %}</strong>
-                    <strong class="text-success" data-bind="visible: events_pending() === 0">{% trans "All Caught Up" %}</strong>
-                    <strong class="text-warning" data-bind="visible: events_pending() > 0">{% trans "Working" %},</strong>
-                    <span data-bind="visible: events_pending() > 0">
-                        <span data-bind="text: events_pending"></span>
-                        {% trans "event(s) queued" %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <strong>{% trans "Reminder Status:" %}</strong>
+                        <strong class="text-success" data-bind="visible: events_pending() === 0">{% trans "All Caught Up" %}</strong>
+                        <strong class="text-warning" data-bind="visible: events_pending() > 0">{% trans "Working" %},</strong>
+                        <span data-bind="visible: events_pending() > 0">
+                            <span data-bind="text: events_pending"></span>
+                            {% trans "event(s) queued" %}
+                        </span>
+                    </h3>
+                </div>
+                <div class="panel-body">
+                    <p>
+                        {% blocktrans %}
+                        View <a target="_blank" href="{{ scheduled_events_url }}">scheduled events</a>
+                        {% endblocktrans %}
+                    </p>
+                </div>
+            </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <strong>{% trans "SMS Received, Sent" %}</strong>
+                    </h3>
+                </div>
+                <div class="panel-body">
+                    <p>
+                        {% blocktrans %}
+                        View <a target="_blank" href="{{ message_log_url }}">SMS activity</a>
+                        {% endblocktrans %}
+                    </p>
+                    <div class="row">
+                        <div id="sms_count_chart"><svg height="300px"></svg></div>
+                    </div>
+                </div>
+            </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <strong>{% trans "Messaging Events" %}</strong>
+                    </h3>
+                </div>
+                <div class="panel-body">
+                    <p>
+                        {% blocktrans %}
+                        View <a target="_blank" href="{{ messaging_history_url }}">Messaging History</a>
+                        {% endblocktrans %}
+                    </p>
+                    <div class="row">
+                        <div id="event_count_chart"><svg height="300px"></svg></div>
+                    </div>
+                </div>
+            </div>
+            <div>
+                <p>
+                    <span>{% trans "Last updated:" %}</span>
+                    <span data-bind="text: last_refresh_time"></span>
+                    <span>
+                        (<span data-bind="text: project_timezone"></span>)
                     </span>
-                </h3>
-            </div>
-            <div class="panel-body">
-                <p>
-                    {% blocktrans %}
-                    View <a target="_blank" href="{{ scheduled_events_url }}">scheduled events</a>
-                    {% endblocktrans %}
                 </p>
             </div>
-        </div>
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">
-                    <strong>{% trans "SMS Received, Sent" %}</strong>
-                </h3>
-            </div>
-            <div class="panel-body">
-                <p>
-                    {% blocktrans %}
-                    View <a target="_blank" href="{{ message_log_url }}">SMS activity</a>
-                    {% endblocktrans %}
-                </p>
-                <div class="row">
-                    <div id="sms_count_chart"><svg height="300px"></svg></div>
-                </div>
-            </div>
-        </div>
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">
-                    <strong>{% trans "Messaging Events" %}</strong>
-                </h3>
-            </div>
-            <div class="panel-body">
-                <p>
-                    {% blocktrans %}
-                    View <a target="_blank" href="{{ messaging_history_url }}">Messaging History</a>
-                    {% endblocktrans %}
-                </p>
-                <div class="row">
-                    <div id="event_count_chart"><svg height="300px"></svg></div>
-                </div>
-            </div>
-        </div>
-        <div>
-            <p>
-                <span>{% trans "Last updated:" %}</span>
-                <span data-bind="text: last_refresh_time"></span>
-                <span>
-                    (<span data-bind="text: project_timezone"></span>)
-                </span>
-            </p>
         </div>
     </div>
 {% endblock %}

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -168,6 +168,23 @@
                     </div>
                 </div>
             </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <strong>{% trans "Messaging Event Error Summary" %}</strong>
+                    </h3>
+                </div>
+                <div class="panel-body">
+                    <p>
+                        {% blocktrans %}
+                        View <a target="_blank" href="{{ messaging_history_url }}">Messaging History</a>
+                        {% endblocktrans %}
+                    </p>
+                    <div class="row">
+                        <div id="error_count_chart"><svg height="300px"></svg></div>
+                    </div>
+                </div>
+            </div>
             <div>
                 <p>
                     <span>{% trans "Last updated:" %}</span>

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -41,7 +41,7 @@
                             <span class="hq-help-template"
                                   data-title="{% trans 'SMS Paused' %}"
                                   data-container="body"
-                                  data-content="{% trans 'Messages will remain queued until the below conditions are cleared.' %}"
+                                  data-content="{% trans 'Messages will remain queued until the following conditions are cleared.' %}"
                                   data-placement="left">
                             </span>
                         </span>

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -21,15 +21,6 @@
     {% registerurl 'messaging_dashboard' domain %}
     {# Prevent flicker by hiding and using bindingApplied to make visible #}
     <div id="messaging_dashboard" class="container-fluid" style="display: none;" data-bind="visible: bindingApplied">
-        <div>
-            <p>
-                <span>{% trans "Last updated:" %}</span>
-                <span data-bind="text: last_refresh_time"></span>
-                <span>
-                    (<span data-bind="text: project_timezone"></span>)
-                </span>
-            </p>
-        </div>
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title">
@@ -39,16 +30,19 @@
                     <strong class="text-danger" data-bind="visible: !is_sms_currently_allowed()">{% trans "Paused" %}</strong>
                     <span data-bind="visible: queued_sms_count() > 0 || !is_sms_currently_allowed()">
                         (<span data-bind="text: queued_sms_count"></span>
-                        {% trans "SMS in the queue" %})
+                        {% trans "SMS queued" %})
+                    </span>
+                    <span data-bind="visible: !is_sms_currently_allowed()">
+                        <span class="hq-help-template"
+                              data-title="{% trans 'SMS Paused' %}"
+                              data-container="body"
+                              data-content="{% trans 'Messages will remain queued until the below conditions are cleared.' %}"
+                              data-placement="left">
+                        </span>
                     </span>
                 </h3>
             </div>
             <div class="panel-body">
-                <div class="row" data-bind="visible: !is_sms_currently_allowed()">
-                    <p class="help-block">
-                        <span><i class="fa fa-info-circle"></i> {% trans "Messages will remain queued until the below conditions are cleared." %}</span>
-                    </p>
-                </div>
                 <div class="row">
                     <div class="col-xs-2 col-lg-1">
                         <span>{% trans "Daily Usage" %}</span>
@@ -72,8 +66,15 @@
                         </div>
                     </div>
                     <div class="col-xs-4">
-                        <span>{% trans "Daily Limit:" %}</span>
+                        <span data-bind="text: outbound_sms_sent_today"></span>
+                        <span>/</span>
                         <span data-bind="text: daily_outbound_sms_limit"></span>
+                        <span class="hq-help-template"
+                              data-title="{% trans 'Daily Usage' %}"
+                              data-container="body"
+                              data-content="{% trans 'The number of SMS sent today out of the total daily limit for your project.' %}"
+                              data-placement="left">
+                        </span>
                     </div>
                 </div>
                 <div class="row">
@@ -116,7 +117,7 @@
                     <strong class="text-warning" data-bind="visible: events_pending() > 0">{% trans "Working" %},</strong>
                     <span data-bind="visible: events_pending() > 0">
                         <span data-bind="text: events_pending"></span>
-                        {% trans "event(s) in the queue" %}
+                        {% trans "event(s) queued" %}
                     </span>
                 </h3>
             </div>
@@ -125,6 +126,15 @@
                 View <a target="_blank" href="{{ scheduled_events_url }}">scheduled events</a>
                 {% endblocktrans %}
             </div>
+        </div>
+        <div>
+            <p>
+                <span>{% trans "Last updated:" %}</span>
+                <span data-bind="text: last_refresh_time"></span>
+                <span>
+                    (<span data-bind="text: project_timezone"></span>)
+                </span>
+            </p>
         </div>
     </div>
 {% endblock %}

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -138,12 +138,18 @@
                 <div class="panel-heading">
                     <h3 class="panel-title">
                         <strong>{% trans "SMS Received, Sent" %}</strong>
+                        <span class="hq-help-template"
+                              data-title="{% trans 'SMS Received, Sent' %}"
+                              data-container="body"
+                              data-content="{% trans 'Summary of SMS activity. SMS sent represent SMS successfully handed off to an SMS gateway for delivery.' %}"
+                              data-placement="left">
+                        </span>
                     </h3>
                 </div>
                 <div class="panel-body">
                     <p>
                         {% blocktrans %}
-                        View <a target="_blank" href="{{ message_log_url }}">SMS activity</a>
+                        Showing SMS activity over the last 30 days. <a target="_blank" href="{{ message_log_url }}">See all</a>
                         {% endblocktrans %}
                     </p>
                     <div class="row">
@@ -155,12 +161,18 @@
                 <div class="panel-heading">
                     <h3 class="panel-title">
                         <strong>{% trans "Messaging Events" %}</strong>
+                        <span class="hq-help-template"
+                              data-title="{% trans 'Messaging Events' %}"
+                              data-container="body"
+                              data-content="{% trans 'Shows the counts of messaging events that completed successfully as well as those that had errors.' %}"
+                              data-placement="left">
+                        </span>
                     </h3>
                 </div>
                 <div class="panel-body">
                     <p>
                         {% blocktrans %}
-                        View <a target="_blank" href="{{ messaging_history_url }}">Messaging History</a>
+                        Summarizing messaging events over the last 30 days. <a target="_blank" href="{{ messaging_history_url }}">See all</a>
                         {% endblocktrans %}
                     </p>
                     <div class="row">
@@ -172,12 +184,18 @@
                 <div class="panel-heading">
                     <h3 class="panel-title">
                         <strong>{% trans "Messaging Event Error Summary" %}</strong>
+                        <span class="hq-help-template"
+                              data-title="{% trans 'Messaging Event Error Summary' %}"
+                              data-container="body"
+                              data-content="{% trans 'Gives a breakdown of messaging event errors and the counts of their occurrences. Hover over a bar to see the error.' %}"
+                              data-placement="left">
+                        </span>
                     </h3>
                 </div>
                 <div class="panel-body">
                     <p>
                         {% blocktrans %}
-                        View <a target="_blank" href="{{ messaging_history_url }}">Messaging History</a>
+                        Summarizing errors over the last 30 days. <a target="_blank" href="{{ messaging_history_url }}">See all</a>
                         {% endblocktrans %}
                     </p>
                     <div class="row">

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -49,12 +49,12 @@
                 </div>
                 <div class="panel-body">
                     <div class="row">
-                        <div class="col-xs-2 col-lg-1">
-                            <span>{% trans "Daily Usage" %}</span>
-                        </div>
                         <div class="col-xs-1 text-center">
                            <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: is_daily_usage_ok"></span>
                            <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !is_daily_usage_ok()"></span>
+                        </div>
+                        <div class="col-xs-3 col-lg-2">
+                            <span>{% trans "Daily Usage" %}</span>
                         </div>
                         <div class="col-xs-4">
                             <div class="progress">
@@ -83,14 +83,14 @@
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-xs-2 col-lg-1">
-                            <span>{% trans "Restricted Times" %}</span>
-                        </div>
                         <div class="col-xs-1 text-center">
                            <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: within_allowed_sms_times"></span>
                            <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !within_allowed_sms_times()"></span>
                         </div>
-                        <div class="col-xs-9">
+                        <div class="col-xs-3 col-lg-2">
+                            <span>{% trans "Restricted Times" %}</span>
+                        </div>
+                        <div class="col-xs-8">
                             <span data-bind="visible: !uses_restricted_time_windows()">
                                 {% blocktrans %}
                                 Your project currently does not restrict the times of day at which SMS can be sent.

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -1,0 +1,112 @@
+{% extends "hqwebapp/base_section.html" %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+
+{% block stylesheets %}{{ block.super }}
+<style>
+    .messaging-dashboard-indicator{
+        font-size: 20px;
+    };
+</style>
+{% endblock %}
+
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'scheduling/js/dashboard.js' %}"></script>
+{% endblock %}
+
+
+{% block page_content %}
+    {% registerurl 'messaging_dashboard' domain %}
+    {# Prevent flicker by hiding and using bindingApplied to make visible #}
+    <div id="messaging_dashboard" class="container-fluid" style="display: none;" data-bind="visible: bindingApplied">
+        <div>
+            <p>
+                <span>{% trans "Last updated:" %}</span>
+                <span data-bind="text: last_refresh_time"></span>
+                <span>
+                    (<span data-bind="text: project_timezone"></span>)
+                </span>
+            </p>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    <strong>{% trans "SMS Status:" %}</strong>
+                    <strong class="text-success" data-bind="visible: is_sms_currently_allowed() && queued_sms_count() === 0">{% trans "All Caught Up" %}</strong>
+                    <strong class="text-warning" data-bind="visible: is_sms_currently_allowed() && queued_sms_count() > 0">{% trans "Working" %}</strong>
+                    <strong class="text-danger" data-bind="visible: !is_sms_currently_allowed()">{% trans "Paused" %}</strong>
+                    <span data-bind="visible: queued_sms_count() > 0 || !is_sms_currently_allowed()">
+                        (<span data-bind="text: queued_sms_count"></span>
+                        {% trans "SMS in the queue" %})
+                    </span>
+                </h3>
+            </div>
+            <div class="panel-body">
+                <div class="row" data-bind="visible: !is_sms_currently_allowed()">
+                    <p class="help-block">
+                        <span><i class="fa fa-info-circle"></i> {% trans "Messages will remain queued until the below conditions are cleared." %}</span>
+                    </p>
+                </div>
+                <div class="row">
+                    <div class="col-xs-2 col-lg-1">
+                        <span>{% trans "Daily Usage" %}</span>
+                    </div>
+                    <div class="col-xs-1 text-center">
+                       <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: is_daily_usage_ok"></span>
+                       <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !is_daily_usage_ok()"></span>
+                    </div>
+                    <div class="col-xs-4">
+                        <div class="progress">
+                            <div class="progress-bar"
+                                 role="progressbar"
+                                 aria-valuemin="0"
+                                 aria-valuemax="100"
+                                 data-bind="
+                                    style: {width: percentage_daily_outbound_sms_used() + '%'},
+                                    css: {'progress-bar-success': outbound_sms_sent_today() < daily_outbound_sms_limit(),
+                                          'progress-bar-danger': outbound_sms_sent_today() >= daily_outbound_sms_limit()}
+                                 ">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-xs-4">
+                        <span>{% trans "Daily Limit:" %}</span>
+                        <span data-bind="text: daily_outbound_sms_limit"></span>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-2 col-lg-1">
+                        <span>{% trans "Restricted Times" %}</span>
+                    </div>
+                    <div class="col-xs-1 text-center">
+                       <span class="messaging-dashboard-indicator glyphicon glyphicon-ok text-success" aria-hidden="true" data-bind="visible: within_allowed_sms_times"></span>
+                       <span class="messaging-dashboard-indicator glyphicon glyphicon-remove text-danger" aria-hidden="true" data-bind="visible: !within_allowed_sms_times()"></span>
+                    </div>
+                    <div class="col-xs-9">
+                        <span data-bind="visible: !uses_restricted_time_windows()">
+                            {% blocktrans %}
+                            Your project currently does not restrict the times of day at which SMS can be sent.
+                            {% endblocktrans %}
+                        </span>
+                        <span data-bind="visible: uses_restricted_time_windows() && !within_allowed_sms_times()">
+                            {% blocktrans %}
+                            Your project restricts the times of day at which SMS can be sent. SMS will resume sending at
+                            <span data-bind="text: sms_resume_time"></span> (<span data-bind="text: project_timezone"></span>).
+                            {% endblocktrans %}
+                        </span>
+                        <span data-bind="visible: uses_restricted_time_windows() && within_allowed_sms_times()">
+                            {% blocktrans %}
+                            Your project restricts the times of day at which SMS can be sent, but no restrictions are currently active.
+                            {% endblocktrans %}
+                        </span>
+                        {% if request.couch_user.is_domain_admin %}
+                            <a target="_blank" href="{% url 'sms_settings' domain %}">{% trans "Update" %}</a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -146,6 +146,23 @@
                 </div>
             </div>
         </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    <strong>{% trans "Messaging Events" %}</strong>
+                </h3>
+            </div>
+            <div class="panel-body">
+                <p>
+                    {% blocktrans %}
+                    View <a target="_blank" href="{{ messaging_history_url }}">Messaging History</a>
+                    {% endblocktrans %}
+                </p>
+                <div class="row">
+                    <div id="event_count_chart"><svg height="300px"></svg></div>
+                </div>
+            </div>
+        </div>
         <div>
             <p>
                 <span>{% trans "Last updated:" %}</span>

--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -108,5 +108,23 @@
                 </div>
             </div>
         </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    <strong>{% trans "Reminder Status:" %}</strong>
+                    <strong class="text-success" data-bind="visible: events_pending() === 0">{% trans "All Caught Up" %}</strong>
+                    <strong class="text-warning" data-bind="visible: events_pending() > 0">{% trans "Working" %},</strong>
+                    <span data-bind="visible: events_pending() > 0">
+                        <span data-bind="text: events_pending"></span>
+                        {% trans "event(s) in the queue" %}
+                    </span>
+                </h3>
+            </div>
+            <div class="panel-body">
+                {% blocktrans %}
+                View <a target="_blank" href="{{ scheduled_events_url }}">scheduled events</a>
+                {% endblocktrans %}
+            </div>
+        </div>
     </div>
 {% endblock %}

--- a/corehq/messaging/scheduling/urls.py
+++ b/corehq/messaging/scheduling/urls.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.conf.urls import url
 
 from corehq.messaging.scheduling.views import (
+    MessagingDashboardView,
     BroadcastListView,
     CreateScheduleView,
     EditScheduleView,
@@ -12,6 +13,7 @@ from corehq.messaging.scheduling.views import (
 )
 
 urlpatterns = [
+    url(r'^dashboard/$', MessagingDashboardView.as_view(), name=MessagingDashboardView.urlname),
     url(r'^broadcasts/$', BroadcastListView.as_view(), name=BroadcastListView.urlname),
     url(r'^broadcasts/add/$', CreateScheduleView.as_view(), name=CreateScheduleView.urlname),
     url(r'^broadcasts/edit/(?P<broadcast_type>[\w-]+)/(?P<broadcast_id>[\w-]+)/$', EditScheduleView.as_view(),

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -163,9 +163,9 @@ class MessagingDashboardView(BaseMessagingSectionView):
 
         for row in counts:
             if row.direction == INCOMING:
-                inbound_counts[row.date] = row.count
+                inbound_counts[row.date] = row.sms_count
             elif row.direction == OUTGOING:
-                outbound_counts[row.date] = row.count
+                outbound_counts[row.date] = row.sms_count
 
         inbound_values = []
         outbound_values = []


### PR DESCRIPTION
Adds a page which summarizes pertinent messaging info for the project. This can be used for keeping an eye on things and for debugging. It isn't navigable yet, going to have product review it once deployed and then it should likely become the new landing page for the messaging tab.

Screenshots:

Example when everything is caught up:

![dashboard-1](https://user-images.githubusercontent.com/1028814/38583725-e99008ca-3ce1-11e8-965d-3b47280cff41.png)

Example with SMS and reminders queued up:

![dashboard-2](https://user-images.githubusercontent.com/1028814/38583729-ebe1474c-3ce1-11e8-92f6-8786ac066e56.png)

Messaging history and errors:

![dashboard-3](https://user-images.githubusercontent.com/1028814/38583731-edc54914-3ce1-11e8-9b23-aa2a3bd4a257.png)

@kaapstorm 
