### PR TITLE
Get case properties from all apps

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -501,11 +501,13 @@ def get_usercase_properties(app):
 
 def all_case_properties_by_domain(domain, case_types=None, include_parent_properties=True):
     result = {}
+    get_case_types_from_apps = case_types is None
+
     for app in all_apps_by_domain(domain):
         if app.is_remote_app():
             continue
 
-        if case_types is None:
+        if get_case_types_from_apps:
             case_types = app.get_case_types()
 
         property_map = get_case_properties(app, case_types,


### PR DESCRIPTION
If you have more than one app in your domain, this function would only get case properties for case types in the first app it finds. Surprised this hasn't been an issue elsewhere...
