### PR TITLE
Intrahealth | Availability Report - fix calculating total row for dis…

### DIFF
--- a/custom/intrahealth/tests/reports/test_dashboard_1.py
+++ b/custom/intrahealth/tests/reports/test_dashboard_1.py
@@ -63,8 +63,8 @@ class TestDashboard1(YeksiTestCase):
                     {'style': '', 'html': 'pas de donn\xe9es'},
                     {'style': '', 'html': 'pas de donn\xe9es'},
                     {'style': '', 'html': 'pas de donn\xe9es'},
-                    {'style': '', 'html': '100.00%'},
-                    {'style': '', 'html': '100.00%'}
+                    {'style': 'color: red', 'html': '50.00%'},
+                    {'style': 'color: red', 'html': '50.00%'}
                 ],
                 [
                     {'html': 'Region Test'},
@@ -107,8 +107,8 @@ class TestDashboard1(YeksiTestCase):
                 {'style': '', 'html': '100.00%'},
                 {'style': 'color: red', 'html': '80.00%'},
                 {'style': '', 'html': '100.00%'},
-                {'style': 'color: red', 'html': '94.12%'},
-                {'style': 'color: red', 'html': '85.71%'}
+                {'style': 'color: red', 'html': '88.24%'},
+                {'style': 'color: red', 'html': '83.67%'}
             ]
         )
 
@@ -228,13 +228,13 @@ class TestDashboard1(YeksiTestCase):
             total_row,
             [
                 {'html': 'Disponibilit\xe9 (%)'},
-                {'style': 'color: red', 'html': '0.00%'},
-                {'style': 'color: red', 'html': '0.00%'},
-                {'style': 'color: red', 'html': '0.00%'},
-                {'style': 'color: red', 'html': '0.00%'},
-                {'style': 'color: red', 'html': '0.00%'},
-                {'style': 'color: red', 'html': '0.00%'},
-                {'style': 'color: red', 'html': '0.00%'}
+                {'style': '', 'html': '100.00%'},
+                {'html': 'pas de donn\xe9es'},
+                {'html': 'pas de donn\xe9es'},
+                {'html': 'pas de donn\xe9es'},
+                {'style': '', 'html': '100.00%'},
+                {'html': 'pas de donn\xe9es'},
+                {'style': '', 'html': '100.00%'}
             ]
         )
 


### PR DESCRIPTION
…trict and pps level, revert change preventing merging stockout status per month and pps to one
Hi @esoergel,
Here I have fixed calculating total row per district and pps level as well as reverted merging status of stockout per month and pps (if pps during the month was even once stockout it means that for the whole month it is counted as being stockout). The second change was operated by group_by as well as multiple_rows_per_pps_in_month which didn't catch it, as if was true when value was 0, while it shouldn't be - that's why it is no longer `not x.get('x')` but `x.get('x') is None`.