### PR TITLE
treat description as positional argument

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2934,7 +2934,7 @@ class StripePaymentMethod(PaymentMethod):
         """
         return 'auto_pay_{billing_account_id}'.format(billing_account_id=billing_account.id)
 
-    def create_charge(self, card, amount_in_dollars, description=None):
+    def create_charge(self, card, amount_in_dollars, description):
         """ Charges a stripe card and returns a transaction id """
         amount_in_cents = int((amount_in_dollars * Decimal('100')).quantize(Decimal(10)))
         transaction_record = stripe.Charge.create(
@@ -2942,7 +2942,7 @@ class StripePaymentMethod(PaymentMethod):
             customer=self.customer,
             amount=amount_in_cents,
             currency=settings.DEFAULT_CURRENCY,
-            description=description if description else '',
+            description=description,
         )
         return transaction_record.id
 


### PR DESCRIPTION
```StripePaymentMethod.create_charge``` is only called once, and takes a ```description```, so I'm removing dead code and making it a required argument.