### PR TITLE
Only show "Data Corrections" if there is data to correct

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -312,7 +312,7 @@
     {% if show_properties_edit or show_case_rebuild or not case.closed and not is_usercase %}
     <div id="case-actions" class="clearfix form-actions">
         <div class="col-sm-12">
-        {% if show_properties_edit %}
+        {% if show_properties_edit and dynamic_properties %}
             <button type="button" class="btn btn-default pull-left" id="edit-dynamic-properties-trigger">
                 <i class="fa fa-edit"></i>
                 {% trans 'Data Corrections' %}


### PR DESCRIPTION
Context: [FB 275419](https://manage.dimagi.com/default.asp?275419)

This just adds another condition for showing the "Data Corrections" button. 

I considered disabling the button, but the page already uses conditions to determine whether to render buttons, and so I used that approach. I rationalised that we should either show it and offer users the ability to create new properties, or hide it completely, because showing them a button that they can only enable by creating case properties using form submissions could be frustrating.

If people think it would be better to offer the ability to create new case properties than hide the button, or have another opinion, I'm open to suggestions.
