### PR TITLE
fix teardown on tests

### DIFF
--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -226,7 +226,7 @@ class HqdbContext(DatabaseContext):
                 return False
             old_names.append((connection, db["NAME"], True))
 
-        self.old_names = old_names, []
+        self.old_names = old_names
         return True
 
     def delete_couch_databases(self):


### PR DESCRIPTION
that empty list is causing an error on teardown
```
REUSE_DB=1 ./manage.py test corehq.apps.app_manager.tests.test_app_manager:AppManagerTest.testCreateJadJar --reusedb=teardown

Traceback (most recent call last):
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/nose/suite.py", line 228, in run
    self.tearDown()
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/nose/suite.py", line 353, in tearDown
    self.teardownContext(context)
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/nose/suite.py", line 367, in teardownContext
    try_run(context, names)
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/Users/Manish/Projects/commcare-hq/corehq/tests/nose.py", line 256, in teardown
    super(HqdbContext, self).teardown()
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/django_nose/plugin.py", line 430, in teardown
    self.runner.teardown_databases(self.old_names)
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/django/test/runner.py", line 577, in teardown_databases
    keepdb=self.keepdb,
  File "/Users/Manish/.virtualenvs/commcare-hq/lib/python2.7/site-packages/django/test/utils.py", line 303, in teardown_databases
    for connection, old_name, destroy in old_config:
ValueError: need more than 1 value to unpack
```