### PR TITLE
log errors in fixture upload

### DIFF
--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -381,7 +381,8 @@ class FixtureUploadStatusView(FixtureViewMixIn, BaseDomainView):
 def fixture_upload_job_poll(request, domain, download_id, template="fixtures/partials/fixture_upload_status.html"):
     try:
         context = get_download_context(download_id, require_result=True)
-    except TaskFailedError:
+    except TaskFailedError as e:
+        notify_exception(request, message=e.message)
         return HttpResponseServerError()
 
     return render(request, template, context)


### PR DESCRIPTION
support getting a lot of upload errors in fixtures and no clue how to triage.
@millerdev cc @calellowitz 