### PR TITLE
Fuzzy matches accept multiple terms

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -70,8 +70,8 @@ class CaseSearchES(CaseES):
             return (
                 # fuzzy match
                 self._add_query(case_property_text_query(case_property_name, value, fuzziness='AUTO'), clause)
-                # exact match. added to improve the score of exact matches
-                ._add_query(exact_case_property_text_query(case_property_name, value),
+                # non-fuzzy match. added to improve the score of exact matches
+                ._add_query(case_property_text_query(case_property_name, value),
                             queries.SHOULD if positive_clause else clause))
         else:
             return self._add_query(exact_case_property_text_query(case_property_name, value), clause)

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -147,21 +147,16 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                         "query": {
                                             "filtered": {
                                                 "filter": {
-                                                    "and": (
-                                                        {
-                                                            "term": {
-                                                                "case_properties.key.exact": "parrot_name"
-                                                            }
-                                                        },
-                                                        {
-                                                            "term": {
-                                                                "case_properties.value.exact": "polly"
-                                                            }
-                                                        }
-                                                    )
+                                                    "term": {
+                                                        "case_properties.key.exact": "parrot_name"
+                                                    }
                                                 },
                                                 "query": {
-                                                    "match_all": {
+                                                    "match": {
+                                                        "case_properties.value": {
+                                                            "query": "polly",
+                                                            "fuzziness": "0"
+                                                        }
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
@kaapstorm 
https://manage.dimagi.com/default.asp?276440

This gives better scores for queries with a single term that matches exactly. e.g. "Nomran Hooper" would be scored better than "Nomran Booper" even though they both match the fuzzy query. 