### PR TITLE
Yeksi Naa Reports | Fix Tests

### DIFF
--- a/custom/yeksi_naa_reports/tests/__init__.py
+++ b/custom/yeksi_naa_reports/tests/__init__.py
@@ -91,6 +91,15 @@ def tearDownModule():
     _call_center_domain_mock = mock.patch(
         'corehq.apps.callcenter.data_source.call_center_data_source_configuration_provider'
     )
+    domain = Domain.get_by_name('test-pna')
+    engine = connection_manager.get_engine(UCR_ENGINE_ID)
+    metadata = sqlalchemy.MetaData(bind=engine)
+    metadata.reflect(bind=engine, extend_existing=True)
+    path = os.path.join(os.path.dirname(__file__), 'fixtures')
+    for file_name in os.listdir(path):
+        table_name = get_table_name(domain.name, file_name[:-4])
+        table = metadata.tables[table_name]
+        table.drop()
     _call_center_domain_mock.start()
-    Domain.get_by_name('test-pna').delete()
+    domain.delete()
     _call_center_domain_mock.stop()

--- a/custom/yeksi_naa_reports/tests/reports/test_dashboard_1.py
+++ b/custom/yeksi_naa_reports/tests/reports/test_dashboard_1.py
@@ -30,11 +30,11 @@ class TestDashboard1(YeksiTestCase):
             ['Region', 'January 2018', 'February 2018', 'March 2018', 'Avg. Availability']
         )
         self.assertEqual(
-            rows,
-            [
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
                 [u'Region 1', u'no data entered', u'no data entered', u'50.00%', u'50.00%'],
                 [u'Dakar', u'no data entered', u'no data entered', u'100.00%', u'100.00%'],
                 [u'Region Test', u'100.00%', u'100.00%', u'no data entered', u'100.00%'],
                 [u'Thies', u'no data entered', u'no data entered', u'87.50%', u'87.50%']
-            ]
+            ], key=lambda x: x[0])
         )

--- a/custom/yeksi_naa_reports/tests/reports/test_dashboard_2.py
+++ b/custom/yeksi_naa_reports/tests/reports/test_dashboard_2.py
@@ -29,13 +29,13 @@ class TestDashboard2(YeksiTestCase):
             ['Region', 'January 2018', 'February 2018', 'March 2018', 'Target']
         )
         self.assertEqual(
-            rows,
-            [
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
                 ['Region 1', 'no data entered', 'no data entered', '1000.00%'],
                 ['Dakar', 'no data entered', 'no data entered', '52200.00%'],
                 ['Region Test', 'no data entered', '2000.00%', 'no data entered'],
                 ['Thies', 'no data entered', 'no data entered', '2300.00%']
-            ]
+            ], key=lambda x: x[0])
         )
 
     def test_expiration_rate_report(self):
@@ -59,13 +59,13 @@ class TestDashboard2(YeksiTestCase):
             ['Region', 'January 2018', 'February 2018', 'March 2018', 'Target']
         )
         self.assertEqual(
-            rows,
-            [
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
                 ['Region 1', 'no data entered', 'no data entered', '0.00%'],
                 ['Dakar', 'no data entered', 'no data entered', '0.00%'],
                 ['Region Test', 'no data entered', '0.00%', 'no data entered'],
                 ['Thies', 'no data entered', 'no data entered', '0.00%']
-            ]
+            ], key=lambda x: x[0])
         )
 
     def test_recovery_rate_by_pps_report(self):
@@ -89,10 +89,10 @@ class TestDashboard2(YeksiTestCase):
             ['PPS', 'January 2018', 'February 2018', 'March 2018', 'Target']
         )
         self.assertEqual(
-            rows,
-            [
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
                 ['test pps 1', '0.00%', 'no data entered', 'no data entered']
-            ]
+            ], key=lambda x: x[0])
         )
 
     def test_recovery_rate_by_district_report(self):
@@ -116,8 +116,8 @@ class TestDashboard2(YeksiTestCase):
             ['Region', 'January 2018', 'February 2018', 'March 2018', 'Target']
         )
         self.assertEqual(
-            rows,
-            [
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
                 ['District Sud', 'no data entered', 'no data entered', '100.00%'],
                 ['District Khombole', 'no data entered', 'no data entered', '100.00%'],
                 ['District Joal Fadiouth', 'no data entered', 'no data entered', '100.00%'],
@@ -131,7 +131,7 @@ class TestDashboard2(YeksiTestCase):
                 ['District Mbao', 'no data entered', 'no data entered', '100.00%'],
                 ['District Centre', 'no data entered', 'no data entered', '0.00%'],
                 ['District Test', '100.00%', 'no data entered', 'no data entered']
-            ]
+            ], key=lambda x: x[0])
         )
 
     def test_rupture_rate_by_pps_report(self):
