### PR TITLE
log count remaining to datadog

### DIFF
--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -57,4 +57,4 @@ def set_couch_sql_migration_complete(domain):
 
 
 def total_couch_domains_remaining():
-    return DomainES().AND(filters.term('use_sql_backend', False)).count()
+    return DomainES().filter(filters.term('use_sql_backend', False)).count()

--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -57,4 +57,7 @@ def set_couch_sql_migration_complete(domain):
 
 
 def total_couch_domains_remaining():
-    return DomainES().filter(filters.term('use_sql_backend', False)).count()
+    return (DomainES()
+            .filter(filters.term('use_sql_backend', False))
+            .remove_default_filters()
+            .count())

--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -7,6 +7,8 @@ from corehq.apps.domain_migration_flags.api import (
     get_migration_status)
 from corehq.apps.domain_migration_flags.models import MigrationStatus, DomainMigrationProgress
 from corehq.apps.tzmigration.api import set_tz_migration_complete
+from corehq.apps.es.domains import DomainES
+from corehq.apps.es import filters
 
 COUCH_TO_SQL_SLUG = 'couch_to_sql'
 
@@ -52,3 +54,7 @@ def set_couch_sql_migration_complete(domain):
     # we get this for free
     set_tz_migration_complete(domain)
     _notify_dimagi_users_on_domain(domain)
+
+
+def total_couch_domains_remaining():
+    return DomainES().AND(filters.term('use_sql_backend', False)).count()

--- a/corehq/apps/couch_sql_migration/tasks.py
+++ b/corehq/apps/couch_sql_migration/tasks.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+from corehq.util.datadog.gauges import datadog_gauge_task
+from celery.schedules import crontab
+from corehq.apps.couch_sql_migration.progress import total_couch_domains_remaining
+
+
+datadog_gauge_task('commcare.couch_sql_migration.total_remaining',
+                   total_couch_domains_remaining,
+                   run_every=crontab(minute=0, hour=10))


### PR DESCRIPTION
Logs total domains using couch to a datadog dashboard at 10am UTC, i.e. 6am EDT

@snopoke @proteusvacuum 