### PR TITLE
Add last submitting user recipient

### DIFF
--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -443,6 +443,8 @@ def get_rule_recipients(handler):
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF, None)]
     elif handler.recipient == RECIPIENT_OWNER:
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER, None)]
+    elif handler.recipient == RECIPIENT_USER:
+        return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, None)]
     elif handler.recipient == RECIPIENT_USER_GROUP:
         return [(ScheduleInstance.RECIPIENT_TYPE_USER_GROUP, handler.user_group_id)]
     else:
@@ -636,6 +638,7 @@ class Command(BaseCommand):
             RECIPIENT_OWNER,
             RECIPIENT_CASE,
             RECIPIENT_USER_GROUP,
+            RECIPIENT_USER,
         ):
             return None
 

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2670,6 +2670,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         new_choices = [
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF, _("The Case")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER, _("The Case's Owner")),
+            (CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, _("The Case's Last Submitting User")),
         ]
         new_choices.extend(self.fields['recipient_types'].choices)
 
@@ -3179,11 +3180,13 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         result = super(ConditionalAlertScheduleForm, self).distill_recipients()
         recipient_types = self.cleaned_data['recipient_types']
 
-        if CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF in recipient_types:
-            result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF, None))
-
-        if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER in recipient_types:
-            result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER, None))
+        for recipient_type_without_id in (
+            CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
+            CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
+            CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
+        ):
+            if recipient_type_without_id in recipient_types:
+                result.append((recipient_type_without_id, None))
 
         if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM in recipient_types:
             custom_recipient_id = self.cleaned_data['custom_recipient']

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -8,7 +8,7 @@ from corehq.apps.locations.dbaccessors import get_all_users_by_location
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.sms.models import MessagingEvent
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
-from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.models import CommCareUser, WebUser, CouchUser
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.utils import is_commcarecase
@@ -435,7 +435,7 @@ class CaseScheduleInstanceMixin(object):
 
     RECIPIENT_TYPE_SELF = 'Self'
     RECIPIENT_TYPE_CASE_OWNER = 'Owner'
-    RECIPIENT_TYPE_LAST_SUBMTTING_USER = 'LastSubmittingUser'
+    RECIPIENT_TYPE_LAST_SUBMITTING_USER = 'LastSubmittingUser'
     RECIPIENT_TYPE_PARENT_CASE = 'ParentCase'
     RECIPIENT_TYPE_CHILD_CASE = 'SubCase'
     RECIPIENT_TYPE_CUSTOM = 'CustomRecipient'
@@ -463,7 +463,10 @@ class CaseScheduleInstanceMixin(object):
             return self.case
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_OWNER:
             return self.case_owner
-        if self.recipient_type == self.RECIPIENT_TYPE_LAST_SUBMTTING_USER:
+        elif self.recipient_type == self.RECIPIENT_TYPE_LAST_SUBMITTING_USER:
+            if self.case and self.case.modified_by:
+                return CouchUser.get_by_user_id(self.case.modified_by, domain=self.domain)
+
             return None
         elif self.recipient_type == self.RECIPIENT_TYPE_PARENT_CASE:
             return None

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -67,17 +67,41 @@ class ScheduleInstance(PartitionedModel):
     @memoized
     def recipient(self):
         if self.recipient_type == self.RECIPIENT_TYPE_CASE:
-            return CaseAccessors(self.domain).get_case(self.recipient_id)
+            case = CaseAccessors(self.domain).get_case(self.recipient_id)
+            if case.domain != self.domain:
+                return None
+
+            return case
         elif self.recipient_type == self.RECIPIENT_TYPE_MOBILE_WORKER:
-            return CommCareUser.get(self.recipient_id)
+            user = CouchUser.get_by_user_id(self.recipient_id, domain=self.domain)
+            if not isinstance(user, CommCareUser):
+                return None
+
+            return user
         elif self.recipient_type == self.RECIPIENT_TYPE_WEB_USER:
-            return WebUser.get(self.recipient_id)
+            user = CouchUser.get_by_user_id(self.recipient_id, domain=self.domain)
+            if not isinstance(user, WebUser):
+                return None
+
+            return user
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_GROUP:
-            return CommCareCaseGroup.get(self.recipient_id)
+            group = CommCareCaseGroup.get(self.recipient_id)
+            if group.domain != self.domain:
+                return None
+
+            return group
         elif self.recipient_type == self.RECIPIENT_TYPE_USER_GROUP:
-            return Group.get(self.recipient_id)
+            group = Group.get(self.recipient_id)
+            if group.domain != self.domain:
+                return None
+
+            return group
         elif self.recipient_type == self.RECIPIENT_TYPE_LOCATION:
