### PR TITLE
Use PhoneNumber entries in the new reminders framework

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -26,6 +26,7 @@ from corehq.apps.smsbillables.exceptions import RetryBillableTaskException
 from corehq.apps.smsbillables.models import SmsBillable
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.messaging.util import use_phone_entries
 from corehq.toggles import RETRY_SMS_INDEFINITELY
 from corehq.util.celery_utils import no_result_task
 from corehq.util.timezones.conversions import ServerTime
@@ -484,6 +485,9 @@ def _sync_case_phone_number(contact_case):
 @no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
                 default_retry_delay=5 * 60, max_retries=10, bind=True)
 def sync_user_phone_numbers(self, couch_user_id):
+    if not use_phone_entries():
+        return
+
     try:
         _sync_user_phone_numbers(couch_user_id)
     except Exception as e:

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -4,8 +4,9 @@ import jsonfield
 import uuid
 from memoized import memoized
 from django.db import models, transaction
-from corehq.apps.reminders.util import get_one_way_number_for_recipient
-from corehq.apps.sms.api import MessageMetadata, send_sms
+from corehq.apps.reminders.util import get_one_way_number_for_recipient, get_two_way_number_for_recipient
+from corehq.apps.sms.api import MessageMetadata, send_sms, send_sms_to_verified_number
+from corehq.apps.sms.models import PhoneNumber
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.models import CommCareUser
 from corehq.messaging.scheduling.exceptions import (
@@ -19,6 +20,7 @@ from corehq.messaging.templating import (
     SimpleDictTemplateParam,
     CaseMessagingTemplateParam,
 )
+from corehq.messaging.util import use_phone_entries
 from django.utils.functional import cached_property
 
 
@@ -246,19 +248,28 @@ class Content(models.Model):
         return r
 
     @classmethod
-    def get_one_way_phone_number(cls, recipient):
+    def get_two_way_entry_or_phone_number(cls, recipient):
+        """
+        If recipient has a two-way number, returns it as a PhoneNumber entry.
+        If recipient does not have a two-way number but has a phone number configured,
+        returns the one-way phone number as a string.
+        """
+        if use_phone_entries():
+            phone_entry = get_two_way_number_for_recipient(recipient)
+            if phone_entry:
+                return phone_entry
+
         phone_number = get_one_way_number_for_recipient(recipient)
 
-        if not phone_number and isinstance(recipient, CommCareUser):
-            if recipient.memoized_usercase:
-                phone_number = get_one_way_number_for_recipient(recipient.memoized_usercase)
+        # Avoid processing phone numbers that are obviously fake (len <= 3) to
+        # save on processing time
+        if phone_number and len(phone_number) > 3:
+            return phone_number
 
-        if not phone_number or len(phone_number) <= 3:
-            # Avoid processing phone numbers that are obviously fake to
-            # save on processing time
-            return None
+        if isinstance(recipient, CommCareUser) and recipient.memoized_usercase:
+            return cls.get_two_way_entry_or_phone_number(recipient.memoized_usercase)
 
-        return phone_number
+        return None
 
     @staticmethod
     def get_cleaned_message(message_dict, language_code):
@@ -309,12 +320,16 @@ class Content(models.Model):
             messaging_subevent_id=logged_subevent.pk,
         )
 
-    def send_sms_message(self, domain, recipient, phone_number, message, logged_subevent):
+    def send_sms_message(self, domain, recipient, phone_entry_or_number, message, logged_subevent):
         if not message:
             return
 
         metadata = self.get_sms_message_metadata(logged_subevent)
-        send_sms(domain, recipient, phone_number, message, metadata=metadata)
+
+        if isinstance(phone_entry_or_number, PhoneNumber):
+            send_sms_to_verified_number(phone_entry_or_number, message, metadata=metadata, logged_subevent=logged_subevent)
+        else:
+            send_sms(domain, recipient, phone_entry_or_number, message, metadata=metadata)
 
 
 class Broadcast(models.Model):

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -327,7 +327,8 @@ class Content(models.Model):
         metadata = self.get_sms_message_metadata(logged_subevent)
 
         if isinstance(phone_entry_or_number, PhoneNumber):
-            send_sms_to_verified_number(phone_entry_or_number, message, metadata=metadata, logged_subevent=logged_subevent)
+            send_sms_to_verified_number(phone_entry_or_number, message, metadata=metadata,
+                logged_subevent=logged_subevent)
         else:
             send_sms(domain, recipient, phone_entry_or_number, message, metadata=metadata)
 

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -41,8 +41,8 @@ class SMSContent(Content):
             case_id=self.case.case_id if self.case else None,
         )
 
