### PR TITLE
disable heartbeat updates on icds

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -5,6 +5,8 @@ from couchdbkit import ResourceConflict
 from distutils.version import LooseVersion
 
 from datetime import datetime
+
+from django.conf import settings
 from django.http import JsonResponse, Http404, HttpResponse, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
@@ -258,13 +260,15 @@ def heartbeat(request, domain, app_build_id):
         info.update(LatestAppInfo(brief_app_id, domain).get_info())
 
     else:
-        couch_user = request.couch_user
-        try:
-            update_user_reporting_data(app_build_id, app_id, couch_user, request)
-        except ResourceConflict:
-            # https://sentry.io/dimagi/commcarehq/issues/521967014/
-            couch_user = CouchUser.get(couch_user.user_id)
-            update_user_reporting_data(app_build_id, app_id, couch_user, request)
+        if settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS:
+            # disable on icds for now since couch still not happy
+            couch_user = request.couch_user
+            try:
+                update_user_reporting_data(app_build_id, app_id, couch_user, request)
+            except ResourceConflict:
+                # https://sentry.io/dimagi/commcarehq/issues/521967014/
+                couch_user = CouchUser.get(couch_user.user_id)
+                update_user_reporting_data(app_build_id, app_id, couch_user, request)
 
     return JsonResponse(info)
 


### PR DESCRIPTION
Since couch is still struggling let's disable this for now.

https://app.datadoghq.com/dash/278650/couch-health-timeboard?live=true&page=0&is_auto=false&from_ts=1524033654402&to_ts=1524048054402&tile_size=m&tpl_var_environment=icds-new&fullscreen=222175770