### PR TITLE
fix tooltip after nvd3 update

### DIFF
--- a/custom/icds_reports/static/icds_reports/js/spec/awc-reports.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/awc-reports.directive.spec.js
@@ -113,8 +113,8 @@ describe('AWC Reports Directive', function () {
         });
         assert.equal(chart.showValues, true);
         assert.equal(chart.showControls, false);
+        assert.equal(chart.showLegend, false);
         assert.equal(chart.duration, 500);
-        assert.equal(chart.clipVoronoi, false);
         assert.equal(chart.useInteractiveGuideline, true);
         assert.equal(chart.xAxis.axisLabel, '');
         assert.equal(chart.yAxis.axisLabel, '');

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -1929,7 +1929,7 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                         return 'Total number of children between <strong>' + key.series[0].data[0] + ':</strong> ' + key.series[0].data[1];
                     },
                 },
-            }
+            },
         },
     };
 

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -1908,7 +1908,7 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             showValues: true,
             showControls: false,
             useInteractiveGuideline: true,
-            clipVoronoi: false,
+            showLegend: false,
             duration: 500,
             xAxis: {
                 axisLabel: '',
@@ -1923,10 +1923,13 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             yAxis: {
                 axisLabel: '',
             },
-            tooltip: function (x, y, value) {
-                return '<strong>Total number of children between ' + y + ':</strong> ' + value;
-            },
-
+            interactiveLayer: {
+                tooltip: {
+                    contentGenerator: function (key) {
+                        return 'Total number of children between <strong>' + key.series[0].data[0] + ':</strong> ' + key.series[0].data[1];
+                    },
+                },
+            }
         },
     };
 


### PR DESCRIPTION
Hi @emord 

I fixed the tooltip for the chart in the awc_reports/demographics. I think the problem arose after the nvd3 library update for ICDS reports. LINK TO CASE: http://manage.dimagi.com/default.asp?275589

Please let me know if you have any questions.

Regards,
Łukasz