### PR TITLE
Script to create a stable build for ICDS

### DIFF
--- a/scripts/enterprise.yaml
+++ b/scripts/enterprise.yaml
@@ -1,3 +1,3 @@
-trunk: 2018-04-20_17.18-production-deploy
+trunk: 2018-05-17_19.13-production-deploy
 name: enterprise
 pull_requests: []

--- a/scripts/enterprise.yaml
+++ b/scripts/enterprise.yaml
@@ -1,0 +1,3 @@
+trunk: 2018-04-20_17.18-production-deploy
+name: enterprise
+pull_requests: []

--- a/scripts/enterprise_stable.yaml
+++ b/scripts/enterprise_stable.yaml
@@ -1,4 +1,0 @@
-trunk: 2018-04-20_17.18-production-deploy
-name: enterprise_stable
-pull_requests:
-  - 20351

--- a/scripts/enterprise_stable.yaml
+++ b/scripts/enterprise_stable.yaml
@@ -1,0 +1,4 @@
+trunk: 2018-04-20_17.18-production-deploy
+name: enterprise_stable
+pull_requests:
+  - 20351

--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -14,6 +14,10 @@ def get_grep():
     return sh.grep.bake(_tty_out=False)
 
 
+def get_tail():
+    return sh.tail.bake(_tty_out=False)
+
+
 class OriginalBranch(object):
     def __init__(self, git=None):
         self.git = git or get_git()
@@ -37,6 +41,12 @@ def git_current_branch(git=None):
     if branch.startswith('('):
         branch = git.log('--pretty=oneline', n=1).strip().split(' ')[0]
     return branch
+
+
+def git_recent_tags(grep_string="production-deploy"):
+    git, grep, tail = get_git(), get_grep(), get_tail()
+    last_tags = tail(grep(git.tag('--sort=committerdate'), grep_string), n=10)
+    return last_tags
 
 
 def git_submodules(git=None):

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -11,6 +11,7 @@ rebuild staging from yaml configuration (scripts/staging.yaml)
     --deploy        deploy after rebuild is complete
     --no-push       do not push changes (cannot be used with --deploy)
     --skip-fetch    assume local copy is already update date with remote
+    --enterprise    rebuild the enterprise branch
 EOF
 }
 
@@ -38,9 +39,9 @@ do
         no_push=y
         echo no-push
         ;;
-      --stable)
-        stable=y
-        echo stable
+      --enterprise)
+        enterprise=y
+        echo enterprise
         ;;
       *)
         usage
@@ -54,9 +55,9 @@ function rebuildstaging() {
     python scripts/rebuildstaging.py < scripts/staging.yaml "$@"
 }
 
-function rebuildstable() {
-    echo "rebuilding enterprise stable branch, this might take a while..."
-    python scripts/rebuildstaging.py < scripts/enterprise_stable.yaml "$@"
+function rebuildenterprise() {
+    echo "rebuilding enterprise branch"
+    python scripts/rebuildstaging.py < scripts/enterprise.yaml "$@"
 }
 
 args=''
@@ -75,16 +76,16 @@ then
     exit 1
 fi
 
-if [[ $deploy = 'y' && $no_push != 'y' && $stable != 'y' ]]
+if [[ $deploy = 'y' && $no_push != 'y' && $enterprise != 'y' ]]
 then
     rebuildstaging $args && {
         which commcare-cloud \
         && commcare-cloud staging fab deploy:confirm=no \
         || echo 'Could not auto-deploy for you. Run `commcare-cloud staging fab deploy` to deploy.'
     }
-elif [[ $stable == 'y' ]]
+elif [[ $enterprise == 'y' ]]
 then
-    rebuildstable $args
+    rebuildenterprise $args
 else
     rebuildstaging $args
 fi

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -38,6 +38,10 @@ do
         no_push=y
         echo no-push
         ;;
+      --stable)
+        stable=y
+        echo stable
+        ;;
       *)
         usage
         exit 1
