### PR TITLE
specify utf-8 encoding for existing usages of io.open

### DIFF
--- a/app_builder_live_test/compare_perf_stats.py
+++ b/app_builder_live_test/compare_perf_stats.py
@@ -12,7 +12,7 @@ from io import open
 
 def get_stats(path, build_slug):
     perfpath = os.path.join(path, '{}-performance.txt'.format(build_slug))
-    with open(perfpath, 'r') as f:
+    with open(perfpath, 'r', encoding='utf-8') as f:
         lines = f.read().splitlines()
         stats = [line.split(',') for line in lines]
         return {line[0]: {'mem': int(line[1]), 'time': float(line[2])} for line in stats}

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -173,7 +173,7 @@ class AppManagerTest(TestCase):
     def _yesno_source(self):
         # this app fixture uses both the (new) '_attachment'
         # and the (old) 'contents' conventions, to test that both work
-        with open(os.path.join(os.path.dirname(__file__), 'data', 'yesno.json')) as f:
+        with open(os.path.join(os.path.dirname(__file__), 'data', 'yesno.json'), encoding='utf-8') as f:
             return json.load(f)
 
     def _check_has_build_files(self, build, paths):

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -23,7 +23,7 @@ class BuildErrorsTest(SimpleTestCase):
                 del error['module']['unique_id']
 
     def test_subcase_errors(self, mock):
-        with open(os.path.join(os.path.dirname(__file__), 'data', 'subcase-details.json')) as f:
+        with open(os.path.join(os.path.dirname(__file__), 'data', 'subcase-details.json'), encoding='utf-8') as f:
             source = json.load(f)
 
         app = Application.wrap(source)

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -114,7 +114,7 @@ class CommCareSettingsTest(SimpleTestCase):
         static_strings = set(STATICALLY_ANALYZABLE_TRANSLATIONS)
 
         for filepath, keys_to_translate in files_and_keys_to_translate:
-            with open(os.path.join(base_path, filepath)) as f:
+            with open(os.path.join(base_path, filepath), encoding='utf-8') as f:
                 cc_settings = yaml.load(f)
                 for setting in cc_settings:
                     for key in keys_to_translate:

--- a/corehq/apps/case_importer/tracking/tests/test_filestorage.py
+++ b/corehq/apps/case_importer/tracking/tests/test_filestorage.py
@@ -14,19 +14,19 @@ class FilestorageTest(TestCase):
         cls.filename = '/tmp/test_file.txt'
         cls.content = 'this is the message\n'
 
-        with open(cls.filename, 'w') as f:
+        with open(cls.filename, 'w', encoding='utf-8') as f:
             f.write(cls.content)
 
 
 @generate_cases([(transient_file_store,),
                  (persistent_file_store,)], FilestorageTest)
 def test_transient(self, file_store):
-    with open(self.filename, 'r') as f:
+    with open(self.filename, 'r', encoding='utf-8') as f:
         identifier = file_store.write_file(f, 'test_file.txt').identifier
 
     tmpfile = file_store.get_tempfile_ref_for_contents(identifier)
     self.assertEqual(file_extention_from_filename(tmpfile), '.txt')
-    with open(tmpfile) as f:
+    with open(tmpfile, encoding='utf-8') as f:
         self.assertEqual(f.read(), self.content)
 
     self.assertEqual(file_store.get_filename(identifier), 'test_file.txt')

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
 
         self.stdout.ending = "\n"
         self.stderr.ending = "\n"
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding='utf-8') as f:
             domains = [name.strip() for name in f.readlines() if name.strip()]
 
         self.stdout.write("Processing {} domains".format(len(domains)))

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -215,7 +215,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         self._compare_diffs([])
 
     def test_duplicate_form_migration(self):
-        with open('corehq/ex-submodules/couchforms/tests/data/posts/duplicate.xml') as f:
+        with open('corehq/ex-submodules/couchforms/tests/data/posts/duplicate.xml', encoding='utf-8') as f:
             duplicate_form_xml = f.read()
 
         submit_form_locally(duplicate_form_xml, self.domain_name)

--- a/corehq/apps/data_analytics/management/commands/add_to_malt_table.py
+++ b/corehq/apps/data_analytics/management/commands/add_to_malt_table.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
 
     def handle(self, file_paths, **options):
         for arg in file_paths:
