### PR TITLE
retry pillow errors by sending directly back kafka

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -26,7 +26,6 @@ class KafkaProcessor(PillowProcessor):
         self._data_source_name = data_source_name
 
     def process_change(self, pillow_instance, change):
-        from corehq.apps.change_feed.topics import get_topic_for_doc_type
         populate_change_metadata(change, self._data_source_type, self._data_source_name)
         if change.metadata:
             change_meta = change.metadata

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -3,16 +3,13 @@ from __future__ import unicode_literals
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
-from corehq.apps.change_feed.document_types import get_doc_meta_object_from_document, \
-    change_meta_from_doc_meta_and_document
-from corehq.apps.change_feed.exceptions import MissingMetaInformationError
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couchdb_management import couch_config
 from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
-from pillowtop.feed.couch import CouchChangeFeed
+from pillowtop.feed.couch import CouchChangeFeed, populate_change_metadata
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
 
@@ -29,25 +26,17 @@ class KafkaProcessor(PillowProcessor):
         self._data_source_name = data_source_name
 
     def process_change(self, pillow_instance, change):
-        try:
-            document = change.get_document()
-            doc_meta = get_doc_meta_object_from_document(document)
-            change_meta = change_meta_from_doc_meta_and_document(
-                doc_meta=doc_meta,
-                document=document,
-                data_source_type=self._data_source_type,
-                data_source_name=self._data_source_name,
-                doc_id=change.id,
-            )
-        except MissingMetaInformationError:
-            pass
-        else:
+        from corehq.apps.change_feed.topics import get_topic_for_doc_type
+        populate_change_metadata(change, self._data_source_type, self._data_source_name)
+        if change.metadata:
+            change_meta = change.metadata
+            topic = get_topic_for_doc_type(change_meta.document_type, self._data_source_type)
             # change.deleted is used for hard deletions whereas change_meta.is_deletion is for soft deletions.
             # from the consumer's perspective both should be counted as deletions so just "or" them
             # note: it is strange and hard to reproduce that the couch changes feed is providing a "doc"
             # along with a hard deletion, but it is doing that in the wild so we might as well support it.
             change_meta.is_deletion = change_meta.is_deletion or change.deleted
-            self._producer.send_change(get_topic_for_doc_type(doc_meta.raw_doc_type), change_meta)
+            self._producer.send_change(topic, change_meta)
 
 
 def get_default_couch_db_change_feed_pillow(pillow_id, **kwargs):

--- a/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
+++ b/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
@@ -22,7 +22,7 @@ class PillowRetryEnqueuingOperation(GenericEnqueuingOperation):
     @staticmethod
     def _get_items(utcnow):
         errors = PillowError.get_errors_to_process(utcnow=utcnow, limit=1000)
-        return [QueueItem(id=e['id'], key=e['date_next_attempt']) for e in errors]
+        return [QueueItem(id=e.id, key=e.date_next_attempt, object=e) for e in errors]
 
     @classmethod
     def get_items_to_be_processed(cls, utcnow):
@@ -38,7 +38,7 @@ class PillowRetryEnqueuingOperation(GenericEnqueuingOperation):
         return settings.PILLOW_RETRY_QUEUE_ENABLED
 
     def enqueue_item(self, item):
-        process_pillow_retry(item.id)
+        process_pillow_retry(item.object)
 
 
 class Command(PillowRetryEnqueuingOperation):

--- a/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
+++ b/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from psycopg2._psycopg import InterfaceError
 import pytz
 from hqscripts.generic_queue import GenericEnqueuingOperation, QueueItem
+from pillow_retry.const import PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT
 from pillow_retry.models import PillowError
 from pillow_retry.tasks import process_pillow_retry
 from django import db
@@ -16,7 +17,7 @@ class PillowRetryEnqueuingOperation(GenericEnqueuingOperation):
         return "pillow-queue"
 
     def get_enqueuing_timeout(self):
-        return settings.PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT
+        return PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT
 
     @staticmethod
     def _get_items(utcnow):

