### PR TITLE
Fix printing | Prevent cutting last column by allowing wrapping cells

### DIFF
--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -141,6 +141,10 @@ nvd3#sectorChart > div.title.h4 {
         width: 100% !important;
     }
 
+    .dataTable td {
+        white-space: normal !important;
+    }
+
     .row {
         width: 100%;
     }


### PR DESCRIPTION
Hi @emord,
Here I have fixed issue while printing a report in Chrome last column was being cut.