-            with open(arg, 'r') as file:
+            with open(arg, 'r', encoding='utf-8') as file:
                 rows = []
                 reader = csv.reader(file)
                 header_row = True

--- a/corehq/apps/data_interfaces/tests/tests.py
+++ b/corehq/apps/data_interfaces/tests/tests.py
@@ -102,7 +102,7 @@ class BulkArchiveForms(TestCase):
         self.assertIn('No files uploaded', response.content)
 
     def test_bulk_archive_wrong_filetype(self):
-        with open(join(BASE_PATH, WRONG_FILETYPE)) as fp:
+        with open(join(BASE_PATH, WRONG_FILETYPE), encoding='utf-8') as fp:
             response = self.client.post(self.url, {'bulk_upload_file': fp}, follow=True)
             self.assertIn('CommCare HQ does not support that file type.', response.content)
 

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -82,7 +82,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
 
         self.assertIsNotNone(log)
         self.assertIn("Form is a duplicate", log.problem)
-        with open(file) as f:
+        with open(file, encoding='utf-8') as f:
             self.assertEqual(f.read(), log.get_xml())
 
     def _test_submission_error_post_save(self, openrosa_version):
@@ -117,7 +117,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
         f, path = tmpfile()
         with f:
             f.write("this isn't even close to xml")
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             res = self.client.post(self.url, {
                     "xml_submission_file": f
             })
@@ -143,7 +143,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
 
         self.assertIsNotNone(log)
         self.assertIn(message, log.problem)
-        with open(file) as f:
+        with open(file, encoding='utf-8') as f:
             self.assertEqual(f.read(), log.get_xml())
 
     @flag_enabled('DATA_MIGRATION')

--- a/corehq/apps/smsbillables/management/commands/bootstrap_tropo_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_tropo_gateway.py
@@ -25,7 +25,7 @@ def bootstrap_tropo_gateway(apps):
     )
 
     rates_csv = open('corehq/apps/smsbillables/management/'
-                     'pricing_data/tropo_international_rates_2013-12-19.csv', 'r')
+                     'pricing_data/tropo_international_rates_2013-12-19.csv', 'r', encoding='utf-8')
     for line in rates_csv.readlines():
         data = line.split(',')
         if data[1] == 'Fixed Line' and data[4] != '\n':

--- a/corehq/apps/userreports/management/commands/find_datasource_mismatches.py
+++ b/corehq/apps/userreports/management/commands/find_datasource_mismatches.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             data_source_id[-8:],
             datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")
         )
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             headers = ['doc_id', 'column_name', 'inserted_at', 'server_modified_on',
                        'stored_value', 'desired_value', 'message']
             writer = csv.DictWriter(f, headers)

--- a/corehq/apps/userreports/management/commands/load_spec.py
+++ b/corehq/apps/userreports/management/commands/load_spec.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
 
     @log_exception()
     def handle(self, filename, **options):
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
             body = json.loads(f.read())
 
             # intentionally fails hard if bad or missing doc_type

--- a/corehq/apps/userreports/management/commands/resave_couch_forms_and_cases.py
+++ b/corehq/apps/userreports/management/commands/resave_couch_forms_and_cases.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         parser.add_argument('ids_file')
 
     def handle(self, ids_file, **options):
-        with open(ids_file) as f:
+        with open(ids_file, encoding='utf-8') as f:
             doc_ids = [line.strip() for line in f]
         total_doc_ids = len(doc_ids)
         doc_ids = set(doc_ids)
@@ -40,7 +40,7 @@ class Command(BaseCommand):
 
         filename = '{}_{}.csv'.format(ids_file.split('/')[-1],
                                       datetime.datetime.now().isoformat())
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerow(['doc_id', 'status'])
             for doc_id in doc_ids:

--- a/corehq/apps/userreports/tests/test_data_source_repeats.py
+++ b/corehq/apps/userreports/tests/test_data_source_repeats.py
@@ -19,7 +19,7 @@ class RepeatDataSourceTestMixin(object):
     def setUp(self):
         folder = os.path.join(os.path.dirname(__file__), 'data', 'configs')
         sample_file = os.path.join(folder, 'data_source_with_repeat.json')
-        with open(sample_file) as f:
+        with open(sample_file, encoding='utf-8') as f:
             self.config = DataSourceConfiguration.wrap(json.loads(f.read()))
 
 

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -24,7 +24,7 @@ from io import open
 def get_sample_report_config():
     folder = os.path.join(os.path.dirname(__file__), 'data', 'configs')
     sample_file = os.path.join(folder, 'sample_report_config.json')
