### PR TITLE
Remove icons from hqwebapp/js/main.js

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -284,7 +284,7 @@ hqDefine('app_manager/js/app_manager', function () {
         }
 
         $('.sortable .sort-action').addClass('sort-disabled');
-        $('.drag_handle').addClass(hqImport("hqwebapp/js/main").icons.GRIP);
+        $('.drag_handle').addClass('fa fa-arrows-v');
 
         $('.js-appnav-drag-module').on('mouseenter', function() {
             $(this).closest('.js-sorted-li').addClass('appnav-highlight');

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -107,10 +107,10 @@
                 <td class="col-sm-1 text-center">
                     <i style="cursor: pointer;"
                        title="{% trans "Delete"|escapejs %}"
+                       class="fa fa-remove"
                        data-bind="
                         visible: ($parent.columns().length > 1 || $parent.allowsEmptyColumns),
                         click: function(){screen.columns.remove($data);},
-                        css: hqImport('hqwebapp/js/main').icons.DELETE,
                     "></i>
                 </td>
             {# there must be no whitespace between <tbody> and <tr> #}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -34,9 +34,8 @@
             ">
                 <td class="text-center col-sm-1">
                     <span class="sort-disabled" data-bind="ifnot: grip"></span>
-                    <i class="grip sortable-handle" data-bind="
+                    <i class="grip sortable-handle fa fa-arrows-v" data-bind="
                         if: grip,
-                        css: hqImport('hqwebapp/js/main').icons.GRIP,
                         event: {mousedown: function(){ $(':focus').blur(); }}
                     "></i>
                 </td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_search_properties.html
@@ -15,9 +15,8 @@
                 <input class="form-control" type="text" data-bind="value: property.label"/>
             </td>
             <td class="col-sm-2">
-                <i style="cursor: pointer;"
-                   data-bind="click: $parent.removeProperty,
-                              css: hqImport('hqwebapp/js/main').icons.DELETE"></i>
+                <i style="cursor: pointer;" class="fa fa-remove"
+                   data-bind="click: $parent.removeProperty"></i>
             </td>
         </tr>
     </script>
@@ -77,9 +76,8 @@
                                 />
                             </td>
                             <td class="col-sm-2">
-                                <i style="cursor: pointer;"
-                                   data-bind="click: $parent.removeDefaultProperty,
-                                              css: hqImport('hqwebapp/js/main').icons.DELETE"></i>
+                                <i style="cursor: pointer;" class="fa fa-remove"
+                                   data-bind="click: $parent.removeDefaultProperty"></i>
                             </td>
                         </tr>
                     </tbody>

--- a/corehq/apps/app_manager/templates/app_manager/partials/custom_instances.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/custom_instances.html
@@ -36,9 +36,8 @@
                     /><!-- Not directly sent to server since there is no "name" attribute -->
                 </td>
                 <td class="col-sm-2">
-                    <i style="cursor: pointer;"
-                       data-bind="click: $parent.removeInstance,
-                                  css: hqImport('hqwebapp/js/main').icons.DELETE"></i>
+                    <i style="cursor: pointer;" class="fa fa-remove"
+                       data-bind="click: $parent.removeInstance"></i>
                 </td>
             </tr>
         </tbody>

--- a/corehq/apps/app_manager/templates/app_manager/partials/enable_schedule.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/enable_schedule.html
@@ -53,9 +53,8 @@
     <script id="phase-template" type="text/html">
         <tr class="phase" data-bind="style: {cursor: 'move'}">
             <td>
-                <i class="grip sortable-handle"
-                   data-bind="css: hqImport('hqwebapp/js/main').icons.GRIP,
-                              event: {mousedown: function(){ $(':focus').blur(); }},
+                <i class="grip sortable-handle fa fa-arrows-v"
+                   data-bind="event: {mousedown: function(){ $(':focus').blur(); }},
                               visible: $data !== $parent.selectedPhase()"></i>
                 <input data-bind="value: name, visibleAndSelect: $data === $parent.selectedPhase(),
                                   event: { blur: function() { $parent.selectPhase(''); } }"/>

--- a/corehq/apps/app_manager/templates/app_manager/partials/enable_schedule.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/enable_schedule.html
@@ -65,9 +65,8 @@
             </td>
             <td data-bind="text: form_abbreviations"></td>
             <td>
-                <i style="cursor: pointer;"
-                   data-bind="css: hqImport('hqwebapp/js/main').icons.DELETE,
-                              click: $parent.removePhase,
+                <i style="cursor: pointer;" class="fa fa-remove"
+                   data-bind="click: $parent.removePhase,
                               visible: forms().length == 0
                               "></i>
                 <i style="cursor: pointer;"

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
@@ -63,7 +63,7 @@
                     <tr class="row"
                         data-bind="attr: {'data-order': _sortableOrder}">
                         <td>
-                            <i class="grip sortable-handle" data-bind="css: hqImport('hqwebapp/js/main').icons.GRIP"></i>
+                            <i class="grip sortable-handle fa fa-arrows-v"></i>
                         </td>
                         <td>
                             <select class="form-control"

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
@@ -125,10 +125,7 @@
                         </td>
                         <td>
                             <i title="{% trans 'Delete' %}" style="cursor: pointer;"
-                               data-bind="
-                                click: $root.removeReport,
-                                css: hqImport('hqwebapp/js/main').icons.DELETE
-                            "></i>
+                               class="fa fa-remove" data-bind="click: $root.removeReport"></i>
                         </td>
                     </tr>
                 </tbody>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -351,7 +351,6 @@ hqDefine('hqwebapp/js/main', [
         beforeUnloadCallback: beforeUnloadCallback,
         eventize: eventize,
         icons: {
-            GRIP: 'icon-resize-vertical icon-blue fa fa-arrows-v',
             ADD: 'icon-plus icon-blue fa fa-plus',
             DELETE: 'icon-remove icon-blue fa fa-remove',
         },

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -352,7 +352,6 @@ hqDefine('hqwebapp/js/main', [
         eventize: eventize,
         icons: {
             ADD: 'icon-plus icon-blue fa fa-plus',
-            DELETE: 'icon-remove icon-blue fa fa-remove',
         },
         initBlock: initBlock,
         initDeleteButton: DeleteButton.init,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -350,9 +350,6 @@ hqDefine('hqwebapp/js/main', [
     return {
         beforeUnloadCallback: beforeUnloadCallback,
         eventize: eventize,
-        icons: {
-            ADD: 'icon-plus icon-blue fa fa-plus',
-        },
         initBlock: initBlock,
         initDeleteButton: DeleteButton.init,
         initSaveButton: SaveButton.init,

--- a/corehq/apps/reports/templates/reports/filters/explorer_columns.html
+++ b/corehq/apps/reports/templates/reports/filters/explorer_columns.html
@@ -41,9 +41,8 @@
                                         <input type="text" class="form-control" data-bind="value: label" /></td>
                                         <td>
                                             <i style="cursor: pointer;"
-                                               data-bind="click: $parent.removeProperty,
-                                                      css: hqImport('hqwebapp/js/main').icons.DELETE"
-                                               class="icon-remove icon-blue fa fa-remove"></i>
+                                               data-bind="click: $parent.removeProperty"
+                                               class="fa fa-remove"></i>
                                         </td>
                                 </tr>
                             </tbody>

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -20,7 +20,7 @@ hqDefine("translations/js/translations", function() {
                     this.value = hqImport('hqwebapp/js/ui-element').input().val(value);
                     this.solid = true;
 
-                    this.$delete = $('<button class="btn btn-danger"><i></i></button>').addClass(hqImport('hqwebapp/js/main').icons.DELETE).click(function() {
+                    this.$delete = $('<button class="btn btn-danger"><i class="fa fa-remove"></i></button>').click(function() {
                         $(this).remove();
                         translation_ui.deleteTranslation(that.key.val());
                     }).css({

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -27,7 +27,7 @@ hqDefine("translations/js/translations", function() {
                         cursor: 'pointer',
                     }).attr('title', gettext("Delete Translation"));
 
-                    this.$add = $('<button class="btn btn-default"><i></i></button>').addClass(hqImport('hqwebapp/js/main').icons.ADD).click(function() {
+                    this.$add = $('<button class="btn btn-default"><i class="fa fa-plus"></i></button>').click(function() {
                         // remove any trailing whitespace from the input box
                         that.key.val($.trim(that.key.val()));
                         if (that.key.val() && !translation_ui.translations[that.key.val()]) {

--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -87,9 +87,7 @@ TODO:
     {# the .hide().fadeIn() will fail badly on FireFox #}
     ><tr data-bind="attr: {'data-order': _sortableOrder}">
         <td>
-            <i class="grip sortable-handle" data-bind="
-                css: hqImport('hqwebapp/js/main').icons.GRIP + ' hq-icon-full'
-            "></i>
+            <i class="grip sortable-handle hq-icon-full fa fa-arrows-v"></i>
         </td>
 
         <td data-bind="css:{'has-error': $parent.showWarnings() && !isValid()}">


### PR DESCRIPTION
This was going to be annoying to requirejs-ify. But now that we're off of Bootstrap 2, each of these is only 2 classes instead of 4 so it's not a big deal to just put them directly in the HTML.

@gcapalbo 