### PR TITLE
Requirejs: fix billing account form missing dependency

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -4,6 +4,7 @@ hqDefine('accounting/js/billing_account_form', [
     'hqwebapp/js/initial_page_data',
     'accounting/js/credits_tab',
     'hqwebapp/js/stay_on_tab',
+    'accounting/js/widgets',
 ], function (
     $,
     ko,


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?275993

Introduced in https://github.com/dimagi/commcare-hq/pull/19357/

The main module for the Manage Billing Accounts page didn't include the module that initializes widgets like the select2 for emails.

@esoergel / @nickpell 