-    with open(sample_file) as f:
+    with open(sample_file, encoding='utf-8') as f:
         structure = json.loads(f.read())
         return ReportConfiguration.wrap(structure)
 
@@ -32,7 +32,7 @@ def get_sample_report_config():
 def get_sample_data_source():
     folder = os.path.join(os.path.dirname(__file__), 'data', 'configs')
     sample_file = os.path.join(folder, 'sample_data_source.json')
-    with open(sample_file) as f:
+    with open(sample_file, encoding='utf-8') as f:
         structure = json.loads(f.read())
         return DataSourceConfiguration.wrap(structure)
 
@@ -40,7 +40,7 @@ def get_sample_data_source():
 def get_data_source_with_related_doc_type():
     folder = os.path.join(os.path.dirname(__file__), 'data', 'configs')
     sample_file = os.path.join(folder, 'parent_child_data_source.json')
-    with open(sample_file) as f:
+    with open(sample_file, encoding='utf-8') as f:
         structure = json.loads(f.read())
         return DataSourceConfiguration.wrap(structure)
 

--- a/corehq/blobs/management/commands/blob_storage_report.py
+++ b/corehq/blobs/management/commands/blob_storage_report.py
@@ -157,7 +157,7 @@ def accumulate_put_requests(files):
         if filepath == "-":
             load_puts(sys.stdin, data)
         else:
-            with open(filepath, "r") as fileobj:
+            with open(filepath, "r", encoding='utf-8') as fileobj:
                 load_puts(fileobj, data)
     return data
 
@@ -291,7 +291,7 @@ def make_row_writer(output_file, write_csv):
         return write
 
     if output_file != sys.stdout:
-        output_file = open(output_file, "w")
+        output_file = open(output_file, "w", encoding='utf-8')
     if write_csv:
         writer = csv.writer(output_file, dialect="excel")
         write = writer.writerow

--- a/corehq/blobs/management/commands/check_blob_logs.py
+++ b/corehq/blobs/management/commands/check_blob_logs.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         old_db = blob_db.old_db
         new_db = blob_db.new_db
         for filepath in files:
-            with open(filepath) as fh:
+            with open(filepath, encoding='utf-8') as fh:
                 for line in fh:
                     if not line:
                         continue

--- a/corehq/blobs/management/commands/run_blob_migration.py
+++ b/corehq/blobs/management/commands/run_blob_migration.py
@@ -79,5 +79,5 @@ class Command(BaseCommand):
                 "{}-blob-migration-{}.txt".format(slug, now))
             assert not os.path.exists(summary_file), summary_file
             assert not os.path.exists(log_file), log_file
-            with open(summary_file, "w", 1) as fh, tee_output(fh):
+            with open(summary_file, "w", 1, encoding='utf-8') as fh, tee_output(fh):
                 do_migration()

--- a/corehq/blobs/tests/test_init.py
+++ b/corehq/blobs/tests/test_init.py
@@ -24,7 +24,7 @@ def test_get_blobdb(self, msg, root=True, blob_dir=None):
     with tempdir() as tmp:
         if root == b"file":
             tmp = join(tmp, b"file")
