### PR TITLE
adding migrate case attachments now that they are in the blob db

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -477,7 +477,7 @@ def _migrate_case_attachments(couch_case, sql_case):
             attachment_from=attachment.attachment_from,
             content_type=attachment.server_mime,
             content_length=attachment.content_length,
-            blob_id=attachment.id,
+            blob_id=blob.id,
             blob_bucket=couch_case._blobdb_bucket(),
             properties=attachment.attachment_properties,
             md5=attachment.server_md5

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -467,9 +467,9 @@ def _migrate_case_actions(couch_case, sql_case):
 
 def _migrate_case_attachments(couch_case, sql_case):
     """Copy over attachment meta """
-    attachments = []
     for name, attachment in six.iteritems(couch_case.case_attachments):
-        attachments.append(CaseAttachmentSQL(
+        blob = couch_case.blobs[name]
+        sql_case.track_create(CaseAttachmentSQL(
             name=name,
             case=sql_case,
             identifier=attachment.identifier,
@@ -482,7 +482,6 @@ def _migrate_case_attachments(couch_case, sql_case):
             properties=attachment.attachment_properties,
             md5=attachment.server_md5
         ))
-    sql_case.unsaved_attachments = attachments
 
 
 def _migrate_case_indices(couch_case, sql_case):


### PR DESCRIPTION
This shouldn't be an issue that will have to be fixed retroactively for migrated domains, but might as well be a supported part of the migration at the very least
```
snopoke [3:49 AM]
Case attachments aren't really a supported thing (though there probably area a few cases out there with attachments)
```
@snopoke @proteusvacuum 