### PR TITLE
Corrects toggle bug and fixes mobile ab test

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -25,6 +25,9 @@
 
 {% block app_view_tabs %}
   {% analytics_ab_test 'kissmetrics.release_manager_ab' ab_test %}
+  {% if mobile_experience_ab_test %}
+  {% analytics_ab_test 'kissmetrics.mobile_signups_test_march2018test' mobile_experience_ab_test %}
+  {% endif %}
   {% initial_page_data 'app_id' app.id %}
   {% initial_page_data 'app_version' app.version %}
   {% initial_page_data 'application_profile_url' application_profile_url %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -85,7 +85,7 @@
 {% include 'app_manager/partials/download_async_modal.html' with element_id='download-zip-modal' %}
 
 
- {% if request|toggle_enabled:"MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER" and request|toggle_enabled:"MOBILE_SIGNUP_REDIRECT_AB_TEST" %}
+ {% if is_mobile_experience %}
     <div class="full-screen-no-background-modal modal fade" id="mobile-experience-modal">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -128,6 +128,20 @@ def get_releases_context(request, domain, app_id):
     build_profile_access = domain_has_privilege(domain, privileges.BUILD_PROFILES)
     prompt_settings_form = PromptUpdateSettingsForm.from_app(app, request_user=request.couch_user)
 
+    is_in_mobile_experiment = toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.enabled(
+        request.couch_user.username
+    )
+    is_mobile_ab = toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
+        request.couch_user.username, toggles.NAMESPACE_USER
+    )
+    if is_in_mobile_experiment:
+        context.update({
+            'mobile_experience_ab_test': {
+                'name': 'mobile_signups_test_march2018test',
+                'version': 'variation' if is_mobile_ab else 'control',
+            },
+        })
+
     context.update({
         'release_manager': True,
         'can_send_sms': can_send_sms,
@@ -145,12 +159,7 @@ def get_releases_context(request, domain, app_id):
         'prompt_settings_url': reverse(PromptSettingsUpdateView.urlname, args=[domain, app_id]),
         'prompt_settings_form': prompt_settings_form,
         'full_name': request.couch_user.full_name,
-        'is_mobile_experience': (
-            toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.enabled(
-                request.couch_user.username, toggles.NAMESPACE_USER) and
-            toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
-                request.couch_user.username, toggles.NAMESPACE_USER)
-        )
+        'is_mobile_experience': (is_in_mobile_experiment and is_mobile_ab),
     })
     if not app.is_remote_app():
         context.update({

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/mobile_experience_warning.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/mobile_experience_warning.js
@@ -1,15 +1,17 @@
 hqDefine('hqwebapp/js/mobile_experience_warning', function() {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
-        cookieName = "has-seen-mobile-experience-warning";
+    $(function() {
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
+            cookieName = "has-seen-mobile-experience-warning";
 
-    if (initialPageData("is_mobile_experience") && !$.cookie(cookieName)) {
-        $(function() {
+        if (initialPageData("is_mobile_experience") && !$.cookie(cookieName)) {
             var toggles = hqImport('hqwebapp/js/toggles');
             if (!toggles.toggleEnabled('MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER') ||
                     !toggles.toggleEnabled('MOBILE_SIGNUP_REDIRECT_AB_TEST')) {
                 return;
             }
             $.cookie(cookieName, true);
+
+            $('.full-screen-no-background-modal').css('width', $(window).innerWidth() + 'px');
 
             var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
                 url = initialPageData.reverse('send_mobile_reminder'),
@@ -31,7 +33,7 @@ hqDefine('hqwebapp/js/mobile_experience_warning', function() {
             $("#send-mobile-reminder-button").click(sendReminder);
             $modal.modal();
             kissmetrix.track.event('Saw mobile experience warning');
-        });
-    }
+        }
+    });
 
 });

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -129,7 +129,7 @@
               <i class="fcc fcc-flower fa-spin"></i>
             </p>
           </div>
-          {% crispy reg_form   %}
+          {% crispy reg_form %}
           <div class="form-step final-step" style="display: none;">
 
             {% include "registration/partials/register_new_user/submit_info.html" %}

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -158,7 +158,7 @@ def send_domain_registration_email(recipient, domain_name, guid, full_name):
         'url_prefix': '' if settings.STATIC_CDN else 'http://' + DNS_name,
         "is_mobile_experience": (
             toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.enabled(
-                recipient, toggles.NAMESPACE_USER) and
+                recipient) and
             toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
                 recipient, toggles.NAMESPACE_USER)
         ),

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -131,6 +131,7 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
         if self.request.user_agent.is_mobile:
             toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.set(email, True)
 
+        track_workflow(email, "Requested new account")
         login(self.request, new_user)
 
     @allow_remote_invocation

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -127,20 +127,10 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
             web_user.save()
 
         email = new_user.email
-        properties = {}
 
         if self.request.user_agent.is_mobile:
-            toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.set(
-                email, True, toggles.NAMESPACE_USER
-            )
-            variation = toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
-                email, toggles.NAMESPACE_USER
-            )
-            properties = {
-                "mobile_signups_test_march2018test": "variation" if variation else "control"
-            }
+            toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.set(email, True)
 
-        track_workflow(email, "Requested new account", properties)
         login(self.request, new_user)
 
     @allow_remote_invocation
@@ -185,7 +175,7 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
                 'success': True,
                 'is_mobile_experience': (
                     toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.enabled(
-                        username, toggles.NAMESPACE_USER) and
+                        username) and
                     toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST.enabled(
                         username, toggles.NAMESPACE_USER)
                 ),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -125,6 +125,9 @@ class StaticToggle(object):
         )
 
     def set(self, item, enabled, namespace=None):
+        if namespace == NAMESPACE_USER:
+            namespace = None  # because:
+            #     __init__() ... self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
         set_toggle(self.slug, item, enabled, namespace)
 
     def required_decorator(self):


### PR DESCRIPTION
@jmtroth0 @orangejenny cc @millerdev @esoergel 

apparently when a `StaticToggle` is set specifying the user namespace, `user:` is prepended to the string, but when it's fetch (due to legacy reasons) users never have `user:` prepended to the string, so if the user namespace is specified it's set to `None`, thereby creating an inconsistency with `enabled` and `set` on a `StaticToggle`.

Also fixes the mobile ab test js popup and sends the ab test info thru javascript, as that's how ab tests have been sent in the past, we know it works, and i want to avoid another PR to update this one.