### PR TITLE
Kill unsubscribe view

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -699,19 +699,6 @@ def bsd_license(request):
     return render_static(request, "bsd_license.html", _("BSD License"))
 
 
-def unsubscribe(request, user_id):
-    # todo in the future we should not require a user to be logged in to unsubscribe.
-    from django.contrib import messages
-    from corehq.apps.settings.views import MyAccountSettingsView
-    messages.info(request,
-                  _('Check "Opt out of emails about new features '
-                    'and other CommCare updates" in your account '
-                    'settings and then click "Update Information" '
-                    'if you do not want to receive future emails '
-                    'from us.'))
-    return HttpResponseRedirect(reverse(MyAccountSettingsView.urlname))
-
-
 class BasePageView(TemplateView):
     urlname = None  # name of the view used in urls
     page_title = None  # what shows up in the <title>

--- a/urls.py
+++ b/urls.py
@@ -13,7 +13,7 @@ from corehq.apps.domain.utils import legacy_domain_re
 from django.contrib import admin
 from corehq.apps.app_manager.views.phone import list_apps
 from corehq.apps.domain.views import ProBonoStaticView, logo
-from corehq.apps.hqwebapp.views import apache_license, bsd_license, cda, unsubscribe, redirect_to_dimagi
+from corehq.apps.hqwebapp.views import apache_license, bsd_license, cda, redirect_to_dimagi
 from corehq.apps.reports.views import ReportNotificationUnsubscribeView
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import static
 from corehq.apps.reports.urls import report_urls
@@ -139,8 +139,6 @@ urlpatterns = [
     url(r'^exchange/cda_basic/$', TemplateView.as_view(template_name='cda.html'), name='cda_basic'),
     url(r'^exchange/cda/$', cda, name='cda'),
     url(r'^sms_in/$', sms_in, name='sms_in'),
-    url(r'^unsubscribe/(?P<user_id>[\w-]+)/',
-        unsubscribe, name='unsubscribe'),
     url(r'^wisepill/', include('custom.apps.wisepill.urls')),
     url(r'^pro_bono/$', ProBonoStaticView.as_view(),
         name=ProBonoStaticView.urlname),


### PR DESCRIPTION
This is part of the old mass emails page that was killed in https://github.com/dimagi/commcare-hq/pull/10159, it was added way back in https://github.com/dimagi/commcare-hq/commit/64916a13d6528e587bc0acfc1b455d8a3a69b8fd

@dannyroberts / @biyeun 