### PR TITLE
fix REUSE_DB docs to show --reusedb does not require REUSE_DB=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,11 @@ To avoid having to run the databse setup for each test run you can specify the `
 
     $ REUSE_DB=1 ./manage.py test corehq.apps.app_manager
 
-    # drop the current test DB and create a fresh one
-    $ REUSE_DB=1 ./manage.py test corehq.apps.app_manager --reusedb=reset
+Or, to drop the current test DB and create a fresh one
+    $ ./manage.py test corehq.apps.app_manager --reusedb=reset
 
-See `corehq.tests.nose.HqdbContext` for full description of `REUSE_DB`.
+See `corehq.tests.nose.HqdbContext` for full description
+of `REUSE_DB` and `--reusedb`.
 
 ### Running tests by tag
 You can run all tests with a certain tag as follows:


### PR DESCRIPTION
Second attempt at addressing https://github.com/dimagi/commcare-hq/pull/20303/files#r182779422