### PR TITLE
Added possibility to enable in one domain custom reports from several modules

### DIFF
--- a/custom/intrahealth/reports/__init__.py
+++ b/custom/intrahealth/reports/__init__.py
@@ -10,6 +10,8 @@ from corehq.util.translation import localize
 from custom.intrahealth.sqldata import NombreData, TauxConsommationData
 from django.utils.translation import ugettext as _
 from memoized import memoized
+
+from custom.yeksi_naa_reports.reports import Dashboard1Report, Dashboard2Report, Dashboard3Report
 from dimagi.utils.parsing import json_format_date
 from six.moves import zip
 from six.moves import range

--- a/custom/intrahealth/reports/__init__.py
+++ b/custom/intrahealth/reports/__init__.py
@@ -11,7 +11,6 @@ from custom.intrahealth.sqldata import NombreData, TauxConsommationData
 from django.utils.translation import ugettext as _
 from memoized import memoized
 
-from custom.yeksi_naa_reports.reports import Dashboard1Report, Dashboard2Report, Dashboard3Report
 from dimagi.utils.parsing import json_format_date
 from six.moves import zip
 from six.moves import range

--- a/custom/yeksi_naa_reports/ucr/data_sources/visite_de_l_operateur.json
+++ b/custom/yeksi_naa_reports/ucr/data_sources/visite_de_l_operateur.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "test-pna"
+    "test-pna",
+    "ipm-senegal"
   ],
   "config": {
     "table_id": "yeksi_naa_reports_visite_de_l_operateur",

--- a/custom/yeksi_naa_reports/ucr/data_sources/visite_de_l_operateur_per_product.json
+++ b/custom/yeksi_naa_reports/ucr/data_sources/visite_de_l_operateur_per_product.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "test-pna"
+    "test-pna",
+    "ipm-senegal"
   ],
   "config": {
     "table_id": "yeksi_naa_reports_visite_de_l_operateur_per_product",

--- a/custom/yeksi_naa_reports/ucr/data_sources/visite_de_l_operateur_per_program.json
+++ b/custom/yeksi_naa_reports/ucr/data_sources/visite_de_l_operateur_per_program.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "test-pna"
+    "test-pna",
+    "ipm-senegal"
   ],
   "config": {
     "table_id": "yeksi_naa_reports_visite_de_l_operateur_per_program",

--- a/custom/yeksi_naa_reports/ucr/data_sources/yeksi_naa_reports_logisticien.json
+++ b/custom/yeksi_naa_reports/ucr/data_sources/yeksi_naa_reports_logisticien.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "test-pna"
+    "test-pna",
+    "ipm-senegal"
   ],
   "config": {
     "table_id": "yeksi_naa_reports_logisticien",

--- a/settings.py
+++ b/settings.py
@@ -2257,6 +2257,11 @@ DOMAIN_MODULE_MAP = {
     'test-pna': 'custom.yeksi_naa_reports',
 }
 
+# Domains mapping which use custom reports from several modules
+CUSTOM_REPORTS_DOMAINS_MAP = {
+    'ipm-senegal': ('custom.intrahealth', 'custom.yeksi_naa_reports')
+}
+
 THROTTLE_SCHED_REPORTS_PATTERNS = (
     # Regex patterns matching domains whose scheduled reports use a
     # separate queue so that they don't hold up the background queue.


### PR DESCRIPTION
Hi @esoergel 

I added the possibility to enable custom reports from several modules in one domain. This is related to the ```ipm-senegal``` domain because now we have two modules with reports (```intrahealth``` and ```yeksi_custom_reports```). I heard from Ashley that you tried to enable both custom reports for ```ipm-senegal``` domain.

Please let me know if you have any questions.

Regards,
Łukasz