### PR TITLE
Externalize js: record list widget

### DIFF
--- a/corehq/apps/reminders/templates/reminders/partial/record_list_widget.html
+++ b/corehq/apps/reminders/templates/reminders/partial/record_list_widget.html
@@ -14,35 +14,3 @@
 <button type="button" id="id_add_{{ name }}" class="btn btn-success">
     <i class="icon-plus"></i> {% trans "Add Parameter" %}
 </button>
-
-<script>
-$(".record-list-widget").each(function() {
-    var $widget = $(this),
-        name = $widget.data("name"),
-        value = $widget.data("value");
-
-    var param_counter = 0;
-
-    function add_param(nm, val) {
-        $widget.append('<tr> \
-                <td><input type="text" class="form-control" name="additional_params.'+param_counter+'.name" value="'+nm+'" /></td> \
-                <td><input type="text" class="form-control" name="additional_params.'+param_counter+'.value" value="'+val+'" /></td> \
-                <td><span id="id_remove_record_'+param_counter+'" class="btn btn-danger"><i class="icon-remove"></i> {% trans "Remove" %}</span></td> \
-            </tr>');
-        $("#id_remove_record_"+param_counter).click(function(){
-            $(this).parent().parent().remove();
-        });
-        param_counter++;
-    }
-
-    $(function(){
-        _.each(value, function(pair) {
-            add_param(pair.name, pair.value);
-        });
-
-        $("#id_add_" + name).click(function() {
-            add_param("", "");
-        });
-    });
-});
-</script>

--- a/corehq/apps/reminders/templates/reminders/partial/record_list_widget.html
+++ b/corehq/apps/reminders/templates/reminders/partial/record_list_widget.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 
 <table class="table table-striped table-bordered">
     <thead>
@@ -8,19 +9,24 @@
             <th></th>
         </tr>
     </thead>
-    <tbody id="id_{{ name }}"></tbody>
+    <tbody id="id_{{ name }}" class="record-list-widget" data-value="{% html_attr value %}" data-name="{{ name }}"></tbody>
 </table>
 <button type="button" id="id_add_{{ name }}" class="btn btn-success">
     <i class="icon-plus"></i> {% trans "Add Parameter" %}
 </button>
 
 <script>
