### PR TITLE
perf improvement

### DIFF
--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -10,7 +10,6 @@ import yaml
 import six
 from io import open
 
-from corehq.util.quickcache import quickcache
 
 PROFILE_SETTINGS_TO_TRANSLATE = [
     'name',
@@ -93,12 +92,12 @@ def _load_commcare_settings_layout(doc_type):
     return layout
 
 
-@quickcache([], timeout=60 * 60 * 24)
+@memoized
 def get_custom_commcare_settings():
     return _load_custom_commcare_settings()
 
 
-@quickcache(['doc_type'], timeout=60 * 60 * 24)
+@memoized
 def get_commcare_settings_layout(doc_type):
     if doc_type == "LinkedApplication":
         return {}

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -93,12 +93,12 @@ def _load_commcare_settings_layout(doc_type):
     return layout
 
 
-@quickcache([], timeout=60*60*24)
+@quickcache([], timeout=60 * 60 * 24)
 def get_custom_commcare_settings():
     return _load_custom_commcare_settings()
 
 
-@quickcache(['doc_type'], timeout=60*60*24)
+@quickcache(['doc_type'], timeout=60 * 60 * 24)
 def get_commcare_settings_layout(doc_type):
     if doc_type == "LinkedApplication":
         return {}

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -146,7 +146,7 @@ def get_app_view_context(request, app):
     context = {}
 
     settings_layout = copy.deepcopy(
-        get_commcare_settings_layout(request.user)[app.get_doc_type()]
+        get_commcare_settings_layout(app.get_doc_type())
     )
     for section in settings_layout:
         new_settings = []


### PR DESCRIPTION
- remove redundant "user" argument
- quickcache for a day instead of memoizing methods
- call just the app doc type instead of finding layout for all doc types and then selecting the app doc type