### PR TITLE
Revert externalize js of drilldown filters

### DIFF
--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -164,49 +164,6 @@ hqDefine("reports/js/filters/main", [
             $el.koApplyBindings(model);
             model.load(data.locs, data.locId);
         });
-        $('.report-filter-drilldown-options').each(function (i, el) {
-            var $el = $(el), data = $el.data();
-            if ($el.parents('.report-filter-form-drilldown').length > 0) return;
-            if (data.isEmpty) return;
-            var model = drilldownOptions.drilldownOptionFilterControl({
-                drilldown_map: data.drilldownMap,
-                controls: data.controls,
-                selected: data.selected,
-                notifications: data.notifications,
-            });
-            $('#' + data.cssId).koApplyBindings(model);
-            model.init();
-        });
-        $('.report-filter-form-drilldown').each(function (i, el) {
-            // This is copied from drilldown-options above because the order matters
-            // http://manage.dimagi.com/default.asp?231773
-            var $el = $(el), data = $el.data();
-            if (!data.isEmpty) {
-                var model = drilldownOptions.drilldownOptionFilterControl({
-                    drilldown_map: data.drilldownMap,
-                    controls: data.controls,
-                    selected: data.selected,
-                    notifications: data.notifications,
-                });
-                $('#' + data.cssId).koApplyBindings(model);
-                model.init();
-            }
-
-            if (data.unknownAvailable || data.displayAppType) {
-                advancedFormsOptions.advancedFormsOptions(
-                    $('#' + data.cssId + '-advanced-options'),
-                    {
-                        show: data.showAdvanced,
-                        is_unknown_shown: data.isUnknownShown,
-                        selected_unknown_form: data.selectedUnknownForm,
-                        all_unknown_forms: data.allUnknownForms,
-                        caption_text: data.captionText,
-                        css_id: data.cssId,
-                        css_class: data.cssClass,
-                    }
-                );
-            }
-        });
         $('.report-filter-logtag').each(function(i, el) {
             var $el = $(el), data = $el.data();
             if (data.defaultOn) {

--- a/corehq/apps/reports/templates/reports/filters/drilldown_options.html
+++ b/corehq/apps/reports/templates/reports/filters/drilldown_options.html
@@ -5,13 +5,7 @@
 {% if is_empty %}
 <div class="alert alert-info">{{ empty_text }}</div>
 {% else %}
-<div id="{{ css_id }}" class="well well-sm report-filter-drilldown-options"
-     data-drilldown-map='{% html_attr option_map %}'
-     data-controls='{% html_attr controls %}'
-     data-selected='{{ selected|JSON }}'
-     data-notifications='{% html_attr notifications %}'
-     data-is-empty='{{ is_empty|JSON }}'
-     data-css-id='{{ css_id }}'>
+<div id="{{ css_id }}" class="well well-sm">
     <div data-bind="foreach: controls">
         <div class="form-group"
              data-bind="visible: is_visible">
@@ -38,4 +32,18 @@
     <div class="alert alert-info" data-bind="fadeVisible: notification.is_visible, html: notification.message"></div>
  </div>
  {% endif %}
+{% endblock %}
+{% block filter_js %}
+{% if not is_empty %}
+<script>
+    $.getScript("{% static 'reports/js/report_filter.drilldown_options.js' %}", function () {
+       $('#{{ css_id }}').drilldownOptionFilter({
+           drilldown_map: {{ option_map|JSON }},
+           controls: {{ controls|JSON }},
+           selected: {{ selected|JSON }},
+           notifications: {{ notifications|JSON }},
+       });
+    });
+</script>
+{% endif %}
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
@@ -2,91 +2,110 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% block filter_content %}
-    {% if unknown_available %}
-        <div class="{{ css_id }}-unknown_controls" data-bind="visible: show" style="margin-bottom:1em;">
-            <div class="radio">
-                <label>
-                    <input type="radio"
-                        data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
-                        data-known="#{{ css_id }}-known_control"
-                        name="{{ slug }}_{{ unknown.slug }}"
-                        id="{{ css_id }}_{{ unknown.slug }}_hide"
-                        value="">
-                    {% trans 'Known Forms' %}
-                    <span class="hq-help-template"
-                        data-title="{% trans "What are Known Forms?" %}"
-                        data-content="{% trans "Known Forms are forms that have IDs which can be matched to existing or deleted CommCare Applications in your Project." %}"
-                    ></span>
-                </label>
-            </div>
-            <div class="radio">
-                <label>
-                    <input type="radio"
-                        data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
-                        data-known="#{{ css_id }}-known_control"
-                        name="{{ slug }}_{{ unknown.slug }}"
-                        id="{{ css_id }}_{{ unknown.slug }}_show"
-                        value="yes">
-                    {% trans 'Unknown Forms (Possibly Deleted)' %}
-                    <span class="hq-help-template"
-                        data-title="{% trans "What are Unknown Forms?" %}"
-                        data-content="{% trans "We tried and tried, but these form IDs did not belong to any CommCare Applications (existing or deleted) in your Project. It might mean that these forms once belonged to an application, were deleted from it, and then replaced by a different form." %}"
-                    ></span>
-                </label>
-            </div>
-        </div>
-        <div class="well well-sm {{ css_id }}-unknown_controls" data-bind="visible: is_unknown_shown">
-            <div class="form-group">
-                <label class="control-label col-xs-4 col-md-2" for="{{ css_id }}-{{ unknown.slug }}_xmlns">
-                    {% trans 'Choose Unknown Form' %}
-                </label>
-                <div class="col-xs-8 col-md-10">
-                    <select class="form-control"
-                            id="{{ css_id }}-{{ unknown.slug }}_xmlns"
-                            name="{{ slug }}_{{ unknown.slug }}_xmlns"
-                            data-bind="options: all_unknown_forms,
-                            optionsText: 'text', optionsValue: 'val',
-                            optionsCaption: caption_text, value: selected_unknown_form"></select>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-
-    <div id="{{ css_id }}-known_control"
-        class="report-filter-form-drilldown"
-        data-unknown-available='{{ unknown_available|JSON }}'
-        data-is-empty='{{ is_empty|JSON }}'
-        data-drilldown-map='{% html_attr option_map %}'
-        data-controls='{% html_attr controls %}'
-        data-selected='{{ selected|JSON }}'
-        data-notifications='{% html_attr notifications %}'
-        data-display-app-type='{{ display_app_type|JSON }}'
-        data-show-advanced='{{ show_advanced|JSON }}'
-        data-is-unknown-shown='{{ unknown.show|JSON }}'
-        data-selected-unknown-form='{{ unknown.selected }}'
-        data-all-unknown-forms='{% html_attr unknown.options %}'
-        data-caption-text='{{ unknown.default_text }}'
-        data-css-id='{{ css_id }}'
-        data-css-class='{{ css_id }}-unknown_controls'>
-            {{ block.super }}
+{% if unknown_available %}
+<div class="{{ css_id }}-unknown_controls" data-bind="visible: show" style="margin-bottom:1em;">
+    <div class="radio">
+        <label>
+            <input type="radio"
+                   data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
+                   data-known="#{{ css_id }}-known_control"
+                   name="{{ slug }}_{{ unknown.slug }}"
+                   id="{{ css_id }}_{{ unknown.slug }}_hide"
+                   value="">
+            {% trans 'Known Forms' %}
+            <span class="hq-help-template"
+                data-title="{% trans "What are Known Forms?" %}"
+                data-content="{% trans "Known Forms are forms that have IDs which can be matched to existing or deleted CommCare Applications in your Project." %}"
+            ></span>
+        </label>
     </div>
-
-    {% if unknown_available or display_app_type %}
-        <div id="{{ css_id }}-advanced-options" style="margin-top: -.8em;">
-            <div class="checkbox">
-                <label>
-                    <input name="show_advanced" type="checkbox" data-bind="checked: show" />
-                    {% trans "Show Advanced Options" %}
-                </label>
-            </div>
+    <div class="radio">
+        <label>
+            <input type="radio"
+                   data-bind="checked: is_unknown_shown, hideKnownForms: is_unknown_shown"
+                   data-known="#{{ css_id }}-known_control"
+                   name="{{ slug }}_{{ unknown.slug }}"
+                   id="{{ css_id }}_{{ unknown.slug }}_show"
+                   value="yes">
+            {% trans 'Unknown Forms (Possibly Deleted)' %}
+            <span class="hq-help-template"
+                data-title="{% trans "What are Unknown Forms?" %}"
+                data-content="{% trans "We tried and tried, but these form IDs did not belong to any CommCare Applications (existing or deleted) in your Project. It might mean that these forms once belonged to an application, were deleted from it, and then replaced by a different form." %}"
+            ></span>
+        </label>
+    </div>
+</div>
+<div class="well well-sm {{ css_id }}-unknown_controls" data-bind="visible: is_unknown_shown">
+    <div class="form-group">
+        <label class="control-label col-xs-4 col-md-2" for="{{ css_id }}-{{ unknown.slug }}_xmlns">
+            {% trans 'Choose Unknown Form' %}
+        </label>
+        <div class="col-xs-8 col-md-10">
+            <select class="form-control"
+                    id="{{ css_id }}-{{ unknown.slug }}_xmlns"
+                    name="{{ slug }}_{{ unknown.slug }}_xmlns"
+                    data-bind="options: all_unknown_forms,
+                    optionsText: 'text', optionsValue: 'val',
+                    optionsCaption: caption_text, value: selected_unknown_form"></select>
         </div>
-    {% endif %}
+    </div>
+</div>
+{% endif %}
+<div id="{{ css_id }}-known_control">
+    {{ block.super }}
+</div>
 
-    {% if hide_fuzzy.show %}
-        <div class="alert alert-warning {{ css_id }}-unknown_controls"
-            data-bind="visible: show"
-            style="margin-top: 1em;">
-            {% include 'reports/filters/partials/fuzzy_checkbox.html' %}
-        </div>
-    {% endif %}
+{% if unknown_available or display_app_type %}
+<div id="{{ css_id }}-advanced-options" style="margin-top: -.8em;">
+    <div class="checkbox">
+        <label>
+            <input name="show_advanced" type="checkbox" data-bind="checked: show" />
+            {% trans "Show Advanced Options" %}
+        </label>
+    </div>
+</div>
+{% endif %}
+
+{% if hide_fuzzy.show %}
+<div class="alert alert-warning {{ css_id }}-unknown_controls"
+     data-bind="visible: show"
+     style="margin-top: 1em;">
+    {% include 'reports/filters/partials/fuzzy_checkbox.html' %}
+</div>
+{% endif %}
+{% endblock %}
+
+{% block filter_js %}
+<script>
+
+ $.when(
+     $.getScript("{% static 'reports/js/filters/drilldown_options.js' %}"),
+     $.getScript("{% static 'reports/js/filters/advanced_forms_options.js' %}")
+ ).done(function () {
+
+     // This is copied from drilldown_options.html because the order matters
+     {% if not is_empty %}
+     $('#{{ css_id }}').drilldownOptionFilter({
+         drilldown_map: {{ option_map|JSON }},
+         controls: {{ controls|JSON }},
+         selected: {{ selected|JSON }},
+         notifications: {{ notifications|JSON }},
+     });
+     {% endif %}
+
+     {% if unknown_available or display_app_type %}
+     $('#{{ css_id }}-advanced-options').advanceFormsOptions({
+         show: {{ show_advanced|JSON }},
+         is_unknown_shown: {{ unknown.show|yesno:'true,false' }},
+         selected_unknown_form: '{{ unknown.selected }}',
+         all_unknown_forms: {{ unknown.options|JSON }},
+         caption_text: '{{ unknown.default_text }}',
+         css_id: '{{ css_id }}',
+         css_class: '{{ css_id }}-unknown_controls',
+     });
+     {% endif %}
+
+ });
+
+</script>
 {% endblock %}


### PR DESCRIPTION
Not a straight rollback because of the number of band-aid fixes that have been done over the past few days. Almost identical to https://github.com/dimagi/commcare-hq/pull/20218, I think the only difference is that the .js files were renamed in https://github.com/dimagi/commcare-hq/pull/20325 and I kept the new names.

fyi @jmtroth0 
code buddy @sravfeyn 