### PR TITLE
Make permissions more consistent across messaging pages

### DIFF
--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -72,13 +72,6 @@ ACTION_DEACTIVATE = 'deactivate'
 ACTION_DELETE = 'delete'
 
 
-survey_reminders_permission = lambda *args, **kwargs: (
-    require_permission(Permissions.edit_data)(
-        requires_privilege_with_fallback(privileges.INBOUND_SMS)(*args, **kwargs)
-    )
-)
-
-
 def add_migration_in_progress_message(request):
     messages.warning(
         request,
@@ -511,7 +504,7 @@ class AddStructuredKeywordView(BaseMessagingSectionView):
 
     @method_decorator(requires_privilege_with_fallback(privileges.INBOUND_SMS))
     def dispatch(self, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+        return super(AddStructuredKeywordView, self).dispatch(*args, **kwargs)
 
     @property
     def parent_pages(self):
@@ -1105,7 +1098,7 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
 
     @method_decorator(requires_privilege_with_fallback(privileges.INBOUND_SMS))
     def dispatch(self, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+        return super(KeywordsListView, self).dispatch(*args, **kwargs)
 
     @property
     def page_url(self):

--- a/corehq/messaging/decorators.py
+++ b/corehq/messaging/decorators.py
@@ -22,7 +22,4 @@ def require_privilege_but_override_for_migrator(privilege):
     return decorate
 
 
-def reminders_framework_permission(fn):
-    return require_permission(Permissions.edit_data)(
-        require_privilege_but_override_for_migrator(privileges.REMINDERS_FRAMEWORK)(fn)
-    )
+reminders_framework_permission = require_privilege_but_override_for_migrator(privileges.REMINDERS_FRAMEWORK)


### PR DESCRIPTION
The messaging tab is currently invisible unless a user has edit data privileges in their project. Some of the individual views weren't also checking for edit data permission so any user in the project could view them with the url. This makes it so that all views now also check for the edit data privilege.

@millerdev @orangejenny 