--- a/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
+++ b/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
@@ -6,7 +6,7 @@ import pytz
 from hqscripts.generic_queue import GenericEnqueuingOperation, QueueItem
 from pillow_retry.const import PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT
 from pillow_retry.models import PillowError
-from pillow_retry.tasks import process_pillow_retry
+from pillow_retry.api import process_pillow_retry
 from django import db
 
 
@@ -38,7 +38,7 @@ class PillowRetryEnqueuingOperation(GenericEnqueuingOperation):
         return settings.PILLOW_RETRY_QUEUE_ENABLED
 
     def enqueue_item(self, item):
-        process_pillow_retry.delay(item.id)
+        process_pillow_retry(item.id)
 
 
 class Command(PillowRetryEnqueuingOperation):

--- a/corehq/ex-submodules/pillow_retry/api.py
+++ b/corehq/ex-submodules/pillow_retry/api.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import sys
+
+from corehq.apps.change_feed.data_sources import get_document_store
+from corehq.apps.change_feed.producer import producer
+from corehq.apps.change_feed.topics import get_topic_for_doc_type
+from dimagi.utils.logging import notify_error
+from pillow_retry import const
+from pillow_retry.models import PillowError
+from pillowtop.exceptions import PillowNotFoundError
+from pillowtop.feed.couch import CouchChangeFeed
+from pillowtop.utils import get_pillow_by_name
+
+
+def process_pillow_retry(error_doc_id):
+    try:
+        error_doc = PillowError.objects.get(id=error_doc_id)
+    except PillowError.DoesNotExist:
+        return
+
+    pillow_name_or_class = error_doc.pillow
+    try:
+        pillow = get_pillow_by_name(pillow_name_or_class)
+    except PillowNotFoundError:
+        pillow = None
+
+    if not pillow:
+        notify_error((
+            "Could not find pillowtop class '%s' while attempting a retry. "
+            "If this pillow was recently deleted then this will be automatically cleaned up eventually. "
+            "If not, then this should be looked into."
+        ) % pillow_name_or_class)
+        try:
+            error_doc.total_attempts = const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
+            error_doc.save()
+        finally:
+            return
+
+    change = error_doc.change_object
+    try:
+        change_metadata = change.metadata
+        if change_metadata:
+            document_store = get_document_store(
+                data_source_type=change_metadata.data_source_type,
+                data_source_name=change_metadata.data_source_name,
+                domain=change_metadata.domain
+            )
+            change.document_store = document_store
+        if isinstance(pillow.get_change_feed(), CouchChangeFeed):
+            pillow.process_change(change)
+        else:
+            if change_metadata.data_source_type in ('couch', 'sql'):
+                data_source_type = change_metadata.data_source_type
+            else:
+                # legacy metadata will have other values for non-sql
+                # can remove this once all legacy errors have been processed
+                data_source_type = 'sql'
+            producer.send_change(
+                get_topic_for_doc_type(
+                    change_metadata.document_type,
+                    data_source_type
+                ),
+                change_metadata
+            )
+    except Exception:
+        ex_type, ex_value, ex_tb = sys.exc_info()
+        error_doc.add_attempt(ex_value, ex_tb)
+        error_doc.save()
+    else:
+        error_doc.delete()

--- a/corehq/ex-submodules/pillow_retry/api.py
+++ b/corehq/ex-submodules/pillow_retry/api.py
@@ -8,18 +8,12 @@ from corehq.apps.change_feed.producer import producer
 from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from dimagi.utils.logging import notify_error
 from pillow_retry import const
-from pillow_retry.models import PillowError
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.feed.couch import CouchChangeFeed
 from pillowtop.utils import get_pillow_by_name
 
 
-def process_pillow_retry(error_doc_id):
-    try:
-        error_doc = PillowError.objects.get(id=error_doc_id)
-    except PillowError.DoesNotExist:
-        return
-
+def process_pillow_retry(error_doc):
     pillow_name_or_class = error_doc.pillow
     try:
         pillow = get_pillow_by_name(pillow_name_or_class)

