### PR TITLE
Allow comparisons in case search index

### DIFF
--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 
-PATH = 'case_properties'
+CASE_PROPERTIES_PATH = 'case_properties'
+INDICES_PATH = 'indices'
+REFERENCED_ID = 'referenced_id'
 VALUE_TEXT = 'value'
 VALUE_DATE = 'value_date'
 VALUE_NUMERIC = 'value_numeric'

--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+PATH = 'case_properties'
+VALUE_TEXT = 'value'
+VALUE_NUMERIC = 'value_numeric'
+RELEVANCE_SCORE = "commcare_search_score"

--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -4,5 +4,6 @@ from __future__ import unicode_literals
 
 PATH = 'case_properties'
 VALUE_TEXT = 'value'
+VALUE_DATE = 'value_date'
 VALUE_NUMERIC = 'value_numeric'
 RELEVANCE_SCORE = "commcare_search_score"

--- a/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
+++ b/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
@@ -12,7 +12,7 @@ RENAMES = (
     ("applications-to-elasticsearch", "ApplicationToElasticsearchPillow-hqapps_2016-10-20_1835"),
     ("all-cases-to-elasticsearch", "CaseToElasticsearchPillow-hqcases_2016-03-04"),
     ("all-xforms-to-elasticsearch", "XFormToElasticsearchPillow-xforms_2016-07-07"),
-    ("case-search-to-elasticsearch", "CaseSearchToElasticsearchPillow-case_search_2016-03-15"),
+    ("case-search-to-elasticsearch", "CaseSearchToElasticsearchPillow-case_search_2018-04-18"),
     ("GroupPillow", "GroupPillow-hqgroups_20150403_1501"),
     ("GroupToUserPillow", "GroupToUserPillow-hqusers_2016-09-29"),
     ("KafkaDomainPillow", "KafkaDomainPillow-hqdomains_2016-08-08"),

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -70,6 +70,15 @@ class CaseSearchES(CaseES):
         """
         return self._add_query(self._get_query(key, queries.regexp('{}.value'.format(PATH), regex)), clause)
 
+    def numeric_range_case_property_query(self, key, gt=None, gte=None, lt=None, lte=None):
+        """
+        Search for all cases where case property `key` fulfills the range criteria.
+        """
+        return self._add_query(
+            self._get_query(key, filters.range_filter('{}.value_numeric'.format(PATH), gt, gte, lt, lte)),
+            queries.MUST,
+        )
+
     def _add_query(self, new_query, clause):
         current_query = self._query.get(queries.BOOL)
         if current_query is None:

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -15,6 +15,7 @@ from __future__ import unicode_literals
 from corehq.apps.case_search.const import (
     PATH,
     RELEVANCE_SCORE,
+    VALUE_DATE,
     VALUE_NUMERIC,
     VALUE_TEXT,
 )
@@ -82,6 +83,15 @@ class CaseSearchES(CaseES):
         """
         return self._add_query(
             self._get_query(key, queries.range_query("{}.{}".format(PATH, VALUE_NUMERIC), gt, gte, lt, lte)),
+            clause,
+        )
+
+    def date_range_case_property_query(self, key, gt=None, gte=None, lt=None, lte=None, clause=queries.MUST):
+        """
+        Search for all cases where case property `key` fulfills the date range criteria.
+        """
+        return self._add_query(
+            self._get_query(key, queries.date_range("{}.{}".format(PATH, VALUE_DATE), gt, gte, lt, lte)),
             clause,
         )
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -76,13 +76,13 @@ class CaseSearchES(CaseES):
             clause,
         )
 
-    def numeric_range_case_property_query(self, key, gt=None, gte=None, lt=None, lte=None):
+    def numeric_range_case_property_query(self, key, gt=None, gte=None, lt=None, lte=None, clause=queries.MUST):
         """
         Search for all cases where case property `key` fulfills the range criteria.
         """
         return self._add_query(
             self._get_query(key, queries.range_query("{}.{}".format(PATH, VALUE_NUMERIC), gt, gte, lt, lte)),
-            queries.MUST,
+            clause,
         )
 
     def _add_query(self, new_query, clause):

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -52,14 +52,14 @@ class CaseSearchES(CaseES):
         Can be chained with regular filters . Running a set_query after this will destroy it.
         Clauses can be any of SHOULD, MUST, or MUST_NOT
         """
-        if fuzzy and clause != queries.MUST:
-            raise ValueError("You can't run {} queries as fuzzy".format(clause))
-
         if fuzzy:
-            # fuzzy match
-            self = self._add_query(self._get_query(key, value, fuzziness='AUTO'), queries.MUST)
-            # exact match. added to improve the score of exact matches
-            return self._add_query(self._get_query(key, value, fuzziness='0'), queries.SHOULD)
+            positive_clause = clause != queries.MUST_NOT
+            return (
+                # fuzzy match
+                self._add_query(self._get_query(key, value, fuzziness='AUTO'), clause)
+                # exact match. added to improve the score of exact matches
+                ._add_query(self._get_query(key, value, fuzziness='0'),
+                            queries.SHOULD if positive_clause else clause))
         else:
             return self._add_query(self._get_query(key, value, fuzziness='0'), clause)
 

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -12,6 +12,7 @@ are available, and put 'em here if you end up using any of 'em.
 """
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from .filters import range_filter
 import re
 
 MUST = "must"
@@ -152,3 +153,5 @@ def regexp(field, regex):
             }
         }
     }