-            return SQLLocation.by_location_id(self.recipient_id)
+            location = SQLLocation.by_location_id(self.recipient_id)
+            if location.domain != self.domain:
+                return None
+
+            return location
         else:
             raise UnknownRecipientType(self.recipient_type)
 

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import uuid
 from django.test import TestCase
+from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.data_interfaces.tests.util import create_case
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.hqcase.utils import update_case
@@ -17,6 +18,7 @@ from corehq.messaging.scheduling.models import TimedSchedule, TimedEvent, SMSCon
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseScheduleInstanceMixin,
     CaseTimedScheduleInstance,
+    ScheduleInstance,
 )
 from corehq.messaging.scheduling.tests.util import delete_timed_schedules
 from corehq.util.test_utils import create_test_case
@@ -49,6 +51,9 @@ class SchedulingRecipientTest(TestCase):
         cls.group = Group(domain=cls.domain, users=[cls.mobile_user.get_id])
         cls.group.save()
 
+        cls.case_group = CommCareCaseGroup(domain=cls.domain)
+        cls.case_group.save()
+
     @classmethod
     def tearDownClass(cls):
         cls.domain_obj.delete()
@@ -61,6 +66,117 @@ class SchedulingRecipientTest(TestCase):
 
     def user_ids(self, users):
         return [user.get_id for user in users]
+
+    @run_with_all_backends
+    def test_specific_case_recipient(self):
+        with create_case(self.domain, 'person') as case:
+            instance = ScheduleInstance(
+                domain=self.domain,
+                recipient_type=ScheduleInstance.RECIPIENT_TYPE_CASE,
+                recipient_id=case.case_id,
+            )
+            self.assertEqual(instance.recipient.case_id, case.case_id)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_CASE,
+            recipient_id='id-does-not-exist',
+        )
+        self.assertIsNone(instance.recipient)
+
+    def test_specific_mobile_worker_recipient(self):
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_MOBILE_WORKER,
+            recipient_id=self.mobile_user.get_id,
+        )
+        self.assertTrue(isinstance(instance.recipient, CommCareUser))
+        self.assertEqual(instance.recipient.get_id, self.mobile_user.get_id)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_MOBILE_WORKER,
+            recipient_id=self.web_user.get_id,
+        )
+        self.assertIsNone(instance.recipient)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_MOBILE_WORKER,
+            recipient_id='id-does-not-exist',
+        )
+        self.assertIsNone(instance.recipient)
+
+    def test_specific_web_user_recipient(self):
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_WEB_USER,
+            recipient_id=self.web_user.get_id,
+        )
+        self.assertTrue(isinstance(instance.recipient, WebUser))
+        self.assertEqual(instance.recipient.get_id, self.web_user.get_id)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_WEB_USER,
+            recipient_id=self.mobile_user.get_id,
+        )
+        self.assertIsNone(instance.recipient)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_WEB_USER,
+            recipient_id='id-does-not-exist',
+        )
+        self.assertIsNone(instance.recipient)
+
+    def test_specific_case_group_recipient(self):
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_CASE_GROUP,
+            recipient_id=self.case_group.get_id,
+        )
+        self.assertTrue(isinstance(instance.recipient, CommCareCaseGroup))
+        self.assertEqual(instance.recipient.get_id, self.case_group.get_id)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_CASE_GROUP,
+            recipient_id='id-does-not-exist',
+        )
+        self.assertIsNone(instance.recipient)
+
+    def test_specific_group_recipient(self):
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_USER_GROUP,
+            recipient_id=self.group.get_id,
+        )
+        self.assertTrue(isinstance(instance.recipient, Group))
+        self.assertEqual(instance.recipient.get_id, self.group.get_id)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_USER_GROUP,
+            recipient_id='id-does-not-exist',
+        )
+        self.assertIsNone(instance.recipient)
+
+    def test_specific_location_recipient(self):
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_LOCATION,
+            recipient_id=self.city_location.location_id,
+        )
+        self.assertTrue(isinstance(instance.recipient, SQLLocation))
+        self.assertEqual(instance.recipient.location_id, self.city_location.location_id)
+
+        instance = ScheduleInstance(
+            domain=self.domain,
+            recipient_type=ScheduleInstance.RECIPIENT_TYPE_LOCATION,
+            recipient_id='id-does-not-exist',
+        )
+        self.assertIsNone(instance.recipient)
 
     @run_with_all_backends
     def test_case_recipient(self):


### PR DESCRIPTION
Adds the last submitting user of a case to the recipient list in the new reminders framework, for parity with the old one.

@millerdev @orangejenny 