### PR TITLE
Allow new reminders migrator to see reminder configurations for community projects

### DIFF
--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -57,6 +57,7 @@ from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.messaging.decorators import reminders_framework_permission
 from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -70,11 +71,6 @@ ACTION_ACTIVATE = 'activate'
 ACTION_DEACTIVATE = 'deactivate'
 ACTION_DELETE = 'delete'
 
-reminders_framework_permission = lambda *args, **kwargs: (
-    require_permission(Permissions.edit_data)(
-        requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK)(*args, **kwargs)
-    )
-)
 
 survey_reminders_permission = lambda *args, **kwargs: (
     require_permission(Permissions.edit_data)(

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -106,10 +106,9 @@ class ScheduledRemindersCalendarView(BaseMessagingSectionView):
     template_name = 'reminders/partial/scheduled_reminders.html'
 
     @method_decorator(requires_old_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @method_decorator(reminders_framework_permission)
     def dispatch(self, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+        return super(ScheduledRemindersCalendarView, self).dispatch(*args, **kwargs)
 
     @property
     def page_context(self):
@@ -721,14 +720,13 @@ class CreateBroadcastView(BaseMessagingSectionView):
     force_create_new_broadcast = False
 
     @method_decorator(requires_old_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_jquery_ui
     @use_timepicker
     @use_select2
     def dispatch(self, *args, **kwargs):
         if self.reminders_migration_in_progress and not self.new_reminders_migrator:
             return HttpResponseRedirect(reverse(BroadcastListView.urlname, args=[self.domain]))
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+        return super(CreateBroadcastView, self).dispatch(*args, **kwargs)
 
     @property
     @memoized
@@ -892,10 +890,9 @@ class RemindersListView(BaseMessagingSectionView):
     page_title = ugettext_noop("Reminder Definitions")
 
     @method_decorator(requires_old_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(request, *args, **kwargs)
+        return super(RemindersListView, self).dispatch(request, *args, **kwargs)
 
     @property
     def page_url(self):
@@ -998,7 +995,6 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
     DELETE_BROADCAST = 'delete_broadcast'
 
     @method_decorator(requires_old_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
         return super(BroadcastListView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -69,6 +69,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.utils import is_commcarecase
+from corehq.messaging.decorators import require_privilege_but_override_for_migrator
 from corehq.messaging.scheduling.async_handlers import SMSSettingsAsyncHandler
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from corehq.messaging.smsbackends.telerivet.models import SQLTelerivetBackend
@@ -131,7 +132,7 @@ class BaseMessagingSectionView(BaseDomainView):
     def can_use_inbound_sms(self):
         return has_privilege(self.request, privileges.INBOUND_SMS)
 
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
+    @method_decorator(require_privilege_but_override_for_migrator(privileges.OUTBOUND_SMS))
     def dispatch(self, *args, **kwargs):
         return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -169,10 +169,9 @@ class ComposeMessageView(BaseMessagingSectionView):
         return page_context
 
     @method_decorator(require_permission(Permissions.edit_data))
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_typeahead
     def dispatch(self, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+        return super(ComposeMessageView, self).dispatch(*args, **kwargs)
 
 
 @require_api_user_permission(PERMISSION_POST_SMS)
@@ -1645,10 +1644,6 @@ class SubscribeSMSView(BaseMessagingSectionView):
     urlname = 'subscribe_sms'
     page_title = ugettext_noop("Subscribe SMS")
 
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
-    def dispatch(self, *args, **kwargs):
-        return super(SubscribeSMSView, self).dispatch(*args, **kwargs)
-
     @property
     def commtrack_settings(self):
         return Domain.get_by_name(self.domain).commtrack_settings
@@ -2006,7 +2001,6 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
         return self.get(request, *args, **kwargs)
 
     @method_decorator(domain_admin_required)
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_timepicker
     @use_select2
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/messaging/decorators.py
+++ b/corehq/messaging/decorators.py
@@ -1,0 +1,11 @@
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import Permissions
+from corehq import privileges
+
+
+reminders_framework_permission = lambda *args, **kwargs: (
+    require_permission(Permissions.edit_data)(
+        requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK)(*args, **kwargs)
+    )
+)

--- a/corehq/messaging/decorators.py
+++ b/corehq/messaging/decorators.py
@@ -1,11 +1,27 @@
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.toggles import NEW_REMINDERS_MIGRATOR
 from corehq import privileges
+from functools import wraps
+
+
+def require_privilege_but_override_for_migrator(privilege):
+    def decorate(fn):
+        @wraps(fn)
+        def wrapped(request, *args, **kwargs):
+            if (
+                hasattr(request, 'couch_user') and
+                NEW_REMINDERS_MIGRATOR.enabled(request.couch_user.username)
+            ):
+                return fn(request, *args, **kwargs)
+            return requires_privilege_with_fallback(privilege)(fn)(request, *args, **kwargs)
+        return wrapped
+    return decorate
 
 
 reminders_framework_permission = lambda *args, **kwargs: (
     require_permission(Permissions.edit_data)(
-        requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK)(*args, **kwargs)
+        require_privilege_but_override_for_migrator(privileges.REMINDERS_FRAMEWORK)(*args, **kwargs)
     )
 )

--- a/corehq/messaging/decorators.py
+++ b/corehq/messaging/decorators.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
@@ -20,8 +21,7 @@ def require_privilege_but_override_for_migrator(privilege):
     return decorate
 
 
-reminders_framework_permission = lambda *args, **kwargs: (
-    require_permission(Permissions.edit_data)(
-        require_privilege_but_override_for_migrator(privileges.REMINDERS_FRAMEWORK)(*args, **kwargs)
+def reminders_framework_permission(fn):
+    return require_permission(Permissions.edit_data)(
+        require_privilege_but_override_for_migrator(privileges.REMINDERS_FRAMEWORK)(fn)
     )
-)

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -286,7 +286,6 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
     ACTION_DELETE_SCHEDULED_BROADCAST = 'delete_scheduled_broadcast'
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @method_decorator(require_permission(Permissions.edit_data))
     @use_datatables
     def dispatch(self, *args, **kwargs):
@@ -402,7 +401,6 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
     read_only_mode = False
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @method_decorator(require_permission(Permissions.edit_data))
     @use_jquery_ui
     @use_timepicker
@@ -545,7 +543,6 @@ class ConditionalAlertListView(BaseMessagingSectionView, DataTablesAJAXPaginatio
     ACTION_DELETE = 'delete'
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @method_decorator(require_permission(Permissions.edit_data))
     @use_datatables
     def dispatch(self, *args, **kwargs):
@@ -651,7 +648,6 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
     read_only_mode = False
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @method_decorator(require_permission(Permissions.edit_data))
     @use_jquery_ui
     @use_timepicker

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -30,6 +30,7 @@ from corehq.apps.hqwebapp.decorators import use_datatables, use_select2, use_jqu
 from corehq.apps.hqwebapp.views import DataTablesAJAXPaginationMixin
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.messaging.decorators import reminders_framework_permission
 from corehq.messaging.scheduling.async_handlers import MessagingRecipientHandler, ConditionalAlertAsyncHandler
 from corehq.messaging.scheduling.forms import (
     BroadcastForm,
@@ -286,7 +287,7 @@ class BroadcastListView(BaseMessagingSectionView, DataTablesAJAXPaginationMixin)
     ACTION_DELETE_SCHEDULED_BROADCAST = 'delete_scheduled_broadcast'
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(require_permission(Permissions.edit_data))
+    @method_decorator(reminders_framework_permission)
     @use_datatables
     def dispatch(self, *args, **kwargs):
         return super(BroadcastListView, self).dispatch(*args, **kwargs)
@@ -401,7 +402,7 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
     read_only_mode = False
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(require_permission(Permissions.edit_data))
+    @method_decorator(reminders_framework_permission)
     @use_jquery_ui
     @use_timepicker
     @use_select2
@@ -543,7 +544,7 @@ class ConditionalAlertListView(BaseMessagingSectionView, DataTablesAJAXPaginatio
     ACTION_DELETE = 'delete'
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(require_permission(Permissions.edit_data))
+    @method_decorator(reminders_framework_permission)
     @use_datatables
     def dispatch(self, *args, **kwargs):
         return super(ConditionalAlertListView, self).dispatch(*args, **kwargs)
@@ -648,7 +649,7 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
     read_only_mode = False
 
     @method_decorator(_requires_new_reminder_framework())
-    @method_decorator(require_permission(Permissions.edit_data))
+    @method_decorator(reminders_framework_permission)
     @use_jquery_ui
     @use_timepicker
     @use_select2


### PR DESCRIPTION
This will allow me to see reminder configuration information for projects that are on community when I'm doing the migration to the new reminders framework. This privilege is only given based on the `NEW_REMINDERS_MIGRATOR` toggle.

The first two commits were just a little bit of cleanup. Best reviewed by commit

@nickpell @calellowitz 