### PR TITLE
Remove inline js from help_bubble.html

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/help_bubble.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/help_bubble.html
@@ -3,11 +3,4 @@
         data-title="{{ field.label }}"
         data-content="{{ help_bubble_text }}"
     ></span>
-    <script>
-        $(function () {
-            $('.hq-help-template').each(function () {
-                hqImport("hqwebapp/js/main").transformHelpTemplate($(this), true);
-            });
-        });
-    </script>
 {% endif %}


### PR DESCRIPTION
This logic is also in [main.js](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/main.js#L85-L87). Verified that the forms using `FieldWithHelpBubble` (`SettingsForm` in sms, `BaseScheduleCaseReminder`, `DataSourceForm` in report builder, `ReprocessMessagingCaseUpdatesForm`) are normal forms that appear on page load and will be covered by main.js.

@esoergel / @jmtroth0 / @gcapalbo 