### PR TITLE
only using new url for existing reports

### DIFF
--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -89,7 +89,9 @@
         <inline-edit params="
           value: reportDescription,
           id: 'report-description',
+	  {% if existing_report.get_id %}
           url: '{% url "update_report_description" domain existing_report.get_id %}',
+	  {% endif %}
           placeholder: '{% trans "Enter report description here"|escapejs %}',
           readOnlyClass: 'app-comment',
           cols: 50,


### PR DESCRIPTION
 @gbova @proteusvacuum @biyeun 
The new url created in https://github.com/dimagi/commcare-hq/pull/20379 does not work if the report has not be saved yet. This only uses it if it is an existing report. Confirmed this properly updates description for new and existing reports.