### PR TITLE
Add support for SMS Surveys to new reminders framework

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1328,7 +1328,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         if isinstance(content, (SMSContent, CustomContent)):
             return cls.CONTENT_SMS, None, None
         elif isinstance(content, SMSSurveyContent):
-            app, module, form = content.get_memoized_app_module_form(domain)
+            app, module, form, requires_input = content.get_memoized_app_module_form(domain)
             form_name = form.full_path_name if form else None
             return cls.CONTENT_SMS_SURVEY, content.form_unique_id, form_name
         elif isinstance(content, EmailContent):

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -6,7 +6,13 @@ from memoized import memoized
 from django.db import models, transaction
 from corehq.apps.reminders.util import get_one_way_number_for_recipient, get_two_way_number_for_recipient
 from corehq.apps.sms.api import MessageMetadata, send_sms, send_sms_to_verified_number
-from corehq.apps.sms.models import PhoneNumber
+from corehq.apps.sms.models import (
+    MessagingEvent,
+    PhoneNumber,
+    WORKFLOW_REMINDER,
+    WORKFLOW_KEYWORD,
+    WORKFLOW_BROADCAST,
+)
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.models import CommCareUser
 from corehq.messaging.scheduling.exceptions import (
@@ -227,6 +233,20 @@ class Content(models.Model):
         if schedule_instance:
             self.schedule_instance = schedule_instance
 
+    @staticmethod
+    def get_workflow(logged_event):
+        if logged_event.source in (
+            MessagingEvent.SOURCE_IMMEDIATE_BROADCAST,
+            MessagingEvent.SOURCE_SCHEDULED_BROADCAST,
+        ):
+            return WORKFLOW_BROADCAST
+        elif logged_event.source == MessagingEvent.SOURCE_CASE_RULE:
+            return WORKFLOW_REMINDER
+        elif logged_event.source == MessagingEvent.SOURCE_KEYWORD:
+            return WORKFLOW_KEYWORD
+
+        return None
+
     @cached_property
     def case_rendering_context(self):
         """
@@ -250,11 +270,15 @@ class Content(models.Model):
         return r
 
     @classmethod
-    def get_two_way_entry_or_phone_number(cls, recipient):
+    def get_two_way_entry_or_phone_number(cls, recipient, try_user_case=True):
         """
         If recipient has a two-way number, returns it as a PhoneNumber entry.
         If recipient does not have a two-way number but has a phone number configured,
         returns the one-way phone number as a string.
+
+        If try_user_case is True and recipient is a CommCareUser who doesn't have a
+        two-way or one-way phone number, then it will try to get the two-way or
+        one-way number from the user's user case if one exists.
         """
         if use_phone_entries():
             phone_entry = get_two_way_number_for_recipient(recipient)
@@ -268,7 +292,7 @@ class Content(models.Model):
         if phone_number and len(phone_number) > 3:
             return phone_number
 
-        if isinstance(recipient, CommCareUser) and recipient.memoized_usercase:
+        if try_user_case and isinstance(recipient, CommCareUser) and recipient.memoized_usercase:
             return cls.get_two_way_entry_or_phone_number(recipient.memoized_usercase)
 
         return None

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -6,10 +6,20 @@ from corehq.apps.accounting.utils import domain_is_on_trial
 from corehq.apps.app_manager.exceptions import XFormIdNotUnique
 from corehq.apps.app_manager.models import Form
 from corehq.apps.hqwebapp.tasks import send_mail_async
+from corehq.apps.smsforms.app import start_session
+from corehq.apps.smsforms.util import form_requires_input, critical_section_for_smsforms_sessions
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.models.abstract import Content
 from corehq.apps.reminders.models import EmailUsage
-from corehq.apps.sms.models import MessagingEvent
+from corehq.apps.sms.api import (
+    MessageMetadata,
+    send_sms,
+    send_sms_to_verified_number,
+)
+from corehq.apps.sms.models import MessagingEvent, PhoneNumber, PhoneBlacklist
+from corehq.apps.sms.util import format_message_list, touchforms_error_is_config_error
+from corehq.apps.smsforms.models import SQLXFormsSession
 from couchdbkit.resource import ResourceNotFound
 from memoized import memoized
 from dimagi.utils.logging import notify_exception
@@ -17,6 +27,7 @@ from dimagi.utils.modules import to_function
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
+from touchforms.formplayer.api import TouchformsError
 
 
 class SMSContent(Content):
@@ -131,28 +142,172 @@ class SMSSurveyContent(Content):
             app = form.get_app()
             module = form.get_module()
         except (ResourceNotFound, XFormIdNotUnique):
-            return None, None, None
+            return None, None, None, None
 
         if app.domain != domain:
-            return None, None, None
+            return None, None, None, None
 
-        return app, module, form
+        return app, module, form, form_requires_input(form)
+
+    def phone_has_opted_out(self, phone_entry_or_number):
+        if isinstance(phone_entry_or_number, PhoneNumber):
+            pb = PhoneBlacklist.get_by_phone_number_or_none(phone_entry_or_number.phone_number)
+        else:
+            pb = PhoneBlacklist.get_by_phone_number_or_none(phone_entry_or_number)
+
+        return pb is not None and not pb.send_sms
 
     def send(self, recipient, logged_event):
-        print('*******************************')
-        print('To:', recipient)
-        print('SMS Survey: ', self.form_unique_id)
-        print('*******************************')
+        app, module, form, requires_input = self.get_memoized_app_module_form(logged_event.domain)
+        if any([o is None for o in (app, module, form)]):
+            logged_event.error(MessagingEvent.ERROR_CANNOT_FIND_FORM)
+            return
+
+        logged_subevent = logged_event.create_subevent_from_contact_and_content(
+            recipient,
+            self,
+            case_id=self.case.case_id if self.case else None,
+        )
+
+        # We don't try to look up the phone number from the user case in this scenario
+        # because this use case involves starting a survey session, which can be
+        # very different if the contact is a user or is a case. So here if recipient
+        # is a user we only allow them to fill out the survey as the user contact, and
+        # not the user case contact.
+        phone_entry_or_number = self.get_two_way_entry_or_phone_number(recipient, try_use_case=False)
+
+        if phone_entry_or_number is None:
+            logged_subevent.error(MessagingEvent.ERROR_NO_PHONE_NUMBER)
+            return
+
+        if requires_input and not isinstance(phone_entry_or_number, PhoneNumber):
+            logged_subevent.error(MessagingEvent.ERROR_NO_TWO_WAY_PHONE_NUMBER)
+            return
+
+        # The SMS framework already checks if the number has opted out before sending to
+        # it. But for this use case we check for it here because we don't want to start
+        # the survey session if they've opted out.
+        if self.phone_has_opted_out(phone_entry_or_number):
+            logged_subevent.error(MessagingEvent.ERROR_PHONE_OPTED_OUT)
+            return
+
+        with critical_section_for_smsforms_sessions(recipient.get_id):
+            # Get the case to submit the form against, if any
+            case_id = None
+            if is_commcarecase(recipient):
+                case_id = recipient.case_id
+            elif self.case:
+                case_id = self.case.case_id
+
+            if form.requires_case() and not case_id:
+                logged_subevent.error(MessagingEvent.ERROR_NO_CASE_GIVEN)
+                return
+
+            session, responses = self.start_smsforms_session(
+                logged_event.domain,
+                recipient,
+                case_id,
+                phone_entry_or_number,
+                logged_subevent,
+                self.get_workflow(logged_event)
+            )
+
+            if session:
+                logged_subevent.xforms_session = session
+                logged_subevent.save()
+                self.send_first_message(
+                    logged_event.domain,
+                    recipient,
+                    phone_entry_or_number,
+                    session,
+                    responses,
+                    logged_subevent,
+                    self.get_workflow(logged_event)
+                )
+                logged_subevent.completed()
+
+    def start_smsforms_session(self, domain, recipient, case_id, phone_entry_or_number, logged_subevent, workflow):
+        # Close all currently open sessions
+        SQLXFormsSession.close_all_open_sms_sessions(domain, recipient.get_id)
+
+        # Start the new session
+        app, module, form, requires_input = self.get_memoized_app_module_form(domain)
+        try:
+            session, responses = start_session(
+                SQLXFormsSession.create_session_object(
+                    domain,
+                    recipient,
+                    (phone_entry_or_number.phone_number
+                     if isinstance(phone_entry_or_number, PhoneNumber)
+                     else phone_entry_or_number),
+                    app,
+                    form,
+                    expire_after=self.expire_after,
+                    reminder_intervals=self.reminder_intervals,
+                    submit_partially_completed_forms=self.submit_partially_completed_forms,
+                    include_case_updates_in_partial_submissions=self.include_case_updates_in_partial_submissions
+                ),
+                domain,
+                recipient,
+                app,
+                module,
+                form,
+                case_id,
+            )
+        except TouchformsError as e:
+            logged_subevent.error(
+                MessagingEvent.ERROR_TOUCHFORMS_ERROR,
+                additional_error_text=e.response_data.get('human_readable_message')
+            )
+
+            if touchforms_error_is_config_error(e):
+                # Don't reraise the exception because this means there are configuration
+                # issues with the form that need to be fixed. The error is logged in the
+                # above lines.
+                return None, None
+
+            # Reraise the exception so that the framework retries it again later
+            raise
+        except:
+            logged_subevent.error(MessagingEvent.ERROR_TOUCHFORMS_ERROR)
+            # Reraise the exception so that the framework retries it again later
+            raise
+
+        session.workflow = workflow
+        session.save()
+
+        return session, responses
+
+    def send_first_message(self, domain, recipient, phone_entry_or_number, session, responses, logged_subevent,
+            workflow):
+        if len(responses) > 0:
+            message = format_message_list(responses)
+            metadata = MessageMetadata(
+                workflow=workflow,
+                xforms_session_couch_id=session.couch_id,
+            )
+            if isinstance(phone_entry_or_number, PhoneNumber):
+                send_sms_to_verified_number(
+                    phone_entry_or_number,
+                    message,
+                    metadata,
+                    logged_subevent=logged_subevent
+                )
+            else:
+                send_sms(
+                    domain,
+                    recipient,
+                    phone_entry_or_number,
+                    message,
+                    metadata
+                )
 
 
 class IVRSurveyContent(Content):
     form_unique_id = models.CharField(max_length=126)
 
     def send(self, recipient, logged_event):
-        print('*******************************')
-        print('To:', recipient)
-        print('IVR Survey: ', self.form_unique_id)
-        print('*******************************')
+        pass
 
 
 class CustomContent(Content):

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -174,7 +174,7 @@ class SMSSurveyContent(Content):
         # very different if the contact is a user or is a case. So here if recipient
         # is a user we only allow them to fill out the survey as the user contact, and
         # not the user case contact.
-        phone_entry_or_number = self.get_two_way_entry_or_phone_number(recipient, try_use_case=False)
+        phone_entry_or_number = self.get_two_way_entry_or_phone_number(recipient, try_user_case=False)
 
         if phone_entry_or_number is None:
             logged_subevent.error(MessagingEvent.ERROR_NO_PHONE_NUMBER)

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -209,7 +209,10 @@ class SMSSurveyContent(Content):
                 case_id,
                 phone_entry_or_number,
                 logged_subevent,
-                self.get_workflow(logged_event)
+                self.get_workflow(logged_event),
+                app,
+                module,
+                form
             )
 
             if session:
@@ -226,12 +229,12 @@ class SMSSurveyContent(Content):
                 )
                 logged_subevent.completed()
 
-    def start_smsforms_session(self, domain, recipient, case_id, phone_entry_or_number, logged_subevent, workflow):
+    def start_smsforms_session(self, domain, recipient, case_id, phone_entry_or_number, logged_subevent, workflow,
+            app, module, form):
         # Close all currently open sessions
         SQLXFormsSession.close_all_open_sms_sessions(domain, recipient.get_id)
 
         # Start the new session
-        app, module, form, requires_input = self.get_memoized_app_module_form(domain)
         try:
             session, responses = start_session(
                 SQLXFormsSession.create_session_object(


### PR DESCRIPTION
Implements `send` on `SMSSurveyContent` so that sending sms surveys is now functional from the new framework.

The code was mainly just ported from https://github.com/dimagi/commcare-hq/blob/ef538216a50e66725b18bef580aefaa0d064f11f/corehq/apps/reminders/event_handlers.py#L283

@millerdev @dannyroberts 