### PR TITLE
Better username validation

### DIFF
--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -9,7 +9,7 @@ from corehq.apps.users.views.mobile.users import MobileWorkerListView
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.const import ANONYMOUS_USERNAME
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import flag_enabled, generate_cases
 
 
 class TestMobileWorkerListView(TestCase):
@@ -86,3 +86,23 @@ class TestMobileWorkerListView(TestCase):
         })
         content = json.loads(resp.content)
         self.assertTrue('error' in content)
+
+
+@generate_cases((
+    ('jmoney', False),
+    ('jmoney91', False),
+    ('j+money', False),
+    ('j.money', False),
+    ('j_money', False),
+    ('j-money', False),
+    ('j$', True),
+    ('jmoney@something', True),
+    ('jmoney...', True),
+    ('.jmoney', True),
+), TestMobileWorkerListView)
+def test_check_usernames_for_invalid_characters(self, username, error):
+    resp = self._remote_invoke('check_username', {
+        'username': username
+    })
+    content = json.loads(resp.content)
+    self.assertIs('error' in content, error)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -99,7 +99,7 @@ BULK_MOBILE_HELP_SITE = ("https://confluence.dimagi.com/display/commcarepublic"
                          "ManageCommCareMobileWorkers-B.UseBulkUploadtocreatem"
                          "ultipleusersatonce")
 DEFAULT_USER_LIST_LIMIT = 10
-BAD_MOBILE_USERNAME_REGEX = re.compile("[@!#%&'*/=?^`{}|]")
+BAD_MOBILE_USERNAME_REGEX = re.compile("[^A-Za-z.+-_]")
 
 
 def _can_edit_workers_location(web_user, mobile_worker):
@@ -738,8 +738,16 @@ class MobileWorkerListView(HQJSONResponseMixin, BaseUserSettingsView):
             if BAD_MOBILE_USERNAME_REGEX.search(username) is not None:
                 raise ValidationError("Username contained an invalid character")
         except ValidationError:
+            if '..' in username:
+                return {
+                    'error': _("Username may not contain consecutive . (period).")
+                }
+            if username.endswith('.'):
+                return {
+                    'error': _("Username may not end with a . (period).")
+                }
             return {
-                'error': _("Username may only contain letters, numbers, + or .")
+                'error': _("Username may not contain special characters.")
             }
 
         full_username = format_username(username, self.domain)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -99,7 +99,7 @@ BULK_MOBILE_HELP_SITE = ("https://confluence.dimagi.com/display/commcarepublic"
                          "ManageCommCareMobileWorkers-B.UseBulkUploadtocreatem"
                          "ultipleusersatonce")
 DEFAULT_USER_LIST_LIMIT = 10
-BAD_MOBILE_USERNAME_REGEX = re.compile("[^A-Za-z.+-_]")
+BAD_MOBILE_USERNAME_REGEX = re.compile("[^A-Za-z0-9.+-_]")
 
 
 def _can_edit_workers_location(web_user, mobile_worker):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -99,6 +99,7 @@ BULK_MOBILE_HELP_SITE = ("https://confluence.dimagi.com/display/commcarepublic"
                          "ManageCommCareMobileWorkers-B.UseBulkUploadtocreatem"
                          "ultipleusersatonce")
 DEFAULT_USER_LIST_LIMIT = 10
+BAD_MOBILE_USERNAME_REGEX = re.compile("[@!#%&'*/=?^`{}|]")
 
 
 def _can_edit_workers_location(web_user, mobile_worker):
@@ -733,13 +734,12 @@ class MobileWorkerListView(HQJSONResponseMixin, BaseUserSettingsView):
         if username == 'admin' or username == 'demo_user' or username == ANONYMOUS_USERNAME:
             return {'error': _('Username {} is reserved.').format(username)}
         try:
-            validate_email(username)
+            validate_email("{}@example.com".format(username))
+            if BAD_MOBILE_USERNAME_REGEX.search(username) is not None:
+                raise ValidationError("Username contained an invalid character")
         except ValidationError:
             return {
-                'error': _(
-                    "Username may only contain letters, numbers, or any of the following symbols: "
-                    "-!#$%&'*+/=?^_`{}'."
-                )
+                'error': _("Username may only contain letters, numbers, + or .")
             }
 
         full_username = format_username(username, self.domain)


### PR DESCRIPTION
Product note: provides an error message for users trying to use accented characters in a mobile worker's name

https://manage.dimagi.com/default.asp?276956#

We're limited to django's interpretation of what an email user should be so for the most part, there can only be ASCII characters.

Guessing @proteusvacuum @orangejenny @biyeun may have feedback on this