### PR TITLE
Include static data sources to rebuild location UCR

### DIFF
--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -160,6 +160,10 @@ def import_locations_async(domain, file_ref_id):
     importer.mark_complete()
 
     if LOCATIONS_IN_UCR.enabled(domain):
+        # We must rebuild datasources once the location import is complete in
+        # case child locations were not updated, but a parent location was.
+        # For example if a state was updated, the county may reference the state
+        # and need to have its row updated
         datasources = get_datasources_for_domain(domain, "Location", include_static=True)
         for datasource in datasources:
             rebuild_indicators_in_place.delay(datasource.get_id)

--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -160,7 +160,7 @@ def import_locations_async(domain, file_ref_id):
     importer.mark_complete()
 
     if LOCATIONS_IN_UCR.enabled(domain):
-        datasources = get_datasources_for_domain(domain, "Location")
+        datasources = get_datasources_for_domain(domain, "Location", include_static=True)
         for datasource in datasources:
             rebuild_indicators_in_place.delay(datasource.get_id)
 

--- a/corehq/apps/userreports/dbaccessors.py
+++ b/corehq/apps/userreports/dbaccessors.py
@@ -48,7 +48,7 @@ def get_datasources_for_domain(domain, referenced_doc_type=None, include_static=
             static_ds = [ds for ds in static_ds if ds.referenced_doc_type == referenced_doc_type]
         datasources.extend(sorted(static_ds, key=lambda config: config.display_name))
 
-    return sorted(datasources, key=lambda config: config.display_name)
+    return datasources
 
 
 @unit_testing_only

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -645,7 +645,7 @@ class StaticDataSourceConfiguration(JsonObject):
     def by_domain(cls, domain):
         """
         Returns a list of DataSourceConfiguration objects,
-        NOT StaticDataSourceConfigurations.
+        NOT a list of StaticDataSourceConfiguration objects.
         """
         return [ds for ds in cls.all() if ds.domain == domain]
 
@@ -653,7 +653,7 @@ class StaticDataSourceConfiguration(JsonObject):
     def by_id(cls, config_id):
         """
         Returns a DataSourceConfiguration object,
-        NOT a StaticDataSourceConfiguration.
+        NOT a StaticDataSourceConfiguration object.
         """
         mapping = cls.by_id_mapping()
         if config_id not in mapping:

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -643,18 +643,10 @@ class StaticDataSourceConfiguration(JsonObject):
 
     @classmethod
     def by_domain(cls, domain):
-        """
-        Returns a list of DataSourceConfiguration objects,
-        NOT a list of StaticDataSourceConfiguration objects.
-        """
         return [ds for ds in cls.all() if ds.domain == domain]
 
     @classmethod
     def by_id(cls, config_id):
-        """
-        Returns a DataSourceConfiguration object,
-        NOT a StaticDataSourceConfiguration object.
-        """
         mapping = cls.by_id_mapping()
         if config_id not in mapping:
             mapping = cls.by_id_mapping(rebuild=True)


### PR DESCRIPTION
Historical context:

Currently only ICDS uses this type UCR and we had issues in the past where a parent location is updated after the child location (I think it was due to a name change or something) and the UCR had some locations with old info. 

I did a heavy handed fix where I just rebuilt the entire data source (in place so it doesn't delete data), but the method doesn't include static data sources (which is what this fixes). A better fix would only be rebuilding those locations where whose hierarchy has changed, but I didn't see an easy way to do that after an upload. 

I originally threw out the idea of sending the descendant locations to kafka on save because that can fan out extremely quickly and result in 5x the changes necessary (as there are 5 levels to the hierarchy). Could move to doing that if you guys think it's a better approach, though would need to do something to make sure it doesn't effect the prod/softlayer UCR pillows when locations are uploaded

FYI locations  @millerdev @esoergel 