### PR TITLE
Use bytestrings for import names

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -34,17 +34,17 @@ TEST_NON_SERIALIZED_APPS = ['corehq.form_processor']
 SHELL_PLUS_POST_IMPORTS = (
     # Models
     ('datetime'),
-    ('corehq.apps.app_manager.models', 'Application'),
-    ('corehq.apps.domain.models', 'Domain'),
-    ('corehq.apps.groups.models', 'Group'),
-    ('corehq.apps.users.models', ('CouchUser', 'WebUser', 'CommCareUser')),
-    ('casexml.apps.case.models', 'CommCareCase'),
-    ('corehq.form_processor.interfaces.dbaccessors', 'CaseAccessors'),
-    ('couchforms.models', 'XFormInstance'),
+    ('corehq.apps.app_manager.models', b'Application'),
+    ('corehq.apps.domain.models', b'Domain'),
+    ('corehq.apps.groups.models', b'Group'),
+    ('corehq.apps.users.models', (b'CouchUser', b'WebUser', b'CommCareUser')),
+    ('casexml.apps.case.models', b'CommCareCase'),
+    ('corehq.form_processor.interfaces.dbaccessors', (b'CaseAccessors', b'FormAccessors')),
+    ('couchforms.models', b'XFormInstance'),
 
     # Data querying utils
-    ('dimagi.utils.couch.database', 'get_db'),
-    ('corehq.apps.es', '*'),
+    ('dimagi.utils.couch.database', b'get_db'),
+    ('corehq.apps', b'es'),
 )
 
 INTERNAL_IPS = ['127.0.0.1']


### PR DESCRIPTION
I was getting 
```
TypeError: Item in ``from list'' must be str, not unicode
```
when opening shell_plus.

Also took the opportunity to remove the `*` import that was polluting the namespace. Access es stuff in the shell with `es.CasesES` from now on.

