### PR TITLE
Use location CTE queries everywhere

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -427,10 +427,9 @@ INSTALLED_APPS = ('hqscripts',) + DEFAULT_APPS + HQ_APPS + ENIKSHAY_APPS
 # rather than the default 'accounts/profile'
 LOGIN_REDIRECT_URL = 'homepage'
 
-# set to True or False in localsettings to override the value set way down below
-IS_LOCATION_CTE_ENABLED = None
-# IS_LOCATION_CTE_ONLY is always False when IS_LOCATION_CTE_ENABLED == False
-IS_LOCATION_CTE_ONLY = None
+# may be overridden in localsettings
+IS_LOCATION_CTE_ENABLED = True
+IS_LOCATION_CTE_ONLY = True
 
 REPORT_CACHE = 'default'  # or e.g. 'redis'
 
@@ -2327,23 +2326,5 @@ if RESTRICT_USED_PASSWORDS_FOR_NIC_COMPLIANCE:
 
 PACKAGE_MONITOR_REQUIREMENTS_FILE = os.path.join(FILEPATH, 'requirements', 'requirements.txt')
 
-if IS_LOCATION_CTE_ENABLED is None:
-    IS_LOCATION_CTE_ENABLED = UNIT_TESTING or SERVER_ENVIRONMENT in [
-        'localdev',
-        'changeme',  # default value in localsettings.example.py
-        'staging',
-        'softlayer',
-        'production',
-    ]
-
-if IS_LOCATION_CTE_ENABLED and IS_LOCATION_CTE_ONLY is None:
-    # location MPTT is disabled when IS_LOCATION_CTE_ONLY == True
-    IS_LOCATION_CTE_ONLY = UNIT_TESTING or SERVER_ENVIRONMENT in [
-        'localdev',
-        'changeme',  # default value in localsettings.example.py
-        'staging',
-        'softlayer',
-        'production',
-    ]
-else:
-    IS_LOCATION_CTE_ONLY = False
+# IS_LOCATION_CTE_ONLY is always False when IS_LOCATION_CTE_ENABLED == False
+IS_LOCATION_CTE_ONLY = bool(IS_LOCATION_CTE_ENABLED and IS_LOCATION_CTE_ONLY)


### PR DESCRIPTION
This will switch to using CTE queries on ICDS and other envs that were previously using MPTT. CTE queries have been live on production since late April and [query timings have been steady since the switch there](https://app.datadoghq.com/dash/588156/location-query-timing?live=true&from_ts=1523906690842&fullscreen=false&is_auto=false&page=0&tile_size=m&to_ts=1526498690842&tpl_var_env=production).

@snopoke @emord @calellowitz @czue 