### PR TITLE
Don't use background queue for scheduled reports on prod

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -70,9 +70,14 @@ def send_delayed_report(report_id):
     """
     Sends a scheduled report, via celery background task.
     """
-    if settings.SERVER_ENVIRONMENT == 'production' and ReportNotification.get(report_id).domain == 'ews-ghana':
-        # this is used because ews-ghana was spamming the queue:
+    if settings.SERVER_ENVIRONMENT == 'production':
+        # This is to prevent scheduled reports from clogging up the
+        # background queue.
         # https://manage.dimagi.com/default.asp?270029#BugEvent.1457969
+
+        # If this becomes a problem in other environments we should
+        # drop this `if` clause and use `send_report_throttled.delay()`
+        # always.
         send_report_throttled.delay(report_id)
     else:
         send_report.delay(report_id)

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import re
 from datetime import datetime, timedelta
 from dateutil.parser import parse
 import hashlib
@@ -64,20 +66,26 @@ from six.moves import filter
 
 logging = get_task_logger(__name__)
 EXPIRE_TIME = 60 * 60 * 24
+THROTTLED_DOMAINS_PATTERNS = (
+    # Regex patterns matching domains whose scheduled reports use a
+    # separate queue so that they don't hold up the background queue.
+    'ews-ghana$',
+    'mvp-',
+)
 
 
 def send_delayed_report(report_id):
     """
     Sends a scheduled report, via celery background task.
     """
-    if settings.SERVER_ENVIRONMENT == 'production':
-        # This is to prevent scheduled reports from clogging up the
-        # background queue.
+    domain = ReportNotification.get(report_id).domain
+    if (
+        settings.SERVER_ENVIRONMENT == 'production' and
+        any(re.match(pattern, domain) for pattern in THROTTLED_DOMAINS_PATTERNS)
+    ):
+        # This is to prevent a few scheduled reports from clogging up
+        # the background queue.
         # https://manage.dimagi.com/default.asp?270029#BugEvent.1457969
-
-        # If this becomes a problem in other environments we should
-        # drop this `if` clause and use `send_report_throttled.delay()`
-        # always.
         send_report_throttled.delay(report_id)
     else:
         send_report.delay(report_id)


### PR DESCRIPTION
This is meant to address an issue where a bunch of related project spaces held up the background queue with scheduled reports.

@nickpell is this a reasonable solution for *all* scheduled reports on prod? The queue's concurrency is set to 2 at the moment. That seems OK, right?

@gcapalbo 
