### PR TITLE
Find old UCR datasource tables

### DIFF
--- a/corehq/apps/userreports/management/commands/prune_old_datasources.py
+++ b/corehq/apps/userreports/management/commands/prune_old_datasources.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import defaultdict
+
+from alembic.autogenerate.api import compare_metadata
+from django.core.management.base import BaseCommand
+
+from corehq.apps.userreports.models import DataSourceConfiguration, StaticDataSourceConfiguration
+from corehq.apps.userreports.sql.adapter import metadata
+from corehq.apps.userreports.util import get_indicator_adapter
+from corehq.sql_db.connections import connection_manager
+
+from fluff.signals import get_migration_context, reformat_alembic_diffs
+
+
+class Command(BaseCommand):
+    help = "Call DROP TABLE on data sources that no longer exist"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--execute',
+            action='store_true',
+            default=False,
+            help='Not implemented: Actually call DROP TABLE',
+        )
+
+    def handle(self, **options):
+        data_sources = list(DataSourceConfiguration.all())
+        data_sources.extend(list(StaticDataSourceConfiguration.all()))
+
+        tables_by_engine = defaultdict(list)
+        for data_source in data_sources:
+            adapter = get_indicator_adapter(data_source)
+            if hasattr(adapter, 'engine_id'):
+                tables_by_engine[adapter.engine_id].append(adapter.get_table().name)
+
+        diffs_by_engine = defaultdict(list)
+        for engine_id, table_map in tables_by_engine.items():
+            engine = connection_manager.get_engine(engine_id)
+            with engine.begin() as connection:
+                migration_context = get_migration_context(connection, include_object=_include_object)
+                raw_diffs = compare_metadata(migration_context, metadata)
+                diffs = reformat_alembic_diffs(raw_diffs)
+                diffs_by_engine[engine_id] = diffs
+
+        tables_to_remove_by_engine = defaultdict(list)
+
+        for engine_id, diffs in diffs_by_engine.items():
+            for diff in diffs:
+                if diff.type == 'remove_table':
+                    tables_to_remove_by_engine[engine_id].append(diff.table_name)
+
+        for engine_id, tablenames in tables_to_remove_by_engine.items():
+            engine = connection_manager.get_engine(engine_id)
+            for tablename in tablenames:
+                with engine.begin() as connection:
+                    try:
+                        result = connection.execute(
+                            'SELECT COUNT(*), MAX(inserted_at) FROM "{tablename}"'.format(tablename=tablename)
+                        )
+                    except Exception:
+                        print(tablename, "no inserted_at column, probably not UCR")
+                    else:
+                        print(tablename, result.fetchone())
+
+
+def _include_object(object_, name, type_, reflected, compare_to):
+    if type_ != 'table':
+        return False
+
+    if not name.startswith('config_report_'):
+        return False
+
+    return True

--- a/corehq/apps/userreports/management/commands/prune_old_datasources.py
+++ b/corehq/apps/userreports/management/commands/prune_old_datasources.py
@@ -20,6 +20,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            '--engine_id',
+            action='store',
+            help='Only check this DB engine',
+        )
+        parser.add_argument(
             '--execute',
             action='store_true',
             default=False,
@@ -34,6 +39,8 @@ class Command(BaseCommand):
         for data_source in data_sources:
             adapter = get_indicator_adapter(data_source)
             if hasattr(adapter, 'engine_id'):
+                if options.get('engine_id') and options['engine_id'] != adapter.engine_id:
+                    continue
                 tables_by_engine[adapter.engine_id].append(adapter.get_table().name)
 
         diffs_by_engine = defaultdict(list)

--- a/corehq/ex-submodules/fluff/signals.py
+++ b/corehq/ex-submodules/fluff/signals.py
@@ -263,12 +263,14 @@ def rebuild_table(engine, pillow, indicator_doc):
         pillow.reset_checkpoint()
 
 
-def get_migration_context(connection, table_names):
-    opts = {
-        'include_symbol': partial(include_symbol, table_names),
-        'compare_type': True,
-        # 'compare_server_default': True  # we don't care about this
-    }
+def get_migration_context(connection, table_names=None, include_object=None):
+    opts = {'compare_type': True}
+
+    if callable(include_object):
+        opts['include_object'] = include_object
+    else:
+        opts['include_symbol'] = partial(include_symbol, table_names)
+
     return MigrationContext.configure(connection, opts=opts)
 
 


### PR DESCRIPTION
@snopoke we talked about this this morning
@esoergel you asked me about this on another PR

This won't actually delete them, but it gives us the info of tables we should drop, number of records and the latest `inserted_at` value which should be on all UCRs and would give us an idea of when it was last updated