### PR TITLE
adding other modules to block

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -291,6 +291,7 @@ class CouchSqlDomainMigrator(object):
         assert not stale_get_export_count(domain_name)
         assert not any(custom_report_domain == domain_name
                        for custom_report_domain in settings.DOMAIN_MODULE_MAP.keys())
+        assert domain_name not in settings.OTHER_DOMAINS_WITH_CUSTOM_MODULES
 
     def _with_progress(self, doc_types, iterable, progress_name='Migrating'):
         if self.with_progress:

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -95,6 +95,8 @@ class MigrationTestCase(BaseMigrationTestCase):
     def test_migration_custom_report(self):
         with self.assertRaises(AssertionError):
             self._do_migration("up-nrhm")
+        with self.assertRaises(AssertionError):
+            self._do_migration("logistics")
 
     def test_basic_form_migration(self):
         create_and_save_a_form(self.domain_name)

--- a/settings.py
+++ b/settings.py
@@ -2256,6 +2256,16 @@ DOMAIN_MODULE_MAP = {
     'test-pna': 'custom.yeksi_naa_reports',
 }
 
+OTHER_DOMAINS_WITH_CUSTOM_MODULES = [
+    'fri',
+    'hope',
+    'logistics',
+    'icds',
+    'hki',
+    'nikshay',
+]
+
+
 THROTTLE_SCHED_REPORTS_PATTERNS = (
     # Regex patterns matching domains whose scheduled reports use a
     # separate queue so that they don't hold up the background queue.


### PR DESCRIPTION
follow up to #20403

These seem to be the other domains that aren't in the `DOMAIN_MODULE_MAP` but do have domain modules named after them. At least ICDS is already psql I think, not that I would migrate that one by mistake, but I figured I might as well include the complete list here.

@gcapalbo @esoergel @nickpell 