### PR TITLE
Added comment column in config file, small fixes in the expression definition

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -54,17 +54,17 @@ class AbtExpressionSpec(JsonObject):
         return {q['value']: q for q in questions}
 
     @classmethod
-    def _get_question_options(cls, item, question_path):
+    def _get_question_options(cls, item, question_path, section='data'):
         """
         Return a list of option values for the given question path and item
         (which is a dict representation of an XFormInstance)
         """
         questions = cls._get_questions(item['app_id'], item['xmlns'], cls._get_language(item))
-        question = questions.get('/data/' + "/".join(question_path), {})
+        question = questions.get('/' + section + '/' + "/".join(question_path), {})
         return question.get("options", [])
 
     @classmethod
-    def _get_unchecked(cls, xform_instance, question_path, answer, ignore=None):
+    def _get_unchecked(cls, xform_instance, question_path, answer, ignore=None, section='data'):
         """
         Return the unchecked options in the given question.
         Do not return any which appear in the option ignore parameter.
@@ -73,7 +73,9 @@ class AbtExpressionSpec(JsonObject):
         ignore should be a list of strings.
         """
         answer = answer or ""
-        options = {o['value']: o['label'] for o in cls._get_question_options(xform_instance, question_path)}
+        options = {
+            o['value']: o['label'] for o in cls._get_question_options(xform_instance, question_path, section)
+        }
         checked = set(answer.split(" "))
         unchecked = set(options.keys()) - checked
         relevant_unchecked = unchecked - set(ignore)
@@ -188,11 +190,13 @@ class AbtExpressionSpec(JsonObject):
                 if warning_type == "unchecked" and form_value:
                     # Don't raise flag if no answer given
                     ignore = spec.get("ignore", [])
+                    section = spec.get("section", "data")
                     unchecked = self._get_unchecked(
                         item,
                         spec.get('base_path', []) + spec['question'],
                         form_value,
-                        ignore
+                        ignore,
+                        section
                     )
                     if unchecked:
                         # Raise a flag because there are unchecked answers.
@@ -222,11 +226,12 @@ class AbtExpressionSpec(JsonObject):
                         })
                 elif warning_type == "not_selected" and form_value:
                     value = spec.get("velue", "")
