### PR TITLE
stop trying to load app config

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -165,8 +165,6 @@ class ConnectionManager(object):
                             self._add_django_db(read_db, read_db)
 
         for app, weights in settings.LOAD_BALANCED_APPS.items():
-            # this tests that the app_label is real and raises an exception if not
-            apps.get_app_config(app)
             self.read_database_mapping[app] = []
             for db_alias, weighting in weights:
                 assert isinstance(weighting, int), 'weighting must be int'


### PR DESCRIPTION
@snopoke @emord 
removing the line that caused problems here here https://github.com/dimagi/commcare-cloud/pull/1637

This removes validation that the apps are real but otherwise does not affect the functioning. I can go back to the drawing board for validation, but in the short term this seems reasonable. The worst thing that can happen is that if the app_label is entered wrong in `localsettings` load balancing won't happen. It can't break anything.