### PR TITLE
remove usages of deprecated Exception.message

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -361,7 +361,7 @@ class AutoPayInvoicePaymentHandler(object):
             try:
                 self._pay_invoice(invoice)
             except Exception as e:
-                log_accounting_error("Error autopaying invoice %d: %s" % (invoice.id, e.message))
+                log_accounting_error("Error autopaying invoice %d: %s" % (invoice.id, e))
 
     def _pay_invoice(self, invoice):
         log_accounting_info("[Autopay] Autopaying invoice {}".format(invoice.id))

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6061,7 +6061,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             except ModuleNotFoundException as ex:
                 errors.append({
                     "type": "missing module",
-                    "message": ex.message
+                    "message": six.text_type(ex)
                 })
 
         for form in self.get_forms():

--- a/corehq/apps/commtrack/tests/test_programs.py
+++ b/corehq/apps/commtrack/tests/test_programs.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django.test import TestCase
 from corehq.apps.commtrack.tests.util import bootstrap_domain, bootstrap_products, TEST_DOMAIN
 from corehq.apps.programs.models import Program
@@ -26,7 +28,7 @@ class ProgramsTest(TestCase):
         with self.assertRaises(Exception) as context:
             self.default_program.delete()
 
-        self.assertEqual(context.exception.message, 'You cannot delete the default program')
+        self.assertEqual(six.text_type(context.exception), 'You cannot delete the default program')
 
         # assign some product to the new program
         self.products[0].program_id = self.new_program._id

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -5,6 +5,8 @@ import csv342 as csv
 import io
 import json
 import uuid
+
+import six
 from couchdbkit import ResourceNotFound
 from django.contrib import messages
 from django.core.cache import cache
@@ -268,7 +270,7 @@ class ArchiveFormView(DataInterfaceSection):
             messages.success(self.request, _("We received your file and are processing it. "
                                              "You will receive an email when it has finished."))
         except BulkUploadCasesException as e:
-            messages.error(self.request, e.message)
+            messages.error(self.request, six.text_type(e))
         return None
 
     def post(self, request, *args, **kwargs):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import logging
+
+import six
 from couchdbkit import ResourceNotFound
 from django.http import (
     HttpResponseBadRequest,
@@ -80,7 +82,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             ]
             datadog_counter(MULTIMEDIA_SUBMISSION_ERROR_COUNT, tags=details)
             notify_exception(request, "Received a submission with POST.keys()", details)
-            response = HttpResponseBadRequest(e.message)
+            response = HttpResponseBadRequest(six.text_type(e))
             _record_metrics(metric_tags, 'unknown', response)
             return response
 

--- a/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime
+
+import six
 from django.test import SimpleTestCase
 from xml.etree import cElementTree as ElementTree
 from casexml.apps.case.mock import CaseBlock, CaseBlockError
@@ -37,7 +39,7 @@ class CaseBlockTest(SimpleTestCase):
                 case_name='Johnny',
                 update={'case_name': 'Johnny'},
             ).as_xml()
-        self.assertEqual(context.exception.message, "Key 'case_name' specified twice")
+        self.assertEqual(six.text_type(context.exception), "Key 'case_name' specified twice")
 
     def test_buggy_behavior(self):
         """The following is a BUG; should fail!! Should fix and change tests"""

--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -62,7 +62,7 @@ class PillowError(models.Model):
         self.date_last_attempt = date or datetime.utcnow()
         self.error_type = path_from_object(exception)
 
-        self.error_traceback = "{}\n\n{}".format(exception.message, "".join(traceback.format_tb(traceb)))
+        self.error_traceback = "{}\n\n{}".format(exception, "".join(traceback.format_tb(traceb)))
 
         if self.current_attempt <= settings.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS:
             time_till_next = settings.PILLOW_RETRY_REPROCESS_INTERVAL * math.pow(self.current_attempt, settings.PILLOW_RETRY_BACKOFF_FACTOR)