+
+range_query = range_filter

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -12,7 +12,7 @@ are available, and put 'em here if you end up using any of 'em.
 """
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from .filters import range_filter
+from .filters import range_filter, date_range
 import re
 
 MUST = "must"
@@ -154,4 +154,6 @@ def regexp(field, regex):
         }
     }
 
+
 range_query = range_filter
+date_range = date_range

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from unittest import TestCase
+from django.test.testcases import SimpleTestCase
 
 from corehq.apps.es.case_search import CaseSearchES, flatten_result, RELEVANCE_SCORE
 from corehq.apps.es.tests.utils import ElasticTestMixin
 from corehq.elastic import SIZE_LIMIT
 
 
-class TestCaseSearchES(ElasticTestMixin, TestCase):
+class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
 
     def setUp(self):
         self.es = CaseSearchES()
@@ -105,7 +105,9 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
                                             }
                                         }
                                     }
-                                },
+                                }
+                            ],
+                            "should": [
                                 {
                                     "nested": {
                                         "path": "case_properties",
@@ -127,9 +129,7 @@ class TestCaseSearchES(ElasticTestMixin, TestCase):
                                             }
                                         }
                                     }
-                                }
-                            ],
-                            "should": [
+                                },
                                 {
                                     "nested": {
                                         "path": "case_properties",

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -58,10 +58,16 @@ def _get_case_properties(doc_dict):
     else:
         dynamic_case_properties = CommCareCase.wrap(doc_dict).dynamic_case_properties()
 
-    return base_case_properties + [
-        {'key': key, 'value': value}
-        for key, value in six.iteritems(dynamic_case_properties)
-    ]
+    dynamic_mapping = []
+    for key, value in six.iteritems(dynamic_case_properties):
+        mapping = {'key': key, 'value': value}
+        try:
+            mapping['value_numeric'] = float(value)  # cast as a Java double in Elasticsearch
+        except ValueError:
+            pass
+        dynamic_mapping.append(mapping)
+
+    return base_case_properties + dynamic_mapping
 
 
 class CaseSearchPillowProcessor(ElasticProcessor):

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -73,7 +73,7 @@ def _get_case_properties(doc_dict):
             value_date = parse_date(value)
             if value_date:
                 mapping[VALUE_DATE] = value_date
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         dynamic_mapping.append(mapping)

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -12,6 +12,7 @@ from corehq.apps.case_search.models import case_search_enabled_domains, \
     case_search_enabled_for_domain
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
+from corehq.apps.case_search.const import VALUE_NUMERIC, VALUE_TEXT
 from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
@@ -60,9 +61,9 @@ def _get_case_properties(doc_dict):
 
     dynamic_mapping = []
     for key, value in six.iteritems(dynamic_case_properties):
-        mapping = {'key': key, 'value': value}
+        mapping = {'key': key, VALUE_TEXT: value}
         try:
-            mapping['value_numeric'] = float(value)  # cast as a Java double in Elasticsearch
+            mapping[VALUE_NUMERIC] = float(value)  # cast as a Java double in Elasticsearch
         except ValueError:
             pass
         dynamic_mapping.append(mapping)

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -66,7 +66,7 @@ def _get_case_properties(doc_dict):
 
         try:
             mapping[VALUE_NUMERIC] = float(value)  # cast as a Java double in Elasticsearch
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         try:

--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -70,6 +70,7 @@
             "type": "multi_field"
         },
         "indices": {
+            "type": "nested",
             "dynamic": false,
             "properties": {
                 "doc_type": {
@@ -88,8 +89,7 @@
                 "relationship": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "location_id": {
             "type": "string"

--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -23,6 +23,10 @@
                 },
                 "value_numeric": {
                     "type": "double"
+                },
+                "value_date": {
+                    "type": "date",
+                    "format": "__DATE_FORMATS_STRING__"
                 }
             }
         },

--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -20,6 +20,9 @@
                 },
                 "value": {
                     "type": "string"
+                },
+                "value_numeric": {
+                    "type": "double"
                 }
             }
         },

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -6,7 +6,7 @@ from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
 
-CASE_SEARCH_INDEX = es_index("case_search_2016-03-15")
+CASE_SEARCH_INDEX = es_index("case_search_2018-04-18")
 CASE_SEARCH_ALIAS = "case_search"
 CASE_SEARCH_MAX_RESULTS = 100
 CASE_SEARCH_MAPPING = mapping_from_json('case_search_mapping.json')

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -34,7 +34,7 @@ class ProdIndexManagementTest(SimpleTestCase):
 EXPECTED_PROD_INDICES = [
     {
         "alias": "case_search",
-        "index": "test_case_search_2016-03-15",
+        "index": "test_case_search_2018-04-18",
         "type": "case",
         "meta": {
             "settings": {

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -30,7 +30,7 @@
     "CaseSearchToElasticsearchPillow": {
         "advertised_name": "CaseSearchToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "CaseSearchToElasticsearchPillow-test_case_search_2016-03-15",
+        "checkpoint_id": "CaseSearchToElasticsearchPillow-test_case_search_2018-04-18",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseSearchToElasticsearchPillow"
     },


### PR DESCRIPTION
This adds a `numeric_range_case_property_query` and `date_range_case_property_query`, which allows us to do range queries against case properties e.g. 

```py
CaseSearchES()
.domain('children-only')
.case_property_query('person_name', 'baby')
.numeric_range_case_property_query('age', lte=5)
.date_range_case_property_query('dob', gte=date(2013, 8, 15)
.run()
```
Not crazy about these verbose names, so open to suggestion.

Will require a reindex of the case search index, but this is only pertinent for prod currently, and there are only 566,099 cases in that index. By a rough estimate, this should take about 2 hours to complete, so might be best to do this over the weekend. 

This is the start of a solutions feature that we are working on this quarter, so nothing uses these yet. 

This PR also fixes a bug that hadn't been encountered yet, where fuzzy text queries would not respect the `clause`. 

:blowfish: / :blowfish: 