### PR TITLE
Fix use of io.open in LogFilePlugin

### DIFF
--- a/corehq/tests/noseplugins/logfile.py
+++ b/corehq/tests/noseplugins/logfile.py
@@ -25,6 +25,8 @@ except ImportError:
 from unittest.runner import TextTestResult, _WritelnDecorator
 from nose.plugins import Plugin
 
+import six
+
 
 class LogFilePlugin(Plugin):
     """Log test failures to file"""
@@ -47,7 +49,8 @@ class LogFilePlugin(Plugin):
             self.start = datetime.datetime.now()
 
     def setup_log(self):
-        self.log_file = _WritelnDecorator(open(self.log_path, "w"))
+        mode = "w" if six.PY3 else "wb"
+        self.log_file = _WritelnDecorator(open(self.log_path, mode))
         self.log_file.writeln(" ".join(quote(a) for a in self.argv))
         self.log_file.writeln(str(self.start))
         self.result = TextTestResult(self.log_file, True, 0)


### PR DESCRIPTION
Broken by #20435. I have not tested it on Python 3 yet, so it might still be broken there.

@nickpell 