### PR TITLE
Allow cases with no owner

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -52,6 +52,8 @@ def get_case_location(case):
     primary location, return None.
     """
     case_owner = get_wrapped_owner(get_owner_id(case))
+    if not case_owner:
+        return None
     if isinstance(case_owner, SQLLocation):
         return case_owner
     location_id = case_owner.get_location_id(case.domain)

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -297,6 +297,14 @@ class CaseLocationTests(LocationHierarchyTestCase):
         location = get_case_location(case)
         self.assertIsNone(location)
 
+    def test_no_owner(self):
+        """
+        get_case_location should return None when the case has no owner
+        """
+        form, (case, ) = _create_case(domain=self.domain, case_id=uuid.uuid4().hex, owner_id=None)
+        location = get_case_location(case)
+        self.assertIsNone(location)
+
     def test_openmrs_location_uuid_set(self):
         """
         get_openmrs_location_uuid should return the OpenMRS location UUID that corresponds to a case's location


### PR DESCRIPTION
owner_id of cases created with App Preview is None (when not using "Login as" ). This small change avoids erroring when testing.
