### PR TITLE
cleanup after calling set_request in tests

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -188,6 +188,11 @@ class TestNewSyncSpecifics(TestCase):
         )
         cls.user_id = cls.user.user_id
 
+    @classmethod
+    def tearDownClass(cls):
+        set_request(None)
+        super(TestNewSyncSpecifics, cls).tearDownClass()
+
     def test_legacy_support_toggle(self):
         restore_config = RestoreConfig(self.project, restore_user=self.user)
         factory = CaseFactory(domain=self.project.name, case_defaults={'owner_id': self.user_id})

--- a/corehq/util/tests/test_global_request.py
+++ b/corehq/util/tests/test_global_request.py
@@ -21,3 +21,7 @@ class GlobalRequestTest(SimpleTestCase):
     def test_get_domain_null(self):
         set_request(None)
         self.assertEqual(None, get_request_domain())
+
+    def tearDown(self):
+        set_request(None)
+        super(GlobalRequestTest, self).tearDown()


### PR DESCRIPTION
Leaving ```_thread_local.request``` in a modified state after running tests was causing problems when I tried to combine combining test runner workers.