-                    if form_value and value not in self._question_answered(form_value):
+                    if form_value and value not in form_value:
+                        warning_question_data = partial if not spec.get('warning_question_root', False) else item
                         docs.append({
                             'flag': self._get_flag_name(item, spec),
                             'warning': self._get_warning(spec, item).format(
-                                msg=self._get_val(partial, spec.get('warning_question', None)) or ""
+                                msg=self._get_val(warning_question_data, spec.get('warning_question', None)) or ""
                             ),
                             'comments': self._get_comments(partial, spec),
                             'names': names,
@@ -238,10 +243,11 @@ class AbtExpressionSpec(JsonObject):
                         self._question_answered(form_value) and
                         self._raise_for_any_answer(danger_value)
                     ):
+                        warning_question_data = partial if not spec.get('warning_question_root', False) else item
                         docs.append({
                             'flag': self._get_flag_name(item, spec),
                             'warning': self._get_warning(spec, item).format(
-                                msg=self._get_val(partial, spec.get('warning_question', None)) or ""
+                                msg=self._get_val(warning_question_data, spec.get('warning_question', None)) or ""
                             ),
                             'comments': self._get_comments(partial, spec),
                             'names': names,

--- a/custom/abt/reports/flagspecs_v2.yaml
+++ b/custom/abt/reports/flagspecs_v2.yaml
@@ -2,6 +2,7 @@
 http://openrosa.org/formdesigner/9C9BEDDA-9BF8-447F-A713-3148BDC2C1CE:
   - question: [sop_physical]
     base_path: [morning_mobilization_grp, Q1]
+    comment: [sop_physical_addl]
     flag_name: "1. Have the Team Leaders performed a physical inspection of each Spray Operator, looking for symptoms such as nausea, dizziness, confusion, breathing problems, skin irritation, excessive sweating, fatigue, weakness, alcohol intoxication, etc.?"
     flag_name_fr: "1. Les chefs d'équipe ont-ils procédé à une inspection physique de chaque opérateur de pulvérisation pour rechercher des symptômes tels que nausées, vertiges, confusion, problèmes respiratoires, irritation cutanée, transpiration excessive, fatigue, faiblesse, intoxication alcoolique, etc.?"
     answer: "no"
@@ -9,6 +10,7 @@ http://openrosa.org/formdesigner/9C9BEDDA-9BF8-447F-A713-3148BDC2C1CE:
     warning_fr: "Problème signalé: Les chefs d'équipe n'effectuent pas d'inspection physique occasionnelle des opérations spéciales le matin."
   - question: [sop_health_problems]
     base_path: [morning_mobilization_grp]
+    comment: [sop_health_problems_action]
     flag_name: "1a. Were any health problems observed among the Spray Operators?"
     flag_name_fr: "1a. Des problèmes de santé ont-ils été observés parmi les opérateurs de pulvérisation?"
     answer: "yes"
@@ -16,6 +18,7 @@ http://openrosa.org/formdesigner/9C9BEDDA-9BF8-447F-A713-3148BDC2C1CE:
     warning_fr: "Problème de santé observé chez les opérateurs de pulvérisation. Remplissez un formulaire de rapport d'incident, si les symptômes sont probablement liés au travail."
   - question: [sop_eaten]
     base_path: [morning_mobilization_grp, Q2]
+    comment: [sop_eaten_addl]
     flag_name: "2. Have the Spray Operators eaten breakfast and had plenty of water to drink prior to donning PPE?"
     flag_name_fr: "2. Les opérateurs de pulvérisation ont-ils déjeuné et bu beaucoup d'eau avant d'enfiler les EPI?"
     answer: "no"
@@ -23,20 +26,24 @@ http://openrosa.org/formdesigner/9C9BEDDA-9BF8-447F-A713-3148BDC2C1CE:
     warning_fr: "Problème signalé: Les opérateurs de pulvérisation ne sont pas correctement nourris ou hydratés avant d'enfiler les EPI."
   - question: [sop_full_ppe]
     base_path: [morning_mobilization_grp, Q3]
+    comment: [sop_full_ppe_addl]
     flag_name: "3. Are SOs in full PPE before boarding truck?"
     flag_name_fr: "3. Les OPs sont-ils en EPI complet avant l'embarquement?"
     warning_type: unchecked
     ignore: ["none"]
+    section: "Morning_Mobilization_2018"
     warning: "Problem reported: Spray operator(s) not wearing {msg} before boarding transport. "
     warning_fr: "Problème signalé: Le (s) opérateur (s) de pulvérisation ne porte (s) pas {msg} avant l'embarquement."
   - question: [sop_eating_after_ppe]
     base_path: [morning_mobilization_grp, Q4]
+    comment: [sop_eating_after_ppe_addl]
     flag_name: "4. Are any Spray Operators eating or drinking after donning PPE?"
     flag_name_fr: "4. Les opérateurs de pulvérisation mangent-ils ou boivent-ils après avoir porté des EPI?"
-    answer: "no"
+    answer: "yes"
     warning: "Problem reported: Spray operator(s) eating or drinking after donning PPE."
     warning_fr: "Problème signalé: Opérateur (s) de pulvérisation mangeant ou buvant après avoir enfilé des EPI."
   - question: [sop_fill_pumps]
+    comment: [sop_fill_pumps_addl]
     base_path: [morning_mobilization_grp, Q5]
     flag_name: "5. Do operators fill spray pumps using the contents of drums 1, 3, and 5 and 7 from the previous day's progressive rinse?"
     flag_name_fr: "5. Les opérateurs remplissent-ils les pompes de pulvérisation en utilisant le contenu des fûts 1, 3 et 5 et 7 du rinçage progressif de la veille?"
@@ -44,6 +51,7 @@ http://openrosa.org/formdesigner/9C9BEDDA-9BF8-447F-A713-3148BDC2C1CE:
     warning: "Problem reported: Spray operator(s) not using insecticide left over from previous day."
     warning_fr: "Problème signalé: Opérateur (s) de pulvérisation n'utilisant pas l'insecticide restant de la veille."
   - question: [barrels_empty_check]
+    comment: [barrels_empty_check_addl]
     base_path: [morning_mobilization_grp, Q6]
     flag_name: "6. Are barrels 1, 3, 5 and 7 empty when Spray Operators depart for the field?"
     flag_name_fr: "6. Les fûts  1, 3, 5 et 7 sont-ils vides lorsque les opérateurs de pulvérisation partent pour le travail?"
@@ -53,6 +61,7 @@ http://openrosa.org/formdesigner/9C9BEDDA-9BF8-447F-A713-3148BDC2C1CE:
 # Form 2 - Trans Veh Insp
 http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
   - question: [current_certificate_issued]
+    comment: [current_certificate_issued_addl]
     base_path: [vehicle_inspection_grp, Q1]
     flag_name: "1. Is the current certificate issued after the ECO or authorized VectorLink representative inspected this vehicle in the vehicle?"
     flag_name_fr: "1. Le certificat actuel est-il délivré après que le représentant autorisé ou le représentant autorisé de VectorLink a inspecté ce véhicule dans le véhicule?"
@@ -60,6 +69,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Vehicle was not inspected prior to contract."
     warning_fr: "Problème noté: Le véhicule n'a pas été inspecté avant le contrat."
   - question: [transport_certification]
+    comment: [transport_certification_addl]
     base_path: [vehicle_inspection_grp, transport_certification_grp, Q2]
     flag_name: "2. Does the driver and/or vehicle have the needed certification (driver's license, etc.) for transporting hazardous goods or numerous people?"
     flag_name_fr: "2. Le conducteur et / ou le véhicule ont-ils la certification requise (permis de conduire, etc.) pour transporter des marchandises dangereuses ou de nombreuses personnes?"
@@ -67,6 +77,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Driver is not driving with their license and/or certificate."
     warning_fr: "Problème noté: Le conducteur ne conduit pas avec sa licence et / ou son certificat."
   - question: [driver_safety_training]
+    comment: [driver_safety_training_addl]
     base_path: [vehicle_inspection_grp, Q3]
     flag_name: "3. Has the driver attended safety training?"
     flag_name_fr: "3. Le conducteur a-t-il suivi une formation à la sécurité?"
@@ -74,6 +85,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Provide safety training for driver."
     warning_fr: "Problème noté: Fournir une formation de sécurité au conducteur."
   - question: [pesticides_transported]
+    comment: [pesticides_transported_addl]
     base_path: [vehicle_inspection_grp, Q4]
     flag_name: "4. Other than the pesticide sachets or bottles for the day's use, are any pesticides transported in the same vehicle with the operators?"
     flag_name_fr: "4. À part les sachets ou bouteilles de pesticide pour l'utilisation quotidienne, y a-t-il des pesticides transportés dans le même véhicule avec les opérateurs?"
@@ -81,6 +93,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Separate transportation needed for operators and pesticides other than the day's supply."
     warning_fr: "Problème noté: Séparer le transport des pesticides nécessaires pour les opérateurs et les pesticides autres que l'approvisionnement du jour."
   - question: [consumer_goods_transported]
+    comment: [consumer_goods_transported_addl]
     base_path: [vehicle_inspection_grp, Q5]
     flag_name: "5. Are food products, animal feed, or consumer goods transported in the same truck as pesticides?"
     flag_name_fr: "5. Les produits alimentaires, les aliments pour animaux ou les biens de consommation sont-ils transportés dans le même camion que les pesticides?"
@@ -88,6 +101,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Mixed goods transportation violation, suggest re-training."
     warning_fr: "Problème noté: Violation en transportant des marchandises mixtes, suggére une nouvelle formation."
   - question: [drivers_equipped]
+    comment: [drivers_equipped_addl]
     base_path: [vehicle_inspection_grp, Q6]
     flag_name: "6. Do drivers have a cellphone and appropriate PPE (boots, gloves, and filter mask) in case of a spill or accident?"
     flag_name_fr: "6. Les conducteurs ont-ils un téléphone portable et des EPI appropriés (bottes, gants et masque filtrant) en cas de déversement ou d'accident?"
@@ -95,6 +109,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Drivers do not have cell telephone and/or appropriate PPE."
     warning_fr: "Problème noté: Les conducteurs n'ont pas de téléphone cellulaire et / ou d'EPI approprié."
   - question: [pesticides_secured]
+    comment: [pesticides_secured_addl]
     base_path: [vehicle_inspection_grp, Q7]
     flag_name: "7. If this vehicle transports pesticide, can the pesticides be adequately secured and tied down in the vehicle?"
     flag_name_fr: "7. Si ce véhicule transporte des pesticides, les pesticides peuvent-ils être correctement fixés et attachés dans le véhicule?"
@@ -102,6 +117,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Need to provide materials for securing and tying down pesticides in the vehicle"
     warning_fr: "Problème noté: Nécessité de fournir des matériaux pour sécuriser et attacher les pesticides dans le véhicule"
   - question: [fire_extinguisher]
+    comment: [fire_extinguisher_addl]
     base_path: [vehicle_inspection_grp, Q8]
     flag_name: "8. Does the vehicle have a fire extinguisher?"
     flag_name_fr: "8. Le véhicule est-il équipé d'un extincteur?"
@@ -109,6 +125,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem reported: Pesticide transport vehicle must always carry a fire extinguisher."
     warning_fr: "Problème signalé: Le véhicule de transport de pesticides doit toujours transporter un extincteur."
   - question: [seats_railings]
+    comment: [seats_railings_addl]
     base_path: [vehicle_inspection_grp, Q9]
     flag_name: "9. If this vehicle transports operators, does the spray operator transport vehicle have seats and railings?"
     flag_name_fr: "9. Si ce véhicule transporte des opérateurs, le véhicule de transport de l'opérateur de pulvérisation a-t-il des sièges et des rampes?"
@@ -116,22 +133,27 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Spray operator transport vehicle must be configured with seats and railings"
     warning_fr: "Problème noté: Le véhicule de transport par des opérateurs de pulvérisation doit être configuré avec des sièges et des rampes"
   - question: [first_aid_stocked]
+    comment: [first_aid_stocked_addl]
     base_path: [vehicle_inspection_grp, Q10]
     flag_name: "10. Is there a fully-stocked first aid kit in the vehicle?"
     flag_name_fr: "10. Y a-t-il une trousse de premiers soins bien garnie dans le véhicule?"
     warning_type: unchecked
     ignore: ["none"]
+    section: 'Vehicle_Transportaion_2018'
     warning: "Problem noted: Missing {msg} for first aid kit for the vehicle. Confirm delivery date for {msg} for first aid kit."
     warning_fr: "Problème noté: Manquant {msg} pour la trousse de premiers soins pour le véhicule. Confirmer la date de livraison pour {msg} pour la trousse de premiers soins."
   - question: [spill_prep]
+    comment: [spill_prep_addl]
     base_path: [vehicle_inspection_grp, Q11]
     flag_name: "11. Is there a 1. spill kit, and 2. spill/emergency/accident response procedures in the vehicle?"
     flag_name_fr: "11. Y a-t-il une 1. trousse de déversement et 2. des procédures d'intervention en cas de déversement / urgence / accident dans le véhicule?"
     warning_type: unchecked
     ignore: ["none"]
-    warning: "Problem noted: Missing (List unchecked items) for the vehicle. Confirm delivery date for (List missing items)."
-    warning_fr: "Problème noté: Manquant (Liste des éléments non vérifiés) pour le véhicule. Confirmer la date de livraison pour (Liste des articles manquants)."
+    section: 'Vehicle_Transportaion_2018'
+    warning: "Problem noted: Missing {msg} for the vehicle. Confirm delivery date for (List missing items)."
+    warning_fr: "Problème noté: Manquant {msg} pour le véhicule. Confirmer la date de livraison pour (Liste des articles manquants)."
   - question: [sops_seated_properly]
+    comment: [sops_seated_properly_addl]
     base_path: [vehicle_inspection_grp, sears_grp, Q12]
     flag_name: "12. Are the operators properly seated in the transport vehicle with the pump secured between their legs?"
     flag_name_fr: "12. Les opérateurs sont-ils correctement assis dans le véhicule de transport avec les pompes fixées entre leurs jambes?"
@@ -139,6 +161,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem reported: Spray operators must be properly seated with the pump secured between their legs in the transport vehicle."
     warning_fr: "Problème signalé: Les opérateurs de pulvérisation doivent être correctement assis avec la pompe fixée entre leurs jambes dans le véhicule de transport."
   - question: [vehicle_overcrowded]
+    comment: [vehicle_overcrowded_addl]
     base_path: [vehicle_inspection_grp, Q13]
     flag_name: "13. Is the vehicle overcrowded?"
     flag_name_fr: "13. Le véhicule est-il trop plein?"
@@ -146,6 +169,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
     warning: "Problem noted: Need to provide additional vehicle for spray operators."
     warning_fr: "Problème noté: Nécessité de fournir un véhicule supplémentaire pour les opérateurs de pulvérisation."
   - question: [pesticide_leakage]
+    comment: [pesticide_leakage_addl]
     base_path: [vehicle_inspection_grp, Q14]
     flag_name: "14. Is there evidence of pesticide leakage in the trucks?"
     flag_name_fr: "14. Y a-t-il des signes de fuite de pesticide dans les camions?"
@@ -155,6 +179,7 @@ http://openrosa.org/formdesigner/DBE47466-9B6A-45F0-AF48-16D4CC605CC3:
 # Form 3 - End of Day clean up
 http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
   - question: [sop_return_in_ppe]
+    comment: [sop_return_in_ppe_addl]
     base_path: [obs_rcd_mgmt_grp, Q1]
     flag_name: "1. Do the spray operators continue to wear PPE on the way back to the operations site?"
     flag_name_fr: "1. Les opérateurs de pulvérisation continuent-ils à porter des EPI sur le chemin du retour vers le site d'exploitation?"
@@ -162,6 +187,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: All spray operators must continue to wear PPE on the way back to the operations site."
     warning_fr: "Problème signalé: tous les opérateurs de pulvérisation doivent continuer de porter l'EPI sur le chemin de retour des sites opérationnels"
   - question: [eating_in_ppe]
+    comment: [eating_in_ppe_addl]
     base_path: [obs_rcd_mgmt_grp, Q2]
     flag_name: "2. Is anyone eating or drinking prior to removing PPE and washing?"
     flag_name_fr: "2. Est-ce que vous observez quelqu'un qui mange ou qui boit avant d'enlever l'équipement de protection individuelle et de se laver?"
@@ -169,6 +195,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Eating and/or drinking violation."
     warning_fr: "Problème signalé: infraction faite en mangeant et/ou en buvant "
   - question: [wash_criteria_met]
+    comment: [wash_criteria_met_addl]
     base_path: [obs_rcd_mgmt_grp, Q3]
     flag_name: "Team Leaders are supervising the cleaning and wash-up"
     flag_name_fr: "Les chefs d'équipe supervisent le nettoyage des materiels et que les OPs se douchent"
@@ -177,6 +204,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Team Leaders not supervising cleaning and wash-up."
     warning_fr: "Problème signalé: Les chefs d'équipe ne supervisent pas le rinçage et le nettoyage"
   - question: [wash_criteria_met]
+    comment: [wash_criteria_met_addl]
     base_path: [obs_rcd_mgmt_grp, Q3]
     flag_name: "The wash facilities have soap and water available for operators"
     flag_name_fr: "Les douches disposent du savon et de l'eau pour les opérateurs"
@@ -185,6 +213,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Wash facilities with soap and water must be available to operators."
     warning_fr: "Problem reported: Wash facilities with soap and water must be available to operators."
   - question: [wash_criteria_met]
+    comment: [wash_criteria_met_addl]
     base_path: [obs_rcd_mgmt_grp, Q3]
     flag_name: "All people (spray operators, washers, maintenance techs) in the wash/soak pit area are wearing full PPE"
     flag_name_fr: "Toutes les personnes (opérateurs de pulvérisation, laveuses, techniciennes d'entretien) dans la zone de lavage / puits d'infiltration portent un EPI complet"
@@ -193,6 +222,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: All personnel in the wash area must wear full PPE."
     warning_fr: "Problème signalé: Tout le personnel dans l'aire de lavage doit porter un EPI complet."
   - question: [accidents]
+    comment: [accidents_addl]
     base_path: [obs_rcd_mgmt_grp, Q4]
     flag_name: "4. Have there been any accidents today? (Pesticide exposure, vehicle accidents, other injuries or property damage)"
     flag_name_fr: "4. Est-ce qu'il y a eu des accidents aujourd'hui? (Exposition aux pesticides, accidents de la route, autres blessures ou dommages matériels)"
@@ -200,6 +230,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: An incident has been reported and an Incident Report Form is needed immediately. Follow up with Sector Manager to be sure accident report form is filed and sent to TPM and ECM."
     warning_fr: "Problème signalé: Un incident a été signalé et un formulaire de rapport d'incident est nécessaire immédiatement. Effectuez un suivi auprès du chef de secteur pour vous assurer que le formulaire de rapport d'accident est rempli et envoyé à TPM et à ECM."
   - question: [sop_irritation]
+    comment: [sop_irritation_addl]
     base_path: [obs_rcd_mgmt_grp, Q5]
     flag_name: "5. Have any spray operators complained of irritation (throat, skin, etc.)?"
     flag_name_fr: "5. Les opérateurs de pulvérisation se sont-ils plaints d'irritation (gorge, peau, etc.)?"
@@ -207,6 +238,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Possible exposure reported: Follow-up on status of SO complaining of irritation and ensure incident report has been sent to home office TPM and ECM."
     warning_fr: "Exposition possible signalée: Suivi du statut de OP se plaignant d'irritation et s'assurer que le rapport d'incident a été envoyé au bureau à domicile TPM et ECM."
   - question: [form_criteria_check]
+    comment: [form_criteria_check_addl]
     base_path: [obs_rcd_mgmt_grp, Q6]
     flag_name: "Spray operators completed their daily report forms"
     flag_name_fr: "Les opérateurs de pulvérisation ont rempli leur formulaire de rapport quotidien"
@@ -215,6 +247,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Spray operators must complete daily report forms."
     warning_fr: "Problème signalé: Les opérateurs de pulvérisation doivent remplir des formulaires de rapport quotidiens."
   - question: [form_criteria_check]
+    comment: [form_criteria_check_addl]
     base_path: [obs_rcd_mgmt_grp, Q6]
     flag_name: "Forms are checked by spray supervisors"
     flag_name_fr: "Les formulaires sont vérifiés par les superviseurs de pulvérisation"
@@ -223,6 +256,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Supervisors must check spray forms."
     warning_fr: "Problème signalé: Les superviseurs doivent vérifier les formulaires de pulvérisation."
   - question: [adequate_gravel]
+    comment: [adequate_gravel_addl]
     base_path: [fsp_grp, Q7]
     flag_name: "7. Is there adequate gravel to act as a filter?"
     flag_name_fr: "7. Y a-t-il suffisamment de gravier pour agir comme un filtre?"
@@ -230,6 +264,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Inadequate gravel in soak pit."
     warning_fr: "Problème signalé: Gravier inadéquat dans la fosse d'infiltration"
   - question: [empties_returned]
+    comment: [empties_returned_addl]
     base_path: [fsp_grp, Q8]
     flag_name: "8. Upon return to the storehouse, are full and empty sachets/bottles returned to stores?"
     flag_name_fr: "8. À leur retour à l'entrepôt, les sachets / bouteilles pleins et vides sont-ils retournés dans les magasins?"
@@ -237,6 +272,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Storekeeper must keep records of pesticides handed out and returned."
     warning_fr: "Problème signalé: Le magasinier doit tenir des registres des pesticides distribués et retournés."
   - question: [effluent_catch]
+    comment: [effluent_catch_addl]
     base_path: [fsp_grp, Q9]
     flag_name: "9. Is there a sloped concrete catchment area or tarpaulin spread out on the ground to catch all effluent?"
     flag_name_fr: "9. Y a-t-il un aire de lavage en pente ou un morceau de plastique etalée sur le sol pour capter tous les effluents?"
@@ -244,6 +280,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Triple rinse and wash area must be covered with leak-proof surface and sloped soak pit."
     warning_fr: "Problème signalé: Le triple rinçage et la zone de lavage doivent être couverts d'une surface étanche et d'une fosse d'infiltration inclinée"
   - question: [drums_water]
+    comment: [drums_water_addl]
     base_path: [fsp_grp, Q10]
     flag_name: "10. Do the #2, 4 and 6 drums have sufficient water for today's cleanup?"
     flag_name_fr: "10. Les tambours n ° 2, 4 et 6 ont-ils assez d'eau pour le nettoyage d'aujourd'hui?"
@@ -251,6 +288,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Insufficient water for triple rinse."
     warning_fr: "Problème signalé: Eau insuffisante pour le triple rinçage."
   - question: [pesticide_emptied]
+    comment: [pesticide_emptied_addl]
     base_path: [fsp_grp, Q11]
     flag_name: "11. Is all pesticide remaining in pumps emptied into the #1 drum?"
     flag_name_fr: "11. Tout le pesticide restant dans les pompes est-il vidé dans le fut numero 1 ?"
@@ -258,6 +296,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Notify operations coordinator of triple-rinse violations."
     warning_fr: "Informer le coordinateur des opérations des violations de triple rinçage."
   - question: [pumps_rinsed]
+    comment: [pumps_rinsed_addl]
     base_path: [fsp_grp, Q12]
     flag_name: "12. Are spray pumps triple rinsed using the progressive rinse method?"
     flag_name_fr: "12. Les pompes de pulvérisation sont-elles rincées trois fois en utilisant la méthode de rinçage progressif?"
@@ -265,6 +304,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Triple-rinse violations."
     warning_fr: "Problème signalé: violations du triple rinçage."
   - question: [pumps_outside_rinsed]
+    comment: [pumps_outside_rinsed_addl]
     base_path: [fsp_grp, Q13]
     flag_name: "13. Are the outsides of the pumps rinsed off into the soak pit?"
     flag_name_fr: "13. L'extérieur des pompes est-il rincé dans le puisard ?"
@@ -272,6 +312,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Pumps not properly washed"
     warning_fr: "Problème signalé: Pompes pas bien lavées"
   - question: [equipment_rinsed]
+    comment: [equipment_rinsed_addl]
     base_path: [fsp_grp, Q14]
     flag_name: "14. Are the helmets, face shields, boots, and gloves rinsed off into the soak pit?"
     flag_name_fr: "14. Les casques, les masques, les bottes et les gants sont-ils rincés dans le puisard ?"
@@ -279,6 +320,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: PPE not properly washed"
     warning_fr: "Problème signalé: EPI pas bien lavé"
   - question: [contaminated_water_disposed]
+    comment: [contaminated_water_disposed_addl]
     base_path: [fsp_grp, Q15]
     flag_name: "15. Is the soak pit used to dispose of all contaminated water?"
     flag_name_fr: "15. Est-ce que le puisard est utilisé pour recuiellir toute l'eau contaminée?"
@@ -286,6 +328,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported:  Improper disposal of wastewater."
     warning_fr: "Problème signalé: Mauvais traitement des eaux usées."
   - question: [contaminated_water_drains]
+    comment: [contaminated_water_drains_addl]
     base_path: [fsp_grp, Q16]
     flag_name: "16. Does all contaminated water drain properly into the soak pit?"
     flag_name_fr: "16. L'eau contaminée est-elle drainée correctement dans le puisard ?"
@@ -293,6 +336,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Water not draining properly into soak-pit."
     warning_fr: "Problème signalé: L'eau ne s'écoule pas correctement dans la fosse."
   - question: [effluent_absorbed]
+    comment: [effluent_absorbed_addl]
     base_path: [fsp_grp, Q17]
     flag_name: "17. Is the soak pit absorbing all the effluent waste without creating a puddle and/or run off?"
     flag_name_fr: "17. Le puisard absorbe-t-elle tous les effluents sans créer de flaque d'eau et / ou de ruissellement?"
@@ -300,6 +344,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Soak-pit not draining properly."
     warning_fr: "Problème signalé: La fosse n'est pas drainée correctement."
   - question: [pumps_hung]
+    comment: [pumps_hung_addl]
     base_path: [fsp_grp, Q18]
     flag_name: "18. Are spray pumps hung upside down to dry?"
     flag_name_fr: "18. Les pompes de pulvérisation sont-elles suspendues à l'envers pour sécher?"
@@ -307,6 +352,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Pumps not hung up to dry"
     warning_fr: "Problème signalé: Les pompes ne sont pas suspendues à sécher"
   - question: [pumps_stored_properly]
+    comment: [pumps_stored_properly_addl]
     base_path: [fsp_grp, Q19]
     flag_name: "19. Are washed spray pumps stored in an orderly way for easy preparation the next day?"
     flag_name_fr: "19. Est-ce que les pompes nettoyées sont rangées de manière ordonnée pour une préparation facile le jour suivant?"
@@ -314,6 +360,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Pumps not stored properly."
     warning_fr: "Problème signalé: Les pompes ne sont pas stockées correctement.."
   - question: [drums_covered]
+    comment: [drums_covered_addl]
     base_path: [fsp_grp, Q20]
     flag_name: "20. Are the covers placed on the 7 triple-rinse drums after all pumps are cleaned?"
     flag_name_fr: "20. Les couvercles sont-ils placés sur les 7 fûts  à triple rinçage après le nettoyage de toutes les pompes?"
@@ -321,147 +368,168 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
     warning: "Problem reported: Rinse and/or waste drums not covered overnight."
     warning_fr: "Problème signalé: Barils d'eau de rinçage  et / ou d'effluents non couverts pendant la nuit."
   - question: [msp_avoid_water]
-    base_path: [fsp_grp, Q21]
+    comment: [msp_avoid_water_addl]
+    base_path: [msp_grp, Q21]
     flag_name: "21. Is the mobile soak pit located away from water bodies, steep slopes or flood prone areas?"
     flag_name_fr: "21. Le puisard mobile est- il situé à l'écart des plans d'eau, des pentes abruptes ou des zones sujettes aux inondations?"
     answer: "no"
     warning: "Problem reported: Mobile soak pit not installed away from water bodies, steep slopes, or flood prone areas."
     warning_fr: "Problème signalé: Le puisard mobile n'est pas installé à l'écart des plans d'eau, des pentes abruptes ou des zones sujettes aux inondations"
   - question: [sachets_returned]
-    base_path: [fsp_grp, Q22]
+    comment: [sachets_returned_addl]
+    base_path: [msp_grp, Q22]
     flag_name: "22. Are empty sachets/bottles and full sachets/bottles returned to the team leader and recorded?"
     flag_name_fr: "22. Les sachets / bouteilles vides et les sachets / bouteilles pleins sont-ils retournés au chef d'équipe et enregistrés?"
     answer: "no"
     warning: "Problem reported: Storekeeper must keep records of pesticides handed out and returned."
     warning_fr: "Problème signalé: Le magasinier doit tenir des registres des pesticides distribués et retournés."
   - question: [barrel_water_present]
-    base_path: [fsp_grp, Q23]
+    comment: [barrel_water_present_action]
+    base_path: [msp_grp]
     flag_name: "23a. Is there any water in the collection barrel at the beginning of clean up?"
     flag_name_fr: "23a. Y a-t-il de l'eau dans le tonneau de collecte au début du nettoyage?"
     answer: "yes"
     warning: "Problem reported: Waste water from collection barrel left at the wash area overnight."
     warning_fr: "Problème signalé: Les eaux usées provenant du fût de collecte sont restées dans l'aire de lavage pendant la nuit."
   - question: [msp_correctly_installed]
-    base_path: [fsp_grp, Q24]
+    comment: [msp_correctly_installed_addl]
+    base_path: [msp_grp, Q24]
     flag_name: "24. Is the mobile soak pit correctly installed with tarpaulin spread out on the ground that is sloped towards the mobile soak pit to catch all effluent?"
     flag_name_fr: "24. Le puisard mobile est-elle correctement installé avec un morceau de plastic éparpillées sur le sol incliné vers le puisard recuiellir tous les effluents?"
     answer: "no"
     warning: "Problem reported: Triple rinse and wash area must be covered with leak-proof surface and sloped to mobile soak pit."
     warning_fr: "Problème signalé: L'aire de triple rinçage et  lavage doit être couvert d'une surface étanche et incliné vers le puisard mobile."
   - question: [rinse_water_drums]
-    base_path: [fsp_grp, Q25]
+    comment: [rinse_water_drums_addl]
+    base_path: [msp_grp, Q25]
     flag_name: "25. Do the 3 rinse water drums have sufficient water for today's cleanup?"
     flag_name_fr: "25. Les 3 bidons d'eau de rinçage ont-ils suffisamment d'eau pour le nettoyage d'aujourd'hui?"
     answer: "no"
     warning: "Problem reported: Insufficient water for triple rinse."
     warning_fr: "Problème signalé: Eau insuffisante pour le triple rinçage."
   - question: [pesticide_emptied]
-    base_path: [fsp_grp, Q26]
+    comment: [pesticide_emptied_addl]
+    base_path: [msp_grp, Q26]
     flag_name: "26. Is all pesticide remaining in pumps emptied into the collection drum?"
     flag_name_fr: "26. Tous les résidus de pesticides dans les pompes sont-ils vidés dans le fût de collecte?"
     answer: "no"
     warning: "Notify operations coordinator of triple-rinse violations."
     warning_fr: "Informer le coordinateur des opérations des violations de triple rinçage  "
   - question: [pumps_depressurized]
-    base_path: [fsp_grp, Q28]
+    comment: [pumps_depressurized_addl]
+    base_path: [msp_grp, Q28]
     flag_name: "28. Are the pumps depressurized into the collection drum before opening them to dump rinse water?"
     flag_name_fr: "28. Les pompes sont-elles dépressurisées dans le tonneau de collecte avant de les ouvrir pour vider l'eau de rinçage?"
     answer: "no"
     warning: "Problem reported: Pumps not properly emptied"
     warning_fr: "Problème signalé: Pompes mal vidées"
   - question: [pumps_rinsed]
-    base_path: [fsp_grp, Q27]
+    comment: [pumps_rinsed_addl]
+    base_path: [msp_grp, Q27]
     flag_name: "27. Are spray pumps triple rinsed using the progressive rinse method?"
     flag_name_fr: "27. Les pompes de pulvérisation sont-elles rincées trois fois en utilisant la méthode de rinçage progressif?"
     answer: "no"
     warning: "Problem reported: Triple-rinse violations."
     warning_fr: "Problème signalé: violations du triple rinçage."
   - question: [pumps_rinsed_outside]
-    base_path: [fsp_grp, Q29]
+    comment: [pumps_rinsed_outside_addl]
+    base_path: [msp_grp, Q29]
     flag_name: "29. Are the outsides of the pumps rinsed off in the wash area so that wash water drains to the soak pit?"
     flag_name_fr: "29. L'extérieur des pompes est-il rincé dans la zone de lavage de sorte que l'eau  s'écoule dans le puisard ?"
     answer: "no"
     warning: "Problem reported: Pumps not properly washed"
     warning_fr: "Problème signalé: Pompes pas bien lavées"
   - question: [waste_water_distributed]
-    base_path: [fsp_grp, Q30]
+    comment: [waste_water_distributed_addl]
+    base_path: [msp_grp, Q30]
     flag_name: "30. Is the waste water from the collection drum distributed among the spray pumps for the next day?"
     flag_name_fr: "30. Les eaux usées provenant du tonneau de collecte sont-elles réparties entre les pompes de pulvérisation pour le lendemain?"
     answer: "no"
     warning: "Problem reported: Waste water from collection drum not distributed into spray pumps."
     warning_fr: "Problème signalé: Les eaux usées provenant du fût de collecte ne sont pas distribuées dans les pompes de pulvérisation."
   - question: [equipment_rinsed]
-    base_path: [fsp_grp, Q31]
+    comment: [equipment_rinsed_addl]
+    base_path: [msp_grp, Q31]
     flag_name: "31. Are the helmets, face shields, boots, and gloves rinsed off in the wash area?"
     flag_name_fr: "31. Les casques, masques, bottes et gants sont-ils rincés dans la zone de lavage?"
     answer: "no"
     warning: "Problem reported: PPE not properly washed"
     warning_fr: "Problème signalé: EPI mal lavé"
   - question: [workers_wash]
-    base_path: [fsp_grp, Q32]
+    comment: [workers_wash_addl]
+    base_path: [msp_grp, Q32]
     flag_name: "32. Do workers at a minimum wash their face and hands with soap and water?"
     flag_name_fr: "32. Les travailleurs se lavent -ils au moins le visage et les mains avec de l'eau et du savon?"
     answer: "no"
     warning: "Problem reported: Operators must wash hands and face with soap and water after removing PPE."
     warning_fr: "Problème signalé: Les opérateurs doivent se laver les mains et le visage avec de l'eau et du savon après avoir retiré l'EPI."
   - question: [msp_used]
-    base_path: [fsp_grp, Q33]
+    comment: [msp_used_addl]
+    base_path: [msp_grp, Q33]
     flag_name: "33. Is the mobile soak pit used to dispose of all contaminated waste water from cleaning the helmet, face shield, gloves, boots, and outside of the pump?"
     flag_name_fr: "33. Le puisard mobile est-il utilisée pour se débarrasser de toutes les eaux usées contaminées provenant du nettoyage du casque, du masque facial, des gants, des bottes et de l'extérieur de la pompe?"
     answer: "no"
     warning: "Problem reported:  Improper disposal of wastewater."
     warning_fr: "Problème signalé: Mauvais traitement des eaux usées."
   - question: [contaminated_water_drains]
-    base_path: [fsp_grp, Q34]
+    comment: [contaminated_water_drains_addl]
+    base_path: [msp_grp, Q34]
     flag_name: "34. Does all contaminated waste water drain properly into the mobile soak pit?"
     flag_name_fr: "34. Toutes les eaux usées contaminées sont-elles évacuées correctement dans le puisard mobile?"
     answer: "no"
     warning: "Problem reported: Water not draining properly into mobile soak pit."
     warning_fr: "Problème signalé: L'eau ne s'écoule pas correctement vers le puisard mobile."
   - question: [effluent_absorbed]
-    base_path: [fsp_grp, Q35]
+    comment: [effluent_absorbed_addl]
+    base_path: [msp_grp, Q35]
     flag_name: "35. Is the soak pit absorbing all the effluent waste without creating a puddle and/or run off?"
     flag_name_fr: "35. Le puisard absorbe-t-il tous les effluents sans créer de flaque d'eau et / ou de ruissellement?"
     answer: "no"
     warning: "Problem reported: Mobile soak pit not draining properly."
     warning_fr: "Problème signalé: L'eau ne se vide pas correctement du puisard"
   - question: [drums_covered]
-    base_path: [fsp_grp, Q36]
+    comment: [drums_covered_addl]
+    base_path: [msp_grp, Q36]
     flag_name: "36. Are the covers placed on the 4 triple-rinse drums after all pumps are cleaned?"
     flag_name_fr: "36. Les couvercles sont-ils placés sur les 4 tonneaux à triple rinçage après le nettoyage de toutes les pompes?"
     answer: "no"
     warning: "Problem reported: Rinse and/or waste drums not covered overnight."
     warning_fr: "Problème signalé: Barils d'eau de rinçage  et / ou d'effluents non couverts pendant la nuit."
   - question: [ground_restored]
-    base_path: [fsp_grp]
+    comment: [ground_restored_action]
+    base_path: [msp_grp]
     flag_name: "37a. Have the barrels been removed, hole for MSP refilled, and the ground returned to its original state?"
     flag_name_fr: "37a. Les tonneaux ont-ils été enlevés, les trous de puisards mobile effacer et le sol est remis à son état d'origine?"
     answer: "no"
     warning: "Problem reported: MSP not properly restored."
     warning_fr: "Problème signalé: MSP pas correctement restauré."
   - question: [msp_removed]
-    base_path: [fsp_grp]
+    comment: [msp_removed_action]
+    base_path: [msp_grp]
     flag_name: "37b. Has the MSP been pulled out of the ground with the hole covered and site secured?"
     flag_name_fr: "37a. Les tonneaux ont-ils été enlevés, le trou pour le PM a-t-il été rempli et le sol est revenu à son état d'origine?"
     answer: "no"
     warning: "Problem reported: MSP installation site not secured at the end of the day."
     warning_fr: "Problème signalé: Le site d'installation de MSP n'est pas sécurisé à la fin de la journée."
   - question: [msp_secure]
-    base_path: [fsp_grp]
+    comment: [msp_secure_action]
+    base_path: [msp_grp]
     flag_name: "38a. Is the MSP kept in a secure room after returning from cleaning up?"
     flag_name_fr: "38a. Le PM est-il gardé dans une pièce sécurisée après être son nettoyage?"
     answer: "no"
     warning: "Problem reported: MSP has to be secured at the end of day."
     warning_fr: "Problème signalé: MSP doit être sécurisé à la fin de la journée."
   - question: [overalls_wash]
-    base_path: [fsp_grp, Q39]
+    comment: [overalls_wash_addl]
+    base_path: [msp_grp, Q39]
     flag_name: "39. Are the overalls transported back to the main fixed soak pit to be washed?"
     flag_name_fr: "39. Les salopettes sont-elles transportées dans le principal puisard pour les à laver?"
     answer: "no"
     warning: "Problem reported: Porters not transporting overalls to be washed and dried"
     warning_fr: "Problème signalé: Les porteurs ne transportent pas les combinaisons à laver et sécher"
   - question: [overalls_clean]
-    base_path: [fsp_grp, Q40]
+    comment: [overalls_clean_addl]
+    base_path: [msp_grp, Q40]
     flag_name: "40. Do the operators have clean overalls for the next day?"
     flag_name_fr: "40. Les opérateurs ont-ils des salopettes pour le lendemain?"
     answer: "no"
@@ -470,6 +538,7 @@ http://openrosa.org/formdesigner/381E6260-1C5F-4755-BA33-871E464A1C71:
 # Form 4 - Storekeeper
 http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
   - question: [ledger_present]
+    comment: [ledger_present_addl]
     base_path: [stock_audit_grp, Q1]
     flag_name: "1. Is a stock ledger/register present at the store?"
     flag_name_fr: "1. Est-ce-que le registre / registre des stocks est présent dans le magasin?"
@@ -477,6 +546,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Stock ledger not present."
     warning_fr: "Problème signalé: pas de registre de stock dans le magasin"
   - question: [ledger_updated]
+    comment: [ledger_updated_addl]
     base_path: [stock_audit_grp, Q2]
     flag_name: "2. Is the store ledger book fully updated?"
     flag_name_fr: "2. Est-ce-que le livre grand du magasin est entièrement mis à jour?"
@@ -484,6 +554,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: The store ledger book is not fully updated."
     warning_fr: "Problème signalé: le registre de stock n'est pas entièrement mis à jour "
   - question: [stock_cards_mounted]
+    comment: [stock_cards_mounted_addl]
     base_path: [stock_audit_grp, Q3]
     flag_name: "3. Are the stock cards mounted for each item?"
     flag_name_fr: "3. Est-ce-que chaque article possède sa propre fiche de stock ?"
@@ -491,6 +562,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Stock cards not mounted."
     warning_fr: "Problème signalé : fiches de stocks non montées "
   - question: [stock_cards_updated]
+    comment: [stock_cards_updated_addl]
     base_path: [stock_audit_grp, Q4]
     flag_name: "4. Are the stock cards up to date?"
     flag_name_fr: "4. Est-ce-que les cartes de stock sont à jour?"
@@ -498,6 +570,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Deficient stock record-keeping."
     warning_fr: "Problème signalé: les fiches de stocks insuffisants "
   - question: [separate_pages_updated]
+    comment: [separate_pages_updated_addl]
     base_path: [stock_audit_grp, Q5]
     flag_name: "5. Are the separate ledger pages and stock cards for empty bottles/sachets and used dust masks up to date?"
     flag_name_fr: "5. Est-ce-que les pages de registre et les fiches de stock séparées pour les bouteilles / sachets vides et les masques antipoussières usagés sont à jour?"
@@ -505,6 +578,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Deficient stock record-keeping: empty bottles and waste stock."
     warning_fr: "Problème signalé: fiches de stocks manquantes : bouteilles/sachets vides et stocks de déchets "
   - question: [separate_cards_batch]
+    comment: [separate_cards_batch_addl]
     base_path: [stock_audit_grp, Q6]
     flag_name: "6. If there are insecticides that expire during spray, are there separate stock cards for each batch of insecticide?"
     flag_name_fr: "6. S'il y a des insecticides qui expirent pendant la pulvérisation, existe-t-il des fiches de stock distinctes pour chaque lot d'insecticide?"
@@ -512,6 +586,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: No separate stock cards for expiring insecticide."
     warning_fr: "Problème signalé: pas de fiches de sotck séparés pour les insecticides périmés "
   - question: [expired_insecticides_separate]
+    comment: [expired_insecticides_separate_addl]
     base_path: [stock_audit_grp, Q7]
     flag_name: "7. Have insecticides that expire during the spray season been physically separated from the other insecticides in the store room?"
     flag_name_fr: "7. Est-ce-que les insecticides qui expirent pendant la saison de pulvérisation ont été physiquement séparés des autres insecticides dans le magasin?"
@@ -519,6 +594,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Expiring insecticide not physically separated from others."
     warning_fr: "Problème signalé: les insecticides périmés ne sont pas séparés physiquement des autres insecticides dans le magasin"
   - question: [stock_used_cards]
+    comment: [stock_used_cards_addl]
     base_path: [stock_audit_grp, Q8]
     flag_name: "8. Using the stock cards, can the storekeeper indicate the quantity of stock that has been used to date?"
     flag_name_fr: "8. À l'aide des fiches de stock, le magasinier peut-il indiquer la quantité de stock utilisée à ce jour?"
@@ -526,6 +602,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Deficient record-keeping: usage."
     warning_fr: "Problème signalé: fiches de stock déficient: utilisation."
   - question: [balance_mismatch]
+    comment: [balance_mismatch_addl]
     base_path: [stock_audit_grp, Q9]
     flag_name: "9. Is the balance in the store ledger book different from the balance on the stock card for all stock items?"
     flag_name_fr: "9. La balance du livre du grand magasin est-elle différente du solde de la carte de stock pour tous les articles en stock?"
@@ -533,6 +610,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: The balance in the store ledger book does not match the balance on the stock card for all stock items."
     warning_fr: "Problème signalé: La balance dans du registre du magasin ne correspond pas au solde de la fiche de stock pour tous les articles en stock."
   - question: [balance_match_stock]
+    comment: [balance_match_stock_addl]
     base_path: [stock_audit_grp, Q10]
     flag_name: "10. Does the balance on the stock card equal to the result of a physical stock count for each item?"
     flag_name_fr: "10. Est-ce-que le solde de la carte de stock est égal au résultat d'un compte de stock physique pour chaque article?"
@@ -540,6 +618,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: The balance on the stock card does not equal the result of a physical stock count for all items."
     warning_fr: "Problème signalé: le solde des fiches de stock ne correspond pas au résultat d'un comptage physique"
   - question: [reconciliation_completed]
+    comment: [reconciliation_completed_addl]
     base_path: [stock_audit_grp, Q11]
     flag_name: "11. Is the Insecticide Reconciliation Form completed daily?"
     flag_name_fr: "11. Est-ce-que le formulaire de rapprochement des insecticides est-il rempli journalièrement?"
@@ -547,6 +626,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: The Insecticide Reconciliation Form is not completed daily."
     warning_fr: "Problème signalé: Le formulaire de rapprochement des insecticides n'est pas rempli tous les jours."
   - question: [balance_match_opening]
+    comment: [balance_match_opening_addl]
     base_path: [stock_audit_grp, Q12]
     flag_name: "12. Does the sum of the stock balance on the stock card + the stock issued out for the day + the stock balance of empty sachets/bottles, equal to the opening balance plus any subsequent receipts in the ledger?"
     flag_name_fr: "12. Est-ce que la somme du solde du stock sur la carte de stock + le stock émis pour la journée + le solde du stock de sachets / bouteilles vides, égal au solde d'ouverture plus les reçus ultérieurs dans le grand livre?"
@@ -554,6 +634,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: The stock balance records of pesticides does not reconcile."
     warning_fr: "Problème signalé: Les registres de stocks de pesticides ne concordent pas."
   - question: [pesticide_mishandling]
+    comment: [pesticide_mishandling_addl]
     base_path: [safety_reqs_grp, Q13]
     flag_name: "13. Do people handle pesticides while not wearing masks, gloves, boots and overalls?"
     flag_name_fr: "13. Les gens manipulent-ils des pesticides sans porter de masques, de gants, de bottes et de combinaisons?"
@@ -561,6 +642,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Personnel handling pesticides without wearing masks, gloves, boots, and overalls."
     warning_fr: "Problème signalé: le personnel manipule le pesticide sans porter masque, gants, bottes et combinaison"
   - question: [eating_warehouse]
+    comment: [eating_warehouse_addl]
     base_path: [safety_reqs_grp, Q14]
     flag_name: "14. Do warehouse teams eat inside the warehouse?"
     flag_name_fr: "14. Est-ce que les équipes d'entrepôt mangent à l'intérieur de l'entrepôt?"
@@ -568,6 +650,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Workers eating inside warehouse while IRS pesticides are in stock."
     warning_fr: "Problème signalé: le personnel entrain de manger dans le magasin de pesticide "
   - question: [poisoning_symptoms]
+    comment: [poisoning_symptoms_addl]
     base_path: [safety_reqs_grp, Q15]
     flag_name: "15. Are storekeepers familiar with the symptoms of pesticide poisoning?"
     flag_name_fr: "15. Est-ce que les charge de stocks sont-ils familiers avec les symptômes de l'empoisonnement aux pesticides?"
@@ -575,22 +658,27 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Storekeeper not familiar with symptoms of poisoning for the current pesticide(s)."
     warning_fr: "Problème signalé: le magasinier n'est pas familier aux signes d'intoxication"
   - question: [first_aid_check]
+    comment: [first_aid_check_addl]
     base_path: [safety_reqs_grp, Q16]
     flag_name: "16. Are the following items in the emergency first aid kit?"
     flag_name_fr: "16. Les articles suivants sont-ils inclus dans la trousse de premiers soins d'urgence?"
     warning_type: unchecked
     ignore: ["none"]
+    section: 'Storekeeper_Perf_SOP_2018'
     warning: "Problem reported: First aid items are needed for this facility. Missing: {msg}"
     warning_fr: "Problème signalé: besoins en éléments de premier secours. Manquant: {msg}"
   - question: [warehouse_spill_kit]
+    comment: [warehouse_spill_kit_addl]
     base_path: [safety_reqs_grp, Q17]
     flag_name: "17. Is there a complete spill kit and a fire extinguisher in the warehouse?"
     flag_name_fr: "17. Y a-t-il une trousse de déversement complète et un extincteur dans l'entrepôt?"
     warning_type: unchecked
     ignore: ["none"]
+    section: 'Storekeeper_Perf_SOP_2018'
     warning: "Problem reported: Storeroom missing: {msg}"
     warning_fr: "Problème signalé: manquant dans le magasin de stockage: {msg}"
   - question: [nearest_health_facility_known]
+    comment: [nearest_health_facility_known_addl]
     base_path: [safety_reqs_grp, Q18]
     flag_name: "18. Does the storekeeper know where the nearest health facility is located?"
     flag_name_fr: "18. Est-ce que le magasinier sait où se trouve l'éstablissement de santé le plus proche?"
@@ -598,6 +686,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Storekeeper does not know location of nearest health facility."
     warning_fr: "Problème signalé: le magasinier ne sait pas où se trouve la structure de santé la plus proche"
   - question: [antidotes_provided]
+    comment: [antidotes_provided_addl]
     base_path: [safety_reqs_grp, Q19]
     flag_name: "19. Were the antidotes for the pesticide in use provided to the nearest health facility?"
     flag_name_fr: "19. Est-ce que les antidotes pour le pesticide utilisé ont été fournis à l'établissement de santé le plus proche?"
@@ -605,6 +694,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Antidotes may not be available in the nearest health facility."
     warning_fr: "Problème signalé: l'antidote n'est pas disponible au niveau de la strcuture de santé la plus proche"
   - question: [soap_available]
+    comment: [soap_available_addl]
     base_path: [store_materials_grp, Q20]
     flag_name: "20. Are there soap and water basins available for washing hands?"
     flag_name_fr: "20. Est-ce qu'il y a des bassins, savons et d'eau pour se laver les mains?"
@@ -612,6 +702,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported:  Water basins not provided in storeroom for washing hands."
     warning_fr: "Problème signalé: bassines d'eau non disponibles dans le magasin pour le lavage des mains "
   - question: [msds_posted]
+    comment: [msds_posted_addl]
     base_path: [store_materials_grp, Q21]
     flag_name: "21. Is the current pesticide Material Safety Data Sheet (MSDS) posted?"
     flag_name_fr: "21. La ou les fiches de données de sécurité (FDS) du ou des pesticides actuels est-elle affichée?"
@@ -619,6 +710,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Material Safety Data sheet for the current pesticide(s) not posted."
     warning_fr: "Problem reported: Material Safety Data sheet for the current pesticide(s) not posted."
   - question: [thermometer_available]
+    comment: [thermometer_available_addl]
     base_path: [store_materials_grp, Q22]
     flag_name: "22. Is there a functional thermometer for monitoring daily temperature in the storage facility?"
     flag_name_fr: "22.  Est-ce que il y a un thermomètre fonctionnel pour surveiller la température quotidienne dans l'installation de stockage?"
@@ -626,6 +718,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Thermometer needed in storeroom."
     warning_fr: "Problème signalé: besoin de thermomètre dans le magasin de stockage "
   - question: [pesticide_leakage]
+    comment: [pesticide_leakage_addl]
     base_path: [pesticide_management_grp, Q23]
     flag_name: "23. Is there any evidence of pesticide leakage?"
     flag_name_fr: "23. Y a-t-il des signes de fuite de pesticide?"
@@ -633,6 +726,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Pesticide leak discovered in storeroom."
     warning_fr: "Problème signalé: Fuite de pesticide découverte dans l'entrepôt"
   - question: [contaminants_separated]
+    comment: [contaminants_separated_addl]
     base_path: [pesticide_management_grp, Q24]
     flag_name: "24. Are the insecticide and contaminated waste stored away from other materials in the store?"
     flag_name_fr: "24. L'insecticide et les déchets contaminés sont-ils stockés à l'écart des autres matériaux dans le magasin?"
@@ -640,6 +734,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Deficient pesticide and contaminated waste storage procedures."
     warning_fr: "Problème signalé: Procédures d'entreposage des pesticides et des déchets contaminés déficients"
   - question: [pesticides_labeled]
+    comment: [pesticides_labeled_addl]
     base_path: [pesticide_management_grp, Q25]
     flag_name: "25. Are pesticides properly labeled?"
     flag_name_fr: "25. Les pesticides sont-ils correctement étiquetés?"
@@ -647,6 +742,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Deficient pesticide labeling."
     warning_fr: "Problème signalé: Étiquetage des pesticides déficient."
   - question: [insecticide_fefo]
+    comment: [insecticide_fefo_addl]
     base_path: [pesticide_management_grp, Q26]
     flag_name: "26. Are the insecticides distributed on a 'first expired, first out' (FEFO) system so that the insecticide that expires first is distributed first?"
     flag_name_fr: "26. Les insecticides sont-ils distribués dans un système «premier expiré, premier sorti» (FEFO) de sorte que l'insecticide qui expire le premier est distribué en premier?"
@@ -654,6 +750,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Not using FEFO inventory system."
     warning_fr: "Problème signalé: Système d'inventaire FEFO non utilisé "
   - question: [insecticides_expired]
+    comment: [insecticides_expired_addl]
     base_path: [pesticide_management_grp, Q27]
     flag_name: "27. Are there any insecticides past their expiration date?"
     flag_name_fr: "27. Y a-t-il des insecticides après leur date de péremption?"
@@ -661,6 +758,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Expired pesticides in storeroom."
     warning_fr: "Problème signalé: Pesticides expirés dans le magasin."
   - question: [barrels_empties_labeled]
+    comment: [barrels_empties_labeled_addl]
     base_path: [pesticide_management_grp, Q28]
     flag_name: "28. Are barrels or containers for empty sachets and empty bottles and used masks available and clearly labeled?"
     flag_name_fr: "28. Y a-t-il des fûts ou des contenants pour les sachets vides et les bouteilles vides et les masques usagés disponibles et clairement étiquetés?"
@@ -668,6 +766,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Deficient storage and/or labeling of hazardous waste."
     warning_fr: "roblème signalé: Stockage et / ou étiquetage déficient des déchets dangereux"
   - question: [number_empties_match]
+    comment: [number_empties_match_addl]
     base_path: [pesticide_management_grp, Q29]
     flag_name: "29. Does the number of empty sachets/bottles (including those sachets/bottles in the field at this moment) equal what the storekeeper indicates as the quantity of stock issued to date?"
     flag_name_fr: "29. Le nombre de sachets / bouteilles vides (y compris les sachets / bouteilles sur le terrain en ce moment) est-il égal à ce que le magasinier indique comme quantité de stock délivré à ce jour?"
@@ -675,13 +774,15 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning: "Problem reported: Pesticide inventory does not balance."
     warning_fr: "Problème signalé: Inventaire des pesticides non conforme "
   - question: [pesticide_stored_high]
+    comment: [pesticide_stored_high_addl]
     base_path: [pesticide_management_grp, Q30]
     flag_name: "30. Is the pesticide stock stored no more than 2 m high and off of the ground?"
     flag_name_fr: "30. Le stock de pesticides n'est-il pas entreposé à plus de 2 m de hauteur et hors du sol?"
     answer: "no"
-    warning: "30. Le stock de pesticides n'est-il pas entreposé à plus de 2 m de hauteur et hors du sol?"
+    warning: "Problem reported: Improper pesticide storage: Skids and/or stacking height."
     warning_fr: "Problème signalé: Stockage inadéquat des pesticides: patins et / ou hauteur d'empilage"
   - question: [excess_accumulated_waste]
+    comment: [excess_accumulated_waste_addl]
     base_path: [pesticide_management_grp, Q31]
     flag_name: "31. Is there more than one spray season of accumulated solid waste?"
     flag_name_fr: "31. Y a-t-il plus d'une saison de pulvérisation de déchets solides accumulés?"
@@ -691,6 +792,7 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
 # Form 5 - HO Prep & SOP Perf
 http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
   - question: [items_removed]
+    comment: [items_removed_addl]
     base_path: [household_prep_grp, Q1]
     flag_name: "1. Have all movable items been removed from the structure?"
     flag_name_fr: "1. Tous les objets mobiles ont-ils été retirés de la structure?"
@@ -698,6 +800,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Belongings not removed from structure."
     warning_fr: "Problème signalé: Les effets personnels ne sont pas retirés de la structure."
   - question: [furniture_covered]
+    comment: [furniture_covered_addl]
     base_path: [household_prep_grp, Q2]
     flag_name: "2. Have all non-moveable furniture items been moved to the middle of the room and properly covered with a plastic sheet?"
     flag_name_fr: "2. Tous les meubles non mobiles ont-ils été déplacés au milieu de la pièce et correctement recouverts d'une feuille de plastique?"
@@ -705,19 +808,22 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Immovable items not moved to the center of the room/items not covered with plastic sheet."
     warning_fr: "Problème signalé: Les articles immobiliers qui n'ont pas été déplacés vers le centre de la pièce / les articles non recouverts d'une feuille de plastique."
   - question: [items_hanging]
+    comment: [items_hanging_addl]
     base_path: [household_prep_grp, Q3]
     flag_name: "3. Are there any items on the walls or hanging from the ceiling (posters, pictures, shoes, toothbrushes)?"
     answer: "yes"
     warning: "Problem reported: Items not removed from the wall or ceiling."
     warning_fr: "Problème signalé : Articles non retirés du mur ou du plafond"
   - question: [food_removed]
-    base_path: [household_prep_grp, Q4]
+    comment: [food_removed_action]
+    base_path: [household_prep_grp]
     flag_name: "4a. Was the food removed before spraying?"
     flag_name_fr: "4a. La nourriture a-t-elle été enlevée avant la pulvérisation?"
     answer: "no"
     warning: "Problem reported: Rooms containing food were sprayed by operator."
     warning_fr: "Problème signalé: des pièces contenant des aliments ont été pulvérisés "
   - question: [unmovable_people]
+    comment: [unmovable_people_addl]
     base_path: [household_prep_grp, Q5]
     flag_name: "5. If there are people (sick, elderly, babies) who cannot be moved in a structure, is this structure being sprayed?"
     flag_name_fr: "5. Y-a-t-il des personnes (malades, âgées, bébés) qui ne peuvent pas être déplacées dans une structure, cette structure est-elle pulvérisée?"
@@ -725,13 +831,15 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: House sprayed with sick, elderly, or babies in home."
     warning_fr: "Problème signalé:  Une maison a été aspergée avec des malades, de personnes âgées ou de bébés à la maison."
   - question: [triple_rinse]
-    base_path: [insecticide_prep_grp, Q6]
+    comment: [triple_rinse_action]
+    base_path: [insecticide_prep_grp]
     flag_name: "6a. Does the operator triple-rinse the bottle while preparing the pesticide in the tank?"
     flag_name_fr: "6a. Est-ce-que l'opérateur rinse trois fois la bouteille pendant la préparation du pesticide dans le réservoir?"
     answer: "no"
     warning: "Problem reported: Spray operator not observing bottle triple rinse procedure."
     warning_fr: "Problème signalé : L'opérateur de pulvérisation ne respecte pas la procédure de  triple rinçage de la bouteille."
   - question: [tank_volume]
+    comment: [tank_volume_addl]
     base_path: [insecticide_prep_grp, Q7]
     flag_name: "7. Is the final tank volume, including water and insecticide, observed to be 7.5L?"
     flag_name_fr: "7. Est-ce-que le volume final du réservoir, y compris l'eau et l'insecticide, atteigne de 7,5 L?"
@@ -739,6 +847,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Tank does not have the correct amount of water and insecticide."
     warning_fr: "Problème signalé: Le réservoir n'a pas la bonne quantité d'eau et d'insecticide."
   - question: [tank_shaken]
+    comment: [tank_shaken_addl]
     base_path: [insecticide_prep_grp, Q8]
     flag_name: "8. Is the tank shaken to mix the contents before pressurizing?"
     flag_name_fr: "8. Est-ce -que le réservoir est agité pour mélanger le contenu avant de le mettre sous pression?"
@@ -746,6 +855,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator not properly mixing pesticide before pressurizing tank."
     warning_fr: "Problem reported: Spray operator not properly mixing pesticide before pressurizing tank."
   - question: [pump_pressurized]
+    comment: [pump_pressurized_addl]
     base_path: [insecticide_prep_grp, Q9]
     flag_name: "9. Is the Hudson pump pressurized to 55 psi, or the Goizper pump pressurized until the safety valve begins releasing pressure and the red marker is visible before spraying?"
     flag_name_fr: "9. La pompe Hudson est-elle pressurisée à 55 psi, ou la pompe Goizper est-elle sous pression jusqu'à ce que la soupape de sécurité commence à relâcher la pression et que le marqueur rouge soit visible avant la pulvérisation?"
@@ -753,22 +863,28 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator not correctly pressurizing tank before spraying."
     warning_fr: "Problème signalé: La pompe n'est pas correctement pressurisée"
   - question: [sop_full_ppe]
+    comment: [sop_full_ppe_addl]
     base_path: [spray_observe_grp, Q10]
     flag_name: "10. Is the spray operator in full PPE?"
     flag_name_fr: "10. L'opérateur de pulvérisation est-il en EPI complet?"
     warning_type: unchecked
     ignore: ["none"]
+    section: 'Homeowner_Prep_and_SOP_2018'
     warning: "Problem reported: Spray operator not wearing full PPE."
     warning_fr: "Problème signalé: l'opérateur n'a pas porté l'EPI au complet"
   - question: [sop_eating_during_spray]
+    comment: [sop_eating_during_spray_addl]
     base_path: [spray_observe_grp, Q11]
     flag_name: "11. Is the spray operator observed smoking, eating, or drinking during household preparation or spraying?"
     flag_name_fr: "11.Est-ce-que l'opérateur de pulvérisation est observé en train de fumer, de manger ou de boire pendant la préparation du ménage ou la pulvérisation?"
     answer: "yes"
     warning_question: [sop_id]
+    comment: [sop_id_addl]
+    warning_question_root: True
     warning: "Problem reported: Spray operator {msg} drinking, or eating during household preparation or spraying."
     warning_fr: "Problème signalé: l'Operateur de pulvérisation {msg} est entrain de boire, ou manger pendant la préparation des pièces des bénéficiaires ou la pulverisation"
   - question: [items_moved]
+    comment: [items_moved_addl]
     base_path: [spray_observe_grp, Q12]
     flag_name: "12. Have all immovable items been moved to the center of the room (bed, dresser, etc.)?"
     flag_name_fr: "12. Est-ce-que tous les biens immobiliers ont été déplacés au centre de la pièce (lit, commode, etc.)?"
@@ -776,6 +892,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Immovable items not moved to the center of the room/covered before spraying"
     warning_fr: "Problème signalé: les affaires qui ne peuvent être déplacés ne sont  pas déplacés/couvert au centre de la pièce avant la pulvérisation "
   - question: [loose_items_removed]
+    comment: [loose_items_removed_addl]
     base_path: [spray_observe_grp, Q13]
     flag_name: "13. Have all loose items (clothes, mosquito nets, posters/pictures on the wall) been taken out of the house?"
     flag_name_fr: "13. Est-ce-que tous les objets en vrac (vêtements, moustiquaires, affiches / photos sur le mur) ont été retirés de la maison?"
@@ -783,6 +900,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Loose items (clothes, mosquito nets, pictures/posters) not removed from the house before spraying"
     warning_fr: "Problème signalé: Les objets en vrac (vêtements, moustiquaires, photos / affiches) ne sont pas retirés de la maison avant d'être pulvérisés"
   - question: [pump_leaks]
+    comment: [pump_leaks_addl]
     base_path: [spray_observe_grp, Q14]
     flag_name: "14. Are there any leaks from the pump?"
     flag_name_fr: "14. Y a-t-il des fuites de la pompe?"
@@ -790,6 +908,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Pump leaking."
     warning_fr: "Problème signalé : Des fuites proviennent de la pompe"
   - question: [pump_serviced]
+    comment: [pump_serviced_action]
     base_path: [spray_observe_grp]
     flag_name: "14a. Does the operator service the pump before proceeding?"
     flag_name_fr: "14a. L'opérateur entretient-il la pompe avant de continuer?"
@@ -797,6 +916,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator did not immediately service leaking pump."
     warning_fr: "Problème signalé: L'opérateur de pulvérisation n'a pas immédiatement réparé la pompe qui fuit."
   - question: [nozzle_tip]
+    comment: [nozzle_tip_addl]
     base_path: [spray_observe_grp, Q15]
     flag_name: "15. Is the spray operator spraying with the tip of the nozzle 45 cm away from the wall?"
     flag_name_fr: "15. Est-ce-que l'opérateur de pulvérisation pulvérise l'extrémité de la buse à 45 cm du mur?"
@@ -804,6 +924,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator not spraying at the correct distance from the surface."
     warning_fr: "Problème signalé: L'operateur de pulverisation n'a pas respecté la bonne distance à partir du support  "
   - question: [spray_speed]
+    comment: [spray_speed_addl]
     base_path: [spray_observe_grp, Q16]
     flag_name: "16. Is the spray operators maintaining the correct speed of application, i.e., covering 2 meters of vertical wall surface in 5 seconds?"
     flag_name_fr: "16. Est-ce-que les opérateurs de pulvérisation maintiennent la bonne vitesse d'application, c'est-à-dire qu'ils couvrent 2 mètres de surface de paroi verticale en 5 secondes?"
@@ -811,6 +932,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator not spraying at the correct speed."
     warning_fr: "Problème signalé : L’opérateur de pulvérisation ne pulvérise pas à la vitesse correcte. "
   - question: [swath_overlap]
+    comment: [swath_overlap_addl]
     base_path: [spray_observe_grp, swath_grp, Q17]
     flag_name: "17. Is there a 5 cm overlap with each successive swath?"
     flag_name_fr: "17. Y a-t-il un chevauchement de 5 cm avec chaque bande successive?"
@@ -818,6 +940,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Successive spray swath does not have 5 cm overlap."
     warning_fr: "Problème signalé : Il n’y a pas de chevauchement de 5 cm d’une couche à l’autre. "
   - question: [surfaces_sprayed]
+    comment: [surfaces_sprayed_addl]
     base_path: [spray_observe_grp, Q18]
     flag_name: "18. Is the spray operator spraying all the recommended surfaces? (walls, inside of doors, ceiling)"
     flag_name_fr: "18. Est-ce-que l'opérateur de pulvérisation pulvérise toutes les surfaces recommandées? (murs, intérieur des portes, plafond)"
@@ -825,6 +948,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator not spraying all the recommended surfaces."
     warning_fr: "Problème signalé : L’opérateur de pulvérisation ne pulvérise pas toutes les surfaces recommandées"
   - question: [surfaces_sprayed_incorrect]
+    comment: [surfaces_sprayed_incorrect_addl]
     base_path: [spray_observe_grp, Q19]
     flag_name: "19. Is the spray operator spraying floors, metal roofs, the outside of doors, glass, inside of cupboards, wallpaper, food granaries, curtains, latrines, animal pens?"
     flag_name_fr: "19. Est-ce-que l'opérateur de pulvérisation pulvérise les planchers, les toits en métal, l'extérieur des portes, le verre, l'intérieur des placards, le papier peint, les greniers à nourriture, les rideaux, les latrines et les enclos pour animaux?"
@@ -832,6 +956,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator spraying wrong surfaces."
     warning_fr: "Probleme signalé: l'opérateur de pulvérisation pulvérise les mauvaises surfaces "
   - question: [pump_re_pressurized]
+    comment: [pump_re_pressurized_addl]
     base_path: [spray_observe_grp, Q20]
     flag_name: "20. Is the pump re-pressurized if the Hudson tank pressure falls below 35 psi, or the Goizper automatically shuts off?"
     flag_name_fr: "20. Est-ce-que la pompe est remise sous pression si la pression du réservoir Hudson chute en dessous de 35 psi ou si le Goizper s'éteint automatiquement?"
@@ -839,13 +964,15 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator not re-pressurizing tank as required."
     warning_fr: "Problème signalé : l'opérateur de pulvérisation n'a pas représsurisé la pompe "
   - question: [items_removed]
-    base_path: [spray_observe_grp, eaves_grp, Q21]
+    comment: [items_removed_action]
+    base_path: [spray_observe_grp, eaves_grp]
     flag_name: "21a. Were the household items that are normally stored on the porches, roofs and exterior of the walls removed?"
     flag_name_fr: "21a. Est-ce-que les articles ménagers qui sont normalement entreposés sur les porches, les toits et l'extérieur des murs ont été enlevés?"
     answer: "no"
     warning: "Problem reported: Household items not removed from area before spraying eaves."
     warning_fr: "Problème signalé: Les articles ménagers ne sont pas retirés de la zone avant la pulvérisation des avant-toits."
   - question: [house_marked]
+    comment: [house_marked_addl]
     base_path: [spray_observe_grp, Q22]
     flag_name: "22. Did the spray operator correctly mark the house after they completed spraying?"
     flag_name_fr: "22. Est-ce-que l'opérateur de pulvérisation a correctement marqué la maison après avoir terminé la pulvérisation?"
@@ -853,6 +980,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Spray operator did not mark the house correctly"
     warning_fr: "Problème signalé: l'opérateur de pulvérisation n'a pas correctement le marquage "
   - question: [resident_informed]
+    comment: [resident_informed_addl]
     base_path: [sbcc_grp, Q23]
     flag_name: "23. Was the resident informed in advance about the spray activities?"
     flag_name_fr: "23. Est-ce-que le résident a été informé à l'avance des activités de pulvérisation?"
@@ -860,6 +988,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Resident not informed of spray activities."
     warning_fr: "Problème signalé: les bénificiaires ne sont informés de l'activité de pulvérisation "
   - question: [resident_instructed]
+    comment: [resident_instructed_addl]
     base_path: [sbcc_grp, Q24]
     flag_name: "24. Was the resident instructed not to enter for 2 hours, and then open windows and door to air out for 30 minutes before moving back in personal belongings, food items, and animals/sick persons?"
     flag_name_fr: "24. Le résident a-t-il reçu l'ordre de ne pas entrer pendant deux heures, puis d'ouvrir les fenêtres et la porte pour les aérer pendant 30 minutes avant de retourner dans ses effets personnels, ses aliments et ses animaux / personnes malades?"
@@ -867,6 +996,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Resident not informed of post-spray requirements."
     warning_fr: "Problème signalé: les bénéficiaires ne sont pas informés de ne pas entrer pendant 2 h avant d'ouvrir portes et fenêtre 30 min pour aérer avant de remettre les effets personnels, les aliments, et les animaux/personnes malades "
   - question: [resident_instructed_animals]
+    comment: [resident_instructed_animals_addl]
     base_path: [sbcc_grp, Q25]
     flag_name: "25. Was the resident informed to keep all animals outside the structure during spraying and for 2.5 hrs. afterward?"
     flag_name_fr: "25. Est-ce-que le résident a été informé de garder tous les animaux à l'extérieur de la structure pendant la pulvérisation et pendant deux heures et demie? après?"
@@ -874,6 +1004,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Resident not informed of protocol regarding animals."
     warning_fr: "Problème signalé: les résidents ne sont informés des mesures de sécurité par rapport aux animaux "
   - question: [resident_instructed_insect_removal]
+    comment: [resident_instructed_insect_removal_addl]
     base_path: [sbcc_grp, Q26]
     flag_name: "26. Was the resident told to sweep up mosquitoes and other bugs killed by IRS and deposit them in a latrine pit and not to allow children or animals inside until this has been completed?"
     flag_name_fr: "26. Est-ce-que le résident a reçu l'ordre de balayer les moustiques et autres insectes tués par l'IRS et de les déposer dans une fosse de latrines et de ne pas laisser les enfants ou les animaux à l'intérieur jusqu'à ce que cela soit terminé?"
@@ -881,6 +1012,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Resident not informed of post-spray protocol."
     warning_fr: "Problème signalé: les résidents ne sont pas informés des mesures du protocole à suivre après la pulvérisation "
   - question: [resident_instructed_surfaces]
+    comment: [resident_instructed_surfaces_addl]
     base_path: [sbcc_grp, Q27]
     flag_name: "27. Was the resident told not to plaster, paint or clean the sprayed surfaces?"
     flag_name_fr: "27. Est-ce-que le résident a été dit de ne pas enduire, peindre ou nettoyer les surfaces projetées?"
@@ -888,12 +1020,14 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
     warning: "Problem reported: Resident not informed of post-spray protocol."
     warning_fr: "Problème signalé: les résidents ne sont pas informés des mesures du protocole à suivre après la pulvérisation "
   - question: [resident_instructed_health]
+    comment: [resident_instructed_health_addl]
     base_path: [sbcc_grp, Q28]
     flag_name: "28. Was the resident informed to wash itchy skin, and to go to a health clinic if they don't feel well after their house has been sprayed?"
     answer: "no"
     warning: "Problem reported: Resident not informed of potential exposure protocol."
     warning_fr: "Problème signalé: les residents ne sont pas informés du protocole en cas d'exposition"
   - question: [sop_data]
+    comment: [sop_data_addl]
     base_path: [sbcc_grp, Q29]
     flag_name: "29. Is the spray operator accurately recording data?"
     flag_name_fr: "29.Est ce-que l'opérateur de pulvérisation enregistre correctement les données?"


### PR DESCRIPTION
Hi @nickpell 

I added some changes to VectorLink Report. I added comment column to the config file, and I added a parameter to the ```_get_question_options``` method. So now we can define the root element. Mostly the data we have in ```data``` root, but in VecrorLink each form have different ```root```. For example questions for form, Spray Operator Morning Mobilization Inspection has root ```Morning_Mobilization_2018```.

Please let me know if you have any question.

Regards,
Łukasz