--- a/corehq/ex-submodules/pillow_retry/const.py
+++ b/corehq/ex-submodules/pillow_retry/const.py
@@ -1,0 +1,15 @@
+
+# If an error still has not been processed in this number of minutes, enqueue it
+# again.
+PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT = 60 * 24
+
+# Number of minutes to wait before retrying an unsuccessful processing attempt
+PILLOW_RETRY_REPROCESS_INTERVAL = 5
+
+# Max number of processing attempts before giving up on processing the error
+PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS = 3
+
+# After an error's total attempts exceeds this number it will only be re-attempted
+# once after being reset. This is to prevent numerous retries of errors that aren't
+# getting fixed
+PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF = PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS * 3

--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -161,21 +161,3 @@ class PillowError(models.Model):
             current_attempt=0,
             date_next_attempt=datetime.utcnow()
         )
-
-    @classmethod
-    def get_pillows(cls):
-        results = PillowError.objects.values('pillow').annotate(count=Count('pillow'))
-        return (p['pillow'] for p in results)
-
-    @classmethod
-    def get_error_types(cls):
-        results = PillowError.objects.values('error_type').annotate(count=Count('error_type'))
-        return (e['error_type'] for e in results)
-
-
-# Stub models file, also used in tests
-from dimagi.ext.couchdbkit import Document
-
-
-class Stub(Document):
-    pass

--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -107,7 +107,7 @@ class PillowError(models.Model):
         return error
 
     @classmethod
-    def get_errors_to_process(cls, utcnow, limit=None, skip=0, fetch_full=False):
+    def get_errors_to_process(cls, utcnow, limit=None, skip=0):
         """
         Get errors according the following rules:
 
@@ -126,8 +126,6 @@ class PillowError(models.Model):
         :param utcnow:      The current date and time in UTC.
         :param limit:       Paging limit param.
         :param skip:        Paging skip param.
-        :param fetch_full:  If True return the whole PillowError object otherwise return a
-                            a dict containing 'id' and 'date_next_attempt' keys.
         """
         max_attempts = const.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS
         multi_attempts_cutoff = const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
@@ -141,8 +139,6 @@ class PillowError(models.Model):
         # temporarily disable queuing of ConfigurableReportKafkaPillow errors
         query = query.filter(~models.Q(pillow='corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'))
 
-        if not fetch_full:
-            query = query.values('id', 'date_next_attempt')
         if limit is not None:
             return query[skip:skip+limit]
         else:

--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -57,9 +57,11 @@ class PillowError(models.Model):
         app_label = 'pillow_retry'
         unique_together = ('doc_id', 'pillow',)
 
-    def add_attempt(self, exception, traceb, date=None):
-        self.current_attempt += 1
-        self.total_attempts += 1
+    def add_attempt(self, exception, traceb, change_meta=None, date=None):
+        new_attempts = change_meta.attempts if change_meta else 1
+
+        self.current_attempt += new_attempts
+        self.total_attempts += new_attempts
         self.date_last_attempt = date or datetime.utcnow()
         self.error_type = path_from_object(exception)
 

--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -101,6 +101,7 @@ class PillowError(models.Model):
             )
 
             if change.metadata:
+                error.date_created = change.metadata.publish_timestamp
                 error.change_metadata = change.metadata.to_json()
 
         return error

--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-
 from __future__ import unicode_literals
+
 import sys
 
 from celery.schedules import crontab
@@ -11,13 +11,14 @@ from django.conf import settings
 from django.db.models import Count
 
 from corehq.apps.change_feed.data_sources import get_document_store
+from corehq.apps.change_feed.producer import producer
+from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from corehq.util.datadog.gauges import datadog_gauge
-from dimagi.utils.couch import release_lock
-from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.logging import notify_error
 from pillow_retry import const
 from pillow_retry.models import PillowError
 from pillowtop.exceptions import PillowNotFoundError
+from pillowtop.feed.couch import CouchChangeFeed
 from pillowtop.utils import get_pillow_by_name
 
 logger = get_task_logger(__name__)
@@ -58,7 +59,22 @@ def process_pillow_retry(error_doc_id):
                 domain=change_metadata.domain
             )
             change.document_store = document_store
