### PR TITLE
Switct to location CTE queries on prod

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2358,6 +2358,7 @@ if IS_LOCATION_CTE_ENABLED and IS_LOCATION_CTE_ONLY is None:
         'changeme',  # default value in localsettings.example.py
         'staging',
         'softlayer',
+        'production',
     ]
 else:
     IS_LOCATION_CTE_ONLY = False


### PR DESCRIPTION
This is to reduce the load on prod while I'm on vacation. I don't expect any issues as I've been monitoring the differences between CTE and MPTT queries for a few days and nothing major has popped up so far.

This PR can be reverted if there are issues with location CTE queries. Reverting it will switch back to comparing the results of MPTT and CTE queries.

Note: `'production'` can also be removed from the `IS_LOCATION_CTE_ENABLED` list if CTE queries are problematic _and_ running both MPTT and CTE queries puts too much load on the system (this has not been a problem for the last few days, so I'd be surprised if this were an issue). Doing that would revert to only using MPTT.

@esoergel @biyeun 