@@ -155,8 +155,8 @@ class TestDashboard2(YeksiTestCase):
             ['PPS', 'January 2018', 'February 2018', 'March 2018', 'Target']
         )
         self.assertEqual(
-            rows,
-            [
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
                 ['test pps 1', '0.00%', 'no data entered', 'no data entered'],
                 ['PPS 1', 'no data entered', 'no data entered', '0.00%'],
                 ['PPS 3', 'no data entered', 'no data entered', '0.00%'],
@@ -180,5 +180,5 @@ class TestDashboard2(YeksiTestCase):
                 ['PPS 2', 'no data entered', 'no data entered', '0.00%'],
                 ['PPS 1', 'no data entered', 'no data entered', '0.00%'],
                 ['PPS 1', 'no data entered', 'no data entered', '0.00%']
-            ]
+            ], key=lambda x: x[0])
         )

--- a/custom/yeksi_naa_reports/tests/reports/test_dashboard_3.py
+++ b/custom/yeksi_naa_reports/tests/reports/test_dashboard_3.py
@@ -1,58 +1,59 @@
-# from __future__ import absolute_import
-# from __future__ import unicode_literals
-# from mock.mock import MagicMock
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from mock.mock import MagicMock
 
-# from custom.yeksi_naa_reports.tests.utils import YeksiTestCase
-# from custom.yeksi_naa_reports.reports import Dashboard3Report
+from custom.yeksi_naa_reports.tests.utils import YeksiTestCase
+from custom.yeksi_naa_reports.reports import Dashboard3Report
 
 
-# class TestDashboard3(YeksiTestCase):
+class TestDashboard3(YeksiTestCase):
 
-#     def test_valuation_of_pna_stock_per_product_data_report(self):
-#         mock = MagicMock()
-#         mock.couch_user = self.user
-#         mock.GET = {
-#             'location_id': '',
-#             'month_start': '1',
-#             'year_start': '2018',
-#             'month_end': '3',
-#             'year_end': '2018',
-#         }
+    def test_valuation_of_pna_stock_per_product_data_report(self):
+        mock = MagicMock()
+        mock.couch_user = self.user
+        mock.GET = {
+            'location_id': '',
+            'month_start': '1',
+            'year_start': '2018',
+            'month_end': '3',
+            'year_end': '2018',
+        }
 
-#         dashboard3_report = Dashboard3Report(request=mock, domain='test-pna')
+        dashboard3_report = Dashboard3Report(request=mock, domain='test-pna')
 
-#         valuation_of_pna_stock_per_product_data_report = \
-#             dashboard3_report.report_context['reports'][0]['report_table']
-#         headers = valuation_of_pna_stock_per_product_data_report['headers'].as_export_table[0]
-#         rows = valuation_of_pna_stock_per_product_data_report['rows']
+        valuation_of_pna_stock_per_product_data_report = \
+            dashboard3_report.report_context['reports'][0]['report_table']
+        headers = valuation_of_pna_stock_per_product_data_report['headers'].as_export_table[0]
+        rows = valuation_of_pna_stock_per_product_data_report['rows']
 
