### PR TITLE
Turn on no-implicit-globals in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
         "no-new-object": ["error"],
         "no-unneeded-ternary": ["error"],
         "no-throw-literal": ["error"],
+        "no-implicit-globals": ["error"],
 
         "eslint-dimagi/no-unblessed-new": ["error", ["Date", "Error", "RegExp"]],
     }


### PR DESCRIPTION
https://eslint.org/docs/rules/no-implicit-globals

They cause problems as pages get migrated to requirejs.

@gcapalbo 