### PR TITLE
Check consistency automatically before committing

### DIFF
--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -302,7 +302,10 @@ def convert_saved_export_to_export_instance(
     if isinstance(instance, CaseExportInstance):
         migration_meta.has_case_history = instance.has_case_history_table
 
-    if not dryrun:
+    has_issues = any([migration_meta.skipped_tables,
+                      migration_meta.skipped_columns,
+                      migration_meta.has_case_history])
+    if not dryrun and (force_convert_columns or not has_issues):
         migration_meta.save()
         instance.save()
         if inferred_schema:


### PR DESCRIPTION
@jmtroth0
Currently this whole thing is run with --dryrun, then the results are checked, and it's run again from scratch without --dryrun to convert all exports in the domain. This instead lets me do a non dry run and have it skip over problematic exports.