### PR TITLE
Fallback to not looking at all forms in ES

### DIFF
--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -17,6 +17,7 @@ from corehq.apps.reports.analytics.esaccessors import (
 )
 from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter, BaseSingleOptionFilter
 from corehq.const import MISSING_APP_ID
+from corehq.elastic import ESError
 from couchforms.analytics import get_all_xmlns_app_id_pairs_submitted_to_in_domain
 from memoized import memoized
 
@@ -135,6 +136,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
             },
             'display_app_type': self.display_app_type,
             'support_email': settings.SUPPORT_EMAIL,
+            'all_form_retrieval_failed': self.all_form_retrieval_failed,
         })
 
         if self.display_app_type and not context['selected']:
@@ -206,13 +208,25 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         return final_map
 
     @property
+    def all_form_retrieval_failed(self):
+        return getattr(self, '_all_form_retrieval_failed', False)
+
+    @property
     @memoized
     def _all_forms(self):
         """
-            Here we grab all forms ever submitted to this domain on CommCare HQ or all forms that the Applications
-            for this domain know about.
+        Here we grab all forms ever submitted to this domain on CommCare HQ or all forms that the Applications
+        for this domain know about.
+
+        This fails after a couple hundred million forms are submitted to the domain.
+        After that happens we'll just display a warning
         """
-        form_buckets = get_all_xmlns_app_id_pairs_submitted_to_in_domain(self.domain)
+        try:
+            form_buckets = get_all_xmlns_app_id_pairs_submitted_to_in_domain(self.domain)
+        except ESError:
+            self._all_form_retrieval_failed = True
+            form_buckets = []
+
         all_submitted = {self.make_xmlns_app_key(xmlns, app_id)
                          for xmlns, app_id in form_buckets}
         from_apps = set(self._application_forms)

--- a/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
@@ -89,4 +89,11 @@
             {% include 'reports/filters/partials/fuzzy_checkbox.html' %}
         </div>
     {% endif %}
+
+    {% if all_form_retrieval_failed %}
+        <div class="alert alert-warning" data-bind="visible: show" style="margin-top: 1em;">
+          {% trans "Filtering by unknown forms is currently unavailable for this project." %}
+          {% trans "If the problem persists please report an issue." %}
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?276519

Not surprisingly, trying to query every form that has ever been submitted by a domain has a breaking point.

This doesn't exactly fix this issue, but it falls back to displaying current applications and their forms, which should be enough to unblock ICDS. A better solution will be out of scope for interrupt