### PR TITLE
Allow custom SQL in UCR

### DIFF
--- a/corehq/apps/userreports/custom/data_source.py
+++ b/corehq/apps/userreports/custom/data_source.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.utils.decorators import method_decorator
+from memoized import memoized
+
+from corehq.apps.reports.api import ReportDataSource
+from corehq.apps.userreports.decorators import catch_and_raise_exceptions
+from corehq.apps.userreports.mixins import ConfigurableReportDataSourceMixin
+
+
+class ConfigurableReportCustomDataSource(ConfigurableReportDataSourceMixin, ReportDataSource):
+    @property
+    def _provider(self):
+        pass
+
+    @property
+    def filters(self):
+        pass
+
+    @property
+    def order_by(self):
+        pass
+
+    @property
+    def columns(self):
+        pass
+
+    @memoized
+    @method_decorator(catch_and_raise_exceptions)
+    def get_data(self, start=None, limit=None):
+        return self._provider.get_data(start, limit)
+
+    @method_decorator(catch_and_raise_exceptions)
+    def get_total_records(self):
+        return self._provider.get_total_records()
+
+    @method_decorator(catch_and_raise_exceptions)
+    def get_total_row(self):
+        return self._provider.get_total_row()

--- a/corehq/apps/userreports/custom/data_source.py
+++ b/corehq/apps/userreports/custom/data_source.py
@@ -7,12 +7,12 @@ from memoized import memoized
 from corehq.apps.reports.api import ReportDataSource
 from corehq.apps.userreports.decorators import catch_and_raise_exceptions
 from corehq.apps.userreports.mixins import ConfigurableReportDataSourceMixin
+from dimagi.utils.modules import to_function
 
 
 class ConfigurableReportCustomDataSource(ConfigurableReportDataSourceMixin, ReportDataSource):
-    @property
-    def _provider(self):
-        pass
+    def set_provider(self, provider_string):
+        self._provider = to_function(provider_string, failhard=True)
 
     @property
     def filters(self):