-        pillow.process_change(change)
+        if isinstance(pillow.get_change_feed(), CouchChangeFeed):
+            pillow.process_change(change)
+        else:
+            if change_metadata.data_source_type in ('couch', 'sql'):
+                data_source_type = change_metadata.data_source_type
+            else:
+                # legacy metadata will have other values for non-sql
+                # can remove this once all legacy errors have been processed
+                data_source_type = 'sql'
+            producer.send_change(
+                get_topic_for_doc_type(
+                    change_metadata.document_type,
+                    data_source_type
+                ),
+                change_metadata
+            )
     except Exception:
         ex_type, ex_value, ex_tb = sys.exc_info()
         error_doc.add_attempt(ex_value, ex_tb)

--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -1,86 +1,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
-
 from celery.schedules import crontab
 from celery.task import periodic_task
-from celery.task import task
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db.models import Count
 
-from corehq.apps.change_feed.data_sources import get_document_store
-from corehq.apps.change_feed.producer import producer
-from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from corehq.util.datadog.gauges import datadog_gauge
-from dimagi.utils.logging import notify_error
-from pillow_retry import const
 from pillow_retry.models import PillowError
-from pillowtop.exceptions import PillowNotFoundError
-from pillowtop.feed.couch import CouchChangeFeed
-from pillowtop.utils import get_pillow_by_name
-
-logger = get_task_logger(__name__)
-
-
-@task(queue='pillow_retry_queue', ignore_result=True)
-def process_pillow_retry(error_doc_id):
-    try:
-        error_doc = PillowError.objects.get(id=error_doc_id)
-    except PillowError.DoesNotExist:
-        return
-
-    pillow_name_or_class = error_doc.pillow
-    try:
-        pillow = get_pillow_by_name(pillow_name_or_class)
-    except PillowNotFoundError:
-        pillow = None
-
-    if not pillow:
-        notify_error((
-            "Could not find pillowtop class '%s' while attempting a retry. "
-            "If this pillow was recently deleted then this will be automatically cleaned up eventually. "
-            "If not, then this should be looked into."
-        ) % pillow_name_or_class)
-        try:
-            error_doc.total_attempts = const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
-            error_doc.save()
-        finally:
-            return
-
-    change = error_doc.change_object
-    try:
-        change_metadata = change.metadata
-        if change_metadata:
-            document_store = get_document_store(
-                data_source_type=change_metadata.data_source_type,
-                data_source_name=change_metadata.data_source_name,
-                domain=change_metadata.domain
-            )
-            change.document_store = document_store
-        if isinstance(pillow.get_change_feed(), CouchChangeFeed):
-            pillow.process_change(change)
-        else:
-            if change_metadata.data_source_type in ('couch', 'sql'):
-                data_source_type = change_metadata.data_source_type
-            else:
-                # legacy metadata will have other values for non-sql
-                # can remove this once all legacy errors have been processed
-                data_source_type = 'sql'
-            producer.send_change(
-                get_topic_for_doc_type(
-                    change_metadata.document_type,
-                    data_source_type
-                ),
-                change_metadata
-            )
-    except Exception:
-        ex_type, ex_value, ex_tb = sys.exc_info()
-        error_doc.add_attempt(ex_value, ex_tb)
-        error_doc.save()
-    else:
-        error_doc.delete()
 
 
 @periodic_task(

--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -15,6 +15,7 @@ from corehq.util.datadog.gauges import datadog_gauge
 from dimagi.utils.couch import release_lock
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.logging import notify_error
+from pillow_retry import const
 from pillow_retry.models import PillowError
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.utils import get_pillow_by_name
@@ -42,7 +43,7 @@ def process_pillow_retry(error_doc_id):
             "If not, then this should be looked into."
         ) % pillow_name_or_class)
         try:
-            error_doc.total_attempts = PillowError.multi_attempts_cutoff() + 1
+            error_doc.total_attempts = const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
             error_doc.save()
         finally:
             return

--- a/corehq/ex-submodules/pillow_retry/tests.py
+++ b/corehq/ex-submodules/pillow_retry/tests.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from mock import MagicMock
 
 from pillow_retry.models import PillowError
+from pillow_retry import const
 from pillow_retry.tasks import process_pillow_retry
 from pillowtop import get_all_pillow_configs
 from pillowtop.checkpoints.manager import PillowCheckpoint
