### PR TITLE
enable profiling in production

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
+
 from couchdbkit import ResourceConflict
 from distutils.version import LooseVersion
 
@@ -15,6 +17,7 @@ from iso8601 import iso8601
 
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
+from dimagi.utils.decorators.profile import profile
 from dimagi.utils.logging import notify_exception
 from casexml.apps.case.cleanup import claim_case, get_first_claim
 from casexml.apps.case.fixtures import CaseDBFixture
@@ -44,6 +47,9 @@ from .utils import (
     demo_user_restore_response, get_restore_user, is_permitted_to_restore,
     handle_401_response)
 from corehq.apps.users.util import update_device_meta, update_latest_builds, update_last_sync
+
+
+PROFILE_PROBABILITY = os.getenv(b'COMMCARE_PROFILE_RESTORE_PROBABILITY', 0)
 
 
 @location_safe
@@ -163,6 +169,7 @@ def get_restore_params(request):
     }
 
 
+@profile('commcare_ota_get_restore_response.prof', probability=PROFILE_PROBABILITY)
 def get_restore_response(domain, couch_user, app_id=None, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -17,7 +17,7 @@ from iso8601 import iso8601
 
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
-from dimagi.utils.decorators.profile import profile
+from dimagi.utils.decorators.profile_prod import profile_prod
 from dimagi.utils.logging import notify_exception
 from casexml.apps.case.cleanup import claim_case, get_first_claim
 from casexml.apps.case.fixtures import CaseDBFixture
@@ -171,7 +171,7 @@ def get_restore_params(request):
     }
 
 
