### PR TITLE
adding option for load balanced apps

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -4,6 +4,7 @@ import random
 from contextlib import contextmanager
 from six.moves.urllib.parse import urlencode
 
+from django.apps import apps
 from django.conf import settings
 import sqlalchemy
 from sqlalchemy.orm.scoping import scoped_session
@@ -164,6 +165,8 @@ class ConnectionManager(object):
                             self._add_django_db(read_db, read_db)
 
         for app, weights in settings.LOAD_BALANCED_APPS.items():
+            # this tests that the config is real and raises an exception if not
+            apps.get_app_config(app)
             self.read_database_mapping[app] = []
             for db_alias, weighting in weights:
                 assert isinstance(weighting, int), 'weighting must be int'

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -112,7 +112,7 @@ class ConnectionManager(object):
 
     def get_load_balanced_db_alias(self, app_label, default):
         return self.get_load_balanced_read_db(app_label, default)
-        
+
     def close_scoped_sessions(self):
         for helper in self._session_helpers.values():
             helper.Session.remove()

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -155,6 +155,14 @@ class ConnectionManager(object):
                         if read_db != write_db:
                             self._add_django_db(read_db, read_db)
 
+        for app, weights in settings.LOAD_BALANCED_APPS.items():
+            self.read_database_mapping[app] = []
+            for db_alias, weighting in weights:
+                assert isinstance(weighting, int), 'weighting must be int'
+                assert db_alias in settings.DATABASES, db_alias
+
+                self.read_database_mapping[app].extend([db_alias] * weighting)
+
         if DEFAULT_ENGINE_ID not in self.db_connection_map:
             self._add_django_db(DEFAULT_ENGINE_ID, 'default')
         if UCR_ENGINE_ID not in self.db_connection_map:

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -165,7 +165,7 @@ class ConnectionManager(object):
                             self._add_django_db(read_db, read_db)
 
         for app, weights in settings.LOAD_BALANCED_APPS.items():
