### PR TITLE
Fetch export docs in chunks

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -443,8 +443,14 @@ class ESQuery(object):
         return self.size(0).run().total
 
     def get_ids(self):
-        """Performs a minimal query to get the ids of the matching documents"""
+        """Performs a minimal query to get the ids of the matching documents
+
+        For very large sets of IDs, use ``scroll_ids`` instead"""
         return self.exclude_source().run().doc_ids
+
+    def scroll_ids(self):
+        """Returns a generator of all matching ids"""
+        return self.exclude_source().size(5000).scroll()
 
 
 class ESQuerySet(object):

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -17,6 +17,7 @@ from soil import DownloadBase
 
 from couchexport.export import FormattedRow, get_writer
 from couchexport.models import Format
+from corehq.elastic import iter_es_docs
 from corehq.toggles import PAGINATED_EXPORTS
 from corehq.util.files import safe_filename
 from corehq.util.datadog.gauges import datadog_histogram
@@ -334,12 +335,8 @@ def get_export_file(export_instances, filters, progress_tracker=None):
 
 def get_export_documents(export_instance, filters):
     query = _get_export_query(export_instance, filters)
-    # size here limits each scroll request, not the total number of results
-    # We believe we can occasionally hit the 5m limit to process a single scroll window
-    # with a window size of 1000 (https://manage.dimagi.com/default.asp?248384).
-    # Thus, smaller window size is intentional
-    # Another option we have is to bump the "scroll" parameter up from "5m"
-    return query.size(200).scroll()
+    doc_ids = list(query.scroll_ids())
+    return iter_es_docs(query.index, doc_ids)
 
 
 def _get_export_query(export_instance, filters):
@@ -360,7 +357,7 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
     the given documents.
     :param writer: An open _Writer
     :param export_instance: An ExportInstance
-    :param documents: A ScanResult, or if progress_tracker is None, any iterable yielding documents
+    :param documents: An iterable yielding documents
     :param progress_tracker: A task for soil to track progress against
     :return: None
     """

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -334,11 +334,14 @@ def get_export_file(export_instances, filters, progress_tracker=None):
 
 
 def get_export_documents(export_instance, filters):
+    # Pull doc ids from elasticsearch and stream to disk
     query = _get_export_query(export_instance, filters)
     _, temp_path = tempfile.mkstemp()
     with open(temp_path, 'w') as f:
         for doc_id in query.scroll_ids():
             f.write(doc_id + '\n')
+
+    # Stream doc ids from disk and fetch documents from ES in chunks
     with open(temp_path) as f:
         doc_ids = (doc_id.strip() for doc_id in f)
         for doc in iter_es_docs(query.index, doc_ids):

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -234,7 +234,8 @@ def iter_es_docs(index_name, ids):
     """Returns a generator which pulls documents from elasticsearch in chunks"""
     for ids_chunk in chunked(ids, 100):
         for result in mget_query(index_name, ids_chunk, source=True):
-            yield result['_source']
+            if result['found']:
+                yield result['_source']
 
 
 def scroll_query(index_name, q, es_instance_alias=ES_DEFAULT_INSTANCE):


### PR DESCRIPTION
https://trello.com/c/riVG09rj/191-exports-reduce-es-overhead

The current behavior keeps a scroll query open for the duration of the query, which has caused issues in the past.  This PR instead pulls all ids up front in a scroll query, streams that to disk, then reads from disk in chunks and fetches from ES.  If I did this right, it should never have the full set of IDs (let alone docs) in memory at once.

Product FYI:
The old behavior (a scroll query) stores the state of the docs when the query is initiated, so the results are a snapshot from that time. One effect of this change is that we will lose that behavior - results will be fetched throughout the duration of the export task, so if a task takes one hour, some cases may be 1 hour more up-to-date than others.  In my estimation, this is an acceptable tradeoff for what should be a more reliable export task.

@snopoke this is the behavior we discussed
@emord @nickpell