### PR TITLE
Change version in requirements from 0.1.2 to 0.1.3

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -99,7 +99,7 @@ dnspython==1.15.0
 raven==6.1.0
 quickcache==0.2.0
 zeep==1.6.0
-git+git://github.com/dimagi/ethiopian-date-converter@v0.1.2#egg=ethiopian-date-converter
+git+git://github.com/dimagi/ethiopian-date-converter@v0.1.3#egg=ethiopian-date-converter
 git+git://github.com/dimagi/architect@v0.5.7a2#egg=architect
 contextlib2==0.5.4
 hiredis==0.2.0


### PR DESCRIPTION
I noticed ethiopian-date-converter is up to 0.1.3:
https://github.com/dimagi/ethiopian-date-converter/blob/master/ethiopian_date/__init__.py#L17 & https://github.com/dimagi/ethiopian-date-converter/releases
updating requirements.txt to reflect that