### PR TITLE
Allow hiding maintenance alert

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -289,14 +289,28 @@ hqDefine('hqwebapp/js/main', [
             }
         });
 
+        // Maintenance alerts
+        var $maintenance = $(".alert-maintenance");
+        if ($maintenance.length) {
+            var id = $maintenance.data("id"),
+                alertCookie = "alert_maintenance";
+            if ($.cookie(alertCookie) == id) {  // eslint-disable-line eqeqeq
+                $maintenance.addClass('hide');
+            } else {
+                $maintenance.on('click', '.close', function() {
+                    $.cookie(alertCookie, id, { expires: 7, path: '/' });
+                });
+            }
+        }
+
         // EULA modal
-        var cookieName = "gdpr_rollout";
-        if (!$.cookie(cookieName)) {
+        var eulaCookie = "gdpr_rollout";
+        if (!$.cookie(eulaCookie)) {
             var $modal = $("#eulaModal");
             if ($modal.length) {
                 $("body").addClass("has-eula");
                 $("#eula-snooze").click(function() {
-                    $.cookie(cookieName, true, { expires: 1, path: '/' });
+                    $.cookie(eulaCookie, true, { expires: 1, path: '/' });
                     $("body").removeClass("has-eula");
                 });
                 $("#eula-agree").click(function() {

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/alerts.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/alerts.less
@@ -14,6 +14,8 @@
 .alert-maintenance {
   z-index: @zindex-navbar;
   position: relative;
+  text-align: center;
+  margin-bottom: 0;
 }
 
 .alert-ui-notify.helpbubble {

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -498,7 +498,9 @@ def maintenance_alert():
         return ''
     else:
         return format_html(
-            '<div class="alert alert-warning alert-maintenance" style="text-align: center; margin-bottom: 0;">{}</div>',
+            '<div class="alert alert-warning alert-maintenance" data-id="{}">{}{}</div>',
+            alert.id,
+            mark_safe('<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>'),
             mark_safe(alert.html),
         )
 


### PR DESCRIPTION
Adds an X to the maintenance alert to close it. Once closed, a cookie keeps it closed. The cookie is alert-specific, so any new alert will pop up.

@esoergel 