### PR TITLE
Pin tornado

### DIFF
--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -1,5 +1,5 @@
 flower==0.9.2
-tornado<0.5
+tornado<5.0
 newrelic
 errand-boy==0.3.8
 setproctitle==1.1.9

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -1,4 +1,5 @@
 flower==0.9.2
+tornado<0.5
 newrelic
 errand-boy==0.3.8
 setproctitle==1.1.9


### PR DESCRIPTION
Updating flower trigggered an update to flower. historically the old version of the flower required tornado 4.2, but now it requires >=4.2. (also on master it requires >=4.2<5.0 but that version hasn't been released.)

We can't use tornado 5.0 anyways because it requires > 2.7.9 (https://github.com/tornadoweb/tornado/blob/master/docs/releases/v5.0.0.rst) and we run 2.7.6 on prod because we're still on 12.04