### PR TITLE
Data corrections: display labels by default

### DIFF
--- a/corehq/apps/reports/static/reports/spec/data_corrections_spec.js
+++ b/corehq/apps/reports/static/reports/spec/data_corrections_spec.js
@@ -160,6 +160,8 @@ describe('Data Corrections', function () {
                 assert.sameMembers(expected, _.map($(".data-corrections-modal .test-property:visible"), function(p) { return p.innerText; }));
             };
 
+            assert($(".data-corrections-modal .nav > :first-child").hasClass("active"), "Should display first property by default");
+
             // Display and search english values
             model.updateDisplayProperty("name");
             assertVisibleText(["orange", "red", "yellow"]);

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -19,7 +19,7 @@
                     <!-- ko if: displayProperties.length > 1 -->
                         <ul class="nav nav-pills">
                             <!-- ko foreach: displayProperties -->
-                            <li data-bind="click: function() { $root.updateDisplayProperty(property) }, css: { active: $root.displayProperty() === property }">
+                                <li data-bind="click: function() { $root.updateDisplayProperty(property) }, css: { active: $root.displayProperty() === property }">
                                     <a data-bind="text: name"></a>
                                 </li>
                             <!--/ko-->

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -19,7 +19,7 @@
                     <!-- ko if: displayProperties.length > 1 -->
                         <ul class="nav nav-pills">
                             <!-- ko foreach: displayProperties -->
-                                <li data-bind="click: $root.updateDisplayProperty(property), css: { active: $root.displayProperty() === property }">
+                            <li data-bind="click: function() { $root.updateDisplayProperty(property) }, css: { active: $root.displayProperty() === property }">
                                     <a data-bind="text: name"></a>
                                 </li>
                             <!--/ko-->


### PR DESCRIPTION
UAT suggestion. Also makes sense since "Labels" is the first element in the nav.

Without the function wrapper, the click handler gets executed for each element when the page is loaded...weird little knockout quirk.

@snopoke 