### PR TITLE
Revert "identify standby and calculate delay util"

### DIFF
--- a/corehq/apps/userreports/sql/connection.py
+++ b/corehq/apps/userreports/sql/connection.py
@@ -11,5 +11,5 @@ def get_engine_id(an_object, allow_read_replicas=False):
     from corehq.apps.userreports.models import DataSourceConfiguration
     assert isinstance(an_object, DataSourceConfiguration)
     if allow_read_replicas:
-        return connection_manager.get_load_balanced_read_db_alais(an_object.engine_id)
+        return connection_manager.get_load_balanced_read_engine_id(an_object.engine_id)
     return an_object.engine_id

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -1,9 +1,8 @@
-from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import random
 from contextlib import contextmanager
 from six.moves.urllib.parse import urlencode
-import six
 
 from django.apps import apps
 from django.conf import settings
@@ -11,11 +10,6 @@ import sqlalchemy
 from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from django.core import signals
-
-from corehq.util.test_utils import unit_testing_only
-
-from .util import select_db_for_read
-
 
 DEFAULT_ENGINE_ID = 'default'
 UCR_ENGINE_ID = 'ucr'
@@ -106,18 +100,19 @@ class ConnectionManager(object):
         """
         return self._get_or_create_helper(engine_id).engine
 
-    def get_load_balanced_read_db_alais(self, engine_id, default=None):
-        """
-        returns the load balanced read db alias based on list of read databases
-            and their weights obtained from settings.REPORTING_DATABASES and
-            settings.LOAD_BALANCED_APPS.
-
-            If a suitable db is not found returns the `default` or `engine_id` itself
-        """
+    def get_load_balanced_read_db(self, engine_id, default=None):
         read_dbs = self.read_database_mapping.get(engine_id, [])
-        load_balanced_db = select_db_for_read(read_dbs)
+        if read_dbs:
+            return random.choice(read_dbs)
+        elif default is not None:
+            return default
+        return engine_id
 
-        return load_balanced_db or default or engine_id
+    def get_load_balanced_read_engine_id(self, engine_id):
+        return self.get_load_balanced_read_db(engine_id)
+
+    def get_load_balanced_db_alias(self, app_label, default):
+        return self.get_load_balanced_read_db(app_label, default)
 
     def close_scoped_sessions(self):
         for helper in self._session_helpers.values():
@@ -152,25 +147,30 @@ class ConnectionManager(object):
         else:
             for engine_id, db_config in reporting_db_config.items():
                 write_db = db_config
-                weighted_read_dbs = None
+                read = None
                 if isinstance(db_config, dict):
                     write_db = db_config['WRITE']
-                    weighted_read_dbs = db_config['READ']
-                    dbs = [db for db, weight in weighted_read_dbs]
-                    assert set(dbs).issubset(set(settings.DATABASES))
+                    read = db_config['READ']
+                    for db_alias, weighting in read:
+                        assert isinstance(weighting, int), 'weighting must be int'
+                        assert db_alias in settings.DATABASES, db_alias
 
                 self._add_django_db(engine_id, write_db)
-                if weighted_read_dbs:
-                    self.read_database_mapping[engine_id] = weighted_read_dbs
-                    for read_db, weighting in weighted_read_dbs:
+                if read:
+                    self.read_database_mapping[engine_id] = []
+                    for read_db, weighting in read:
                         assert read_db == write_db or read_db not in self.db_connection_map, read_db
+                        self.read_database_mapping[engine_id].extend([read_db] * weighting)
                         if read_db != write_db:
                             self._add_django_db(read_db, read_db)
 
-        for app, weighted_read_dbs in settings.LOAD_BALANCED_APPS.items():
-            self.read_database_mapping[app] = weighted_read_dbs
-            dbs = [db for db, weight in weighted_read_dbs]
-            assert set(dbs).issubset(set(settings.DATABASES))
+        for app, weights in settings.LOAD_BALANCED_APPS.items():
+            self.read_database_mapping[app] = []
+            for db_alias, weighting in weights:
+                assert isinstance(weighting, int), 'weighting must be int'
+                assert db_alias in settings.DATABASES, db_alias
+
+                self.read_database_mapping[app].extend([db_alias] * weighting)
 
         if DEFAULT_ENGINE_ID not in self.db_connection_map:
             self._add_django_db(DEFAULT_ENGINE_ID, 'default')
@@ -226,7 +226,6 @@ def _close_connections(**kwargs):
 signals.request_finished.connect(_close_connections)
 
 
-@unit_testing_only
 @contextmanager
 def override_engine(engine_id, connection_url):
     original_url = connection_manager.get_connection_string(engine_id)

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -96,10 +96,10 @@ def db_for_read_write(model, write=True):
     elif app_label in (ICDS_MODEL, ICDS_REPORTS_APP):
         engine_id = ICDS_UCR_ENGINE_ID
         if not write:
-            engine_id = connection_manager.get_load_balanced_read_db_alais(ICDS_UCR_ENGINE_ID)
+            engine_id = connection_manager.get_load_balanced_read_engine_id(ICDS_UCR_ENGINE_ID)
         return connection_manager.get_django_db_alias(engine_id)
     else:
         default_db = partition_config.get_main_db()
         if not write:
-            return connection_manager.get_load_balanced_read_db_alais(app_label, default_db)
+            return connection_manager.get_load_balanced_db_alias(app_label, default_db)
         return default_db

--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -1,15 +1,12 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
-
-import mock
 from collections import Counter
 
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
 
 from corehq.sql_db.connections import ConnectionManager
-from corehq.sql_db.util import filter_out_stale_standbys
 from six.moves import range
 
 
@@ -21,7 +18,6 @@ def _get_db_config(db_name):
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': '5432',
-        'HQ_ACCEPTABLE_STANDBY_DELAY': 3
     }
 
 
@@ -59,8 +55,7 @@ class ConnectionManagerTests(SimpleTestCase):
             'other': 'postgresql+psycopg2://:@localhost:5432/other'
         })
 
-    @mock.patch('corehq.sql_db.util.get_replication_delay_for_standby', return_value=0)
-    def test_read_load_balancing(self, *args):
+    def test_read_load_balancing(self):
         reporting_dbs = {
             'ucr': {
                 'WRITE': 'ucr',
@@ -75,7 +70,6 @@ class ConnectionManagerTests(SimpleTestCase):
                 'other': 'postgresql+psycopg2://:@localhost:5432/other'
             })
 
-
             # test that load balancing works with a 10% margin for randomness
             total_requests = 10000
             randomness_margin = total_requests * 0.1
@@ -84,7 +78,7 @@ class ConnectionManagerTests(SimpleTestCase):
                 alias: weight * total_requests // total_weighting
                 for alias, weight in reporting_dbs['ucr']['READ']
             }
-            balanced = Counter(manager.get_load_balanced_read_db_alais('ucr') for i in range(total_requests))
+            balanced = Counter(manager.get_load_balanced_read_engine_id('ucr') for i in range(total_requests))
             for db, requests in balanced.items():
                 self.assertAlmostEqual(requests, expected[db], delta=randomness_margin)
 
@@ -92,60 +86,5 @@ class ConnectionManagerTests(SimpleTestCase):
             manager = ConnectionManager()
             self.assertEqual(
                 ['default', 'default', 'default'],
-                [manager.get_load_balanced_read_db_alais('default') for i in range(3)]
-            )
-
-    @mock.patch('corehq.sql_db.util.get_replication_delay_for_standby', lambda x: {'ucr': 4}.get(x, 0))
-    def test_standby_filtering(self, *args):
-        reporting_dbs = {
-            'ucr_engine': {
-                'WRITE': 'ucr',
-                'READ': [('ucr', 8), ('other', 1)]
-            },
-        }
-        with override_settings(REPORTING_DATABASES=reporting_dbs):
-            # should always return the `other` db since `ucr` has bad replication delay
-            manager = ConnectionManager()
-            self.assertEqual(
-                ['other', 'other', 'other'],
-                [manager.get_load_balanced_read_db_alais('ucr_engine') for i in range(3)]
-            )
-
-    @mock.patch('corehq.sql_db.util.get_replication_delay_for_standby', return_value=0)
-    def test_load_balanced_read_apps(self, mock):
-        load_balanced_apps = {
-            'users': [
-                ('users_db1', 5),
-            ]
-        }
-
-        with override_settings(
-            LOAD_BALANCED_APPS=load_balanced_apps,
-            DATABASES = {
-                'default': _get_db_config('default'),
-                'users_db1': _get_db_config('users_db1')}):
-            manager = ConnectionManager()
-            self.assertEqual(
-                manager.get_load_balanced_read_db_alais('users', default="default_option"),
-                'users_db1'
-            )
-
-        with override_settings(LOAD_BALANCED_APPS=load_balanced_apps):
-            # load_balanced_db should be part of settings.DATABASES
-            with self.assertRaises(AssertionError):
-                ConnectionManager().get_load_balanced_read_db_alais('users')
-
-
-        # If `LOAD_BALANCED_APPS` is not set for an app, it should point to default kwarg
-        manager = ConnectionManager()
-        self.assertEqual(
-            manager.get_load_balanced_read_db_alais('users', default='default_option'),
-            'default_option'
-        )
-
-    def test_filter_out_stale_standbys(self, *args):
-        with mock.patch('corehq.sql_db.util.get_replication_delay_for_standby', lambda x: {'ucr': 2, 'default': 4}.get(x, 0)):
-            self.assertEqual(
-                filter_out_stale_standbys(['ucr', 'default']),
-                ['ucr']
+                [manager.get_load_balanced_read_engine_id('default') for i in range(3)]
             )

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -1,24 +1,16 @@
 from __future__ import absolute_import
-from __future__ import division
 from __future__ import unicode_literals
 import uuid
 from collections import defaultdict
-from numpy import random
 
+from corehq.sql_db.config import partition_config
 from django.conf import settings
 from django import db
 from django.db.utils import InterfaceError as DjangoInterfaceError
 from functools import wraps
 from psycopg2._psycopg import InterfaceError as Psycopg2InterfaceError
 import six
-from memoized import memoized
-
-from corehq.sql_db.config import partition_config
-from corehq.util.quickcache import quickcache
-
-
-ACCEPTABLE_STANDBY_DELAY_SECONDS = 3
-LOAD_BALANCE_FREQUENCY_SECONDS = 30
+from corehq.sql_db.models import PartitionedModel
 
 
 def run_query_across_partitioned_databases(model_class, q_expression, values=None, annotate=None):
@@ -142,7 +134,6 @@ def handle_connection_failure(get_db_aliases=get_default_db_aliases):
 
 
 def get_all_sharded_models():
-    from corehq.sql_db.models import PartitionedModel
     for subclass in _get_all_nested_subclasses(PartitionedModel):
         if not subclass._meta.abstract:
             yield subclass
@@ -159,97 +150,3 @@ def _get_all_nested_subclasses(cls):
         if subclass not in seen:
             seen.add(subclass)
             yield subclass
-
-
-@memoized
-def get_standby_databases():
-    standby_dbs = []
-    for db_alias in settings.DATABASES:
-        with db.connections[db_alias].cursor() as cursor:
-            cursor.execute("SELECT pg_is_in_recovery()")
-            [(is_standby, )] = cursor.fetchall()
-            if is_standby:
-                standby_dbs.append(db_alias)
-    return standby_dbs
-
-
-def get_replication_delay_for_standby(db_alias):
-    """
-    Finds the replication delay for given database by running a SQL query on standby database.
-        See https://www.postgresql.org/message-id/CADKbJJWz9M0swPT3oqe8f9+tfD4-F54uE6Xtkh4nERpVsQnjnw@mail.gmail.com
-
-    If the given database is not a standby database, zero delay is returned
-    If standby process (wal_receiver) is not running on standby a `VERY_LARGE_DELAY` is returned
-    """
-    if db_alias not in get_standby_databases():
-        return 0
-    # used to indicate that the wal_receiver process on standby is not running
-    VERY_LARGE_DELAY = 100000
-    sql = """
-    SELECT
-    CASE
-        WHEN NOT EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN {delay}
-        WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0
-        ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
-    END
-    AS replication_lag;
-    """.format(delay=VERY_LARGE_DELAY)
-    with db.connections[db_alias].cursor() as cursor:
-        cursor.execute(sql)
-        [(delay, )] = cursor.fetchall()
-        return delay
-
-
-@memoized
-def get_standby_delays_by_db():
-    ret = {}
-    for _db, config in six.iteritems(settings.DATABASES):
-        delay = config.get('HQ_ACCEPTABLE_STANDBY_DELAY')
-        if delay:
-            ret[_db] = delay
-    return ret
-
-
-def filter_out_stale_standbys(dbs):
-    # from given list of databases filters out those with more than
-    #   acceptable standby delay, if that database is a standby
-    delays_by_db = get_standby_delays_by_db()
-    return [
-        db
-        for db in dbs
-        if get_replication_delay_for_standby(db) <= delays_by_db.get(db, ACCEPTABLE_STANDBY_DELAY_SECONDS)
-    ]
-
-
-@quickcache(['weighted_dbs'], timeout=LOAD_BALANCE_FREQUENCY_SECONDS, skip_arg=lambda *args: settings.UNIT_TESTING)
-def select_db_for_read(weighted_dbs):
-    """
-    Returns a randomly selected database per the weights assigned from
-        a list of databases. If any database is standby and its replication has
-        more than accesptable delay, that db is dropped from selection
-
-    Args:
-        weighted_dbs: a list of tuple of db and the weight.
-            [
-                ("pgmain", 5),
-                ("pgmainstandby", 5)
-            ]
-
-    """
-    # convert to a db to weight dictionary
-    weights_by_db = {_db: weight for _db, weight in weighted_dbs}
-
-    # filter out stale standby dbs
-    fresh_dbs = filter_out_stale_standbys(weights_by_db.keys())
-    dbs = []
-    weights = []
-    for _db, weight in six.iteritems(weights_by_db):
-        if _db in fresh_dbs:
-            dbs.append(_db)
-            weights.append(weight)
-
-    if dbs:
-        # normalize weights of remaining dbs
-        total_weight = sum(weights)
-        normalized_weights = [float(weight) / total_weight for weight in weights]
-        return random.choice(dbs, p=normalized_weights)

--- a/settings.py
+++ b/settings.py
@@ -861,10 +861,10 @@ WAREHOUSE_DATABASE_ALIAS = 'default'
 # Example format:
 # {
 # "users":
-#     [
-#      ("pgmain", 5),
-#      ("pgmainstandby", 5)
-#     ]
+#     {
+#      ["pgmain", 5],
+#      ["pgmainstandby", 5]
+#     }
 # }
 LOAD_BALANCED_APPS = {}
 


### PR DESCRIPTION
reverts #20315 

```python
@quickcache(['weighted_dbs'], timeout=LOAD_BALANCE_FREQUENCY_SECONDS, skip_arg=lambda *args: settings.UNIT_TESTING)
def select_db_for_read(weighted_dbs):
   ...
```

Having this cached means we end up using the same DB for ALL reads until the cache expires. My bad for not catching that in review.