### PR TITLE
Add case property regular expression match as rule criteria option

### DIFF
--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -601,6 +601,7 @@ class CaseRuleCriteriaForm(forms.Form):
             'MATCH_NOT_EQUAL': MatchPropertyDefinition.MATCH_NOT_EQUAL,
             'MATCH_HAS_VALUE': MatchPropertyDefinition.MATCH_HAS_VALUE,
             'MATCH_HAS_NO_VALUE': MatchPropertyDefinition.MATCH_HAS_NO_VALUE,
+            'MATCH_REGEX': MatchPropertyDefinition.MATCH_REGEX,
         }
 
     def compute_initial(self, rule):
@@ -655,6 +656,14 @@ class CaseRuleCriteriaForm(forms.Form):
     @property
     def allow_date_case_property_filter(self):
         return True
+
+    @property
+    def allow_regex_case_property_match(self):
+        # The framework allows for this, it's just historically only
+        # been an option for messaging conditonal alert rules and not
+        # case update rules. So for now the option is just hidden in
+        # the case update rule UI.
+        return False
 
     def __init__(self, domain, *args, **kwargs):
         if 'initial' in kwargs:
@@ -826,6 +835,22 @@ class CaseRuleCriteriaForm(forms.Form):
                 result.append({
                     'property_name': property_name,
                     'property_value': str(property_value),
+                    'match_type': match_type,
+                })
+            elif match_type == MatchPropertyDefinition.MATCH_REGEX:
+                property_value = obj['property_value']
+
+                if not property_value:
+                    raise ValidationError(_("Please enter a valid regular expression to match"))
+
+                try:
+                    re.compile(property_value)
+                except:
+                    raise ValidationError(_("Please enter a valid regular expression to match"))
+
+                result.append({
+                    'property_name': property_name,
+                    'property_value': property_value,
                     'match_type': match_type,
                 })
 

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -527,6 +527,7 @@ class MatchPropertyDefinition(CaseRuleCriteriaDefinition):
     MATCH_NOT_EQUAL = 'NOT_EQUAL'
     MATCH_HAS_VALUE = 'HAS_VALUE'
     MATCH_HAS_NO_VALUE = 'HAS_NO_VALUE'
+    MATCH_REGEX = 'REGEX'
 
     MATCH_CHOICES = (
         MATCH_DAYS_BEFORE,
@@ -535,6 +536,7 @@ class MatchPropertyDefinition(CaseRuleCriteriaDefinition):
         MATCH_NOT_EQUAL,
         MATCH_HAS_VALUE,
         MATCH_HAS_NO_VALUE,
+        MATCH_REGEX,
     )
 
     property_name = models.CharField(max_length=126)
@@ -611,6 +613,22 @@ class MatchPropertyDefinition(CaseRuleCriteriaDefinition):
     def check_has_no_value(self, case, now):
         return not self.check_has_value(case, now)
 
+    def check_regex(self, case, now):
+        try:
+            regex = re.compile(self.property_value)
+        except:
+            return False
+
+        for value in self.get_case_values(case):
+            if isinstance(value, six.string_types):
+                try:
+                    if regex.match(value):
+                        return True
+                except:
+                    pass
+
+        return False
+
     def matches(self, case, now):
         return {
             self.MATCH_DAYS_BEFORE: self.check_days_before,
@@ -619,6 +637,7 @@ class MatchPropertyDefinition(CaseRuleCriteriaDefinition):
             self.MATCH_NOT_EQUAL: self.check_not_equal,
             self.MATCH_HAS_VALUE: self.check_has_value,
             self.MATCH_HAS_NO_VALUE: self.check_has_no_value,
+            self.MATCH_REGEX: self.check_regex,
         }.get(self.match_type)(case, now)
 
 

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_criteria.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_criteria.js
@@ -142,11 +142,11 @@ hqDefine("data_interfaces/js/case_rule_criteria", function() {
                 obj.days(initial.server_modified_boundary);
                 self.criteria.push(obj);
             }
-
             $.each(initial.property_match_definitions, function(index, value) {
                 if(
                     value.match_type === constants.MATCH_EQUAL ||
                     value.match_type === constants.MATCH_NOT_EQUAL ||
+                    value.match_type === constants.MATCH_REGEX ||
                     value.match_type === constants.MATCH_HAS_VALUE ||
                     value.match_type === constants.MATCH_HAS_NO_VALUE
                 ) {

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
@@ -101,6 +101,9 @@
                 <option value="{{ form.constants.MATCH_NOT_EQUAL }}">{% trans "does not equal" %}</option>
                 <option value="{{ form.constants.MATCH_HAS_VALUE }}">{% trans "has a value" %}</option>
                 <option value="{{ form.constants.MATCH_HAS_NO_VALUE }}">{% trans "does not have a value" %}</option>
+                {% if form.allow_regex_case_property_match %}
+                <option value="{{ form.constants.MATCH_REGEX }}">{% trans "matches the regular expression" %}</option>
+                {% endif %}
             </select>
         </div>
         <div class="controls col-xs-2" data-bind="visible: show_property_value_input()">

--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -496,6 +496,16 @@ def migrate_rule(handler, schedule):
                 property_value=handler.start_value,
                 match_type=MatchPropertyDefinition.MATCH_EQUAL,
             )
+        elif handler.start_match_type == MATCH_REGEX:
+            if not handler.start_value:
+                raise ValueError("Expected start_value")
+
+            rule.add_criteria(
+                MatchPropertyDefinition,
+                property_name=handler.start_property,
+                property_value=handler.start_value,
+                match_type=MatchPropertyDefinition.MATCH_REGEX,
+            )
         else:
             raise ValueError("Unexpected start_match_type '%s'" % handler.start_match_type)
 
@@ -585,7 +595,7 @@ class Command(BaseCommand):
         if handler.start_match_type in (MATCH_EXACT, MATCH_REGEX) and not handler.start_value:
             return None
 
-        if handler.start_match_type not in (MATCH_EXACT, MATCH_ANY_VALUE):
+        if handler.start_match_type not in (MATCH_EXACT, MATCH_ANY_VALUE, MATCH_REGEX):
             return None
 
         if not handler.start_property:

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -3343,6 +3343,10 @@ class ConditionalAlertCriteriaForm(CaseRuleCriteriaForm):
     def allow_date_case_property_filter(self):
         return False
 
+    @property
+    def allow_regex_case_property_match(self):
+        return True
+
     def set_read_only_fields_during_editing(self):
         # Django also handles keeping the field's value to its initial value no matter what is posted
         # https://docs.djangoproject.com/en/1.11/ref/forms/fields/#disabled


### PR DESCRIPTION
Adds case property regex match as a rule criteria option to the new reminders framework, for parity with the old one.

@millerdev @orangejenny 