### PR TITLE
Don't put css_id in quotes

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter.html
+++ b/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter.html
@@ -5,7 +5,7 @@
            class="form-control report-filter-datespan-filter"
            id="{{ filter.css_id }}-input"
            name="{{ filter.css_id }}"
-           data-css-id='{{ filter.css_id|JSON }}'/>
+           data-css-id='{{ filter.css_id }}'/>
     <input type="hidden" id="{{ filter.css_id }}-start" name="{{ filter.css_id }}-start" />
     <input type="hidden" id="{{ filter.css_id }}-end" name="{{ filter.css_id }}-end" />
 {% endblock %}


### PR DESCRIPTION
Context: [FB 274345](https://manage.dimagi.com/default.asp?274345)

The `JSON` filter was wrapping `css_id` in quotation marks, e.g. 

```html
    <input type="text"
           class="form-control report-filter-datespan-filter"
           id="timeEnd_09f40526_0-input"
           name="timeEnd_09f40526_0"
           data-css-id='"timeEnd_09f40526_0"'/>
```

So that when it [got used here][1], it produced an invalid element ID.

buddy @gcapalbo cc @jmtroth0 and co-interruptee @dannyroberts 

  [1]: https://github.com/dimagi/commcare-hq/blob/d6e2fe07b6d30486b091fba20907967f0ad778b8/corehq/apps/reports/static/reports/js/filters/main.js#L56
