### PR TITLE
reup/tracking

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -306,13 +306,13 @@ class CouchSqlDomainMigrator(object):
         for timing in timing_context.to_list():
             datadog_counter(
                 metric_name_template % timing.full_name,
-                tags=['duration:%s' % bucket_value(timing.duration, TIMING_BUCKETS))
+                tags=['duration:%s' % bucket_value(timing.duration, TIMING_BUCKETS)])
             normalize_denominator = getattr(timing, 'normalize_denominator', None)
             if normalize_denominator:
                 datadog_counter(
                     metric_name_template_normalized % timing.full_name,
                     tags=['duration:%s' % bucket_value(timing.duration / normalize_denominator,
-                                                       NORMALIZED_TIMING_BUCKETS))
+                                                       NORMALIZED_TIMING_BUCKETS)])
 
 
 TIMING_BUCKETS = (0.1, 1, 5, 10, 30, 60, 60 * 5, 60 * 10, 60 * 60, 60 * 60 * 12, 60 * 60 * 24)

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from __future__ import division
 import os
 import uuid
 from datetime import datetime

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -30,7 +30,7 @@ from corehq.form_processor.utils.general import set_local_domain_sql_backend_ove
 from corehq.toggles import COUCH_SQL_MIGRATION_BLACKLIST
 from corehq.util.log import with_progress_bar
 from corehq.util.timer import TimingContext
-from corehq.util.datadog.gauges import datadog_histogram
+from corehq.util.datadog.gauges import datadog_histogram, datadog_counter
 from corehq.util.pagination import PaginationEventHandler
 from couchforms.models import XFormInstance, doc_types as form_doc_types, all_known_formlike_doc_types
 from dimagi.utils.couch.database import iter_docs
@@ -572,3 +572,4 @@ def commit_migration(domain_name):
     if not should_use_sql_backend(domain_name):
         Domain.get_by_name.clear(Domain, domain_name)
         assert should_use_sql_backend(domain_name)
+    datadog_counter("commcare.couch_sql_migration.total_committed")

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -301,8 +301,8 @@ class CouchSqlDomainMigrator(object):
             return iterable
 
     def _send_timings(self, timing_context):
-        metric_name_template = "commcare.%s.duration"
-        metric_name_template_normalized = "commcare.%s.duration.normalized"
+        metric_name_template = "commcare.%s.count"
+        metric_name_template_normalized = "commcare.%s.count.normalized"
         for timing in timing_context.to_list():
             datadog_counter(
                 metric_name_template % timing.full_name,

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -22,6 +22,8 @@ from corehq.util.markup import shell_green, shell_red
 from couchforms.dbaccessors import get_form_ids_by_type
 from couchforms.models import doc_types, XFormInstance
 from six.moves import input, zip_longest
+import logging
+_logger = logging.getLogger('main_couch_sql_datamigration')
 
 
 class Command(BaseCommand):
@@ -207,3 +209,4 @@ def _blow_away_migration(domain):
 
     sql_case_ids = CaseAccessorSQL.get_deleted_case_ids_in_domain(domain)
     CaseAccessorSQL.hard_delete_cases(domain, sql_case_ids)
+    _logger.info("blew away migration for domain {}".format(domain))

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -541,13 +541,14 @@ class MigrationTestCase(BaseMigrationTestCase):
         with patch_datadog() as received_stats:
             self._do_migration_and_assert_flags(self.domain_name)
         tracked_stats = [
-            'commcare.couch_sql_migration.unprocessed_cases',
-            'commcare.couch_sql_migration.main_forms',
-            'commcare.couch_sql_migration.unprocessed_forms',
-            'commcare.couch_sql_migration.case_diffs',
-            'commcare.couch_sql_migration',
+            'commcare.couch_sql_migration.unprocessed_cases.count.duration:',
+            'commcare.couch_sql_migration.main_forms.count.duration:',
+            'commcare.couch_sql_migration.unprocessed_forms.count.duration:',
+            'commcare.couch_sql_migration.case_diffs.count.duration:',
+            'commcare.couch_sql_migration.count.duration:',
         ]
-        self.assertItemsEqual(tracked_stats, received_stats.keys())
+        for t_stat in tracked_stats:
+            self.assertTrue(any(r_stat.startswith(t_stat) for r_stat in received_stats))
 
 class LedgerMigrationTests(BaseMigrationTestCase):
     def setUp(self):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -34,6 +34,7 @@ from corehq.util.test_utils import (
     trap_extra_setup, TestFileMixin
 )
 from couchforms.models import XFormInstance
+from corehq.util.test_utils import patch_datadog
 
 
 class BaseMigrationTestCase(TestCase, TestFileMixin):
@@ -536,6 +537,17 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assertEqual(1, len(self._get_case_ids()))
         self._compare_diffs([])
 
+    def test_timings(self):
+        with patch_datadog() as received_stats:
+            self._do_migration_and_assert_flags(self.domain_name)
+        tracked_stats = [
+            'commcare.couch_sql_migration.unprocessed_cases',
+            'commcare.couch_sql_migration.main_forms',
+            'commcare.couch_sql_migration.unprocessed_forms',
+            'commcare.couch_sql_migration.case_diffs',
+            'commcare.couch_sql_migration',
+        ]
+        self.assertItemsEqual(tracked_stats, received_stats.keys())
 
 class LedgerMigrationTests(BaseMigrationTestCase):
     def setUp(self):

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import unicode_literals
 import time
 
+from memoized import memoized
 import itertools
 
 
@@ -63,6 +64,17 @@ class NestableTimer(object):
     @property
     def is_leaf_node(self):
         return not self.subs
+
+    @property
+    def is_root_node(self):
+        return not self.parent
+
+    @property
+    @memoized
+    def full_name(self):
+        if self.is_root_node:
+            return self.name
+        return "%s.%s" % (self.parent.full_name, self.name)
 
     def __repr__(self):
         return "NestableTimer(name='{}', beginning={}, end={}, parent='{}')".format(

--- a/settings.py
+++ b/settings.py
@@ -116,6 +116,7 @@ PRIVATE_SECTOR_DATAMIGRATION = "%s/%s" % (FILEPATH, "private_sector_datamigratio
 FORMPLAYER_TIMING_FILE = "%s/%s" % (FILEPATH, "formplayer.timing.log")
 FORMPLAYER_DIFF_FILE = "%s/%s" % (FILEPATH, "formplayer.diff.log")
 SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
+MAIN_COUCH_SQL_DATAMIGRATION = "%s/%s" % (FILEPATH, "main_couch_sql_datamigration.log")
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}
@@ -1206,7 +1207,15 @@ LOGGING = {
             'filename': SOFT_ASSERTS_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 200  # Backup 2000 MB of logs
-        }
+        },
+        'main_couch_sql_datamigration': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'simple',
+            'filename': MAIN_COUCH_SQL_DATAMIGRATION,
+            'maxBytes': 10 * 1024 * 1024,
+            'backupCount': 20
+        },
     },
     'root': {
         'level': 'INFO',


### PR DESCRIPTION
This is the basics for some tracking on the couch->sql migration process. It's probably clearest to go through this commit by commit 🐠. 

There are some objectionable things in here, so I'll start off by highlighting a few things to keep an eye out for off the bat -->
1) Use of TimingContext started off _almost_ elegant, but reduces readability
2) Timing normalization is very naive and crude
3) I've used statsd before with graphite and grafana before, but not datadog. If I should be using tags or keying in a different way let me know. Also a histogram seemed right for this, but I couldn't find the config for what buckets it creates. Could someone point me in the right direction for that?

@snopoke @millerdev @esoergel buddy: @gcapalbo