### PR TITLE
Stream FormExportInstances to Angular

### DIFF
--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import itertools
+
 from dimagi.utils.couch.database import safe_delete, iter_docs
 from corehq.util.test_utils import unit_testing_only
 from corehq.apps.reports.models import CaseExportSchema, FormExportSchema
@@ -87,7 +89,7 @@ def get_case_export_instances(domain):
 
 
 def _iter_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_getter):
-    exports = old_exports_getter(domain) + new_exports_getter(domain)
+    exports = itertools.chain(old_exports_getter(domain), new_exports_getter(domain))
     if not has_deid_permissions:
         return (e for e in exports if not e.is_safe)
     return exports  # Unsorted

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from dimagi.utils.couch.database import safe_delete
+
+from itertools import chain
+
+from dimagi.utils.couch.database import safe_delete, iter_docs
 from corehq.util.test_utils import unit_testing_only
 from corehq.apps.reports.models import CaseExportSchema, FormExportSchema
 
@@ -71,6 +74,13 @@ def get_form_export_instances(domain):
     return _get_export_instance(FormExportInstance, key)
 
 
+def iter_form_export_instances(domain):
+    from .models import FormExportInstance
+
+    key = [domain, 'FormExportInstance']
+    return _iter_export_instances(FormExportInstance, key)
+
+
 def get_case_export_instances(domain):
     from .models import CaseExportInstance
 
@@ -78,10 +88,15 @@ def get_case_export_instances(domain):
     return _get_export_instance(CaseExportInstance, key)
 
 
-def _get_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_getter):
+def _iter_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_getter):
     exports = old_exports_getter(domain) + new_exports_getter(domain)
     if not has_deid_permissions:
-        exports = [e for e in exports if not e.is_safe]
+        return (e for e in exports if not e.is_safe)
+    return exports  # Unsorted
+
+
+def _get_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_getter):
+    exports = _iter_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_getter)
     return sorted(exports, key=lambda x: x.name)
 
 
@@ -96,6 +111,10 @@ def get_form_exports_by_domain(domain, has_deid_permissions):
     new_exports_getter = get_form_export_instances
     return _get_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_getter)
 
+def iter_form_exports_by_domain(domain, has_deid_permissions):
+    old_exports_getter = FormExportSchema.get_stale_exports  # Still returns a list
+    new_exports_gen = iter_form_export_instances
+    return _iter_saved_exports(domain, has_deid_permissions, old_exports_getter, new_exports_gen)
 
 def get_export_count_by_domain(domain):
     exports = get_form_exports_by_domain(domain, True)
@@ -112,6 +131,18 @@ def _get_export_instance(cls, key):
         reduce=False,
     ).all()
     return [cls.wrap(result['doc']) for result in results]
+
+
+def _iter_export_instances(cls, key):
+    results = cls.get_db().view(
+        'export_instances_by_domain/view',
+        startkey=key,
+        endkey=key + [{}],
+        include_docs=False,
+        reduce=False,
+    ).all()
+    result_ids = [result['id'] for result in results]
+    return iter_docs(cls.get_db(), result_ids)
 
 
 def get_all_daily_saved_export_instance_ids():

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -142,7 +142,7 @@ def _iter_export_instances(cls, key):
         reduce=False,
     ).all()
     result_ids = [result['id'] for result in results]
-    return iter_docs(cls.get_db(), result_ids)
+    return (cls.wrap(doc) for doc in iter_docs(cls.get_db(), result_ids))
 
 
 def get_all_daily_saved_export_instance_ids():

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from itertools import chain
-
 from dimagi.utils.couch.database import safe_delete, iter_docs
 from corehq.util.test_utils import unit_testing_only
 from corehq.apps.reports.models import CaseExportSchema, FormExportSchema

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -33,7 +33,7 @@ from corehq.apps.app_manager.models import Domain, Application, RemoteApp, Modul
 from corehq.apps.export.utils import (
     convert_saved_export_to_export_instance,
     _convert_index_to_path_nodes,
-    revert_new_exports,
+    iter_reverted_new_exports,
     _is_remote_app_conversion,
     _is_form_stock_question,
 )
@@ -965,7 +965,7 @@ class TestRevertNewExports(TestCase):
             export.delete()
 
     def test_revert_new_exports(self):
-        reverted = revert_new_exports(self.new_exports)
+        reverted = list(iter_reverted_new_exports(self.new_exports))
         self.assertListEqual(reverted, [])
         for export in self.new_exports:
             self.assertTrue(export.doc_type.endswith(DELETED_SUFFIX))
