### PR TITLE
Filter out parent properties in data dictionary util

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -35,12 +35,20 @@ def get_all_case_properties(domain, case_types=None):
     for case_type in case_types:
         properties = set()
         schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
-        for group_schema in schema.group_schemas:
-            for item in group_schema.items:
-                if item.tag:
-                    name = item.tag
-                else:
-                    name = '/'.join([p.name for p in item.path])
+
+        # only the first schema contains case properties. The others contain meta info
+        group_schema = schema.group_schemas[0]
+        for item in group_schema.items:
+            if len(item.path) > 1:
+                continue
+
+            if item.tag:
+                name = item.tag
+            else:
+                name = item.path[-1].name
+
+            if '/' not in name:
+                # Filter out index and parent properties as some are stored as parent/prop in item.path
                 properties.add(name)
 
         case_type_props_from_app = case_properties_from_apps.get(case_type, {})


### PR DESCRIPTION
Product description: This removes undesirable options like 'update' from the data corrections UI

https://manage.dimagi.com/default.asp?275419

These properties were filtered out of the data dictionary later in https://github.com/dimagi/commcare-hq/blob/f076b166a7b307c722770f2d446b9c2b1cfaefd3/corehq/apps/data_dictionary/util.py#L87-L91 and the only other place this is used is in data corrections which is what the ticket is for. Currently export schema and data dictionary do some similar things and the API doesn't seem very clear (and I wrote some of this original code). May be worth going back later to re-think the interaction