### PR TITLE
Add some checks around ScheduleInstance reprocessing

### DIFF
--- a/corehq/messaging/management/commands/queue_schedule_instances.py
+++ b/corehq/messaging/management/commands/queue_schedule_instances.py
@@ -73,6 +73,8 @@ class Command(BaseCommand):
                 if skip_domain(domain):
                     continue
 
+                # We use a non-blocking lock here with a timeout of one hour to make sure
+                # that we only retry non-processed schedule instances once an hour.
                 enqueue_lock = self.get_enqueue_lock(cls, schedule_instance_id, next_event_due)
                 if enqueue_lock.acquire(blocking=False):
                     self.get_task(cls).delay(schedule_instance_id)
@@ -83,6 +85,7 @@ class Command(BaseCommand):
                 if skip_domain(domain):
                     continue
 
+                # See comment above about why we use a non-blocking lock here.
                 enqueue_lock = self.get_enqueue_lock(cls, schedule_instance_id, next_event_due)
                 if enqueue_lock.acquire(blocking=False):
                     self.get_task(cls).delay(case_id, schedule_instance_id)

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -19,7 +19,7 @@ from corehq.sql_db.models import PartitionedModel
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_domain, coerce_timezone_value
 from couchdbkit.exceptions import ResourceNotFound
-from datetime import tzinfo
+from datetime import tzinfo, timedelta
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from memoized import memoized
 from dimagi.utils.modules import to_function


### PR DESCRIPTION
- defines an interval over which ScheduleInstances can be processed, after which they are considered stale and their content is no longer sent
- uses non-blocking locks to ensure that we don't try sending the same content to the same recipient twice in the event of retrying a failed processing attempt with a long list of recipients

@millerdev @dannyroberts 