### PR TITLE
Allow users to copy a form to different app

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3573,7 +3573,7 @@ class AdvancedModule(ModuleBase):
                 )
 
                 if from_module.parent_select.active:
-                    from_app = from_module.get_app()
+                    from_app = from_module.get_app()  # A form can be copied from a module in a different app.
                     select_chain = get_select_chain(from_app, from_module, include_self=False)
                     for n, link in enumerate(reversed(list(enumerate(select_chain)))):
                         i, module = link

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6025,21 +6025,13 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         source = update_form_unique_ids(source)
         return update_report_module_ids(source)
 
-    def copy_form(self, module_id, form_id, to_module_id, to_app=None):
+    def copy_form(self, from_module, form, to_module, rename=False):
         """
         The case type of the two modules conflict,
         copying (confusingly) is still allowed.
         This is intentional.
 
         """
-        if to_app is None:
-            to_app = self
-        from_module = self.get_module(module_id)
-        form = from_module.get_form(form_id)
-        to_module = to_app.get_module(to_module_id)
-        return self._copy_form(from_module, form, to_module, to_app, rename=True)
-
-    def _copy_form(self, from_module, form, to_module, *args, **kwargs):
         copy_source = deepcopy(form.to_json())
         # only one form can be a release notes form, so set them to False explicitly when copying
         copy_source['is_release_notes_form'] = False
@@ -6047,7 +6039,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         if 'unique_id' in copy_source:
             del copy_source['unique_id']
 
-        if 'rename' in kwargs and kwargs['rename']:
+        if rename:
             for lang, name in six.iteritems(copy_source['name']):
                 with override(lang):
                     copy_source['name'][lang] = _('Copy of {name}').format(name=name)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6039,7 +6039,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
 
     def _copy_form(self, from_module, form, to_module, *args, **kwargs):
         copy_source = deepcopy(form.to_json())
-        # only one form can be a release notes form, so set them to False explicity when copying
+        # only one form can be a release notes form, so set them to False explicitly when copying
         copy_source['is_release_notes_form'] = False
         copy_source['enable_release_notes'] = False
         if 'unique_id' in copy_source:

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -19,7 +19,7 @@ hqDefine("app_manager/js/forms/copy_form_to_app", function () {
             })
         );
         return self;
