### PR TITLE
add parent id references to autogenerated data sources

### DIFF
--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -121,7 +121,7 @@ def _export_item_to_ucr_indicator(export_item):
                         "property_name": "indices"
                     },
                     "filter_expression": {
-                       "type": "boolean_expression",
+                        "type": "boolean_expression",
                         "expression": {
                             "type": "property_name",
                             "property_name": "referenced_type"

--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -51,7 +51,7 @@ def get_form_data_sources(app):
 
     for module in app.get_modules():
         for form in module.get_forms():
-            forms = {form.xmlns: get_form_data_source(app, form)}
+            forms[form.xmlns] = get_form_data_source(app, form)
 
     return forms
 

--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from corehq.apps.app_manager.xform import XForm
-from corehq.apps.export.models import FormExportDataSchema, CaseExportDataSchema
+from corehq.apps.export.models import FormExportDataSchema, CaseExportDataSchema, CaseIndexItem
 from corehq.apps.export.system_properties import BOTTOM_MAIN_FORM_TABLE_PROPERTIES, MAIN_CASE_TABLE_PROPERTIES
 from corehq.apps.userreports.app_manager.data_source_meta import make_form_data_source_filter, \
     make_case_data_source_filter
@@ -106,15 +106,53 @@ def _export_item_to_ucr_indicator(export_item):
     :param export_item:
     :return: a dict ready to be inserted into a UCR data source
     """
+    if isinstance(export_item, CaseIndexItem):
+        # dereference indices
+        inner_expression = {
+            "type": "nested",
+            # this pulls out the entire CommCareCaseIndex object
+            "argument_expression": {
+                "type": "array_index",
+                "array_expression": {
+                    # filter indices down to those with the correct case type
+                    "type": "filter_items",
+                    "items_expression": {
+                        "type": "property_name",
+                        "property_name": "indices"
+                    },
+                    "filter_expression": {
+                       "type": "boolean_expression",
+                        "expression": {
+                            "type": "property_name",
+                            "property_name": "referenced_type"
+                        },
+                        "operator": "eq",
+                        "property_value": export_item.case_type
+                    }
+                },
+                # return the first (assumes only 0 or 1)
+                "index_expression": {
+                    "type": "constant",
+                    "constant": 0
+                }
+            },
+            # this pulls out the referenced case ID from the object
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "referenced_id"
+            }
+        }
+    else:
+        inner_expression = {
+            "type": "property_path",
+            'property_path': [p.name for p in export_item.path],
+        }
     return {
         "type": "expression",
         "column_id": get_column_name(export_item.readable_path, add_hash=False),
         "display_name": export_item.path[-1].name,
         "datatype": export_item.datatype or 'string',
-        "expression": {
-            "type": "property_path",
-            'property_path': [p.name for p in export_item.path],
-        }
+        "expression": inner_expression,
     }
 
 

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -9,7 +9,6 @@ from mock import patch
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.xform_builder import XFormBuilder
 from corehq.apps.export.dbaccessors import delete_all_export_data_schemas
 from corehq.apps.export.system_properties import MAIN_CASE_TABLE_PROPERTIES
 from corehq.apps.userreports.app_manager.helpers import get_case_data_sources, get_form_data_sources

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -7,7 +7,10 @@ from django.test import TestCase
 from mock import patch
 
 from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.xform_builder import XFormBuilder
+from corehq.apps.export.dbaccessors import delete_all_export_data_schemas
 from corehq.apps.export.system_properties import MAIN_CASE_TABLE_PROPERTIES
 from corehq.apps.userreports.app_manager.helpers import get_case_data_sources, get_form_data_sources
 from corehq.apps.userreports.reports.builder import DEFAULT_CASE_PROPERTY_DATATYPES
@@ -17,6 +20,7 @@ from corehq.apps.userreports.tests.utils import get_simple_xform
 class AppManagerDataSourceConfigTest(TestCase):
     domain = 'userreports_test'
     case_type = 'app_data_case'
+    parent_type = 'app_data_parent'
     case_properties = {
         'first_name': 'string',
         'last_name': 'string',
@@ -30,16 +34,24 @@ class AppManagerDataSourceConfigTest(TestCase):
         factory = AppFactory(domain=cls.domain)
         m0, f0 = factory.new_basic_module('A Module', cls.case_type)
         f0.source = get_simple_xform()
-        cls.form = f0
+        f0.name = {'en': 'Main Form'}
         factory.form_requires_case(f0, case_type=cls.case_type, update={
             cp: '/data/{}'.format(cp) for cp in cls.case_properties.keys()
         })
+        cls.form = f0
+        m1, f1 = factory.new_basic_module('Parent Module', cls.parent_type)
+        f1.source = get_simple_xform()
+        f1.name = {'en': 'Parent Form'}
+        factory.form_opens_case(f1, case_type=cls.parent_type)
+        factory.form_opens_case(f1, case_type=cls.case_type, is_subcase=True)
+        cls.form2 = f1
         cls.app = factory.app
         cls.app.save()
 
     @classmethod
     def tearDownClass(cls):
         cls.app.delete()
+        delete_all_export_data_schemas()
         super(AppManagerDataSourceConfigTest, cls).tearDownClass()
 
     def setUp(self):
@@ -54,10 +66,10 @@ class AppManagerDataSourceConfigTest(TestCase):
     def test_simple_case_management(self, datetime_mock):
         fake_time_now = datetime(2015, 4, 24, 12, 30, 8, 24886)
         datetime_mock.utcnow.return_value = fake_time_now
-
+        index_column_id = 'indices.app_data_parent'
         app = self.app
         data_sources = get_case_data_sources(app)
-        self.assertEqual(1, len(data_sources))
+        self.assertEqual(2, len(data_sources))
         data_source = data_sources[self.case_type]
         self.assertEqual(self.domain, data_source.domain)
         self.assertEqual('CommCareCase', data_source.referenced_doc_type)
@@ -81,14 +93,16 @@ class AppManagerDataSourceConfigTest(TestCase):
             datetime_columns +
             [
                 "doc_id", "case_type", "last_modified_by_user_id", "opened_by_user_id",
-                "closed", "closed_by_user_id", "owner_id", "name", "state", "external_id"
+                "closed", "closed_by_user_id", "owner_id", "name", "state", "external_id",
             ] +
             list(self.case_properties.keys())
+            + [index_column_id]
         )
         self.assertEqual(expected_columns, set(col_back.id for col_back in data_source.get_columns()))
 
         modified_on = datetime(2014, 11, 12, 15, 37, 49)
         opened_on = datetime(2014, 11, 11, 23, 34, 34, 25)
+        parent_id = 'fake-parent-id'
         sample_doc = CommCareCase(
             _id='some-doc-id',
             modified_on=modified_on,
@@ -102,8 +116,12 @@ class AppManagerDataSourceConfigTest(TestCase):
             last_name='test last',
             children='3',
             dob='2001-01-01',
+            indices=[
+                CommCareCaseIndex(
+                    identifier='parent', referenced_type=self.parent_type, referenced_id=parent_id
+                )
+            ]
         ).to_json()
-
 
         def _get_column_property(column):
             # this is the mapping of column id to case property path
@@ -123,6 +141,8 @@ class AppManagerDataSourceConfigTest(TestCase):
 
             if result.column.id == "inserted_at":
                 self.assertEqual(fake_time_now, result.value)
+            if result.column.id == index_column_id:
+                self.assertEqual(parent_id, result.value)
             elif result.column.id == "last_modified_date":
                 self.assertEqual(modified_on, result.value)
             elif result.column.id == "opened_date":
@@ -138,7 +158,7 @@ class AppManagerDataSourceConfigTest(TestCase):
     def test_simple_form_data_source(self):
         app = self.app
         data_sources = get_form_data_sources(app)
-        self.assertEqual(1, len(data_sources))
+        self.assertEqual(2, len(data_sources))
         data_source = data_sources[self.form.xmlns]
         form_properties = copy(self.case_properties)
         form_properties['state'] = 'string'


### PR DESCRIPTION
related to something that I want to add to https://github.com/dimagi/commcare-hq/pull/20874/ (the ability to traverse parent/child case relationships). :fish: 

the first commit fixes a longstanding bug in code that was only ever used in tests that only just now was revealed.

