### PR TITLE
prefetching parents to optimize creation of LocationSet

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -260,7 +260,7 @@ def _cte_get_location_fixture_queryset(user):
     ).annotate(
         path=fixture_ids.col.path,
         depth=fixture_ids.col.depth,
-    ).with_cte(fixture_ids).prefetch_related('location_type')
+    ).with_cte(fixture_ids).prefetch_related('location_type', 'parent')
 
     return result
 


### PR DESCRIPTION
@millerdev @pr33thi 
hey, this makes the creation of `LocationSet`, used in domains that still require the hierarchical location fixture in their restores *cough* ICDS *cough*, significantly faster. I worked on this optimization for the old mptt restores but since those are no longer utilized, i thought I would port it here. In basic profiling it brought the restore for one user with a lot of locations down from 9.5 minutes to 1 minute.