### PR TITLE
fix key error

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2035,7 +2035,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 'commcare_location_ids': user_location_data(location_ids)
             })
         else:
-            self.user_data.pop('commcare_location_ids')
+            if 'commcare_location_ids' in self.user_data:
+                self.user_data.pop('commcare_location_ids')
 
         # try to set primary-location if not set already
         if not self.location_id and location_ids:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2035,8 +2035,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 'commcare_location_ids': user_location_data(location_ids)
             })
         else:
-            if 'commcare_location_ids' in self.user_data:
-                self.user_data.pop('commcare_location_ids')
+            self.user_data.pop('commcare_location_ids', None)
 
         # try to set primary-location if not set already
         if not self.location_id and location_ids:


### PR DESCRIPTION
[Celery Task](http://hqcelery1.internal-va.commcarehq.org:5555/task/8371c534-834b-4ecd-b381-05d07c798e1c)

```
Traceback (most recent call last):
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/cchq/www/production/releases/2018-04-13_19.41/corehq/apps/users/tasks.py", line 42, in bulk_upload_async
    task=task,
  File "/home/cchq/www/production/releases/2018-04-13_19.41/corehq/apps/users/bulkupload.py", line 538, in create_or_update_users_and_groups
    user.reset_locations(location_ids)
  File "/home/cchq/www/production/releases/2018-04-13_19.41/corehq/apps/users/models.py", line 2038, in reset_locations
    self.user_data.pop('commcare_location_ids')
  File "jsonobject/utils.pyx", line 40, in jsonobject.jsonobject.utils.SimpleDict.pop
KeyError: u'commcare_location_ids'
```