### PR TITLE
Restyle exports table

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -37,7 +37,6 @@
                     <i class="grip sortable-handle" data-bind="
                         if: grip,
                         css: hqImport('hqwebapp/js/main').icons.GRIP,
-                        style: {cursor: 'move'},
                         event: {mousedown: function(){ $(':focus').blur(); }}
                     "></i>
                 </td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
@@ -63,7 +63,7 @@
                     <tr class="row"
                         data-bind="attr: {'data-order': _sortableOrder}">
                         <td>
-                            <i class="grip sortable-handle" data-bind="css: hqImport('hqwebapp/js/main').icons.GRIP, style: {cursor: 'move'}"></i>
+                            <i class="grip sortable-handle" data-bind="css: hqImport('hqwebapp/js/main').icons.GRIP"></i>
                         </td>
                         <td>
                             <select class="form-control"

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -62,7 +62,7 @@ hqDefine('export/js/models', function () {
         // Set column widths
         self.questionColumnClass = ko.computed(function() {
             var width = 6;
-            if (self.type() === 'case' && hqImport('hqwebapp/js/toggles').previewEnabled('SPLIT_MULTISELECT_CASE_EXPORT')) {
+            if (self.type && self.type() === 'case' && hqImport('hqwebapp/js/toggles').previewEnabled('SPLIT_MULTISELECT_CASE_EXPORT')) {
                 width--;
             }
             if (self.isDeidColumnVisible()) {
@@ -72,7 +72,7 @@ hqDefine('export/js/models', function () {
         });
         self.displayColumnClass = ko.computed(function() {
             var width = 5;
-            if (self.type() === 'case' && hqImport('hqwebapp/js/toggles').previewEnabled('SPLIT_MULTISELECT_CASE_EXPORT')) {
+            if (self.type && self.type() === 'case' && hqImport('hqwebapp/js/toggles').previewEnabled('SPLIT_MULTISELECT_CASE_EXPORT')) {
                 width--;
             }
             if (self.isDeidColumnVisible()) {

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -59,6 +59,28 @@ hqDefine('export/js/models', function () {
             });
         }));
 
+        // Set column widths
+        self.questionColumnClass = ko.computed(function() {
+            var width = 6;
+            if (self.type() === 'case' && hqImport('hqwebapp/js/toggles').previewEnabled('SPLIT_MULTISELECT_CASE_EXPORT')) {
+                width--;
+            }
+            if (self.isDeidColumnVisible()) {
+                width--;
+            }
+            return "col-sm-" + width;
+        });
+        self.displayColumnClass = ko.computed(function() {
+            var width = 5;
+            if (self.type() === 'case' && hqImport('hqwebapp/js/toggles').previewEnabled('SPLIT_MULTISELECT_CASE_EXPORT')) {
+                width--;
+            }
+            if (self.isDeidColumnVisible()) {
+                width--;
+            }
+            return "col-sm-" + width;
+        });
+
         self.hasHtmlFormat = ko.pureComputed(function() {
             return this.export_format() === constants.EXPORT_FORMATS.HTML;
         }, self);

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -141,12 +141,12 @@
                         name: 'ko-export-column-template'
                     }
                 ">
-                    <tr class="sortable-handle" data-bind="
+                    <tr data-bind="
                         visible: column.isVisible($parent),
                         attr: {'data-order': _sortableOrder}
                         ">
                         <td class="text-center">
-                            <span class="sortable-handle" style="cursor: move;">
+                            <span class="sortable-handle">
                                 <i class="fa fa-arrows-v"></i>
                             </span>
                             &nbsp;&nbsp;&nbsp;

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -27,41 +27,6 @@
             <!-- /ko -->
         </legend>
         <div class="col-sm-12" data-bind="visibleFade: table.selected">
-            <div class="form-group pull-right btn-group">
-                <!-- Advanced Button -->
-                <button type="button" class="btn btn-default" data-bind="
-                    click: table.toggleShowAdvanced,
-                    css: {active: table.showAdvanced}">
-                    <span data-bind="visible: !table.showAdvanced()">
-                    {% trans "Show Advanced Questions" %}
-                    </span>
-                    <span data-bind="visible: table.showAdvanced">
-                    {% trans "Hide Advanced Questions" %}
-                    </span>
-                </button>
-
-                <!-- Deleted Button -->
-                <button class="btn btn-default" data-bind="
-                    click: $root.toggleShowDeleted.bind($root),
-                    css: {active: table.showDeleted}
-                    ">
-                    <span data-bind="visible: !table.showDeleted()">
-                    {% if export_instance.type == 'form' %}
-                        {% trans "Show Deleted Questions" %}
-                    {% else %}
-                        {% trans "Show Deleted Properties" %}
-                    {% endif %}
-                    </span>
-
-                    <span data-bind="visible: table.showDeleted()">
-                    {% if export_instance.type == 'form' %}
-                        {% trans "Hide Deleted Questions" %}
-                    {% else %}
-                        {% trans "Hide Deleted Properties" %}
-                    {% endif %}
-                    </span>
-                </button>
-            </div>
             <div class="form-group">
                 <label class="col-sm-4 col-md-3 col-lg-2 control-label">{% trans "Sheet Name" %}</label>
                 <div class="col-sm-9 col-md-8 col-lg-6">
@@ -85,16 +50,51 @@
                 <thead>
                 <tr class="nodrag nodrop">
                     <th class="col-sm-1"></th>
-                    <th class="col-sm-1">{% trans "Include this Field?" %}<br />
+                    <th class="col-sm-1">{% trans "Include?" %}<br />
                         <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
                         <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
                     </th>
                     <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
-                    {% if export_instance.type == 'form' %}
-                        {% trans "Question" %}
-                    {% else %}
-                        {% trans "Property" %}
-                    {% endif %}
+                        {% if export_instance.type == 'form' %}
+                            {% trans "Question" %}
+                        {% else %}
+                            {% trans "Property" %}
+                        {% endif %}
+                        <br />
+
+                        <!-- Advanced Button -->
+                        <button type="button" class="btn btn-default btn-xs" data-bind="
+                            click: table.toggleShowAdvanced,
+                            css: {active: table.showAdvanced}">
+                            <span data-bind="visible: !table.showAdvanced()">
+                            {% trans "Show Advanced Questions" %}
+                            </span>
+                            <span data-bind="visible: table.showAdvanced">
+                            {% trans "Hide Advanced Questions" %}
+                            </span>
+                        </button>
+
+                        <!-- Deleted Button -->
+                        <button class="btn btn-default btn-xs" data-bind="
+                            click: $root.toggleShowDeleted.bind($root),
+                            css: {active: table.showDeleted}
+                            ">
+                            <span data-bind="visible: !table.showDeleted()">
+                            {% if export_instance.type == 'form' %}
+                                {% trans "Show Deleted Questions" %}
+                            {% else %}
+                                {% trans "Show Deleted Properties" %}
+                            {% endif %}
+                            </span>
+
+                            <span data-bind="visible: table.showDeleted()">
+                            {% if export_instance.type == 'form' %}
+                                {% trans "Hide Deleted Questions" %}
+                            {% else %}
+                                {% trans "Hide Deleted Properties" %}
+                            {% endif %}
+                            </span>
+                        </button>
                     </th>
                     <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
                         {% trans "Display" %}<br />

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -188,9 +188,10 @@
                                         'data-toggle': column.help_text ? 'tooltip' : null
                                     },
                                     css: {
-                                        'export-tooltip': column.translatedHelp()
+                                        'export-tooltip': column.translatedHelp(),
+                                        'break-all-words': 1,
                                     }
-                                " style="word-break: break-all;"></code>
+                                "></code>
                             <!-- /ko -->
                             <!-- ko if: column.isEditable() -->
                             <input

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -53,7 +53,7 @@
                         <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
                         <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
                     </th>
-                    <th class="col-sm-6"><!-- TODO: shrink if extra columns are present -->
+                    <th data-bind="attr: { 'class': $root.questionColumnClass }">
                         {% if export_instance.type == 'form' %}
                             {% trans "Question" %}
                         {% else %}
@@ -95,7 +95,7 @@
                             </span>
                         </button>
                     </th>
-                    <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
+                    <th data-bind="attr: { 'class': $root.displayColumnClass }">
                         {% trans "Display" %}<br />
                         {% if export_instance.type == 'form' %}
                         <a
@@ -114,7 +114,7 @@
                     <th class="col-sm-2">{% trans "Type" %}</th>
                     {% endif %}
                     {% if allow_deid %}
-                    <th class="col-sm-2" class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
+                    <th class="col-sm-2 deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
                     {% endif %}
                 </tr>
                 </thead>

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -190,7 +190,7 @@
                             <!-- ko if: !column.isEditable() -->
                             <code data-toggle="tooltip" data-placement="top"
                                 data-bind="
-                                    text: column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty(),
+                                    text: column.formatProperty(),
                                     attr: {
                                         'data-original-title': column.help_text,
                                         'data-toggle': column.help_text ? 'tooltip' : null

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -111,7 +111,15 @@
                         {% endif %}
                     </th>
                     {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
-                    <th class="col-sm-2">{% trans "Type" %}</th>
+                    <th class="col-sm-2">
+                        {% trans "Type" %}
+                        <span data-bind="
+                            makeHqHelp: {
+                                name: '{% trans "Split multi-select data" %}',
+                                placement: 'left'
+                            }
+                        "></span>
+                    </th>
                     {% endif %}
                     {% if allow_deid %}
                     <th class="col-sm-2 deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
@@ -213,12 +221,6 @@
                                     submit: column.addUserDefinedOption
                                 ">
                                 <div class="form-group">
-                                    <span class="pull-right" data-bind="
-                                        makeHqHelp: {
-                                            name: '{% trans "Split multi-select data" %}',
-                                            placement: 'left'
-                                        }
-                                    "></span>
                                     <select style="width:200px" class="form-control" data-bind="
                                         options: hqImport('export/js/const').USER_DEFINED_SPLIT_TYPES,
                                         value: column.split_type,

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -87,19 +87,19 @@
                     <table class="table table-bordered table-striped table-condensed" id="field-select">
                         <thead>
                         <tr class="nodrag nodrop">
-                            <th></th>
-                            <th>{% trans "Include this Field?" %}<br />
+                            <th class="col-sm-1"></th>
+                            <th class="col-sm-1">{% trans "Include this Field?" %}<br />
                                 <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
                                 <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
                             </th>
-                            <th>
+                            <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
                             {% if export_instance.type == 'form' %}
                                 {% trans "Question" %}
                             {% else %}
                                 {% trans "Property" %}
                             {% endif %}
                             </th>
-                            <th>
+                            <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
                                 {% trans "Display" %}<br />
                                 {% if export_instance.type == 'form' %}
                                 <a
@@ -115,10 +115,10 @@
                                 {% endif %}
                             </th>
                             {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
-                            <th>{% trans "Type" %}</th>
+                            <th class="col-sm-2">{% trans "Type" %}</th>
                             {% endif %}
                             {% if allow_deid %}
-                            <th class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
+                            <th class="col-sm-2" class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
                             {% endif %}
                         </tr>
                         </thead>
@@ -185,7 +185,7 @@
                                     <!-- ko if: !column.isEditable() -->
                                     <code data-toggle="tooltip" data-placement="top"
                                         data-bind="
-                                            text: column.formatProperty(),
+                                            text: column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty(),
                                             attr: {
                                                 'data-original-title': column.help_text,
                                                 'data-toggle': column.help_text ? 'tooltip' : null
@@ -193,7 +193,7 @@
                                             css: {
                                                 'export-tooltip': column.translatedHelp()
                                             }
-                                        "></code>
+                                        " style="word-break: break-all;"></code>
                                     <!-- /ko -->
                                     <!-- ko if: column.isEditable() -->
                                     <input
@@ -283,11 +283,10 @@
                                 </td>
                                 {% endif %}
                             </tr>
-
                         </tbody>
                     </table>
-                </div>
-            </div>
+                </div><!-- end .col-md-X -->
+            </div><!-- end .form-group -->
         </div>
     </div>
 </script>

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -76,217 +76,212 @@
                 </div>
             </div>
             <!-- /ko -->
-            <div class="form-group">
-                <label class="col-md-3 col-lg-2 control-label">
-                    <strong>{% trans "Choose the fields you want to export." %}</strong><br />
-                    <span style="font-weight: normal">
-                    {% trans "You can drag and drop fields to reorder them.  You can also rename fields, which will update the headers in the export file." %}
-                    </span>
-                </label>
-                <div class="col-md-9 col-lg-10">
-                    <table class="table table-bordered table-striped table-condensed" id="field-select">
-                        <thead>
-                        <tr class="nodrag nodrop">
-                            <th class="col-sm-1"></th>
-                            <th class="col-sm-1">{% trans "Include this Field?" %}<br />
-                                <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
-                                <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
-                            </th>
-                            <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
-                            {% if export_instance.type == 'form' %}
-                                {% trans "Question" %}
-                            {% else %}
-                                {% trans "Property" %}
-                            {% endif %}
-                            </th>
-                            <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
-                                {% trans "Display" %}<br />
-                                {% if export_instance.type == 'form' %}
-                                <a
-                                    class="btn btn-xs"
-                                    data-bind="click: table.useLabels, css: { 'btn-primary': table.displayType() === 'labels', 'btn-default': table.displayType() !== 'labels'}">
-                                    {% trans "Use question labels" %}
-                                </a>
-                                <a
-                                    class="btn btn-xs"
-                                    data-bind="click: table.useIds, css: { 'btn-primary': table.displayType() === 'ids', 'btn-default': table.displayType() !== 'ids'}">
-                                    {% trans "Use question ids" %}
-                                </a>
-                                {% endif %}
-                            </th>
-                            {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
-                            <th class="col-sm-2">{% trans "Type" %}</th>
-                            {% endif %}
-                            {% if allow_deid %}
-                            <th class="col-sm-2" class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
-                            {% endif %}
-                        </tr>
-                        </thead>
+            <h4>{% trans "Choose the fields you want to export." %}</h4>
+            <div class="help-block">
+                {% trans "You can drag and drop fields to reorder them.  You can also rename fields, which will update the headers in the export file." %}
+            </div>
 
-
-                        {% if request|toggle_enabled:"ALLOW_USER_DEFINED_EXPORT_COLUMNS" %}
-                        <tfoot>
-                            <tr>
-                                <td colspan="100%">
-                                    <button class="btn btn-default btn-sm" data-bind="
-                                        click: table.addUserDefinedExportColumn
-                                    ">
-                                    {% trans "Add custom export property" %}
-                                    </button>
-                                </td>
-                            </tr>
-                        </tfoot>
+            <table class="table table-bordered table-striped table-condensed" id="field-select">
+                <thead>
+                <tr class="nodrag nodrop">
+                    <th class="col-sm-1"></th>
+                    <th class="col-sm-1">{% trans "Include this Field?" %}<br />
+                        <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
+                        <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
+                    </th>
+                    <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
+                    {% if export_instance.type == 'form' %}
+                        {% trans "Question" %}
+                    {% else %}
+                        {% trans "Property" %}
+                    {% endif %}
+                    </th>
+                    <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
+                        {% trans "Display" %}<br />
+                        {% if export_instance.type == 'form' %}
+                        <a
+                            class="btn btn-xs"
+                            data-bind="click: table.useLabels, css: { 'btn-primary': table.displayType() === 'labels', 'btn-default': table.displayType() !== 'labels'}">
+                            {% trans "Use question labels" %}
+                        </a>
+                        <a
+                            class="btn btn-xs"
+                            data-bind="click: table.useIds, css: { 'btn-primary': table.displayType() === 'ids', 'btn-default': table.displayType() !== 'ids'}">
+                            {% trans "Use question ids" %}
+                        </a>
                         {% endif %}
+                    </th>
+                    {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
+                    <th class="col-sm-2">{% trans "Type" %}</th>
+                    {% endif %}
+                    {% if allow_deid %}
+                    <th class="col-sm-2" class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
+                    {% endif %}
+                </tr>
+                </thead>
 
-                        <tbody data-bind="
-                            sortable: {
-                                data: table.columns,
-                                as: 'column',
-                                name: 'ko-export-column-template'
-                            }
+
+                {% if request|toggle_enabled:"ALLOW_USER_DEFINED_EXPORT_COLUMNS" %}
+                <tfoot>
+                    <tr>
+                        <td colspan="100%">
+                            <button class="btn btn-default btn-sm" data-bind="
+                                click: table.addUserDefinedExportColumn
+                            ">
+                            {% trans "Add custom export property" %}
+                            </button>
+                        </td>
+                    </tr>
+                </tfoot>
+                {% endif %}
+
+                <tbody data-bind="
+                    sortable: {
+                        data: table.columns,
+                        as: 'column',
+                        name: 'ko-export-column-template'
+                    }
+                ">
+                    <tr class="sortable-handle" data-bind="
+                        visible: column.isVisible($parent),
+                        attr: {'data-order': _sortableOrder}
                         ">
-                            <tr class="sortable-handle" data-bind="
-                                visible: column.isVisible($parent),
-                                attr: {'data-order': _sortableOrder}
+                        <td class="sortable-handle text-center">
+                            <i class="fa fa-arrows-v"></i>
+                        </td>
+                        <td>
+                            <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
+                            <input type="checkbox"
+                                   class="field-include"
+                                   disabled="disabled" />
+                            <!--/ko-->
+                            <!--ko ifnot: ($root.is_deidentified() && column.item.isCaseName()) -->
+                            <input type="checkbox"
+                                   class="field-include"
+                                   data-bind="checked: column.selected" />
+                            <!--/ko-->
+                            <!-- ko if: column.isEditable() -->
+                            <div class="remove-user-defined-column pull-right">
+                                <button class="btn btn-danger btn-xs" data-bind="
+                                    click: function() {
+                                        $parent.columns.remove(column)
+                                    }
                                 ">
-                                <td class="sortable-handle text-center">
-                                    <i class="fa fa-arrows-v"></i>
-                                </td>
-                                <td>
-                                    <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
-                                    <input type="checkbox"
-                                           class="field-include"
-                                           disabled="disabled" />
-                                    <!--/ko-->
-                                    <!--ko ifnot: ($root.is_deidentified() && column.item.isCaseName()) -->
-                                    <input type="checkbox"
-                                           class="field-include"
-                                           data-bind="checked: column.selected" />
-                                    <!--/ko-->
-                                    <!-- ko if: column.isEditable() -->
-                                    <div class="remove-user-defined-column pull-right">
-                                        <button class="btn btn-danger btn-xs" data-bind="
-                                            click: function() {
-                                                $parent.columns.remove(column)
-                                            }
-                                        ">
-                                        {% trans "Remove" %}
-                                        </button>
-                                    </div>
-                                    <!-- /ko -->
-                                </td>
-                                <td>
-                                    <span data-bind="foreach: { data: column.tags, as: 'tag' }">
-                                        <span data-bind="
-                                            text: tag,
-                                            attr: { class: hqImport('export/js/utils').getTagCSSClass(tag) }"></span>
-                                    </span>
+                                {% trans "Remove" %}
+                                </button>
+                            </div>
+                            <!-- /ko -->
+                        </td>
+                        <td>
+                            <span data-bind="foreach: { data: column.tags, as: 'tag' }">
+                                <span data-bind="
+                                    text: tag,
+                                    attr: { class: hqImport('export/js/utils').getTagCSSClass(tag) }"></span>
+                            </span>
 
-                                    <!-- ko if: !column.isEditable() -->
-                                    <code data-toggle="tooltip" data-placement="top"
-                                        data-bind="
-                                            text: column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty(),
-                                            attr: {
-                                                'data-original-title': column.help_text,
-                                                'data-toggle': column.help_text ? 'tooltip' : null
-                                            },
-                                            css: {
-                                                'export-tooltip': column.translatedHelp()
-                                            }
-                                        " style="word-break: break-all;"></code>
-                                    <!-- /ko -->
-                                    <!-- ko if: column.isEditable() -->
-                                    <input
-                                        type="text"
-                                        class="form-control"
-                                        data-bind="
-                                            value: column.customPathString
-                                        "
-                                    />
-                                    <!-- /ko -->
-                                </td>
-                                <td><input class="form-control" type="text" data-bind="value: column.label" /></td>
-                                {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
-                                <td>
-                                    <form
-                                        class="form-horizontal col-xs-12"
-                                        data-bind="
-                                            if: column.doc_type() === 'SplitUserDefinedExportColumn',
-                                            submit: column.addUserDefinedOption
-                                        ">
-                                        <div class="form-group">
-                                            <span class="pull-right" data-bind="
-                                                makeHqHelp: {
-                                                    name: '{% trans "Split multi-select data" %}',
-                                                    placement: 'left'
-                                                }
-                                            "></span>
-                                            <select style="width:200px" class="form-control" data-bind="
-                                                options: hqImport('export/js/const').USER_DEFINED_SPLIT_TYPES,
-                                                value: column.split_type,
-                                            "/></select>
-                                        </div>
-                                        <!-- ko if: column.split_type() === hqImport('export/js/const').MULTISELECT_SPLIT_TYPE -->
-                                        <div class="form-group">
-                                            <button class="btn btn-default btn-xs" data-bind="
-                                                visible: !column.showOptions(),
-                                                click: function() {column.showOptions(true);}
-                                            ">{% trans "Show Options" %}</button>
+                            <!-- ko if: !column.isEditable() -->
+                            <code data-toggle="tooltip" data-placement="top"
+                                data-bind="
+                                    text: column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty() + column.formatProperty(),
+                                    attr: {
+                                        'data-original-title': column.help_text,
+                                        'data-toggle': column.help_text ? 'tooltip' : null
+                                    },
+                                    css: {
+                                        'export-tooltip': column.translatedHelp()
+                                    }
+                                " style="word-break: break-all;"></code>
+                            <!-- /ko -->
+                            <!-- ko if: column.isEditable() -->
+                            <input
+                                type="text"
+                                class="form-control"
+                                data-bind="
+                                    value: column.customPathString
+                                "
+                            />
+                            <!-- /ko -->
+                        </td>
+                        <td><input class="form-control" type="text" data-bind="value: column.label" /></td>
+                        {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
+                        <td>
+                            <form
+                                class="form-horizontal col-xs-12"
+                                data-bind="
+                                    if: column.doc_type() === 'SplitUserDefinedExportColumn',
+                                    submit: column.addUserDefinedOption
+                                ">
+                                <div class="form-group">
+                                    <span class="pull-right" data-bind="
+                                        makeHqHelp: {
+                                            name: '{% trans "Split multi-select data" %}',
+                                            placement: 'left'
+                                        }
+                                    "></span>
+                                    <select style="width:200px" class="form-control" data-bind="
+                                        options: hqImport('export/js/const').USER_DEFINED_SPLIT_TYPES,
+                                        value: column.split_type,
+                                    "/></select>
+                                </div>
+                                <!-- ko if: column.split_type() === hqImport('export/js/const').MULTISELECT_SPLIT_TYPE -->
+                                <div class="form-group">
+                                    <button class="btn btn-default btn-xs" data-bind="
+                                        visible: !column.showOptions(),
+                                        click: function() {column.showOptions(true);}
+                                    ">{% trans "Show Options" %}</button>
 
-                                            <button class="btn btn-default btn-xs" data-bind="
-                                                visible: column.showOptions(),
-                                                click: function() {column.showOptions(false);}
-                                            ">{% trans "Hide Options" %}</button>
-                                        </div>
-                                        <div data-bind="visible: column.showOptions()">
-                                            <ul class="list-group" data-bind="
-                                                foreach: column.user_defined_options
-                                            ">
-                                                <li class="list-group-item">
-                                                    <span data-bind="text: $data"></span>
-                                                    <i
-                                                        style="cursor: pointer"
-                                                        class="text-danger fa fa-trash pull-right"
-                                                        data-bind="click: column.removeUserDefinedOption.bind(column)"
-                                                        ></i>
-                                                </li>
-                                            </ul>
-                                            <div class="form-group">
-                                                <div style="max-width: 200px" class="input-group">
-                                                    <input
-                                                        class="form-control input-sm"
-                                                        type="text"
-                                                        data-bind="value: column.userDefinedOptionToAdd"/>
-                                                    <span class="input-group-btn">
-                                                        <button
-                                                            type="submit"
-                                                            class="btn btn-default btn-sm"
-                                                            data-bind="click: column.addUserDefinedOption">
-                                                        {% trans "Add" %}
-                                                        </button>
-                                                    </span>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <!-- /ko -->
-                                    </div>
-                                </td>
-                                {% endif %}
-                                {% if allow_deid %}
-                                <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
-                                    <select class="form-control" data-bind="
-                                        value: deid_transform,
-                                        options: getDeidOptions(),
-                                        optionsText: getDeidOptionText
+                                    <button class="btn btn-default btn-xs" data-bind="
+                                        visible: column.showOptions(),
+                                        click: function() {column.showOptions(false);}
+                                    ">{% trans "Hide Options" %}</button>
+                                </div>
+                                <div data-bind="visible: column.showOptions()">
+                                    <ul class="list-group" data-bind="
+                                        foreach: column.user_defined_options
                                     ">
-                                    </select>
-                                </td>
-                                {% endif %}
-                            </tr>
-                        </tbody>
-                    </table>
-                </div><!-- end .col-md-X -->
-            </div><!-- end .form-group -->
+                                        <li class="list-group-item">
+                                            <span data-bind="text: $data"></span>
+                                            <i
+                                                style="cursor: pointer"
+                                                class="text-danger fa fa-trash pull-right"
+                                                data-bind="click: column.removeUserDefinedOption.bind(column)"
+                                                ></i>
+                                        </li>
+                                    </ul>
+                                    <div class="form-group">
+                                        <div style="max-width: 200px" class="input-group">
+                                            <input
+                                                class="form-control input-sm"
+                                                type="text"
+                                                data-bind="value: column.userDefinedOptionToAdd"/>
+                                            <span class="input-group-btn">
+                                                <button
+                                                    type="submit"
+                                                    class="btn btn-default btn-sm"
+                                                    data-bind="click: column.addUserDefinedOption">
+                                                {% trans "Add" %}
+                                                </button>
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- /ko -->
+                            </div>
+                        </td>
+                        {% endif %}
+                        {% if allow_deid %}
+                        <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
+                            <select class="form-control" data-bind="
+                                value: deid_transform,
+                                options: getDeidOptions(),
+                                optionsText: getDeidOptionText
+                            ">
+                            </select>
+                        </td>
+                        {% endif %}
+                    </tr>
+                </tbody>
+            </table>
         </div>
     </div>
 </script>

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -49,12 +49,11 @@
             <table class="table table-bordered table-striped table-condensed" id="field-select">
                 <thead>
                 <tr class="nodrag nodrop">
-                    <th class="col-sm-1"></th>
                     <th class="col-sm-1">{% trans "Include?" %}<br />
                         <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
                         <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
                     </th>
-                    <th class="col-sm-5"><!-- TODO: shrink if extra columns are present -->
+                    <th class="col-sm-6"><!-- TODO: shrink if extra columns are present -->
                         {% if export_instance.type == 'form' %}
                             {% trans "Question" %}
                         {% else %}
@@ -146,10 +145,11 @@
                         visible: column.isVisible($parent),
                         attr: {'data-order': _sortableOrder}
                         ">
-                        <td class="sortable-handle text-center">
-                            <i class="fa fa-arrows-v"></i>
-                        </td>
-                        <td>
+                        <td class="text-center">
+                            <span class="sortable-handle" style="cursor: move;">
+                                <i class="fa fa-arrows-v"></i>
+                            </span>
+                            &nbsp;&nbsp;&nbsp;
                             <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
                             <input type="checkbox"
                                    class="field-include"

--- a/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
@@ -11,11 +11,6 @@ nav.appmanager-content {
   margin-bottom: 20px;
 }
 
-// Used to indicate sortable table rows (i.e., case list rows)
-.sortable-handle {
-  cursor: move;
-}
-
 @z-index-trash: 20;
 
 @appnav-width: @app-manager-sidebar-width;

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/tables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/tables.less
@@ -10,6 +10,10 @@
   color: #ffffff;
 }
 
+.sortable-handle {
+  cursor: move;
+}
+
 .table-editprops {
 
   table-layout: fixed;

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/key_value_mapping.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/key_value_mapping.html
@@ -8,7 +8,7 @@
                             attr: {'data-order': _sortableOrder}">
                 <div class="row">
                     <div class="col-sm-1">
-                        <i class="sortable-handle fa fa-arrows-v"  style="cursor: move;"></i>
+                        <i class="sortable-handle fa fa-arrows-v"></i>
                     </div>
 
                         <div class="col-sm-3">

--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -87,7 +87,7 @@ TODO:
     {# the .hide().fadeIn() will fail badly on FireFox #}
     ><tr data-bind="attr: {'data-order': _sortableOrder}">
         <td>
-            <i class="grip sortable-handle" style="cursor: move;" data-bind="
+            <i class="grip sortable-handle" data-bind="
                 css: hqImport('hqwebapp/js/main').icons.GRIP + ' hq-icon-full'
             "></i>
         </td>


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?274337

The main fix is to change the line breaking to allow breaking mid-word, which is a little ugly but I think better than the horizontal scrolling and tiny text boxes.

@esoergel / @biyeun 

Before:
<img width="1357" alt="screen shot 2018-05-07 at 4 39 39 pm" src="https://user-images.githubusercontent.com/1486591/39723920-473897e2-5215-11e8-87c0-c60d5f87f12f.png">

After:
<img width="1173" alt="screen shot 2018-05-07 at 4 41 43 pm" src="https://user-images.githubusercontent.com/1486591/39724038-997aaffe-5215-11e8-9c7c-7ce9aa2ba386.png">