-#         self.assertEqual(
-#             headers,
-#             ['Product', 'January 2018', 'February 2018', 'March 2018']
-#         )
-#         self.assertItemsEqual(
-#             rows,
-#             [
-#                 ['NEVIRAPINE 200MG CP.', '0.00', '0.00', '0.00'],
-#                 ['DISPOSITIF INTRA UTERIN (TCU 380 A) - DIU', '0.00', '0.00', '0.00'],
-#                 ['RIFAMPICINE+ISONIAZIDE+PYRAZINAMIDE+ETHAMBUTOL (150+75+400+2', '0.00', '0.00', '0.00'],
-#                 ['TEST RAPIDE HIV 1/2 (SD BIOLINE)', '0.00', '0.00', '0.00'],
-#                 ['Produit 15', '0.00', '0.00', '0.00'],
-#                 ['LEVONORGESTREL+ETHYNILESTRADIOL+FER (0.15+0.03+75)MG (MICROGYNON)', '0.00', '0.00', '0.00'],
-#                 ['PARACETAMOL 500MG CP.', '0.00', '0.00', '0.00'],
-#                 ['ALBENDAZOL 4% SB.', '0.00', '0.00', '0.00'],
-#                 ['ACETATE DE MEDROXY PROGESTERONE 104MG/0.65ML INJ. (SAYANA PRESS)', '0.00', '0.00', '0.00'],
-#                 ['ACT ADULTE', '0.00', '0.00', '0.00'],
-#                 ['EFAVIRENZ 600MG CP.', '0.00', '0.00', '0.00'],
-#                 ['Produit 14', '0.00', '0.00', '0.00'],
-#                 ['Produit 10', '0.00', '0.00', '0.00'],
-#                 ['ACETATE DE MEDROXY PROGESTERONE 150MG/ML+S A B KIT (1+1) (DEPO-PROVERA)',
-#                  '0.00', '0.00', '0.00'],
-#                 ['RIFAMPICINE+ISONIAZIDE+PYRAZINAMIDE (60+30+150)MG CP. DISPER', '0.00', '0.00', '0.00'],
-#                 ['Produit 2', '0.00', '0.00', '0.00'],
-#                 ['RIFAMPICINE+ISONIAZIDE (150+75)MG CP.', '0.00', '0.00', '0.00'],
-#                 ['Produit 12', '0.00', '0.00', '0.00'],
-#                 ['ACT PETIT ENFANT', '0.00', '0.00', '0.00'],
-#                 ['LAMIVUDINE+NEVIRAPINE+ZIDOVUDINE (30+50+60)MG CP.', '0.00', '0.00', '0.00'],
-#                 ['Produit 1', '0.00', '0.00', '0.00']]
-#         )
+        self.assertEqual(
+            headers,
+            ['Product', 'January 2018', 'February 2018', 'March 2018']
+        )
+        self.assertItemsEqual(
+            sorted(rows, key=lambda x: x[0]),
+            sorted([
+                ['NEVIRAPINE 200MG CP.', '0.00', '0.00', '0.00'],
+                ['DISPOSITIF INTRA UTERIN (TCU 380 A) - DIU', '0.00', '0.00', '0.00'],
+                ['RIFAMPICINE+ISONIAZIDE+PYRAZINAMIDE+ETHAMBUTOL (150+75+400+2', '0.00', '0.00', '0.00'],
+                ['TEST RAPIDE HIV 1/2 (SD BIOLINE)', '0.00', '0.00', '0.00'],
+                ['Produit 15', '0.00', '0.00', '0.00'],
+                ['LEVONORGESTREL+ETHYNILESTRADIOL+FER (0.15+0.03+75)MG (MICROGYNON)', '0.00', '0.00', '0.00'],
+                ['PARACETAMOL 500MG CP.', '0.00', '0.00', '0.00'],
+                ['ALBENDAZOL 4% SB.', '0.00', '0.00', '0.00'],
+                ['ACETATE DE MEDROXY PROGESTERONE 104MG/0.65ML INJ. (SAYANA PRESS)', '0.00', '0.00', '0.00'],
+                ['ACT ADULTE', '0.00', '0.00', '0.00'],
+                ['EFAVIRENZ 600MG CP.', '0.00', '0.00', '0.00'],
+                ['Produit 14', '0.00', '0.00', '0.00'],
+                ['Produit 10', '0.00', '0.00', '0.00'],
+                ['ACETATE DE MEDROXY PROGESTERONE 150MG/ML+S A B KIT (1+1) (DEPO-PROVERA)',
+                 '0.00', '0.00', '0.00'],
+                ['RIFAMPICINE+ISONIAZIDE+PYRAZINAMIDE (60+30+150)MG CP. DISPER', '0.00', '0.00', '0.00'],
+                ['Produit 2', '0.00', '0.00', '0.00'],
+                ['RIFAMPICINE+ISONIAZIDE (150+75)MG CP.', '0.00', '0.00', '0.00'],
+                ['Produit 12', '0.00', '0.00', '0.00'],
+                ['ACT PETIT ENFANT', '0.00', '0.00', '0.00'],
+                ['LAMIVUDINE+NEVIRAPINE+ZIDOVUDINE (30+50+60)MG CP.', '0.00', '0.00', '0.00'],
+                ['Produit 1', '0.00', '0.00', '0.00']
+            ], key=lambda x: x[0])
+        )


### PR DESCRIPTION
Hi @czue, @nickpell,
This change drops table with test data for static data sources to fix usage of REUSE_DB=1.
As well as adds sorting to tests.
This PR addresses the issue of builds suddenly failing.