### PR TITLE
Support bulk translations for cchq-only strings

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -54,8 +54,8 @@ def _create_custom_app_strings(app, lang, for_default=False):
     yield id_strings.homescreen_title(), app.name
     yield id_strings.app_display_name(), app.name
 
-    yield 'cchq.case', "Case"
-    yield 'cchq.referral', "Referral"
+    for id, value in id_strings.REGEX_DEFAULT_VALUES.items():
+        yield id, value
 
     if for_default:
         # include language code names and current language
@@ -118,11 +118,6 @@ def _create_custom_app_strings(app, lang, for_default=False):
             yield _get_custom_icon_app_locale_and_value(custom_icon_form, custom_icon_text, module=module)
 
         if hasattr(module, 'report_configs'):
-            yield id_strings.report_menu(), 'Reports'
-            yield id_strings.report_name_header(), 'Report Name'
-            yield id_strings.report_description_header(), 'Report Description'
-            yield id_strings.report_last_sync(), 'Last Sync'
-            yield id_strings.report_data_table(), 'Data Table'
             for config in module.report_configs:
                 yield id_strings.report_command(config.uuid), trans(config.header)
                 yield id_strings.report_name(config.uuid), trans(config.header)
@@ -196,7 +191,10 @@ class AppStringsBase(object):
 
     @memoized
     def get_default_translations(self, lang, commcare_version):
-        return self._load_translations(lang, commcare_version=commcare_version)
+        translations = self._load_translations(lang, commcare_version=commcare_version)
+        for id, value in id_strings.REGEX_DEFAULT_VALUES.items():
+            translations[id] = value
+        return translations
 
     def create_custom_app_strings(self, app, lang, for_default=False):
         custom = dict(_create_custom_app_strings(app, lang, for_default=for_default))

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -46,6 +46,7 @@ REGEXES = []
 REGEX_DEFAULT_VALUES = {}
 
 
+# Do not use this outside of this module, since it modifies module-level variables
 def pattern(pattern, default=None):
     REGEXES.append(_format_to_regex(pattern))
     if default:

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -43,11 +43,14 @@ def _regex_union(regexes):
 
 
 REGEXES = []
+REGEX_DEFAULT_VALUES = {}
 
 
-def pattern(*patterns):
-    for pattern in patterns:
-        REGEXES.append(_format_to_regex(pattern))
+def pattern(pattern, default=None):
+    REGEXES.append(_format_to_regex(pattern))
+    if default:
+        REGEX_DEFAULT_VALUES[pattern] = default
+
     return lambda fn: fn
 
 
@@ -66,12 +69,22 @@ def current_language():
     return "lang.current"
 
 
+@pattern('cchq.case', default="Case")
+def _case_detail_title_locale():
+    return 'cchq.case'
+
+
+@pattern('cchq.referral', default="Referral")
+def _referral_detail_title_locale():
+    return 'cchq.referral'
+
+
 @pattern('m%d.%s.title')
 def detail_title_locale(detail_type):
     if detail_type.startswith('case') or detail_type.startswith('search'):
-        return "cchq.case"
+        return _case_detail_title_locale()
     elif detail_type.startswith('referral'):
-        return "cchq.referral"
+        return _referral_detail_title_locale()
 
 
 @pattern('m%d.%s.tab.%d.title')
@@ -236,22 +249,22 @@ def report_command(report_id):
     return 'reports.{report_id}'.format(report_id=report_id)
 
 
-@pattern('cchq.report_menu')
+@pattern('cchq.report_menu', default='Reports')
 def report_menu():
     return 'cchq.report_menu'
 
 
-@pattern('cchq.report_name_header')
+@pattern('cchq.report_name_header', default='Report Name')
 def report_name_header():
     return 'cchq.report_name_header'
 
 
-@pattern('cchq.report_description_header')
+@pattern('cchq.report_description_header', default='Report Description')
 def report_description_header():
     return 'cchq.report_description_header'
 
 
-@pattern('cchq.report_data_table')
+@pattern('cchq.report_data_table', default='Data Table')
 def report_data_table():
     return 'cchq.report_data_table'
 
@@ -271,7 +284,7 @@ def report_description(report_id):
     return 'cchq.reports.{report_id}.description'.format(report_id=report_id)
 
 
-@pattern('cchq.report_last_sync')
+@pattern('cchq.report_last_sync', default='Last Sync')
 def report_last_sync():
     return 'cchq.report_last_sync'
 


### PR DESCRIPTION
Part of https://manage.dimagi.com/default.asp?276262

This adds strings that aren't app-specific and also don't appear in the mobile codebase to the CommCare UI translations download.

@gcapalbo 