### PR TITLE
Make explicit webapps link generators

### DIFF
--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -10,18 +10,25 @@ def should_show_preview_app(request, app, username):
     return not app.is_remote_app()
 
 
-def webapps_url(domain, app_id=None, module_id=None, form_id=None, case_id=None):
+def _webapps_url(domain, app_id, steps):
     url = reverse('formplayer_main', args=[domain])
-    query_dict = {}
-    if app_id:
-        query_dict['appId'] = app_id
-        if module_id is not None:
-            query_dict['steps'] = [module_id]
-            query_dict['page'] = None
-            query_dict['search'] = None
-            if form_id is not None:
-                query_dict['steps'].append(form_id)
-                if case_id is not None:
-                    query_dict['steps'].append(case_id)
+    query_dict = {
+        'appId': app_id,
+        'steps': steps,
+        'page': None,
+        'search': None,
+    }
     query_string = quote(json.dumps(query_dict))
     return "{base_url}#{query}".format(base_url=url, query=query_string)
+
+
+def webapps_module_form_case(domain, app_id, module_id, form_id, case_id):
+    return _webapps_url(domain, app_id, steps=[module_id, form_id, case_id])
+
+
+def webapps_module_case_form(domain, app_id, module_id, case_id, form_id):
+    return _webapps_url(domain, app_id, steps=[module_id, case_id, form_id])
+
+
+def webapps_module(domain, app_id, module_id):
+    return _webapps_url(domain, app_id, steps=[module_id])

--- a/custom/_legacy/pact/api.py
+++ b/custom/_legacy/pact/api.py
@@ -61,11 +61,12 @@ def get_cloudcare_app():
 
 
 def get_cloudcare_url(case_id, mode):
-    from corehq.apps.cloudcare.utils import webapps_url
+    from corehq.apps.cloudcare.utils import webapps_module_form_case
 
     app_dict = get_cloudcare_app()
     build_id = app_dict['build_id']
-    return webapps_url(PACT_DOMAIN, app_id=build_id, module_id=0, form_id=app_dict[mode], case_id=case_id)
+    return webapps_module_form_case(
+        PACT_DOMAIN, app_id=build_id, module_id=0, form_id=app_dict[mode], case_id=case_id)
 
 
 class PactFormAPI(DomainAPI):

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -22,7 +22,7 @@ from django.views.generic.base import View, TemplateView, RedirectView
 
 
 from corehq import toggles
-from corehq.apps.cloudcare.utils import webapps_url
+from corehq.apps.cloudcare.utils import webapps_module
 from corehq.apps.domain.decorators import login_and_domain_required, api_auth
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.hqwebapp.views import BugReportView
@@ -222,7 +222,7 @@ class DashboardView(TemplateView):
             kwargs['is_web_user'] = True
         elif is_commcare_user and self._has_helpdesk_role():
             build_id = get_latest_issue_tracker_build_id()
-            kwargs['report_an_issue_url'] = webapps_url(
+            kwargs['report_an_issue_url'] = webapps_module(
                 domain=self.domain,
                 app_id=build_id,
                 module_id=0,

--- a/custom/succeed/reports/all_patients.py
+++ b/custom/succeed/reports/all_patients.py
@@ -17,7 +17,7 @@ from custom.succeed.reports.patient_task_list import PatientTaskListReport
 from custom.utils.utils import clean_IN_filter_value
 from memoized import memoized
 from corehq.apps.cloudcare.api import get_cloudcare_app
-from corehq.apps.cloudcare.utils import webapps_url
+from corehq.apps.cloudcare.utils import webapps_module_case_form
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
 from django.utils import html
 from custom.succeed.reports import EMPTY_FIELD, CM7, CM_APP_CM_MODULE, OUTPUT_DATE_FORMAT
@@ -84,11 +84,11 @@ def edit_link(case_id, app_dict, latest_build):
     module = app_dict['modules'][CM_APP_CM_MODULE]
     form_idx = [ix for (ix, f) in enumerate(module['forms']) if f['xmlns'] == CM7][0]
     return html.mark_safe("<a target='_blank' class='ajax_dialog' href='%s'>Edit</a>") \
-        % html.escape(webapps_url(domain=app_dict['domain'],
-                                  app_id=latest_build,
-                                  module_id=CM_APP_CM_MODULE,
-                                  form_id=form_idx,
-                                  case_id=case_id))
+        % html.escape(webapps_module_case_form(domain=app_dict['domain'],
+                                               app_id=latest_build,
+                                               module_id=CM_APP_CM_MODULE,
+                                               form_id=form_idx,
+                                               case_id=case_id))
 
 
 def case_link(name, case_id):

--- a/custom/succeed/reports/patient_details.py
+++ b/custom/succeed/reports/patient_details.py
@@ -4,7 +4,7 @@ from couchdbkit.exceptions import ResourceNotFound
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
 from corehq.apps.cloudcare.api import get_cloudcare_app
-from corehq.apps.cloudcare.utils import webapps_url
+from corehq.apps.cloudcare.utils import webapps_module_case_form
 from django.utils import html
 from memoized import memoized
 from custom.succeed.utils import get_app_build, SUCCEED_CM_APPNAME, SUCCEED_PM_APPNAME, SUCCEED_CHW_APPNAME, \
@@ -49,11 +49,11 @@ class PatientDetailsReport(CustomProjectReport, ElasticProjectInspectionReport, 
         except IndexError:
             form_idx = None
 
-        url = webapps_url(domain=self.domain,
-                          app_id=app_build_id,
-                          module_id=module_idx,
-                          form_id=form_idx,
-                          case_id=case_id)
+        url = webapps_module_case_form(domain=self.domain,
+                                       app_id=app_build_id,
+                                       module_id=module_idx,
+                                       form_id=form_idx,
+                                       case_id=case_id)
         return html.escape(url)
 
     def update_app_info(self):

--- a/custom/succeed/reports/patient_task_list.py
+++ b/custom/succeed/reports/patient_task_list.py
@@ -7,7 +7,7 @@ from sqlagg.base import AliasColumn
 from sqlagg.columns import SimpleColumn
 from sqlagg.filters import EQ, OR, IN
 from corehq.apps.cloudcare.api import get_cloudcare_app
-from corehq.apps.cloudcare.utils import webapps_url
+from corehq.apps.cloudcare.utils import webapps_module_case_form
 from corehq.apps.reports.sqlreport import SqlTabularReport, AggregateColumn, DatabaseColumn, DataFormatter, \
     TableDataFormat
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
@@ -57,11 +57,11 @@ class PatientTaskListReport(SqlTabularReport, CustomProjectReport, ProjectReport
         except IndexError:
             form_idx = None
 
-        return html.escape(webapps_url(domain=self.domain,
-                                       app_id=app_build_id,
-                                       module_id=module_idx,
-                                       form_id=form_idx,
-                                       case_id=case_id))
+        return html.escape(webapps_module_case_form(domain=self.domain,
+                                                    app_id=app_build_id,
+                                                    module_id=module_idx,
+                                                    form_id=form_idx,
+                                                    case_id=case_id))
 
     def name_link(self, name, doc_id, is_closed):
         if is_closed == 0:


### PR DESCRIPTION
@emord https://manage.dimagi.com/default.asp?275373
Steps aren't always in a consistent order, so this specifies a handler for each
version we care about.  It also makes all arguments required.  This shouldn't
change any behavior except:
* The succeed code is all switched to select case, then form
* When linking to a module, now "page" and "search" are included, but these seem
to be ignored, so I figure that's fine