### PR TITLE
handle new lines

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -233,7 +233,7 @@ class CouchSqlDomainMigrator(object):
 
     def _calculate_case_diffs(self):
         cases = {}
-        pool = Pool(5)
+        pool = Pool(10)
         changes = _get_case_iterator(self.domain).iter_all_changes()
         for change in self._with_progress(CASE_DOC_TYPES, changes, progress_name='Calculating diffs'):
             cases[change.id] = change.get_document()

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         self.stdout.ending = "\n"
         self.stderr.ending = "\n"
         with open(path, 'r') as f:
-            domains = [name.strip() for name in f.readlines()]
+            domains = [name.strip() for name in f.readlines() if name.strip()]
 
         self.stdout.write("Processing {} domains".format(len(domains)))
         for domain in with_progress_bar(domains, oneline=False):


### PR DESCRIPTION
A couple small things. 

It was trying to migrate a domain `''` because I left a newline at the top of a file, which should be handled.

Also, since it's requesting 1000 cases at a time, it seemed like that pool could be allowed to get larger if it wanted to

@proteusvacuum 