### PR TITLE
fix Saved Credit Cards section of Billing Information

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
@@ -74,7 +74,7 @@ hqDefine("accounting/js/stripe_card_manager", function() {
 
     var stripeCardModel = function(card, baseUrl, cardManager){
         'use strict';
-        var self = this;
+        var self = {};
         var mapping = {
             include: ['brand', 'last4', 'exp_month','exp_year', 'is_autopay'],
             copy: ['url', 'token'],


### PR DESCRIPTION
Currently, if you have a saved credit card and go to the Billing Information page, the following JS error happens:

```
jquery.min.js?version=1055018:2 Uncaught TypeError: Cannot set property 'wrap' of undefined
    at stripeCardModel (stripe_card_manager.js?version=6081f2d:83)
    at Object.create (stripe_card_manager.js?version=6081f2d:153)
    at knockout_mapping.ko.min.js:8
    at s (knockout_mapping.ko.min.js:7)
    at k (knockout_mapping.ko.min.js:8)
    at o (knockout_mapping.ko.min.js:12)
    at o (knockout_mapping.ko.min.js:11)
    at knockout_mapping.ko.min.js:12
    at p (knockout_mapping.ko.min.js:14)
    at o (knockout_mapping.ko.min.js:12)
```

This prevents you from seeing your saved cards and from adding additional cards.

Example: https://www.commcarehq.org/a/nick-project/settings/project/billing_information/