### PR TITLE
removing domain link validation from copy form

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -73,9 +73,6 @@ class CopyApplicationForm(forms.Form):
         if self.cleaned_data.get('linked'):
             if not LINKED_DOMAINS.enabled(domain):
                 raise forms.ValidationError("The target project space does not have linked apps enabled.")
-            if DomainLink.all_objects.filter(linked_domain=domain).exists():
-                raise forms.ValidationError(
-                    "The target project space is already linked to a different domain")
         return self.cleaned_data
 
 

--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -75,7 +75,7 @@ class CopyApplicationForm(forms.Form):
             if not LINKED_DOMAINS.enabled(domain):
                 raise forms.ValidationError("The target project space does not have linked apps enabled.")
             link = DomainLink.objects.filter(linked_domain=domain)
-            if link and link[0].master_domain != domain:
+            if link and link[0].master_domain != self.from_domain:
                 raise forms.ValidationError(
                     "The target project space is already linked to a different domain")
         return self.cleaned_data


### PR DESCRIPTION
@esoergel 
http://manage.dimagi.com/default.asp?275491

The existing validation prevents domains with any existing domain link from copying linked apps, even if that is to the domain that is already linked, or in this case if it ever had a deleted domain link. This should fix it to match proper validation from the backend.