### PR TITLE
remove TEST_APPS

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -385,9 +385,6 @@ ENIKSHAY_APPS = (
     'custom.enikshay.two_b_release_1',
 )
 
-# DEPRECATED use LOCAL_APPS instead; can be removed with testrunner.py
-TEST_APPS = ()
-
 # also excludes any app starting with 'django.'
 APPS_TO_EXCLUDE_FROM_TESTS = (
     'captcha',

--- a/testsettings.py
+++ b/testsettings.py
@@ -11,7 +11,6 @@ INSTALLED_APPS = (
     'testapps.test_elasticsearch',
     'testapps.test_pillowtop',
 ) + tuple(INSTALLED_APPS)
-assert not TEST_APPS, "TEST_APPS is deprecated; use LOCAL_APPS instead"
 
 TEST_RUNNER = 'django_nose.BasicNoseRunner'
 NOSE_ARGS = [


### PR DESCRIPTION
testrunner.py is no more - looks like it is safe to remove ```TEST_APPS```