@@ -48,6 +52,11 @@ done
 function rebuildstaging() {
     echo "rebuilding staging branch, this might take a while..."
     python scripts/rebuildstaging.py < scripts/staging.yaml "$@"
+}
+
+function rebuildstable() {
+    echo "rebuilding enterprise stable branch, this might take a while..."
+    python scripts/rebuildstaging.py < scripts/enterprise_stable.yaml "$@"
 }
 
 args=''
@@ -66,13 +75,16 @@ then
     exit 1
 fi
 
-if [[ $deploy = 'y' && $no_push != 'y' ]]
+if [[ $deploy = 'y' && $no_push != 'y' && $stable != 'y' ]]
 then
     rebuildstaging $args && {
         which commcare-cloud \
         && commcare-cloud staging fab deploy:confirm=no \
         || echo 'Could not auto-deploy for you. Run `commcare-cloud staging fab deploy` to deploy.'
     }
+elif [[ $stable == 'y' ]]
+then
+    rebuildstable $args
 else
     rebuildstaging $args
 fi

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -53,7 +53,7 @@ class BranchConfig(jsonobject.JsonObject):
     name = jsonobject.StringProperty()
     branches = jsonobject.ListProperty(six.text_type)
     submodules = jsonobject.DictProperty(lambda: BranchConfig)
-    pull_request = jsonobject.ListProperty(six.text_type)
+    pull_requests = jsonobject.ListProperty(six.text_type)
 
     def normalize(self):
         for submodule, subconfig in self.submodules.items():

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -92,7 +92,7 @@ def fetch_remote(base_config, name="origin"):
 
         for pr in config.pull_requests:
             print("  [{path}] fetching pull request {pr}".format(**locals()))
-            pr = 'pull/{pr}/head:stable/{pr}'.format(pr=pr)
+            pr = 'pull/{pr}/head:enterprise/{pr}'.format(pr=pr)
             jobs.append(gevent.spawn(git.fetch, 'origin', pr))
 
     gevent.joinall(jobs)
@@ -219,7 +219,7 @@ def rebuild_staging(config, print_details=True, push=True):
                 else:
                     print("ok")
             for pr in config.pull_requests:
-                branch = "stable/{pr}".format(pr=pr)
+                branch = "enterprise/{pr}".format(pr=pr)
                 print("  [{cwd}] Merging {pr} into {name}".format(
                     cwd=path,
                     pr=pr,

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -31,21 +31,21 @@ from gevent import monkey
 import six
 monkey.patch_all()
 
+import contextlib
 import os
-import jsonobject
 import sh
 import sys
-import contextlib
-import gevent
 
 from fabric.colors import red
-from sh_verbose import ShVerbose
+import gevent
 from gitutils import (
     OriginalBranch,
     get_git,
     has_merge_conflict,
     print_merge_details,
 )
+import jsonobject
+from sh_verbose import ShVerbose
 
 
 class BranchConfig(jsonobject.JsonObject):


### PR DESCRIPTION
Saw that ICDS will eventually get added to the normal deploy rotation on Mondays. This week seems like it has been particularly bad with many reverts/hotfixes happening after deploy, which makes this feel even more important. This would hopefully cut down on high visibility bugs hitting ICDS and stressful IST firefighting.

My proposal for this is to base the branch on the tag from the Friday deploy and merge specific PRs into that branch. (We can't use branch names as they are often deleted after merging). I'm assuming that between Friday and Monday any issues will have been identified and we can get specific PRs in before then, but could also change to Thursday if we want a full working day.

Followup if going this route:
- [ ] change ICDS to always deploy enterprise_stable branch
- [ ] change other enterprise deployments (swiss/PNA) to always deploy this branch
- [ ] automatically get the last tag that was deployed to production (should probably always be last friday though)
- [ ] is there a way to warn if one of the branches contains a migration?

This is a super hacky 30 min MVP but when I was glancing through rebuildstaging it looked like random hacks were par for the course.  this script could probably use some love in general.

@dimagi/scale-team  Thoughts on this?
@dannyroberts you'll probably have good thoughts on this as well