### PR TITLE
Use is_distinct_from instead of !=

### DIFF
--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -52,7 +52,7 @@ class MPR2APersonCases(ConfigurableReportCustomQueryProvider):
         }[x]
         column &= {
             "resident": columns.resident == "yes",
-            "migrant": columns.resident != "yes",
+            "migrant": columns.resident.is_distinct_from("yes"),
         }[y]
 
         if z is None:


### PR DESCRIPTION
Learned an important lesson that `column != value` returns NULL when the column is NULL, not true or false