### PR TITLE
Add http libs to prod-requirements

### DIFF
--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -5,3 +5,5 @@ errand-boy==0.3.8
 setproctitle==1.1.9
 uWSGI==2.0.11.2
 ipython==5.2.2
+ndg-httpsclient==0.5.0
+pyasn1==0.4.3


### PR DESCRIPTION
@snopoke Saw that you fixed web10 with these. I just installed these for web11. I'm guessing that these were installed implicitly, then we upgraded some other libraries that no longer needed them, but I'm not really sure. Hopefully alerts-icds is less noisy