### PR TITLE
adding django nose to uninstall requirements

### DIFF
--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -5,3 +5,4 @@ mocker
 ethiopian-date
 architect
 ethiopian-date-converter
+django-nose


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/basecommand.py", line 228, in main
    status = self.run(options, args)
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 305, in run
    session=session, autobuilding=True
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/wheel.py", line 773, in build
    python_tag=python_tag,
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/wheel.py", line 633, in _build_one
    python_tag=python_tag)
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/wheel.py", line 637, in _build_one_inside_env
    if self.__build_one(req, temp_dir.path, python_tag=python_tag):
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/wheel.py", line 663, in __build_one
    base_args = self._base_setup_args(req)
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/wheel.py", line 659, in _base_setup_args
    SETUPTOOLS_SHIM % req.setup_py
  File "/usr/local/lib/python2.7/site-packages/pip/_internal/req/req_install.py", line 415, in setup_py
    assert self.source_dir, "No source dir for %s" % self
AssertionError: No source dir for django-nose from git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose in /vendor/lib/python2.7/site-packages (from -r requirements/test-requirements.txt (line 3))
```
looks like similar failures as to what we saw with the ethiopian date converter. hopefully this fixes it too

@esoergel @millerdev 