### PR TITLE
ICDS Reports | Add map legend height to map height

### DIFF
--- a/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
+++ b/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
@@ -122,7 +122,8 @@ function IndieMapController($scope, $compile, $location, $filter, storageService
         if (vm.map.data) {
             _.extend(vm.mapPlugins, {
                 customTable: function () {
-                    if (this.options.rightLegend !== null) {
+                    if (this.options.rightLegend !== null &&
+                        d3.select(this.options.element)[0][0].lastChild.className !== 'map-kpi-outer') {
                         var html = [
                             '<div class="map-kpi" style="width: 310px;">',
                             '<div class="row no-margin">',
@@ -173,9 +174,14 @@ function IndieMapController($scope, $compile, $location, $filter, storageService
 
                         html.push('</div>');
                         d3.select(this.options.element).append('div')
-                            .attr('class', '')
-                            .attr('style', 'position: absolute; top: 2%; left: 0; z-index: -1')
+                            .attr('class', 'map-kpi-outer')
+                            .attr('style', 'position: absolute; top: 15px; left: 0; z-index: -1')
                             .html(html.join(''));
+                        var mapHeight = d3.select(this.options.element)[0][0].offsetHeight;
+                        var legendHeight = d3.select(this.options.element)[0][0].lastElementChild.offsetHeight;
+                        if (mapHeight < legendHeight + 15) {
+                            d3.select(this.options.element)[0][0].style.height = legendHeight + 15 + "px";
+                        }
                     }
                 },
             });


### PR DESCRIPTION
Hi @czue,
I have made a change to prevent map legend being unable to be read in its entirety, by being under the bottom panel to choose between map and chart view, as well as it was able to get in the spot of a chart on block view.
I have made this change in this way because we are using position absolute on the legend as well as z-index = -1 to allow the map to be on top of legend if the screen is smaller. It is essentially making the height of the map bigger when necessary,
Also in line 125, I have added a check to prevent 2 legends from loading on top of another.