### PR TITLE
Revert 20384 jls/rename toggles js

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
@@ -11,10 +11,10 @@ hqDefine('hqwebapp/js/toggles', function () {
     };
     return {
         toggleEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('#toggles').toggles, toggleName);
+            return genericToggleEnabled(hqImport('hqwebapp/js/toggles_template').toggles, toggleName);
         },
         previewEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('#toggles').previews, toggleName);
+            return genericToggleEnabled(hqImport('hqwebapp/js/toggles_template').previews, toggleName);
         },
     };
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/js/toggles_template.js
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/js/toggles_template.js
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-hqDefine('#toggles', function () {
+hqDefine('hqwebapp/js/toggles_template', function () {
     return {
         toggles: {{ toggles_dict|JSON }},
         previews: {{ previews_dict|JSON }}

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -299,7 +299,7 @@ def toggle_js_url(domain, username):
 def toggle_js_domain_cachebuster(domain):
     # to get fresh cachebusters on the next deploy
     # change the date below (output from *nix `date` command)
-    #   Mon Oct 31 10:30:09 EDT 2016
+    #   Wed Apr 25 14:12:12 EDT 2018
     return random_hex()[:3]
 
 

--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -30,10 +30,6 @@ class TestRequireJS(SimpleTestCase):
                 match = re.search(r'^\s*hqDefine\([\'"]([^\'"]*)[\'"]', line)
                 if match:
                     module = match.group(1)
-                    # Special case: renaming toggles seems to cause a bug
-                    # See http://manage.dimagi.com/default.asp?275208
-                    if module == "#toggles":
-                        continue
                     if not filename.endswith(module + ".js"):
                         errors.append("Module {} defined in file {}".format(module, filename))
 


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/20384 - rename the module again and this time bust the cache.

@dannyroberts 
code buddy @sravfeyn  

@biyeun can this get into today's deploy? Some people are still having issues because of an outdated cache.