-            with open(tmp, "w") as fh:
+            with open(tmp, "w", encoding='utf-8') as fh:
                 fh.write("x")
         conf = SharedDriveConfiguration(
             shared_drive_path=tmp if root else root,

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -98,7 +98,7 @@ class BaseMigrationTest(TestCase):
             mod.BlobMigrationState.objects.get(slug=self.slug)
 
             # verify: migrated data was written to the file
-            with open(filename) as fh:
+            with open(filename, encoding='utf-8') as fh:
                 lines = list(fh)
             lines_by_id = {d["_id"]: d for d in (json.loads(x) for x in lines)}
             for doc in docs:
@@ -590,7 +590,7 @@ class TestMigrateBackend(TestCase):
             missing_log = set()
             fields = ["doc_type", "doc_id", "blob_identifier", "blob_bucket"]
             for n, ignore in enumerate(mod.MIGRATIONS[self.slug].migrators):
-                with open("{}.{}".format(filename, n)) as fh:
+                with open("{}.{}".format(filename, n), encoding='utf-8') as fh:
                     for line in fh:
                         doc = json.loads(line)
                         missing_log.add(tuple(doc[x] for x in fields))

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -56,7 +56,7 @@ class BaseTestCase(SimpleTestCase):
             return os.path.exists(self.path)
 
         def open(self):
-            return open(self.path)
+            return open(self.path, encoding='utf-8')
 
         def listdir(self):
             return os.listdir(self.path)
@@ -552,7 +552,7 @@ class TestBlobMixinWithMigratingDbBeforeCopyToNew(TestBlobMixinWithS3Backend):
             super_ = super(TestBlobMixinWithMigratingDbBeforeCopyToNew.TestBlob, self)
             if super_.exists():
                 return super_.open()
-            return open(self.fspath)
+            return open(self.fspath, encoding='utf-8')
 
         def listdir(self):
             super_ = super(TestBlobMixinWithMigratingDbBeforeCopyToNew.TestBlob, self)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -21,7 +21,7 @@ def get_test_file_json(filename):
     base = os.path.dirname(__file__)
     file_path = 'data'
     path = os.path.join(base, file_path, '%s.json' % filename)
-    with open(path) as f:
+    with open(path, encoding='utf-8') as f:
         file_contents = f.read()
 
     return json.loads(file_contents)

--- a/corehq/form_processor/management/commands/make_sharded_sql_function.py
+++ b/corehq/form_processor/management/commands/make_sharded_sql_function.py
@@ -26,11 +26,11 @@ class Command(LabelCommand):
         self._create_accessor_function(sql_function_name, SQL_PROXY_ACCESSOR_DIR)
 
     def _create_accessor_function(self, sql_function_name, accessor_dir):
-        with open(os.path.join(accessor_dir, TEMPLATE_NAME)) as f:
+        with open(os.path.join(accessor_dir, TEMPLATE_NAME), encoding='utf-8') as f:
             template_string = f.read()
 
         template = Engine().from_string(template_string)
         rendered_template = template.render({'sql_function_name': sql_function_name})
 
-        with open(os.path.join(accessor_dir, '{}.sql'.format(sql_function_name)), 'w+') as f:
+        with open(os.path.join(accessor_dir, '{}.sql'.format(sql_function_name)), 'w+', encoding='utf-8') as f:
             f.write(rendered_template)

--- a/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
@@ -81,7 +81,7 @@ class Command(BaseCommand):
             repeater.__class__.__name__,
             datetime.datetime.utcnow().isoformat())
         print("Writing log of changes to {}".format(filename))
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerow(('RepeatRecord ID', 'Payload ID', 'Failure Reason', 'Deleted?', 'Reason'))
             writer.writerows(redundant_log)

--- a/corehq/motech/repeaters/management/commands/generate_repeater_report.py
+++ b/corehq/motech/repeaters/management/commands/generate_repeater_report.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
         return file_name
 
     def _load_record_ids_from_file(self, file_path):
-        with open(file_path, 'rU') as csvfile:
+        with open(file_path, 'rU', encoding='utf-8') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 self.record_ids.append(row['record_id'])

--- a/corehq/motech/repeaters/management/commands/update_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/update_cancelled_records.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
             action,
             repeater.__class__.__name__,
             datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M.%S'))
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerow(('record_id', 'payload_id', 'state', 'message'))
 

--- a/corehq/sql_db/operations.py
+++ b/corehq/sql_db/operations.py
@@ -84,7 +84,7 @@ class RunSqlLazy(RunSQL):
             super(RunSqlLazy, self).database_backwards(app_label, schema_editor, from_state, to_state)
 
     def _render_template(self, path):
-        with open(self.sql) as f:
+        with open(self.sql, encoding='utf-8') as f:
             template_string = f.read()
 
         template = engines['django'].from_string(template_string)

--- a/corehq/tests/noseplugins/timing.py
+++ b/corehq/tests/noseplugins/timing.py
@@ -49,7 +49,7 @@ class TimingPlugin(Plugin):
         self.threshold = options.threshold
 
     def begin(self):
