### PR TITLE
Remove JSON for loc_id property

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/location_async.html
+++ b/corehq/apps/reports/templates/reports/filters/location_async.html
@@ -16,7 +16,7 @@
 <div class="form-group report-filter-location-async"
      data-bind="visible: show_location_filter_bool()"
      data-make-optional='{{ make_optional|JSON }}'
-     data-loc-id='{{ loc_id|JSON }}'
+     data-loc-id='{{ loc_id }}'
      data-location-url='{{ api_root }}'
      data-hierarchy='{{ hierarchy|JSON }}'
      data-auto-drill='{{ auto_drill|JSON }}'


### PR DESCRIPTION
Hi @jmtroth0 

I fix the problem after your changes in this commit: 338f113ff0f366790e4bcec75e7903c9fb4b222c

If we use ```JSON``` on the string value we will have on double quotes on the beginning and on the end of string, something like ```""example string""``` but we want ```"example string"```.

Please let me know if you have any questions.

Regards,
Łukasz