### PR TITLE
Clean up uninstall requirements

### DIFF
--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -1,8 +1,4 @@
-djtables
-xlutils
-github3.py
-mocker
-ethiopian-date
+# https://github.com/maxtepkeev/architect/pull/52
 architect
+# https://github.com/django-nose/django-nose/pull/228
 django-nose
-amqplib


### PR DESCRIPTION
Removes some unnecessary lines from uninstall requirements.

@millerdev looks like we have two requirements that are getting uninstalled and reinstalled for every test (1 for a PR I have, 1 for one you have). Our PRs don't look like they'll go anywhere on the main repo. Do you know of a better way to pip install our changes outside of making our own package?