@@ -134,7 +135,7 @@ class PillowRetryTestCase(TestCase):
         self.assertEqual(len(errors), 3)
 
     def test_get_errors_to_process_max_limit(self):
-        # see settings.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
+        # see const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
         date = datetime.utcnow()
 
         def make_error(id, current_attempt, total_attempts):
@@ -147,29 +148,29 @@ class PillowRetryTestCase(TestCase):
         # current_attempts <= limit, total_attempts <= limit
         make_error(
             'to-process1',
-            settings.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS,
-            settings.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
+            const.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS,
+            const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
         )
 
         # current_attempts = 0, total_attempts > limit
         make_error(
             'to-process2',
             0,
-            settings.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
+            const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
         )
 
         # current_attempts > limit, total_attempts <= limit
         make_error(
             'not-processed1',
-            settings.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS + 1,
-            settings.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
+            const.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS + 1,
+            const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF
         )
 
         # current_attempts <= limit, total_attempts > limit
         make_error(
             'not-processed2',
-            settings.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS,
-            settings.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
+            const.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS,
+            const.PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF + 1
         )
 
         errors = PillowError.get_errors_to_process(date, fetch_full=True).all()
@@ -189,7 +190,7 @@ class PillowRetryTestCase(TestCase):
 
     def test_bulk_reset(self):
         for i in range(0, 5):
-            error = create_error(_change(id=i), attempts=settings.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS)
+            error = create_error(_change(id=i), attempts=const.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS)
             error.save()
 
         errors = PillowError.get_errors_to_process(datetime.utcnow()).all()

--- a/corehq/ex-submodules/pillow_retry/tests/test_all_pillows.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_all_pillows.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import uuid
+
+from django.conf import settings
+from django.test import TestCase
+from mock import MagicMock
+
+from pillow_retry.models import PillowError
+from pillowtop import get_all_pillow_configs
+from pillowtop.dao.exceptions import DocumentMissingError
+from pillowtop.feed.interface import Change
+
+
+class ExceptionA(Exception):
+    pass
+
+
+class PillowtopRetryAllPillowsTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(PillowtopRetryAllPillowsTests, cls).setUpClass()
+        cls._PILLOWTOPS = settings.PILLOWTOPS
+        if not settings.PILLOWTOPS:
+            # assumes HqTestSuiteRunner, which blanks this out and saves a copy here
+            settings.PILLOWTOPS = settings._PILLOWTOPS
+
+    @classmethod
+    def tearDownClass(cls):
+        settings.PILLOWTOPS = cls._PILLOWTOPS
+        super(PillowtopRetryAllPillowsTests, cls).tearDownClass()
+
+    def tearDown(self):
+        PillowError.objects.all().delete()
+
+    def test_all_pillows_handle_errors(self):
+        all_pillow_configs = list(get_all_pillow_configs())
+        for pillow_config in all_pillow_configs:
+            self._test_error_logging_for_pillow(pillow_config)
+
+    def _test_error_logging_for_pillow(self, pillow_config):
+        pillow = _pillow_instance_from_config_with_mock_process_change(pillow_config)
+        if pillow.retry_errors:
+            exc_class = Exception
+            exc_class_string = 'exceptions.Exception'
+        else:
+            exc_class = DocumentMissingError
+            exc_class_string = 'pillowtop.dao.exceptions.DocumentMissingError'
+
+        pillow.process_change = MagicMock(side_effect=exc_class(pillow.pillow_id))
+        doc = self._get_random_doc()
+        pillow.process_with_error_handling(Change(id=doc['id'], sequence_id='3', document=doc))
+
+        errors = PillowError.objects.filter(pillow=pillow.pillow_id).all()
+        self.assertEqual(1, len(errors), pillow_config)
+        error = errors[0]
+        self.assertEqual(error.doc_id, doc['id'], pillow_config)
+        self.assertEqual(exc_class_string, error.error_type)
+        self.assertIn(pillow.pillow_id, error.error_traceback)
+
+    def _get_random_doc(self):
+        return {
+            'id': uuid.uuid4().hex,
+            'doc_type': 'CommCareCase',
+            'type': 'mother',
+            'domain': 'pillow-retry-domain',
+        }
+
+
+def _pillow_instance_from_config_with_mock_process_change(pillow_config):
+    pillow_class = pillow_config.get_class()
+    if pillow_config.instance_generator is None:
+        instance = pillow_class()
+    else:
+        instance = pillow_config.get_instance()
+
+    return instance

