### PR TITLE
All case properties in importer

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -187,6 +187,10 @@ def get_all_case_properties(app):
     return get_case_properties(app, app.get_case_types(), defaults=('name',))
 
 
+def get_all_case_properties_for_case_type(domain, case_type):
+    return all_case_properties_by_domain(domain, [case_type]).get(case_type, [])
+
+
 def get_usercase_properties(app):
     if is_usercase_in_use(app.domain):
         # TODO: add name here once it is fixed to concatenate first and last in form builder

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.utils.translation import ugettext as _
 import itertools
-from corehq.apps.case_importer.util import get_case_properties_for_case_type, \
-    RESERVED_FIELDS
+from corehq.apps.case_importer.util import RESERVED_FIELDS
+from corehq.apps.app_manager.app_schemas.case_properties import get_all_case_properties_for_case_type
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 from dimagi.ext import jsonobject
 
@@ -32,7 +32,7 @@ def get_suggested_case_fields(domain, case_type, exclude=None):
     special_field_specs = (field_spec for field_spec in get_special_fields(domain))
 
     dynamic_field_specs = (FieldSpec(field=field, show_in_menu=True)
-                           for field in get_case_properties_for_case_type(domain, case_type))
+                           for field in get_all_case_properties_for_case_type(domain, case_type))
 
     return _combine_field_specs(
         itertools.chain(special_field_specs, dynamic_field_specs),

--- a/corehq/apps/case_importer/tests/test_importer_util.py
+++ b/corehq/apps/case_importer/tests/test_importer_util.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from django.test import SimpleTestCase, override_settings
-import mock
-from corehq.apps.case_importer.util import is_valid_owner, \
-    get_case_properties_for_case_type
-from corehq.apps.export.models import CaseExportDataSchema, ExportGroupSchema, \
-    MAIN_TABLE, ExportItem, PathNode
+from django.test import SimpleTestCase
+from corehq.apps.case_importer.util import is_valid_owner
 from corehq.apps.users.models import CommCareUser, DomainMembership, WebUser
 
 
@@ -23,36 +19,6 @@ class ImporterUtilsTest(SimpleTestCase):
 
     def test_web_user_owner_nomatch(self):
         self.assertFalse(is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'nomatch'))
-
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
-    def test_get_case_properties_for_case_type(self):
-        schema = CaseExportDataSchema(
-            group_schemas=[
-                ExportGroupSchema(
-                    path=MAIN_TABLE,
-                    items=[
-                        ExportItem(
-                            path=[PathNode(name='name')],
-                            label='name',
-                            last_occurrences={},
-                        ),
-                        ExportItem(
-                            path=[PathNode(name='color')],
-                            label='color',
-                            last_occurrences={},
-                        ),
-                    ],
-                    last_occurrences={},
-                ),
-            ],
-        )
-
-        with mock.patch(
-                'corehq.apps.export.models.new.CaseExportDataSchema.generate_schema_from_builds',
-                return_value=schema):
-            case_types = get_case_properties_for_case_type('test-domain', 'case-type')
-
-        self.assertEqual(sorted(case_types), ['color', 'name'])
 
 
 def _mk_user(domain):

--- a/corehq/apps/case_importer/tests/test_suggested_fields.py
+++ b/corehq/apps/case_importer/tests/test_suggested_fields.py
@@ -8,7 +8,7 @@ from corehq.util.test_utils import DocTestMixin
 
 
 class SuggestedFieldTest(SimpleTestCase, DocTestMixin):
-    @mock.patch('corehq.apps.case_importer.suggested_fields.get_case_properties_for_case_type')
+    @mock.patch('corehq.apps.case_importer.suggested_fields.get_all_case_properties_for_case_type')
     @mock.patch('corehq.apps.case_importer.suggested_fields.get_special_fields')
     def _test(self, get_special_fields, get_case_properties_for_case_type,
               special_fields, case_properties, excluded_fields, expected_result):

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -410,20 +410,6 @@ def get_id_from_name(name, domain, cache):
     return id
 
 
-def get_case_properties_for_case_type(domain, case_type):
-    schema = CaseExportDataSchema.generate_schema_from_builds(
-        domain,
-        None,
-        case_type,
-    )
-    group_schemas = [gs for gs in schema.group_schemas if gs.path == MAIN_TABLE]
-    case_properties = set([item.path[0].name for item in group_schemas[0].items]) if group_schemas else set()
-    if not should_use_sql_backend(domain):
-        from corehq.apps.hqcase.dbaccessors import get_case_properties
-        case_properties |= set(get_case_properties(domain, case_type))
-    return sorted(case_properties)
-
-
 def get_importer_error_message(e):
     if isinstance(e, ImporterRefError):
         # I'm not totally sure this is the right error, but it's what was being

