### PR TITLE
filter fixes

### DIFF
--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -217,7 +217,7 @@ class BaseDrilldownOptionFilter(BaseReportFilter):
             ]
         """
         raise NotImplementedError("drilldown_map must be implemented")
-    
+
     @classmethod
     def get_labels(cls):
         """

--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -188,13 +188,13 @@ hqDefine("reports/js/filters/main", [
                     selected: data.selected,
                     notifications: data.notifications,
                 });
-                $el.find('#' + data.cssId).koApplyBindings(model);
+                $('#' + data.cssId).koApplyBindings(model);
                 model.init();
             }
 
             if (data.unknownAvailable || data.displayAppType) {
                 advancedFormsOptions.advancedFormsOptions(
-                    $el.find('#' + data.cssId + '-advanced-options'),
+                    $('#' + data.cssId + '-advanced-options'),
                     {
                         show: data.showAdvanced,
                         is_unknown_shown: data.isUnknownShown,

--- a/corehq/apps/reports/templates/reports/filters/drilldown_options.html
+++ b/corehq/apps/reports/templates/reports/filters/drilldown_options.html
@@ -10,7 +10,8 @@
      data-controls='{% html_attr controls %}'
      data-selected='{{ selected|JSON }}'
      data-notifications='{% html_attr notifications %}'
-     data-is-empty='{{ is_empty|JSON }}'>
+     data-is-empty='{{ is_empty|JSON }}'
+     data-css-id='{{ css_id }}'>
     <div data-bind="foreach: controls">
         <div class="form-group"
              data-bind="visible: is_visible">

--- a/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
@@ -2,91 +2,91 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% block filter_content %}
-<div class="report-filter-form-drilldown"
-     data-unknown-available='{{ unknown_available|JSON }}'
-     data-is-empty='{{ is_empty|JSON }}'
-     data-drilldown-map='{% html_attr option_map %}'
-     data-controls='{% html_attr controls %}'
-     data-selected='{{ selected|JSON }}'
-     data-notifications='{% html_attr notifications %}'
-     data-display-app-type='{{ display_app_type|JSON }}'
-     data-show='{{ show_advanced|JSON }}'
-     data-is-unknown-shown='{{ unknown.show|JSON }}'
-     data-selected-unknown-form='{{ unknown.selected }}'
-     data-all-unknown-forms='{% html_attr unknown.options %}'
-     data-caption-text='{{ unknown.default_text }}'
-     data-css-id='{{ css_id }}'
-     data-css-class='{{ css_id }}-unknown_controls'>
     {% if unknown_available %}
-    <div class="{{ css_id }}-unknown_controls" data-bind="visible: show" style="margin-bottom:1em;">
-        <div class="radio">
-            <label>
-                <input type="radio"
-                    data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
-                    data-known="#{{ css_id }}-known_control"
-                    name="{{ slug }}_{{ unknown.slug }}"
-                    id="{{ css_id }}_{{ unknown.slug }}_hide"
-                    value="">
-                {% trans 'Known Forms' %}
-                <span class="hq-help-template"
-                    data-title="{% trans "What are Known Forms?" %}"
-                    data-content="{% trans "Known Forms are forms that have IDs which can be matched to existing or deleted CommCare Applications in your Project." %}"
-                ></span>
-            </label>
-        </div>
-        <div class="radio">
-            <label>
-                <input type="radio"
-                    data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
-                    data-known="#{{ css_id }}-known_control"
-                    name="{{ slug }}_{{ unknown.slug }}"
-                    id="{{ css_id }}_{{ unknown.slug }}_show"
-                    value="yes">
-                {% trans 'Unknown Forms (Possibly Deleted)' %}
-                <span class="hq-help-template"
-                    data-title="{% trans "What are Unknown Forms?" %}"
-                    data-content="{% trans "We tried and tried, but these form IDs did not belong to any CommCare Applications (existing or deleted) in your Project. It might mean that these forms once belonged to an application, were deleted from it, and then replaced by a different form." %}"
-                ></span>
-            </label>
-        </div>
-    </div>
-    <div class="well well-sm {{ css_id }}-unknown_controls" data-bind="visible: is_unknown_shown">
-        <div class="form-group">
-            <label class="control-label col-xs-4 col-md-2" for="{{ css_id }}-{{ unknown.slug }}_xmlns">
-                {% trans 'Choose Unknown Form' %}
-            </label>
-            <div class="col-xs-8 col-md-10">
-                <select class="form-control"
-                        id="{{ css_id }}-{{ unknown.slug }}_xmlns"
-                        name="{{ slug }}_{{ unknown.slug }}_xmlns"
-                        data-bind="options: all_unknown_forms,
-                        optionsText: 'text', optionsValue: 'val',
-                        optionsCaption: caption_text, value: selected_unknown_form"></select>
+        <div class="{{ css_id }}-unknown_controls" data-bind="visible: show" style="margin-bottom:1em;">
+            <div class="radio">
+                <label>
+                    <input type="radio"
+                        data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
+                        data-known="#{{ css_id }}-known_control"
+                        name="{{ slug }}_{{ unknown.slug }}"
+                        id="{{ css_id }}_{{ unknown.slug }}_hide"
+                        value="">
+                    {% trans 'Known Forms' %}
+                    <span class="hq-help-template"
+                        data-title="{% trans "What are Known Forms?" %}"
+                        data-content="{% trans "Known Forms are forms that have IDs which can be matched to existing or deleted CommCare Applications in your Project." %}"
+                    ></span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio"
+                        data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
+                        data-known="#{{ css_id }}-known_control"
+                        name="{{ slug }}_{{ unknown.slug }}"
+                        id="{{ css_id }}_{{ unknown.slug }}_show"
+                        value="yes">
+                    {% trans 'Unknown Forms (Possibly Deleted)' %}
+                    <span class="hq-help-template"
+                        data-title="{% trans "What are Unknown Forms?" %}"
+                        data-content="{% trans "We tried and tried, but these form IDs did not belong to any CommCare Applications (existing or deleted) in your Project. It might mean that these forms once belonged to an application, were deleted from it, and then replaced by a different form." %}"
+                    ></span>
+                </label>
             </div>
         </div>
-    </div>
+        <div class="well well-sm {{ css_id }}-unknown_controls" data-bind="visible: is_unknown_shown">
+            <div class="form-group">
+                <label class="control-label col-xs-4 col-md-2" for="{{ css_id }}-{{ unknown.slug }}_xmlns">
+                    {% trans 'Choose Unknown Form' %}
+                </label>
+                <div class="col-xs-8 col-md-10">
+                    <select class="form-control"
+                            id="{{ css_id }}-{{ unknown.slug }}_xmlns"
+                            name="{{ slug }}_{{ unknown.slug }}_xmlns"
+                            data-bind="options: all_unknown_forms,
+                            optionsText: 'text', optionsValue: 'val',
+                            optionsCaption: caption_text, value: selected_unknown_form"></select>
+                </div>
+            </div>
+        </div>
     {% endif %}
-    <div id="{{ css_id }}-known_control">
-        {{ block.super }}
+
+    <div id="{{ css_id }}-known_control"
+        class="report-filter-form-drilldown"
+        data-unknown-available='{{ unknown_available|JSON }}'
+        data-is-empty='{{ is_empty|JSON }}'
+        data-drilldown-map='{% html_attr option_map %}'
+        data-controls='{% html_attr controls %}'
+        data-selected='{{ selected|JSON }}'
+        data-notifications='{% html_attr notifications %}'
+        data-display-app-type='{{ display_app_type|JSON }}'
+        data-show='{{ show_advanced|JSON }}'
+        data-is-unknown-shown='{{ unknown.show|JSON }}'
+        data-selected-unknown-form='{{ unknown.selected }}'
+        data-all-unknown-forms='{% html_attr unknown.options %}'
+        data-caption-text='{{ unknown.default_text }}'
+        data-css-id='{{ css_id }}'
+        data-css-class='{{ css_id }}-unknown_controls'>
+            {{ block.super }}
     </div>
 
     {% if unknown_available or display_app_type %}
-    <div id="{{ css_id }}-advanced-options" style="margin-top: -.8em;">
-        <div class="checkbox">
-            <label>
-                <input name="show_advanced" type="checkbox" data-bind="checked: show" />
-                {% trans "Show Advanced Options" %}
-            </label>
+        <div id="{{ css_id }}-advanced-options" style="margin-top: -.8em;">
+            <div class="checkbox">
+                <label>
+                    <input name="show_advanced" type="checkbox" data-bind="checked: show" />
+                    {% trans "Show Advanced Options" %}
+                </label>
+            </div>
         </div>
-    </div>
     {% endif %}
 
     {% if hide_fuzzy.show %}
-    <div class="alert alert-warning {{ css_id }}-unknown_controls"
-        data-bind="visible: show"
-        style="margin-top: 1em;">
-        {% include 'reports/filters/partials/fuzzy_checkbox.html' %}
-    </div>
+        <div class="alert alert-warning {{ css_id }}-unknown_controls"
+            data-bind="visible: show"
+            style="margin-top: 1em;">
+            {% include 'reports/filters/partials/fuzzy_checkbox.html' %}
+        </div>
     {% endif %}
-</div>
 {% endblock %}


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?274718#1485652

2376ff3 adds css-id to data in the basic drilldown option filter --> fixes the problem in the asha_report

d684feb doesn't wrap the entire filter so that ko.applybindings can be applied to multiple things in it. --> fixes clark's problem (use ?w=1)

@orangejenny 