### PR TITLE
Update session language on login

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -8,6 +8,7 @@ from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA256
 from Crypto.Signature import PKCS1_PSS
 from django.templatetags.i18n import language_name
+from django.utils.translation import activate, LANGUAGE_SESSION_KEY
 
 from memoized import memoized
 from dimagi.utils.logging import notify_exception
@@ -136,3 +137,13 @@ def get_environment_friendly_name():
     except KeyError:
         env = settings.SERVER_ENVIRONMENT
     return env
+
+
+def update_session_language(req, old_lang, new_lang):
+    # Update the language for this session if the user signing in has a different language than the current
+    # session default
+    if new_lang != old_lang:
+        # update the current session's language setting
+        req.session[LANGUAGE_SESSION_KEY] = new_lang
+        # and activate it for the current thread so the response page is translated too
+        activate(new_lang)

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -332,7 +332,7 @@ def _login(req, domain_name, template_name):
 
     if 'auth-username' in req.POST:
         new_lang = CouchUser.get_by_username(req.POST['auth-username']).language
-        old_lang = req.session[LANGUAGE_SESSION_KEY]
+        old_lang = req.session.get(LANGUAGE_SESSION_KEY)
         update_session_language(req, old_lang, new_lang)
     if req.user.is_authenticated and req.method == "GET":
         redirect_to = req.GET.get('next', '')

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -28,7 +28,9 @@ from django.template import loader
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_noop, activate, LANGUAGE_SESSION_KEY
+
+
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import TemplateView
@@ -42,6 +44,7 @@ from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
 from corehq.apps.hqadmin.service_checks import CHECKS, run_checks
 from corehq.apps.users.landing_pages import get_redirect_url, get_cloudcare_urlname
+from corehq.apps.users.models import CouchUser
 
 from corehq.form_processor.utils.general import should_use_sql_backend
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
@@ -379,6 +382,9 @@ def login(req):
 
     req_params = req.GET if req.method == 'GET' else req.POST
     domain = req_params.get('domain', None)
+
+    _update_session_language(req)
+
     return _login(req, domain, "login_and_password/login.html")
 
 
@@ -392,7 +398,22 @@ def domain_login(req, domain, template_name="login_and_password/login.html"):
     # necessary domain contexts:
     req.project = project
 
+    _update_session_language(req)
+
     return _login(req, domain, template_name)
+
+
+def _update_session_language(req):
+    # Update the language for this session if the user signing in has a different language than the current
+    # session default
+    if 'auth-username' in req.POST:
+        new_lang = CouchUser.get_by_username(req.POST['auth-username']).language
+        old_lang = req.session[LANGUAGE_SESSION_KEY]
+        if new_lang != old_lang:
+            # update the current session's language setting
+            req.session[LANGUAGE_SESSION_KEY] = new_lang
+            # and activate it for the current thread so the response page is translated too
+            activate(new_lang)
 
 
 class HQLoginView(LoginView):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -376,9 +376,7 @@ def _login(req, domain_name, template_name):
 @two_factor_exempt
 @sensitive_post_parameters('auth-password')
 def login(req):
-    # this view, and the one below, is overridden because
-    # we need to set the base template to use somewhere
-    # somewhere that the login page can access it.
+    # This is a wrapper around the _login view
 
     if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
         login_url = reverse('domain_login', kwargs={'domain': 'icds-cas'})
@@ -386,12 +384,12 @@ def login(req):
 
     req_params = req.GET if req.method == 'GET' else req.POST
     domain = req_params.get('domain', None)
-
     return _login(req, domain, "login_and_password/login.html")
 
 
 @location_safe
 def domain_login(req, domain, template_name="login_and_password/login.html"):
+    # This is a wrapper around the _login view which sets a different template
     project = Domain.get_by_name(domain)
     if not project:
         raise Http404

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -376,9 +376,7 @@ def _login(req, domain_name, template_name):
 @two_factor_exempt
 @sensitive_post_parameters('auth-password')
 def login(req):
-    # this view, and the one below, is overridden because
-    # we need to set the base template to use somewhere
-    # somewhere that the login page can access it.
+    # This is a wrapper around the _login view
 
     if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
         login_url = reverse('domain_login', kwargs={'domain': 'icds-cas'})
@@ -392,6 +390,7 @@ def login(req):
 
 @location_safe
 def domain_login(req, domain, template_name="login_and_password/login.html"):
+    # This is a wrapper around the _login view which sets a different template
     project = Domain.get_by_name(domain)
     if not project:
         raise Http404

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -5,7 +5,7 @@ import re
 from base64 import b64encode
 from django.views.decorators.debug import sensitive_post_parameters
 from pygooglechart import QRChart
-from corehq.apps.hqwebapp.utils import sign
+from corehq.apps.hqwebapp.utils import sign, update_session_language
 from corehq.apps.settings.forms import (
     HQPasswordChangeForm, HQPhoneNumberMethodForm, HQDeviceValidationForm,
     HQTOTPDeviceForm, HQPhoneNumberForm, HQTwoFactorMethodForm, HQEmptyForm
@@ -23,8 +23,7 @@ import langcodes
 
 from django.http import HttpResponseRedirect, HttpResponse
 from django.utils.decorators import method_decorator
-from django.utils.translation import (ugettext as _, ugettext_noop, ugettext_lazy,
-    activate, LANGUAGE_SESSION_KEY)
+from django.utils.translation import (ugettext as _, ugettext_noop, ugettext_lazy)
 from corehq.apps.domain.decorators import (login_and_domain_required, require_superuser,
                                            login_required, two_factor_exempt)
 from django.urls import reverse
@@ -218,11 +217,8 @@ class MyAccountSettingsView(BaseMyAccountView):
             old_lang = self.request.couch_user.language
             self.settings_form.update_user()
             new_lang = self.request.couch_user.language
-            if new_lang != old_lang:
-                # update the current session's language setting
-                request.session[LANGUAGE_SESSION_KEY] = new_lang
-                # and activate it for the current thread so the response page is translated too
-                activate(new_lang)
+            update_session_language(request, old_lang, new_lang)
+
         return self.get(request, *args, **kwargs)
 
 


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?276714#1503064

Example: A user logs in and updates their language to Spanish, which changes the session language to spanish. They log out, and another user (with English associated with their account), the language stays set to Spanish.

The fix: On login, added a check for whether the user's language is different than the current session language, and if so, update the session language.

I put it in `hqwebapp/utils.py` so that it could be used when a user logs in and when they update their language.