### PR TITLE
only get type if case

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1956,7 +1956,7 @@ def _get_cases_changed_context(domain, form, case_id=None):
             "table": get_tables_as_columns(b, definition, timezone=get_timezone_for_request()),
             "url": url,
             "valid_case": valid_case,
-            "case_type": this_case.type if valid_case else None,
+            "case_type": this_case.type if this_case and valid_case else None,
         })
 
     return {


### PR DESCRIPTION
I was trying to look at this case [37VM8HRBHE7NZ0O4SGMGVOW04](https://www.commcarehq.org/a/dodoma/reports/form_data/37VM8HRBHE7NZ0O4SGMGVOW04/) when this [error](https://sentry.io/dimagi/commcarehq/issues/572588562/?query=is%3Aunresolved) came up. I don't know much about what this function does or what effect `valid_case` has, so I didn't want to change it's behavior.

It's also possible that this is unlikely to happen since it's been around for just over a year and this was a 6 year old form that triggered it.

Looks like the bug would have been introduced [here](https://github.com/dimagi/commcare-hq/commit/d7234d45f224cf162782849f48b5de72a09f8c79)
@proteusvacuum @esoergel 