### PR TITLE
Turn off appcues changes

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -7,16 +7,6 @@
 
 {% block title %}{{ module.name|clean_trans:langs }}{% endblock %}
 
-{% block stylesheets %}{{ block.super }}
-    {% if request|toggle_enabled:"APPCUES_AB_TEST" %}
-        <style type="text/css">
-            .helpbubble {
-                display: none !important;
-            }
-        </style>
-    {% endif %}
-{% endblock stylesheets %}
-
 {% block js %}
     {{ block.super }}
     {% compress js %}


### PR DESCRIPTION
Leaving the A/B test assignment in place because we're planning to do another round of testing. 

Marshall will turn this off on the appcues side, all that needs to be done on HQ is re-show the help bubbles, which we'd been hiding from users who were in the test.

@jmtroth0 / @snopoke 