### PR TITLE
Case Search DSL

### DIFF
--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 CASE_PROPERTIES_PATH = 'case_properties'
 INDICES_PATH = 'indices'
 REFERENCED_ID = 'referenced_id'
+IDENTIFIER = 'identifier'
 VALUE_TEXT = 'value'
 VALUE_DATE = 'value_date'
 VALUE_NUMERIC = 'value_numeric'

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -1,0 +1,150 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.utils.translation import ugettext as _
+from eulxml.xpath.ast import Step, serialize
+from six import integer_types, string_types
+
+from corehq.apps.es import filters
+from corehq.apps.es.case_search import (
+    CaseSearchES,
+    case_property_range_query,
+    exact_case_property_text_query,
+    reverse_index_case_query,
+)
+
+
+class CaseFilterError(Exception):
+
+    def __init__(self, message, filter_part):
+        self.filter_part = filter_part
+        super(CaseFilterError, self).__init__(message)
+
+
+def print_ast(node):
+    """Prints the AST provided by eulxml.xpath.parse
+
+    Useful for debugging particular expressions
+    """
+    def visit(node, indent):
+        print("\t" * indent, node)  # noqa
+
+        if hasattr(node, 'left'):
+            indent += 1
+            visit(node.left, indent)
+
+        if hasattr(node, 'op'):
+            print("\t" * indent, "##### {} #####".format(node.op))  # noqa
+
+        if hasattr(node, 'right'):
+            visit(node.right, indent)
+            indent -= 1
+
+    visit(node, 0)
+
+
+def build_filter_from_ast(domain, node):
+    """Builds an ES filter from an AST provided by eulxml.xpath.parse
+    """
+
+    OP_MAPPING = {
+        'and': filters.AND,
+        'not': filters.NOT,
+        'or': filters.OR,
+    }
+    COMPARISON_MAPPING = {
+        '>': 'gt',
+        '>=': 'gte',
+        '<': 'lt',
+        '<=': 'lte',
+    }
+
+    EQ = "="
+    NEQ = "!="
+
+    def walk_related_cases(node):
+        """Return a query that will fulfill the filter on the related case.
+
+        Since ES has no way of performing joins, we filter down in stages:
+        1. Find the ids of all cases where the condition is met
+        2. Walk down the case hierarchy, finding all related cases with the right identifier to the ids
+        found in (1).
+        3. Return the lowest of these ids as an related case query filter
+        """
+
+        ids = parent_property_lookup(node)  # the ids of the highest level cases that match the case_property
+
+        # walk down the tree and select all child cases
+        n = node.left
+        while is_related_case_lookup(n):
+            n = n.left
+            # Performs a "join" to find related cases
+            # Fetches all the case ids from ES which are children of the previous level
+            # This has the potential to be a very large list
+            ids = child_case_lookup(ids, identifier=serialize(n.right))
+            if not ids:
+                break
+        final_identifier = serialize(n.left)
+        return reverse_index_case_query(ids, final_identifier)
+
+    def parent_property_lookup(node):
+        """given a node of the form `parent/foo = 'thing'`, return all case_ids where `foo = thing`
+        """
+        new_query = "{} {} '{}'".format(serialize(node.left.right), node.op, node.right)
+        return CaseSearchES().domain(domain).xpath_query(domain, new_query).scroll_ids()
+
+    def child_case_lookup(case_ids, identifier):
+        """returns a list of all case_ids who have parents `case_id` with the relationship `identifier`
+        """
+        return CaseSearchES().domain(domain).get_child_cases(case_ids, identifier).scroll_ids()
+
+    def is_related_case_lookup(node):
+        """Returns whether a particular AST node is a related case lookup
+
+        e.g. `parent/host/thing = 'foo'`
+        """
+        return hasattr(node, 'left') and hasattr(node.left, 'op') and node.left.op == '/'
+
+    def visit(node):
+        if not hasattr(node, 'op'):
+            raise CaseFilterError(
+                _("Your filter is required to have at least one boolean operator (e.g. '=', '!=')"),
+                serialize(node)
+            )
+
+        if is_related_case_lookup(node):
+            # this node represents a filter on a property for a related case
+            return walk_related_cases(node)
+
+        if node.op in [EQ, NEQ]:
+            if isinstance(node.left, Step) and isinstance(node.right, integer_types + (string_types, float)):
+                # This is a leaf node
+                q = exact_case_property_text_query(serialize(node.left), node.right)
+                if node.op == '!=':
+                    return filters.NOT(q)
+                return q
+            elif isinstance(node.right, Step):
+                raise CaseFilterError(
+                    _("You cannot reference a case property on the right side "
+                      "of a boolean operation. If \"{}\" is meant to be a value, please surround it with "
+                      "quotation marks.").format(serialize(node.right)),
+                    serialize(node)
+                )
+            else:
+                raise CaseFilterError(
+                    _("We didn't understand what you were trying to do with {}").format(serialize(node)),
+                    serialize(node)
+                )
+
+        if node.op in list(COMPARISON_MAPPING.keys()):
+            return case_property_range_query(serialize(node.left), **{COMPARISON_MAPPING[node.op]: node.right})
+
+        if node.op in list(OP_MAPPING.keys()):
+            # This is another branch in the tree
+            return OP_MAPPING[node.op](visit(node.left), visit(node.right))
+
+        raise CaseFilterError(
+            _("We don't know what to do with operator '{}'. Please try reformatting your query.".format(node.op)),
+            serialize(node)
+        )
+
+    return visit(node)

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -46,7 +46,7 @@ def build_filter_from_ast(domain, node):
     """Builds an ES filter from an AST provided by eulxml.xpath.parse
     """
 
