### PR TITLE
Fix filter warning criteria for report builder `Default Filter`

### DIFF
--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -178,7 +178,7 @@ TODO:
                 attr: {disabled: !existsInCurrentVersion()}
             "/>
             <!--/ko-->
-            <label class="help-block" data-bind="if: $parent.showWarnings() && !filterValue()">
+            <label class="help-block" data-bind="if: $parent.showWarnings() && !(filterValue() || filterOperator())">
                 {% trans "Filter Value should not be blank." %}</label>
         </td>
         <!--/ko-->

--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -162,7 +162,7 @@ TODO:
         <!--/ko-->
 
         <!--ko if: $parent.hasFilterValueCol -->
-        <td class="form-group" data-bind="css:{'has-error': $parent.showWarnings() && !filterValue()}">
+        <td class="form-group" data-bind="css:{'has-error': $parent.showWarnings() && !(filterValue() || filterOperator())}">
             <!--ko if: $data.format() === 'Date'-->
             <select class="form-control input-sm" data-bind="
                 options: $root.dateRangeOptions,


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?277574
Any date selected would display a "Filter Value should not be blank" warning. This fixes a bug that made it always show up for dates. 