### PR TITLE
Stop datatables from making double requests on every load

### DIFF
--- a/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
@@ -217,13 +217,6 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                 $('.dataTables_paginate a').on('click', function () {
                     datatable.fnAdjustColumnSizing();
                 });
-                // This fixes a bug in some browsers where if the first column
-                // contains a large amount of data, it will overlap with the
-                // second column. This makes sure after load, the columns are
-                // re-adjusted.
-                setTimeout( function () {
-                    datatable.fnAdjustColumnSizing();
-                }, 10);
 
                 // This fixes a display bug in some browsers where the pagination
                 // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows


### PR DESCRIPTION
@emord @kaapstorm 

According to [this](https://github.com/dimagi/commcare-hq/pull/10291/files/e306f2a9185c6e21a94b616692fcdb4095c91b79#r54713794), this should happen when there is a lot of text in the left most column. I wasn't able to reproduce in any new browser (chrome, ff). 

Having every report load the data twice for everyone seems worse than having very specific users have overlap in a few reports. If we get reports of this again, I think we should solve the problem in a less hacky way (e.g. testing to see if the left column contains more than X characters and only then resizing, for example).

### Chrome
![screenshot from 2018-05-17 09-51-00](https://user-images.githubusercontent.com/146896/40181746-d622febc-59b7-11e8-8ec1-13baadee2839.png)

### FF
![screenshot from 2018-05-17 09-52-13](https://user-images.githubusercontent.com/146896/40181818-0541fb8a-59b8-11e8-9873-d46c6b397bf7.png)
