### PR TITLE
Revert "Upgrade celery to 3.1.25"

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ restkit==4.2.2
 iso8601==0.1.11
 jsonobject==0.9.1
 jsonobject-couchdbkit==0.9.0.0
-celery==3.1.25
+celery==3.1.18
 # required by django-digest
 decorator==4.0.11
 django==1.11.13


### PR DESCRIPTION
Reverts dimagi/commcare-hq#20323

I want to see if this helps with stability.  If it doesn't, I'll revert this change (ie, upgrade back to 3.1.25).