### PR TITLE
Add `preview` to getDetails params

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -111,6 +111,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
 
     FormplayerFrontend.reqres.setHandler("entity:get:details", function (options, isPersistent) {
         options.isPersistent = isPersistent;
+        options.preview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         return Menus.API.queryFormplayer(options, 'get_details');
     });
 });


### PR DESCRIPTION
The route for getting case details is different from other queries and doesn't have the `preview` boolean yet; add it. 