@@ -976,7 +976,7 @@ class TestRevertNewExports(TestCase):
         saved_export_schema.save()
         self.new_exports[0].legacy_saved_export_schema_id = saved_export_schema._id
 
-        reverted = revert_new_exports(self.new_exports)
+        reverted = list(iter_reverted_new_exports(self.new_exports))
         self.assertEqual(len(reverted), 1)
         self.assertFalse(reverted[0].doc_type.endswith(DELETED_SUFFIX))
         saved_export_schema.delete()

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -581,34 +581,34 @@ def _is_remote_app_conversion(domain, app_id, export_type):
         return any([app.is_remote_app() for app in apps])
 
 
-def revert_new_exports(new_exports, dryrun=False):
+def iter_reverted_new_exports(new_exports, dryrun=False):
     """
-    Takes a list of new style ExportInstance and marks them as deleted as well as restoring
+    Takes an iterable of new style ExportInstance and marks them as deleted as well as restoring
     the old export it was converted from (if it was converted from an old export)
 
-    :param new_exports: List of ExportInstance
-    :returns: Any old exports that were restored when decommissioning the new exports
+    :param new_exports: Iterable of ExportInstances
+    :returns: An iterable of any old exports that were restored when decommissioning the new exports
     """
-    reverted_exports = []
     for new_export in new_exports:
+        old_export = None
         if new_export.legacy_saved_export_schema_id:
             schema_cls = FormExportSchema if new_export.type == FORM_EXPORT else CaseExportSchema
             old_export = schema_cls.get(new_export.legacy_saved_export_schema_id)
             old_export.doc_type = old_export.doc_type.rstrip(DELETED_SUFFIX)
             if not dryrun:
                 old_export.save()
-            reverted_exports.append(old_export)
         new_export.doc_type += DELETED_SUFFIX
         if not dryrun:
             new_export.save()
-    return reverted_exports
+        if old_export:
+            yield old_export
 
 
 def revert_migrate_domain(domain, dryrun=False):
     instances = get_form_export_instances(domain)
     instances.extend(get_case_export_instances(domain))
 
-    reverted_exports = revert_new_exports(instances, dryrun=dryrun)
+    reverted_exports = list(iter_reverted_new_exports(instances, dryrun=dryrun))
 
     for reverted_export in reverted_exports:
         print('Reverted export: {}'.format(reverted_export._id))

--- a/corehq/apps/hqwebapp/tests/test_views.py
+++ b/corehq/apps/hqwebapp/tests/test_views.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from django.test import TestCase
+
+import doctest
+
+from django.test import TestCase, SimpleTestCase
 from django.urls import reverse
 
 from corehq.apps.domain.tests.test_views import BaseAutocompleteTest
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.models import Domain
+import corehq.apps.hqwebapp.views
+from corehq.apps.hqwebapp.views import json_iterdump
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
@@ -117,3 +122,25 @@ class TestBugReport(TestCase):
 
         # Shouldn't be able to update description as commcare user
         self.assertIsNone(domain_object.project_description)
+
+
+class JsonIteratorTests(SimpleTestCase):
+
+    def test_no_gen(self):
+        data = {'foo': [0, 1, 2]}
+        iterator = json_iterdump(data)
+        json_data = ''.join(iterator)
+        self.assertEqual(json_data, '{"foo": [0, 1, 2]}')
+
+    def test_gen(self):
+        data = {'foo': (i for i in range(3))}
+        iterator = json_iterdump(data)
+        json_data = ''.join(iterator)
+        self.assertEqual(json_data, '{"foo": [0, 1, 2]}')
+
+
+class DocTests(SimpleTestCase):
+
+    def test_doctests(self):
+        results = doctest.testmod(corehq.apps.hqwebapp.views)
+        self.assertEqual(results.failed, 0)


### PR DESCRIPTION
Context: https://manage.dimagi.com/default.asp?274447
TL;DR: A project space is running out of memory when Angular fetches a list of FormExportInstances.

In this PR:
* Iterate FormExportInstances with `iter_docs`
* A generator that yields a JSON document and allows generators in the input data. (At the moment we only need dictionaries, but trivial (and tempting) to make more generic.)
* A StreamingHttpResponse subclass to use this JSON generator

I'm opening this PR for some feedback on my approach. If this seems reasonable, I'll add tests for `FormExportListView` and test this properly. If I've duplicated a similar approach somewhere else, I'd be happy to reuse existing work, or adapt to an existing pattern/idiom.

Might be easiest to :blowfish: but probably small enough to :office:.
