### PR TITLE
Externalize js: reassign cases

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/archive_forms.js
@@ -24,6 +24,7 @@ hqDefine("data_interfaces/js/archive_forms", function() {
         $(allFormsButtonSelector).prop('checked', false);
     }
 
+    // Similar to case_management.js, would be good to combine the two
     $(function() {
         // bindings for 'all' button
         $(document).on('click', managementSelector + ' a.select-visible', function() {

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -1,150 +1,217 @@
 /* globals _, ko, casexml, $ */
+hqDefine("data_interfaces/js/case_management", function() {
+    var CaseManagement = function (o) {
+        'use strict';
+        var self = {};
 
-var CaseManagement = function (o) {
-    'use strict';
-    var self = {};
+        self.receiverUrl = o.receiverUrl;
+        self.updatedCase = null;
+        self.webUserID = o.webUserID;
+        self.webUserName = o.webUserName;
+        self.form_name = o.form_name;
 
-    self.receiverUrl = o.receiverUrl;
-    self.updatedCase = null;
-    self.webUserID = o.webUserID;
-    self.webUserName = o.webUserName;
-    self.form_name = o.form_name;
+        // What's checked in the table below
+        self.selected_cases = ko.observableArray();
+        self.selected_owners = ko.observableArray();
+        self.selected_owner_types = ko.observableArray();
 
-    // What's checked in the table below
-    self.selected_cases = ko.observableArray();
-    self.selected_owners = ko.observableArray();
-    self.selected_owner_types = ko.observableArray();
+        // What we're assigning to
+        self.new_owner = ko.observable();
 
-    // What we're assigning to
-    self.new_owner = ko.observable();
+        self.is_submit_enabled = ko.computed(function () {
+            return !!self.new_owner();
+        }, self);
 
-    self.is_submit_enabled = ko.computed(function () {
-        return !!self.new_owner();
-    }, self);
+        self.should_show_owners = ko.observable(true);
 
-    self.should_show_owners = ko.observable(true);
+        var enddate = new Date(o.enddate),
+            now = new Date();
+        self.on_today = (enddate.toDateString() === now.toDateString());
 
-    var enddate = new Date(o.enddate),
-        now = new Date();
-    self.on_today = (enddate.toDateString() === now.toDateString());
-
-    var getOwnerType = function (owner_id) {
-        if (owner_id.startsWith('u')) {
-            return 'user';
-        } else if (owner_id.startsWith('sg')) {
-            return 'group';
-        }
-    };
-
-    var updateCaseRow = function (case_id, owner_id, owner_type) {
-        return function(data, textStatus) {
-            var $checkbox = $('#data-interfaces-reassign-cases input[data-caseid="' + case_id + '"].selected-commcare-case'),
-                username = $('#reassign_owner_select').data().select2.data().text,
-                date_message = (self.on_today) ? '<span title="0"></span>' :
-                    '<span class="label label-warning" title="0">Out of range of filter. Will ' +
-                                    'not appear on page refresh.</span>';
-            $checkbox.data('owner', owner_id);
-            $checkbox.data('ownertype', owner_type);
-
-            var $row = $checkbox.closest("tr"),
-                group_label = '';
-
-            if (owner_type === 'group') {
-                group_label = ' <span class="label label-inverse" title="'+username+'">group</span>';
+        var getOwnerType = function (owner_id) {
+            if (owner_id.startsWith('u')) {
+                return 'user';
+            } else if (owner_id.startsWith('sg')) {
+                return 'group';
             }
-
-            $row.find('td:nth-child(4)').html(username +group_label+' <span class="label label-info" title="' + username +
-                                            '">updated</span>');
-            $row.find('td:nth-child(5)').html('Today ' + date_message);
-            $checkbox.prop("checked", false).change();
         };
-    };
 
-    self.changeNewOwner = function () {
-        self.new_owner($('#reassign_owner_select').val());
-    };
+        var updateCaseRow = function (case_id, owner_id, owner_type) {
+            return function(data, textStatus) {
+                var $checkbox = $('#data-interfaces-reassign-cases input[data-caseid="' + case_id + '"].selected-commcare-case'),
+                    username = $('#reassign_owner_select').data().select2.data().text,
+                    date_message = (self.on_today) ? '<span title="0"></span>' :
+                        '<span class="label label-warning" title="0">Out of range of filter. Will ' +
+                                        'not appear on page refresh.</span>';
+                $checkbox.data('owner', owner_id);
+                $checkbox.data('ownertype', owner_type);
 
-    self.updateCaseSelection = function (data, event) {
-        var $checkbox = $(event.currentTarget),
-            caseID = $checkbox.data('caseid'),
-            ownerID = $checkbox.data('owner'),
-            ownerType = $checkbox.data('ownertype');
+                var $row = $checkbox.closest("tr"),
+                    group_label = '';
 
-        var ind = self.selected_cases().indexOf(caseID),
-            $selectedRow = $checkbox.closest('tr');
+                if (owner_type === 'group') {
+                    group_label = ' <span class="label label-inverse" title="'+username+'">group</span>';
+                }
 
-        if ($checkbox.is(':checked')) {
-            $selectedRow.addClass('active');
-            if (ind < 0) {
-                self.selected_cases.push(caseID);
+                $row.find('td:nth-child(4)').html(username +group_label+' <span class="label label-info" title="' + username +
+                                                '">updated</span>');
+                $row.find('td:nth-child(5)').html('Today ' + date_message);
+                $checkbox.prop("checked", false).change();
+            };
+        };
+
+        self.changeNewOwner = function () {
+            self.new_owner($('#reassign_owner_select').val());
+        };
+
+        self.updateCaseSelection = function (data, event) {
+            var $checkbox = $(event.currentTarget),
+                caseID = $checkbox.data('caseid'),
+                ownerID = $checkbox.data('owner'),
+                ownerType = $checkbox.data('ownertype');
+
+            var ind = self.selected_cases().indexOf(caseID),
+                $selectedRow = $checkbox.closest('tr');
+
+            if ($checkbox.is(':checked')) {
+                $selectedRow.addClass('active');
+                if (ind < 0) {
+                    self.selected_cases.push(caseID);
+                }
+                self.selected_owner_types.push(ownerType);
+                self.selected_owners.push(ownerID);
+            } else {
+                $selectedRow.removeClass('active');
+                if (ind >= 0) {
+                    self.selected_cases.splice(ind, 1);
+                }
+                self.selected_owner_types.splice(self.selected_owner_types().indexOf(ownerType), 1);
+                self.selected_owners.splice(self.selected_owners().indexOf(ownerID), 1);
             }
-            self.selected_owner_types.push(ownerType);
-            self.selected_owners.push(ownerID);
-        } else {
-            $selectedRow.removeClass('active');
-            if (ind >= 0) {
-                self.selected_cases.splice(ind, 1);
+        };
+
+        self.clearCaseSelection = function () {
+            self.selected_cases.removeAll();
+        };
+
+        self.updateCaseOwners = function (form) {
+            var new_owner = $(form).find('#reassign_owner_select').val(),
+                $modal = $('#caseManagementStatusModal'),
+                owner_type = getOwnerType(new_owner);
+
+            if (new_owner.includes('__')) {
+                // groups and users have different number of characters before the id
+                // users are u__id and groups are sg__id
+                new_owner = new_owner.slice(new_owner.indexOf('__') + 2);
             }
-            self.selected_owner_types.splice(self.selected_owner_types().indexOf(ownerType), 1);
-            self.selected_owners.splice(self.selected_owners().indexOf(ownerID), 1);
-        }
-    };
 
-    self.clearCaseSelection = function () {
-        self.selected_cases.removeAll();
-    };
+            if (_.isEmpty(new_owner)) {
+                $modal.find('.modal-body').text("Please select an owner");
+                $modal.modal('show');
+            } else {
+                $(form).find("[type='submit']").disableButton();
+                for (var i = 0; i < self.selected_cases().length; i++) {
+                    var case_id = self.selected_cases()[i],
+                        xform;
+                    xform = casexml.CaseDelta.wrap({
+                        case_id: case_id,
+                        properties: {owner_id: new_owner},
+                    }).asXFormInstance({
+                        user_id: self.webUserID,
+                        username: self.webUserName,
+                        form_name: self.form_name,
+                    }).serialize();
 
-    self.updateCaseOwners = function (form) {
-        var new_owner = $(form).find('#reassign_owner_select').val(),
-            $modal = $('#caseManagementStatusModal'),
-            owner_type = getOwnerType(new_owner);
+                    $.ajax({
+                        url: self.receiverUrl,
+                        type: 'post',
+                        data: xform,
+                        success: updateCaseRow(case_id, new_owner, owner_type),
+                    });
 
-        if (new_owner.includes('__')) {
-            // groups and users have different number of characters before the id
-            // users are u__id and groups are sg__id
-            new_owner = new_owner.slice(new_owner.indexOf('__') + 2);
-        }
-
-        if (_.isEmpty(new_owner)) {
-            $modal.find('.modal-body').text("Please select an owner");
-            $modal.modal('show');
-        } else {
-            $(form).find("[type='submit']").disableButton();
-            for (var i = 0; i < self.selected_cases().length; i++) {
-                var case_id = self.selected_cases()[i],
-                    xform;
-                xform = casexml.CaseDelta.wrap({
-                    case_id: case_id,
-                    properties: {owner_id: new_owner},
-                }).asXFormInstance({
-                    user_id: self.webUserID,
-                    username: self.webUserName,
-                    form_name: self.form_name,
-                }).serialize();
-
-                $.ajax({
-                    url: self.receiverUrl,
-                    type: 'post',
-                    data: xform,
-                    success: updateCaseRow(case_id, new_owner, owner_type),
-                });
-
+                }
             }
-        }
+        };
+
+        return self;
     };
 
-    return self;
-};
+    ko.bindingHandlers.caseReassignmentForm = {
+        update: function(element, valueAccessor) {
+            var value = valueAccessor()();
+            var $element = $(element);
+            if (value.length > 0) {
+                $element.slideDown();
+            } else {
+                $element.find("[type='submit']").enableButton();
+                $element.slideUp();
+            }
+        },
+    };
 
-ko.bindingHandlers.caseReassignmentForm = {
-    update: function(element, valueAccessor) {
-        var value = valueAccessor()();
-        var $element = $(element);
-        if (value.length > 0) {
-            $element.slideDown();
-        } else {
-            $element.find("[type='submit']").enableButton();
-            $element.slideUp();
+    $(function() {
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+            interfaceSelector = '#data-interfaces-reassign-cases',
+            caseManagementModel = CaseManagement({
+                receiverUrl: initialPageData.reverse("receiver_secure_post"),
+                enddate: initialPageData.get("reassign_cases_enddate"),
+                webUserID: initialPageData.get("web_user_id"),
+                webUserName: initialPageData.get("web_username"),
+                form_name: gettext("Case Reassignment (via HQ)"),
+        });
+
+        // Apply bindings whenever report content is refreshed
+        $(document).on('ajaxSuccess', function(e, xhr, ajaxOptions) {
+            if (ajaxOptions.url.indexOf(initialPageData.get("js_options").asyncUrl) === -1) {
+                return;
+            }
+
+            // Apply bindings to reassignment interface and select2
+            $(interfaceSelector).koApplyBindings(caseManagementModel);
+
+            $('#reassign_owner_select').select2({
+                placeholder: gettext("Search for users or groups"),
+                ajax: {
+                    url: initialPageData.reverse("reassign_case_options"),
+                    data: function (term, page) {
+                        return {
+                            q: term
+                        };
+                    },
+                    dataType: 'json',
+                    quietMillis: 250,
+                    results: function (data, page) {
+                        return {
+                            total: data.total,
+                            results: data.results,
+                        };
+                    },
+                    cache: true
+                }
+            });
+        });
+
+        // Event handlers for selecting & de-selecting cases
+        // Similar to archive_forms.js, would be good to combine the two
+        $(document).on("click", interfaceSelector + " a.select-all", function () {
+            $(interfaceSelector).find('input.selected-commcare-case').prop('checked', true).change();
+            return false;
+        });
+
+        function selectNone() {
+            $(interfaceSelector).find('input.selected-commcare-case:checked').prop('checked', false).change();
         }
-    },
-};
+
+        $(document).on("click", interfaceSelector + " a.select-none", function() {
+            selectNone();
+            return false;
+        });
+
+        $(document).on("mouseup", interfaceSelector + " .dataTables_paginate a", selectNone);
+        $(document).on("change", interfaceSelector + " .dataTables_length select", selectNone);
+
+        $(document).on("change", interfaceSelector + " input.selected-commcare-case", function(e) {
+            caseManagementModel.updateCaseSelection({}, e);
+        });
+    });
+});

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -28,34 +28,34 @@ hqDefine("data_interfaces/js/case_management", function() {
             now = new Date();
         self.on_today = (enddate.toDateString() === now.toDateString());
 
-        var getOwnerType = function (owner_id) {
-            if (owner_id.startsWith('u')) {
+        var getOwnerType = function (ownerId) {
+            if (ownerId.startsWith('u')) {
                 return 'user';
-            } else if (owner_id.startsWith('sg')) {
+            } else if (ownerId.startsWith('sg')) {
                 return 'group';
             }
         };
 
-        var updateCaseRow = function (case_id, owner_id, owner_type) {
-            return function(data, textStatus) {
-                var $checkbox = $('#data-interfaces-reassign-cases input[data-caseid="' + case_id + '"].selected-commcare-case'),
+        var updateCaseRow = function (caseId, ownerId, ownerType) {
+            return function() {
+                var $checkbox = $('#data-interfaces-reassign-cases input[data-caseid="' + caseId + '"].selected-commcare-case'),
                     username = $('#reassign_owner_select').data().select2.data().text,
-                    date_message = (self.on_today) ? '<span title="0"></span>' :
+                    dateMessage = (self.on_today) ? '<span title="0"></span>' :
                         '<span class="label label-warning" title="0">Out of range of filter. Will ' +
                                         'not appear on page refresh.</span>';
-                $checkbox.data('owner', owner_id);
-                $checkbox.data('ownertype', owner_type);
+                $checkbox.data('owner', ownerId);
+                $checkbox.data('ownertype', ownerType);
 
                 var $row = $checkbox.closest("tr"),
-                    group_label = '';
+                    groupLabel = '';
 
-                if (owner_type === 'group') {
-                    group_label = ' <span class="label label-inverse" title="'+username+'">group</span>';
+                if (ownerType === 'group') {
+                    groupLabel = ' <span class="label label-inverse" title="'+username+'">group</span>';
                 }
 
-                $row.find('td:nth-child(4)').html(username +group_label+' <span class="label label-info" title="' + username +
+                $row.find('td:nth-child(4)').html(username + groupLabel +' <span class="label label-info" title="' + username +
                                                 '">updated</span>');
-                $row.find('td:nth-child(5)').html('Today ' + date_message);
+                $row.find('td:nth-child(5)').html('Today ' + dateMessage);
                 $checkbox.prop("checked", false).change();
             };
         };
@@ -95,27 +95,27 @@ hqDefine("data_interfaces/js/case_management", function() {
         };
 
         self.updateCaseOwners = function (form) {
-            var new_owner = $(form).find('#reassign_owner_select').val(),
+            var newOwner = $(form).find('#reassign_owner_select').val(),
                 $modal = $('#caseManagementStatusModal'),
-                owner_type = getOwnerType(new_owner);
+                ownerType = getOwnerType(newOwner);
 
-            if (new_owner.includes('__')) {
+            if (newOwner.includes('__')) {
                 // groups and users have different number of characters before the id
                 // users are u__id and groups are sg__id
-                new_owner = new_owner.slice(new_owner.indexOf('__') + 2);
+                newOwner = newOwner.slice(newOwner.indexOf('__') + 2);
             }
 
-            if (_.isEmpty(new_owner)) {
+            if (_.isEmpty(newOwner)) {
                 $modal.find('.modal-body').text("Please select an owner");
                 $modal.modal('show');
             } else {
                 $(form).find("[type='submit']").disableButton();
                 for (var i = 0; i < self.selected_cases().length; i++) {
-                    var case_id = self.selected_cases()[i],
+                    var caseId = self.selected_cases()[i],
                         xform;
                     xform = casexml.CaseDelta.wrap({
-                        case_id: case_id,
-                        properties: {owner_id: new_owner},
+                        case_id: caseId,
+                        properties: {owner_id: newOwner},
                     }).asXFormInstance({
                         user_id: self.webUserID,
                         username: self.webUserName,
@@ -126,7 +126,7 @@ hqDefine("data_interfaces/js/case_management", function() {
                         url: self.receiverUrl,
                         type: 'post',
                         data: xform,
-                        success: updateCaseRow(case_id, new_owner, owner_type),
+                        success: updateCaseRow(caseId, newOwner, ownerType),
                     });
 
                 }
@@ -158,7 +158,7 @@ hqDefine("data_interfaces/js/case_management", function() {
                 webUserID: initialPageData.get("web_user_id"),
                 webUserName: initialPageData.get("web_username"),
                 form_name: gettext("Case Reassignment (via HQ)"),
-        });
+            });
 
         // Apply bindings whenever report content is refreshed
         $(document).on('ajaxSuccess', function(e, xhr, ajaxOptions) {
@@ -173,21 +173,21 @@ hqDefine("data_interfaces/js/case_management", function() {
                 placeholder: gettext("Search for users or groups"),
                 ajax: {
                     url: initialPageData.reverse("reassign_case_options"),
-                    data: function (term, page) {
+                    data: function (term) {
                         return {
-                            q: term
+                            q: term,
                         };
                     },
                     dataType: 'json',
                     quietMillis: 250,
-                    results: function (data, page) {
+                    results: function (data) {
                         return {
                             total: data.total,
                             results: data.results,
                         };
                     },
-                    cache: true
-                }
+                    cache: true,
+                },
             });
         });
 

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -38,7 +38,7 @@ var CaseManagement = function (o) {
 
     var updateCaseRow = function (case_id, owner_id, owner_type) {
         return function(data, textStatus) {
-            var $checkbox = $('#case-management input[data-caseid="' + case_id + '"].selected-commcare-case'),
+            var $checkbox = $('#data-interfaces-reassign-cases input[data-caseid="' + case_id + '"].selected-commcare-case'),
                 username = $('#reassign_owner_select').data().select2.data().text,
                 date_message = (self.on_today) ? '<span title="0"></span>' :
                     '<span class="label label-warning" title="0">Out of range of filter. Will ' +

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -2,7 +2,7 @@
 
 var CaseManagement = function (o) {
     'use strict';
-    var self = this;
+    var self = {};
 
     self.receiverUrl = o.receiverUrl;
     self.updatedCase = null;
@@ -132,6 +132,8 @@ var CaseManagement = function (o) {
             }
         }
     };
+
+    return self;
 };
 
 ko.bindingHandlers.caseReassignmentForm = {

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -40,6 +40,7 @@
         });
 
         // Event handlers for selecting & de-selecting cases
+        // Similar to archive_forms.js, would be good to combine the two
         $(document).on("click", interfaceSelector + " a.select-all", function () {
             $(interfaceSelector).find('input.selected-commcare-case').prop('checked', true).change();
             return false;

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -3,67 +3,6 @@
 {% load report_tags %}
 {% load i18n %}
 
-{% block js-inline %} {{ block.super }}
-    <script>
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
-            interfaceSelector = '#data-interfaces-reassign-cases';
-
-        // Apply bindings to reassignment interface and select2
-        var caseManagementModel = CaseManagement({
-            receiverUrl: initialPageData.reverse("receiver_secure_post"),
-            enddate: initialPageData.get("reassign_cases_enddate"),
-            webUserID: initialPageData.get("web_user_id"),
-            webUserName: initialPageData.get("web_username"),
-            form_name: gettext("Case Reassignment (via HQ)"),
-        });
-        $(interfaceSelector).koApplyBindings(caseManagementModel);
-
-        $('#reassign_owner_select').select2({
-            placeholder: gettext("Search for users or groups"),
-            ajax: {
-                url: initialPageData.reverse("reassign_case_options"),
-                data: function (term, page) {
-                    return {
-                        q: term
-                    };
-                },
-                dataType: 'json',
-                quietMillis: 250,
-                results: function (data, page) {
-                    return {
-                        total: data.total,
-                        results: data.results,
-                    };
-                },
-                cache: true
-            }
-        });
-
-        // Event handlers for selecting & de-selecting cases
-        // Similar to archive_forms.js, would be good to combine the two
-        $(document).on("click", interfaceSelector + " a.select-all", function () {
-            $(interfaceSelector).find('input.selected-commcare-case').prop('checked', true).change();
-            return false;
-        });
-
-        function selectNone() {
-            $(interfaceSelector).find('input.selected-commcare-case:checked').prop('checked', false).change();
-        }
-
-        $(document).on("click", interfaceSelector + " a.select-none", function() {
-            selectNone();
-            return false;
-        });
-
-        $(document).on("mouseup", interfaceSelector + " .dataTables_paginate a", selectNone);
-        $(document).on("change", interfaceSelector + " .dataTables_length select", selectNone);
-
-        $(document).on("change", interfaceSelector + " input.selected-commcare-case", function(e) {
-            caseManagementModel.updateCaseSelection({}, e);
-        });
-    </script>
-{% endblock %}
-
 {% block reportcontent %}
     <div id="data-interfaces-reassign-cases">
         <div class="row">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -5,7 +5,10 @@
 
 {% block js-inline %} {{ block.super }}
     <script>
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+            interfaceSelector = '#data-interfaces-reassign-cases';
+
+        // Apply bindings to reassignment interface and select2
         var caseManagementModel = CaseManagement({
             receiverUrl: initialPageData.reverse("receiver_secure_post"),
             enddate: initialPageData.get("reassign_cases_enddate"),
@@ -13,34 +16,7 @@
             webUserName: initialPageData.get("web_username"),
             form_name: gettext("Case Reassignment (via HQ)"),
         });
-        function applyBindings() {
-            var $caseManagement = $('#data-interfaces-reassign-cases');
-            $caseManagement.koApplyBindings(caseManagementModel);
-
-            $caseManagement.find('a.select-all').click(function () {
-                $caseManagement.find('input.selected-commcare-case').prop('checked', true).change();
-                return false;
-            });
-
-            $caseManagement.find('a.select-none').click(function() {selectNone(); return false;});
-            $caseManagement.find('.dataTables_paginate a').mouseup(selectNone);
-            $caseManagement.find('.dataTables_length select').change(selectNone);
-
-            function selectNone() {
-                $caseManagement.find('input.selected-commcare-case:checked').prop('checked', false).change();
-            }
-        }
-
-        $(document).on("change", "#data-interfaces-reassign-cases input.selected-commcare-case", function(e) {
-            caseManagementModel.updateCaseSelection({}, e);
-        });
-
-        var keepTrying = setInterval(function () {
-            if (window.reportTables !== undefined) {
-                clearInterval(keepTrying);
-                applyBindings();
-            }
-        }, 1000);
+        $(interfaceSelector).koApplyBindings(caseManagementModel);
 
         $('#reassign_owner_select').select2({
             placeholder: gettext("Search for users or groups"),
@@ -61,6 +37,28 @@
                 },
                 cache: true
             }
+        });
+
+        // Event handlers for selecting & de-selecting cases
+        $(document).on("click", interfaceSelector + " a.select-all", function () {
+            $(interfaceSelector).find('input.selected-commcare-case').prop('checked', true).change();
+            return false;
+        });
+
+        function selectNone() {
+            $(interfaceSelector).find('input.selected-commcare-case:checked').prop('checked', false).change();
+        }
+
+        $(document).on("click", interfaceSelector + " a.select-none", function() {
+            selectNone();
+            return false;
+        });
+
+        $(document).on("mouseup", interfaceSelector + " .dataTables_paginate a", selectNone);
+        $(document).on("change", interfaceSelector + " .dataTables_length select", selectNone);
+
+        $(document).on("change", interfaceSelector + " input.selected-commcare-case", function(e) {
+            caseManagementModel.updateCaseSelection({}, e);
         });
     </script>
 {% endblock %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -5,18 +5,16 @@
 
 {% block js-inline %} {{ block.super }}
     <script>
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
-            options = {
-                receiverUrl: initialPageData.reverse("receiver_secure_post"),
-                enddate: initialPageData.get("reassign_cases_enddate"),
-                webUserID: initialPageData.get("web_user_id"),
-                webUserName: initialPageData.get("web_username"),
-                form_name: gettext("Case Reassignment (via HQ)"),
-        };
-
-        var caseManagementModel = CaseManagement(options);
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        var caseManagementModel = CaseManagement({
+            receiverUrl: initialPageData.reverse("receiver_secure_post"),
+            enddate: initialPageData.get("reassign_cases_enddate"),
+            webUserID: initialPageData.get("web_user_id"),
+            webUserName: initialPageData.get("web_username"),
+            form_name: gettext("Case Reassignment (via HQ)"),
+        });
         function applyBindings() {
-            var $caseManagement = $('#case-management');
+            var $caseManagement = $('#data-interfaces-reassign-cases');
             $caseManagement.koApplyBindings(caseManagementModel);
 
             $caseManagement.find('a.select-all').click(function () {
@@ -33,18 +31,14 @@
             }
         }
 
-        function applyCheckboxListeners() {
-            $('input.selected-commcare-case', '#case-management').on('change', function(event) {
-                caseManagementModel.updateCaseSelection({}, event);
-            });
-        }
+        $(document).on("change", "#data-interfaces-reassign-cases input.selected-commcare-case", function(e) {
+            caseManagementModel.updateCaseSelection({}, e);
+        });
 
         var keepTrying = setInterval(function () {
             if (window.reportTables !== undefined) {
                 clearInterval(keepTrying);
                 applyBindings();
-                applyCheckboxListeners();
-                window.reportTables.fnDrawCallback = applyCheckboxListeners;
             }
         }, 1000);
 
@@ -72,7 +66,7 @@
 {% endblock %}
 
 {% block reportcontent %}
-    <div id="case-management">
+    <div id="data-interfaces-reassign-cases">
         <div class="row">
             <form class="well form-inline" style="margin: 1em; display: none;" data-bind="submit: updateCaseOwners, caseReassignmentForm: selected_cases">
                 <label for="reassign_owner_select" class="inline">{% trans 'Reassign selected cases to' %} </label>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -5,15 +5,16 @@
 
 {% block js-inline %} {{ block.super }}
     <script>
-        var OPTIONS = {
-            receiverUrl: '{% url "receiver_secure_post" domain %}',
-            enddate: '{{ datespan.enddate_param_utc }}',
-            webUserID: '{{ request.couch_user.userID }}',
-            webUserName: '{{ request.couch_user.username }}',
-            form_name: '{%  trans "Case Reassignment (via HQ)" %}'
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+            options = {
+                receiverUrl: initialPageData.reverse("receiver_secure_post"),
+                enddate: initialPageData.get("reassign_cases_enddate"),
+                webUserID: initialPageData.get("web_user_id"),
+                webUserName: initialPageData.get("web_username"),
+                form_name: gettext("Case Reassignment (via HQ)"),
         };
 
-        var caseManagementModel = new CaseManagement(OPTIONS);
+        var caseManagementModel = CaseManagement(options);
         function applyBindings() {
             var $caseManagement = $('#case-management');
             $caseManagement.koApplyBindings(caseManagementModel);
@@ -48,9 +49,9 @@
         }, 1000);
 
         $('#reassign_owner_select').select2({
-            placeholder: '{% trans "Search for users or groups" %}',
+            placeholder: gettext("Search for users or groups"),
             ajax: {
-                url: '{% url "reassign_case_options" domain %}',
+                url: initialPageData.reverse("reassign_case_options"),
                 data: function (term, page) {
                     return {
                         q: term

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -5,11 +5,6 @@
 
 {% block js-inline %} {{ block.super }}
     <script>
-    $.when(
-        $.getScript("{% static 'case/js/cheapxml.js' %}"),
-        $.getScript("{% static 'case/js/casexml.js' %}"),
-        $.getScript("{% static 'data_interfaces/js/case_management.js' %}")
-    ).done(function () {
         var OPTIONS = {
             receiverUrl: '{% url "receiver_secure_post" domain %}',
             enddate: '{{ datespan.enddate_param_utc }}',
@@ -72,7 +67,6 @@
                 cache: true
             }
         });
-    });
     </script>
 {% endblock %}
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -12,6 +12,7 @@ from django.http import HttpResponse, Http404, HttpResponseRedirect
 from django.template.context import RequestContext
 from django.template.loader import render_to_string
 from django.shortcuts import render
+from django.urls import NoReverseMatch
 from corehq.apps.domain.utils import normalize_domain_name
 
 from corehq.apps.reports.tasks import export_all_rows_task
@@ -509,6 +510,11 @@ class GenericReportView(object):
 
     @property
     def js_options(self):
+        async_url = ''
+        try:
+            async_url = self.get_url(domain=self.domain, render_as='async', relative=True)
+        except NoReverseMatch:
+            pass
         return {
             'async': self.asynchronous,
             'domain': self.domain,
@@ -522,7 +528,7 @@ class GenericReportView(object):
             'emailDefaultSubject': self.rendered_report_title,
             'type': self.dispatcher.prefix,
             'urlRoot': self.url_root,
-            'asyncUrl': self.get_url(domain=self.domain, render_as='async', relative=True),
+            'asyncUrl': async_url,
         }
 
     def update_filter_context(self):

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -510,11 +510,10 @@ class GenericReportView(object):
 
     @property
     def js_options(self):
-        async_url = ''
         try:
             async_url = self.get_url(domain=self.domain, render_as='async', relative=True)
         except NoReverseMatch:
-            pass
+            async_url = ''
         return {
             'async': self.asynchronous,
             'domain': self.domain,

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -29,7 +29,7 @@ from corehq.apps.hqwebapp.decorators import (
 )
 from corehq.apps.users.models import CouchUser
 from corehq.util.timezones.utils import get_timezone_for_user
-from corehq.util.view_utils import absolute_reverse
+from corehq.util.view_utils import absolute_reverse, reverse
 from couchexport.export import export_from_tables
 from couchexport.shortcuts import export_response
 from dimagi.utils.couch.pagination import DatatablesParams
@@ -522,6 +522,7 @@ class GenericReportView(object):
             'emailDefaultSubject': self.rendered_report_title,
             'type': self.dispatcher.prefix,
             'urlRoot': self.url_root,
+            'asyncUrl': self.get_url(domain=self.domain, render_as='async', relative=True),
         }
 
     def update_filter_context(self):
@@ -723,7 +724,7 @@ class GenericReportView(object):
         raise Http404
 
     @classmethod
-    def get_url(cls, domain=None, render_as=None, **kwargs):
+    def get_url(cls, domain=None, render_as=None, relative=False, **kwargs):
         # NOTE: I'm pretty sure this doesn't work if you ever pass in render_as
         # but leaving as is for now, as it should be obvious as soon as that
         # breaks something
@@ -737,8 +738,9 @@ class GenericReportView(object):
         url_args = [domain] if domain is not None else []
         if render_as is not None:
             url_args.append(render_as+'/')
-        return absolute_reverse(cls.dispatcher.name(),
-                                args=url_args + [cls.slug])
+        if relative:
+            return reverse(cls.dispatcher.name(), args=url_args + [cls.slug])
+        return absolute_reverse(cls.dispatcher.name(), args=url_args + [cls.slug])
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -21,6 +21,9 @@
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
     {% include 'reports/partials/filters_js.html' %}
     {% include 'reports/partials/graphs/charts_js.html' %}
+    <script src="{% static 'case/js/cheapxml.js' %}"></script>
+    <script src="{% static 'case/js/casexml.js' %}"></script>
+    <script src="{% static 'data_interfaces/js/case_management.js' %}"></script>
     <script src="{% static 'data_interfaces/js/archive_forms.js' %}"></script>
     <script src="{% static 'hqpillow_retry/js/pillow_errors.js' %}"></script>
     {% endcompress %}

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -89,6 +89,14 @@
 
 {% block page_content %}
     {% initial_page_data 'js_options' report.js_options %}
+
+    {# Needed for case reassignment interface #}
+    {% initial_page_data "reassign_cases_enddate" datespan.enddate_param_utc %}
+    {% initial_page_data "web_user_id" request.couch_user.userID %}
+    {% initial_page_data "web_username" request.couch_user.username %}
+    {% registerurl "reassign_case_options" domain %}
+    {% registerurl "receiver_secure_post" domain %}
+
     {% if request.datespan %}
         {% initial_page_data 'startdate' datespan.startdate|date:"Y-m-d" %}
         {% initial_page_data 'enddate' datespan.enddate|date:"Y-m-d" %}


### PR DESCRIPTION
Took a while to decide where to hook the js in for this one. Ended up adding an `ajaxSuccess` listener that checks to see if the request matches the report and if so runs the js to initialize the case reassignment ui.

@jmtroth0 / @millerdev 
code buddy @sravfeyn 