### PR TITLE
begin removing UnicodeWriter

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import date, timedelta
 
+import csv342 as csv
 import io
 
 from celery.schedules import crontab
@@ -17,7 +18,6 @@ from corehq.apps.es.users import UserES
 from corehq.apps.hqadmin.models import HistoricalPillowCheckpoint
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.util.soft_assert import soft_assert
-from dimagi.utils.csv import UnicodeWriter
 from dimagi.utils.logging import notify_error
 from dimagi.utils.django.email import send_HTML_email
 from dimagi.utils.web import get_site_domain
@@ -115,8 +115,8 @@ def send_mass_emails(username, real_email, subject, html, text):
 
 
 def _mass_email_attachment(name, rows):
-    csv_file = io.BytesIO()
-    writer = UnicodeWriter(csv_file)
+    csv_file = io.StringIO()
+    writer = csv.writer(csv_file)
     writer.writerow(['Email', 'Error'])
     writer.writerows(rows)
     attachment = {

--- a/corehq/apps/hqadmin/views/reports.py
+++ b/corehq/apps/hqadmin/views/reports.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import six.moves.html_parser
 import json
 from collections import defaultdict
+import csv342 as csv
 from datetime import timedelta
 
 from django.contrib import messages
@@ -41,7 +42,6 @@ from corehq.util.supervisord.api import (
     all_pillows_supervisor_status,
     pillow_supervisor_status
 )
-from dimagi.utils.csv import UnicodeWriter
 from dimagi.utils.dates import add_months
 from dimagi.utils.decorators.datespan import datespan_in_request
 from dimagi.utils.django.management import export_as_csv_action
@@ -199,7 +199,7 @@ def _gir_csv_response(month, year):
     field_names = GIR_FIELDS
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename=gir.csv'
-    writer = UnicodeWriter(response)
+    writer = csv.writer(response)
     writer.writerow(list(field_names))
     for months in domain_months.values():
         writer.writerow(months[0].export_row(months[1:]))

--- a/corehq/ex-submodules/auditcare/views.py
+++ b/corehq/ex-submodules/auditcare/views.py
@@ -2,13 +2,13 @@
 #for more information see: http://code.google.com/p/django-axes/
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import csv342 as csv
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from auditcare.utils import login_template
-from dimagi.utils import csv 
 from auditcare.decorators.login import lockout_response
 from auditcare.decorators.login import log_request
 from auditcare.inspect import history_for_doc
@@ -30,8 +30,8 @@ VERBOSE = getattr(settings, 'AXES_VERBOSE', True)
 def export_all(request):
     auditEvents = AccessAudit.view("auditcare/by_date_access_events", descending=True, include_docs=True).all()
     response = HttpResponse()
-    response['Content-Disposition'] = 'attachment; filename="AuditAll.xls"'
-    writer = csv.UnicodeWriter(response)
+    response['Content-Disposition'] = 'attachment; filename="AuditAll.csv"'
+    writer = csv.writer(response)
     writer.writerow(['User', 'Access Type', 'Date'])
     for a in auditEvents:
         writer.writerow([a.user, a.access_type, a.event_date])

--- a/custom/enikshay/tasks.py
+++ b/custom/enikshay/tasks.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
+import csv342 as csv
 import datetime
 import io
-from dimagi.utils.csv import UnicodeWriter
 from collections import defaultdict, namedtuple
 import pytz
 import sys
@@ -71,6 +71,22 @@ BatchStatus = namedtuple('BatchStatus',
 
 CACHE_KEY = "reconciliation-task-{}"
 cache = get_redis_client()
+
+
+class UnicodeWriter(object):
+    """
+    A CSV writer which will write rows to CSV file "f" using utf-8.
+    """
+    def __init__(self, f, dialect=csv.excel, **kwds):
+        # Redirect output to a queue
+        self.writer = csv.writer(f, dialect=dialect, **kwds)
+
+    def writerow(self, row):
+        self.writer.writerow([six.text_type(s).encode("utf-8") for s in row])
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
 
 
 def enikshay_task(self):


### PR DESCRIPTION
We should just use ```csv342``` in a py2/3 compatible way instead of ```UnicodeWriter```, which doesn't actually handle non-ascii unicode well.

@dimagi/py3 