### PR TITLE
Simplify logic and flow of ParentCasePropertyBuilder

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -185,6 +185,24 @@ def _propagate_and_normalize_case_properties(case_properties_by_case_type, paren
     and return something in the same format but with all parent refs propagated
     up (and if `include_parent_properties`, down) the chain
 
+    A note about *implementation*. The approach used here is to first receive all possible
+    case properties from all sources, but with inconsistent parent/<property> strewn about.
+    (For example child may have parent/<foo> but parent does not have <foo>.)
+    Then (in this method), the mapping of case types to property sets is flattened
+    to a single set of `_CasePropertyRef`s, which represents each property
+    (conceptually "parent/<property> relative to <case_type>")
+    as a pair of
+      - _CaseTypeRef ('parent' [or parent/parent, etc.] relative to <case_type>)
+      - case property (the string)
+    Finally, this set is copied over to a new set, but with each case_type_ref of each
+    case_property_ref replaced with its most cononical form
+    (or forms in the rare case that a case_type_ref resolves to more than one case_type,
+    i.e. a child case has more than one case type that can be its parent).
+    Additionally, if include_parent_properties is True, each cononical form is then splatted
+    out into all of the other forms it can take: (child, 'parent/parent', property) becomes
+    (parent, 'parent', property) and (grandparent, '', property) as well. (Note I'm using
+    conceptual notation here, whereas in the code each of these is a `_CasePropertyRef`.)
+
     :param case_properties_by_case_type: {case_type: set(case_property)} mapping,
            where case_property is a string of the form "(parent/)*<case_property>"
     :param parent_type_map: {case_type: {relationship: [parent_type]}}

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -27,7 +27,7 @@ class ParentCasePropertyBuilder(object):
 
     @property
     @memoized
-    def forms_info(self):
+    def _forms_info(self):
         """
         Pull out (module's case_type, form) for every form in the app
 
@@ -43,9 +43,9 @@ class ParentCasePropertyBuilder(object):
 
     @property
     @memoized
-    def case_sharing_app_forms_info(self):
+    def _case_sharing_app_forms_info(self):
         forms_info = []
-        for app in self.get_other_case_sharing_apps_in_domain():
+        for app in self._get_other_case_sharing_apps_in_domain():
             for module in app.get_modules():
                 for form in module.get_forms():
                     forms_info.append((module.case_type, form))
@@ -55,9 +55,9 @@ class ParentCasePropertyBuilder(object):
     def get_parent_types_and_contributed_properties(self, case_type, include_shared_properties=True):
         parent_types = set()
         case_properties = set()
-        forms_info = self.forms_info
+        forms_info = self._forms_info
         if self.app.case_sharing and include_shared_properties:
-            forms_info += self.case_sharing_app_forms_info
+            forms_info += self._case_sharing_app_forms_info
 
         for m_case_type, form in forms_info:
             p_types, c_props = form.get_parent_types_and_contributed_properties(m_case_type, case_type)
@@ -71,7 +71,7 @@ class ParentCasePropertyBuilder(object):
         return set(p[0] for p in parent_types)
 
     @memoized
-    def get_other_case_sharing_apps_in_domain(self):
+    def _get_other_case_sharing_apps_in_domain(self):
         return get_case_sharing_apps_in_domain(self.app.domain, self.app.id)
 
     @memoized
@@ -83,8 +83,8 @@ class ParentCasePropertyBuilder(object):
 
         case_properties = set(self.defaults) | set(self.per_type_defaults.get(case_type, []))
 
-        for m_case_type, form in self.forms_info:
-            updates = self.get_case_updates(form, case_type)
+        for m_case_type, form in self._forms_info:
+            updates = self._get_case_updates(form, case_type)
             if include_parent_properties:
                 case_properties.update(updates)
             else:
@@ -93,7 +93,7 @@ class ParentCasePropertyBuilder(object):
                 # Currently if a property is only ever updated via parent property
                 # reference, then I think it will not appear in the schema.
                 case_properties.update(p for p in updates if "/" not in p)
-            case_properties.update(self.get_save_to_case_updates(form, case_type))
+            case_properties.update(self._get_save_to_case_updates(form, case_type))
 
         if toggles.DATA_DICTIONARY.enabled(self.app.domain):
             data_dict_props = CaseProperty.objects.filter(case_type__domain=self.app.domain,
@@ -114,7 +114,7 @@ class ParentCasePropertyBuilder(object):
                 for property in get_properties_recursive(parent_type[0]):
                     case_properties.add('%s/%s' % (parent_type[1], property))
         if self.app.case_sharing and include_shared_properties:
-            for app in self.get_other_case_sharing_apps_in_domain():
+            for app in self._get_other_case_sharing_apps_in_domain():
                 case_properties.update(
                     get_case_properties(
                         app, [case_type],
@@ -125,11 +125,11 @@ class ParentCasePropertyBuilder(object):
         return case_properties
 
     @memoized
-    def get_case_updates(self, form, case_type):
+    def _get_case_updates(self, form, case_type):
         return form.get_case_updates(case_type)
 
     @memoized
-    def get_save_to_case_updates(self, form, case_type):
+    def _get_save_to_case_updates(self, form, case_type):
         return form.get_save_to_case_updates(case_type)
 
     def get_parent_type_map(self, case_types, allow_multiple_parents=False):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -18,6 +18,21 @@ import six
 logger = logging.getLogger(__name__)
 
 
+def _get_forms_info(app):
+    """
+    Pull out (module's case_type, form) for every form in the app
+
+    This lets us handle just the info we care about more directly
+    """
+    if app.doc_type == 'RemoteApp':
+        return []
+    forms_info = []
+    for module in app.get_modules():
+        for form in module.get_forms():
+            forms_info.append((module.case_type, form))
+    return forms_info
+
+
 class ParentCasePropertyBuilder(object):
 
     def __init__(self, app, defaults=(), per_type_defaults=None):
@@ -28,27 +43,14 @@ class ParentCasePropertyBuilder(object):
     @property
     @memoized
     def _forms_info(self):
-        """
-        Pull out (module's case_type, form) for every form in the app
-
-        This lets us handle just the info we care about more directly
-        """
-        forms_info = []
-        if self.app.doc_type == 'RemoteApp':
-            return forms_info
-        for module in self.app.get_modules():
-            for form in module.get_forms():
-                forms_info.append((module.case_type, form))
-        return forms_info
+        return _get_forms_info(self.app)
 
     @property
     @memoized
     def _case_sharing_app_forms_info(self):
         forms_info = []
         for app in self._get_other_case_sharing_apps_in_domain():
-            for module in app.get_modules():
-                for form in module.get_forms():
-                    forms_info.append((module.case_type, form))
+            forms_info.extend(_get_forms_info(app))
         return forms_info
 
     @memoized

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -72,7 +72,7 @@ class ParentCasePropertyBuilder(object):
         case_properties = set()
 
         for form in self._get_relevant_forms(include_shared_properties):
-            case_properties.update(form.get_contributed_subcase_properties(case_type))
+            case_properties.update(form.get_all_contributed_subcase_properties().get(case_type, set()))
         return case_properties
 
     def get_parent_types(self, case_type):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -53,13 +53,17 @@ class ParentCasePropertyBuilder(object):
             forms_info.extend(_get_forms_info(app))
         return forms_info
 
+    def _get_all_forms_info(self, include_shared_properties):
+        if self.app.case_sharing and include_shared_properties:
+            return self._forms_info + self._case_sharing_app_forms_info
+        else:
+            return self._forms_info
+
     @memoized
     def get_parent_types_and_contributed_properties(self, case_type, include_shared_properties=True):
         parent_types = set()
         case_properties = set()
-        forms_info = self._forms_info
-        if self.app.case_sharing and include_shared_properties:
-            forms_info += self._case_sharing_app_forms_info
+        forms_info = self._get_all_forms_info(include_shared_properties=include_shared_properties)
 
         for m_case_type, form in forms_info:
             p_types, c_props = form.get_parent_types_and_contributed_properties(m_case_type, case_type)

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -67,14 +67,6 @@ class ParentCasePropertyBuilder(object):
             parent_types.update(form.get_contributed_case_relationships(case_type))
         return parent_types
 
-    @memoized
-    def get_contributed_subcase_properties(self, case_type, include_shared_properties=True):
-        case_properties = set()
-
-        for form in self._get_relevant_forms(include_shared_properties):
-            case_properties.update(form.get_all_contributed_subcase_properties().get(case_type, set()))
-        return case_properties
-
     def get_parent_types(self, case_type):
         parent_types = self.get_case_relationships(case_type)
         return set(p[0] for p in parent_types)
@@ -110,9 +102,6 @@ class ParentCasePropertyBuilder(object):
             case_properties |= {prop.name for prop in data_dict_props}
 
         parent_types = self.get_case_relationships(case_type, include_shared_properties)
-        contributed_properties = self.get_contributed_subcase_properties(
-            case_type, include_shared_properties)
-        case_properties.update(contributed_properties)
         if include_parent_properties:
             get_properties_recursive = functools.partial(
                 self.get_properties,

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -60,11 +60,11 @@ class ParentCasePropertyBuilder(object):
         return all_case_updates
 
     @memoized
-    def get_contributed_parent_types(self, case_type, include_shared_properties=True):
+    def get_case_relationships(self, case_type, include_shared_properties=True):
         parent_types = set()
 
         for form in self._get_relevant_forms(include_shared_properties):
-            parent_types.update(form.get_contributed_parent_types(case_type))
+            parent_types.update(form.get_contributed_case_relationships(case_type))
         return parent_types
 
     @memoized
@@ -76,7 +76,7 @@ class ParentCasePropertyBuilder(object):
         return case_properties
 
     def get_parent_types(self, case_type):
-        parent_types = self.get_contributed_parent_types(case_type)
+        parent_types = self.get_case_relationships(case_type)
         return set(p[0] for p in parent_types)
 
     @memoized
@@ -109,7 +109,7 @@ class ParentCasePropertyBuilder(object):
                                                           case_type__name=case_type, deprecated=False)
             case_properties |= {prop.name for prop in data_dict_props}
 
-        parent_types = self.get_contributed_parent_types(case_type, include_shared_properties)
+        parent_types = self.get_case_relationships(case_type, include_shared_properties)
         contributed_properties = self.get_contributed_subcase_properties(
             case_type, include_shared_properties)
         case_properties.update(contributed_properties)
@@ -141,7 +141,7 @@ class ParentCasePropertyBuilder(object):
         """
         parent_map = defaultdict(dict)
         for case_type in case_types:
-            parent_types = self.get_contributed_parent_types(case_type)
+            parent_types = self.get_case_relationships(case_type)
             rel_map = defaultdict(list)
             for parent_type, relationship in parent_types:
                 rel_map[relationship].append(parent_type)

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -103,9 +103,9 @@ class ParentCasePropertyBuilder(object):
 
         updates_by_case_type = self._get_all_case_updates(include_shared_properties)
         case_properties = (
-                set(self.defaults) |
-                set(self.per_type_defaults.get(case_type, [])) |
-                updates_by_case_type[case_type]
+            set(self.defaults) |
+            set(self.per_type_defaults.get(case_type, [])) |
+            updates_by_case_type[case_type]
         )
 
         if toggles.DATA_DICTIONARY.enabled(self.app.domain):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -102,16 +102,17 @@ class ParentCasePropertyBuilder(object):
                                                           case_type__name=case_type, deprecated=False)
             case_properties |= {prop.name for prop in data_dict_props}
 
-        parent_types = self.get_case_relationships_for_case_type(case_type, include_shared_properties)
+        case_relationships = self.get_case_relationships_for_case_type(
+            case_type, include_shared_properties)
         if include_parent_properties:
             get_properties_recursive = functools.partial(
                 self.get_properties,
                 already_visited=already_visited + (case_type,),
                 include_shared_properties=include_shared_properties
             )
-            for parent_type in parent_types:
-                for property in get_properties_recursive(parent_type[0]):
-                    case_properties.add('%s/%s' % (parent_type[1], property))
+            for case_type, identifier in case_relationships:
+                for property in get_properties_recursive(case_type):
+                    case_properties.add('%s/%s' % (identifier, property))
         else:
             # exclude case updates that reference properties like "parent/property_name"
             case_properties = {p for p in case_properties if "/" not in p}

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -292,8 +292,10 @@ class ParentCasePropertyBuilder(object):
             case_type: {prop.name for prop in props} for case_type, props in groupby(
                 CaseProperty.objects
                 .filter(case_type__domain=self.app.domain, deprecated=False)
+                .select_related("case_type")
                 .order_by('case_type__name'),
                 key=attrgetter('case_type.name')
+
             )
         }
 

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -97,7 +97,7 @@ class ParentCasePropertyBuilder(object):
 
         case_properties = set(self.defaults) | set(self.per_type_defaults.get(case_type, []))
 
-        for form in self._forms:
+        for form in self._get_all_forms(include_shared_properties):
             updates = self._get_case_updates(form, case_type)
             if include_parent_properties:
                 case_properties.update(updates)
@@ -127,15 +127,6 @@ class ParentCasePropertyBuilder(object):
             for parent_type in parent_types:
                 for property in get_properties_recursive(parent_type[0]):
                     case_properties.add('%s/%s' % (parent_type[1], property))
-        if self.app.case_sharing and include_shared_properties:
-            for app in self._get_other_case_sharing_apps_in_domain():
-                case_properties.update(
-                    get_case_properties(
-                        app, [case_type],
-                        include_shared_properties=False,
-                        include_parent_properties=include_parent_properties,
-                    ).get(case_type, [])
-                )
         return case_properties
 
     @memoized

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -452,7 +452,7 @@ class ParentCasePropertyBuilder(object):
         }
 
 
