### PR TITLE
use session context

### DIFF
--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -277,14 +277,9 @@ class SqlData(ReportDataSource):
         for c in self.columns:
             qc.append_column(c.view)
 
-        session = connection_manager.get_scoped_session(self.engine_id)
-        try:
+        session_helper = connection_manager.get_session_helper(self.engine_id)
+        with session_helper.session_context() as session:
             return qc.resolve(session.connection(), self.filter_values)
-        except Exception:
-            session.rollback()
-            raise
-        finally:
-            session.remove()
 
     @property
     def data(self):


### PR DESCRIPTION
The only real difference here is that this calls
`session.close()` in the finally block instead of
`session.remove()`. `remove` calls `close` but it
also removes the session from the scope preventing
it's re-use.

Here's the source for the context manager for reference: https://github.com/dimagi/commcare-hq/blob/ad5aa018821d8f573b6f68378b721c926fd71664/corehq/sql_db/connections.py#L52

buddy @orangejenny 