### PR TITLE
Use debian jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # When changing this file, also update Dockerfile-py3
-FROM python:2.7
+FROM python:2.7-jessie
 MAINTAINER Dimagi <devops@dimagi.com>
 
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,5 +1,5 @@
 # Based on Dockerfile. Use diff to compare them.
-FROM python:3.6
+FROM python:3.6-jessie
 MAINTAINER Dimagi <devops@dimagi.com>
 
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
Our docker build has been broken for a couple of weeks. I think that it's because the base python image upgraded from debian jessie to stretch. And stretch does not provide jdk 7

Seems like the best option, but other options could be:
- upgrading to jdk 8 (I'm not sure what we need)
- moving to an alpine based image

@snopoke I think you looked into this before and couldn't reproduce

Going to self merge because this won't get caught by tests