--- a/corehq/ex-submodules/pillow_retry/tests/test_model.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_model.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.test import TestCase
 from six.moves import range
 
-from pillow_retry.tasks import process_pillow_retry
+from pillow_retry.api import process_pillow_retry
 from pillow_retry import const
 from pillow_retry.models import PillowError
 from pillowtop.checkpoints.manager import PillowCheckpoint

--- a/corehq/ex-submodules/pillow_retry/tests/test_retry.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_retry.py
@@ -1,0 +1,156 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.test import TestCase
+from fakecouch import FakeCouchDb
+from kafka import KafkaConsumer
+from kafka.common import KafkaUnavailableError
+from mock import MagicMock, patch
+
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message, KafkaChangeFeed
+from corehq.apps.change_feed.data_sources import SOURCE_COUCH
+from corehq.apps.change_feed.pillow import get_change_feed_pillow_for_db
+from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import trap_extra_setup
+from pillow_retry.api import process_pillow_retry
+from pillow_retry.models import PillowError
+from pillowtop.feed.couch import populate_change_metadata
+from pillowtop.feed.interface import Change
+from pillowtop.pillow.interface import ConstructedPillow
+from pillowtop.processors.sample import CountingProcessor
+from testapps.test_pillowtop.utils import process_pillow_changes
+
+
+class TestException(Exception):
+    pass
+
+
+class TestMixin(object):
+
+    def _check_errors(self, expected_attempts, message=None):
+        errors = list(PillowError.objects.filter(pillow=self.pillow.pillow_id).all())
+        self.assertEqual(1, len(errors))
+
+        self.assertEqual("pillow_retry.tests.test_retry.TestException", errors[0].error_type)
+        self.assertEqual(expected_attempts, errors[0].total_attempts)
+        self.assertEqual(expected_attempts, errors[0].current_attempt)
+
+        if message:
+            self.assertIn(message, errors[0].error_traceback)
+
+        return errors
+
+
+class CouchPillowRetryProcessingTest(TestCase, TestMixin):
+    def setUp(self):
+        self._fake_couch = FakeCouchDb()
+        self._fake_couch.dbname = 'test_commcarehq'
+        with trap_extra_setup(KafkaUnavailableError):
+            self.consumer = KafkaConsumer(
+                topics.CASE,
+                group_id='test-consumer',
+                bootstrap_servers=[settings.KAFKA_URL],
+                consumer_timeout_ms=100,
+            )
+        self.pillow = get_change_feed_pillow_for_db('fake-changefeed-pillow-id', self._fake_couch)
+        self.original_process_change = self.pillow.process_change
+
+    def tearDown(self):
+        PillowError.objects.all().delete()
+
+    def test(self):
+        document = {
+            'doc_type': 'CommCareCase',
+            'type': 'mother',
+            'domain': 'kafka-test-domain',
+        }
+
+        change = Change(id='test-id', sequence_id='3', document=document)
+        populate_change_metadata(change, SOURCE_COUCH, self._fake_couch.dbname)
+
+        with patch('pillow_retry.api.get_pillow_by_name', return_value=self.pillow):
+            # first change creates error
+            message = 'test retry 1'
+            self.pillow.process_change = MagicMock(side_effect=TestException(message))
+            self.pillow.process_with_error_handling(change)
+
+            errors = self._check_errors(1, message)
+
+            # second attempt updates error
+            process_pillow_retry(errors[0])
+
+            errors = self._check_errors(2)
+
+            # third attempt successful
+            self.pillow.process_change = self.original_process_change
+            process_pillow_retry(errors[0])
+
+            errors = list(PillowError.objects.filter(pillow=self.pillow.pillow_id).all())
+            self.assertEqual(0, len(errors))
+
+            message = next(self.consumer)
+
+            change_meta = change_meta_from_kafka_message(message.value)
+            self.assertEqual(SOURCE_COUCH, change_meta.data_source_type)
+            self.assertEqual(self._fake_couch.dbname, change_meta.data_source_name)
+            self.assertEqual('test-id', change_meta.document_id)
+            self.assertEqual(document['doc_type'], change_meta.document_type)
+            self.assertEqual(document['type'], change_meta.document_subtype)
+            self.assertEqual(document['domain'], change_meta.domain)
+            self.assertEqual(False, change_meta.is_deletion)
+
+
+class KakfaPillowRetryProcessingTest(TestCase, TestMixin):
+
+    def setUp(self):
+        self.processor = CountingProcessor()
+        self.pillow = ConstructedPillow(
+            name='test-kafka-case-feed',
+            checkpoint=None,
+            change_feed=KafkaChangeFeed(
+                topics=[topics.CASE, topics.CASE_SQL], group_id='test-kafka-case-feed'
+            ),
+            processor=self.processor
+        )
+        self.original_process_change = self.pillow.process_change
+
+    def tearDown(self):
+        ensure_index_deleted(CASE_INDEX_INFO.index)
+
+    def test(self):
+        document = {
+            '_id': 'test-id',
+            'doc_type': 'CommCareCase',
+            'type': 'mother',
+            'domain': 'kafka-test-domain',
+        }
+
+        change = Change(id='test-id', sequence_id='3', document=document)
+        populate_change_metadata(change, SOURCE_COUCH, 'test_commcarehq')
+
+        with patch('pillow_retry.api.get_pillow_by_name', return_value=self.pillow):
+            # first change creates error
+            message = 'test retry 1'
+            self.pillow.process_change = MagicMock(side_effect=TestException(message))
+            self.pillow.process_with_error_handling(change)
+
+            errors = self._check_errors(1, message)
+
+            # second attempt updates error
+            with process_pillow_changes(self.pillow):
+                process_pillow_retry(errors[0])
+
+            errors = self._check_errors(2)
+
+            # third attempt successful
+            self.pillow.process_change = self.original_process_change
+            with process_pillow_changes(self.pillow):
+                process_pillow_retry(errors[0])
+
+            errors = list(PillowError.objects.filter(pillow=self.pillow.pillow_id).all())
+            self.assertEqual(0, len(errors))
+
+            self.assertEqual(1, self.processor.count)

