### PR TITLE
Add ability to sort report by case property value

### DIFF
--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -37,7 +37,7 @@ SPECIAL_CASE_PROPERTIES_MAP = {
 
     '@status': SpecialCaseProperty('@status', lambda doc: 'closed' if doc.get('closed') else 'open', 'closed'),
 
-    'name': SpecialCaseProperty('name', lambda doc: doc.get('name'), 'name'),
+    'name': SpecialCaseProperty('name', lambda doc: doc.get('name'), 'name.exact'),
     'case_name': SpecialCaseProperty('case_name', lambda doc: doc.get('name'), 'name.exact'),
 
     'external_id': SpecialCaseProperty('external_id', lambda doc: doc.get('external_id', ''), 'external_id'),
@@ -48,6 +48,9 @@ SPECIAL_CASE_PROPERTIES_MAP = {
 SPECIAL_CASE_PROPERTIES = list(SPECIAL_CASE_PROPERTIES_MAP.keys())
 
 
+# Properties that can be shown in the report but are not stored on the case or in the case index
+# These properties are computed in `SafeCaseDisplay` when each case is displayed
+# Hence, they cannot be sorted on
 CASE_COMPUTED_METADATA = [
     'closed_by_username',
     'last_modified_by_user_username',

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -159,7 +159,25 @@ class CaseSearchES(CaseES):
 
     def sort_by_case_property(self, case_property_name, desc=False):
         sort_filter = filters.term("{}.key.exact".format(CASE_PROPERTIES_PATH), case_property_name)
-        return self.nested_sort(CASE_PROPERTIES_PATH, VALUE, sort_filter, desc)
+        self = self.nested_sort(
+            CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'numeric'),
+            sort_filter,
+            desc,
+            reset_sort=True
+        )
+        self = self.nested_sort(
+            CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'date'),
+            sort_filter,
+            desc,
+            reset_sort=False
+        )
+        self = self.nested_sort(
+            CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'exact'),
+            sort_filter,
+            desc,
+            reset_sort=False
+        )
+        return self
 
 
 def case_property_filter(case_property_name, value):

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -159,25 +159,22 @@ class CaseSearchES(CaseES):
 
     def sort_by_case_property(self, case_property_name, desc=False):
         sort_filter = filters.term("{}.key.exact".format(CASE_PROPERTIES_PATH), case_property_name)
-        self = self.nested_sort(
+        return self.nested_sort(
             CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'numeric'),
             sort_filter,
             desc,
             reset_sort=True
-        )
-        self = self.nested_sort(
+        ).nested_sort(
             CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'date'),
             sort_filter,
             desc,
             reset_sort=False
-        )
-        self = self.nested_sort(
+        ).nested_sort(
             CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'exact'),
             sort_filter,
             desc,
             reset_sort=False
         )
-        return self
 
 
 def case_property_filter(case_property_name, value):


### PR DESCRIPTION
This is merging into the base PR https://github.com/dimagi/commcare-hq/pull/20715 until that gets merged, as I don't want that one to get any larger.

Adds the ability to sort the report by case property.

It needs to add 3 sort params because we don't know ahead of time what the datatype of each property is (and there is no consistency). This allows us to properly sort values that are accurately stored as numbers and dates (yes, in theory dates stored as yyyy-mm-dd sort properly as text, but this is in case someone is manually storing dates in a different format).