-        self.output = (open(self.timing_file, "w")
+        self.output = (open(self.timing_file, "w", encoding='utf-8')
                        if self.timing_file else sys.__stdout__)
         if not self.pretty_output:
             self.csv = csv.writer(self.output)

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -103,12 +103,12 @@ class TestFileMixin(object):
 
     @classmethod
     def get_file(cls, name, ext, override_path=None):
-        with open(cls.get_path(name, ext, override_path)) as f:
+        with open(cls.get_path(name, ext, override_path), encoding='utf-8') as f:
             return f.read()
 
     @classmethod
     def write_xml(cls, name, xml, override_path=None):
-        with open(cls.get_path(name, '.xml', override_path), 'w') as f:
+        with open(cls.get_path(name, '.xml', override_path), 'w', encoding='utf-8') as f:
             return f.write(xml)
 
     @classmethod

--- a/custom/_legacy/mvp_docs/tests/test_pillows.py
+++ b/custom/_legacy/mvp_docs/tests/test_pillows.py
@@ -195,7 +195,7 @@ def _save_form_and_case(test):
 
 
 def _fake_indicators(filename):
-    with open(os.path.join(os.path.dirname(__file__), 'data', filename)) as f:
+    with open(os.path.join(os.path.dirname(__file__), 'data', filename), encoding='utf-8') as f:
         indicators = json.loads(f.read())
         return [_wrap(i) for i in indicators]
 

--- a/custom/_legacy/pact/tests/dot_ordering.py
+++ b/custom/_legacy/pact/tests/dot_ordering.py
@@ -65,7 +65,7 @@ class dotsOrderingTests(TestCase):
 
         self.form_a = ""
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'dots_data',
-                               '05_uncheck_a.xml')) as fin:
+                               '05_uncheck_a.xml'), encoding='utf-8') as fin:
             self.form_a = fin.read() % {
                 'encounter_date': ANCHOR_DATE_A.strftime('%Y-%m-%d'),
                 'anchor_date': ANCHOR_DATE_A.strftime("%d %b %Y")
@@ -73,7 +73,7 @@ class dotsOrderingTests(TestCase):
 
         self.form_b = ""
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'dots_data',
-                               '06_uncheck_b.xml')) as fin:
+                               '06_uncheck_b.xml'), encoding='utf-8') as fin:
             self.form_b = fin.read() % {
                 'encounter_date': ANCHOR_DATE_B.strftime('%Y-%m-%d'),
                 'anchor_date': ANCHOR_DATE_B.strftime("%d %b %Y")

--- a/custom/_legacy/pact/tests/dot_submission.py
+++ b/custom/_legacy/pact/tests/dot_submission.py
@@ -69,16 +69,16 @@ class dotsSubmissionTests(TestCase):
 
         self.pillbox_form = ""
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'dots_data',
-                               '01_pillbox.xml')) as fin:
+                               '01_pillbox.xml'), encoding='utf-8') as fin:
             self.pillbox_form = fin.read()
 
         self.no_pillbox_form = ""
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'dots_data',
-                               '02_no_pillbox.xml')) as fin:
+                               '02_no_pillbox.xml'), encoding='utf-8') as fin:
             self.no_pillbox_form = fin.read()
         self.no_pillbox_form2 = ""
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'dots_data',
-                               '03_no_pillbox.xml')) as fin:
+                               '03_no_pillbox.xml'), encoding='utf-8') as fin:
             self.no_pillbox_form2 = fin.read()
 
     def tearDown(self):

--- a/custom/bihar/tests/test_homevisits.py
+++ b/custom/bihar/tests/test_homevisits.py
@@ -161,7 +161,7 @@ class TestHomeVisits(TestCase):
     def _load_case(self, filename, format_dict=None):
         format_dict = format_dict or {}
         fullpath = os.path.join(os.path.dirname(__file__), 'data', 'cases', filename)
-        with open(fullpath, 'r') as f:
+        with open(fullpath, 'r', encoding='utf-8') as f:
             raw = f.read()
             formatted = raw % format_dict
             return BiharCase.from_dump(json.loads(formatted))

--- a/custom/champ/tests/__init__.py
+++ b/custom/champ/tests/__init__.py
@@ -40,7 +40,7 @@ def setUpModule():
         metadata.reflect(bind=engine, extend_existing=True)
         path = os.path.join(os.path.dirname(__file__), 'fixtures')
         for file_name in os.listdir(path):
-            with open(os.path.join(path, file_name)) as f:
+            with open(os.path.join(path, file_name), encoding='utf-8') as f:
                 table_name = get_table_name(domain.name, file_name[:-4])
                 table = metadata.tables[table_name]
                 postgres_copy.copy_from(f, table, engine, format=b'csv', null=b'', header=True)

