### PR TITLE
support settings.GREENHOUSE_API_KEY as unicode or bytestring

### DIFF
--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import hashlib
 import hmac
 import json
+import six
 
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -32,7 +33,11 @@ class GreenhouseCandidateView(View):
         return super(GreenhouseCandidateView, self).dispatch(request=request, args=args, kwargs=kwargs)
 
     def post(self, request, *args, **kwargs):
-        digester = hmac.new(settings.GREENHOUSE_API_KEY, request.body, hashlib.sha256)
+        digester = hmac.new(
+            settings.GREENHOUSE_API_KEY.encode('utf-8')
+            if isinstance(settings.GREENHOUSE_API_KEY, six.text_type) else settings.GREENHOUSE_API_KEY,
+            request.body, hashlib.sha256
+        )
         calculated_signature = digester.hexdigest()
 
         signature_header = request.META.get('HTTP_SIGNATURE', '').split()


### PR DESCRIPTION
First argument to ```hmac.new``` must be a bytestring.

@dimagi/py3 