### PR TITLE
Hide some reports from navigation in ICDS

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -277,6 +277,10 @@ class MessageLogReport(BaseCommConnectLogReport):
 
     exportable = True
 
+    @classmethod
+    def show_in_navigation(cls, domain=None, project=None, user=None):
+        return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
+
     def get_message_type_filter(self):
         filtered_types = MessageTypeFilter.get_value(self.request, self.domain)
         if filtered_types:
@@ -731,6 +735,10 @@ class MessagingEventsReport(BaseMessagingEventReport):
         PhoneNumberFilter,
     ]
     ajax_pagination = True
+
+    @classmethod
+    def show_in_navigation(cls, domain=None, project=None, user=None):
+        return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
 
     @property
     def headers(self):
@@ -1633,6 +1641,9 @@ class ScheduleInstanceReport(ProjectReport, ProjectReportParametersMixin, Generi
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
+        if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+            return False
+
         return (
             (user and toggles.NEW_REMINDERS_MIGRATOR.enabled(user.username)) or
             (project and project.uses_new_reminders)


### PR DESCRIPTION
ICDS uses a `report_whitelist` on the `Domain` object which is making all messaging reports raise a 404 right now. There are some reports that we should have access to for debugging, but we don't want them to be navigable normally. My plan is to add these reports to the `report_whitelist`:

    message_log
    messaging_events
    message_event_detail
    survey_detail
    scheduled_messaging_events

and then the changes in this PR will make it so that none of these reports show up in the navigation. The only way to get to them will be to either type in the url or get to it from the new messaging dashboard (which will initially be seen only by superusers in ICDS).

@jmtroth0 
fyi @millerdev @snopoke 