### PR TITLE
add FormSubmissionBuilder for programattically generating more complex submissions

### DIFF
--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -16,7 +16,7 @@ from corehq.apps.reports.formdetails.readable import (
     get_readable_form_data,
     get_readable_data_for_submission)
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
-from corehq.form_processor.utils.xform import get_simple_form_xml, FormSubmissionBuilder
+from corehq.form_processor.utils.xform import FormSubmissionBuilder
 
 
 class ReadableFormdataTest(SimpleTestCase):

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -16,7 +16,7 @@ from corehq.apps.reports.formdetails.readable import (
     get_readable_form_data,
     get_readable_data_for_submission)
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
-from corehq.form_processor.utils.xform import get_simple_form_xml
+from corehq.form_processor.utils.xform import get_simple_form_xml, FormSubmissionBuilder
 
 
 class ReadableFormdataTest(SimpleTestCase):
@@ -293,7 +293,10 @@ class ReadableFormTest(TestCase):
         super(ReadableFormTest, self).tearDown()
 
     def test_get_readable_data_for_submission(self):
-        formxml = get_simple_form_xml('123')
+        formxml = FormSubmissionBuilder(
+            form_id='123',
+            form_properties={'dalmation_count': 'yes'}
+        ).as_xml_string()
 
         xform = submit_form_locally(formxml, self.domain).xform
         actual, _ = get_readable_data_for_submission(xform)

--- a/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
+++ b/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
@@ -16,7 +16,6 @@ DOMAIN = 'test-form-accessor'
 GDPR_SIMPLE_FORM = """<?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="{form_name}" xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
     xmlns="{xmlns}">
-    <dalmation_count>yes</dalmation_count>
     <n0:meta xmlns:n0="http://openrosa.org/jr/xforms">
         <n0:deviceID>{device_id}</n0:deviceID>
         <n0:timeStart>{time_start}</n0:timeStart>
@@ -31,7 +30,6 @@ GDPR_SIMPLE_FORM = """<?xml version='1.0' ?>
 EXPECTED_FORM_XML = """<?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="New Form" xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
     xmlns="http://openrosa.org/formdesigner/form-processor">
-    <dalmation_count>yes</dalmation_count>
     <n0:meta xmlns:n0="http://openrosa.org/jr/xforms">
         <n0:deviceID>DEV IL</n0:deviceID>
         <n0:timeStart>2013-04-19T16:53:02.000000Z</n0:timeStart>

--- a/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
+++ b/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
@@ -16,6 +16,7 @@ DOMAIN = 'test-form-accessor'
 GDPR_SIMPLE_FORM = """<?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="{form_name}" xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
     xmlns="{xmlns}">
+    {form_properties}
     <n0:meta xmlns:n0="http://openrosa.org/jr/xforms">
         <n0:deviceID>{device_id}</n0:deviceID>
         <n0:timeStart>{time_start}</n0:timeStart>

--- a/corehq/form_processor/tests/test_utils.py
+++ b/corehq/form_processor/tests/test_utils.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from collections import OrderedDict
+
+from django.test import SimpleTestCase
+
+from corehq.form_processor.utils.xform import build_form_xml_from_property_dict
+
+
+class FormSubmissionBuilderTest(SimpleTestCase):
+
+    def test_property_dict_to_xml_empty(self):
+        self.assertEqual('', build_form_xml_from_property_dict({}))
+
+    def test_property_dict_to_xml_single_item(self):
+        self.assertEqual(
+            '<my-property>some value</my-property>',
+            build_form_xml_from_property_dict({'my-property': 'some value'})
+        )
+
+    def test_property_dict_to_xml_multiple_item(self):
+        props = OrderedDict()
+        props['p1'] = 'v1'
+        props['p2'] = 'v2'
+        self.assertEqual(
+            '<p1>v1</p1><p2>v2</p2>',
+            build_form_xml_from_property_dict(props)
+        )
+
+    def test_invalid_tag(self):
+        with self.assertRaises(ValueError):
+            build_form_xml_from_property_dict({'no spaces': 'are allowed'})

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime
+from lxml import etree
 
 import iso8601
 import pytz
@@ -64,6 +65,16 @@ class FormSubmissionBuilder(object):
         if not self.metadata.user_id:
             form_xml = form_xml.replace('<n1:userID>{}</n1:userID>'.format(self.metadata.user_id), '')
         return form_xml
+
+
+def build_form_xml_from_property_dict(form_properties, separator=''):
+    elements = []
+    for key, value in form_properties.items():
+        prop = etree.Element(key)
+        prop.text = value
+        elements.append(prop)
+
+    return separator.join(etree.tostring(e) for e in elements)
 
 
 def get_simple_form_xml(form_id, case_id=None, metadata=None, simple_form=SIMPLE_FORM):

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -78,7 +78,7 @@ def get_simple_form_xml(form_id, case_id=None, metadata=None, simple_form=SIMPLE
     ).as_xml_string()
 
 
-def get_simple_wrapped_form(form_id, case_id=None, metadata=None, save=True, simple_form=SIMPLE_FORM):
+def get_simple_wrapped_form(form_id, metadata=None, save=True, simple_form=SIMPLE_FORM):
     from corehq.form_processor.interfaces.processor import FormProcessorInterface
 
     metadata = metadata or TestFormMetadata()

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -18,7 +18,7 @@ from dimagi.utils.parsing import json_format_datetime
 SIMPLE_FORM = """<?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="{form_name}" xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
     xmlns="{xmlns}">
-    <dalmation_count>yes</dalmation_count>
+    {form_properties}
     <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
         <n1:deviceID>{device_id}</n1:deviceID>
         <n1:timeStart>{time_start}</n1:timeStart>
@@ -51,16 +51,19 @@ class FormSubmissionBuilder(object):
     Utility/helper object for building a form submission
     """
 
-    def __init__(self, form_id, metadata=None, case_blocks=None, form_template=SIMPLE_FORM):
+    def __init__(self, form_id, metadata=None, case_blocks=None, form_properties=None, form_template=SIMPLE_FORM):
         self.form_id = form_id
         self.metadata = metadata or TestFormMetadata()
         self.case_blocks = case_blocks or []
         self.form_template = form_template
+        self.form_properties = form_properties or {}
 
     def as_xml_string(self):
         case_block_xml = ''.join(cb.as_string() for cb in self.case_blocks)
+        form_properties_xml = build_form_xml_from_property_dict(self.form_properties)
         form_xml = self.form_template.format(
-            uuid=self.form_id, case_block=case_block_xml, **self.metadata.to_json()
+            uuid=self.form_id, form_properties=form_properties_xml, case_block=case_block_xml,
+            **self.metadata.to_json()
         )
         if not self.metadata.user_id:
             form_xml = form_xml.replace('<n1:userID>{}</n1:userID>'.format(self.metadata.user_id), '')


### PR DESCRIPTION
Inspired by the newly discovered (to me) `XFormBuilder` I took a crack at making a utility to make creating more complex form submissions (primarily for tests) slightly easier.

It's currently rather limited - in that it only allows you to specify a single-level dict of property/value pairs (and also adds multi-case-block support). May extend it in the future if people think it's useful and I need additional features.

Our entire mock submission pipeline is built on likely unsafe string formatting operations, so I wasn't too bothered about releasing something minimal/somewhat hacky to start.

Review anyway you like, wait for tests