### PR TITLE
Set minimum year to 1950

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "angular-leaflet-directive": "angular-leaflet#^0.10.0",
     "angular-perfect-scrollbar": "^0.1.0",
     "angular-busy": "^4.1.4",
-    "angular-daterangepicker": "^0.2.2",
     "ui-select": "angular-ui/ui-select#v0.13.2",
     "backbone": "0.9.1",
     "backbone-1.3.2": "backbone#1.3.2",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "backbone-1.3.2": "backbone#1.3.2",
     "backbone.marionette": "2.4.5",
     "bootstrap": "3.3.7",
-    "bootstrap-daterangepicker": "2.1.13",
+    "bootstrap-daterangepicker": "3.0.3",
     "bootstrap-switch": "3.3.2",
     "bootstrap-timepicker": "0.5.1",
     "bootstrap-tour": "0.10.2",


### PR DESCRIPTION
@orangejenny pretty sure this is not want you wanted when you suggested it. https://manage.dimagi.com/default.asp?273985#1500027

We currently use daterangepicker 2.1.13, but the docs are for 3.x. I didn't see anyway to get a versioned of the docs, so I looked at the code and found `minDate` instead of `minYear`: https://github.com/dangrossman/daterangepicker/blob/v2.1.27/daterangepicker.js Also we can't currently upgrade because we have an angular-daterangepicker dependency. I think we can get rid of that, but guessing you know most about the state of removing angular and how that library may be used.

This works in always showing the minimum as 1950, but you can no longer go past that. previously it appears that this works by using a window of x years. By default it goes back 50 years to 1968. When you select 1968, the dropdown will then go back to 1918, which seems not ideal, but better than this. Looking through the code it does not seem possible to change this window