### PR TITLE
fix location sync

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -277,7 +277,7 @@ def _mptt_get_location_fixture_queryset(user):
 
         locs_below_expand_from = _get_children(expand_from_locations, expand_to_level)
         locs_at_or_above_expand_from = (SQLLocation.active_objects
-                                        ._mptt_get_queryset_ancestors(expand_from_locations, include_self=True))
+                                        ._mptt_get_queryset_ancestors(expand_from_locations, include_self=True).prefetch_related('parent', 'location_type__code'))
         locations_to_sync = locs_at_or_above_expand_from | locs_below_expand_from
         if location_type.include_only.exists():
             locations_to_sync = locations_to_sync.filter(location_type__in=location_type.include_only.all())
@@ -316,7 +316,7 @@ def _get_children(expand_from_locations, expand_to_level):
     """
     children = (SQLLocation.active_objects
                 ._mptt_get_queryset_descendants(expand_from_locations)
-                .prefetch_related('location_type'))
+                .prefetch_related('location_type__code', 'parent'))
     if expand_to_level is not None:
         children = children.filter(level__lte=expand_to_level)
     return children

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -277,7 +277,7 @@ def _mptt_get_location_fixture_queryset(user):
 
         locs_below_expand_from = _get_children(expand_from_locations, expand_to_level)
         locs_at_or_above_expand_from = (SQLLocation.active_objects
-                                        ._mptt_get_queryset_ancestors(expand_from_locations, include_self=True).prefetch_related('parent', 'location_type__code'))
+                                        ._mptt_get_queryset_ancestors(expand_from_locations, include_self=True).prefetch_related('parent', 'location_type'))
         locations_to_sync = locs_at_or_above_expand_from | locs_below_expand_from
         if location_type.include_only.exists():
             locations_to_sync = locations_to_sync.filter(location_type__in=location_type.include_only.all())
@@ -316,7 +316,7 @@ def _get_children(expand_from_locations, expand_to_level):
     """
     children = (SQLLocation.active_objects
                 ._mptt_get_queryset_descendants(expand_from_locations)
-                .prefetch_related('location_type__code', 'parent'))
+                .prefetch_related('location_type', 'parent'))
     if expand_to_level is not None:
         children = children.filter(level__lte=expand_to_level)
     return children

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -92,12 +92,6 @@ class FixtureHasLocationsMixin(TestXmlMixin):
     def assert_fixture_queryset_equals_locations(self, desired_locations):
         actual = get_location_fixture_queryset(self.user).values_list('name', flat=True)
         self.assertItemsEqual(actual, desired_locations)
-        self.assert_mptt_fixture_queryset_equals_locations(desired_locations)
-
-    @override_settings(IS_LOCATION_CTE_ONLY=False, IS_LOCATION_CTE_ENABLED=False)
-    def assert_mptt_fixture_queryset_equals_locations(self, desired_locations):
-        actual = get_location_fixture_queryset(self.user).values_list('name', flat=True)
-        self.assertItemsEqual(actual, desired_locations)
 
 
 @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
@@ -747,6 +741,12 @@ class ShouldSyncLocationFixturesTest(TestCase):
         self.assertFalse(
             should_sync_locations(SyncLog(date=after_archive), locations_queryset, self.user.to_ota_restore_user())
         )
+
+
+@mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
+@override_settings(IS_LOCATION_CTE_ONLY=False, IS_LOCATION_CTE_ENABLED=False)
+class MPTTLocationFixturesTest(LocationFixturesTest):
+    pass
 
 
 @mock.patch('corehq.apps.domain.models.Domain.uses_locations', lambda: True)

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -236,7 +236,6 @@ class LocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
         location_type.expand_from_root = True
         location_type.expand_to = self.locations['Suffolk'].location_type
         location_type.save()
-        import ipdb; ipdb.set_trace()
         self._assert_fixture_matches_file(
             'expand_from_root_to_county',
             ['Massachusetts', 'Suffolk', 'Middlesex', 'New York', 'New York City']

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -12,6 +12,7 @@ from corehq.util.test_utils import flag_enabled
 
 from datetime import datetime, timedelta
 from django.test import TestCase
+from django.test.utils import override_settings
 from casexml.apps.phone.models import SyncLog
 from casexml.apps.phone.tests.utils import create_restore_user, call_fixture_generator
 from corehq.apps.domain.shortcuts import create_domain
@@ -89,6 +90,12 @@ class FixtureHasLocationsMixin(TestXmlMixin):
         self.assertXmlEqual(desired_fixture, fixture)
 
     def assert_fixture_queryset_equals_locations(self, desired_locations):
+        actual = get_location_fixture_queryset(self.user).values_list('name', flat=True)
+        self.assertItemsEqual(actual, desired_locations)
+        self.assert_mptt_fixture_queryset_equals_locations(desired_locations)
+
+    @override_settings(IS_LOCATION_CTE_ONLY=False, IS_LOCATION_CTE_ENABLED=False)
+    def assert_mptt_fixture_queryset_equals_locations(self, desired_locations):
         actual = get_location_fixture_queryset(self.user).values_list('name', flat=True)
         self.assertItemsEqual(actual, desired_locations)
 
@@ -229,6 +236,7 @@ class LocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
         location_type.expand_from_root = True
         location_type.expand_to = self.locations['Suffolk'].location_type
         location_type.save()
+        import ipdb; ipdb.set_trace()
         self._assert_fixture_matches_file(
             'expand_from_root_to_county',
             ['Massachusetts', 'Suffolk', 'Middlesex', 'New York', 'New York City']


### PR DESCRIPTION
@snopoke 
This fixes the bug that broke PNA. The deeper I got into debugging the more confused I am about how this issue didn't break ICDS restores before (or maybe it did in some cases and that caused UCR load issues?) Either way, this should solve the IT restore location issue while not breaking PNA