-@profile('commcare_ota_get_restore_response.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
+@profile_prod('commcare_ota_get_restore_response.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
 def get_restore_response(domain, couch_user, app_id=None, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -49,7 +49,7 @@ from .utils import (
 from corehq.apps.users.util import update_device_meta, update_latest_builds, update_last_sync
 
 
-PROFILE_PROBABILITY = os.getenv(b'COMMCARE_PROFILE_RESTORE_PROBABILITY', 0)
+PROFILE_PROBABILITY = float(os.getenv(b'COMMCARE_PROFILE_RESTORE_PROBABILITY', 0))
 
 
 @location_safe

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -50,6 +50,8 @@ from corehq.apps.users.util import update_device_meta, update_latest_builds, upd
 
 
 PROFILE_PROBABILITY = float(os.getenv(b'COMMCARE_PROFILE_RESTORE_PROBABILITY', 0))
+PROFILE_LIMIT = os.getenv(b'COMMCARE_PROFILE_RESTORE_LIMIT')
+PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else None
 
 
 @location_safe
@@ -169,7 +171,7 @@ def get_restore_params(request):
     }
 
 
-@profile('commcare_ota_get_restore_response.prof', probability=PROFILE_PROBABILITY)
+@profile('commcare_ota_get_restore_response.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
 def get_restore_response(domain, couch_user, app_id=None, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -17,7 +17,7 @@ from iso8601 import iso8601
 
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
-from dimagi.utils.decorators.profile_prod import profile_prod
+from dimagi.utils.decorators.profile import profile_prod
 from dimagi.utils.logging import notify_exception
 from casexml.apps.case.cleanup import claim_case, get_first_claim
 from casexml.apps.case.fixtures import CaseDBFixture

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import logging
+import os
 
 import six
 from couchdbkit import ResourceNotFound
@@ -40,11 +41,15 @@ from django.views.decorators.csrf import csrf_exempt
 from couchforms.const import MAGIC_PROPERTY
 from couchforms import openrosa_response
 from couchforms.getters import MultimediaBug
+from dimagi.utils.decorators.profile import profile
 from dimagi.utils.logging import notify_exception
 from corehq.apps.ota.utils import handle_401_response
 from corehq import toggles
 
+PROFILE_PROBABILITY = os.getenv(b'COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0)
 
+
+@profile('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY)
 def _process_form(request, domain, app_id, user_id, authenticated,
                   auth_cls=AuthContext):
     metric_tags = [

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -47,9 +47,11 @@ from corehq.apps.ota.utils import handle_401_response
 from corehq import toggles
 
 PROFILE_PROBABILITY = float(os.getenv(b'COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0))
+PROFILE_LIMIT = os.getenv(b'COMMCARE_PROFILE_SUBMISSION_LIMIT')
+PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else None
 
 
-@profile('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY)
+@profile('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
 def _process_form(request, domain, app_id, user_id, authenticated,
                   auth_cls=AuthContext):
     metric_tags = [

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -48,7 +48,7 @@ from corehq import toggles
 
 PROFILE_PROBABILITY = float(os.getenv(b'COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0))
 PROFILE_LIMIT = os.getenv(b'COMMCARE_PROFILE_SUBMISSION_LIMIT')
-PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else None
+PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 
 
 @profile_prod('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -41,7 +41,7 @@ from django.views.decorators.csrf import csrf_exempt
 from couchforms.const import MAGIC_PROPERTY
 from couchforms import openrosa_response
 from couchforms.getters import MultimediaBug
-from dimagi.utils.decorators.profile import profile
+from dimagi.utils.decorators.profile import profile_prod
 from dimagi.utils.logging import notify_exception
 from corehq.apps.ota.utils import handle_401_response
 from corehq import toggles
@@ -51,7 +51,7 @@ PROFILE_LIMIT = os.getenv(b'COMMCARE_PROFILE_SUBMISSION_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else None
 
 
-@profile('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
+@profile_prod('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
 def _process_form(request, domain, app_id, user_id, authenticated,
                   auth_cls=AuthContext):
     metric_tags = [

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -46,7 +46,7 @@ from dimagi.utils.logging import notify_exception
 from corehq.apps.ota.utils import handle_401_response
 from corehq import toggles
 
-PROFILE_PROBABILITY = os.getenv(b'COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0)
+PROFILE_PROBABILITY = float(os.getenv(b'COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0))
 
 
 @profile('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY)

--- a/corehq/ex-submodules/dimagi/utils/decorators/profile.py
+++ b/corehq/ex-submodules/dimagi/utils/decorators/profile.py
@@ -39,6 +39,9 @@ def profile(log_file, probability=1):
         This makes it easy to run and compare multiple trials.
     :param probability: A number N between 0 and 1 such that P(profile) ~= N
     """
+    assert isinstance(probability, (int, float)), 'probability must be numeric'
+    assert 0 <= probability <= 1, 'probability must be in range [0, 1]'
+
     if not os.path.isabs(log_file):
         log_file = os.path.join(PROFILE_LOG_BASE, log_file)
 

--- a/corehq/ex-submodules/dimagi/utils/decorators/profile.py
+++ b/corehq/ex-submodules/dimagi/utils/decorators/profile.py
@@ -26,7 +26,11 @@ except Exception:
 # Source: http://code.djangoproject.com/wiki/ProfilingDjango
 
 
-def profile(log_file, probability=1, limit=None):
+def profile(log_file):
+    return profile_prod(log_file, 1, None)
+
+
+def profile_prod(log_file, probability, limit):
     """Profile some callable.
 
     This decorator uses the hotshot profiler to profile some callable (like
@@ -56,12 +60,12 @@ def profile(log_file, probability=1, limit=None):
         header = '=' * 100
         logger.warn("""
         %(header)s
-        Profiling enabled for %(module)s.%(name)s with probability %(prob)s.
+        Profiling enabled for %(module)s.%(name)s with probability %(prob)s and limit %(limit)s.
         Output will be written to %(base)s-[datetime]%(ext)s
         %(header)s
         """, {
             'header': header, 'module': f.__module__, 'name': f.__name__,
-            'prob': probability, 'base': base, 'ext': ext
+            'prob': probability, 'base': base, 'ext': ext, 'limit': limit
         })
 
         class Scope:

--- a/docs/profiling.rst
+++ b/docs/profiling.rst
@@ -57,7 +57,7 @@ turn this on and off and possibly only profile a limited number of function call
 This can be accomplished by using an environment variable to set the probability of profiling a function.
 Here's an example::
 
-    @profile('locations_download.prof', probability=float(os.getenv('PROFILE_LOCATIONS_EXPORT', 0))
+    @profile_prod('locations_download.prof', probability=float(os.getenv('PROFILE_LOCATIONS_EXPORT', 0))
     def location_export(request, domain):
         ....
 
@@ -69,7 +69,7 @@ variable. Values closer to 1 will get more profiling.
 You can also limit the total number of profiles to be recorded using the `limit` keyword argument.
 You could also expose this via an environment variable or some other method to make it configurable::
 
-    @profile('locations_download.prof', limit=10)
+    @profile_prod('locations_download.prof', 1, limit=10)
     def location_export(request, domain):
         ....
 

--- a/docs/profiling.rst
+++ b/docs/profiling.rst
@@ -49,6 +49,30 @@ These are created in /tmp/ by default, however you can change it by adding a val
 
 Note that the files created are huge; this code should only be run locally.
 
+Profiling in production
+^^^^^^^^^^^^^^^^^^^^^^^
+The same method can be used to profile functions in production. Obviously we want to be able to
+turn this on and off and possibly only profile a limited number of function calls.
+
+This can be accomplished by using an environment variable to set the probability of profiling a function.
+Here's an example::
+
+    @profile('locations_download.prof', probability=float(os.getenv('PROFILE_LOCATIONS_EXPORT', 0))
+    def location_export(request, domain):
+        ....
+
+By default this wil not do any profiling but if the `PROFILE_LOCATIONS_EXPORT` environment variable
+is set to a value between 0 and 1 and the Django process is restarted then the function will
+get profiled. The number of profiles that are done will depend on the value of the environment
+variable. Values closer to 1 will get more profiling.
+
+You can also limit the total number of profiles to be recorded using the `limit` keyword argument.
+You could also expose this via an environment variable or some other method to make it configurable::
+
+    @profile('locations_download.prof', limit=10)
+    def location_export(request, domain):
+        ....
+
 
 Creating a more useful output from the dump file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The idea here is that you could temporarily change the environment on a web worker to set the environment variables and then restart a worker.

Clearing the env vars and restarting the worker again would stop the profiling.

You can also set how often to profile (as a probability).