--- a/corehq/apps/zapier/api/v0_5.py
+++ b/corehq/apps/zapier/api/v0_5.py
@@ -6,7 +6,7 @@ from tastypie.exceptions import NotFound
 from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.resources.v0_4 import XFormInstanceResource, BaseApplicationResource
 from corehq.apps.api.resources.v0_5 import DoesNothingPaginator
-from corehq.apps.case_importer.util import get_case_properties_for_case_type
+from corehq.apps.app_manager.app_schemas.case_properties import get_all_case_properties_for_case_type
 from corehq.apps.export.system_properties import MAIN_FORM_TABLE_PROPERTIES
 from corehq.apps.zapier.util import remove_advanced_fields
 from corehq.apps.app_manager.models import Application
@@ -147,6 +147,7 @@ CASE_PROPERTIES = {
     "properties__owner_id": "Owner ID",
     "properties__date_opened": "Date opened",
     "properties__external_id": "External ID",
+    "properties__type": "Type",
 }
 
 
@@ -164,7 +165,8 @@ class ZapierCustomFieldCaseResource(BaseZapierCustomFieldResource):
         if not domain or not case_type:
             return []
 
-        for prop in get_case_properties_for_case_type(domain, case_type):
+        props = get_all_case_properties_for_case_type(domain, case_type)
+        for prop in props:
             custom_fields.append(CustomField(
                 dict(
                     type='unicode',
@@ -219,7 +221,7 @@ class ZapierCustomActionFieldCaseResource(BaseZapierCustomFieldResource):
                 )
             ))
 
-        for prop in get_case_properties_for_case_type(domain, case_type):
+        for prop in get_all_case_properties_for_case_type(domain, case_type):
             custom_fields.append(CustomField(
                 dict(
                     type='unicode',

--- a/corehq/apps/zapier/tests/test_fields.py
+++ b/corehq/apps/zapier/tests/test_fields.py
@@ -4,10 +4,9 @@ from django.test.testcases import TestCase, SimpleTestCase
 from django.test.client import Client
 from tastypie.resources import Resource
 
-from casexml.apps.case.mock import CaseFactory
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.zapier.api.v0_5 import ZapierCustomFieldCaseResource
 from corehq.apps.zapier.util import remove_advanced_fields
-from six.moves import range
 
 
 class TestRemoveAdvancedFields(SimpleTestCase):
@@ -120,6 +119,16 @@ class TestZapierCustomFields(TestCase):
         super(TestZapierCustomFields, cls).setUpClass()
         cls.test_url = "http://commcarehq.org/?domain=joto&case_type=teddiursa"
 
+    def setUp(self):
+        self.domain = "joto"
+        self.case_type = 'teddiursa'
+        app_factory = AppFactory(self.domain)
+        m, f = app_factory.new_basic_module('m', self.case_type)
+        app_factory.form_requires_case(f, case_type=self.case_type, update={
+            'prop1': '/data/prop1', 'move_type': '/data/move_type', 'mood': '/data/mood', 'level': '/data/level'
+        })
+        app_factory.app.save()
+
     def test_case_fields(self):
 
         expected_fields = [
@@ -127,8 +136,6 @@ class TestZapierCustomFields(TestCase):
             {"help_text": "", "key": "properties__mood", "label": "Mood", "type": "unicode"},
             {"help_text": "", "key": "properties__move_type", "label": "Move type", "type": "unicode"},
             {"help_text": "", "key": "properties__name", "label": "Name", "type": "unicode"},
-            {"help_text": "", "key": "properties__opened_on", "label": "Opened on", "type": "unicode"},
-            {"help_text": "", "key": "properties__owner_id", "label": "Owner id", "type": "unicode"},
             {"help_text": "", "key": "properties__prop1", "label": "Prop1", "type": "unicode"},
             {"help_text": "", "key": "properties__type", "label": "Type", "type": "unicode"},
             {"help_text": "", "key": "date_closed", "label": "Date closed", "type": "unicode"},
@@ -147,14 +154,5 @@ class TestZapierCustomFields(TestCase):
         request = Client().get(self.test_url).wsgi_request
         bundle = Resource().build_bundle(data={}, request=request)
 
-        factory = CaseFactory(domain="joto")
-        factory.create_case(
-            case_type='teddiursa',
-            owner_id='owner1',
-            case_name='dre',
-            update={'prop1': 'blah', 'move_type': 'scratch', 'mood': 'happy', 'level': '100'}
-        )
-
-        actual_fields = ZapierCustomFieldCaseResource().obj_get_list(bundle)
-        for i in range(len(actual_fields)):
-            self.assertEqual(expected_fields[i], actual_fields[i].get_content())
+        actual_fields = [field.get_content() for field in ZapierCustomFieldCaseResource().obj_get_list(bundle)]
+        self.assertItemsEqual(expected_fields, actual_fields)


### PR DESCRIPTION
This came up here: https://github.com/dimagi/commcare-hq/pull/20179

Looks like we have a bunch of ways of getting all case properties... The case importer was doing this using a different method than other parts of the code, so I removed that util to avoid confusion.

