### PR TITLE
Remove inline js from multi_field.html

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/multi_field.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/multi_field.html
@@ -6,13 +6,6 @@
                 data-title="{{ multifield.label_html }}"
                 data-content="{{ help_bubble_text }}"
             ></span>
-            <script>
-                $(function () {
-                    $('.hq-help-template').each(function () {
-                      hqImport("hqwebapp/js/main").transformHelpTemplate($(this), true);
-                    });
-                });
-            </script>
         {% endif %}
     </label>
     <div class="controls {{ field_class }} controls-multiple">


### PR DESCRIPTION
Same idea as https://github.com/dimagi/commcare-hq/pull/20493 B3MultiField with help text is used in sms settings, AddAutomaticCaseUpdateRuleForm, and the schedule case reminder forms, which are all normal forms that are already taken care of by main.js.

@esoergel / @gcapalbo 