--- a/custom/champ/tests/utils.py
+++ b/custom/champ/tests/utils.py
@@ -66,7 +66,7 @@ class TestDataSourceExpressions(SimpleTestCase):
             cls.data_source_name
         )
 
-        with open(data_source_file) as f:
+        with open(data_source_file, encoding='utf-8') as f:
             cls.data_source = DataSourceConfiguration.wrap(json.loads(f.read())['config'])
             cls.named_expressions = cls.data_source.named_expression_objects
 

--- a/custom/icds/management/commands/cleanup_orphan_migration.py
+++ b/custom/icds/management/commands/cleanup_orphan_migration.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         self.db = shard
         self.case_accessor = CaseAccessors(self.domain)
         failed_updates = []
-        with open(log_file, "w") as fh:
+        with open(log_file, "w", encoding='utf-8') as fh:
             fh.write('--------Successful Form Ids----------\n')
             chunk_num = 1
             for orphan_case_chunk in self._get_cases():

--- a/custom/icds/management/commands/close_orphaned_cases.py
+++ b/custom/icds/management/commands/close_orphaned_cases.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         total_cases = CaseES().domain(domain).case_type('household').is_closed().count()
         self.case_accessor = CaseAccessors(domain)
         failed_updates = []
-        with open(log_file, "w") as fh:
+        with open(log_file, "w", encoding='utf-8') as fh:
             fh.write('--------Successful Form Ids----------\n')
             for cases in chunked(with_progress_bar(self._get_cases_to_process(domain), total_cases), 100):
                 related_cases = self._get_related_cases(cases)

--- a/custom/icds/management/commands/export_orphaned_cases.py
+++ b/custom/icds/management/commands/export_orphaned_cases.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         owners = SQLLocation.objects.get_queryset_descendants(relevant_districts, include_self=True)
         owner_name_mapping = {loc.location_id: loc.name for loc in owners}
         hh_cases = self._get_closed_hh_cases(list(owner_name_mapping))
-        with open(child_file, 'w') as child_csv:
+        with open(child_file, 'w', encoding='utf-8') as child_csv:
             child_writer = csv.writer(child_csv)
             child_writer.writerow(CSV_HEADERS)
             for cases in chunked(with_progress_bar(hh_cases, hh_cases.count), 500):

--- a/custom/icds/management/commands/find_cases_with_no_delivery.py
+++ b/custom/icds/management/commands/find_cases_with_no_delivery.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
     def handle(self, csv_file, **options):
         self.domain = 'icds-cas'
         self.case_accessor = CaseAccessors(self.domain)
-        with open(csv_file, "w") as csv_file:
+        with open(csv_file, "w", encoding='utf-8') as csv_file:
             field_names = [
                 'case_id', 'owner_id', 'modified_on', 'server_modified_on',
                 'add', 'edd', 'ccs_phase', 'num_pnc_visits', 'current_schedule_phase'

--- a/custom/icds/management/commands/phone_number_data.py
+++ b/custom/icds/management/commands/phone_number_data.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
     def handle(self, infile, outfile, *args, **options):
         self.case_accessor = CaseAccessors('icds-cas')
-        with open(infile, 'r') as old, open(outfile, 'w') as new:
+        with open(infile, 'r', encoding='utf-8') as old, open(outfile, 'w', encoding='utf-8') as new:
             reader = csv.reader(old)
             writer = csv.writer(new)
             headers = next(reader)

--- a/custom/icds/management/commands/phone_number_data_2.py
+++ b/custom/icds/management/commands/phone_number_data_2.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, infile, outfile, *args, **options):
         self.case_accessor = CaseAccessors('icds-cas')
-        with open(infile, 'r') as old, open(outfile, 'w') as new:
+        with open(infile, 'r', encoding='utf-8') as old, open(outfile, 'w', encoding='utf-8') as new:
             reader = csv.reader(old)
             writer = csv.writer(new)
             headers = next(reader)

--- a/custom/icds_reports/management/commands/export_non_aadhar.py
+++ b/custom/icds_reports/management/commands/export_non_aadhar.py
@@ -35,7 +35,10 @@ class Command(BaseCommand):
         awc_location_table_name = get_table_name(domain, AWC_LOCATION_TABLE_ID)
         session = session_helper.Session
 