+$(".record-list-widget").each(function() {
+    var $widget = $(this),
+        name = $widget.data("name"),
+        value = $widget.data("value");
+
     var param_counter = 0;
 
     function add_param(nm, val) {
-        $("#id_{{ name }}").append('<tr> \
-                <td><input type="text" name="additional_params.'+param_counter+'.name" value="'+nm+'" /></td> \
-                <td><input type="text" name="additional_params.'+param_counter+'.value" value="'+val+'" /></td> \
+        $widget.append('<tr> \
+                <td><input type="text" class="form-control" name="additional_params.'+param_counter+'.name" value="'+nm+'" /></td> \
+                <td><input type="text" class="form-control" name="additional_params.'+param_counter+'.value" value="'+val+'" /></td> \
                 <td><span id="id_remove_record_'+param_counter+'" class="btn btn-danger"><i class="icon-remove"></i> {% trans "Remove" %}</span></td> \
             </tr>');
         $("#id_remove_record_"+param_counter).click(function(){
@@ -30,12 +36,13 @@
     }
 
     $(function(){
-        {% for pair in value %}
-        add_param("{{ pair.name }}", "{{ pair.value }}");
-        {% endfor %}
+        _.each(value, function(pair) {
+            add_param(pair.name, pair.value);
+        });
 
-        $("#id_add_{{ name }}").click(function() {
+        $("#id_add_" + name).click(function() {
             add_param("", "");
         });
     });
+});
 </script>

--- a/corehq/apps/sms/static/sms/js/add_gateway.js
+++ b/corehq/apps/sms/static/sms/js/add_gateway.js
@@ -2,7 +2,7 @@ hqDefine('sms/js/add_gateway', function() {
     var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
         AddGatewayFormHandler = hqImport('sms/js/add_gateway_form_handler').AddGatewayFormHandler;
 
-    function add_param($widget, count, nm, val) {
+    function addParam($widget, count, nm, val) {
         $widget.append('<tr> \
                 <td><input type="text" class="form-control" name="additional_params.'+count+'.name" value="'+nm+'" /></td> \
                 <td><input type="text" class="form-control" name="additional_params.'+count+'.value" value="'+val+'" /></td> \
@@ -32,11 +32,11 @@ hqDefine('sms/js/add_gateway', function() {
                 value = $widget.data("value");
 
             _.each(value, function(pair) {
-                count = add_param($widget, count, pair.name, pair.value);
+                count = addParam($widget, count, pair.name, pair.value);
             });
 
             $("#id_add_" + name).click(function() {
-                count = add_param($widget, count, "", "");
+                count = addParam($widget, count, "", "");
             });
         });
     });

--- a/corehq/apps/sms/static/sms/js/add_gateway.js
+++ b/corehq/apps/sms/static/sms/js/add_gateway.js
@@ -2,6 +2,19 @@ hqDefine('sms/js/add_gateway', function() {
     var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
         AddGatewayFormHandler = hqImport('sms/js/add_gateway_form_handler').AddGatewayFormHandler;
 
+    function add_param($widget, count, nm, val) {
+        $widget.append('<tr> \
+                <td><input type="text" class="form-control" name="additional_params.'+count+'.name" value="'+nm+'" /></td> \
+                <td><input type="text" class="form-control" name="additional_params.'+count+'.value" value="'+val+'" /></td> \
+                <td><span id="id_remove_record_'+count+'" class="btn btn-danger"><i class="icon-remove"></i> {% trans "Remove" %}</span></td> \
+            </tr>');
+        $("#id_remove_record_"+count).click(function(){
+            $(this).parent().parent().remove();
+        });
+        count++;
+        return count;
+    }
+
     $(function () {
         var gatewayFormHandler = new AddGatewayFormHandler({
             share_backend: initialPageData.get('give_other_domains_access'),
@@ -11,5 +24,20 @@ hqDefine('sms/js/add_gateway', function() {
         });
         $('#add-gateway-form').koApplyBindings(gatewayFormHandler);
         gatewayFormHandler.init();
+
+        $(".record-list-widget").each(function() {
+            var count = 0,
+                $widget = $(this),
+                name = $widget.data("name"),
+                value = $widget.data("value");
+
+            _.each(value, function(pair) {
+                count = add_param($widget, count, pair.name, pair.value);
+            });
+
+            $("#id_add_" + name).click(function() {
+                count = add_param($widget, count, "", "");
+            });
+        });
     });
 });

--- a/corehq/apps/sms/static/sms/js/add_gateway.js
+++ b/corehq/apps/sms/static/sms/js/add_gateway.js
@@ -6,7 +6,7 @@ hqDefine('sms/js/add_gateway', function() {
         $widget.append('<tr> \
                 <td><input type="text" class="form-control" name="additional_params.'+count+'.name" value="'+nm+'" /></td> \
                 <td><input type="text" class="form-control" name="additional_params.'+count+'.value" value="'+val+'" /></td> \
-                <td><span id="id_remove_record_'+count+'" class="btn btn-danger"><i class="icon-remove"></i> {% trans "Remove" %}</span></td> \
+                <td><span id="id_remove_record_'+count+'" class="btn btn-danger"><i class="fa fa-remove"></i> ' + gettext('Remove') + '</span></td> \
             </tr>');
         $("#id_remove_record_"+count).click(function(){
             $(this).parent().parent().remove();


### PR DESCRIPTION
@gcapalbo `RecordListField` shows up in `KeywordForm` as well as `HttpBackendForm`, but from what I can tell, the js from `record_list_widget.html` doesn't run on the keyword pages and instead they just use the knockout bindings defined in `reminders/keyword.html`. Does that sound right?

@jmtroth0 

code buddy @sravfeyn 