### PR TITLE
Create update_report_description url for report builder

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
@@ -95,7 +95,7 @@ hqDefine('hqwebapp/js/components/inline_edit', function() {
                         url: self.url,
                         type: 'POST',
                         dataType: 'JSON',
-                        data: data,
+                        data: JSON.stringify(data),
                         success: function (data) {
                             self.isSaving(false);
                             self.hasError(false);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
@@ -95,7 +95,7 @@ hqDefine('hqwebapp/js/components/inline_edit', function() {
                         url: self.url,
                         type: 'POST',
                         dataType: 'JSON',
-                        data: JSON.stringify(data),
+                        data: data,
                         success: function (data) {
                             self.isSaving(false);
                             self.hasError(false);

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -89,6 +89,7 @@
         <inline-edit params="
           value: reportDescription,
           id: 'report-description',
+          url: '{% url "update_report_description" domain existing_report.get_id %}',
           placeholder: '{% trans "Enter report description here"|escapejs %}',
           readOnlyClass: 'app-comment',
           cols: 50,

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -77,7 +77,8 @@ urlpatterns = [
         ucr_download_job_poll, name='ucr_download_job_poll'),
 
     # Update Report Description
-    url(r'^builder/update_report_description/(?P<report_id>[\w-]+)', update_report_description, name='update_report_description'),
+    url(r'^builder/update_report_description/(?P<report_id>[\w-]+)', update_report_description,
+        name='update_report_description'),
 
     # apis
     url(r'^api/choice_list/(?P<report_id>[\w-]+)/(?P<filter_id>[\w-]+)/$',

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -25,6 +25,7 @@ from corehq.apps.userreports.views import (
     choice_list_api,
     ExpressionDebuggerView,
     evaluate_expression,
+    update_report_description,
     undelete_data_source, undelete_report, DataSourceDebuggerView, evaluate_data_source)
 
 urlpatterns = [
@@ -74,6 +75,9 @@ urlpatterns = [
         DownloadUCRStatusView.as_view(), name=DownloadUCRStatusView.urlname),
     url(r'^export_job_poll/(?P<download_id>[0-9a-fA-Z]{25,32})/$',
         ucr_download_job_poll, name='ucr_download_job_poll'),
+
+    # Update Report Description
+    url(r'^builder/update_report_description/(?P<report_id>[\w-]+)', update_report_description, name='update_report_description'),
 
     # apis
     url(r'^api/choice_list/(?P<report_id>[\w-]+)/(?P<filter_id>[\w-]+)/$',

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -654,6 +654,14 @@ class ConfigureReport(ReportBuilderView):
             raise Http404()
 
 
+def update_report_description(request, domain, report_id):
+    new_description = json.loads(request.body)["value"]
+    report = get_document_or_404(ReportConfiguration, domain, report_id)
+    report.description = new_description
+    report.save()
+    return json_response({})
+
+
 def _get_form_type(report_type):
     assert report_type in (None, "list", "table", "chart", "map")
     if report_type == "list" or report_type is None:

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -655,7 +655,7 @@ class ConfigureReport(ReportBuilderView):
 
 
 def update_report_description(request, domain, report_id):
-    new_description = json.loads(request.body)["value"]
+    new_description = request.POST['value']
     report = get_document_or_404(ReportConfiguration, domain, report_id)
     report.description = new_description
     report.save()


### PR DESCRIPTION
FB: http://manage.dimagi.com/default.asp?256319

When a user updated a report's description in Report Builder, it wasn't saving properly. I added a method `update_report_description` that saves the new description to the report, and call it from the inline-edit widget in `configure_report.html`.