-    }
+    };
 
     var appsModulesModel = function (appsModules) {
         var self = {};
@@ -30,10 +30,9 @@ hqDefine("app_manager/js/forms/copy_form_to_app", function () {
         );
         self.selectedAppId = ko.observable(self.apps()[0].id);
         self.selectedApp = ko.computed(function () {
-            var selected = _.filter(self.apps(), function (app) {
+            return _.find(self.apps(), function (app) {
                 return app.id === self.selectedAppId();
             });
-            return selected.length ? selected[0] : undefined;
         });
         return self;
     };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -1,0 +1,50 @@
+/* globals hqDefine, ko, _ */
+hqDefine("app_manager/js/forms/copy_form_to_app", function () {
+    "use strict";
+
+    var module = function (moduleId, moduleName) {
+        var self = {};
+        self.id = moduleId;
+        self.name = moduleName;
+        return self;
+    };
+
+    var application = function (appId, appName, modules) {
+        var self = {};
+        self.id = appId;
+        self.name = appName;
+        self.modules = ko.observableArray(
+            _.map(modules, function (mod) {
+                return module(mod["module_id"], mod["name"]);
+            })
+        );
+        return self;
+    }
+
+    var appsModulesModel = function (appsModules) {
+        var self = {};
+        self.apps = ko.observableArray(
+            _.map(appsModules, function (app) {
+                return application(app["app_id"], app["name"], app["modules"]);
+            })
+        );
+        self.selectedAppId = ko.observable(self.apps()[0].id);
+        self.selectedApp = ko.computed(function () {
+            var selected = _.filter(self.apps(), function (app) {
+                return app.id === self.selectedAppId();
+            });
+            return selected.length ? selected[0] : undefined;
+        });
+        return self;
+    };
+
+    $(function () {
+        var $appModuleSelection = $("#app-module-selection");
+        var viewModel = appsModulesModel(
+            hqImport("hqwebapp/js/initial_page_data").get("apps_modules"),
+        );
+        if ($appModuleSelection.length) {
+            $appModuleSelection.koApplyBindings(viewModel);
+        }
+    });
+});

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -2,22 +2,28 @@
 hqDefine("app_manager/js/forms/copy_form_to_app", function () {
     "use strict";
 
-    var module = function (moduleId, moduleName) {
+    var module = function (moduleId, moduleName, isCurrentModule) {
         var self = {};
         self.id = moduleId;
         self.name = moduleName;
+        self.isCurrent = isCurrentModule;
         return self;
     };
 
-    var application = function (appId, appName, modules) {
+    var application = function (appId, appName, isCurrentApp, modules) {
         var self = {};
         self.id = appId;
         self.name = appName;
+        self.isCurrent = isCurrentApp;
         self.modules = ko.observableArray(
             _.map(modules, function (mod) {
-                return module(mod["module_id"], mod["name"]);
+                return module(mod["module_id"], mod["name"], mod["is_current"]);
             })
         );
+        var currentModule = _.find(self.modules(), function (mod) {
+            return mod.isCurrent;
+        });
+        self.selectedModuleId = ko.observable(currentModule ? currentModule.id : undefined);
         return self;
     };
 
@@ -25,10 +31,13 @@ hqDefine("app_manager/js/forms/copy_form_to_app", function () {
         var self = {};
         self.apps = ko.observableArray(
             _.map(appsModules, function (app) {
-                return application(app["app_id"], app["name"], app["modules"]);
+                return application(app["app_id"], app["name"], app["is_current"], app["modules"]);
             })
         );
-        self.selectedAppId = ko.observable(self.apps()[0].id);
+        var currentApp = _.find(self.apps(), function (app) {
+            return app.isCurrent;
+        });
+        self.selectedAppId = ko.observable(currentApp ? currentApp.id : undefined);
         self.selectedApp = ko.computed(function () {
             return _.find(self.apps(), function (app) {
                 return app.id === self.selectedAppId();

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -41,7 +41,7 @@ hqDefine("app_manager/js/forms/copy_form_to_app", function () {
     $(function () {
         var $appModuleSelection = $("#app-module-selection");
         var viewModel = appsModulesModel(
-            hqImport("hqwebapp/js/initial_page_data").get("apps_modules"),
+            hqImport("hqwebapp/js/initial_page_data").get("apps_modules")
         );
         if ($appModuleSelection.length) {
             $appModuleSelection.koApplyBindings(viewModel);

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -77,6 +77,11 @@
         <script src="{% static 'app_manager/js/forms/custom_instances.js' %}"></script>
         {% endcompress %}
     {% endif %}
+    {% if allow_form_copy and request|toggle_enabled:"COPY_FORM_TO_APP" %}
+        {% compress js %}
+        <script src="{% static 'app_manager/js/forms/copy_form_to_app.js' %}"></script>
+        {% endcompress %}
+    {% endif %}
 {% endblock %}
 
 {% block pre_form_content %}
@@ -141,6 +146,9 @@
     {% initial_page_data 'is_allowed_to_be_release_notes_form' is_allowed_to_be_release_notes_form %}
     {% initial_page_data 'is_training_module' is_training_module %}
     {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
+    {% if allow_form_copy and request|toggle_enabled:"COPY_FORM_TO_APP" %}
+        {% initial_page_data 'apps_modules' apps_modules %}
+    {% endif %}
     {% registerurl "validate_form_for_build" domain app.id form.unique_id %}
 
     {# End of form navigation #}

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html
@@ -12,9 +12,29 @@
                     </h4>
                 </div>
                 <div class="panel-body">
+                    {% if request|toggle_enabled:"COPY_FORM_TO_APP" %}
+                    <span id="app-module-selection">
+                        <select name="to_app_id"
+                                class='form-control'
+                                style="min-width: 150px;"
+                                data-bind="options: apps,
+                                           optionsText: 'name',
+                                           optionsValue: 'id',
+                                           value: selectedAppId"></select>
+                        <!-- ko with: selectedApp -->
+                        <select name="to_module_id"
+                                class='form-control'
+                                style="min-width: 150px;"
+                                data-bind="options: modules,
+                                           optionsText: 'name',
+                                           optionsValue: 'id'"></select>
+                        <!-- /ko -->
+                    </span>
+                    {% else %}
                     <select name='to_module_id' class='form-control' style="min-width: 150px;">{% for mod in app.get_modules %}
                         <option value={{ mod.id }}>{{ mod.name|html_trans:langs }}</option>
                         {% endfor %}</select>
+                    {% endif %}
                     <button class='btn btn-default' type="submit">
                         <i class="fa fa-copy"></i>
                         {% trans "Copy" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html
@@ -27,7 +27,8 @@
                                 style="min-width: 150px;"
                                 data-bind="options: modules,
                                            optionsText: 'name',
-                                           optionsValue: 'id'"></select>
+                                           optionsValue: 'id',
+                                           value: selectedModuleId"></select>
                         <!-- /ko -->
                     </span>
                     {% else %}

--- a/corehq/apps/app_manager/tests/test_form_xmlns.py
+++ b/corehq/apps/app_manager/tests/test_form_xmlns.py
@@ -92,7 +92,7 @@ class FormXmlnsTest(SimpleTestCase, TestXmlMixin):
         old_form = self.form
         old_form.source = self.get_source()
 
-        new_form = self.app._copy_form(self.module, old_form, self.module)
+        new_form = self.app.copy_form(self.module, old_form, self.module)
 
         self.assertEqual(new_form.xmlns, XMLNS_PREFIX + new_form.unique_id)
         self.assertIn(new_form.xmlns, new_form.source)

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -255,14 +255,10 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         src_app.copy_form(src_module, original_form, dst_module, rename=True)
 
-        form_count = 0
-        for f in src_app.get_forms():
-            form_count += 1
-        self.assertEqual(form_count, 1, 'Form copied to the wrong app')
-        form_count = 0
-        for f in dst_app.get_forms():
-            form_count += 1
-        self.assertEqual(form_count, 1)
+        self.assertEqual(len(list(src_app.get_forms())), 1, 'Form copied to the wrong app')
+        dst_app_forms = list(dst_app.get_forms())
+        self.assertEqual(len(dst_app_forms), 1)
+        self.assertEqual(dst_app_forms[0].name['en'], 'Copy of Untitled Form')
 
     def test_owner_name(self):
         self._test_generic_suite('owner-name')

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -236,7 +236,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         original_form = app.new_form(module.id, "Untitled Form", None)
         original_form.source = '<source>'
 
-        app._copy_form(module, original_form, module, rename=True)
+        app.copy_form(module, original_form, module, rename=True)
 
         form_count = 0
         for f in app.get_forms():
@@ -253,7 +253,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         dst_app = Application.new_app('domain', "Destination Application")
         dst_module = dst_app.add_module(AdvancedModule.new_module('Destination Module', None))
 
-        src_app._copy_form(src_module, original_form, dst_module, dst_app, rename=True)
+        src_app.copy_form(src_module, original_form, dst_module, rename=True)
 
         form_count = 0
         for f in src_app.get_forms():

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -245,6 +245,25 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 self.assertEqual(f.name['en'], 'Copy of {}'.format(original_form.name['en']))
         self.assertEqual(form_count, 2, 'Copy form has copied multiple times!')
 
+    def test_copy_form_to_app(self):
+        src_app = Application.new_app('domain', "Source Application")
+        src_module = src_app.add_module(AdvancedModule.new_module('Source Module', None))
+        original_form = src_app.new_form(src_module.id, "Untitled Form", None)
+        original_form.source = '<source>'
+        dst_app = Application.new_app('domain', "Destination Application")
+        dst_module = dst_app.add_module(AdvancedModule.new_module('Destination Module', None))
+
+        src_app._copy_form(src_module, original_form, dst_module, dst_app, rename=True)
+
+        form_count = 0
+        for f in src_app.get_forms():
+            form_count += 1
+        self.assertEqual(form_count, 1, 'Form copied to the wrong app')
+        form_count = 0
+        for f in dst_app.get_forms():
+            form_count += 1
+        self.assertEqual(form_count, 1)
+
     def test_owner_name(self):
         self._test_generic_suite('owner-name')
 

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -59,7 +59,7 @@ class TestViews(TestCase):
     def tearDownClass(cls):
         cls.user.delete()
         cls.build.delete()
-        cls.domain.delete()
+        cls.project.delete()
         super(TestViews, cls).tearDownClass()
 
     def test_download_file_bad_xform_404(self, mock):
@@ -88,8 +88,9 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_edit_commcare_profile(self, mock):
-        app = Application.new_app(self.project.name, "TestApp")
-        app.save()
+        app2 = Application.new_app(self.project.name, "TestApp2")
+        app2.save()
+        self.addCleanup(lambda: Application.get_db().delete_doc(app2.id))
         data = {
             "custom_properties": {
                 "random": "value",
@@ -97,7 +98,7 @@ class TestViews(TestCase):
             }
         }
 
-        response = self.client.post(reverse('edit_commcare_profile', args=[self.project.name, app._id]),
+        response = self.client.post(reverse('edit_commcare_profile', args=[self.project.name, app2._id]),
                                     json.dumps(data),
                                     content_type='application/json')
 
@@ -113,7 +114,7 @@ class TestViews(TestCase):
             }
         }
 
-        response = self.client.post(reverse('edit_commcare_profile', args=[self.project.name, app._id]),
+        response = self.client.post(reverse('edit_commcare_profile', args=[self.project.name, app2._id]),
                                     json.dumps(data),
                                     content_type='application/json')
 

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -237,6 +237,7 @@ class TestViews(TestCase):
         deleted_app.add_module(Module.new_module("Module0", "en"))
         deleted_app.save()
         deleted_app.delete_app()
+        deleted_app.save()
         self.addCleanup(lambda: Application.get_db().delete_doc(deleted_app.id))
 
         apps_modules = get_apps_modules(self.domain.name)
@@ -247,6 +248,6 @@ class TestViews(TestCase):
             'Each app should only have one module'
         )
         self.assertEqual(
-            apps_modules[0]['modules']['name'], {'en': 'Module0'},
-            'Module name should be a dictionary'
+            apps_modules[0]['modules'][0]['name'], 'Module0',
+            'Module name should be translated'
         )

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -672,10 +672,7 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
     if toggles.CUSTOM_ICON_BADGES.enabled(domain):
         context['form_icon'] = form.custom_icon if form.custom_icon else CustomIcon()
 
-    if (
-            toggles.COPY_FORM_TO_APP.enabled(domain) or
-            toggles.COPY_FORM_TO_APP.enabled(request.user.username)
-    ):
+    if toggles.COPY_FORM_TO_APP.enabled_for_request(request):
         context['apps_modules'] = get_apps_modules(domain)
 
     if context['allow_form_workflow'] and toggles.FORM_LINK_WORKFLOW.enabled(domain):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -515,15 +515,18 @@ def get_apps_modules(domain):
     """
     Returns a domain's apps and their modules
     """
-    return [{
-        'app_id': app.id,
-        'name': app.name,
-        'modules': [{
-            'module_id': module.id,
-            'name': clean_trans(module.name, app.langs),
-        } for module in app.modules]
-    } for app in get_apps_in_domain(domain, include_remote=False)
-    if app.doc_type == 'Application']  # No linked apps, no deleted apps
+    return [
+        {
+            'app_id': app.id,
+            'name': app.name,
+            'modules': [{
+                'module_id': module.id,
+                'name': clean_trans(module.name, app.langs),
+            } for module in app.modules]
+        }
+        for app in get_apps_in_domain(domain, include_remote=False)
+        if app.doc_type == 'Application'  # No linked apps, no deleted apps
+    ]
 
 
 def get_form_view_context_and_template(request, domain, form, langs, messages=messages):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -513,10 +513,13 @@ def get_form_questions(request, domain, app_id):
 
 def get_apps_modules(domain, current_app_id=None, current_module_id=None):
     """
-    Returns a domain's apps and their modules.
+    Returns a domain's Applications and their modules.
 
     If current_app_id and current_module_id are given, "is_current" is
-    set to True for them.
+    set to True for them. The interface uses this to select the current
+    app and module by default.
+
+    Linked, deleted and remote apps are omitted.
     """
     return [
         {
@@ -529,8 +532,10 @@ def get_apps_modules(domain, current_app_id=None, current_module_id=None):
                 'is_current': module.unique_id == current_module_id,
             } for module in app.modules]
         }
-        for app in get_apps_in_domain(domain, include_remote=False)
-        if app.doc_type == 'Application'  # No linked apps, no deleted apps
+        for app in get_apps_in_domain(domain)
+        # No linked, deleted or remote apps. (Use app.doc_type not
+        # app.get_doc_type() so that the suffix isn't dropped.)
+        if app.doc_type == 'Application'
     ]
 
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -127,7 +127,7 @@ def copy_form(request, domain, app_id, form_unique_id):
     to_module = to_app.get_module(to_module_id)
     new_form = None
     try:
-        new_form = app.copy_form(module.id, form.id, to_module.id, to_app)
+        new_form = app.copy_form(module, form, to_module, rename=True)
         if module['case_type'] != to_module['case_type']:
             messages.warning(request, CASE_TYPE_CONFLICT_MSG, extra_tags="html")
         to_app.save()

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -511,17 +511,22 @@ def get_form_questions(request, domain, app_id):
     return json_response(xform_questions)
 
 
-def get_apps_modules(domain):
+def get_apps_modules(domain, current_app_id=None, current_module_id=None):
     """
-    Returns a domain's apps and their modules
+    Returns a domain's apps and their modules.
+
+    If current_app_id and current_module_id are given, "is_current" is
+    set to True for them.
     """
     return [
         {
             'app_id': app.id,
             'name': app.name,
+            'is_current': app.id == current_app_id,
             'modules': [{
                 'module_id': module.id,
                 'name': clean_trans(module.name, app.langs),
+                'is_current': module.unique_id == current_module_id,
             } for module in app.modules]
         }
         for app in get_apps_in_domain(domain, include_remote=False)
@@ -673,7 +678,7 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
         context['form_icon'] = form.custom_icon if form.custom_icon else CustomIcon()
 
     if toggles.COPY_FORM_TO_APP.enabled_for_request(request):
-        context['apps_modules'] = get_apps_modules(domain)
+        context['apps_modules'] = get_apps_modules(domain, app.id, module.unique_id)
 
     if context['allow_form_workflow'] and toggles.FORM_LINK_WORKFLOW.enabled(domain):
         def qualified_form_name(form, auto_link):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -469,6 +469,13 @@ CASE_DETAIL_PRINT = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+COPY_FORM_TO_APP = StaticToggle(
+    'copy_form_to_app',
+    'Allow copying a form from one app to another',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN, NAMESPACE_USER],
+)
+
 DATA_FILE_DOWNLOAD = StaticToggle(
     'data_file_download',
     'UW: Offer hosting and sharing data files for downloading, e.g. cleaned and anonymised form exports',


### PR DESCRIPTION
This was written to allow the L10K project to copy forms and their case management from a development app to a live app.

It is hidden behind a feature flag. If it's useful enough, we could consider dropping the flag.

For now I think the flag offsets the risk of preserving current functionality that allows users to copy forms from a module of one case type to a module of a different case type. (See [this mysterious docstring][1] written by @dannyroberts on 2013-12-12.) If you feel that we should change this behaviour, that seems wise, but maybe @dannyroberts can weigh in first.

  [1]: https://github.com/dimagi/commcare-hq/blob/9bf564262910a898b4afa102efa831ce0206a7fb/corehq/apps/app_manager/models.py#L6032

Labeling "Hold off" to give Cody a chance to check this on Staging.

buddy @mkangia cc @snopoke 
