### PR TITLE
Fallback to 'Untitled' in FormsByApplication filter

### DIFF
--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -391,6 +391,9 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         """
         if isinstance(obj, six.string_types):
             return obj
+        if not obj:
+            return _('Untitled')
+
         val = obj.get(display_lang)
         if val:
             return val


### PR DESCRIPTION
This is one of those cases that shouldn't happen, but I have a form/app in a weird state somewhere locally and regularly get tripped up by an IndexError coming from here.

Marking invisible because this shouldn't be happening on prod.

@sravfeyn 