-        with open(os.path.join(os.path.dirname(__file__), 'sql_scripts', 'select_non_aadhar.sql')) as f:
+        with open(
+            os.path.join(os.path.dirname(__file__), 'sql_scripts', 'select_non_aadhar.sql'),
+            encoding='utf-8'
+        ) as f:
             sql_script = f.read()
             rows = session.execute(
                 sql_script % {

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -136,7 +136,7 @@ def _create_aggregate_functions(cursor):
         celery_task_logger.info("Starting icds reports create_functions")
         for sql_function_path in SQL_FUNCTION_PATHS:
             path = os.path.join(os.path.dirname(__file__), *sql_function_path)
-            with open(path, "r") as sql_file:
+            with open(path, "r", encoding='utf-8') as sql_file:
                 sql_to_execute = sql_file.read()
                 cursor.execute(sql_to_execute)
         celery_task_logger.info("Ended icds reports create_functions")
@@ -152,7 +152,7 @@ def _update_aggregate_locations_tables(cursor):
     try:
         path = os.path.join(os.path.dirname(__file__), 'sql_templates', 'update_locations_table.sql')
         celery_task_logger.info("Starting icds reports update_location_tables")
-        with open(path, "r") as sql_file:
+        with open(path, "r", encoding='utf-8') as sql_file:
             sql_to_execute = sql_file.read()
             cursor.execute(sql_to_execute)
         celery_task_logger.info("Ended icds reports update_location_tables_sql")

--- a/custom/icds_reports/tests/__init__.py
+++ b/custom/icds_reports/tests/__init__.py
@@ -104,7 +104,7 @@ def setUpModule():
         metadata.reflect(bind=engine, extend_existing=True)
         path = os.path.join(os.path.dirname(__file__), 'fixtures')
         for file_name in os.listdir(path):
-            with open(os.path.join(path, file_name)) as f:
+            with open(os.path.join(path, file_name), encoding='utf-8') as f:
                 table_name = FILE_NAME_TO_TABLE_MAPPING[file_name[:-4]]
                 table = metadata.tables[table_name]
                 if not table_name.startswith('icds_dashboard_'):

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -113,7 +113,7 @@ class ICDSMixin(object):
 
     @property
     def sources(self):
-        with open(os.path.join(os.path.dirname(__file__), self.resource_file)) as f:
+        with open(os.path.join(os.path.dirname(__file__), self.resource_file), encoding='utf-8') as f:
             return json.loads(f.read())[self.slug]
 
     @property

--- a/custom/intrahealth/tests/__init__.py
+++ b/custom/intrahealth/tests/__init__.py
@@ -77,7 +77,7 @@ def setUpModule():
         metadata.reflect(bind=engine, extend_existing=True)
         path = os.path.join(os.path.dirname(__file__), 'fixtures')
         for file_name in os.listdir(path):
-            with open(os.path.join(path, file_name)) as f:
+            with open(os.path.join(path, file_name), encoding='utf-8') as f:
                 table_name = get_table_name(domain.name, file_name[:-4])
                 table = metadata.tables[table_name]
                 postgres_copy.copy_from(f, table, engine, format=b'csv', null=b'', header=True)

--- a/custom/intrahealth/tests/test_fluffs.py
+++ b/custom/intrahealth/tests/test_fluffs.py
@@ -26,7 +26,7 @@ class TestFluffs(IntraHealthTestCase):
         super(TestFluffs, cls).setUpClass()
         cls.table = cls.taux_sat_table
         cls.couverture = cls.couverture_table
-        with open(os.path.join(DATAPATH, 'taux.xml')) as f:
+        with open(os.path.join(DATAPATH, 'taux.xml'), encoding='utf-8') as f:
             xml = f.read()
             xml_obj = ElementTree.fromstring(xml)
             xml_obj[2][4].text = cls.mobile_worker.get_id
@@ -36,7 +36,7 @@ class TestFluffs(IntraHealthTestCase):
                     user_id=cls.mobile_worker.get_id, domain=TEST_DOMAIN, authenticated=True
                 )
             ).xform
