### PR TITLE
Persona Field fixes

### DIFF
--- a/corehq/apps/analytics/README.md
+++ b/corehq/apps/analytics/README.md
@@ -67,8 +67,12 @@ We track various user properties as [Hubspot Contact Properties](http://knowledg
 #### Hubspot Form Submissions
 We use the hubspot form API to submit forms to hubspot via the `_send_form_to_hubspot` function in the analytics tasks file. You can look through that file for examples but the general procedure is to create a new function with the `@analytics_task()` decorator to make it asynchronous and ensure it is retried on failure. This function should then call `_send_form_to_hubspot` with the form id of the form you are trying to submit. All form ids are listed as constants at the top of the file, and new forms can be created on the hubspot site.
 
-#### Signup Related Hubspot Analytics
-Much of the analytics we use in hubspot are generated during the signup process. We send down those analytics in the `track_user_sign_in_on_hubspot` [function](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/analytics/tasks.py#L181). Both a dictionary or properties, and a special signup form are sent down then and if changes need to be made to sign up analytics, they should be made there.
+#### Sign-In and Sign-Up Hubspot Form Tracking
+A special signup form are sent down to hubspot in `track_user_sign_in_on_hubspot`. This is just for handling the specific hubspot forms during the sign in / sign up process.
+
+#### User Registration Hubspot Analytics
+Much of the analytics we use in hubspot are generated during the user registration process. We send down those analytics in the `track_web_user_registration_hubspot`.
+Any changes to user properties related to the registration forms should be made here.
 
 #### Testing
 

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -7,7 +7,6 @@ from corehq.apps.analytics.tasks import (
     track_user_sign_in_on_hubspot,
     HUBSPOT_COOKIE,
     update_hubspot_properties,
-    get_hubspot_fields_tracked_on_registration,
 )
 from corehq.apps.analytics.utils import get_meta
 from corehq.apps.registration.views import ProcessRegistrationView
@@ -165,6 +164,4 @@ def track_user_login(sender, request, user, **kwargs):
                 return
 
         meta = get_meta(request)
-        tracked_fields = get_hubspot_fields_tracked_on_registration(request, couch_user.get_email())
-        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta, request.path,
-                                            tracked_fields)
+        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta, request.path)

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -42,12 +42,6 @@ hqDefine('registration/js/new_user.ko', function () {
 
         _private.submitSuccessAnalytics = function (data) {
             _kissmetrics.track.event("Account Creation was Successful");
-            if (data.persona) {
-                _kissmetrics.track.event("Persona Field Filled Out", {
-                    personaChoice: data.persona,
-                    personaOther: data.persona_other,
-                });
-            }
             if (_private.isAbPhoneNumber) {
                 _kissmetrics.track.event("Phone Number Field Filled Out");
             }

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -22,8 +22,9 @@ from corehq.apps.analytics.tasks import (
     track_workflow,
     track_confirmed_account_on_hubspot,
     track_clicked_signup_on_hubspot,
-    update_hubspot_properties,
-    HUBSPOT_COOKIE)
+    HUBSPOT_COOKIE,
+    track_web_user_registration_hubspot,
+)
 from corehq.apps.analytics.utils import get_meta
 from corehq.apps.app_manager.dbaccessors import domain_has_apps
 from corehq.apps.domain.decorators import login_required
@@ -121,8 +122,9 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
             username=reg_form.cleaned_data['email'],
             password=reg_form.cleaned_data['password']
         )
+        web_user = WebUser.get_by_username(new_user.username)
+
         if 'phone_number' in reg_form.cleaned_data and reg_form.cleaned_data['phone_number']:
-            web_user = WebUser.get_by_username(new_user.username)
             web_user.phone_numbers.append(reg_form.cleaned_data['phone_number'])
             web_user.save()
 
@@ -131,7 +133,27 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
         if self.request.user_agent.is_mobile:
             toggles.MOBILE_SIGNUP_REDIRECT_AB_TEST_CONTROLLER.set(email, True)
 
-        track_workflow(email, "Requested new account")
+        # registration analytics
+        persona = reg_form.cleaned_data['persona']
+        persona_other = reg_form.cleaned_data['persona_other']
+        appcues_ab_test = toggles.APPCUES_AB_TEST.enabled(web_user.username,
+                                                          toggles.NAMESPACE_USER)
+
+        track_workflow(email, "Registered new account")
+        track_workflow(email, "Persona Field Filled Out", {
+            'personachoice': persona,
+            'personaother': persona_other,
+        })
+
+        track_web_user_registration_hubspot.delay(
+            web_user,
+            {
+                'buyer_persona': persona,
+                'buyer_persona_other': persona_other,
+                "appcues_test": "On" if appcues_ab_test else "Off",
+            }
+        )
+
         login(self.request, new_user)
 
     @allow_remote_invocation


### PR DESCRIPTION
Something strange is happening causing the persona fields to be dropped on a small number of new user registrations. This might be due to the fact that properties are collected and sent on the sign up signal and any form information is taken from the request, not directly from the form.

So, for added clarity and more straightforward application, I added just the hubspot tracking properties related to user registration exactly where it belongs: directly at user registration, not after the login signal so that it has to detect if the request was a sign in or sign up and who knows what other strange stuff is happening with the form data...

I also moved the kissmetrics tracking to using the backend to send data, as there seems to be another strange issue with the javascript implementation. It will at least eliminate the possibility of adblock tinkering for the core registration analytics.

@orangejenny / @calellowitz 