### PR TITLE
make it clearer that new versions of excel work

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -194,7 +194,7 @@ hqDefine('export/js/models', function () {
         } else if (format === constants.EXPORT_FORMATS.XLS) {
             return gettext('Excel (older versions)');
         } else if (format === constants.EXPORT_FORMATS.XLSX) {
-            return gettext('Excel 2007');
+            return gettext('Excel 2007+');
         }
     };
 

--- a/corehq/apps/export/templates/export/customize_export_old.html
+++ b/corehq/apps/export/templates/export/customize_export_old.html
@@ -58,7 +58,7 @@
                 >
                     <select id="format-select" class="form-control" data-bind="value: custom_export.default_format">
                         <option value="csv">{% trans "CSV (Zip file)" %}</option>
-                        <option value="xlsx">{% trans "Excel 2007" %}</option>
+                        <option value="xlsx">{% trans "Excel 2007+" %}</option>
                         <option value="xls">{% trans "Excel (older versions)" %}</option>
                         <option value="html">{% trans "Excel Dashboard Integration" %}</option>
                     </select>


### PR DESCRIPTION
this changes the export format dropdown option from "Excel 2007" to "Excel 2007+"

just something small i noticed that I thought would be a slight improvement. cc @dimagi/product 