-        with open(os.path.join(DATAPATH, 'operateur.xml')) as f:
+        with open(os.path.join(DATAPATH, 'operateur.xml'), encoding='utf-8') as f:
             xml = f.read()
             cls.couverture_form = submit_form_locally(
                 xml, TEST_DOMAIN, auth_context=AuthContext(

--- a/custom/intrahealth/tests/test_reports.py
+++ b/custom/intrahealth/tests/test_reports.py
@@ -21,7 +21,7 @@ class TestReports(IntraHealthTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestReports, cls).setUpClass()
-        with open(os.path.join(DATAPATH, 'taux.xml')) as f:
+        with open(os.path.join(DATAPATH, 'taux.xml'), encoding='utf-8') as f:
             xml = f.read()
             xml_obj = ElementTree.fromstring(xml)
             xml_obj[2][4].text = cls.mobile_worker.get_id

--- a/custom/intrahealth/tests/utils.py
+++ b/custom/intrahealth/tests/utils.py
@@ -72,7 +72,7 @@ class TestDataSourceExpressions(SimpleTestCase):
             cls.data_source_name
         )
 
-        with open(data_source_file) as f:
+        with open(data_source_file, encoding='utf-8') as f:
             cls.data_source = DataSourceConfiguration.wrap(json.loads(f.read())['config'])
             cls.named_expressions = cls.data_source.named_expression_objects
             cls.base_item_expression = cls.data_source.base_item_expression

--- a/custom/up_nrhm/tests/__init__.py
+++ b/custom/up_nrhm/tests/__init__.py
@@ -41,7 +41,7 @@ def setUpModule():
         metadata.reflect(bind=engine, extend_existing=True)
         path = os.path.join(os.path.dirname(__file__), 'fixtures')
         for file_name in os.listdir(path):
-            with open(os.path.join(path, file_name)) as f:
+            with open(os.path.join(path, file_name), encoding='utf-8') as f:
                 table_name = get_table_name(domain.name, file_name[:-4])
                 table = metadata.tables[table_name]
                 postgres_copy.copy_from(f, table, engine, format=b'csv', null=b'', header=True)

--- a/custom/up_nrhm/tests/utils.py
+++ b/custom/up_nrhm/tests/utils.py
@@ -28,7 +28,7 @@ class UpNrhmTestCase(TestCase):
             cls.data_source_name
         )
 
-        with open(data_source_file) as f:
+        with open(data_source_file, encoding='utf-8') as f:
             cls.data_source = DataSourceConfiguration.wrap(json.loads(f.read())['config'])
             cls.named_expressions = cls.data_source.named_expression_objects
             cls.base_item_expression = cls.data_source.base_item_expression

--- a/custom/world_vision/tests/utils.py
+++ b/custom/world_vision/tests/utils.py
@@ -13,6 +13,6 @@ class WVTest(TestCase):
 
     def setUp(self):
         fullpath = os.path.join(os.path.dirname(__file__), 'data', self.file_name)
-        with open(fullpath, 'r') as f:
+        with open(fullpath, 'r', encoding='utf-8') as f:
             raw = f.read()
             self.case = CommCareCase.wrap(json.loads(raw))

--- a/scripts/checkyaml.py
+++ b/scripts/checkyaml.py
@@ -9,13 +9,13 @@ from io import open
 
 def checkyaml(filename):
     try:
-        yaml.load(open(filename))
+        yaml.load(open(filename), encoding='utf-8')
     except yaml.YAMLError as e:
         print("Error in file {}".format(filename), end=' ')
         if hasattr(e, "problem_mark"):
             mark = e.problem_mark
             print("on line {} (column {}):".format(mark.line + 1, mark.column + 1))
-            f = open(filename)
+            f = open(filename, encoding='utf-8')
             for _ in range(mark.line + 1):
                 print('    ' + f.readline().rstrip('\n'))
             print('    ' + (' ' * mark.column) + '^')

--- a/testapps/test_pillowtop/tests/test_settings.py
+++ b/testapps/test_pillowtop/tests/test_settings.py
@@ -41,7 +41,7 @@ class PillowtopSettingsTest(TestCase, TestFileMixin):
 
     def _rewrite_file(self, pillow_configs):
         # utility that should only be called manually
-        with open(self.get_path('all-pillow-meta', 'json'), 'w') as f:
+        with open(self.get_path('all-pillow-meta', 'json'), 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps({config.name: _pillow_meta_from_config(config) for config in pillow_configs},
                            indent=4, sort_keys=True)


### PR DESCRIPTION
Production uses UTF-8 as the default encoding, so this shouldn't change any behavior on production.

Does not touch instances of ```io.open``` that have ```'rb'``` or ```'wb'```.

@dimagi/py3 