### PR TITLE
is_superuser -> support toggle

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -341,7 +341,7 @@
                         </div>
                     </div>
                 {% endif %}
-                {% if request.user.is_superuser %}
+                {% if request|toggle_enabled:"SUPPORT" %}
                     <div class="panel panel-appmanager">
                         <div class="panel-heading">
                             <h4 class="panel-title">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_table.html
@@ -97,7 +97,7 @@
                 'error': build_broken
             }">
           <div class="panel-heading">
-              {% if request.user.is_superuser %}
+              {% if request|toggle_enabled:"SUPPORT" %}
                   <div class="release-trash-container">
                     <a href="#"
                        class="hide release-remove"

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -170,7 +170,7 @@ requires proptable.css to be included in the main template
         <br/>
         <ul class="list-inline">
             {% if instance.app_id %}<li><a href="{% url "view_app" domain instance.app_id %}">{% trans "View app" %}</a></li>{% endif %}
-            {% if request.user.is_superuser %}
+            {% if request|toggle_enabled:"SUPPORT" %}
                 {% if instance.build_id %}
                     <li><a href="{% url "download_index" domain instance.build_id %}">{% trans "View build" %}</a></li>
                 {% endif %}


### PR DESCRIPTION
Followup from https://github.com/dimagi/commcare-hq/pull/19998

Product note: This will require dimagi staff to turn on the "Support" toggle in order to see:

- Delete builds
- View Form source on form page
- View Source Files from "publish" modal on releases page