### PR TITLE
increasing timeout for form breakdown

### DIFF
--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -4,6 +4,7 @@ import datetime
 
 from corehq.apps.es import FormES
 from corehq.apps.es.aggregations import TermsAggregation
+from corehq.elastic import ES_EXPORT_INSTANCE
 from corehq.util.quickcache import quickcache
 
 from dimagi.utils.parsing import json_format_datetime
@@ -183,7 +184,7 @@ def get_exports_by_form(domain):
 
 
 def get_form_count_breakdown_for_domain(domain):
-    query = (FormES()
+    query = (FormES(es_instance_alias=ES_EXPORT_INSTANCE)
              .domain(domain)
              .aggregation(
                  TermsAggregation("app_id", "app_id").aggregation(


### PR DESCRIPTION
@proteusvacuum @esoergel 
http://manage.dimagi.com/default.asp?275042#1489042
This es query was intermittently timing out, so i am bumping up the timeout to 30 seconds

@esoergel and @snopoke 
I am curious if either of you have thoughts on bumping the es timeout to 30 seconds globally. It feels like es timeouts happen a fair bit, and our usual response at least begins with bumping that number.