### PR TITLE
RequireJS custom bundle for report filters

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/yaml/requirejs.yaml
+++ b/corehq/apps/hqwebapp/static/hqwebapp/yaml/requirejs.yaml
@@ -74,3 +74,12 @@ modules:
       - reports/js/standard_hq_report
     exclude:
       - hqwebapp/js/common
+
+  # Limited bundle for report filters, ignoring the not-yet-migrated drilldown filters.
+  - name: reports/js/filters/bundle
+    include:
+      - reports/js/filters/main
+      - reports/js/filters/button_group
+      - reports/js/filters/select2s
+    exclude:
+      - hqwebapp/js/common


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?274840

https://github.com/dimagi/commcare-hq/pull/20325 moved advanced_forms_options.js and drilldown_options.js into reports/js/filters. All of the files in that directory get merged into a single requirejs bundle that's used by the view lookup table page, which means that all files in that directory need to be requirejs-compatible. But I don't want to change those files until the report filters are more stable, so instead I'm making a custom requirejs bundle for that directory that doesn't include those files.

Should go into today's deploy.

@jmtroth0 / @millerdev 
code buddy @sravfeyn 