### PR TITLE
Search for case property existence

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -145,7 +145,7 @@ def build_filter_from_ast(domain, node):
                 return filters.AND(case_property_exists(case_property_name), filters.NOT(q))
             if value == '' and node.op == '=':
                 # e.g. `foo = ''`
-                # The user is asking for all cases where the case property is either the empty string ('') or not set
+                # The user is asking for all cases where the case is either the empty string ('') or not set
                 return filters.OR(filters.NOT(case_property_exists(case_property_name)), q)
             if node.op == '!=':
                 return filters.NOT(q)

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -10,6 +10,7 @@ hqDefine('case_search/js/case_search', function(){
         self.includeClosed = ko.observable(false);
         self.results = ko.observableArray();
         self.count = ko.observable();
+        self.took = ko.observable();
         self.case_data_url = caseDataUrl;
         self.xpath = ko.observable();
         self.parameters = ko.observableArray();
@@ -30,6 +31,7 @@ hqDefine('case_search/js/case_search', function(){
         self.submit = function(){
             self.results([]);
             self.count("-");
+            self.took(null);
             $.post({
                 url: window.location.href,
                 data: {q: JSON.stringify({
@@ -44,6 +46,7 @@ hqDefine('case_search/js/case_search', function(){
                 success: function(data){
                     self.results(data.values);
                     self.count(data.count);
+                    self.took(data.took);
                 },
                 error: function(response){
                     var alertUser = hqImport("hqwebapp/js/alert_user").alert_user;

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -11,6 +11,7 @@ hqDefine('case_search/js/case_search', function(){
         self.results = ko.observableArray();
         self.count = ko.observable();
         self.took = ko.observable();
+        self.query = ko.observable();
         self.case_data_url = caseDataUrl;
         self.xpath = ko.observable();
         self.parameters = ko.observableArray();
@@ -32,6 +33,7 @@ hqDefine('case_search/js/case_search', function(){
             self.results([]);
             self.count("-");
             self.took(null);
+            self.query(null);
             $.post({
                 url: window.location.href,
                 data: {q: JSON.stringify({
@@ -47,6 +49,7 @@ hqDefine('case_search/js/case_search', function(){
                     self.results(data.values);
                     self.count(data.count);
                     self.took(data.took);
+                    self.query(data.query);
                 },
                 error: function(response){
                     var alertUser = hqImport("hqwebapp/js/alert_user").alert_user;

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -118,7 +118,12 @@
 
         <div class="row">
             <div class="col-sm-12">
-                <h3>{% trans "Results" %} <small data-bind="text: count"></small></h3>
+                <h3>{% trans "Results" %}
+                    <small data-bind="visible: count">
+                        <span data-bind="text: count"></span> results
+                        <span data-bind="visible: took">in <span data-bind="text: took"></span>ms</span>
+                    </small>
+                </h3>
             </div>
             <div class="col-sm-12">
                 <table class="table table-striped">

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -125,6 +125,10 @@
                     </small>
                 </h3>
             </div>
+            <div class="col-sm-12" data-bind="visible: query">
+                <a role="button" data-toggle="collapse" data-target="#query">Show Query</a>
+                <pre id="query" class="collapse" data-bind="text: query"></pre>
+            </div>
             <div class="col-sm-12">
                 <table class="table table-striped">
                     <thead>

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -98,6 +98,63 @@ class TestFilterDsl(SimpleTestCase):
         }
         self.assertEqual(expected_filter, build_filter_from_ast("domain", parsed))
 
+    def test_case_property_existence(self):
+        self.maxDiff = None
+        parsed = parse_xpath("property != ''")
+        expected_filter = {
+            "and": (
+                {
+                    "nested": {
+                        "path": "case_properties",
+                        "query": {
+                            "filtered": {
+                                "filter": {
+                                    "term": {
+                                        "case_properties.key.exact": "property"
+                                    }
+                                },
+                                "query": {
+                                    "match_all": {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "not": {
+                        "nested": {
+                            "path": "case_properties",
+                            "query": {
+                                "filtered": {
+                                    "filter": {
+                                        "and": (
+                                            {
+                                                "term": {
+                                                    "case_properties.key.exact": "property"
+                                                }
+                                            },
+                                            {
+                                                "term": {
+                                                    "case_properties.value.exact": ""
+                                                }
+                                            }
+                                        )
+                                    },
+                                    "query": {
+                                        "match_all": {
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        }
+        self.assertEqual(expected_filter, build_filter_from_ast("domain", parsed))
+
+
     def test_nested_filter(self):
         parsed = parse_xpath("(name = 'farid' or name = 'leila') and dob <= '2017-02-11'")
         expected_filter = {

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -76,4 +76,8 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         if xpath:
             search = search.xpath_query(self.domain, xpath)
         search_results = search.run()
-        return json_response({'values': search_results.raw_hits, 'count': search_results.total})
+        return json_response({
+            'values': search_results.raw_hits,
+            'count': search_results.total,
+            'took': search_results.raw['took'],
+        })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -80,4 +80,5 @@ class CaseSearchView(DomainViewMixin, TemplateView):
             'values': search_results.raw_hits,
             'count': search_results.total,
             'took': search_results.raw['took'],
+            'query': search_results.query.dumps(pretty=True),
         })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -53,7 +53,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         include_closed = query.get("includeClosed", False)
         xpath = query.get("xpath")
         search = CaseSearchES()
-        search = search.domain(self.domain).size(CASE_SEARCH_MAX_RESULTS)
+        search = search.domain(self.domain).size(10)
         if not include_closed:
             search = search.is_closed(False)
         if case_type:

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -253,10 +253,11 @@ def reverse_index_case_query(case_ids, identifier=None):
         )
     )
 
+
 def case_property_exists(case_property_name):
     """Returns cases where case_property_name is set
-    """
 
+    """
     return queries.nested(
         CASE_PROPERTIES_PATH,
         queries.filtered(

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -253,6 +253,18 @@ def reverse_index_case_query(case_ids, identifier=None):
         )
     )
 
+def case_property_exists(case_property_name):
+    """Returns cases where case_property_name is set
+    """
+
+    return queries.nested(
+        CASE_PROPERTIES_PATH,
+        queries.filtered(
+            queries.match_all(),
+            filters.term('{}.key.exact'.format(CASE_PROPERTIES_PATH), case_property_name),
+        )
+    )
+
 
 def _base_property_query(case_property_name, query):
     return queries.nested(


### PR DESCRIPTION
Allows for queries `property = ''` and `property != ''` to work as users would expect them to. 

Also adds some more debugging stuff to the case search admin view thing to start getting a sense of how long these queries are taking in ES. 

:blowfish: / :fishing_pole_and_fish: 