### PR TITLE
Discrepancy in percent unweighed indicator in Program Summary

### DIFF
--- a/custom/icds_reports/reports/new_born_with_low_weight.py
+++ b/custom/icds_reports/reports/new_born_with_low_weight.py
@@ -76,7 +76,9 @@ def get_newborn_with_low_birth_weight_map(domain, config, loc_level, show_test=F
                     'value': indian_formatted_number(low_birth_total)
                 },
                 {
-                    'indicator': 'Total Number of children born and weight in given month{}:'.format(chosen_filters),
+                    'indicator': 'Total Number of children born and weight in given month{}:'.format(
+                        chosen_filters
+                    ),
                     'value': indian_formatted_number(in_month_total)
                 },
                 {

--- a/custom/icds_reports/reports/new_born_with_low_weight.py
+++ b/custom/icds_reports/reports/new_born_with_low_weight.py
@@ -76,14 +76,20 @@ def get_newborn_with_low_birth_weight_map(domain, config, loc_level, show_test=F
                     'value': indian_formatted_number(low_birth_total)
                 },
                 {
+                    'indicator': 'Total Number of children born and weight in given month{}:'.format(chosen_filters),
+                    'value': indian_formatted_number(in_month_total)
+                },
+                {
                     'indicator': '% newborns with LBW in given month{}:'.format(chosen_filters),
-                    'value': '%.2f%%' % (
-                        low_birth_total * 100 / float(in_month_total or 1))
+                    'value': '%.2f%%' % (low_birth_total * 100 / float(in_month_total or 1))
+                },
+                {
+                    'indicator': '% of children with weight in normal{}:'.format(chosen_filters),
+                    'value': '%.2f%%' % ((in_month_total - low_birth_total) * 100 / float(in_month_total or 1))
                 },
                 {
                     'indicator': '% Unweighted{}:'.format(chosen_filters),
-                    'value': '%.2f%%' % (
-                        in_month_total * 100 / float(total or 1))
+                    'value': '%.2f%%' % ((total - in_month_total) * 100 / float(total or 1))
                 }
             ]
 

--- a/custom/icds_reports/static/icds_reports/js/spec/newborn_with_low_weight.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/newborn_with_low_weight.directive.spec.js
@@ -94,7 +94,9 @@ describe('Newborn Low Weight Directive', function () {
             '<p>test</p>'
             + '<div>Total Number of Newborns born in given month: <strong>20</strong></div>'
             + '<div>Number of Newborns with LBW in given month: <strong>5</strong></div>'
+            + '<div>Total Number of children born and weight in given month: <strong>10</strong></div>'
             + '<div>% newborns with LBW in given month: <strong>50.00%</strong></div>'
+            + '<div>% of children with weight in normal: <strong>50.00%</strong></div>'
             + '<div>% Unweighted: <strong>50.00%</strong></div></div>');
     });
 
