### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,15 +24,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 # -- Custom configuration -----------------------------------------------------
 
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return Mock()
-
 # mock out stubborn modules that are hard to pip install
 # https://docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
 MOCK_MODULES = ["PIL.Image", "PIL"]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)
 
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
No idea why I did this weird subclass thing in the first place, but it seems to work fine with just `MagicMock()` - I guess the interface must've changed a bit, because that subclass breaks the build.