### PR TITLE
Fetch case properties from CaseExportDataSchema during case import

### DIFF
--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -23,6 +23,7 @@ from corehq.apps.users.util import format_username
 from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.util.workbook_reading import open_any_workbook, Workbook, \
     SpreadsheetFileEncrypted, SpreadsheetFileNotFound, SpreadsheetFileInvalidError
 from couchexport.export import SCALAR_NEVER_WAS
@@ -416,8 +417,11 @@ def get_case_properties_for_case_type(domain, case_type):
         case_type,
     )
     group_schemas = [gs for gs in schema.group_schemas if gs.path == MAIN_TABLE]
-    if group_schemas:
-        return sorted(set([item.path[0].name for item in group_schemas[0].items]))
+    case_properties = set([item.path[0].name for item in group_schemas[0].items]) if group_schemas else set()
+    if not should_use_sql_backend(domain):
+        from corehq.apps.hqcase.dbaccessors import get_case_properties
+        case_properties |= set(get_case_properties(domain, case_type))
+    return sorted(case_properties)
 
 
 def get_importer_error_message(e):

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -7,6 +7,8 @@ from django.utils.translation import ugettext_lazy as _
 from couchdbkit import NoResultFound
 
 from corehq.apps.case_importer.const import LookupErrors, ImportErrors
+from corehq.apps.export.models import CaseExportDataSchema
+from corehq.apps.export.models.new import MAIN_TABLE
 from corehq.apps.groups.models import Group
 from corehq.apps.case_importer.exceptions import (
     ImporterExcelFileEncrypted,
@@ -21,7 +23,6 @@ from corehq.apps.users.util import format_username
 from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.util.workbook_reading import open_any_workbook, Workbook, \
     SpreadsheetFileEncrypted, SpreadsheetFileNotFound, SpreadsheetFileInvalidError
 from couchexport.export import SCALAR_NEVER_WAS
@@ -409,23 +410,14 @@ def get_id_from_name(name, domain, cache):
 
 
 def get_case_properties_for_case_type(domain, case_type):
-    # todo: seems like poor boundaries for this function care about the backend
-    # todo: get_case_properties just always return the right answer,
-    # todo: possibly by moving this there.
-    if should_use_sql_backend(domain):
-        from corehq.apps.export.models import CaseExportDataSchema
-        from corehq.apps.export.models.new import MAIN_TABLE
-        schema = CaseExportDataSchema.generate_schema_from_builds(
-            domain,
-            None,
-            case_type,
-        )
-        group_schemas = [gs for gs in schema.group_schemas if gs.path == MAIN_TABLE]
-        if group_schemas:
-            return sorted(set([item.path[0].name for item in group_schemas[0].items]))
-    else:
-        from corehq.apps.hqcase.dbaccessors import get_case_properties
-        return get_case_properties(domain, case_type)
+    schema = CaseExportDataSchema.generate_schema_from_builds(
+        domain,
+        None,
+        case_type,
+    )
+    group_schemas = [gs for gs in schema.group_schemas if gs.path == MAIN_TABLE]
+    if group_schemas:
+        return sorted(set([item.path[0].name for item in group_schemas[0].items]))
 
 
 def get_importer_error_message(e):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?273858#1481819
I'm not sure why this distinction was here... but the `CaseExportDataSchema` seems to work for both `SQL` and `couch` domains.

