### PR TITLE
Add Parent Case recipient to new reminders framework

### DIFF
--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -447,6 +447,8 @@ def get_rule_recipients(handler):
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER, None)]
     elif handler.recipient == RECIPIENT_USER:
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, None)]
+    elif handler.recipient == RECIPIENT_PARENT_CASE:
+        return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE, None)]
     elif handler.recipient == RECIPIENT_USER_GROUP:
         return [(ScheduleInstance.RECIPIENT_TYPE_USER_GROUP, handler.user_group_id)]
     else:
@@ -686,6 +688,7 @@ class Command(BaseCommand):
             RECIPIENT_CASE,
             RECIPIENT_USER_GROUP,
             RECIPIENT_USER,
+            RECIPIENT_PARENT_CASE,
         ):
             return None
 

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2671,6 +2671,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF, _("The Case")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER, _("The Case's Owner")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, _("The Case's Last Submitting User")),
+            (CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE, _("The Case's Parent Case")),
         ]
         new_choices.extend(self.fields['recipient_types'].choices)
 
@@ -3184,6 +3185,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
+            CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE,
         ):
             if recipient_type_without_id in recipient_types:
                 result.append((recipient_type_without_id, None))

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -485,6 +485,9 @@ class CaseScheduleInstanceMixin(object):
 
             return None
         elif self.recipient_type == self.RECIPIENT_TYPE_PARENT_CASE:
+            if self.case:
+                return self.case.parent
+
             return None
         elif self.recipient_type == self.RECIPIENT_TYPE_CHILD_CASE:
             return None


### PR DESCRIPTION
Adds the parent case recipient to the new reminders framework, for parity with the old framework.

@millerdev @orangejenny 