### PR TITLE
Allow apps being converted to v2 use custom slugs

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
@@ -282,7 +282,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
         var availableReports = options.availableReports || [];
         var saveURL = options.saveURL;
         self.supportSyncDelay = options.mobileUcrVersion !== 1;
-        self.supportCustomUcrSlug = options.mobileUcrVersion >= 2;
+        self.supportCustomUcrSlug = options.mobileUcrVersion !== 1;
         self.globalSyncDelay = options.globalSyncDelay;
         self.staticFilterData = options.staticFilterData;
         self.languages = options.languages;


### PR DESCRIPTION
Make https://docs.google.com/document/d/1RbO8LXfKmFbJPLbshtFNVYSi1hX9nAb_9YPufEPgdVg/edit available for apps on mobile UCR v1.5 (converting to 2)
@emord