### PR TITLE
rebuild cases

### DIFF
--- a/corehq/apps/cleanup/management/commands/rebuild_cases.py
+++ b/corehq/apps/cleanup/management/commands/rebuild_cases.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+import logging
+from django.core.management.base import BaseCommand
+
+from corehq.form_processor.backends.sql.processor import FormProcessorSQL
+from corehq.form_processor.models import RebuildWithReason
+
+
+logger = logging.getLogger('rebuild_cases')
+logger.setLevel('DEBUG')
+
+
+class Command(BaseCommand):
+    help = ('Rebuild given cases')
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('cases_csv_file')
+
+    def handle(self, domain, cases_csv_file, **options):
+        cases = []
+        with open(cases_csv_file, 'r') as f:
+            lines = f.readlines()
+            cases = [l.strip() for l in lines]
+
+        rebuild_cases(domain, cases, logger)
+
+
+def rebuild_cases(domain, cases, logger):
+    detail = RebuildWithReason(reason='undo UUID clash')
+    for case_id in cases:
+        try:
+            FormProcessorSQL.hard_rebuild_case(domain, case_id, detail)
+            logger.info('Case %s rebuilt' % case_id)
+        except Exception as e:
+            logger.error("Exception rebuilding case %s".format(case_id))
+            logger.exception("message")
+

--- a/corehq/apps/cleanup/management/commands/rebuild_cases.py
+++ b/corehq/apps/cleanup/management/commands/rebuild_cases.py
@@ -34,7 +34,6 @@ def rebuild_cases(domain, cases, logger):
         try:
             FormProcessorSQL.hard_rebuild_case(domain, case_id, detail)
             logger.info('Case %s rebuilt' % case_id)
-        except Exception as e:
+        except:
             logger.error("Exception rebuilding case %s".format(case_id))
             logger.exception("message")
-


### PR DESCRIPTION
This time when running `undo_uuid_clash` most of the edits went through, but while rebuilding for one of the cases a form was not found, so the rest of cases are not rebuilt. When we run the command again it doesn't try to rebuild cases anymore since the forms are rebuilt. 

I have saved all the running logs, so I know what cases need to be rebuilt. So I wrote a command to rebuild just cases (there were no ledgers to be rebuilt). 

I couldn't find why one of the forms related to a case wasn't found. But when I run this new command I will have more info

