### PR TITLE
Data corrections: search by selected property

### DIFF
--- a/corehq/apps/reports/static/reports/spec/data_corrections_spec.js
+++ b/corehq/apps/reports/static/reports/spec/data_corrections_spec.js
@@ -166,9 +166,11 @@ describe('Data Corrections', function () {
             search("yellow");
             assertVisibleProperties(["yellow"]);
 
-            // Display spanish values
+            // Display and search spanish values
             model.updateDisplayProperty("spanish");
             assertVisibleText(["anaranjado", "rojo", "amarillo"]);
+            search("rojo");
+            assertVisibleProperties(["red"]);
         });
     });
 });


### PR DESCRIPTION
UAT feedback reported that the search box always searched by question id, regardless of whether you were looking at ids or labels.

This used to work properly, but I got too aggressive about deleting code and removed it in https://github.com/dimagi/commcare-hq/pull/19973/commits/9866789cc774233a894cda91d5dab0d106158336

@snopoke 