### PR TITLE
Remove limitation warning for extended trial

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1990,12 +1990,6 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
             crispy.Div(
                 crispy.Div(
                     crispy.HTML(_(
-                        '<p><i class="fa fa-info-circle"></i> The trial includes '
-                        'access to all features, 5 mobile workers, and 25 SMS.  Fees '
-                        'apply for users or SMS in excess of these limits (1 '
-                        'USD/user/month, regular SMS fees).</p>'
-                    )),
-                    crispy.HTML(_(
                         '<p><i class="fa fa-info-circle"></i> The trial will begin as soon '
                         'as you hit "Update" and end on <span data-bind="text: end_date"></span>.  '
                         'On <span data-bind="text: end_date"></span> '


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?275507

This PR just removes the label on Extended Trial that says, "The trial includes access to all features, 5 mobile workers, and 25 SMS.  Fees apply for users or SMS in excess of these limits (1 USD/user/month, regular SMS fees)", because that limitation does not exist.