### PR TITLE
VectoLink - changed language to french in reports for vectorlink-burkina-faso domain

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -108,7 +108,7 @@ class AbtExpressionSpec(JsonObject):
         """
         Return the language in which this row should be rendered.
         """
-        if item.get("domain", None) in ("airsmadagascar", "abtmali"):
+        if item.get("domain", None) in ("airsmadagascar", "abtmali", "vectorlink-burkina-faso"):
             return "fra"
         country = cls._get_val(item, ["location_data", "country"])
         if country in ["Senegal", 'S\xe9n\xe9gal', "Benin", "Mali", "Madagascar"]:


### PR DESCRIPTION
Hi @calellowitz ,

I changed the language to french in the report for vectorlink-burkina-faso domain. 

Please let me know if you have any questions.

Regards,
Łukasz