### PR TITLE
Fix for: Async pagination breaks the excel download

### DIFF
--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -89,6 +89,7 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
         'corehq.apps.reports.filters.commtrack.ProgramFilter',
     ]
     exportable = True
+    exportable_all = True
     emailable = True
     ajax_pagination = True
     asynchronous = True
@@ -192,6 +193,11 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
     @property
     def rows(self):
         return [pd[0:2] + ['%.1f%%' % d for d in pd[2:]] for pd in self.product_data]
+
+    @property
+    def get_all_rows(self):
+        self.pagination.count = self.total_records
+        return self.rows
 
     def get_data_for_graph(self):
         ret = [


### PR DESCRIPTION
Ticket: https://manage.dimagi.com/default.asp?277721

I implemented async pagination for products here: https://github.com/dimagi/commcare-hq/pull/20876

Issue: that change made it so that exporting the report to excel only reports the first 10 items.

Fixed it by using `exportable_all = True` and implemented `get_all_rows` to return every single row.

**I do have a question: the reason we made the report loading async was because it took forever for all of these entries to get retrieved, and the page would time out. Would this not cause the same problem?