### PR TITLE
Fix js error from ejs indicators PR

### DIFF
--- a/corehq/apps/crud/static/crud/js/admin.js
+++ b/corehq/apps/crud/static/crud/js/admin.js
@@ -141,7 +141,7 @@ hqDefine("crud/js/admin", function() {
         }
 
         // CRUD pages will have supplied a crud_item
-        var crudItem = initialPageData("js_options").crud_item;
+        var crudItem = (initialPageData("js_options") || {}).crud_item;
         if (!crudItem) {
             return;
         }


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/20771 which throws a repeating js error on the saved reports page.

@gcapalbo 
should go in today's deploy please @nickpell 