### PR TITLE
ICDS: height_recorded_in_month indicator - replace height_eligible to valid_in_month

### DIFF
--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -859,8 +859,13 @@
         "expression": {
           "type": "conditional",
           "test": {
-            "type": "named",
-            "name": "height_eligible"
+            "type": "boolean_expression",
+            "operator": "eq",
+            "property_value": "yes",
+            "expression": {
+              "type": "named",
+              "name": "valid_in_month"
+            }
           },
           "expression_if_true": {
             "type": "named",


### PR DESCRIPTION
Hi @emord 

I replace the height_eligible to valid_in_month for height_recorded_in_month column in child_health_cases_monthly_tableau2.

More context in case: http://manage.dimagi.com/default.asp?277399

Please let me know if you have any questions.

Regards,
Łukasz