### PR TITLE
Add datadog counter for partial es results

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -18,14 +18,13 @@ from corehq.apps.api.util import object_does_not_exist
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.es.utils import flatten_field_dict
 from corehq.apps.reports.filters.forms import FormsByApplicationFilter
-from corehq.elastic import ESError, get_es_new
+from corehq.elastic import ESError, get_es_new, report_shard_failures
 from corehq.pillows.base import restore_property_dict, VALUE_TAG
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX
-from corehq.util.datadog.gauges import datadog_counter
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 from no_exceptions.exceptions import Http400
@@ -146,8 +145,7 @@ class ESView(View):
 
         try:
             es_results = self.es.search(self.index, es_type, body=es_query)
-            if es_results.get('_shards', {}).get('failed'):
-                datadog_counter('commcare.es.partial_results', value=1)
+            report_shard_failures(es_results)
         except ElasticsearchException as e:
             if 'query_string' in es_query.get('query', {}).get('filtered', {}).get('query', {}):
                 # the error may have been caused by a bad query string
@@ -334,8 +332,7 @@ class UserES(ESView):
 
         try:
             es_results = self.es.search(self.index, es_type, body=es_query)
-            if es_results.get('_shards', {}).get('failed'):
-                datadog_counter('commcare.es.partial_results', value=1)
+            report_shard_failures(es_results)
         except ElasticsearchException as e:
             msg = "Error in elasticsearch query [%s]: %s\nquery: %s" % (
                 self.index, str(e), es_query)

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -421,6 +421,8 @@ def es_query(params=None, facets=None, terms=None, q=None, es_index=None, start_
 
     try:
         result = es.search(meta.index, meta.type, body=q)
+        if result.get('_shards', {}).get('failed'):
+            datadog_counter('commcare.es.partial_results', value=1)
     except ElasticsearchException as e:
         raise ESError(e)
 

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -12,7 +12,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ElasticsearchException
 
 from corehq.apps.es.utils import flatten_field_dict
-from corehq.util.datadog.gauges import datadog_counter, datadog_histogram
+from corehq.util.datadog.gauges import datadog_counter
 from corehq.pillows.mappings.app_mapping import APP_INDEX
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO


### PR DESCRIPTION
Want to see if shard failures are what is causing partial results to be returned from ES. 