-            # this tests that the config is real and raises an exception if not
+            # this tests that the app_label is real and raises an exception if not
             apps.get_app_config(app)
             self.read_database_mapping[app] = []
             for db_alias, weighting in weights:

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -99,12 +99,20 @@ class ConnectionManager(object):
         """
         return self._get_or_create_helper(engine_id).engine
 
-    def get_load_balanced_read_engine_id(self, engine_id):
+    def get_load_balanced_read_db(self, engine_id, default=None):
         read_dbs = self.read_database_mapping.get(engine_id, [])
         if read_dbs:
             return random.choice(read_dbs)
+        elif default is not None:
+            return default
         return engine_id
 
+    def get_load_balanced_read_engine_id(self, engine_id):
+        return self.get_load_balanced_read_db(engine_id)
+
+    def get_load_balanced_db_alias(self, app_label, default):
+        return self.get_load_balanced_read_db(app_label, default)
+        
     def close_scoped_sessions(self):
         for helper in self._session_helpers.values():
             helper.Session.remove()

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import random
 from django.conf import settings
 
 from memoized import memoized

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -107,7 +107,6 @@ def db_for_read_write(model, write=True):
             # a tuple is returned with one item, the lag as a timedelta
             lag = cursor.fetchone()[0]
             # lag is None for master node
-            if lag is not None and lag.total_seconds() < settings.STANDBY_LAG
+            if lag is not None and lag.total_seconds() < settings.STANDBY_LAG:
                 return alias
-            return 'default'
         return partition_config.get_main_db()

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import random
-
 from django.conf import settings
 from django.db import connections
-
-from memoized import memoized
 
 from corehq.sql_db.connections import connection_manager, ICDS_UCR_ENGINE_ID, get_icds_ucr_db_alias
 from .config import partition_config
@@ -105,5 +101,13 @@ def db_for_read_write(model, write=True):
         return connection_manager.get_django_db_alias(engine_id)
     else:
         if not write:
-            return connection_manager.get_load_balanced_read_engine_id(app_label)
+            alias = connection_manager.get_load_balanced_read_engine_id(app_label)
+            cursor = connections[alias].cursor()
+            cursor.execute('SELECT now() - pg_last_xact_replay_timestamp() AS replication_delay;')
+            # a tuple is returned with one item, the lag as a timedelta
+            lag = cursor.fetchone()[0]
+            # lag is None for master node
+            if lag is not None and lag.total_seconds() < settings.STANDBY_LAG
+                return alias
+            return 'default'
         return partition_config.get_main_db()

--- a/settings.py
+++ b/settings.py
@@ -877,6 +877,8 @@ DATADOG_APP_KEY = None
 SYNCLOGS_SQL_DB_ALIAS = 'default'
 WAREHOUSE_DATABASE_ALIAS = 'default'
 
+LOAD_BALANCED_APPS = {}
+
 # Override with the PEM export of an RSA private key, for use with any
 # encryption or signing workflows.
 HQ_PRIVATE_KEY = None

--- a/settings.py
+++ b/settings.py
@@ -880,10 +880,10 @@ WAREHOUSE_DATABASE_ALIAS = 'default'
 # A dict of django apps in which the reads are
 # split betweeen the primary and standby db machines
 # Example format:
-# { 
-# "users": 
+# {
+# "users":
 #     {
-#      ["pgmain", 5], 
+#      ["pgmain", 5],
 #      [pgmainstandby", 5]
 #     }
 # }

--- a/settings.py
+++ b/settings.py
@@ -884,7 +884,7 @@ WAREHOUSE_DATABASE_ALIAS = 'default'
 # "users":
 #     {
 #      ["pgmain", 5],
-#      [pgmainstandby", 5]
+#      ["pgmainstandby", 5]
 #     }
 # }
 LOAD_BALANCED_APPS = {}

--- a/settings.py
+++ b/settings.py
@@ -879,6 +879,8 @@ WAREHOUSE_DATABASE_ALIAS = 'default'
 
 LOAD_BALANCED_APPS = {}
 
+STANDBY_LAG = 60
+
 # Override with the PEM export of an RSA private key, for use with any
 # encryption or signing workflows.
 HQ_PRIVATE_KEY = None

--- a/settings.py
+++ b/settings.py
@@ -877,8 +877,10 @@ DATADOG_APP_KEY = None
 SYNCLOGS_SQL_DB_ALIAS = 'default'
 WAREHOUSE_DATABASE_ALIAS = 'default'
 
+
 LOAD_BALANCED_APPS = {}
 
+# Maximum seconds of standby lag before we stop reading from it
 STANDBY_LAG = 60
 
 # Override with the PEM export of an RSA private key, for use with any

--- a/settings.py
+++ b/settings.py
@@ -877,11 +877,17 @@ DATADOG_APP_KEY = None
 SYNCLOGS_SQL_DB_ALIAS = 'default'
 WAREHOUSE_DATABASE_ALIAS = 'default'
 
-
+# A dict of django apps in which the reads are
+# split betweeen the primary and standby db machines
+# Example format:
+# { 
+# "users": 
+#     {
+#      ["pgmain", 5], 
+#      [pgmainstandby", 5]
+#     }
+# }
 LOAD_BALANCED_APPS = {}
-
-# Maximum seconds of standby lag before we stop reading from it
-STANDBY_LAG = 60
 
 # Override with the PEM export of an RSA private key, for use with any
 # encryption or signing workflows.


### PR DESCRIPTION
@snopoke 
How does this look for the hq setup of load balanced read in main db apps?
`LOAD_BALANCED_APPS` would be a dict with form
```
{ 
"users": 
    {
     "pgmain": 5, 
     "pgmainstandby": 5
    }
}
```
The acceptable delay value for each db can be added to this dict when that is implemented