### PR TITLE
Fix import app page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -123,8 +123,6 @@ appmanager-main-container{% if formdesigner %} formdesigner-content-wrapper{% en
     {{ block.super }}
     {% if app.is_deleted %}
         {% include 'app_manager/partials/undo_delete_app.html' %}
-    {% elif app %}
-        {% include 'app_manager/partials/confirm_delete_app.html' %}
     {% endif %}
 {% endblock modals %}
 

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -123,7 +123,7 @@ appmanager-main-container{% if formdesigner %} formdesigner-content-wrapper{% en
     {{ block.super }}
     {% if app.is_deleted %}
         {% include 'app_manager/partials/undo_delete_app.html' %}
-    {% else %}
+    {% elif app %}
         {% include 'app_manager/partials/confirm_delete_app.html' %}
     {% endif %}
 {% endblock modals %}

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -208,4 +208,5 @@
 
 {% block modals %}{{ block.super }}
     {% include "hqwebapp/rollout_revert_modal.html" %}
+    {% include 'app_manager/partials/confirm_delete_app.html' %}
 {% endblock %}


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/20773

`managed_app.html` always has an app. In `apps_base.html`, `app` can be `None`, which breaks the `{% url "delete_app" domain app.id %}` in the modal.

@gcapalbo / @emord 