### PR TITLE
Revert "allow any CommCare version for testing target version"

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -173,6 +173,7 @@
   values: ['none', 'commcare', 'commcare_lts']
   value_names: ['None', 'CommCare', 'CommCare LTS']
   default: 'none'
+  since: '2.43'
 
 - id: mobile_ucr_restore_version
   name: Mobile UCR Restore Version


### PR DESCRIPTION
Reverts dimagi/commcare-hq#20239

To be merged after 2.43 is released