--- a/corehq/sql_db/tests/test_model_partitioning.py
+++ b/corehq/sql_db/tests/test_model_partitioning.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import re
+import six
+
 from corehq.form_processor.tests.utils import (
     only_run_with_partitioned_database,
     only_run_with_non_partitioned_database,
@@ -31,7 +33,7 @@ class PartitionedModelsTestMixin(object):
                 # is raised otherwise we won't be able to run any more queries.
                 model_class.objects.using(db).count()
         except ProgrammingError as e:
-            self.assertIsNotNone(re.match('.*relation.*does not exist.*', e.message))
+            self.assertIsNotNone(re.match('.*relation.*does not exist.*', six.text_type(e)))
         else:
             self.fail()
 

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -40,7 +40,7 @@ def clean_exception(exception):
     # couchdbkit doesn't provide a better way for us to catch this exception
     if (
         isinstance(exception, AssertionError) and
-        exception.message.startswith('received an invalid response of type')
+        six.text_type(exception).startswith('received an invalid response of type')
     ):
         message = ("It looks like couch returned an invalid response to "
                    "couchdbkit.  This could contain sensitive information, "

--- a/corehq/util/tests/test_log.py
+++ b/corehq/util/tests/test_log.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django.test import SimpleTestCase
 from ..log import clean_exception
 
@@ -14,11 +16,11 @@ class TestLogging(SimpleTestCase):
                 'response of type %s: %s' % (type(result), repr(result))
         except AssertionError as e:
             pass
-        self.assertIn(result, e.message)
-        self.assertNotIn(result, clean_exception(e).message)
+        self.assertIn(result, six.text_type(e))
+        self.assertNotIn(result, six.text_type(clean_exception(e)))
 
     def test_that_I_didnt_break_anything(self):
         exception = AssertionError("foo")
         cleaned_exception = clean_exception(exception)
         self.assertEqual(exception.__class__, cleaned_exception.__class__)
-        self.assertEqual(exception.message, cleaned_exception.message)
+        self.assertEqual(six.text_type(exception), six.text_type(cleaned_exception.message))

--- a/corehq/util/tests/test_log.py
+++ b/corehq/util/tests/test_log.py
@@ -23,4 +23,4 @@ class TestLogging(SimpleTestCase):
         exception = AssertionError("foo")
         cleaned_exception = clean_exception(exception)
         self.assertEqual(exception.__class__, cleaned_exception.__class__)
-        self.assertEqual(six.text_type(exception), six.text_type(cleaned_exception.message))
+        self.assertEqual(six.text_type(exception), six.text_type(cleaned_exception))

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -97,10 +97,10 @@ def _get_json_exception_response(code, request, exception, log_message=None):
 
 
 def _json_exception_response_data(code, exception):
-    if isinstance(exception.message, six.text_type):
-        message = six.text_type(exception)
+    if isinstance(exception.args[0], six.binary_type):
+        message = exception.args[0].decode('utf-8')
     else:
-        message = str(exception).decode('utf-8')
+        message = six.text_type(exception)
     data = {
         'error': code,
         'message': message

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -202,7 +202,7 @@ class WorkbookJSONReader(object):
         try:
             self.wb = openpyxl.load_workbook(filename, use_iterators=True, data_only=True)
         except (BadZipfile, InvalidFileException) as e:
-            raise InvalidExcelFileException(e.message)
+            raise InvalidExcelFileException(six.text_type(e))
         self.worksheets_by_title = {}
         self.worksheets = []
 

--- a/corehq/util/workbook_reading/adapters/xls.py
+++ b/corehq/util/workbook_reading/adapters/xls.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from contextlib import contextmanager
 from datetime import datetime, time, date
+
+import six
 import xlrd
 from corehq.util.workbook_reading import Worksheet, Cell, Workbook, SpreadsheetFileInvalidError, \
     SpreadsheetFileNotFound, SpreadsheetFileEncrypted
@@ -14,12 +16,12 @@ def open_xls_workbook(filename):
         with xlrd.open_workbook(filename) as xlrd_workbook:
             yield _XLSWorkbookAdaptor(xlrd_workbook).to_workbook()
     except xlrd.XLRDError as e:
-        if e.message == 'Workbook is encrypted':
-            raise SpreadsheetFileEncrypted(e.message)
+        if six.text_type(e) == 'Workbook is encrypted':
+            raise SpreadsheetFileEncrypted(six.text_type(e))
         else:
-            raise SpreadsheetFileInvalidError(e.message)
+            raise SpreadsheetFileInvalidError(six.text_type(e))
     except IOError as e:
-        raise SpreadsheetFileNotFound(e.message)
+        raise SpreadsheetFileNotFound(six.text_type(e))
 
 
 class _XLSWorksheetAdaptor(object):

--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from zipfile import BadZipfile
 from datetime import datetime, time
 import openpyxl
+import six
 from openpyxl.utils.datetime import from_excel
 from openpyxl.utils.exceptions import InvalidFileException
 from corehq.util.workbook_reading import Worksheet, Cell, Workbook, \
@@ -35,7 +36,7 @@ def open_xlsx_workbook(filename):
             if f.read(8) == XLSX_ENCRYPTED_MARKER:
                 raise SpreadsheetFileEncrypted('Workbook is encrypted')
             else:
-                raise SpreadsheetFileInvalidError(e.message)
+                raise SpreadsheetFileInvalidError(six.text_type(e))
         yield _XLSXWorkbookAdaptor(openpyxl_workbook).to_workbook()
 
 

--- a/corehq/util/workbook_reading/tests/test_errors.py
+++ b/corehq/util/workbook_reading/tests/test_errors.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django.test import SimpleTestCase
 
 from corehq.util.workbook_reading import SpreadsheetFileNotFound, SpreadsheetFileInvalidError, \
@@ -12,7 +14,7 @@ class SpreadsheetErrorsTest(SimpleTestCase):
         with self.assertRaises(SpreadsheetFileExtError) as cxt:
             with open_any_workbook(get_file('badext', 'ext')):
                 pass
-        self.assertRegexpMatches(cxt.exception.message,
+        self.assertRegexpMatches(six.text_type(cxt.exception),
                                  r'File .*/ext/badext.ext does not end in .xls or .xlsx')
 
 
@@ -35,4 +37,4 @@ def test_file_encrypted(self, open_workbook, ext):
     with self.assertRaises(SpreadsheetFileEncrypted) as cxt:
         with open_workbook(get_file('encrypted', ext)):
             pass
-    self.assertEqual(cxt.exception.message, 'Workbook is encrypted')
+    self.assertEqual(six.text_type(cxt.exception), 'Workbook is encrypted')

--- a/custom/ewsghana/handlers/soh.py
+++ b/custom/ewsghana/handlers/soh.py
@@ -204,7 +204,7 @@ class SOHHandler(KeywordHandler):
             self.respond(six.text_type(INVALID_MESSAGE))
             return True
         except ProductCodeException as e:
-            self.respond(e.message)
+            self.respond(six.text_type(e))
             return True
         except Exception as e:
             if settings.UNIT_TESTING or settings.DEBUG:

--- a/custom/icds/tests/test_ls_aggregate_performance.py
+++ b/custom/icds/tests/test_ls_aggregate_performance.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django.test import SimpleTestCase, TestCase
 from mock import patch, Mock
 
@@ -130,4 +132,4 @@ class TestAWWAggregatePerformanceIndicator(BaseAggregatePerformanceTestCase):
         visits.return_value = etree.fromstring(self.get_xml('visit_fixture'))
         with self.assertRaises(IndicatorError) as e:
             run_indicator_for_user(self.aww, AWWAggregatePerformanceIndicator, language_code='en')
-        self.assertIn('Attribute awc_opened_count not found in restore for AWC AWC1', e.exception.message)
+        self.assertIn('Attribute awc_opened_count not found in restore for AWC AWC1', six.text_type(e.exception))

--- a/custom/ilsgateway/tanzania/handlers/zipline.py
+++ b/custom/ilsgateway/tanzania/handlers/zipline.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
+
 from corehq.apps.products.models import SQLProduct
 from custom.ilsgateway.tanzania.handlers.keyword import KeywordHandler
 from custom.ilsgateway.tanzania.reminders import INVALID_PRODUCT_CODE
 from custom.zipline.api import ProductQuantity
+
 from six.moves import zip
 
 
@@ -58,7 +62,7 @@ class ZiplineGenericHandler(KeywordHandler):
         try:
             parsed_report = self.parse_message(content)
         except ParseError as e:
-            self.respond(e.message)
+            self.respond(six.text_type(e))
             return True
 
         for product_code, quantity in parsed_report:


### PR DESCRIPTION
Removes instances of:
```
DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
```
Only touches instances with test coverage.

@dimagi/py3 