### PR TITLE
Externalize javascript: pillow errors

### DIFF
--- a/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/pillow_errors.js
+++ b/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/pillow_errors.js
@@ -1,7 +1,8 @@
 hqDefine("hqpillow_retry/js/pillow_errors", function() {
     $(function() {
         $(document).on('click', '#check_all', function() {
-            var oTable = $('#report_table_' + hqImport('hqwebapp/js/initial_page_data').get('slug')).dataTable();
+            var slug = hqImport('hqwebapp/js/initial_page_data').get('slug'),
+                oTable = $('#report_table_' + slug).dataTable();
             $('input', oTable.fnGetNodes()).prop('checked', this.checked);
         });
     });

--- a/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/pillow_errors.js
+++ b/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/pillow_errors.js
@@ -1,0 +1,8 @@
+hqDefine("hqpillow_retry/js/pillow_errors", function() {
+    $(function() {
+        $(document).on('click', '#check_all', function() {
+            var oTable = $('#report_table_' + hqImport('hqwebapp/js/initial_page_data').get('slug')).dataTable();
+            $('input', oTable.fnGetNodes()).prop('checked', this.checked);
+        });
+    });
+});

--- a/corehq/apps/hqpillow_retry/templates/hqpillow_retry/pillow_errors.html
+++ b/corehq/apps/hqpillow_retry/templates/hqpillow_retry/pillow_errors.html
@@ -3,18 +3,6 @@
 {% load report_tags %}
 {% load i18n %}
 
-{% block js-inline %} {{ block.super }}
-    <script>
-        $(function() {
-            $('#check_all').click( function() {
-                var oTable = $('#report_table_{{ report.slug }}').dataTable();
-                $('input', oTable.fnGetNodes()).prop('checked', this.checked);
-            });
-        });
-    </script>
-{% endblock %}
-
-
 {% block reporttable %}
 {% if not report.needs_filters %}
     <form action="{% url "pillow_errors" %}" method="post">

--- a/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
@@ -7,7 +7,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
     googleAnalytics
 ) {
     var HQReportDataTables = function(options) {
-        var self = this;
+        var self = {};
         self.dataTableElem = options.dataTableElem || '.datatable';
         self.paginationType = options.paginationType || 'bs_normal';
         self.defaultRows = options.defaultRows || 10;
@@ -47,7 +47,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
         self.datatable = null;
         self.rendered = false;
 
-        this.render_footer_row = (function() {
+        self.render_footer_row = (function() {
             var $dataTableElem = $(self.dataTableElem);
             return function(id, row) {
                 if ($dataTableElem.find('tfoot').length === 0) {
@@ -64,7 +64,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
             };
         })();
 
-        this.render = function () {
+        self.render = function () {
             if (self.rendered) {
                 $(self.dataTableElem).each(function () {
                     if ($.fn.dataTable.versionCheck) {
@@ -108,7 +108,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                     params.aaSorting = self.aaSorting || self.customSort;
                 }
 
-                if(self.ajaxSource) {
+                if (self.ajaxSource) {
                     params.bServerSide = true;
                     params.bProcessing = true;
                     params.sAjaxSource = {
@@ -168,7 +168,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                                 if (jqXHR.status === 400) {
                                     $(".dataTables_empty").html(self.badRequestErrorText);
                                 } else {
-                                    $(".dataTables_empty").html(self.errorText);                                
+                                    $(".dataTables_empty").html(self.errorText);
                                 }
                                 $(".dataTables_empty").show();
                                 if (self.errorCallbacks) {
@@ -280,7 +280,9 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                     $(self.dataTableElem).trigger('hqreport.tabular.lengthChange', $(this).val());
                 });
             });
-        };
+        };  // end of self.render
+
+        return self;
     };
 
     $.extend( $.fn.dataTableExt.oStdClasses, {

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -21,6 +21,7 @@
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
     {% include 'reports/partials/filters_js.html' %}
     <script src="{% static 'data_interfaces/js/archive_forms.js' %}"></script>
+    <script src="{% static 'hqpillow_retry/js/pillow_errors.js' %}"></script>
     {% endcompress %}
     {% for script in report.js_scripts %}
         <script src="{{ script|static }}"></script>
@@ -88,6 +89,8 @@
         {% initial_page_data 'startdate' datespan.startdate|date:"Y-m-d" %}
         {% initial_page_data 'enddate' datespan.enddate|date:"Y-m-d" %}
     {% endif %}
+    {% initial_page_data 'slug' report.slug %}
+
     {% block filter_panel %}
         {% include "reports/standard/partials/filter_panel.html" %}
     {% endblock %}


### PR DESCRIPTION
This is just the behavior for a little "select all" checkbox. It could be useful to make these kinds of extra interactions in reports more reusable from both a UI and a code perspective - this could probably share code with bulk archiving forms (https://github.com/dimagi/commcare-hq/pull/20102) - but that's a project for another time.

@jmtroth0 / @calellowitz 