### PR TITLE
.muted => .text-muted

### DIFF
--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -85,7 +85,7 @@
                 {% if stock_transaction.stock_on_hand != action.ledger_values.balance %}
                 <span class="text-danger">
                 {% else %}
-                <span class="muted">
+                <span class="text-muted">
                 {% endif %}
                 {{ action.ledger_values.balance }}</span>
             </td>

--- a/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
@@ -72,7 +72,7 @@
             </thead>
             <thead>
             <tr>
-                <th class="muted" colspan="5"  style="text-align: center;">{% trans 'Queued Files' %}</th>
+                <th class="text-muted" colspan="5"  style="text-align: center;">{% trans 'Queued Files' %}</th>
             </tr>
             </thead>
             <tbody class="hqm-queue">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
@@ -38,7 +38,7 @@
                     {% trans "No data" %}
                 </dt>
                 <dd>
-                    <span class="muted">
+                    <span class="text-muted">
                         {% trans "No properties found." %}
                     </span>
                 </dd>

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1109,7 +1109,7 @@ class GenericTabularReport(GenericReportView):
         return context
 
     def table_cell(self, value, html=None, zerostyle=False):
-        styled_value = '<span class="muted">0</span>' if zerostyle and value == 0 else value
+        styled_value = '<span class="text-muted">0</span>' if zerostyle and value == 0 else value
         return dict(
             sort_key=value,
             html="%s" % styled_value if html is None else html

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -937,7 +937,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
             results.get(json_format_date(date), 0)
             for date in self.dates
         ]
-        styled_date_cols = ['<span class="muted">0</span>' if c == 0 else c for c in date_cols]
+        styled_date_cols = ['<span class="text-muted">0</span>' if c == 0 else c for c in date_cols]
         first_col = self.get_raw_user_link(user) if user else _("Total")
         return [first_col] + styled_date_cols + [sum(date_cols)]
 

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -266,7 +266,7 @@
                         {% if case_data.valid_case %}
                         <span class="pull-right">
                             {% if case_data.is_current_case %}
-                            <strong class="muted">{% trans "(this case)" %}</strong>
+                            <strong class="text-muted">{% trans "(this case)" %}</strong>
                             {% else %}
                             <a class="btn btn-sm btn-primary" href="{{ case_data.url }}" style="margin-top: -6px;">
                                 {% trans "View" %}

--- a/corehq/apps/reports/templates/reports/form/partials/single_form_tree.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form_tree.html
@@ -22,7 +22,7 @@
         </tr>
         {% endif %}
     {% endifchanged %}
-<tr class="form-data-question {% if question.response == None %}muted form-data-skipped{% endif %}">
+<tr class="form-data-question {% if question.response == None %}text-muted form-data-skipped{% endif %}">
     {% if question.children %}
         {% if question.type %}
             <td colspan="2">

--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -64,7 +64,7 @@
 
                             </div>
                         {% else %}
-                            <p class="muted">{% blocktrans %}You are this project's administrator.{% endblocktrans %}</p>
+                            <p class="text-muted">{% blocktrans %}You are this project's administrator.{% endblocktrans %}</p>
                         {% endif %}
                     </td>
                 </tr>

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -42,11 +42,11 @@
         <li>
             <a href="{% url 'create_configurable_report' domain %}">
                 <i class="fa fa-plus"></i>
-                <span class="muted">{% trans "Add report" %}</span>
+                <span class="text-muted">{% trans "Add report" %}</span>
             </a>
             <a href="{% url 'import_configurable_report' domain %}">
                 <i class="fa fa-upload"></i>
-                <span class="muted">{% trans "Import report" %}</span>
+                <span class="text-muted">{% trans "Import report" %}</span>
             </a>
         </li>
     </ul>
@@ -71,25 +71,25 @@
         <li>
             <a href="{% url 'create_configurable_data_source' domain %}">
                 <i class="fa fa-plus"></i>
-                <span class="muted">{% trans "Add data source" %}</span>
+                <span class="text-muted">{% trans "Add data source" %}</span>
             </a>
         </li>
         <li>
             <a href="{% url 'create_configurable_data_source_from_app' domain %}">
                 <i class="fa fa-copy"></i>
-                <span class="muted">{% trans "Data source from application" %}</span>
+                <span class="text-muted">{% trans "Data source from application" %}</span>
             </a>
         </li>
         <li>
             <a href="{% url 'expression_debugger' domain %}">
                 <i class="fa fa-search"></i>
-                <span class="muted">{% trans "Expression Debugger" %}</span>
+                <span class="text-muted">{% trans "Expression Debugger" %}</span>
             </a>
         </li>
         <li>
             <a href="{% url 'data_source_debugger' domain %}">
                 <i class="fa fa-search"></i>
-                <span class="muted">{% trans "Data Source Debugger" %}</span>
+                <span class="text-muted">{% trans "Data Source Debugger" %}</span>
             </a>
         </li>
     </ul>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
@@ -111,8 +111,8 @@
                 {% if case.edit_data.description %}
                 <br>
                 <span class="indenter" style="line-height:0; padding: 0 {{ case.edit_data.indent_px }}px"></span>
-                <div style="display:inline-block" class="case-tree-description muted">
-                    <span class="muted">{{ case.edit_data.description }}</span>
+                <div style="display:inline-block" class="case-tree-description">
+                    <span class="text-muted">{{ case.edit_data.description }}</span>
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
Noticed some .muted leftover from bootstrap 2, which was renamed to .text-muted in bootstrap 3.

Product: this is very minor, it'll just make some secondary text appear in grey instead of black.

@snopoke / @biyeun 