-    OP_MAPPING = {
+    OPERATOR_MAPPING = {
         'and': filters.AND,
         'not': filters.NOT,
         'or': filters.OR,
@@ -138,9 +138,9 @@ def build_filter_from_ast(domain, node):
         if node.op in list(COMPARISON_MAPPING.keys()):
             return case_property_range_query(serialize(node.left), **{COMPARISON_MAPPING[node.op]: node.right})
 
-        if node.op in list(OP_MAPPING.keys()):
+        if node.op in list(OPERATOR_MAPPING.keys()):
             # This is another branch in the tree
-            return OP_MAPPING[node.op](visit(node.left), visit(node.right))
+            return OPERATOR_MAPPING[node.op](visit(node.left), visit(node.right))
 
         raise CaseFilterError(
             _("We don't know what to do with operator '{}'. Please try reformatting your query.".format(node.op)),

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -11,13 +11,8 @@ hqDefine('case_search/js/case_search', function(){
         self.results = ko.observableArray();
         self.count = ko.observable();
         self.case_data_url = caseDataUrl;
-        self.parameters = ko.observableArray([{
-            key: "",
-            value: "",
-            clause: "must",
-            fuzzy: false,
-            regex: '',
-        }]);
+        self.xpath = ko.observable();
+        self.parameters = ko.observableArray();
 
         self.addParameter = function(){
             self.parameters.push({
@@ -43,11 +38,16 @@ hqDefine('case_search/js/case_search', function(){
                     parameters: self.parameters(),
                     customQueryAddition: self.customQueryAddition(),
                     includeClosed: self.includeClosed(),
+                    xpath: self.xpath(),
                 }
                 )},
                 success: function(data){
                     self.results(data.values);
                     self.count(data.count);
+                },
+                error: function(response){
+                    var alertUser = hqImport("hqwebapp/js/alert_user").alert_user;
+                    alertUser(response.responseJSON.message, 'danger');
                 },
             });
         };

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -85,6 +85,16 @@
                                 <span class="btn btn-primary" id="add-input" data-bind="click: addParameter"><i class="fa fa-plus"></i> Add input</span>
                             </div>
                         </div>
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <strong>XPath Expression</strong>
+                            </div>
+                            <div class="panel-body">
+                                <div class="form-group" style="width:100%">
+                                    <textarea style="min-width: 50%" spellcheck="false" class="form-control" name="xpath" type="text" placeholder="e.g: name = 'tyrion' or nickname='the imp'" data-bind="value: xpath"> </textarea>
+                                </div>
+                            </div>
+                        </div>
                         {% if query_additions %}
                         <div class="panel panel-default">
                             <div class="panel-heading">

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -31,7 +31,7 @@ class TestFilterDsl(SimpleTestCase):
                             "and": (
                                 {
                                     "term": {
-                                        "case_properties.key": "name"
+                                        "case_properties.key.exact": "name"
                                     }
                                 },
                                 {
@@ -57,7 +57,7 @@ class TestFilterDsl(SimpleTestCase):
                     "filtered": {
                         "filter": {
                             "term": {
-                                "case_properties.key": "dob"
+                                "case_properties.key.exact": "dob"
                             }
                         },
                         "query": {
@@ -82,7 +82,7 @@ class TestFilterDsl(SimpleTestCase):
                     "filtered": {
                         "filter": {
                             "term": {
-                                "case_properties.key": "number"
+                                "case_properties.key.exact": "number"
                             }
                         },
                         "query": {
@@ -117,7 +117,7 @@ class TestFilterDsl(SimpleTestCase):
                                             "and": (
                                                 {
                                                     "term": {
-                                                        "case_properties.key": "name"
+                                                        "case_properties.key.exact": "name"
                                                     }
                                                 },
                                                 {
@@ -144,7 +144,7 @@ class TestFilterDsl(SimpleTestCase):
                                             "and": (
                                                 {
                                                     "term": {
-                                                        "case_properties.key": "name"
+                                                        "case_properties.key.exact": "name"
                                                     }
                                                 },
                                                 {
@@ -167,7 +167,7 @@ class TestFilterDsl(SimpleTestCase):
                             "filtered": {
                                 "filter": {
                                     "term": {
-                                        "case_properties.key": "dob"
+                                        "case_properties.key.exact": "dob"
                                     }
                                 },
                                 "query": {

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -5,7 +5,7 @@ from elasticsearch.exceptions import ConnectionError
 from eulxml.xpath import parse as parse_xpath
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
-from corehq.apps.case_search.filter_dsl import build_filter_from_ast
+from corehq.apps.case_search.filter_dsl import build_filter_from_ast, CaseFilterError
 from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
@@ -186,6 +186,16 @@ class TestFilterDsl(SimpleTestCase):
 
         built_filter = build_filter_from_ast("domain", parsed)
         self.assertEqual(expected_filter, built_filter)
+
+    def test_self_reference(self):
+        with self.assertRaises(CaseFilterError):
+            build_filter_from_ast(None, parse_xpath("name = other_property"))
+
+        with self.assertRaises(CaseFilterError):
+            build_filter_from_ast(None, parse_xpath("name > other_property"))
+
+        with self.assertRaises(CaseFilterError):
+            build_filter_from_ast(None, parse_xpath("parent/name > other_property"))
 
 
 class TestFilterDslLookups(TestCase):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -1,0 +1,327 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.test import SimpleTestCase, TestCase
+from elasticsearch.exceptions import ConnectionError
+from eulxml.xpath import parse as parse_xpath
+
+from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
+from corehq.apps.case_search.filter_dsl import build_filter_from_ast
+from corehq.apps.es import CaseSearchES
+from corehq.elastic import get_es_new, send_to_elasticsearch
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.pillows.case_search import transform_case_for_elasticsearch
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import trap_extra_setup
+from pillowtop.es_utils import initialize_index_and_mapping
+
+
+class TestFilterDsl(SimpleTestCase):
+    def test_simple_filter(self):
+        parsed = parse_xpath("name = 'farid'")
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "filtered": {
+                        "query": {
+                            "match_all": {}
+                        },
+                        "filter": {
+                            "and": (
+                                {
+                                    "term": {
+                                        "case_properties.key": "name"
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "case_properties.value.exact": "farid"
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        built_filter = build_filter_from_ast("domain", parsed)
+        self.assertEqual(expected_filter, built_filter)
+
+    def test_date_comparison(self):
+        parsed = parse_xpath("dob >= '2017-02-12'")
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "filtered": {
+                        "filter": {
+                            "term": {
+                                "case_properties.key": "dob"
+                            }
+                        },
+                        "query": {
+                            "range": {
+                                "case_properties.value_date": {
+                                    "gte": "2017-02-12",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(expected_filter, build_filter_from_ast("domain", parsed))
+
+    def test_numeric_comparison(self):
+        parsed = parse_xpath("number <= '100.32'")
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "filtered": {
+                        "filter": {
+                            "term": {
+                                "case_properties.key": "number"
+                            }
+                        },
+                        "query": {
+                            "range": {
+                                "case_properties.value_numeric": {
+                                    "lte": 100.32,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(expected_filter, build_filter_from_ast("domain", parsed))
+
+    def test_nested_filter(self):
+        parsed = parse_xpath("(name = 'farid' or name = 'leila') and dob <= '2017-02-11'")
+        expected_filter = {
+            "and": (
+                {
+                    "or": (
+                        {
+                            "nested": {
+                                "path": "case_properties",
+                                "query": {
+                                    "filtered": {
+                                        "query": {
+                                            "match_all": {
+                                            }
+                                        },
+                                        "filter": {
+                                            "and": (
+                                                {
+                                                    "term": {
+                                                        "case_properties.key": "name"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "case_properties.value.exact": "farid"
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "nested": {
+                                "path": "case_properties",
+                                "query": {
+                                    "filtered": {
+                                        "query": {
+                                            "match_all": {
+                                            }
+                                        },
+                                        "filter": {
+                                            "and": (
+                                                {
+                                                    "term": {
+                                                        "case_properties.key": "name"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "case_properties.value.exact": "leila"
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    )
+                },
+                {
+                    "nested": {
+                        "path": "case_properties",
+                        "query": {
+                            "filtered": {
+                                "filter": {
+                                    "term": {
+                                        "case_properties.key": "dob"
+                                    }
+                                },
+                                "query": {
+                                    "range": {
+                                        "case_properties.value_date": {
+                                            "lte": "2017-02-11"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        }
+
+        built_filter = build_filter_from_ast("domain", parsed)
+        self.assertEqual(expected_filter, built_filter)
+
+
+class TestFilterDslLookups(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestFilterDslLookups, cls).setUpClass()
+        with trap_extra_setup(ConnectionError):
+            cls.es = get_es_new()
+            initialize_index_and_mapping(cls.es, CASE_SEARCH_INDEX_INFO)
+
+        cls.child_case_id = 'margaery'
+        cls.parent_case_id = 'mace'
+        cls.grandparent_case_id = 'olenna'
+        cls.domain = "Tyrell"
+        factory = CaseFactory(domain=cls.domain)
+        grandparent_case = CaseStructure(
+            case_id=cls.grandparent_case_id,
+            attrs={
+                'create': True,
+                'case_type': 'grandparent',
+                'update': {
+                    "name": "Olenna",
+                    "alias": "Queen of thorns",
+                    "house": "Tyrell",
+                },
+            })
+
+        parent_case = CaseStructure(
+            case_id=cls.parent_case_id,
+            attrs={
+                'create': True,
+                'case_type': 'parent',
+                'update': {
+                    "name": "Mace",
+                    "house": "Tyrell",
+                },
+            },
+            indices=[CaseIndex(
+                grandparent_case,
+                identifier='mother',
+                relationship='child',
+            )])
+
+        child_case = CaseStructure(
+            case_id=cls.child_case_id,
+            attrs={
+                'create': True,
+                'case_type': 'child',
+                'update': {
+                    "name": "Margaery",
+                    "house": "Tyrell",
+                },
+            },
+            indices=[CaseIndex(
+                parent_case,
+                identifier='father',
+                relationship='extension',
+            )],
+        )
+        for case in factory.create_or_update_cases([child_case]):
+            send_to_elasticsearch('case_search', transform_case_for_elasticsearch(case.to_json()))
+        cls.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
+
+    @classmethod
+    def tearDownClass(self):
+        FormProcessorTestUtils.delete_all_cases()
+        ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
+        super(TestFilterDslLookups, self).tearDownClass()
+
+    def test_parent_lookups(self):
+        parsed = parse_xpath("father/name = 'Mace'")
+        # return all the cases who's parent (relationship named 'father') has case property 'name' = 'Mace'
+
+        expected_filter = {
+            "nested": {
+                "path": "indices",
+                "query": {
+                    "filtered": {
+                        "query": {
+                            "match_all": {
+                            },
+                        },
+                        "filter": {
+                            "and": (
+                                {
+                                    "terms": {
+                                        "indices.referenced_id": [self.parent_case_id],
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "indices.identifier": "father"
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.assertEqual(expected_filter, built_filter)
+        self.assertEqual([self.child_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
+
+    def test_nested_parent_lookups(self):
+        parsed = parse_xpath("father/mother/house = 'Tyrell'")
+
+        expected_filter = {
+            "nested": {
+                "path": "indices",
+                "query": {
+                    "filtered": {
+                        "query": {
+                            "match_all": {
+                            },
+                        },
+                        "filter": {
+                            "and": (
+                                {
+                                    "terms": {
+                                        "indices.referenced_id": [self.parent_case_id],
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "indices.identifier": "father"
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.assertEqual(expected_filter, built_filter)
+        self.assertEqual([self.child_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -1,16 +1,22 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import json
 import re
 
+from django.http import Http404
+from django.views.generic import TemplateView
+
+from corehq.apps.case_search.models import (
+    CaseSearchQueryAddition,
+    case_search_enabled_for_domain,
+    merge_queries,
+)
 from corehq.apps.domain.decorators import cls_require_superuser_or_developer
 from corehq.apps.domain.views import DomainViewMixin
-from django.http import Http404
-from dimagi.utils.web import json_response
-from django.views.generic import TemplateView
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
-from corehq.apps.case_search.models import case_search_enabled_for_domain, CaseSearchQueryAddition, merge_queries
-from corehq.util.view_utils import json_error, BadRequest
+from corehq.util.view_utils import BadRequest, json_error
+from dimagi.utils.web import json_response
 
 
 class CaseSearchView(DomainViewMixin, TemplateView):
@@ -45,6 +51,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         search_params = query.get('parameters', [])
         query_addition = query.get("customQueryAddition", None)
         include_closed = query.get("includeClosed", False)
+        xpath = query.get("xpath")
         search = CaseSearchES()
         search = search.domain(self.domain).size(CASE_SEARCH_MAX_RESULTS)
         if not include_closed:
@@ -65,5 +72,8 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
             new_query = merge_queries(search.get_query(), addition.query_addition)
             search = search.set_query(new_query)
+
+        if xpath:
+            search = search.xpath_query(self.domain, xpath)
         search_results = search.run()
         return json_response({'values': search_results.raw_hits, 'count': search_results.total})

--- a/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
+++ b/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
@@ -12,7 +12,7 @@ RENAMES = (
     ("applications-to-elasticsearch", "ApplicationToElasticsearchPillow-hqapps_2016-10-20_1835"),
     ("all-cases-to-elasticsearch", "CaseToElasticsearchPillow-hqcases_2016-03-04"),
     ("all-xforms-to-elasticsearch", "XFormToElasticsearchPillow-xforms_2016-07-07"),
-    ("case-search-to-elasticsearch", "CaseSearchToElasticsearchPillow-case_search_2018-04-18"),
+    ("case-search-to-elasticsearch", "CaseSearchToElasticsearchPillow-case_search_2018-04-27"),
     ("GroupPillow", "GroupPillow-hqgroups_20150403_1501"),
     ("GroupToUserPillow", "GroupToUserPillow-hqusers_2016-09-29"),
     ("KafkaDomainPillow", "KafkaDomainPillow-hqdomains_2016-08-08"),

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -12,12 +12,17 @@ from corehq.apps.es import case_search as case_search_es
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from six import string_types
+from warnings import warn
+
+import six
+from django.utils.dateparse import parse_date
+from django.utils.translation import ugettext as _
 
 from corehq.apps.case_search.const import (
+    CASE_PROPERTIES_PATH,
+    IDENTIFIER,
     INDICES_PATH,
     REFERENCED_ID,
-    CASE_PROPERTIES_PATH,
     RELEVANCE_SCORE,
     VALUE_DATE,
     VALUE_NUMERIC,
@@ -65,19 +70,19 @@ class CaseSearchES(CaseES):
             positive_clause = clause != queries.MUST_NOT
             return (
                 # fuzzy match
-                self._add_query(self._get_text_query(key, value, fuzziness='AUTO'), clause)
+                self._add_query(case_property_text_query(key, value, fuzziness='AUTO'), clause)
                 # exact match. added to improve the score of exact matches
-                ._add_query(self._get_text_query(key, value, fuzziness='0'),
+                ._add_query(exact_case_property_text_query(key, value),
                             queries.SHOULD if positive_clause else clause))
         else:
-            return self._add_query(self._get_text_query(key, value, fuzziness='0'), clause)
+            return self._add_query(exact_case_property_text_query(key, value), clause)
 
     def regexp_case_property_query(self, key, regex, clause=queries.MUST):
         """
         Search for all cases where case property `key` matches the regular expression in `regex`
         """
         return self._add_query(
-            self._get_query(key, queries.regexp("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_TEXT), regex)),
+            _base_property_query(key, queries.regexp("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_TEXT), regex)),
             clause,
         )
 
@@ -85,24 +90,13 @@ class CaseSearchES(CaseES):
         """
         Search for all cases where case property `key` fulfills the range criteria.
         """
-        return self._add_query(
-            self._get_query(
-                key,
-                queries.range_query("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_NUMERIC), gt, gte, lt, lte)
-            ),
-            clause,
-        )
+        return self._add_query(case_property_range_query(key, gt, gte, lt, lte), clause)
 
     def date_range_case_property_query(self, key, gt=None, gte=None, lt=None, lte=None, clause=queries.MUST):
         """
         Search for all cases where case property `key` fulfills the date range criteria.
         """
-        return self._add_query(
-            self._get_query(
-                key,
-                queries.date_range("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_DATE), gt, gte, lt, lte)
-            ),
-            clause,
+        return self._add_query(case_property_range_query(key, gt, gte, lt, lte), clause)
         )
 
     def _add_query(self, new_query, clause):
@@ -121,43 +115,120 @@ class CaseSearchES(CaseES):
             )
         return self
 
-    def _get_text_query(self, key, value, fuzziness):
-        # Filter by case_properties.key and do a text search in case_properties.value
-        return self._get_query(
-            key,
-            queries.match(value, '{}.{}'.format(CASE_PROPERTIES_PATH, VALUE_TEXT), fuzziness=fuzziness)
-        )
-
-    def _get_query(self, key, query):
-        return queries.nested(
-            CASE_PROPERTIES_PATH,
-            queries.filtered(
-                query,
-                filters.term('{}.key'.format(CASE_PROPERTIES_PATH), key),
-            )
-        )
-
-    def get_child_cases(self, case_ids):
-        """Returns all cases that reference cases with id: `case_ids`
+    def get_child_cases(self, case_ids, identifier):
+        """Returns all cases that reference cases with ids: `case_ids`
         """
-        if isinstance(case_ids, string_types):
+        if isinstance(case_ids, six.string_types):
             case_ids = [case_ids]
 
         return self._add_query(
-            queries.nested(
-                INDICES_PATH,
-                queries.match(" ".join(case_ids), '{}.{}'.format(INDICES_PATH, REFERENCED_ID))
-            ),
+            reverse_index_case_query(case_ids, identifier),
             queries.MUST,
         )
 
 
 def case_property_filter(key, value):
+    warn("Use the query versions of this function from the case_search module instead", DeprecationWarning)
     return filters.nested(
         CASE_PROPERTIES_PATH,
         filters.AND(
             filters.term("{}.key".format(CASE_PROPERTIES_PATH), key),
             filters.term("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_TEXT), value),
+        )
+    )
+
+
+def exact_case_property_text_query(key, value):
+    """Filter by case property.
+
+    This performs an exact match on the value in the case property, including
+    letter casing and punctuation.
+
+    """
+    return queries.nested(
+        CASE_PROPERTIES_PATH,
+        queries.filtered(
+            queries.match_all(),
+            filters.AND(
+                filters.term('{}.key'.format(CASE_PROPERTIES_PATH), key),
+                filters.term('{}.{}.exact'.format(CASE_PROPERTIES_PATH, VALUE_TEXT), value),
+            )
+        )
+    )
+
+
+def case_property_text_query(key, value, fuzziness='0'):
+    """Filter by case_properties.key and do a text search in case_properties.value
+
+    This does not do exact matches on the case property value. If the value has
+    multiple words, they will be OR'd together in this query. You may want to
+    use the `exact_case_property_text_query` instead.
+
+    """
+    return _base_property_query(
+        key,
+        queries.match(value, '{}.{}'.format(CASE_PROPERTIES_PATH, VALUE_TEXT), fuzziness=fuzziness)
+    )
+
+
+def case_property_range_query(key, gt=None, gte=None, lt=None, lte=None):
+    """Returns cases where case property `key` fall into the range provided.
+
+    """
+    kwargs = {'gt': gt, 'gte': gte, 'lt': lt, 'lte': lte}
+    # if its a number, use it
+    try:
+        # numeric range
+        kwargs = {key: float(value) for key, value in six.iteritems(kwargs) if value is not None}
+        return _base_property_query(
+            key,
+            queries.range_query("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_NUMERIC), **kwargs)
+        )
+    except ValueError:
+        pass
+
+    # if its a date, use it
+    # date range
+    kwargs = {key: parse_date(value) for key, value in six.iteritems(kwargs) if value is not None}
+    return _base_property_query(
+        key,
+        queries.date_range("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_DATE), **kwargs)
+    )
+
+
+def reverse_index_case_query(case_ids, identifier=None):
+    """Fetches related cases related by `identifier`.
+
+    For example, in a regular parent/child relationship, given a list of parent
+    case ids, this will return all the child cases which point to the parents
+    with identifier `parent`.
+
+    """
+    if isinstance(case_ids, six.string_types):
+            case_ids = [case_ids]
+
+    if identifier is None:      # some old relationships don't have an identifier specified
+        f = filters.term('{}.{}'.format(INDICES_PATH, REFERENCED_ID), list(case_ids)),
+    else:
+        f = filters.AND(
+            filters.term('{}.{}'.format(INDICES_PATH, REFERENCED_ID), list(case_ids)),
+            filters.term('{}.{}'.format(INDICES_PATH, IDENTIFIER), identifier),
+        )
+    return queries.nested(
+        INDICES_PATH,
+        queries.filtered(
+            queries.match_all(),
+            f
+        )
+    )
+
+
+def _base_property_query(key, query):
+    return queries.nested(
+        CASE_PROPERTIES_PATH,
+        queries.filtered(
+            query,
+            filters.term('{}.key'.format(CASE_PROPERTIES_PATH), key),
         )
     )
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -274,7 +274,7 @@ def flatten_result(hit):
     for case_property in case_properties:
         key = case_property.get('key')
         value = case_property.get('value')
-        if key and value:
+        if key is not None and not key.startswith("@") and value:
             result[key] = value
     return result
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -156,7 +156,7 @@ def case_property_filter(key, value):
     return filters.nested(
         CASE_PROPERTIES_PATH,
         filters.AND(
-            filters.term("{}.key".format(CASE_PROPERTIES_PATH), key),
+            filters.term("{}.key.exact".format(CASE_PROPERTIES_PATH), key),
             filters.term("{}.{}".format(CASE_PROPERTIES_PATH, VALUE_TEXT), value),
         )
     )
@@ -174,7 +174,7 @@ def exact_case_property_text_query(key, value):
         queries.filtered(
             queries.match_all(),
             filters.AND(
-                filters.term('{}.key'.format(CASE_PROPERTIES_PATH), key),
+                filters.term('{}.key.exact'.format(CASE_PROPERTIES_PATH), key),
                 filters.term('{}.{}.exact'.format(CASE_PROPERTIES_PATH, VALUE_TEXT), value),
             )
         )
@@ -252,7 +252,7 @@ def _base_property_query(key, query):
         CASE_PROPERTIES_PATH,
         queries.filtered(
             query,
-            filters.term('{}.key'.format(CASE_PROPERTIES_PATH), key),
+            filters.term('{}.key.exact'.format(CASE_PROPERTIES_PATH), key),
         )
     )
 

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -44,7 +44,7 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                                     "and": (
                                                         {
                                                             "term": {
-                                                                "case_properties.key": "name"
+                                                                "case_properties.key.exact": "name"
                                                             }
                                                         },
                                                         {
@@ -98,7 +98,7 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                                     "and": (
                                                         {
                                                             "term": {
-                                                                "case_properties.key": "name"
+                                                                "case_properties.key.exact": "name"
                                                             }
                                                         },
                                                         {
@@ -125,7 +125,7 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                             "filtered": {
                                                 "filter": {
                                                     "term": {
-                                                        "case_properties.key": "parrot_name"
+                                                        "case_properties.key.exact": "parrot_name"
                                                     }
                                                 },
                                                 "query": {
@@ -149,7 +149,7 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                                     "and": (
                                                         {
                                                             "term": {
-                                                                "case_properties.key": "parrot_name"
+                                                                "case_properties.key.exact": "parrot_name"
                                                             }
                                                         },
                                                         {

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -36,18 +36,23 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                         "path": "case_properties",
                                         "query": {
                                             "filtered": {
-                                                "filter": {
-                                                    "term": {
-                                                        "case_properties.key": "name"
+                                                "query": {
+                                                    "match_all": {
                                                     }
                                                 },
-                                                "query": {
-                                                    "match": {
-                                                        "case_properties.value": {
-                                                            "query": "redbeard",
-                                                            "fuzziness": "0"
+                                                "filter": {
+                                                    "and": (
+                                                        {
+                                                            "term": {
+                                                                "case_properties.key": "name"
+                                                            }
+                                                        },
+                                                        {
+                                                            "term": {
+                                                                "case_properties.value.exact": "redbeard"
+                                                            }
                                                         }
-                                                    }
+                                                    )
                                                 }
                                             }
                                         }
@@ -90,16 +95,21 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                         "query": {
                                             "filtered": {
                                                 "filter": {
-                                                    "term": {
-                                                        "case_properties.key": "name"
-                                                    }
+                                                    "and": (
+                                                        {
+                                                            "term": {
+                                                                "case_properties.key": "name"
+                                                            }
+                                                        },
+                                                        {
+                                                            "term": {
+                                                                "case_properties.value.exact": "redbeard"
+                                                            }
+                                                        }
+                                                    )
                                                 },
                                                 "query": {
-                                                    "match": {
-                                                        "case_properties.value": {
-                                                            "query": "redbeard",
-                                                            "fuzziness": "0"
-                                                        }
+                                                    "match_all": {
                                                     }
                                                 }
                                             }
@@ -136,16 +146,21 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                         "query": {
                                             "filtered": {
                                                 "filter": {
-                                                    "term": {
-                                                        "case_properties.key": "parrot_name"
-                                                    }
+                                                    "and": (
+                                                        {
+                                                            "term": {
+                                                                "case_properties.key": "parrot_name"
+                                                            }
+                                                        },
+                                                        {
+                                                            "term": {
+                                                                "case_properties.value.exact": "polly"
+                                                            }
+                                                        }
+                                                    )
                                                 },
                                                 "query": {
-                                                    "match": {
-                                                        "case_properties.value": {
-                                                            "query": "polly",
-                                                            "fuzziness": "0"
-                                                        }
+                                                    "match_all": {
                                                     }
                                                 }
                                             }

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.test.testcases import SimpleTestCase
 
-from corehq.apps.es.case_search import CaseSearchES, flatten_result, RELEVANCE_SCORE
+from corehq.apps.case_search.const import RELEVANCE_SCORE
+from corehq.apps.es.case_search import CaseSearchES, flatten_result
 from corehq.apps.es.tests.utils import ElasticTestMixin
 from corehq.elastic import SIZE_LIMIT
 
@@ -189,6 +190,7 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                     "_source": {
                         'name': 'blah',
                         'case_properties': [
+                            {'key': '@case_id', 'value': '123'},
                             {'key': 'foo', 'value': 'bar'},
                             {'key': 'baz', 'value': 'buzz'}]
                     }

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -155,16 +155,21 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                                     "query": {
                                         "filtered": {
                                             "filter": {
-                                                "term": {
-                                                    "case_properties.key": "phone_number"
-                                                }
+                                                "and": (
+                                                    {
+                                                        "term": {
+                                                            "case_properties.key.exact": "phone_number"
+                                                        }
+                                                    },
+                                                    {
+                                                        "term": {
+                                                            "case_properties.value.exact": "91999"
+                                                        }
+                                                    }
+                                                ),
                                             },
                                             "query": {
-                                                "match": {
-                                                    "case_properties.value": {
-                                                        "query": "91999",
-                                                        "fuzziness": "0"
-                                                    }
+                                                "match_all": {
                                                 }
                                             }
                                         }
@@ -177,16 +182,22 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                                     "query": {
                                         "filtered": {
                                             "filter": {
-                                                "term": {
-                                                    "case_properties.key": "special_id"
-                                                }
+                                                "and": (
+                                                    {
+                                                        "term": {
+                                                            "case_properties.key.exact": "special_id"
+                                                        }
+                                                    },
+                                                    {
+                                                        "term": {
+                                                            "case_properties.value.exact": "abc123546"
+                                                        }
+                                                    }
+                                                )
+
                                             },
                                             "query": {
-                                                "match": {
-                                                    "case_properties.value": {
-                                                        "query": "abc123546",
-                                                        "fuzziness": "0"
-                                                    }
+                                                "match_all": {
                                                 }
                                             }
                                         }
@@ -199,16 +210,22 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                                     "query": {
                                         "filtered": {
                                             "filter": {
-                                                "term": {
-                                                    "case_properties.key": "name"
-                                                }
+                                                "and": (
+                                                    {
+                                                        "term": {
+                                                            "case_properties.key.exact": "name"
+                                                        }
+                                                    },
+                                                    {
+                                                        "term": {
+                                                            "case_properties.value.exact": "this should be"
+                                                        }
+                                                    }
+                                                )
+
                                             },
                                             "query": {
-                                                "match": {
-                                                    "case_properties.value": {
-                                                        "query": "this should be",
-                                                        "fuzziness": "0"
-                                                    }
+                                                "match_all": {
                                                 }
                                             }
                                         }
@@ -221,16 +238,23 @@ class CaseSearchTests(TestCase, ElasticTestMixin):
                                     "query": {
                                         "filtered": {
                                             "filter": {
-                                                "term": {
-                                                    "case_properties.key": "other_name"
-                                                }
+                                                "and": (
+                                                    {
+                                                        "term": {
+                                                            "case_properties.key.exact": "other_name"
+                                                        }
+                                                    },
+                                                    {
+                                                        "term": {
+                                                            "case_properties.value.exact": (
+                                                                "this word should not be gone"
+                                                            )
+                                                        }
+                                                    }
+                                                )
                                             },
                                             "query": {
-                                                "match": {
-                                                    "case_properties.value": {
-                                                        "query": "this word should not be gone",
-                                                        "fuzziness": "0"
-                                                    }
+                                                "match_all": {
                                                 }
                                             }
                                         }
@@ -394,6 +418,7 @@ class CaseClaimEndpointTests(TestCase):
 
     @run_with_all_backends
     def test_search_endpoint(self):
+        self.maxDiff = None
         known_result = (
             '<results id="case">'  # ("case" is not the case type)
             '<case case_id="{case_id}" '
@@ -406,7 +431,6 @@ class CaseClaimEndpointTests(TestCase):
             '<date_opened>2016-04-17</date_opened>'
             '<commcare_search_score>xxx</commcare_search_score>'
             '<location_id>None</location_id>'
-            '<referrals>None</referrals>'
             '</case>'
             '</results>'.format(
                 case_id=self.case_id,
@@ -429,6 +453,7 @@ class CaseClaimEndpointTests(TestCase):
 
     @patch('corehq.apps.es.es_query.run_query')
     def test_search_query_addition(self, run_query_mock):
+        self.maxDiff = None
         new_must_clause = {
             "bool": {
                 "should": [
@@ -438,13 +463,21 @@ class CaseClaimEndpointTests(TestCase):
                             "query": {
                                 "filtered": {
                                     "filter": {
-                                        "term": {"case_properties.key": "is_inactive"}
+                                        "and": [
+                                            {
+                                                "term": {
+                                                    "case_properties.key.exact": "is_inactive"
+                                                }
+                                            },
+                                            {
+                                                "term": {
+                                                    "case_properties.value.exact": "yes"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "query": {
-                                        "match": {
-                                            "case_properties.value": {
-                                                "fuzziness": "0", "query": "yes"
-                                            }
+                                        "match_all": {
                                         }
                                     }
                                 }
@@ -457,13 +490,21 @@ class CaseClaimEndpointTests(TestCase):
                             "query": {
                                 "filtered": {
                                     "filter": {
-                                        "term": {"case_properties.key": "awaiting_claim"}
+                                        "and": [
+                                            {
+                                                "term": {
+                                                    "case_properties.key.exact": "awaiting_claim"
+                                                }
+                                            },
+                                            {
+                                                "term": {
+                                                    "case_properties.value.exact": "yes"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "query": {
-                                        "match": {
-                                            "case_properties.value": {
-                                                "fuzziness": "0", "query": "yes"
-                                            }
+                                        "match_all": {
                                         }
                                     }
                                 }
@@ -515,12 +556,18 @@ class CaseClaimEndpointTests(TestCase):
                                         'path': 'case_properties',
                                         'query': {
                                             'filtered': {
-                                                'filter': {'term': {'case_properties.key': 'name'}},
-                                                'query': {
-                                                    'match': {
-                                                        'case_properties.value': {
-                                                            'query': some_case_name, 'fuzziness': '0'
+                                                'filter': {
+                                                    "and": (
+                                                        {
+                                                            'term': {'case_properties.key.exact': 'name'}
+                                                        },
+                                                        {
+                                                            'term': {'case_properties.value.exact': some_case_name}
                                                         }
+                                                    )
+                                                },
+                                                'query': {
+                                                    'match_all': {
                                                     }
                                                 }
                                             }

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -52,8 +52,12 @@ def _get_case_properties(doc_dict):
     domain = doc_dict.get('domain')
     assert domain
     base_case_properties = [
+        {'key': '@case_id', 'value': doc_dict.get('_id')},
+        {'key': '@case_type', 'value': doc_dict.get('type')},
+        {'key': '@owner_id', 'value': doc_dict.get('owner_id')},
+        {'key': '@status', 'value': 'closed' if doc_dict.get('closed') else 'open'},
         {'key': 'name', 'value': doc_dict.get('name')},
-        {'key': 'external_id', 'value': doc_dict.get('external_id')}
+        {'key': 'external_id', 'value': doc_dict.get('external_id')},
     ]
     if should_use_sql_backend(domain):
         dynamic_case_properties = OrderedDict(doc_dict['case_json'])

--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -16,10 +16,17 @@
             "dynamic": false,
             "properties": {
                 "key": {
-                    "type": "string"
+                    "type": "string",
+                    "index" : "not_analyzed"
                 },
                 "value": {
-                    "type": "string"
+                    "type": "string",
+                    "fields": {
+                        "exact": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        }
+                    }
                 },
                 "value_numeric": {
                     "type": "double"

--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -17,7 +17,12 @@
             "properties": {
                 "key": {
                     "type": "string",
-                    "index" : "not_analyzed"
+                    "fields": {
+                        "exact": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        }
+                    }
                 },
                 "value": {
                     "type": "string",
@@ -41,7 +46,8 @@
             "type": "boolean"
         },
         "closed_by": {
-            "type": "string"
+            "type": "string",
+            "index": "not_analyzed"
         },
         "closed_on": {
             "format": "__DATE_FORMATS_STRING__",
@@ -60,21 +66,9 @@
             },
             "type": "multi_field"
         },
-        "export_tag": {
-            "type": "string"
-        },
         "external_id": {
-            "fields": {
-                "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
-                },
-                "external_id": {
-                    "index": "analyzed",
-                    "type": "string"
-                }
-            },
-            "type": "multi_field"
+            "type": "string",
+            "index": "not_analyzed"
         },
         "indices": {
             "type": "nested",
@@ -85,21 +79,26 @@
                     "type": "string"
                 },
                 "identifier": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "referenced_id": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "referenced_type": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "relationship": {
+                    "index": "not_analyzed",
                     "type": "string"
                 }
             }
         },
         "location_id": {
-            "type": "string"
+            "type": "string",
+            "index": "not_analyzed"
         },
         "modified_on": {
             "format": "__DATE_FORMATS_STRING__",
@@ -119,18 +118,16 @@
             "type": "multi_field"
         },
         "opened_by": {
-            "type": "string"
+            "type": "string",
+            "index": "not_analyzed"
         },
         "opened_on": {
             "format": "__DATE_FORMATS_STRING__",
             "type": "date"
         },
         "owner_id": {
-            "type": "string"
-        },
-        "referrals": {
-            "enabled": false,
-            "type": "object"
+            "type": "string",
+            "index": "not_analyzed"
         },
         "server_modified_on": {
             "format": "__DATE_FORMATS_STRING__",
@@ -150,10 +147,8 @@
             "type": "multi_field"
         },
         "user_id": {
-            "type": "string"
-        },
-        "version": {
-            "type": "string"
+            "type": "string",
+            "index": "not_analyzed"
         }
     }
 }

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -6,7 +6,7 @@ from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
 
-CASE_SEARCH_INDEX = es_index("case_search_2018-04-18")
+CASE_SEARCH_INDEX = es_index("case_search_2018-04-27")
 CASE_SEARCH_ALIAS = "case_search"
 CASE_SEARCH_MAX_RESULTS = 100
 CASE_SEARCH_MAPPING = mapping_from_json('case_search_mapping.json')

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -34,7 +34,7 @@ class ProdIndexManagementTest(SimpleTestCase):
 EXPECTED_PROD_INDICES = [
     {
         "alias": "case_search",
-        "index": "test_case_search_2018-04-18",
+        "index": "test_case_search_2018-04-27",
         "type": "case",
         "meta": {
             "settings": {

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -30,7 +30,7 @@
     "CaseSearchToElasticsearchPillow": {
         "advertised_name": "CaseSearchToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "CaseSearchToElasticsearchPillow-test_case_search_2018-04-18",
+        "checkpoint_id": "CaseSearchToElasticsearchPillow-test_case_search_2018-04-27",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseSearchToElasticsearchPillow"
     },

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -157,7 +157,8 @@ class CaseSearchPillowTest(TestCase):
         self.assertItemsEqual(list(case_doc['case_properties'][0]), ['key', 'value'])
         for case_property in case_doc['case_properties']:
             key = case_property['key']
-            self.assertEqual(case.get_case_property(key), case_property['value'])
+            if not key.startswith('@'):
+                self.assertEqual(case.get_case_property(key), case_property['value'])
 
     def _assert_index_empty(self):
         self.elasticsearch.indices.refresh(CASE_SEARCH_INDEX)


### PR DESCRIPTION
Adds the ability to search cases on HQ using XPath queries.

Also removes unused properties from the case search index.

This is currently only accessible on the hidden case search admin page for testing, but it lets you do things like this:
![screenshot from 2018-05-03 11-21-23](https://user-images.githubusercontent.com/146896/39587151-d4f1bfe8-4ec6-11e8-8c34-42c18f857518.png)

One deviation from the XPath spec, which I might change depending on what people think: you just reference relationships as `{identifier}/{property}` since there is no concept of "casedb". So if you are looking for a case whose grandparent has a name "freddie", then your query would be `parent/parent/name = 'freddie'`. I believe we do this elsewhere on HQ too. (This works for arbitrary identifiers, e.g. `host` or `voucher_of_prescription`, etc.)

Known issues:
- Doesn't support XPath functions (e.g. `selected()`, `now()`)
- Has very rudimentary error handling
- You can potentially run very expensive queries if you are searching for related cases with very generic case properties (e.g. `parent/parent/@status = 'open'`). 
- You can't search for case_properties that aren't set (`name = ''`), since our version of elasticsearch doesn't let you do this in a performant manner. 

:blowfish: / :tropical_fish: 

@jmtroth0 buddy
@nickpell @ctsims solutions

@esoergel FYI