### PR TITLE
Add reports/js/filters/main.js dependencies to reports_core/base_temp…

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -18,7 +18,7 @@
     <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
     <script src="{% static 'reports/js/maps_utils.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
-    <script src="{% static 'reports/js/filters/main.js' %}"></script>
+    {% include 'reports/partials/filters_js.html' %}
     {% include 'reports/partials/graphs/charts_js.html' %}
     <script src="{% static 'reports_core/js/base_template_new.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
…late_new.html

https://manage.dimagi.com/default.asp?276668

Error was because script tag for `locations/js/location_drilldown.js` wasn't present on the page.

I think this was introduced in https://github.com/dimagi/commcare-hq/commit/a2672b26ad330f930d4c34a2bb156de51b35d634 fyi @jmtroth0 

interrupt @biyeun / @gbova 