### PR TITLE
Mk verify translation upload

### DIFF
--- a/corehq/apps/app_manager/app_translations/__init__.py
+++ b/corehq/apps/app_manager/app_translations/__init__.py
@@ -1,6 +1,8 @@
 from .app_translations import (
     get_unicode_dicts,
     process_bulk_app_translation_upload,
+    read_uploaded_app_translation_file,
+    validate_bulk_app_translation_upload,
     expected_bulk_app_sheet_headers,
     expected_bulk_app_sheet_rows,
     update_form_translations,

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -68,7 +68,7 @@ def read_uploaded_app_translation_file(f, msgs):
     return workbook
 
 
-def process_bulk_app_translation_upload(app, f):
+def process_bulk_app_translation_upload(app, workbook):
     """
     Process the bulk upload file for the given app.
     We return these message tuples instead of calling them now to allow this
@@ -84,10 +84,6 @@ def process_bulk_app_translation_upload(app, f):
     headers = expected_bulk_app_sheet_headers(app)
     expected_sheets = {h[0]: h[1] for h in headers}
     processed_sheets = set()
-
-    workbook = read_uploaded_app_translation_file(f, msgs)
-    if not workbook:
-        return msgs
 
     for sheet in workbook.worksheets:
         # sheet.__iter__ can only be called once, so cache the result
@@ -190,12 +186,8 @@ def process_bulk_app_translation_upload(app, f):
     return msgs
 
 
-def validate_bulk_app_translation_upload(app, f):
+def validate_bulk_app_translation_upload(app, workbook):
     from corehq.apps.app_manager.app_translations.validator import UploadedTranslationsValidator
-    msgs = []
-    workbook = read_uploaded_app_translation_file(f, msgs)
-    if not workbook:
-        return msgs
     msgs = UploadedTranslationsValidator(app, workbook).compare()
     if msgs:
         return [

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -190,6 +190,25 @@ def process_bulk_app_translation_upload(app, f):
     return msgs
 
 
+def validate_bulk_app_translation_upload(app, f):
+    from corehq.apps.app_manager.app_translations.validator import UploadedTranslationsValidator
+    msgs = []
+    workbook = read_uploaded_app_translation_file(f, msgs)
+    if not workbook:
+        return msgs
+    msgs = UploadedTranslationsValidator(app, workbook).compare()
+    if msgs:
+        return [
+            (messages.error,
+             "{}: {}".format(sheet_name, ' '.join(msgs[sheet_name]))
+             )
+            for sheet_name in msgs
+            if msgs[sheet_name]
+        ]
+    else:
+        return [(messages.success, "Uploaded file looks good to process.")]
+
+
 def _make_modules_and_forms_row(row_type, sheet_name, languages,
                                 media_image, media_audio, unique_id):
     """

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -203,7 +203,7 @@ def validate_bulk_app_translation_upload(app, workbook, email):
 @task(queue="email_queue")
 def _email_app_translations_discrepancies(msgs, email, app_name):
     message = '\n\n'.join([
-        """Sheet {}: 
+        """Sheet {}:
            {}""".format(sheet_name, '\n '.join(msgs[sheet_name]))
         for sheet_name in msgs
         if msgs.get(sheet_name)])
@@ -211,7 +211,7 @@ def _email_app_translations_discrepancies(msgs, email, app_name):
     subject = "App Translations Discrepancies for {}".format(app_name)
     body = """Hi,
     Following discrepancies were found for app translations.
-    
+
     {}""".format(message)
 
     send_html_email_async.delay(subject, email, linebreaksbr(body))

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -189,20 +189,12 @@ def process_bulk_app_translation_upload(app, workbook):
     return msgs
 
 
-def validate_bulk_app_translation_upload(app, workbook, send_email, email):
+def validate_bulk_app_translation_upload(app, workbook, email):
     from corehq.apps.app_manager.app_translations.validator import UploadedTranslationsValidator
     msgs = UploadedTranslationsValidator(app, workbook).compare()
     if msgs:
-        if send_email:
-            _email_app_translations_discrepancies(msgs, email, app.name)
-            return [(messages.error, _("Issues found. You should receive an email shortly."))]
-        else:
-            message = ["Sheet {}: {}".format(sheet_name, ' '.join(msgs[sheet_name]))
-                       for sheet_name in msgs
-                       if msgs.get(sheet_name)]
-            return [
-                (messages.error, ' '.join(message))
-            ]
+        _email_app_translations_discrepancies(msgs, email, app.name)
+        return [(messages.error, _("Issues found. You should receive an email shortly."))]
     else:
         return [(messages.success, "No issues found.")]
 

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -52,7 +52,8 @@ def get_unicode_dicts(iterable):
     return rows
 
 
-def read_uploaded_app_translation_file(f, msgs):
+def read_uploaded_app_translation_file(f):
+    msgs = []
     try:
         workbook = WorkbookJSONReader(f)
     # todo: HeaderValueError does not belong here
@@ -68,7 +69,7 @@ def read_uploaded_app_translation_file(f, msgs):
             ).format(e))
         )
         return False
-    return workbook
+    return workbook, msgs
 
 
 def process_bulk_app_translation_upload(app, workbook):

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -52,12 +52,10 @@ class UploadedTranslationsValidator(object):
         number_of_expected_rows = len(expected_rows)
         if number_of_uploaded_rows < number_of_expected_rows:
             msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("less"))
-            iterate_on = [uploaded_rows, expected_rows]
         elif number_of_uploaded_rows > number_of_expected_rows:
             msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("more"))
-            iterate_on = [expected_rows, uploaded_rows]
-        else:
-            iterate_on = [expected_rows, uploaded_rows]
+
+        iterate_on = [expected_rows, uploaded_rows]
         for i, (expected_row, uploaded_row) in enumerate(zip(*iterate_on)):
             for column_name in columns_to_compare:
                 uploaded_value = uploaded_row.get(column_name)

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -4,7 +4,8 @@ from memoized import memoized
 from corehq.apps.app_manager.app_translations import (
     expected_bulk_app_sheet_headers,
     expected_bulk_app_sheet_rows,
-    get_unicode_dicts)
+    get_unicode_dicts,
+)
 from corehq.apps.app_manager.app_translations.const import MODULES_AND_FORMS_SHEET_NAME
 
 COLUMNS_TO_COMPARE = {
@@ -25,8 +26,7 @@ class UploadedTranslationsValidator(object):
         self.headers = None
         self.expected_rows = None
         self.lang_prefix = lang_prefix
-        self.default_language = self.app.default_language
-        self.default_language_column = self.lang_prefix + self.default_language
+        self.default_language_column = self.lang_prefix + self.app.default_language
 
     def _generate_expected_headers_and_rows(self):
         self.headers = {h[0]: h[1] for h in expected_bulk_app_sheet_headers(self.app)}
@@ -66,16 +66,16 @@ class UploadedTranslationsValidator(object):
                     ))
         return msg
 
-    def _compare_module_and_form_sheet(self, sheet_name, uploaded_rows, expected_rows):
-        return self._compare_sheet(sheet_name, uploaded_rows, expected_rows,
+    def _compare_module_and_form_sheet(self, sheet_name, uploaded_rows):
+        return self._compare_sheet(sheet_name, uploaded_rows, self.expected_rows[sheet_name],
                                    COLUMNS_TO_COMPARE['module_and_form'] + [self.default_language_column])
 
-    def _compare_module_sheet(self, sheet_name, uploaded_rows, expected_rows):
-        return self._compare_sheet(sheet_name, uploaded_rows, expected_rows,
+    def _compare_module_sheet(self, sheet_name, uploaded_rows):
+        return self._compare_sheet(sheet_name, uploaded_rows, self.expected_rows[sheet_name],
                                    COLUMNS_TO_COMPARE['module'] + [self.default_language_column])
 
-    def _compare_form_sheet(self, sheet_name, uploaded_rows, expected_rows):
-        return self._compare_sheet(sheet_name, uploaded_rows, expected_rows,
+    def _compare_form_sheet(self, sheet_name, uploaded_rows):
+        return self._compare_sheet(sheet_name, uploaded_rows, self.expected_rows[sheet_name],
                                    COLUMNS_TO_COMPARE['form'] + [self.default_language_column])
 
     def compare(self):
@@ -85,12 +85,11 @@ class UploadedTranslationsValidator(object):
             rows = get_unicode_dicts(sheet)
             sheet_name = sheet.worksheet.title
             if sheet_name == MODULES_AND_FORMS_SHEET_NAME:
-                error_msgs = self._compare_module_and_form_sheet(sheet_name, rows,
-                                                                 self.expected_rows[sheet_name])
+                error_msgs = self._compare_module_and_form_sheet(sheet_name, rows)
             elif 'module' in sheet_name and 'form' not in sheet_name:
-                error_msgs = self._compare_module_sheet(sheet_name, rows, self.expected_rows[sheet_name])
+                error_msgs = self._compare_module_sheet(sheet_name, rows)
             elif 'module' in sheet_name and 'form' in sheet_name:
-                error_msgs = self._compare_form_sheet(sheet_name, rows, self.expected_rows[sheet_name])
+                error_msgs = self._compare_form_sheet(sheet_name, rows)
             else:
                 raise Exception("Got unexpected sheet name %s" % sheet_name)
             if error_msgs:

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -45,7 +45,7 @@ class UploadedTranslationsValidator(object):
         :param for_type: type of sheet, module_and_forms, module, form
         :return: list of errors messages if any
         """
-        columns_to_compare = COLUMNS_TO_COMPARE[for_type] + self.default_language_column
+        columns_to_compare = COLUMNS_TO_COMPARE[for_type] + [self.default_language_column]
         expected_rows = self.expected_rows[sheet_name]
         msg = []
         number_of_uploaded_rows = len(uploaded_rows)

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -47,25 +47,26 @@ class UploadedTranslationsValidator(object):
         """
         columns_to_compare = COLUMNS_TO_COMPARE[for_type] + [self.default_language_column]
         expected_rows = self.expected_rows[sheet_name]
-        msg = []
+        msgs = []
         number_of_uploaded_rows = len(uploaded_rows)
         number_of_expected_rows = len(expected_rows)
         if number_of_uploaded_rows < number_of_expected_rows:
-            msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("less"))
+            msgs.append(ROW_COUNT_MISMATCH_MESSAGE.format("less"))
         elif number_of_uploaded_rows > number_of_expected_rows:
-            msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("more"))
+            msgs.append(ROW_COUNT_MISMATCH_MESSAGE.format("more"))
 
         iterate_on = [expected_rows, uploaded_rows]
-        for i, (expected_row, uploaded_row) in enumerate(zip(*iterate_on)):
+        # 2 to account for the sheet header as well
+        for i, (expected_row, uploaded_row) in enumerate(zip(*iterate_on), 2):
             for column_name in columns_to_compare:
                 uploaded_value = uploaded_row.get(column_name)
                 expected_value = expected_row[self._get_header_index(sheet_name, column_name)]
                 if expected_value != uploaded_value:
-                    # i + 2 to account for the sheet header as well
-                    msg.append("For {}:{}  uploaded '{}' but expected '{}'.".format(
+
+                    msgs.append("For {}:{}  uploaded '{}' but expected '{}'.".format(
                         i + 2, column_name, uploaded_value, expected_value
                     ))
-        return msg
+        return msgs
 
     def compare(self):
         msgs = {}

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -13,7 +13,7 @@ COLUMNS_TO_COMPARE = {
     'module': ['case_property', 'list_or_detail'],
     'form': ['label'],
 }
-ROW_COUNT_MISMATCH_MESSAGE = "We found {} rows than expected. Confirming what was uploaded."
+ROW_COUNT_MISMATCH_MESSAGE = "We found {} rows than expected. Validating what was uploaded."
 
 
 class UploadedTranslationsValidator(object):
@@ -63,8 +63,9 @@ class UploadedTranslationsValidator(object):
                 uploaded_value = uploaded_row.get(column_name)
                 expected_value = expected_row[self._get_header_index(sheet_name, column_name)]
                 if expected_value != uploaded_value:
-                    msg.append("Discrepancy found at row {}, uploaded '{}' but expected '{}' for {}.".format(
-                        i + 1, uploaded_value, expected_value, column_name
+                    # i + 2 to account for the sheet header as well
+                    msg.append("For {}:{}  uploaded '{}' but expected '{}'.".format(
+                        i + 2, column_name, uploaded_value, expected_value
                     ))
         return msg
 

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import
+
+from memoized import memoized
+from corehq.apps.app_manager.app_translations import (
+    expected_bulk_app_sheet_headers,
+    expected_bulk_app_sheet_rows,
+    get_unicode_dicts)
+from corehq.apps.app_manager.app_translations.const import MODULES_AND_FORMS_SHEET_NAME
+
+
+class UploadedTranslationsValidator(object):
+    """
+    this compares the excel sheet uploaded with translations with what would be generated
+    with current app state and flags any discrepancies found between the two
+    """
+    def __init__(self, app, uploaded_workbook, lang_prefix='default_'):
+        self.app = app
+        self.uploaded_workbook = uploaded_workbook
+        self.headers = None
+        self.expected_rows = None
+        self.lang_prefix = lang_prefix
+        self.default_language = self.app.default_language
+
+    def _generate_expected_headers_and_rows(self):
+        self.headers = {h[0]: h[1] for h in expected_bulk_app_sheet_headers(self.app)}
+        self.expected_rows = expected_bulk_app_sheet_rows(self.app)
+
+    @memoized
+    def get_header_index(self, sheet_name, header):
+        for index, _column_name in enumerate(self.headers[sheet_name]):
+            if _column_name == header:
+                return index
+
+    def _compare_sheet(self, sheet_name, uploaded_rows, expected_rows, columns_to_compare):
+        """
+        :param uploaded_rows: dict
+        :param expected_rows: row
+        :param columns_to_compare: columns to compare
+        :return:
+        """
+        msg = []
+        number_of_uploaded_rows = len(uploaded_rows)
+        number_of_expected_rows = len(expected_rows)
+        if number_of_uploaded_rows < number_of_expected_rows:
+            msg.append("We found less rows than expected. Confirming what was uploaded.")
+            iterate_on = zip(uploaded_rows, expected_rows)
+        elif number_of_uploaded_rows > number_of_expected_rows:
+            msg.append("We found more rows than expected. Confirming what was uploaded.")
+            iterate_on = zip(expected_rows, uploaded_rows)
+        else:
+            iterate_on = zip(expected_rows, uploaded_rows)
+        for i, (expected_row, uploaded_row) in enumerate(iterate_on):
+            for column_name in columns_to_compare:
+                uploaded_value = uploaded_row.get(column_name)
+                expected_value = expected_row[self.get_header_index(sheet_name, column_name)]
+                if expected_value != uploaded_value:
+                    msg.append("Discrepancy found at row {}, uploaded '{}' but expected '{}' for {}.".format(
+                        i + 1, uploaded_value, expected_value, column_name
+                    ))
+        return msg
+
+    def _compare_module_and_form_sheet(self, sheet_name, uploaded_rows, expected_rows):
+        columns_to_compare = ['Type', 'sheet_name', self.lang_prefix + self.default_language]
+        return self._compare_sheet(sheet_name, uploaded_rows, expected_rows, columns_to_compare)
+
+    def _compare_module_sheet(self, sheet_name, uploaded_rows, expected_rows):
+        columns_to_compare = ['case_property', 'list_or_detail', self.lang_prefix + self.default_language]
+        return self._compare_sheet(sheet_name, uploaded_rows, expected_rows, columns_to_compare)
+
+    def _compare_form_sheet(self, sheet_name, uploaded_rows, expected_rows):
+        columns_to_compare = ['label', self.lang_prefix + self.default_language]
+        return self._compare_sheet(sheet_name, uploaded_rows, expected_rows, columns_to_compare)
+
+    def compare(self):
+        msgs = {}
+        self._generate_expected_headers_and_rows()
+        for sheet in self.uploaded_workbook.worksheets:
+            rows = get_unicode_dicts(sheet)
+            sheet_name = sheet.worksheet.title
+            if sheet_name == MODULES_AND_FORMS_SHEET_NAME:
+                error_msgs = self._compare_module_and_form_sheet(sheet_name, rows,
+                                                                 self.expected_rows[sheet_name])
+            elif 'module' in sheet_name and 'form' not in sheet_name:
+                error_msgs = self._compare_module_sheet(sheet_name, rows,
+                                                        self.expected_rows[sheet_name])
+            elif 'module' in sheet_name and 'form' in sheet_name:
+                error_msgs = self._compare_form_sheet(sheet_name, rows,
+                                                      self.expected_rows[sheet_name])
+            else:
+                raise Exception("Got unexpected sheet name %s" % sheet_name)
+            if error_msgs:
+                msgs[sheet_name] = error_msgs
+        return msgs

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -7,7 +7,7 @@ from corehq.apps.app_manager.app_translations import (
     get_unicode_dicts,
 )
 from corehq.apps.app_manager.app_translations.const import MODULES_AND_FORMS_SHEET_NAME
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 COLUMNS_TO_COMPARE = {

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -7,13 +7,16 @@ from corehq.apps.app_manager.app_translations import (
     get_unicode_dicts,
 )
 from corehq.apps.app_manager.app_translations.const import MODULES_AND_FORMS_SHEET_NAME
+from django.utils.translation import ugettext as _
+
 
 COLUMNS_TO_COMPARE = {
     'module_and_form': ['Type', 'sheet_name'],
     'module': ['case_property', 'list_or_detail'],
     'form': ['label'],
 }
-ROW_COUNT_MISMATCH_MESSAGE = "We found {} rows than expected. Validating what was uploaded."
+LESS_ROW_COUNT_MISMATCH_MESSAGE = _("We found less rows than expected. Validating what was uploaded.")
+MORE_ROW_COUNT_MISMATCH_MESSAGE = _("We found more rows than expected. Validating what was uploaded.")
 
 
 class UploadedTranslationsValidator(object):
@@ -51,9 +54,9 @@ class UploadedTranslationsValidator(object):
         number_of_uploaded_rows = len(uploaded_rows)
         number_of_expected_rows = len(expected_rows)
         if number_of_uploaded_rows < number_of_expected_rows:
-            msgs.append(ROW_COUNT_MISMATCH_MESSAGE.format("less"))
+            msgs.append(LESS_ROW_COUNT_MISMATCH_MESSAGE)
         elif number_of_uploaded_rows > number_of_expected_rows:
-            msgs.append(ROW_COUNT_MISMATCH_MESSAGE.format("more"))
+            msgs.append(MORE_ROW_COUNT_MISMATCH_MESSAGE)
 
         iterate_on = [expected_rows, uploaded_rows]
         # 2 to account for the sheet header as well

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -52,13 +52,13 @@ class UploadedTranslationsValidator(object):
         number_of_expected_rows = len(expected_rows)
         if number_of_uploaded_rows < number_of_expected_rows:
             msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("less"))
-            iterate_on = zip(uploaded_rows, expected_rows)
+            iterate_on = [uploaded_rows, expected_rows]
         elif number_of_uploaded_rows > number_of_expected_rows:
             msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("more"))
-            iterate_on = zip(expected_rows, uploaded_rows)
+            iterate_on = [expected_rows, uploaded_rows]
         else:
-            iterate_on = zip(expected_rows, uploaded_rows)
-        for i, (expected_row, uploaded_row) in enumerate(iterate_on):
+            iterate_on = [expected_rows, uploaded_rows]
+        for i, (expected_row, uploaded_row) in enumerate(zip(*iterate_on)):
             for column_name in columns_to_compare:
                 uploaded_value = uploaded_row.get(column_name)
                 expected_value = expected_row[self._get_header_index(sheet_name, column_name)]

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -13,6 +13,7 @@ COLUMNS_TO_COMPARE = {
     'module': ['case_property', 'list_or_detail'],
     'form': ['label'],
 }
+ROW_COUNT_MISMATCH_MESSAGE = "We found {} rows than expected. Confirming what was uploaded."
 
 
 class UploadedTranslationsValidator(object):
@@ -50,10 +51,10 @@ class UploadedTranslationsValidator(object):
         number_of_uploaded_rows = len(uploaded_rows)
         number_of_expected_rows = len(expected_rows)
         if number_of_uploaded_rows < number_of_expected_rows:
-            msg.append("We found less rows than expected. Confirming what was uploaded.")
+            msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("less"))
             iterate_on = zip(uploaded_rows, expected_rows)
         elif number_of_uploaded_rows > number_of_expected_rows:
-            msg.append("We found more rows than expected. Confirming what was uploaded.")
+            msg.append(ROW_COUNT_MISMATCH_MESSAGE.format("more"))
             iterate_on = zip(expected_rows, uploaded_rows)
         else:
             iterate_on = zip(expected_rows, uploaded_rows)

--- a/corehq/apps/app_manager/app_translations/validator.py
+++ b/corehq/apps/app_manager/app_translations/validator.py
@@ -44,8 +44,7 @@ class UploadedTranslationsValidator(object):
         :param for_type: type of sheet, module_and_forms, module, form
         :return: list of errors messages if any
         """
-        columns_to_compare = COLUMNS_TO_COMPARE[for_type]
-        columns_to_compare.append(self.default_language_column)
+        columns_to_compare = COLUMNS_TO_COMPARE[for_type] + self.default_language_column
         expected_rows = self.expected_rows[sheet_name]
         msg = []
         number_of_uploaded_rows = len(uploaded_rows)

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -21,7 +21,9 @@ from corehq.apps.app_manager.app_translations import (
     expected_bulk_app_sheet_rows,
     expected_bulk_app_sheet_headers,
     update_form_translations,
-    get_unicode_dicts)
+    get_unicode_dicts,
+    read_uploaded_app_translation_file,
+)
 from six.moves import zip
 
 
@@ -59,7 +61,10 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
 
         with tempfile.TemporaryFile(suffix='.xlsx') as f:
             f.write(file.getvalue())
-            messages = process_bulk_app_translation_upload(self.app, f)
+            messages = []
+            workbook = read_uploaded_app_translation_file(f, messages)
+            assert workbook, messages
+            messages = process_bulk_app_translation_upload(self.app, workbook)
 
         self.assertListEqual(
             [m[1] for m in messages], expected_messages
@@ -77,7 +82,10 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
             expected_messages = ["App Translations Updated!"]
 
         with codecs.open(self.get_path(name, "xlsx")) as f:
-            messages = process_bulk_app_translation_upload(self.app, f)
+            messages = []
+            workbook = read_uploaded_app_translation_file(f, messages)
+            assert workbook, messages
+            messages = process_bulk_app_translation_upload(self.app, workbook)
 
         self.assertListEqual(
             [m[1] for m in messages], expected_messages

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -61,8 +61,7 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
 
         with tempfile.TemporaryFile(suffix='.xlsx') as f:
             f.write(file.getvalue())
-            messages = []
-            workbook = read_uploaded_app_translation_file(f, messages)
+            workbook, messages = read_uploaded_app_translation_file(f)
             assert workbook, messages
             messages = process_bulk_app_translation_upload(self.app, workbook)
 
@@ -82,8 +81,7 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
             expected_messages = ["App Translations Updated!"]
 
         with codecs.open(self.get_path(name, "xlsx")) as f:
-            messages = []
-            workbook = read_uploaded_app_translation_file(f, messages)
+            workbook, messages = read_uploaded_app_translation_file(f)
             assert workbook, messages
             messages = process_bulk_app_translation_upload(self.app, workbook)
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -243,7 +243,7 @@ def get_app_view_context(request, app):
                                     args=(app.domain, app.get_id)),
             'adjective': _("app translation"),
             'plural_noun': _("app translations"),
-            'can_verify_app_translations': toggles.VERIFY_APP_TRANSLATIONS.enabled_for_request(request)
+            'can_validate_app_translations': toggles.VALIDATE_APP_TRANSLATIONS.enabled_for_request(request)
         },
     })
     context.update({

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -64,6 +64,7 @@ from corehq.apps.domain.decorators import (
     login_or_digest,
     api_key_auth)
 from corehq.apps.domain.models import Domain
+from corehq.apps.hqwebapp.forms import AppTranslationsBulkUploadForm
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.linked_domain.applications import create_linked_app
@@ -252,7 +253,8 @@ def get_app_view_context(request, app):
         ),
         'bulk_app_translation_form': get_bulk_upload_form(
             context,
-            context_key="bulk_app_translation_upload"
+            context_key="bulk_app_translation_upload",
+            form_class=AppTranslationsBulkUploadForm,
         )
     })
     context.update({

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -242,6 +242,7 @@ def get_app_view_context(request, app):
                                     args=(app.domain, app.get_id)),
             'adjective': _("app translation"),
             'plural_noun': _("app translations"),
+            'verify_app_translations': toggles.VERIFY_APP_TRANSLATIONS.enabled_for_request(request)
         },
     })
     context.update({

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -242,7 +242,7 @@ def get_app_view_context(request, app):
                                     args=(app.domain, app.get_id)),
             'adjective': _("app translation"),
             'plural_noun': _("app translations"),
-            'verify_app_translations': toggles.VERIFY_APP_TRANSLATIONS.enabled_for_request(request)
+            'can_verify_app_translations': toggles.VERIFY_APP_TRANSLATIONS.enabled_for_request(request)
         },
     })
     context.update({

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -103,12 +103,12 @@ def download_bulk_app_translations(request, domain, app_id):
 @require_can_edit_apps
 @get_file("bulk_upload_file")
 def upload_bulk_app_translations(request, domain, app_id):
-    verify = request.POST.get('verify')
+    validate = request.POST.get('validate')
     app = get_app(domain, app_id)
     msgs = []
     workbook = read_uploaded_app_translation_file(request.file, msgs)
     if workbook:
-        if verify:
+        if validate:
             msgs = validate_bulk_app_translation_upload(app, workbook)
         else:
             msgs = process_bulk_app_translation_upload(app, workbook)

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 
-from corehq import toggles
 from corehq.apps.app_manager.const import APP_TRANSLATION_UPLOAD_FAIL_MESSAGE
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
@@ -28,6 +27,7 @@ from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from dimagi.utils.decorators.view import get_file
 from dimagi.utils.logging import notify_exception
+from dimagi.utils.parsing import string_to_boolean
 import six
 
 
@@ -103,7 +103,7 @@ def download_bulk_app_translations(request, domain, app_id):
 @require_can_edit_apps
 @get_file("bulk_upload_file")
 def upload_bulk_app_translations(request, domain, app_id):
-    validate = request.POST.get('validate')
+    validate = string_to_boolean(request.POST.get('validate'))
     app = get_app(domain, app_id)
     msgs = []
     workbook = read_uploaded_app_translation_file(request.file, msgs)

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -105,8 +105,7 @@ def download_bulk_app_translations(request, domain, app_id):
 def upload_bulk_app_translations(request, domain, app_id):
     validate = string_to_boolean(request.POST.get('validate'))
     app = get_app(domain, app_id)
-    msgs = []
-    workbook = read_uploaded_app_translation_file(request.file, msgs)
+    workbook, msgs = read_uploaded_app_translation_file(request.file)
     if workbook:
         if validate:
             msgs = validate_bulk_app_translation_upload(app, workbook, request.user.email)

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -109,8 +109,7 @@ def upload_bulk_app_translations(request, domain, app_id):
     workbook = read_uploaded_app_translation_file(request.file, msgs)
     if workbook:
         if validate:
-            msgs = validate_bulk_app_translation_upload(app, workbook, request.POST.get('send_email'),
-                                                        request.user.email)
+            msgs = validate_bulk_app_translation_upload(app, workbook, request.user.email)
         else:
             msgs = process_bulk_app_translation_upload(app, workbook)
             app.save()

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -109,7 +109,8 @@ def upload_bulk_app_translations(request, domain, app_id):
     workbook = read_uploaded_app_translation_file(request.file, msgs)
     if workbook:
         if validate:
-            msgs = validate_bulk_app_translation_upload(app, workbook)
+            msgs = validate_bulk_app_translation_upload(app, workbook, request.POST.get('send_email'),
+                                                        request.user.email)
         else:
             msgs = process_bulk_app_translation_upload(app, workbook)
             app.save()

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -27,7 +27,6 @@ from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from dimagi.utils.decorators.view import get_file
 from dimagi.utils.logging import notify_exception
-from dimagi.utils.parsing import string_to_boolean
 import six
 
 
@@ -103,7 +102,7 @@ def download_bulk_app_translations(request, domain, app_id):
 @require_can_edit_apps
 @get_file("bulk_upload_file")
 def upload_bulk_app_translations(request, domain, app_id):
-    validate = string_to_boolean(request.POST.get('validate'))
+    validate = request.POST.get('validate')
     app = get_app(domain, app_id)
     workbook, msgs = read_uploaded_app_translation_file(request.file)
     if workbook:

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -96,12 +96,12 @@ class BulkUploadForm(forms.Form):
     def crispy_form_fields(self, context):
         return [
             crispy.Field(
-                'action',
-            ),
-            crispy.Field(
                 'bulk_upload_file',
                 data_bind="value: file",
-            )
+            ),
+            crispy.Field(
+                'action',
+            ),
         ]
 
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -80,23 +80,24 @@ class BulkUploadForm(forms.Form):
         self.helper.form_method = 'post'
         if action:
             self.helper.form_action = action
-        fields = [
-            "",
+        fields = []
+        if (context_key == "bulk_app_translation_upload" and
+                context['bulk_app_translation_upload']['can_verify_app_translations']):
+            fields.append(crispy.Field(
+                'verify',
+            ))
+        fields.extend([
+            crispy.Field(
+                'action',
+            ),
             crispy.Field(
                 'bulk_upload_file',
                 data_bind="value: file",
             )
-        ]
-        if (context_key == "bulk_app_translation_upload" and
-                context['bulk_app_translation_upload']['verify_app_translations']):
-            fields.append(crispy.Field(
-                'verify',
-            ))
-        fields.append(crispy.Field(
-            'action',
-        ))
+        ])
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
+                "",
                 *fields
             ),
             StrictButton(

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -15,7 +15,7 @@ from corehq.apps.domain.forms import NoAutocompleteMixin
 from corehq.apps.users.models import CouchUser
 
 from crispy_forms import layout as crispy
-from crispy_forms.bootstrap import StrictButton
+from crispy_forms.bootstrap import StrictButton, InlineField
 from crispy_forms.helper import FormHelper
 
 from memoized import memoized
@@ -108,11 +108,16 @@ class BulkUploadForm(forms.Form):
 class AppTranslationsBulkUploadForm(BulkUploadForm):
     validate = forms.BooleanField(label="Just validate and not update translations", required=False,
                                   initial=False)
+    send_email = forms.BooleanField(label="Share issues found via email", required=False,
+                                    initial=False)
 
     def crispy_form_fields(self, context):
         crispy_form_fields = super(AppTranslationsBulkUploadForm, self).crispy_form_fields(context)
         if context.get('can_validate_app_translations'):
-            crispy_form_fields.append(crispy.Field('validate'))
+            crispy_form_fields.extend([
+                InlineField('validate'),
+                InlineField('send_email')
+            ])
         return crispy_form_fields
 
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -106,13 +106,13 @@ class BulkUploadForm(forms.Form):
 
 
 class AppTranslationsBulkUploadForm(BulkUploadForm):
-    verify = forms.BooleanField(label="Just validate and not update translations", required=False,
-                                initial=False)
+    validate = forms.BooleanField(label="Just validate and not update translations", required=False,
+                                  initial=False)
 
     def crispy_form_fields(self, context):
         crispy_form_fields = super(AppTranslationsBulkUploadForm, self).crispy_form_fields(context)
-        if context.get('can_verify_app_translations'):
-            crispy_form_fields.append(crispy.Field('verify'))
+        if context.get('can_validate_app_translations'):
+            crispy_form_fields.append(crispy.Field('validate'))
         return crispy_form_fields
 
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -108,15 +108,12 @@ class BulkUploadForm(forms.Form):
 class AppTranslationsBulkUploadForm(BulkUploadForm):
     validate = forms.BooleanField(label="Just validate and not update translations", required=False,
                                   initial=False)
-    send_email = forms.BooleanField(label="Share issues found via email", required=False,
-                                    initial=False)
 
     def crispy_form_fields(self, context):
         crispy_form_fields = super(AppTranslationsBulkUploadForm, self).crispy_form_fields(context)
         if context.get('can_validate_app_translations'):
             crispy_form_fields.extend([
-                InlineField('validate'),
-                InlineField('send_email')
+                InlineField('validate')
             ])
         return crispy_form_fields
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -69,7 +69,8 @@ class CloudCareAuthenticationForm(EmailAuthenticationForm):
 
 class BulkUploadForm(forms.Form):
     bulk_upload_file = forms.FileField(label="")
-    verify = forms.BooleanField(label="Verify Upload", required=False, initial=False)
+    verify = forms.BooleanField(label="Just validate and not update translations", required=False,
+                                initial=False)
     action = forms.CharField(widget=forms.HiddenInput(), initial='bulk_upload')
 
     def __init__(self, plural_noun, action, context_key, context, *args, **kwargs):

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -69,25 +69,35 @@ class CloudCareAuthenticationForm(EmailAuthenticationForm):
 
 class BulkUploadForm(forms.Form):
     bulk_upload_file = forms.FileField(label="")
+    verify = forms.BooleanField(label="Verify Upload", required=False, initial=False)
     action = forms.CharField(widget=forms.HiddenInput(), initial='bulk_upload')
 
-    def __init__(self, plural_noun, action, form_id, *args, **kwargs):
+    def __init__(self, plural_noun, action, context_key, context, *args, **kwargs):
         super(BulkUploadForm, self).__init__(*args, **kwargs)
+        form_id = context_key + "_form"
         self.helper = FormHelper()
         self.helper.form_id = form_id
         self.helper.form_method = 'post'
         if action:
             self.helper.form_action = action
+        fields = [
+            "",
+            crispy.Field(
+                'bulk_upload_file',
+                data_bind="value: file",
+            )
+        ]
+        if (context_key == "bulk_app_translation_upload" and
+                context['bulk_app_translation_upload']['verify_app_translations']):
+            fields.append(crispy.Field(
+                'verify',
+            ))
+        fields.append(crispy.Field(
+            'action',
+        ))
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
-                "",
-                crispy.Field(
-                    'bulk_upload_file',
-                    data_bind="value: file",
-                ),
-                crispy.Field(
-                    'action',
-                ),
+                *fields
             ),
             StrictButton(
                 ('<i class="fa fa-cloud-upload"></i> Upload %s'

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -54,12 +54,12 @@ def send_confirmation_email(invitation):
                                 text_content=text_content)
 
 
-def get_bulk_upload_form(context, context_key="bulk_upload"):
-    return BulkUploadForm(
+def get_bulk_upload_form(context, context_key="bulk_upload", form_class=BulkUploadForm):
+    return form_class(
         context[context_key]['plural_noun'],
         context[context_key].get('action'),
-        context_key,
-        context
+        context_key + "_form",
+        context.get(context_key)
     )
 
 

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -58,7 +58,8 @@ def get_bulk_upload_form(context, context_key="bulk_upload"):
     return BulkUploadForm(
         context[context_key]['plural_noun'],
         context[context_key].get('action'),
-        context_key + "_form"
+        context_key,
+        context
     )
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1576,3 +1576,10 @@ APP_TRANSLATIONS_WITH_TRANSIFEX = StaticToggle(
     namespaces=[NAMESPACE_USER]
 )
 
+
+VERIFY_APP_TRANSLATIONS = StaticToggle(
+    'verify_app_translations',
+    'Verify app translations before uploading them',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_USER]
+)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1577,9 +1577,9 @@ APP_TRANSLATIONS_WITH_TRANSIFEX = StaticToggle(
 )
 
 
-VERIFY_APP_TRANSLATIONS = StaticToggle(
-    'verify_app_translations',
-    'Verify app translations before uploading them',
+VALIDATE_APP_TRANSLATIONS = StaticToggle(
+    'validate_app_translations',
+    'Validate app translations before uploading them',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_USER]
 )


### PR DESCRIPTION
[Trello Card](https://trello.com/c/jrXUocJu/218-work-on-ways-to-automate-the-currently-manual-processes-involved-with-excel-checking-an-upload-that-still-remain-post-transifex)

This adds the ability for a user to validate app translations before updating the app. Currently behind a FF.

Adds a checkbox for user to just validate translations and share issues if found over email.

<img width="514" alt="screen shot 2018-06-25 at 12 22 12 am" src="https://user-images.githubusercontent.com/3864163/41822488-fd30461c-780d-11e8-9442-bcb3c64f1ba5.png">


Issues found are shared over email which would look like this

<img width="595" alt="screen shot 2018-06-18 at 5 08 33 pm" src="https://user-images.githubusercontent.com/3864163/41534043-b2770cf2-731a-11e8-9ebf-0bec6559f057.png">

For review,
can look at first 2 commits for the major changes, after that it has been a series of improvements so can review all at once.