### PR TITLE
Rename toggles_template.js module

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
@@ -11,10 +11,10 @@ hqDefine('hqwebapp/js/toggles', function () {
     };
     return {
         toggleEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('hqwebapp/js/toggles_template').toggles, toggleName);
+            return genericToggleEnabled(hqImport('#toggles').toggles, toggleName);
         },
         previewEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('hqwebapp/js/toggles_template').previews, toggleName);
+            return genericToggleEnabled(hqImport('#toggles').previews, toggleName);
         },
     };
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/js/toggles_template.js
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/js/toggles_template.js
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-hqDefine('hqwebapp/js/toggles_template', function () {
+hqDefine('#toggles', function () {
     return {
         toggles: {{ toggles_dict|JSON }},
         previews: {{ previews_dict|JSON }}

--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -30,6 +30,10 @@ class TestRequireJS(SimpleTestCase):
                 match = re.search(r'^\s*hqDefine\([\'"]([^\'"]*)[\'"]', line)
                 if match:
                     module = match.group(1)
+                    # Special case: renaming toggles seems to cause a bug
+                    # See http://manage.dimagi.com/default.asp?275208
+                    if module == "#toggles":
+                        continue
                     if not filename.endswith(module + ".js"):
                         errors.append("Module {} defined in file {}".format(module, filename))
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?275208

Introduced in https://github.com/dimagi/commcare-hq/pull/20366

I don't know what the problem is and I can't reproduce the error, but it strongly looks related to this change so I'm just going to revert it.

@dannyroberts I think you originally implemented the js version of toggles. Any bright ideas?

code buddy @sravfeyn 