### PR TITLE
Fix dashboard growth monitoring aggregation

### DIFF
--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -5,7 +5,6 @@ from celery.task import periodic_task
 from django.conf import settings
 
 from corehq.util.datadog.gauges import datadog_gauge
-from corehq.util.decorators import serial_task
 from corehq.util.soft_assert import soft_assert
 from pillowtop.utils import get_all_pillows_json
 
@@ -14,11 +13,6 @@ _assert = soft_assert("{}@{}".format('jemord', 'dimagi.com'))
 
 
 @periodic_task(run_every=crontab(minute="*/2"), queue=settings.CELERY_PERIODIC_QUEUE)
-def run_pillow_datadog_metrics():
-    pillow_datadog_metrics.delay()
-
-
-@serial_task('pillow-datadog-metrics', timeout=30 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
 def pillow_datadog_metrics():
     def _is_couch(pillow):
         # text is couch, json is kafka

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -52,12 +52,20 @@ DASHBOARD_TEAM_MEMBERS = ['jemord', 'ssrikrishnan', 'mharrison', 'vmaheshwari', 
 DASHBOARD_TEAM_EMAILS = ['{}@{}'.format(member_id, 'dimagi.com') for member_id in DASHBOARD_TEAM_MEMBERS]
 _dashboard_team_soft_assert = soft_assert(to=DASHBOARD_TEAM_EMAILS)
 
+CCS_RECORD_MONTHLY_UCR = 'static-ccs_record_cases_monthly_tableau_v2'
+CHILD_HEALTH_MONTHLY_UCR = 'static-child_cases_monthly_tableau_v2'
+if settings.SERVER_ENVIRONMENT == 'softlayer':
+    # Currently QA needs more monthly data, so these are different than on ICDS
+    # If this exists after July 1, ask Emord why these UCRs still exist
+    CCS_RECORD_MONTHLY_UCR = 'extended_ccs_record_monthly_tableau'
+    CHILD_HEALTH_MONTHLY_UCR = 'extended_child_health_monthly_tableau'
+
 
 UCR_TABLE_NAME_MAPPING = [
     {'type': "awc_location", 'name': 'static-awc_location'},
     {'type': 'awc_mgmt', 'name': 'static-awc_mgt_forms'},
-    {'type': 'ccs_record_monthly', 'name': 'static-ccs_record_cases_monthly_tableau_v2'},
-    {'type': 'child_health_monthly', 'name': 'static-child_cases_monthly_tableau_v2'},
+    {'type': 'ccs_record_monthly', 'name': CCS_RECORD_MONTHLY_UCR},
+    {'type': 'child_health_monthly', 'name': CHILD_HEALTH_MONTHLY_UCR},
     {'type': 'daily_feeding', 'name': 'static-daily_feeding_forms'},
     {'type': 'household', 'name': 'static-household_cases'},
     {'type': 'infrastructure', 'name': 'static-infrastructure_form'},

--- a/custom/icds_reports/tests/fixtures/gm_form.csv
+++ b/custom/icds_reports/tests/fixtures/gm_form.csv
@@ -1,4 +1,4 @@
 doc_id,inserted_at,repeat_iteration,timeend,state_id,received_on,child_health_case_id,weight_child,height_child,zscore_grading_wfa,zscore_grading_hfa,zscore_grading_wfh,muac_grading
-april_stunting_normal,2018-04-07,0,2017-04-07,st1,2017-04-01,5632d95c-bb23-46a5-9168-c10f00826fb5,,,,3,,
-april_wasting_severe,2018-04-03,0,2017-04-03,st1,2017-04-01,70b5760f-4258-407f-94de-84f2530d18de,,,,,1,
-may_muac_moderate,2018-05-02,0,2017-05-02,st1,2017-04-01,4403d8c3-f3cf-40e1-b66e-e565cee5e26b,,,,,,2
+april_stunting_normal,2018-04-07,0,2017-04-07,st1,2017-04-01,5632d95c-bb23-46a5-9168-c10f00826fb5,,,0,3,0,0
+april_wasting_severe,2018-04-03,0,2017-04-03,st1,2017-04-01,70b5760f-4258-407f-94de-84f2530d18de,,,0,0,1,0
+may_muac_moderate,2018-05-02,0,2017-05-02,st1,2017-04-01,4403d8c3-f3cf-40e1-b66e-e565cee5e26b,,,0,0,0,2

--- a/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
@@ -95,8 +95,7 @@
             },
             "location_type": "state"
           }
-        },
-        "create_index": true
+        }
       },
       {
         "column_id": "received_on",
@@ -343,6 +342,26 @@
         }
       ]
     },
+    "sql_column_indexes": [
+      {
+        "column_ids": ["state_id", "weight_child"]
+      },
+      {
+        "column_ids": ["state_id", "height_child"]
+      },
+      {
+        "column_ids": ["state_id", "zscore_grading_wfa"]
+      },
+      {
+        "column_ids": ["state_id", "zscore_grading_hfa"]
+      },
+      {
+        "column_ids": ["state_id", "zscore_grading_wfh"]
+      },
+      {
+        "column_ids": ["state_id", "muac_grading"]
+      }
+    ],
     "disable_destructive_rebuild": true
   }
 }


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?276561

The columns that track zscore_grading are defaulted to 0 [here](https://github.com/dimagi/commcare-hq/blob/38c305c0290e957754efc71634a10b9a2171a62f/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json#L232-L249), because we transform them from a string to an integer.

That differs from height and weight in which we just dump whatever raw value there is from the form.

The third commit here changes the interpretation of that in the aggregation.

The fourth commit adds indexes so that the aggregation is faster because all of these columns are very sparse.

@calellowitz fyi

:blowfish: / :blowfish: 

