### PR TITLE
ICDS - show 'Not Applicable' for location above AWC in number of days open indicator - System Usage export

### DIFF
--- a/custom/icds_reports/sqldata/exports/system_usage.py
+++ b/custom/icds_reports/sqldata/exports/system_usage.py
@@ -33,8 +33,8 @@ class SystemUsageExport(ExportableMixin, SqlData):
         agg_columns = [
             DatabaseColumn(
                 'Number of days AWC was open in the given month',
-                SumColumn('awc_num_open'),
-                format_fn=lambda x: (x or 0),
+                SumColumn('awc_days_open'),
+                format_fn=lambda x: (x or 0) if self.loc_level > 4 else "Not Applicable",
                 slug='num_awc_open'
             ),
             DatabaseColumn(

--- a/custom/icds_reports/tests/test_export_data.py
+++ b/custom/icds_reports/tests/test_export_data.py
@@ -1144,12 +1144,6 @@ class TestExportData(TestCase):
         )
 
     def test_system_usage_export(self):
-        print (SystemUsageExport(
-                config={
-                    'domain': 'icds-cas',
-                    'month': datetime(2017, 5, 1)
-                }
-            ).get_excel_data('b1'))
         self.assertListEqual(
             SystemUsageExport(
                 config={
@@ -1160,7 +1154,7 @@ class TestExportData(TestCase):
             [
                 ['System Usage', [
                     [
-                        'State', 
+                        'State',
                         'Number of days AWC was open in the given month',
                         'Number of launched AWCs (ever submitted at least one HH reg form)',
                         'Number of household registration forms', 'Number of add pregnancy forms',
@@ -1181,7 +1175,7 @@ class TestExportData(TestCase):
                     ['st2', 'Not Applicable', 11, 0, 4, 4, 1, 1, 4, 4, 20, 65, 17]
                 ]],
                 ['Export Info', [
-                    ['Generated at', '16:21:11 15 November 2017'], 
+                    ['Generated at', '16:21:11 15 November 2017'],
                     ['Block', 'b1'],
                     ['Month', 'May'],
                     ['Year', 2017]

--- a/custom/icds_reports/tests/test_export_data.py
+++ b/custom/icds_reports/tests/test_export_data.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from __future__ import unicode_literals
-from datetime import date
+from datetime import date, datetime
 import json
 
 from django.core.serializers.json import DjangoJSONEncoder
@@ -1144,196 +1144,100 @@ class TestExportData(TestCase):
         )
 
     def test_system_usage_export(self):
+        print (SystemUsageExport(
+                config={
+                    'domain': 'icds-cas',
+                    'month': datetime(2017, 5, 1)
+                }
+            ).get_excel_data('b1'))
         self.assertListEqual(
             SystemUsageExport(
                 config={
-                    'domain': 'icds-cas'
+                    'domain': 'icds-cas',
+                    'month': datetime(2017, 5, 1)
                 }
             ).get_excel_data('b1'),
             [
-                [
-                    "System Usage",
+                ['System Usage', [
                     [
-                        [
-                            "State",
-                            "Number of days AWC was open in the given month",
-                            "Number of launched AWCs (ever submitted at least one HH reg form)",
-                            "Number of household registration forms",
-                            "Number of add pregnancy forms",
-                            "Number of birth preparedness forms",
-                            "Number of delivery forms",
-                            "Number of PNC forms",
-                            "Number of exclusive breastfeeding forms",
-                            "Number of complementary feeding forms",
-                            "Number of growth monitoring forms",
-                            "Number of take home rations forms",
-                            "Number of due list forms"
-                        ],
-                        [
-                            "st1",
-                            38,
-                            16,
-                            85,
-                            4,
-                            4,
-                            1,
-                            0,
-                            5,
-                            12,
-                            14,
-                            47,
-                            5
-                        ],
-                        [
-                            "st1",
-                            38,
-                            16,
-                            85,
-                            4,
-                            4,
-                            1,
-                            0,
-                            5,
-                            12,
-                            14,
-                            47,
-                            5
-                        ],
-                        [
-                            "st1",
-                            38,
-                            16,
-                            85,
-                            4,
-                            4,
-                            1,
-                            0,
-                            5,
-                            12,
-                            14,
-                            47,
-                            5
-                        ],
-                        [
-                            "st1",
-                            38,
-                            16,
-                            85,
-                            4,
-                            4,
-                            1,
-                            0,
-                            5,
-                            12,
-                            14,
-                            47,
-                            5
-                        ],
-                        [
-                            "st1",
-                            38,
-                            16,
-                            85,
-                            4,
-                            4,
-                            1,
-                            0,
-                            5,
-                            12,
-                            14,
-                            47,
-                            5
-                        ],
-                        [
-                            "st2",
-                            34,
-                            22,
-                            79,
-                            4,
-                            4,
-                            2,
-                            2,
-                            5,
-                            4,
-                            20,
-                            65,
-                            17
-                        ],
-                        [
-                            "st2",
-                            34,
-                            22,
-                            79,
-                            4,
-                            4,
-                            2,
-                            2,
-                            5,
-                            4,
-                            20,
-                            65,
-                            17
-                        ],
-                        [
-                            "st2",
-                            34,
-                            22,
-                            79,
-                            4,
-                            4,
-                            2,
-                            2,
-                            5,
-                            4,
-                            20,
-                            65,
-                            17
-                        ],
-                        [
-                            "st2",
-                            34,
-                            22,
-                            79,
-                            4,
-                            4,
-                            2,
-                            2,
-                            5,
-                            4,
-                            20,
-                            65,
-                            17
-                        ],
-                        [
-                            "st2",
-                            34,
-                            22,
-                            79,
-                            4,
-                            4,
-                            2,
-                            2,
-                            5,
-                            4,
-                            20,
-                            65,
-                            17
-                        ]
-                    ]
-                ],
-                [
-                    "Export Info",
+                        'State', 
+                        'Number of days AWC was open in the given month',
+                        'Number of launched AWCs (ever submitted at least one HH reg form)',
+                        'Number of household registration forms', 'Number of add pregnancy forms',
+                        'Number of birth preparedness forms', 'Number of delivery forms',
+                        'Number of PNC forms', 'Number of exclusive breastfeeding forms',
+                        'Number of complementary feeding forms', 'Number of growth monitoring forms',
+                        'Number of take home rations forms', 'Number of due list forms'
+                    ],
+                    ['st1', 'Not Applicable', 8, 0, 1, 4, 1, 0, 5, 12, 3, 46, 5],
+                    ['st1', 'Not Applicable', 8, 0, 1, 4, 1, 0, 5, 12, 3, 46, 5],
+                    ['st1', 'Not Applicable', 8, 0, 1, 4, 1, 0, 5, 12, 3, 46, 5],
+                    ['st1', 'Not Applicable', 8, 0, 1, 4, 1, 0, 5, 12, 3, 46, 5],
+                    ['st1', 'Not Applicable', 8, 0, 1, 4, 1, 0, 5, 12, 3, 46, 5],
+                    ['st2', 'Not Applicable', 11, 0, 4, 4, 1, 1, 4, 4, 20, 65, 17],
+                    ['st2', 'Not Applicable', 11, 0, 4, 4, 1, 1, 4, 4, 20, 65, 17],
+                    ['st2', 'Not Applicable', 11, 0, 4, 4, 1, 1, 4, 4, 20, 65, 17],
+                    ['st2', 'Not Applicable', 11, 0, 4, 4, 1, 1, 4, 4, 20, 65, 17],
+                    ['st2', 'Not Applicable', 11, 0, 4, 4, 1, 1, 4, 4, 20, 65, 17]
+                ]],
+                ['Export Info', [
+                    ['Generated at', '16:21:11 15 November 2017'], 
+                    ['Block', 'b1'],
+                    ['Month', 'May'],
+                    ['Year', 2017]
+                ]]
+            ]
+        )
+
+    def test_system_usage_export_for_awc_level(self):
+        self.assertListEqual(
+            SystemUsageExport(
+                config={
+                    'domain': 'icds-cas',
+                    'block_id': 'b1',
+                    'aggregation_level': 5,
+                    'month': datetime(2017, 5, 1)
+                },
+                loc_level=5,
+            ).get_excel_data('b1'),
+            [
+                ['System Usage', [
                     [
-                        [
-                            "Generated at",
-                            "16:21:11 15 November 2017"
-                        ],
-                        [
-                            "Block",
-                            "b1"
-                        ]
-                    ]
-                ]
+                        'State',
+                        'District',
+                        'Block',
+                        'Supervisor',
+                        'AWC',
+                        'Number of days AWC was open in the given month',
+                        'Number of launched AWCs (ever submitted at least one HH reg form)',
+                        'Number of household registration forms', 'Number of add pregnancy forms',
+                        'Number of birth preparedness forms', 'Number of delivery forms',
+                        'Number of PNC forms', 'Number of exclusive breastfeeding forms',
+                        'Number of complementary feeding forms', 'Number of growth monitoring forms',
+                        'Number of take home rations forms', 'Number of due list forms'
+                    ],
+                    ['st1', 'd1', 'b1', 's1', 'a1', 18, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's1', 'a17', 11, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's1', 'a25', 13, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's1', 'a33', 12, 'Data Not Entered', 0, 0, 0, 1, 0, 0, 0, 0, 0, 1],
+                    ['st1', 'd1', 'b1', 's1', 'a41', 16, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+                    ['st1', 'd1', 'b1', 's1', 'a49', 14, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's1', 'a9', 18, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a10', 8, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a18', 17, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a2', 10, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a26', 12, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a34', 4, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a42', 7, 'Data Not Entered', 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+                    ['st1', 'd1', 'b1', 's2', 'a50', 19, 'Data Not Entered', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                ]],
+                ['Export Info', [
+                    ['Generated at', '16:21:11 15 November 2017'],
+                    ['Block', 'b1'],
+                    ['Grouped By', 'AWC'],
+                    ['Month', 'May'],
+                    ['Year', 2017]
+                ]],
             ]
         )
 


### PR DESCRIPTION
Hi @emord 

I added ```Not applicable``` message for indicator ```Number of days AWC was open in the given month``` in System Usage export.

CASE: https://manage.dimagi.com/default.asp?277671#1503559

Regards,
Łukasz