### PR TITLE
Upgrade celery to 3.1.25

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ restkit==4.2.2
 iso8601==0.1.11
 jsonobject==0.8.0
 jsonobject-couchdbkit==0.9.0.0
-celery==3.1.18
+celery==3.1.25
 # required by django-digest
 decorator==4.0.11
 django==1.11.12


### PR DESCRIPTION
@gcapalbo any concerns about upgrading this? It's a pretty old change (2016-10-10) so not sure why it hasn't been done before

http://docs.celeryproject.org/en/3.1/changelog.html

