### PR TITLE
add non binding max size and full to locking queue

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -112,7 +112,9 @@ class CouchSqlDomainMigrator(object):
         last_received_on = datetime.min
         # process main forms (including cases and ledgers)
         changes = _get_main_form_iterator(self.domain).iter_all_changes()
-        self.queues = PartiallyLockingQueue("form_id")  # needs to be on self to release appropriately
+        # form_id needs to be on self to release appropriately
+        self.queues = PartiallyLockingQueue("form_id", max_size=50000)
+
         pool = Pool(10)
         for change in self._with_progress(['XFormInstance'], changes):
             self.log_debug('Processing doc: {}({})'.format('XFormInstance', change.id))
@@ -136,6 +138,8 @@ class CouchSqlDomainMigrator(object):
             while True:
                 new_wrapped_form = self.queues.get_next()
                 if not new_wrapped_form:
+                    if self.queues.full:
+                        sleep(0.01)  # swap greenlets
                     break
                 pool.spawn(self._migrate_form_and_associated_models_async, new_wrapped_form)
 
@@ -147,7 +151,7 @@ class CouchSqlDomainMigrator(object):
             else:
                 sleep(0.01)  # swap greenlets
 
-            remaining_items = self.queues.remaining_items() + len(pool)
+            remaining_items = self.queues.remaining_items + len(pool)
             if remaining_items % 10 == 0:
                 self.log_info('Waiting on {} docs'.format(remaining_items))
 
@@ -696,14 +700,16 @@ class PartiallyLockingQueue(object):
         with an object once finished processing
     """
 
-    def __init__(self, queue_id_param="id"):
+    def __init__(self, queue_id_param="id", max_size=-1):
         """
         :queue_id_param string: param of the queued objects to pull an id from
+        :max_size int: the maximum size the queue should reach. -1 means no limit
         """
         self.queue_by_lock_id = defaultdict(deque)
         self.lock_ids_by_queue_id = defaultdict(list)
         self.queue_objs_by_queue_id = dict()
         self.currently_locked = set()
+        self.max_size = max_size
 
         def get_queue_obj_id(queue_obj):
             return getattr(queue_obj, queue_id_param)
@@ -785,8 +791,15 @@ class PartiallyLockingQueue(object):
             return True
         return False
 
+    @property
     def remaining_items(self):
         return len(self.queue_objs_by_queue_id)
+
+    @property
+    def full(self):
+        if self.max_size == -1:
+            return False
+        return self.remaining_items >= self.max_size
 
     def _add_item(self, lock_ids, queue_obj, to_queue=True):
         """

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -727,6 +727,21 @@ class TestLockingQueues(TestCase):
         self.queues.release_lock_for_queue_obj(queue_obj)
         self._check_locks(lock_ids, lock_set=False)
 
+    def test_max_size(self):
+        self.assertEqual(-1, self.queues.max_size)
+        self.assertFalse(self.queues.full)  # not full when no max size set
+        self.queues.max_size = 2  # set max_size
+        lock_ids = ['dali', 'manet', 'monet']
+        queue_obj = DummyObject('osceola')
+        self.queues._add_item(lock_ids, queue_obj)
+        self.assertFalse(self.queues.full)  # not full when not full
+        queue_obj = DummyObject('east osceola')
+        self.queues._add_item(lock_ids, queue_obj)
+        self.assertTrue(self.queues.full)  # full when full
+        queue_obj = DummyObject('west osceola')
+        self.queues._add_item(lock_ids, queue_obj)
+        self.assertTrue(self.queues.full)  # full when over full
+
 
 class DummyObject(object):
     def __init__(self, id=None):


### PR DESCRIPTION
Memory seemed like it could eventually get to be a bit much for supersized domains, so this adds a fairly superficial, pretty outsized limit. I didn't feel a need to raise an exception if it reaches the 'full' point if trying to add one, rather using this as a soft max, but let me know if you think that would be better. Also, let me know if there is another number you think would be reasonable

@millerdev @snopoke @esoergel 