### PR TITLE
default to sql

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -713,6 +713,7 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
             new_domain.internal = InternalProperties()
             new_domain.creating_user = user.username if user else None
             new_domain.date_created = datetime.utcnow()
+            new_domain.use_sql_backend = True
 
             for field in self._dirty_fields:
                 if hasattr(new_domain, field):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -537,13 +537,6 @@ class _AuthorizableMixin(IsMemberOfMixin):
                 return
 
         domain_obj = Domain.get_by_name(domain, strict=True)
-        # if you haven't seen any of these by Feb 2016 you should delete this code.
-        _soft_assert = soft_assert(notify_admins=True)
-        if not _soft_assert(domain_obj,
-                            "Domain membership added before domain created",
-                            {'domain': domain}):
-            domain_obj = Domain(is_active=True, name=domain, date_created=datetime.utcnow())
-            domain_obj.save()
 
         if timezone:
             domain_membership = DomainMembership(domain=domain, timezone=timezone, **kwargs)


### PR DESCRIPTION
I noticed new domains appearing that use couch and was a bit confused, so this should stop that. The first commit is the interesting one here. 

It looks like it should be safe to me, since the apps that people are copying over shouldn't be using too many "advanced features". Let me know if that's a bad assumption.

@snopoke @emord @gcapalbo 