--- a/corehq/ex-submodules/pillowtop/feed/couch.py
+++ b/corehq/ex-submodules/pillowtop/feed/couch.py
@@ -16,6 +16,7 @@ class CouchChangeFeed(ChangeFeed):
         self._last_processed_seq = None
 
     def iter_changes(self, since, forever):
+        from corehq.apps.change_feed.data_sources import SOURCE_COUCH
         extra_args = {'feed': 'continuous'} if forever else {}
         extra_args.update(self._extra_couch_view_params)
         self._last_processed_seq = since
@@ -28,7 +29,9 @@ class CouchChangeFeed(ChangeFeed):
             **extra_args
         )
         for couch_change in changes_stream:
-            yield change_from_couch_row(couch_change, document_store=self._document_store)
+            change = change_from_couch_row(couch_change, document_store=self._document_store)
+            populate_change_metadata(change, SOURCE_COUCH, self._couch_db.dbname)
+            yield change
             self._last_processed_seq = couch_change.get('seq', None)
 
     def get_processed_offsets(self):
@@ -53,6 +56,30 @@ def change_from_couch_row(couch_change, document_store=None):
         deleted=couch_change.get('deleted', False),
         document_store=document_store,
     )
+
+
+def populate_change_metadata(change, data_source_type, data_source_name):
+    from corehq.apps.change_feed.exceptions import MissingMetaInformationError
+    from corehq.apps.change_feed.document_types import get_doc_meta_object_from_document
+    from corehq.apps.change_feed.document_types import change_meta_from_doc_meta_and_document
+
+    if change.metadata:
+        return
+
+    try:
+        document = change.get_document()
+        doc_meta = get_doc_meta_object_from_document(document)
+        change_meta = change_meta_from_doc_meta_and_document(
+            doc_meta=doc_meta,
+            document=document,
+            data_source_type=data_source_type,
+            data_source_name=data_source_name,
+            doc_id=change.id,
+        )
+    except MissingMetaInformationError:
+        pass
+    else:
+        change.metadata = change_meta
 
 
 def get_current_seq(couch_db):

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -15,6 +15,8 @@ class ChangeMeta(jsonobject.JsonObject):
 
     This is only used in kafka-based pillows.
     """
+    _allow_dynamic_properties = False
+
     document_id = DefaultProperty(required=True)
     document_rev = jsonobject.StringProperty()  # Only relevant for Couch documents
     data_source_type = jsonobject.StringProperty(required=True)
@@ -24,7 +26,9 @@ class ChangeMeta(jsonobject.JsonObject):
     domain = jsonobject.StringProperty()
     is_deletion = jsonobject.BooleanProperty()
     publish_timestamp = jsonobject.DateTimeProperty(default=datetime.utcnow)
-    _allow_dynamic_properties = False
+
+    # track of retry attempts
+    attempts = jsonobject.IntegerProperty(default=0)
 
 
 class Change(object):
@@ -73,6 +77,10 @@ class Change(object):
                 self._document_checked = True  # set this flag to avoid multiple redundant lookups
                 self.error_raised = e
         return self.document
+
+    def increment_attempt_count(self):
+        if self.metadata:
+            self.metadata.attempts += 1
 
     def __repr__(self):
         return 'Change id: {}, seq: {}, deleted: {}, metadata: {}, doc: {}'.format(

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -18,10 +18,19 @@ class ChangeMeta(jsonobject.JsonObject):
     _allow_dynamic_properties = False
 
     document_id = DefaultProperty(required=True)
-    document_rev = jsonobject.StringProperty()  # Only relevant for Couch documents
+
+    # Only relevant for Couch documents
+    document_rev = jsonobject.StringProperty()
+
+    # 'couch' or 'sql'
     data_source_type = jsonobject.StringProperty(required=True)
+
+    # couch database name or one of data sources listed in corehq.apps.change_feed.data_sources
     data_source_name = jsonobject.StringProperty(required=True)
+
+    # doc_type property of doc or else the topic name
     document_type = DefaultProperty()
+
     document_subtype = jsonobject.StringProperty()
     domain = jsonobject.StringProperty()
     is_deletion = jsonobject.BooleanProperty()

--- a/settings.py
+++ b/settings.py
@@ -676,29 +676,7 @@ REMINDERS_QUEUE_STALE_REMINDER_DURATION = 7 * 24
 REMINDERS_RATE_LIMIT_COUNT = 30
 REMINDERS_RATE_LIMIT_PERIOD = 60
 
-####### Pillow Retry Queue Settings #######
-
-# Setting this to False no pillowtop errors will get processed.
 PILLOW_RETRY_QUEUE_ENABLED = False
-
-# If an error still has not been processed in this number of minutes, enqueue it
-# again.
-PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT = 60 * 24
-
-# Number of minutes to wait before retrying an unsuccessful processing attempt
-PILLOW_RETRY_REPROCESS_INTERVAL = 5
-
-# Max number of processing attempts before giving up on processing the error
-PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS = 3
-
-# The backoff factor by which to increase re-process intervals by.
-# next_interval = PILLOW_RETRY_REPROCESS_INTERVAL * attempts^PILLOW_RETRY_BACKOFF_FACTOR
-PILLOW_RETRY_BACKOFF_FACTOR = 2
-
-# After an error's total attempts exceeds this number it will only be re-attempted
-# once after being reset. This is to prevent numerous retries of errors that aren't
-# getting fixed
-PILLOW_RETRY_MULTI_ATTEMPTS_CUTOFF = PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS * 3
 
 SUBMISSION_REPROCESSING_QUEUE_ENABLED = True
 


### PR DESCRIPTION
Instead of using celery to reprocess errors put them back into the kafka queue and let the (already scaled out) pillows do the reprocessing.