-def get_case_relationships(app):
+def get_parent_type_map(app):
     builder = ParentCasePropertyBuilder(app)
     return builder.get_parent_type_map(app.get_case_types())
 

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -92,10 +92,12 @@ class ParentCasePropertyBuilder(object):
             return ()
 
         updates_by_case_type = self._get_all_case_updates(include_shared_properties)
-        case_properties = set(self.defaults) | set(self.per_type_defaults.get(case_type, []))
+        case_properties = (
+                set(self.defaults) |
+                set(self.per_type_defaults.get(case_type, [])) |
+                updates_by_case_type[case_type]
+        )
 
-        for form in self._get_relevant_forms(include_shared_properties):
-            case_properties.update(updates_by_case_type[case_type])
 
         if toggles.DATA_DICTIONARY.enabled(self.app.domain):
             data_dict_props = CaseProperty.objects.filter(case_type__domain=self.app.domain,

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -338,12 +338,12 @@ def get_per_type_defaults(domain, case_types=None):
     per_type_defaults = {}
     if (not case_types and is_usercase_in_use(domain)) or USERCASE_TYPE in case_types:
         per_type_defaults = {
-            USERCASE_TYPE: get_usercase_default_properties(domain)
+            USERCASE_TYPE: _get_usercase_default_properties(domain)
         }
 
     callcenter_case_type = get_call_center_case_type_if_enabled(domain)
     if callcenter_case_type and (not case_types or callcenter_case_type in case_types):
-        per_type_defaults[callcenter_case_type] = get_usercase_default_properties(domain)
+        per_type_defaults[callcenter_case_type] = _get_usercase_default_properties(domain)
 
     return per_type_defaults
 
@@ -360,7 +360,7 @@ def get_shared_case_types(app):
 
 
 @quickcache(['domain'])
-def get_usercase_default_properties(domain):
+def _get_usercase_default_properties(domain):
     from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
     from corehq.apps.users.views.mobile.custom_data_fields import CUSTOM_USER_DATA_FIELD_TYPE
 

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from __future__ import print_function
 from collections import defaultdict, deque, namedtuple
 import functools
 from itertools import chain, groupby

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -89,9 +89,7 @@ class ParentCasePropertyBuilder(object):
         case_properties = set(self.defaults) | set(self.per_type_defaults.get(case_type, []))
 
         for form in self._get_relevant_forms(include_shared_properties):
-            updates = self._get_case_updates(form, case_type)
-            case_properties.update(updates)
-            case_properties.update(self._get_save_to_case_updates(form, case_type))
+            case_properties.update(self._get_case_updates(form, case_type))
 
         if toggles.DATA_DICTIONARY.enabled(self.app.domain):
             data_dict_props = CaseProperty.objects.filter(case_type__domain=self.app.domain,
@@ -117,10 +115,6 @@ class ParentCasePropertyBuilder(object):
     @memoized
     def _get_case_updates(self, form, case_type):
         return form.get_all_case_updates().get(case_type, [])
-
-    @memoized
-    def _get_save_to_case_updates(self, form, case_type):
-        return form.get_save_to_case_updates(case_type)
 
     def get_parent_type_map(self, case_types, allow_multiple_parents=False):
         """

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -27,8 +27,7 @@ def _get_forms(app):
         return []
     forms = []
     for module in app.get_modules():
-        for form in module.get_forms():
-            forms.append(form)
+        forms.extend(module.get_forms())
     return forms
 
 
@@ -42,8 +41,7 @@ class ParentCasePropertyBuilder(object):
     def _get_relevant_apps(self, include_shared_properties):
         apps = [self.app]
         if self.app.case_sharing and include_shared_properties:
-            for app in self._get_other_case_sharing_apps_in_domain():
-                apps.append(app)
+            apps.extend(self._get_other_case_sharing_apps_in_domain())
         return apps
 
     @memoized

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -116,7 +116,7 @@ class ParentCasePropertyBuilder(object):
 
     @memoized
     def _get_case_updates(self, form, case_type):
-        return form.get_case_updates_for_case_type(case_type)
+        return form.get_all_case_updates().get(case_type, [])
 
     @memoized
     def _get_save_to_case_updates(self, form, case_type):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -72,8 +72,11 @@ class _CaseRelationshipManager(object):
 
     You can then ask "what are the different ways a `patient` can be referred to?":
 
-    >>> case_relationship_manager.expand_case_type('patient')
-    set([_CaseTypeRef(case_type=u'patient', relationship_path=()), _CaseTypeRef(case_type=u'referral', relationship_path=(u'parent',))])
+    >>> expansions = case_relationship_manager.expand_case_type('patient')
+    >>> for case_type_ref in sorted(expansions):
+    ...     print(case_type_ref)
+    _CaseTypeRef(case_type=u'patient', relationship_path=())
+    _CaseTypeRef(case_type=u'referral', relationship_path=(u'parent',))
 
     This is read "`patient` and `referral`'s parent are the two ways to refer to `patient`".
 

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -173,6 +173,11 @@ class ParentCasePropertyBuilder(object):
         }
 
 
+def get_case_relationships(app):
+    builder = ParentCasePropertyBuilder(app)
+    return builder.get_parent_type_map(app.get_case_types())
+
+
 def get_case_properties(app, case_types, defaults=(),
                         include_shared_properties=True,
                         include_parent_properties=True):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -188,7 +188,7 @@ class ParentCasePropertyBuilder(object):
                 .filter(case_type__domain=self.app.domain, deprecated=False)
                 .order_by('case_type__name'),
                 key=attrgetter('case_type.name')
-            ).items()
+            )
         }
 
     def get_case_relationships_for_case_type(self, case_type):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -38,6 +38,8 @@ def _zip_update(properties_by_case_type, additional_properties_by_case_type):
 
 
 _CaseTypeReference = namedtuple('_CaseTypeReference', ['case_type', 'relationship_path'])
+_PropertyReference = namedtuple('_PropertyReference', ['case_type_ref', 'case_property'])
+_CaseTypeEquivalence = namedtuple('_CaseTypeEquivalence', ['case_type', 'expansion'])
 
 
 class _CaseRelationshipManager(object):
@@ -49,105 +51,111 @@ class _CaseRelationshipManager(object):
 
     @property
     @memoized
-    def _all_possible_references(self):
+    def _all_possible_equivalences(self):
         """
         If referral is a child case of patient, which is the child case of a household,
         then this will return
 
         {
             # a referral is a referral
-            ('referral', _CaseTypeReference('referral', ())),
+            _CaseTypeEquivalence('referral', _CaseTypeReference('referral', ())),
             # a patient is a patient
-            ('patient', _CaseTypeReference('patient', ())),
+            _CaseTypeEquivalence('patient', _CaseTypeReference('patient', ())),
             # a patient is a referal's parent
-            ('patient', _CaseTypeReference('referral', ('parent',)))
+            _CaseTypeEquivalence('patient', _CaseTypeReference('referral', ('parent',)))
             # a household is a household
-            ('household', _CaseTypeReference('household', ())),
+            _CaseTypeEquivalence('household', _CaseTypeReference('household', ())),
             # a household is a patient's parent
-            ('household', _CaseTypeReference('patient', ('parent'))),
+            _CaseTypeEquivalence('household', _CaseTypeReference('patient', ('parent'))),
             # a houseold is a referral's parent's parent
-            ('household', _CaseTypeReference('referral', ('parent', 'parent')))
+            _CaseTypeEquivalence('household', _CaseTypeReference('referral', ('parent', 'parent')))
         }
         """
-        all_possible_references = set()
-        references_queue = deque((case_type, _CaseTypeReference(case_type, ()))
+        all_possible_equivalences = set()
+        references_queue = deque(_CaseTypeEquivalence(case_type, _CaseTypeReference(case_type, ()))
                                  for case_type in self.parent_type_map)
         while True:
             try:
                 current_reference = references_queue.popleft()
             except IndexError:
                 break
-            all_possible_references.add(current_reference)
+            all_possible_equivalences.add(current_reference)
             current_parent, (child, relationship_path) = current_reference
             for relationship, grandparents in self.parent_type_map[current_parent].items():
                 for grandparent in grandparents:
-                    new_reference = (grandparent, _CaseTypeReference(child, relationship_path + (relationship,)))
+                    new_reference = _CaseTypeEquivalence(
+                        case_type=grandparent,
+                        expansion=_CaseTypeReference(child, relationship_path + (relationship,))
+                    )
                     cycle_found = (grandparent == child)
-                    already_visited = (new_reference in all_possible_references)
+                    already_visited = (new_reference in all_possible_equivalences)
                     if not cycle_found and not already_visited:
                         references_queue.append(new_reference)
-        return all_possible_references
+        return all_possible_equivalences
 
     @property
     @memoized
-    def _case_type_to_references(self):
-        case_type_to_references = defaultdict(set)
-        for case_type, reference in self._all_possible_references:
-            case_type_to_references[case_type].add(reference)
-        return case_type_to_references
+    def _case_type_to_expansions(self):
+        case_type_to_expansions = defaultdict(set)
+        for equivalence in self._all_possible_equivalences:
+            case_type_to_expansions[equivalence.case_type].add(equivalence.expansion)
+        return case_type_to_expansions
 
     @property
     @memoized
-    def _reference_to_case_types(self):
-        reference_to_case_types = defaultdict(set)
-        for case_type, reference in self._all_possible_references:
-            reference_to_case_types[reference].add(case_type)
-        return reference_to_case_types
+    def _expansion_to_case_types(self):
+        expansion_to_case_types = defaultdict(set)
+        for case_type, reference in self._all_possible_equivalences:
+            expansion_to_case_types[reference].add(case_type)
+        return expansion_to_case_types
 
     def expand_case_type(self, case_type):
-        return self._case_type_to_references[case_type]
+        return self._case_type_to_expansions[case_type]
 
-    def resolve_reference(self, case_type, relationship_path):
-        return self._reference_to_case_types[_CaseTypeReference(case_type, relationship_path)]
+    def resolve_expansion(self, case_type_ref):
+        return self._expansion_to_case_types[case_type_ref]
+
+
+def _flatten_case_properties(case_properties_by_case_type):
+    result = set()
+    for case_type, properties in case_properties_by_case_type.items():
+        for case_property in properties:
+            case_property_parts = tuple(case_property.split('/'))
+            result.add(_PropertyReference(
+                case_type_ref=_CaseTypeReference(case_type, relationship_path=case_property_parts[:-1]),
+                case_property=case_property_parts[-1]
+            ))
+    return result
 
 
 def _normalize_case_properties(case_properties_by_case_type, parent_type_map,
                                include_parent_properties):
     case_relationship_manager = _CaseRelationshipManager(
         parent_type_map, case_types=case_properties_by_case_type.keys())
-    flattened_case_properties = {
-        (_CaseTypeReference(case_type, relationship_path=case_property_parts[:-1]),
-         case_property_parts[-1])
-        for case_type, case_property_parts in (
-            (case_type, tuple(case_property.split('/')))
-            for case_type, properties in case_properties_by_case_type.items()
-            for case_property in properties
-        )
-    }
+    flattened_case_properties = _flatten_case_properties(case_properties_by_case_type)
     normalized_case_properties = set()
-    for reference, case_property in flattened_case_properties:
-        resolved_case_types = case_relationship_manager.resolve_reference(
-            reference.case_type, reference.relationship_path)
+    for property_ref in flattened_case_properties:
+        resolved_case_types = case_relationship_manager.resolve_expansion(property_ref.case_type_ref)
         if resolved_case_types:
             if include_parent_properties:
                 normalized_case_properties.update({
-                    (expanded_reference, case_property)
+                    _PropertyReference(expanded_reference, property_ref.case_property)
                     for case_type in resolved_case_types
                     for expanded_reference in case_relationship_manager.expand_case_type(case_type)
                 })
             else:
                 normalized_case_properties.update({
-                    (_CaseTypeReference(case_type, ()), case_property)
+                    _PropertyReference(_CaseTypeReference(case_type, ()), property_ref.case_property)
                     for case_type in resolved_case_types
                 })
         else:
             # if e.g. #case/parent doesn't match any known case type, leave the reference as is
-            normalized_case_properties.add((reference, case_property))
+            normalized_case_properties.add(property_ref)
 
     normalized_case_properties_by_case_type = defaultdict(set)
-    for reference, case_property in normalized_case_properties:
-        normalized_case_properties_by_case_type[reference.case_type].add(
-            '/'.join(reference.relationship_path + (case_property,)))
+    for property_ref in normalized_case_properties:
+        normalized_case_properties_by_case_type[property_ref.case_type_ref.case_type].add(
+            '/'.join(property_ref.case_type_ref.relationship_path + (property_ref.case_property,)))
     return normalized_case_properties_by_case_type
 
 

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -28,9 +28,11 @@ class ParentCasePropertyBuilder(object):
     @property
     @memoized
     def forms_info(self):
-        # unfortunate, but biggest speed issue is accessing couchdbkit properties
-        # so compute them once
+        """
+        Pull out (module's case_type, form) for every form in the app
 
+        This lets us handle just the info we care about more directly
+        """
         forms_info = []
         if self.app.doc_type == 'RemoteApp':
             return forms_info

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -198,10 +198,10 @@ def _propagate_and_normalize_case_properties(case_properties_by_case_type, paren
       - _CaseTypeRef ('parent' [or parent/parent, etc.] relative to <case_type>)
       - case property (the string)
     Finally, this set is copied over to a new set, but with each case_type_ref of each
-    case_property_ref replaced with its most cononical form
+    case_property_ref replaced with its most canonical form
     (or forms in the rare case that a case_type_ref resolves to more than one case_type,
     i.e. a child case has more than one case type that can be its parent).
-    Additionally, if include_parent_properties is True, each cononical form is then splatted
+    Additionally, if include_parent_properties is True, each canonical form is then splatted
     out into all of the other forms it can take: (child, 'parent/parent', property) becomes
     (parent, 'parent', property) and (grandparent, '', property) as well. (Note I'm using
     conceptual notation here, whereas in the code each of these is a `_CasePropertyRef`.)
@@ -302,7 +302,7 @@ class ParentCasePropertyBuilder(object):
         Like get_case_relationships, but filters down to a single case type
 
         :param case_type: case type to get relationships for
-        :return: set of (parent, relationship) for this case. See get_case_relationships below.
+        :return: set of (parent_type, relationship) for this case. See get_case_relationships below.
 
         """
         return self.get_case_relationships()[case_type]

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -68,15 +68,28 @@ class ParentCasePropertyBuilder(object):
 
     @memoized
     def get_parent_types_and_contributed_properties(self, case_type, include_shared_properties=True):
+        return (
+            self.get_contributed_parent_types(case_type, include_shared_properties),
+            self.get_contributed_subcase_properties(case_type, include_shared_properties)
+        )
+
+    @memoized
+    def get_contributed_parent_types(self, case_type, include_shared_properties=True):
         parent_types = set()
+        forms_info = self._get_all_forms_info(include_shared_properties=include_shared_properties)
+
+        for _, form in forms_info:
+            parent_types.update(form.get_contributed_parent_types(case_type))
+        return parent_types
+
+    @memoized
+    def get_contributed_subcase_properties(self, case_type, include_shared_properties=True):
         case_properties = set()
         forms_info = self._get_all_forms_info(include_shared_properties=include_shared_properties)
 
         for m_case_type, form in forms_info:
-            p_types, c_props = form.get_parent_types_and_contributed_properties(m_case_type, case_type)
-            parent_types.update(p_types)
-            case_properties.update(c_props)
-        return parent_types, case_properties
+            case_properties.update(form.get_contributed_subcase_properties(case_type))
+        return case_properties
 
     def get_parent_types(self, case_type):
         parent_types, _ = \

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -228,16 +228,16 @@ def _propagate_and_normalize_case_properties(case_properties_by_case_type, paren
         resolved_case_types = case_relationship_manager.resolve_expansion(property_ref.case_type_ref)
         if resolved_case_types:
             if include_parent_properties:
-                normalized_case_properties.update({
+                normalized_case_properties.update(
                     _PropertyRef(expansion, property_ref.case_property)
                     for case_type in resolved_case_types
                     for expansion in case_relationship_manager.expand_case_type(case_type)
-                })
+                )
             else:
-                normalized_case_properties.update({
+                normalized_case_properties.update(
                     _PropertyRef(_CaseTypeRef(case_type, ()), property_ref.case_property)
                     for case_type in resolved_case_types
-                })
+                )
         else:
             # if #case/parent doesn't match any known case type, leave the property_ref as is
             normalized_case_properties.add(property_ref)

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -130,7 +130,7 @@ def _normalize_case_properties(case_properties_by_case_type, parent_type_map,
         if resolved_case_types:
             if include_parent_properties:
                 normalized_case_properties.update({
-                    (reference, case_property)
+                    (expanded_reference, case_property)
                     for case_type in resolved_case_types
                     for expanded_reference in case_relationship_manager.expand_case_type(case_type)
                 })

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -116,7 +116,7 @@ class ParentCasePropertyBuilder(object):
 
     @memoized
     def _get_case_updates(self, form, case_type):
-        return form.get_case_updates_by_case_type(case_type)
+        return form.get_case_updates_for_case_type(case_type)
 
     @memoized
     def _get_save_to_case_updates(self, form, case_type):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -59,6 +59,13 @@ class ParentCasePropertyBuilder(object):
         else:
             return self._forms_info
 
+    def _get_all_case_updates(self, include_shared_properties):
+        all_case_updates = defaultdict(set)
+        for _, form in self._get_all_forms_info(include_shared_properties=include_shared_properties):
+            for case_type, case_properties in form.get_all_case_updates().items():
+                all_case_updates[case_type] |= set(case_properties)
+        return all_case_updates
+
     @memoized
     def get_parent_types_and_contributed_properties(self, case_type, include_shared_properties=True):
         parent_types = set()

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -132,7 +132,7 @@ class ParentCasePropertyBuilder(object):
 
     @memoized
     def _get_case_updates(self, form, case_type):
-        return form.get_case_updates(case_type)
+        return form.get_case_updates_by_case_type(case_type)
 
     @memoized
     def _get_save_to_case_updates(self, form, case_type):

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -147,10 +147,10 @@ class ParentCasePropertyBuilder(object):
         ```
         """
         parent_map = defaultdict(dict)
-        for case_type in case_types:
-            parent_types = self.get_case_relationships_for_case_type(case_type)
+
+        for case_type, case_relationships in self.get_case_relationships().items():
             rel_map = defaultdict(list)
-            for parent_type, relationship in parent_types:
+            for parent_type, relationship in case_relationships:
                 rel_map[relationship].append(parent_type)
 
             for relationship, types in rel_map.items():
@@ -164,6 +164,9 @@ class ParentCasePropertyBuilder(object):
                         )
                     parent_map[case_type][relationship] = types[0]
 
+        if case_types is not None:
+            return {case_type: rel_map for case_type, rel_map in parent_map.items()
+                    if case_type in case_types}
         return parent_map
 
     def get_case_property_map(self, case_types,

--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -19,7 +19,7 @@ def get_casedb_schema(form):
     per_type_defaults = get_per_type_defaults(app.domain, case_types)
     builder = ParentCasePropertyBuilder(app, ['case_name'], per_type_defaults,
                                         include_parent_properties=False)
-    related = builder.get_parent_type_map(case_types, allow_multiple_parents=True)
+    related = builder.get_parent_type_map(case_types)
     map = builder.get_case_property_map(case_types)
     descriptions_dict = get_case_property_description_dict(app.domain)
 

--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -17,9 +17,10 @@ def get_casedb_schema(form):
     base_case_type = form.get_module().case_type if form.requires_case() else None
     case_types = app.get_case_types() | get_shared_case_types(app)
     per_type_defaults = get_per_type_defaults(app.domain, case_types)
-    builder = ParentCasePropertyBuilder(app, ['case_name'], per_type_defaults)
+    builder = ParentCasePropertyBuilder(app, ['case_name'], per_type_defaults,
+                                        include_parent_properties=False)
     related = builder.get_parent_type_map(case_types, allow_multiple_parents=True)
-    map = builder.get_case_property_map(case_types, include_parent_properties=False)
+    map = builder.get_case_property_map(case_types)
     descriptions_dict = get_case_property_description_dict(app.domain)
 
     if base_case_type:

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -72,16 +72,16 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
             'referral_id': 1,
         })
         self.assertCaseProperties(factory.app, 'household', [
-            # 'household_color',
-            # 'household_id',
+            'household_color',
+            'household_id',
             'household_name',
         ])
         self.assertCaseProperties(factory.app, 'patient', [
-            # 'parent/household_color',
+            'parent/household_color',
             'parent/household_id',
             'parent/household_name',
             'patient_id',
-            # 'patient_name',
+            'patient_name',
         ])
         self.assertCaseProperties(factory.app, 'referral', [
             'parent/parent/household_color',

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -7,6 +7,8 @@ from corehq.apps.app_manager.models import Module, AdvancedModule, FormSchedule,
     ScheduleVisit
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import TestXmlMixin
+import doctest
+import corehq.apps.app_manager.app_schemas.case_properties
 
 
 @patch('corehq.apps.app_manager.app_schemas.case_properties.get_per_type_defaults', MagicMock(return_value={}))
@@ -144,3 +146,10 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
             ]
         )
         phase.add_form(form)
+
+
+class DocTests(SimpleTestCase):
+
+    def test_doctests(self):
+        results = doctest.testmod(corehq.apps.app_manager.app_schemas.case_properties)
+        self.assertEqual(results.failed, 0)

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -32,6 +32,25 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
             })
             self.assertCaseProperties(factory.app, 'house', ['foo', 'bar'])
 
+    def test_case_sharing(self):
+        factory1 = AppFactory()
+        factory2 = AppFactory()
+        factory1.app.case_sharing = True
+        factory2.app.case_sharing = True
+
+        with patch('corehq.apps.app_manager.app_schemas.case_properties.get_case_sharing_apps_in_domain')\
+                as mock_sharing:
+            mock_sharing.return_value = [factory1.app, factory2.app]
+            a1m1, a1m1f1 = factory1.new_basic_module('open_patient', 'patient')
+            factory1.form_requires_case(a1m1f1, case_type='patient', update={
+                'app1': 'yes',
+            })
+            a2m1, a2m1f1 = factory2.new_basic_module('open_patient', 'patient')
+            factory1.form_requires_case(a2m1f1, case_type='patient', update={
+                'app2': 'yes',
+            })
+            self.assertCaseProperties(factory1.app, 'patient', ['app1', 'app2'])
+
     def test_scheduler_module(self):
         factory = AppFactory()
         m1, m1f1 = factory.new_basic_module('open_case', 'house')

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -122,7 +122,7 @@ class SchemaTest(SimpleTestCase):
             "key": "@case_id",
         }})
         self.assertEqual(subsets["case"]["structure"]["case_name"], {"description": ""})
-        #self.assertEqual(subsets["parent"]["structure"]["has_well"], {}) TODO
+        self.assertEqual(subsets["parent"]["structure"]["has_well"], {"description": ""})
         self.assertNotIn("parent/has_well", subsets["case"]["structure"])
 
     def test_get_session_schema_for_module_with_no_case_type(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1838,12 +1838,6 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         if self.actions.load_from_form.preload:
             self.actions.load_from_form = PreloadAction()
 
-    def get_parent_types_and_contributed_properties(self, case_type):
-        return (
-            self.get_contributed_parent_types(case_type),
-            self.get_contributed_subcase_properties(case_type)
-        )
-
     @memoized
     def get_contributed_subcase_properties(self, child_case_type):
         case_properties = set()
@@ -3117,12 +3111,6 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             if case_type in scheduler_updates:
                 updates |= scheduler_updates[case_type]
         return updates_by_case_type
-
-    def get_parent_types_and_contributed_properties(self, case_type):
-        return (
-            self.get_contributed_parent_types(case_type),
-            self.get_contributed_subcase_properties(case_type)
-        )
 
     @memoized
     def get_contributed_subcase_properties(self, child_case_type):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1839,13 +1839,10 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
             self.actions.load_from_form = PreloadAction()
 
     @memoized
-    def get_contributed_subcase_properties(self, child_case_type):
-        case_properties = set()
+    def get_all_contributed_subcase_properties(self):
+        case_properties = defaultdict(set)
         for subcase in self.actions.subcases:
-            if subcase.case_type == child_case_type:
-                case_properties.update(
-                    list(subcase.case_properties.keys())
-                )
+            case_properties[subcase.case_type].update(subcase.case_properties.keys())
         return case_properties
 
     @memoized
@@ -3113,13 +3110,10 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
         return updates_by_case_type
 
     @memoized
-    def get_contributed_subcase_properties(self, child_case_type):
-        case_properties = set()
+    def get_all_contributed_subcase_properties(self):
+        case_properties = defaultdict(set)
         for subcase in self.actions.get_subcase_actions():
-            if subcase.case_type == child_case_type:
-                case_properties.update(
-                    list(subcase.case_properties.keys())
-                )
+            case_properties[subcase.case_type].update(subcase.case_properties.keys())
         return case_properties
 
     @memoized

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1411,6 +1411,32 @@ class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
                 "%s is not a valid question" % question_path
             )
 
+    def get_all_case_updates(self):
+        """
+        Collate contributed case updates from all sources within the form
+
+        Subclass must have helper methods defined:
+
+        - get_case_updates
+        - get_all_contributed_subcase_properties
+        - get_save_to_case_updates
+
+        :return: collated {<case_type>: set([<property>])}
+
+        """
+        updates_by_case_type = defaultdict(set)
+
+        for case_type, updates in self.get_case_updates().items():
+            updates_by_case_type[case_type].update(updates)
+
+        for case_type, updates in self.get_all_contributed_subcase_properties().items():
+            updates_by_case_type[case_type].update(updates)
+
+        for case_type, updates in self.get_save_to_case_updates().items():
+            updates_by_case_type[case_type].update(updates)
+
+        return updates_by_case_type
+
 
 class JRResourceProperty(StringProperty):
 
@@ -1812,20 +1838,6 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
             USERCASE_TYPE: {
                 format_key(*item) for item in self.actions.usercase_update.update.items()}
         }
-
-    def get_all_case_updates(self):
-        updates_by_case_type = defaultdict(set)
-
-        for case_type, updates in self.get_case_updates().items():
-            updates_by_case_type[case_type].update(updates)
-
-        for case_type, updates in self.get_all_contributed_subcase_properties().items():
-            updates_by_case_type[case_type].update(updates)
-
-        for case_type, updates in self.get_save_to_case_updates().items():
-            updates_by_case_type[case_type].update(updates)
-
-        return updates_by_case_type
 
     @memoized
     def get_subcase_types(self):
@@ -3124,20 +3136,6 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             scheduler_updates = {}
 
         for case_type, updates in scheduler_updates.items():
-            updates_by_case_type[case_type].update(updates)
-
-        return updates_by_case_type
-
-    def get_all_case_updates(self):
-        updates_by_case_type = defaultdict(set)
-
-        for case_type, updates in self.get_case_updates().items():
-            updates_by_case_type[case_type].update(updates)
-
-        for case_type, updates in self.get_all_contributed_subcase_properties().items():
-            updates_by_case_type[case_type].update(updates)
-
-        for case_type, updates in self.get_save_to_case_updates().items():
             updates_by_case_type[case_type].update(updates)
 
         return updates_by_case_type

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1849,7 +1849,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         return case_properties
 
     @memoized
-    def get_contributed_parent_types(self, child_case_type):
+    def get_contributed_case_relationships(self, child_case_type):
         parent_types = set()
         parent_case_type = self.get_module().case_type
         for subcase in self.actions.subcases:
@@ -3123,7 +3123,7 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
         return case_properties
 
     @memoized
-    def get_contributed_parent_types(self, child_case_type):
+    def get_contributed_case_relationships(self, child_case_type):
         parent_types = set()
         for subcase in self.actions.get_subcase_actions():
             if subcase.case_type == child_case_type:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1794,7 +1794,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
 
         return errors
 
-    def get_case_updates_by_case_type(self, case_type):
+    def get_case_updates_for_case_type(self, case_type):
         return self.get_all_case_updates().get(case_type, [])
 
     def get_all_case_updates(self):
@@ -3094,7 +3094,7 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
 
         return errors
 
-    def get_case_updates_by_case_type(self, case_type):
+    def get_case_updates_for_case_type(self, case_type):
         return self.get_all_case_updates().get(case_type, [])
 
     def get_all_case_updates(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -53,7 +53,7 @@ from django.utils.translation import override, ugettext as _, ugettext
 from django.utils.translation import ugettext_lazy
 from couchdbkit.exceptions import BadValueError
 
-from corehq.apps.app_manager.app_schemas.case_properties import get_case_relationships
+from corehq.apps.app_manager.app_schemas.case_properties import get_parent_type_map
 from corehq.apps.app_manager.detail_screen import PropertyXpathGenerator
 from corehq.apps.linked_domain.applications import get_master_app_version, get_latest_master_app_release
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
@@ -6204,7 +6204,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     @quickcache(['self._id', 'self.version'])
     def get_case_metadata(self):
         from corehq.apps.reports.formdetails.readable import AppCaseMetadata
-        case_relationships = get_case_relationships(self)
+        case_relationships = get_parent_type_map(self)
         meta = AppCaseMetadata()
         descriptions_dict = get_case_property_description_dict(self.domain)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3118,21 +3118,32 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
                 updates |= scheduler_updates[case_type]
         return updates_by_case_type
 
-    @memoized
     def get_parent_types_and_contributed_properties(self, module_case_type, case_type):
-        parent_types = set()
+        return (
+            self.get_contributed_parent_types(case_type),
+            self.get_contributed_subcase_properties(case_type)
+        )
+
+    @memoized
+    def get_contributed_subcase_properties(self, child_case_type):
         case_properties = set()
         for subcase in self.actions.get_subcase_actions():
-            if subcase.case_type == case_type:
+            if subcase.case_type == child_case_type:
                 case_properties.update(
                     list(subcase.case_properties.keys())
                 )
+        return case_properties
+
+    @memoized
+    def get_contributed_parent_types(self, child_case_type):
+        parent_types = set()
+        for subcase in self.actions.get_subcase_actions():
+            if subcase.case_type == child_case_type:
                 for case_index in subcase.case_indices:
                     parent = self.actions.get_action_from_tag(case_index.tag)
                     if parent:
                         parent_types.add((parent.case_type, case_index.reference_id or 'parent'))
-
-        return parent_types, case_properties
+        return parent_types
 
     def update_app_case_meta(self, app_case_meta):
         from corehq.apps.reports.formdetails.readable import FormQuestionResponse

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1275,15 +1275,15 @@ class FormBase(DocumentSchema):
     def is_case_list_form(self):
         return bool(self.case_list_modules)
 
-    def get_save_to_case_updates(self, case_type):
+    def get_save_to_case_updates(self):
         """
         Get a flat list of case property names from save to case questions
         """
-        updates = set()
+        updates_by_case_type = defaultdict(set)
         for save_to_case_update in self.case_references_data.get_save_references():
-            if save_to_case_update.case_type == case_type:
-                updates |= set(save_to_case_update.properties)
-        return updates
+            case_type = save_to_case_update.case_type
+            updates_by_case_type[case_type] |= set(save_to_case_update.properties)
+        return updates_by_case_type
 
 
 class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
@@ -1819,6 +1819,9 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
             updates_by_case_type[case_type].update(updates)
 
         for case_type, updates in self.get_all_contributed_subcase_properties().items():
+            updates_by_case_type[case_type].update(updates)
+
+        for case_type, updates in self.get_save_to_case_updates().items():
             updates_by_case_type[case_type].update(updates)
 
         return updates_by_case_type
@@ -3131,6 +3134,10 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
 
         for case_type, updates in self.get_all_contributed_subcase_properties().items():
             updates_by_case_type[case_type].update(updates)
+
+        for case_type, updates in self.get_save_to_case_updates().items():
+            updates_by_case_type[case_type].update(updates)
+
         return updates_by_case_type
 
     @memoized

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -53,7 +53,7 @@ from django.utils.translation import override, ugettext as _, ugettext
 from django.utils.translation import ugettext_lazy
 from couchdbkit.exceptions import BadValueError
 
-from corehq.apps.app_manager.app_schemas.case_properties import ParentCasePropertyBuilder
+from corehq.apps.app_manager.app_schemas.case_properties import get_case_relationships
 from corehq.apps.app_manager.detail_screen import PropertyXpathGenerator
 from corehq.apps.linked_domain.applications import get_master_app_version, get_latest_master_app_release
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
@@ -6154,8 +6154,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     @quickcache(['self._id', 'self.version'])
     def get_case_metadata(self):
         from corehq.apps.reports.formdetails.readable import AppCaseMetadata
-        builder = ParentCasePropertyBuilder(self)
-        case_relationships = builder.get_parent_type_map(self.get_case_types())
+        case_relationships = get_case_relationships(self)
         meta = AppCaseMetadata()
         descriptions_dict = get_case_property_description_dict(self.domain)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1283,7 +1283,7 @@ class FormBase(DocumentSchema):
         updates_by_case_type = defaultdict(set)
         for save_to_case_update in self.case_references_data.get_save_references():
             case_type = save_to_case_update.case_type
-            updates_by_case_type[case_type] |= set(save_to_case_update.properties)
+            updates_by_case_type[case_type].update(save_to_case_update.properties)
         return updates_by_case_type
 
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1795,15 +1795,19 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         return errors
 
     def get_case_updates(self, case_type):
+        return self.get_all_case_updates().get(case_type, [])
+
+    def get_all_case_updates(self):
         # This method is used by both get_all_case_properties and
         # get_usercase_properties. In the case of usercase properties, use
         # the usercase_update action, and for normal cases, use the
         # update_case action
-        if case_type == self.get_module().case_type or case_type == USERCASE_TYPE:
-            format_key = self.get_case_property_name_formatter()
-            action = self.actions.usercase_update if case_type == USERCASE_TYPE else self.actions.update_case
-            return [format_key(*item) for item in action.update.items()]
-        return []
+        case_type = self.get_module().case_type
+        format_key = self.get_case_property_name_formatter()
+        return {
+            case_type: [format_key(*item) for item in self.actions.update_case.update.items()],
+            USERCASE_TYPE: [format_key(*item) for item in self.actions.usercase_update.update.items()],
+        }
 
     @memoized
     def get_subcase_types(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -85,6 +85,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 
 from corehq.apps.app_manager.commcare_settings import check_condition
 from corehq.apps.app_manager.const import *
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.xpath import (
     dot_interpolate,
     interpolate_xpath,

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1437,6 +1437,15 @@ class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
 
         return updates_by_case_type
 
+    def get_case_updates_for_case_type(self, case_type):
+        """
+        Like get_case_updates filtered by a single case type
+
+        subclass must implement `get_case_updates`
+
+        """
+        return self.get_case_updates().get(case_type, [])
+
 
 class JRResourceProperty(StringProperty):
 
@@ -1820,9 +1829,6 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
             ))
 
         return errors
-
-    def get_case_updates_for_case_type(self, case_type):
-        return self.get_case_updates().get(case_type, [])
 
     def get_case_updates(self):
         # This method is used by both get_all_case_properties and
@@ -3117,9 +3123,6 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             ))
 
         return errors
-
-    def get_case_updates_for_case_type(self, case_type):
-        return self.get_case_updates().get(case_type, [])
 
     def get_case_updates(self):
         updates_by_case_type = defaultdict(set)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1838,7 +1838,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         if self.actions.load_from_form.preload:
             self.actions.load_from_form = PreloadAction()
 
-    def get_parent_types_and_contributed_properties(self, module_case_type, case_type):
+    def get_parent_types_and_contributed_properties(self, case_type):
         return (
             self.get_contributed_parent_types(case_type),
             self.get_contributed_subcase_properties(case_type)
@@ -3118,7 +3118,7 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
                 updates |= scheduler_updates[case_type]
         return updates_by_case_type
 
-    def get_parent_types_and_contributed_properties(self, module_case_type, case_type):
+    def get_parent_types_and_contributed_properties(self, case_type):
         return (
             self.get_contributed_parent_types(case_type),
             self.get_contributed_subcase_properties(case_type)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6205,7 +6205,9 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     @quickcache(['self._id', 'self.version'])
     def get_case_metadata(self):
         from corehq.apps.reports.formdetails.readable import AppCaseMetadata
-        case_relationships = get_parent_type_map(self)
+        # todo: fix this to expect a list of parent types
+        # todo: and get rid of if_multiple_parents_arbitrarily_pick_one arg
+        case_relationships = get_parent_type_map(self, if_multiple_parents_arbitrarily_pick_one=True)
         meta = AppCaseMetadata()
         descriptions_dict = get_case_property_description_dict(self.domain)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1794,7 +1794,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
 
         return errors
 
-    def get_case_updates(self, case_type):
+    def get_case_updates_by_case_type(self, case_type):
         return self.get_all_case_updates().get(case_type, [])
 
     def get_all_case_updates(self):
@@ -3083,7 +3083,7 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
 
         return errors
 
-    def get_case_updates(self, case_type):
+    def get_case_updates_by_case_type(self, case_type):
         return self.get_all_case_updates().get(case_type, [])
 
     def get_all_case_updates(self):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -764,8 +764,7 @@ class AddAutomaticUpdateRuleView(HQJSONResponseMixin, DataInterfaceSection):
 
     @allow_remote_invocation
     def get_case_property_map(self):
-        data = all_case_properties_by_domain(self.domain,
-            include_parent_properties=False)
+        data = all_case_properties_by_domain(self.domain, include_parent_properties=False)
         return {
             'data': data,
             'success': True,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1674,7 +1674,7 @@ class FormExportDataSchema(ExportDataSchema):
 
         case_updates = OrderedSet()
         for form in forms:
-            for update in form.get_case_updates(form.get_module().case_type):
+            for update in form.get_case_updates_by_case_type(form.get_module().case_type):
                 case_updates.add(update)
 
         for form in forms:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1989,7 +1989,7 @@ class CaseExportDataSchema(ExportDataSchema):
             [case_type],
             include_parent_properties=False
         )
-        parent_types = ParentCasePropertyBuilder(app).get_case_relationships(case_type)
+        parent_types = ParentCasePropertyBuilder(app).get_case_relationships_for_case_type(case_type)
         case_schemas = []
         case_schemas.append(cls._generate_schema_from_case_property_mapping(
             case_property_mapping,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1989,7 +1989,7 @@ class CaseExportDataSchema(ExportDataSchema):
             [case_type],
             include_parent_properties=False
         )
-        parent_types = ParentCasePropertyBuilder(app).get_contributed_parent_types(case_type)
+        parent_types = ParentCasePropertyBuilder(app).get_case_relationships(case_type)
         case_schemas = []
         case_schemas.append(cls._generate_schema_from_case_property_mapping(
             case_property_mapping,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1989,10 +1989,7 @@ class CaseExportDataSchema(ExportDataSchema):
             [case_type],
             include_parent_properties=False
         )
-        parent_types, _ = (
-            ParentCasePropertyBuilder(app)
-            .get_parent_types_and_contributed_properties(case_type)
-        )
+        parent_types = ParentCasePropertyBuilder(app).get_contributed_parent_types(case_type)
         case_schemas = []
         case_schemas.append(cls._generate_schema_from_case_property_mapping(
             case_property_mapping,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1674,7 +1674,7 @@ class FormExportDataSchema(ExportDataSchema):
 
         case_updates = OrderedSet()
         for form in forms:
-            for update in form.get_case_updates_by_case_type(form.get_module().case_type):
+            for update in form.get_case_updates_for_case_type(form.get_module().case_type):
                 case_updates.add(update)
 
         for form in forms:


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?269202.

Includes a BIG refactor of the underlying code, going from a messy recursive process, to a (I like to think) streamlined process based on aggregating inputs from all possible sources (forms in apps, data dictionary, etc.) in the same format (`{<case_type>: set([<contributed case property>])`), flattening all of that information (which includes information for _all_ case types), and then doing a one-pass (or fixed-N-pass depending on when you start counting) process to propagate all the parent/child refs up and down. The result is a process that's more easily debuggable and easier to reason with.

Other than fixing the long-standing bug, another nice thing about this new organization is that it is very easy to (in the future) isolate the contribution coming form each app and quickcache that, thus having to pull only (1) the full list of app_ids to include and (2) look up the case property contributions of that app in the cache. Previously, the code kept coming back to the app to look for more things at different times in the recursive process; now it's all pulled up-front and processed separately.

This PR also makes it obvious that when you ask for all of the properties for a single case type, you actually basically have to look up all properties for _all_ case types to make sure you're getting parent child properties correctly propagated. (While technically it's true that you could have separate hierarchically unrelated case types all of which are now getting pulled in, where maybe (maybe?) before they weren't, in my estimation, the overhead here is _by far_ pulling all the apps, which still had to be done before.) The reason I say now it's obvious is that now all of the actual work is done by pulling case contributions for all case types up front, and the methods for getting stuff for a single case type just call those methods and filter down to a single case type. (Things are nicely memoized, so it's not actually less efficient to call these per-case-type methods for multiple different case types.)