@@ -202,8 +204,10 @@ describe('Newborn Low Weight Directive', function () {
         var expected = '<p><strong>Jul 2017</strong></p><br/>'
             + '<div>Total Number of Newborns born in given month: <strong>12</strong></div>'
             + '<div>Number of Newborns with LBW in given month: <strong>5</strong></div>'
-            + '<div>% newborns with LBW in given month: <strong>72.00%</strong></div>'
-            + '<div>% Unweighted: <strong>83.33%</strong></div>';
+            + '<div>Total Number of children born and weight in given month: <strong>10</strong></div>'
+            + '<div>% newborns with LBW in given month: <strong>50.00%</strong></div>'
+            + '<div>% of children with weight in normal: <strong>50.00%</strong></div>'
+            + '<div>% Unweighted: <strong>16.67%</strong></div>';
 
         var result = controller.tooltipContent(month.value, data);
         assert.equal(expected, result);
@@ -214,8 +218,10 @@ describe('Newborn Low Weight Directive', function () {
             '<p>Ambah</p>' +
             '<div>Total Number of Newborns born in given month: <strong>25</strong></div>' +
             '<div>Number of Newborns with LBW in given month: <strong>0</strong></div>' +
+            '<div>Total Number of children born and weight in given month: <strong>0</strong></div>' +
             '<div>% newborns with LBW in given month: <strong>NaN%</strong></div>' +
-            '<div>% Unweighted: <strong>0.00%</strong></div></div>';
+            '<div>% of children with weight in normal: <strong>NaN%</strong></div>' +
+            '<div>% Unweighted: <strong>100.00%</strong></div></div>';
         controllermapOrSectorView.templatePopup = function (d) {
             return controller.templatePopup(d.loc, d.row);
         };

--- a/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
+++ b/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
@@ -32,7 +32,7 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
         var chosenFilters = gender ? ' (' + gender + ') ' : '';
         var total = row ? $filter('indiaNumbers')(row.all) : 'N/A';
         var lowBirth = row ? $filter('indiaNumbers')(row.low_birth) : 'N/A';
-        var in_month_total = row ? $filter('indiaNumbers')(row.in_month) : 'N/A';
+        var inMonthTotal = row ? $filter('indiaNumbers')(row.in_month) : 'N/A';
         var percent = row ? d3.format('.2%')(row.low_birth / (row.in_month || 1)) : 'N/A';
         var percentNormal = row ? d3.format('.2%')((row.in_month - row.low_birth) / (row.in_month || 1)) : 'N/A';
         var unweighedPercent = row ? d3.format('.2%')((row.all - row.in_month) / (row.all || 1)) : 'N/A';
@@ -48,7 +48,7 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
             },
             {
                 indicator_name: 'Total Number of children born and weight in given month: ',
-                indicator_value: in_month_total,
+                indicator_value: inMonthTotal,
             },
             {
                 indicator_name: '% newborns with LBW in given month' + chosenFilters + ': ',

--- a/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
+++ b/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
@@ -32,8 +32,10 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
         var chosenFilters = gender ? ' (' + gender + ') ' : '';
         var total = row ? $filter('indiaNumbers')(row.all) : 'N/A';
         var lowBirth = row ? $filter('indiaNumbers')(row.low_birth) : 'N/A';
+        var in_month_total = row ? $filter('indiaNumbers')(row.in_month) : 'N/A';
         var percent = row ? d3.format('.2%')(row.low_birth / (row.in_month || 1)) : 'N/A';
-        var unweighedPercent = row ? d3.format('.2%')(row.in_month / (row.all || 1)) : 'N/A';
+        var percentNormal = row ? d3.format('.2%')((row.in_month - row.low_birth) / (row.in_month || 1)) : 'N/A';
+        var unweighedPercent = row ? d3.format('.2%')((row.all - row.in_month) / (row.all || 1)) : 'N/A';
         return vm.createTemplatePopup(
             loc.properties.name,
             [{
@@ -45,8 +47,16 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
                 indicator_value: lowBirth,
             },
             {
+                indicator_name: 'Total Number of children born and weight in given month: ',
+                indicator_value: in_month_total,
+            },
+            {
                 indicator_name: '% newborns with LBW in given month' + chosenFilters + ': ',
                 indicator_value: percent,
+            },
+            {
+                indicator_name: '% of children with weight in normal: ',
+                indicator_value: percentNormal,
             },
             {
                 indicator_name: '% Unweighted' + chosenFilters + ': ',
@@ -89,12 +99,26 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
                 indicator_value: $filter('indiaNumbers')(dataInMonth.low_birth),
             },
             {
+                indicator_name: 'Total Number of children born and weight in given month: ',
+                indicator_value: $filter('indiaNumbers')(dataInMonth.in_month),
+            },
+            {
                 indicator_name: '% newborns with LBW in given month: ',
-                indicator_value: d3.format('.2%')(dataInMonth.y),
+                indicator_value: d3.format('.2%')(
+                    (dataInMonth.low_birth) / (dataInMonth.in_month || 1)
+                ),
+            },
+            {
+                indicator_name: '% of children with weight in normal: ',
+                indicator_value: d3.format('.2%')(
+                    (dataInMonth.in_month - dataInMonth.low_birth) / (dataInMonth.in_month || 1)
+                ),
             },
             {
                 indicator_name: '% Unweighted: ',
-                indicator_value: d3.format('.2%')(dataInMonth.in_month / (dataInMonth.all || 1)),
+                indicator_value: d3.format('.2%')(
+                    (dataInMonth.all - dataInMonth.in_month) / (dataInMonth.all || 1)
+                ),
             }]
         );
     };

--- a/custom/icds_reports/tests/reports/test_new_born_with_low_weight.py
+++ b/custom/icds_reports/tests/reports/test_new_born_with_low_weight.py
@@ -112,8 +112,10 @@ class TestNewBornWithLowWeight(TestCase):
             [
                 {'indicator': 'Total Number of Newborns born in given month:', 'value': "7"},
                 {'indicator': 'Number of Newborns with LBW in given month:', 'value': "2"},
+                {'indicator': 'Total Number of children born and weight in given month:', u'value': '4'},
                 {'indicator': '% newborns with LBW in given month:', 'value': '50.00%'},
-                {'indicator': '% Unweighted:', 'value': '57.14%'}
+                {'indicator': '% of children with weight in normal:', 'value': '50.00%'},
+                {'indicator': '% Unweighted:', 'value': '42.86%'},
             ]
         )
 


### PR DESCRIPTION
Hi @emord,
I have made a change in the blue info box on the map view of newborns with low birth weight report to present all data with description and make percentage indicators sum to 100%. Also, I have changed `% Unweighted` numerator from `in_month_total` to `total - in_month_total`.