### PR TITLE
set has built app post successful built

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -120,7 +120,6 @@ from corehq.apps.appstore.models import SnapshotMixin
 from corehq.apps.builds.models import BuildSpec, BuildRecord
 from corehq.apps.hqmedia.models import HQMediaMixin
 from corehq.apps.translations.models import TranslationMixin
-from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import cc_user_domain
 from corehq.apps.domain.models import cached_property, Domain
 from corehq.apps.app_manager import current_builds, app_strings, remote_app, \
@@ -5317,11 +5316,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
 
         copy.build_comment = comment
         copy.comment_from = user_id
-        if user_id:
-            user = CouchUser.get(user_id)
-            if not user.has_built_app:
-                user.has_built_app = True
-                user.save()
         copy.is_released = False
 
         if not copy.is_remote_app():

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -248,7 +248,6 @@ def save_copy(request, domain, app_id):
             user_id = request.couch_user.get_id
             copy = app.make_build(
                 comment=comment,
-                user_id=request.couch_user.get_id,
                 user_id=user_id,
                 previous_version=app.get_latest_app(released_only=False)
             )

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -54,6 +54,7 @@ from corehq.apps.app_manager.views.download import source_files
 from corehq.apps.app_manager.views.settings import PromptSettingsUpdateView
 from corehq.apps.app_manager.views.utils import (back_to_main, encode_if_unicode, get_langs)
 from corehq.apps.builds.models import CommCareBuildConfig
+from corehq.apps.users.models import CouchUser
 import six
 
 
@@ -244,12 +245,15 @@ def save_copy(request, domain, app_id):
 
     if not errors:
         try:
+            user_id = request.couch_user.get_id
             copy = app.make_build(
                 comment=comment,
                 user_id=request.couch_user.get_id,
+                user_id=user_id,
                 previous_version=app.get_latest_app(released_only=False)
             )
             copy.save(increment_version=False)
+            CouchUser.get(user_id).set_has_built_app()
         finally:
             # To make a RemoteApp always available for building
             if app.is_remote_app():

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1572,6 +1572,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
     def get_location_id(self, domain):
         return getattr(self.get_domain_membership(domain), 'location_id', None)
 
+    def set_has_built_app(self):
+        if not self.has_built_app:
+            self.has_built_app = True
+            self.save()
+
 
 class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin):
 


### PR DESCRIPTION
Found this where `has_built_app` is saved as `True` on user within `make_build` even if `save` fails. 

Looks like this is happening only here i.e `make_build` is called only here in this view, so extracting it to this view instead of `make_build` should be safe.