### PR TITLE
Revert "Don't install dev-requirements in docker"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN git config --global url."https://".insteadOf git:// \
  && pip install --upgrade pip \
  && pip install \
     -r /vendor/requirements.txt \
+    -r /vendor/dev-requirements.txt \
     --user --upgrade \
  && rm -rf /root/.cache/pip
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#20930

I think this broke the build:
```
coverage run manage.py test --noinput --stop --verbosity=2 --divide-depth=1 --with-timing --threshold=10 
../run_tests: line 24: /vendor/bin/coverage: No such file or directory
```