### PR TITLE
Use reasonable sorting icons

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datatables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datatables.less
@@ -27,18 +27,27 @@
 
 .datatable .header,
 .dataTable .header {
-  &.headerSortUp {
+  .dt-sort-icon:before{
+    font-family: "Glyphicons Halflings";
+  }
+  &.headerSort {
     .dt-sort-icon:before {
-      content: "\f077";
+      content: "\e150";
+      opacity: 0.2;
     }
   }
-  &.headerSortDown {
+  &.headerSortDesc {
     .dt-sort-icon:before {
-      content: "\f078";
+      content: "\e156";
     }
   }
-  &.headerSortUp,
-  &.headerSortDown {
+  &.headerSortAsc {
+    .dt-sort-icon:before {
+      content: "\e155";
+    }
+  }
+  &.headerSortDesc,
+  &.headerSortAsc {
     background-color: @cc-brand-mid;
   }
 }

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datatables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datatables.less
@@ -29,6 +29,7 @@
 .dataTable .header {
   .dt-sort-icon:before{
     font-family: "Glyphicons Halflings";
+    vertical-align: bottom;
   }
   &.headerSort {
     .dt-sort-icon:before {

--- a/corehq/apps/reports/datatables/__init__.py
+++ b/corehq/apps/reports/datatables/__init__.py
@@ -35,11 +35,17 @@ class DataTablesColumn(object):
 
     @property
     def render_html(self):
+        css_classes = []
+        if self.css_span:
+            css_classes.append("span%d" % self.css_span)
+        if self.sortable:
+            css_classes.append("clickable")
+
         column_params = dict(
             title=self.html,
             sort=self.sortable,
             rotate=self.rotate,
-            css="span%d" % self.css_span if self.css_span > 0 else '',
+            css=" ".join(css_classes),
             rowspan=self.rowspan,
             help_text=self.help_text,
             expected=self.expected,

--- a/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
@@ -283,9 +283,9 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
     };
 
     $.extend( $.fn.dataTableExt.oStdClasses, {
-        "sSortAsc": "header headerSortDown",
-        "sSortDesc": "header headerSortUp",
-        "sSortable": "header",
+        "sSortAsc": "header headerSortAsc",
+        "sSortDesc": "header headerSortDesc",
+        "sSortable": "header headerSort",
     } );
 
     // For sorting rows


### PR DESCRIPTION
There's currently no way of knowing if a column in a report is sortable, short of clicking every single one of them (the cursor doesn't even change). Also, chevrons are very confusing.

![screenshot from 2018-06-11 14-32-59](https://user-images.githubusercontent.com/146896/41250259-62b75708-6d84-11e8-86c7-c520a66d00f5.png)


I would have gone with the default datatables classes (`sorting`, `sorting_asc`, `sorting_desc`), except for some reason we render the table header twice (one has no content, so it isn't shown). Using the default classes adds content to both of those headers, showing the second one. I decided to not try and fix that issue, and used the structure we already have. 

cc @czue 