-        phone_number = self.get_one_way_phone_number(recipient)
-        if not phone_number:
+        phone_entry_or_number = self.get_two_way_entry_or_phone_number(recipient)
+        if not phone_entry_or_number:
             logged_subevent.error(MessagingEvent.ERROR_NO_PHONE_NUMBER)
             return
 
@@ -53,7 +53,7 @@ class SMSContent(Content):
         )
         message = self.render_message(message, recipient, logged_subevent)
 
-        self.send_sms_message(logged_event.domain, recipient, phone_number, message, logged_subevent)
+        self.send_sms_message(logged_event.domain, recipient, phone_entry_or_number, message, logged_subevent)
         logged_subevent.completed()
 
 
@@ -188,14 +188,14 @@ class CustomContent(Content):
             case_id=self.case.case_id if self.case else None,
         )
 
-        phone_number = self.get_one_way_phone_number(recipient)
-        if not phone_number:
+        phone_entry_or_number = self.get_two_way_entry_or_phone_number(recipient)
+        if not phone_entry_or_number:
             logged_subevent.error(MessagingEvent.ERROR_NO_PHONE_NUMBER)
             return
 
         # An empty list of messages returned from a custom content handler means
         # we shouldn't send anything, so we don't log an error for that.
         for message in self.get_list_of_messages(recipient):
-            self.send_sms_message(logged_event.domain, recipient, phone_number, message, logged_subevent)
+            self.send_sms_message(logged_event.domain, recipient, phone_entry_or_number, message, logged_subevent)
 
         logged_subevent.completed()

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -183,16 +183,16 @@ class SchedulingRecipientTest(TestCase):
         self.addCleanup(user3.delete)
 
         self.assertIsNone(user1.memoized_usercase)
-        self.assertIsNone(Content.get_one_way_phone_number(user1))
+        self.assertIsNone(Content.get_two_way_entry_or_phone_number(user1))
 
         with self.create_user_case(user2) as case:
             self.assertIsNotNone(user2.memoized_usercase)
-            self.assertIsNone(Content.get_one_way_phone_number(user2))
+            self.assertIsNone(Content.get_two_way_entry_or_phone_number(user2))
 
         with self.create_user_case(user3) as case:
             update_case(self.domain, case.case_id, case_properties={'contact_phone_number': '12345678'})
             self.assertIsNotNone(user3.memoized_usercase)
-            self.assertEqual(Content.get_one_way_phone_number(user3), '12345678')
+            self.assertEqual(Content.get_two_way_entry_or_phone_number(user3), '12345678')
 
             user3.add_phone_number('87654321')
-            self.assertEqual(Content.get_one_way_phone_number(user3), '87654321')
+            self.assertEqual(Content.get_two_way_entry_or_phone_number(user3), '87654321')

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -8,7 +8,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.form_processor.utils import should_use_sql_backend
 from corehq.messaging.scheduling.util import utcnow
-from corehq.messaging.util import MessagingRuleProgressHelper
+from corehq.messaging.util import MessagingRuleProgressHelper, use_phone_entries
 from corehq.sql_db.util import run_query_across_partitioned_databases
 from corehq.util.celery_utils import no_result_task
 from dimagi.utils.couch import CriticalSection
@@ -44,7 +44,7 @@ def _sync_case_for_messaging(domain, case_id):
     case = CaseAccessors(domain).get_case(case_id)
     sms_tasks.clear_case_caches(case)
 
-    if settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS:
+    if use_phone_entries():
         sms_tasks._sync_case_phone_number(case)
 
     handler_ids = CaseReminderHandler.get_handler_ids_for_case_post_save(case.domain, case.type)

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 from __future__ import unicode_literals
 from dimagi.utils.couch.cache.cache_core import get_redis_client
+from django.conf import settings
 
 
 class MessagingRuleProgressHelper(object):
@@ -65,3 +66,11 @@ class MessagingRuleProgressHelper(object):
             return 100
 
         return int(round(100.0 * current / total, 0))
+
+
+def use_phone_entries():
+    """
+    Phone entries are not used in ICDS because they're not needed and
+    it helps performance to avoid keeping them up to date.
+    """
+    return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS


### PR DESCRIPTION
For parity with the old reminders framework, we now give precedence to a two-way PhoneNumber entry as a preferred number for the recipient when sending them SMS. If no two-way entry exists, we use a one-way number if it exists.

This hasn't mattered up until now because only ICDS has been using the new framework and ICDS only uses one-way numbers (and also doesn't sync PhoneNumber entries), but now that we'll be moving production domains to the new framework this is necessary.

@millerdev @jmtroth0 