--- a/corehq/apps/userreports/custom/data_source.py
+++ b/corehq/apps/userreports/custom/data_source.py
@@ -31,6 +31,9 @@ class ConfigurableReportCustomDataSource(ConfigurableReportDataSourceMixin, Repo
     @method_decorator(catch_and_raise_exceptions)
     def get_data(self, start=None, limit=None):
         ret = self._provider.get_data(self, start, limit)
+
+        # A way to bypass these transforms should be implemented.
+        # We can format data more efficiently in custom code if necessary
         formatter = DataFormatter(DictDataFormat(self.columns, no_value=None))
         formatted_data = list(formatter.format(ret, group_by=self.group_by).values())
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -449,6 +449,7 @@ class ReportConfiguration(UnicodeMixIn, QuickCachedDocumentMixin, Document):
     sort_expression = ListProperty()
     soft_rollout = DecimalProperty(default=0)
     report_meta = SchemaProperty(ReportMeta)
+    custom_query_provider = StringProperty(required=False)
 
     def __unicode__(self):
         return '{} - {}'.format(self.domain, self.title)

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -43,7 +43,7 @@ class ConfigurableReportDataSource(object):
         self._custom_query_provider = custom_query_provider
 
     @classmethod
-    def from_spec(cls, spec, include_prefilters=False, backend=None, custom_query_provider=None):
+    def from_spec(cls, spec, include_prefilters=False, backend=None):
         order_by = [(o['field'], o['order']) for o in spec.sort_expression]
         filters = spec.filters if include_prefilters else spec.filters_without_prefilters
         return cls(
@@ -54,7 +54,7 @@ class ConfigurableReportDataSource(object):
             columns=spec.report_columns,
             order_by=order_by,
             backend=backend,
-            custom_query_provider=custom_query_provider
+            custom_query_provider=spec.custom_query_provider
         )
 
     @property

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -1,0 +1,4 @@
+class MPR2APersonCases(object):
+    pass
+
+mpr_2a_person_cases = MPR2APersonCases()

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -9,6 +9,14 @@ from corehq.apps.userreports.custom.data_source import ConfigurableReportCustomQ
 
 
 class MPR2APersonCases(ConfigurableReportCustomQueryProvider):
+    """Simplified query:
+
+    SELECT owner_id,
+           COUNT(*) FILTER WHERE (sex=X AND resident=Y AND age_death=Z) AS dead_X_Y_Z_count
+    FROM ucr_table
+    WHERE (location_id = A & date_death > B)
+    GROUP BY owner_id
+    """
     def __init__(self, report_data_source):
         self.report_data_source = report_data_source
         self.helper = self.report_data_source.helper

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -16,6 +16,9 @@ class MPR2APersonCases(ConfigurableReportCustomQueryProvider):
     FROM ucr_table
     WHERE (location_id = A & date_death > B)
     GROUP BY owner_id
+
+    Reasons this is needed:
+      - UCR does not support FILTER WHERE clause in select
     """
     def __init__(self, report_data_source):
         self.report_data_source = report_data_source

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 from memoized import memoized
 from sqlalchemy.sql import func
@@ -26,7 +29,7 @@ class MPR2APersonCases(object):
         # also want to show owner_ids without any dead/closed cases
         # Could likely be made more efficient with a subquery
         # Note that for mobile reports date_death is always included in the filter anyways
-        column = (columns.closed_on != None) & (columns.date_death != None)
+        column = (columns.closed_on != None) & (columns.date_death != None)  # noqa: E711
         column &= {
             "F": columns.sex == "F",
             "M": columns.sex == "M",

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from memoized import memoized
 from sqlalchemy.sql import func
 
@@ -95,7 +96,10 @@ class MPR2APersonCases(object):
 
     def get_data(self, report_data_source, start, limit):
         query_obj = self._get_query_object(report_data_source)
-        return [r._asdict() for r in query_obj.group_by(self.table.c.owner_id).all()]
+        return OrderedDict([
+            (r.owner_id, r._asdict())
+            for r in query_obj.group_by(self.table.c.owner_id).all()
+        ])
 
     def get_total_row(self, report_data_source):
         query_obj = self._get_query_object(report_data_source, total_row=True)

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -21,6 +21,10 @@ class MPR2APersonCases(object):
 
     def _column_helper(self, x, y, z=None):
         columns = self.table.c
+        # These first two filters could be added to the where clause, but we
+        # also want to show owner_ids without any dead/closed cases
+        # Could likely be made more efficient with a subquery
+        # Note that for mobile reports date_death is always included in the filter anyways
         column = (columns.closed_on != None) & (columns.date_death != None)
         column &= {
             "F": columns.sex == "F",

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -1,3 +1,4 @@
+from memoized import memoized
 from sqlalchemy.sql import func
 
 
@@ -10,21 +11,67 @@ class MPR2APersonCases(object):
     def table(self):
         return self.helper.get_table()
 
+    @property
+    @memoized
+    def _age_in_days_at_death(self):
+        return (self.table.c.date_death - self.table.c.dob)
+
+    def _count_filter_aggregate_expr(self, column, label):
+        return (func.count(self.table.c.doc_id).filter(column).label(label))
+
+    def _column_helper(self, x, y, z=None):
+        columns = self.table.c
+        column = (columns.closed_on != None) & (columns.date_death != None)
+        column &= {
+            "F": columns.sex == "F",
+            "M": columns.sex == "M",
+            "preg": (columns.female_death_type == "pregnant"),
+            "del": (columns.female_death_type == "delivery"),
+            "pnc": (columns.female_death_type == "pnc"),
+        }[x]
+        column &= {
+            "resident": columns.resident == "yes",
+            "migrant": columns.resident != "yes",
+        }[y]
+
+        if z is None:
+            return self._count_filter_aggregate_expr(column, "dead_{}_{}_count".format(x, y))
+
+        column &= {
+            "neo": self._age_in_days_at_death <= 28,
+            "postneo": self._age_in_days_at_death.between(29, 364),
+            "child": self._age_in_days_at_death.between(365, 1826),
+            "adult": columns.age_at_death_yrs >= 11,
+        }[z]
+
+        return self._count_filter_aggregate_expr(column, "dead_{}_{}_{}_count".format(x, y, z))
+
     def _columns(self, total_row=False):
-        table = self.table
         columns = (
-            func.count(table.c.doc_id).filter(
-                (table.c.closed_on != None) &
-                (table.c.sex == "F") &
-                (table.c.resident == "yes") &
-                (table.c.date_death != None) &
-                (table.c.dob != None) &
-                ((table.c.date_death - table.c.dob).between(0, 28))
-            ).label("dead_F_resident_neo_count"),
+            self._column_helper("F", "resident", "neo"),
+            self._column_helper("M", "resident", "neo"),
+            self._column_helper("F", "migrant", "neo"),
+            self._column_helper("M", "migrant", "neo"),
+            self._column_helper("F", "resident", "postneo"),
+            self._column_helper("M", "resident", "postneo"),
+            self._column_helper("F", "migrant", "postneo"),
+            self._column_helper("M", "migrant", "postneo"),
+            self._column_helper("F", "resident", "child"),
+            self._column_helper("M", "resident", "child"),
+            self._column_helper("F", "migrant", "child"),
+            self._column_helper("M", "migrant", "child"),
+            self._column_helper("F", "migrant", "adult"),
+            self._column_helper("F", "resident", "adult"),
+            self._column_helper("preg", "resident"),
+            self._column_helper("preg", "migrant"),
+            self._column_helper("del", "resident"),
+            self._column_helper("del", "migrant"),
+            self._column_helper("pnc", "resident"),
+            self._column_helper("pnc", "migrant"),
         )
 
         if not total_row:
-            columns = (table.c.owner_id.label("owner_id"),) + columns
+            columns = (self.table.c.owner_id.label("owner_id"),) + columns
 
         return columns
 

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -1,4 +1,56 @@
-class MPR2APersonCases(object):
-    pass
+from sqlalchemy.sql import func
 
-mpr_2a_person_cases = MPR2APersonCases()
+
+class MPR2APersonCases(object):
+    def __init__(self, report_data_source):
+        self.report_data_source = report_data_source
+        self.helper = self.report_data_source.helper
+
+    @property
+    def table(self):
+        return self.helper.get_table()
+
+    def _columns(self, total_row=False):
+        table = self.table
+        columns = (
+            func.count(table.c.doc_id).filter(
+                (table.c.closed_on != None) &
+                (table.c.sex == "F") &
+                (table.c.resident == "yes") &
+                (table.c.date_death != None) &
+                (table.c.dob != None) &
+                ((table.c.date_death - table.c.dob).between(0, 28))
+            ).label("dead_F_resident_neo_count"),
+        )
+
+        if not total_row:
+            columns = (table.c.owner_id.label("owner_id"),) + columns
+
+        return columns
+
+    def _get_query_object(self, report_data_source, total_row=False):
+        filters = self.helper.sql_alchemy_filters
+        filter_values = self.helper.sql_alchemy_filter_values
+        query = (
+            self.helper.adapter.session_helper.Session.query(
+                *self._columns(total_row)
+            )
+            .filter(*filters)
+            .params(filter_values)
+        )
+        if not total_row:
+            query = query.group_by(self.table.c.owner_id)
+        return query
+
+    def get_data(self, report_data_source, start, limit):
+        query_obj = self._get_query_object(report_data_source)
+        return [r._asdict() for r in query_obj.group_by(self.table.c.owner_id).all()]
+
+    def get_total_row(self, report_data_source):
+        query_obj = self._get_query_object(report_data_source, total_row=True)
+        return ["Total"] + [r for r in query_obj.first()]
+
+    def get_total_records(self, report_data_source):
+        return self._get_query_object(report_data_source).count()
+
+mpr_2a_person_cases = MPR2APersonCases

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -52,5 +52,3 @@ class MPR2APersonCases(object):
 
     def get_total_records(self, report_data_source):
         return self._get_query_object(report_data_source).count()
-
-mpr_2a_person_cases = MPR2APersonCases

--- a/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
@@ -13,7 +13,7 @@
     "title": "MPR - 2a - Person cases (Custom SQL) (Static)",
     "description": "",
     "visible": false,
-    "custom_query_provider": "custom.icds_reports.reports.ucr.mpr_2a_person_cases",
+    "custom_query_provider": "custom.icds_reports.reports.ucr.MPR2APersonCases",
     "aggregation_columns": [
       "owner_id"
     ],

--- a/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
@@ -1,0 +1,358 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new"
+  ],
+  "report_id": "static-custom_sql_mpr_2a_person_cases",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR - 2a - Person cases  (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "compare_as_string": false,
+        "datatype": "date",
+        "required": false,
+        "display": "Date of Death",
+        "field": "date_death",
+        "type": "date",
+        "slug": "date_death"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "awc_id",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by AWW"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "supervisor_id",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Supervisor"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "block_id",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Block"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "district_id",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by District"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "state_id",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by State"
+      }
+    ],
+    "columns": [
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        },
+        "column_id": "owner_id",
+        "field": "owner_id",
+        "calculate_total": false,
+        "type": "field",
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_resident_neo_count",
+        "field": "dead_F_resident_neo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_resident_neo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_M_resident_neo_count",
+        "field": "dead_M_resident_neo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_M_resident_neo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_migrant_neo_count",
+        "field": "dead_F_migrant_neo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_migrant_neo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_M_migrant_neo_count",
+        "field": "dead_M_migrant_neo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_M_migrant_neo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_resident_postneo_count",
+        "field": "dead_F_resident_postneo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_resident_postneo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_M_resident_postneo_count",
+        "field": "dead_M_resident_postneo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_M_resident_postneo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_migrant_postneo_count",
+        "field": "dead_F_migrant_postneo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_migrant_postneo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_M_migrant_postneo_count",
+        "field": "dead_M_migrant_postneo_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_M_migrant_postneo_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_resident_child_count",
+        "field": "dead_F_resident_child_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_resident_child_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_M_resident_child_count",
+        "field": "dead_M_resident_child_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_M_resident_child_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_migrant_child_count",
+        "field": "dead_F_migrant_child_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_migrant_child_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_M_migrant_child_count",
+        "field": "dead_M_migrant_child_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_M_migrant_child_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_migrant_adult_count",
+        "field": "dead_F_migrant_adult_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_migrant_adult_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_F_resident_adult_count",
+        "field": "dead_F_resident_adult_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_F_resident_adult_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_preg_resident_count",
+        "field": "dead_preg_resident_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_preg_resident_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_preg_migrant_count",
+        "field": "dead_preg_migrant_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_preg_migrant_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_del_resident_count",
+        "field": "dead_del_resident_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_del_resident_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_del_migrant_count",
+        "field": "dead_del_migrant_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_del_migrant_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_pnc_resident_count",
+        "field": "dead_pnc_resident_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_pnc_resident_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "dead_pnc_migrant_count",
+        "field": "dead_pnc_migrant_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "dead_pnc_migrant_count"
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
@@ -10,9 +10,10 @@
   "report_id": "static-custom_sql_mpr_2a_person_cases",
   "data_source_table": "static-person_cases_v2",
   "config": {
-    "title": "MPR - 2a - Person cases  (Static)",
+    "title": "MPR - 2a - Person cases (Custom SQL) (Static)",
     "description": "",
     "visible": false,
+    "custom_query_provider": "custom.icds_reports.reports.ucr.mpr_2a_person_cases",
     "aggregation_columns": [
       "owner_id"
     ],

--- a/settings.py
+++ b/settings.py
@@ -1906,6 +1906,7 @@ STATIC_UCR_REPORTS = [
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_1_person_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2a_3_child_delivery_forms.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2a_person_cases.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'custom_sql_mpr_2a_person_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2bi_preg_delivery_death_list.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2bii_child_death_list.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2ci_child_birth_list.json'),


### PR DESCRIPTION
This might need a spec, but pushing it up here. Wanted to churn this out this afternoon to see if it was feasible. Would love for some feedback on this, can write out more if anyone thinks its necessary/good to do.

**Problem**
UCRs only implement a subset of SQL functionality. This means that we have to have workarounds in the data sources to do some tasks. 

For example, our largest UCR on ICDS is [person cases](https://github.com/dimagi/commcare-hq/blob/af42ebe12650c08f94171fd3fb09d99c3b9abc3e/custom/icds_reports/ucr/data_sources/person_cases_v2.json) and it has 103 columns. Most of these columns are variations of data that can be contained in 3 or 4 columns. `dead_X_Y_Z_count` where X could be ('M', 'F', 'pregnant', 'delivery', 'pnc'), Y could be (resident, migrant), Z could be ('neo', 'postneo', 'child', 'adult'). There are currently 21 columns just for these indicators, but they could be stored in 5 columns that are already stored on the table (date_death, dob, resident, female_death_type, closed_on).

**Solution**
Add `custom_query_provider` to reports. This will be the path to a class (very similar to how we define `FIXTURE_GENERATORS` or our custom UCR expressions). That class will then provide three endpoints `get_data`, `get_total_records` and `get_total_row`, which will handle the data generation.

The columns and filters must still be defined in ICDS as they will be used by the UI side and also provide the filter values to be passed to the query.

By going through each of the reports I think we could bring those 103 columns down to < 30 (didn't actually go through all of them, just did an estimate)

**Trade offs**
This trades off report processing power for lower memory, storage, and less data source processing power (to put into the db). For the report processing power, we have the option of having it on either the webworker, or postgres. By this I mean all logic could be in the SQL queries (as I've done here) or we could only get the necessary columns and perform sums/counts in python code.

Admittedly I don't have a great way to test this out at ICDS scale. I think that this will be a win as with smaller tables these tables and their indexes will be more likely to be in RAM than requiring a disk seek.

**Notes**
Preferably we could support this in the reporting code, but writing reasonable and sane interfaces is hard and whatever we introduce now will require support in the future.

This should also enable us to convert ~any existing report to UCR (including standard reports), although I'm not sure if all of our filters have an interface in the UCR code. Not proposing to do this now by any stretch, but it'd be nice to have a common interface.

@dimagi/scale-team 