### PR TITLE
change property name for insprector_names

### DIFF
--- a/custom/abt/reports/data_sources/supervisory_v2.json
+++ b/custom/abt/reports/data_sources/supervisory_v2.json
@@ -279,9 +279,12 @@
                 "datatype": "string",
                 "display_name": "inspector_names",
                 "expression": {
-                    "datatype": null,
-                    "property_name": "names",
-                    "type": "property_name"
+                    "type": "root_doc",
+                    "expression": {
+                        "datatype": null,
+                        "property_name": "inspector_names",
+                        "type": "property_name"
+                    }
                 },
                 "is_nullable": true,
                 "is_primary_key": false,


### PR DESCRIPTION
Hi,

I noticed that we use wrong property name for inspector_names.

Please let me know if you have any questions.

Regards,
Łukasz