### PR TITLE
Case list explorer uat feedback

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "CommCareHQ",
   "version": "0.0.1",
   "dependencies": {
+    "ace-builds": "1.3.3",
     "angular": "1.4.4",
     "angular-bootstrap": "^2.5.0",
     "angular-bootstrap-legacy": "0.11.2",

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -170,9 +170,10 @@ def build_filter_from_ast(domain, node):
             case_property_name = serialize(node.left)
             value = node.right
             return case_property_range_query(case_property_name, **{COMPARISON_MAPPING[node.op]: value})
-        except TypeError:
+        except (TypeError, ValueError):
             raise CaseFilterError(
-                _("The right hand side of a comparison must be a number or date"),
+                _("The right hand side of a comparison must be a number or date. "
+                  "Dates must be surrounded in quotation marks"),
                 serialize(node),
             )
 

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -234,6 +234,11 @@ def build_filter_from_ast(domain, node):
 
 
 def build_filter_from_xpath(domain, xpath):
+    error_message = _(
+        "We didn't understand what you were trying to do with {}. "
+        "Please try reformatting your query. "
+        "The operators we accept are: {}"
+    )
     try:
         return build_filter_from_ast(domain, parse_xpath(xpath))
     except TypeError as e:
@@ -241,28 +246,14 @@ def build_filter_from_xpath(domain, xpath):
         if text_error:
             # This often happens if there is a bad operator (e.g. a ~ b)
             bad_part = text_error.groups()[0]
-            raise CaseFilterError(
-                _("We didn't understand what you were trying to do with {}. "
-                  "Please try reformatting your query. "
-                  "The operators we accept are: {}").format(
-                      bad_part,
-                      ", ".join(ALL_OPERATORS)),
-                bad_part,
-            )
+            raise CaseFilterError(error_message.format(bad_part, ", ".join(ALL_OPERATORS)), bad_part)
         raise CaseFilterError(_("Malformed search query"), None)
     except RuntimeError as e:
         # eulxml passes us string errors from YACC
         lex_token_error = re.search(r"LexToken\((\w+),\w?'(.+)'", six.text_type(e))
         if lex_token_error:
             bad_part = lex_token_error.groups()[1]
-            raise CaseFilterError(
-                _("We didn't understand what you were trying to do with {}. "
-                  "Please try reformatting your query. "
-                  "The operators we accept are: {}").format(
-                      bad_part,
-                      ", ".join(ALL_OPERATORS)),
-                bad_part,
-            )
+            raise CaseFilterError(error_message.format(bad_part, ", ".join(ALL_OPERATORS)), bad_part)
         raise CaseFilterError(_("Malformed search query"), None)
 
 

--- a/corehq/apps/case_search/xpath_functions.py
+++ b/corehq/apps/case_search/xpath_functions.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+
+import six
+from django.utils.dateparse import parse_date
+from django.utils.translation import ugettext as _
+
+
+class XPathFunctionException(Exception):
+    pass
+
+
+def date(node):
+    assert node.name == 'date'
+    if len(node.args) != 1:
+        raise XPathFunctionException(_("The \"date\" function only accepts a single argument"))
+    arg = node.args[0]
+
+    if isinstance(arg, int):
+        return (datetime.date(1970, 1, 1) + datetime.timedelta(days=arg)).strftime("%Y-%m-%d")
+
+    if isinstance(arg, six.string_types):
+        try:
+            parsed_date = parse_date(arg)
+        except ValueError:
+            raise XPathFunctionException(_("{} is not a valid date").format(arg))
+
+        if parsed_date is None:
+            raise XPathFunctionException(
+                _("The \"date\" function only accepts strings of the format \"YYYY-mm-dd\"")
+            )
+
+        return arg
+
+    raise XPathFunctionException(
+        "The \"date\" function only accepts integers or strings of the format \"YYYY-mm-dd\""
+    )
+
+
+XPATH_FUNCTIONS = {
+    'date': date,
+}

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -226,7 +226,13 @@ def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lt
 
     # if its a date, use it
     # date range
-    kwargs = {key: parse_date(value) for key, value in six.iteritems(kwargs) if value is not None}
+    kwargs = {
+        key: parse_date(value) for key, value in six.iteritems(kwargs)
+        if value is not None and parse_date(value) is not None
+    }
+    if not kwargs:
+        raise TypeError()       # Neither a date nor number was passed in
+
     return _base_property_query(
         case_property_name,
         queries.date_range("{}.{}.date".format(CASE_PROPERTIES_PATH, VALUE), **kwargs)

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -9,23 +9,20 @@ from corehq.apps.es import case_search as case_search_es
     q = (case_search_es.CaseSearchES()
          .domain('testproject')
 """
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from warnings import warn
 
 import six
 from django.utils.dateparse import parse_date
-from django.utils.translation import ugettext as _
-from eulxml.xpath import parse as parse_xpath
 
 from corehq.apps.case_search.const import (
-    SPECIAL_CASE_PROPERTIES,
     CASE_PROPERTIES_PATH,
     IDENTIFIER,
     INDICES_PATH,
     REFERENCED_ID,
     RELEVANCE_SCORE,
+    SPECIAL_CASE_PROPERTIES,
     SYSTEM_PROPERTIES,
     VALUE,
 )
@@ -117,18 +114,8 @@ class CaseSearchES(CaseES):
         - numeric ranges: "age >= 100 and height < 1.25"
         - related cases: "mother/first_name = 'maeve' or parent/parent/host/age = 13"
         """
-        from corehq.apps.case_search.filter_dsl import (
-            CaseFilterError,
-            build_filter_from_ast,
-        )
-
-        try:
-            return self.filter(build_filter_from_ast(domain, parse_xpath(xpath)))
-        except (TypeError, RuntimeError) as e:
-            raise CaseFilterError(
-                _("Malformed search query: {search_query}").format(search_query=e),
-                None,
-            )
+        from corehq.apps.case_search.filter_dsl import build_filter_from_xpath
+        return self.filter(build_filter_from_xpath(domain, xpath))
 
     def _add_query(self, new_query, clause):
         current_query = self._query.get(queries.BOOL)

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -59,6 +59,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                 'knockout': 'ko',
                 'underscore': '_',
                 'clipboard/dist/clipboard': 'Clipboard',
+                'ace-builds/src-min-noconflict/ace': 'ace',
             };
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -79,37 +79,37 @@ class CaseListExplorer(CaseListReport):
 
     @property
     def columns(self):
-        return [
-            DataTablesColumn(
-                "case_name",
-                prop_name='case_name',
-                sortable=True,
-                visible=False,
-            ),
-            DataTablesColumn(
-                _("View Case"),
-                prop_name='_link',
-                sortable=False,
-            )
-        ] + [
+        if self._is_exporting:
+            persistent_cols = [
+                DataTablesColumn(
+                    "@case_id",
+                    prop_name='@case_id',
+                    sortable=True,
+                )
+            ]
+        else:
+            persistent_cols = [
+                DataTablesColumn(
+                    "case_name",
+                    prop_name='case_name',
+                    sortable=True,
+                    visible=False,
+                ),
+                DataTablesColumn(
+                    _("View Case"),
+                    prop_name='_link',
+                    sortable=False,
+                )
+            ]
+
+        return persistent_cols + [
             DataTablesColumn(
                 column,
                 prop_name=column,
                 sortable=column not in CASE_COMPUTED_METADATA,
             )
-            for column in self._columns
+            for column in CaseListExplorerColumns.get_value(self.request, self.domain)
         ]
-
-    @property
-    def _columns(self):
-        """Columns from the report filter
-        """
-        if self._is_exporting:
-            return CaseListExplorerColumns.EXPORT_PERSISTENT_COLUMNS + [
-                c for c in CaseListExplorerColumns.get_value(self.request, self.domain)
-                if c['name'] not in [p['name'] for p in CaseListExplorerColumns.PERSISTENT_COLUMNS]
-            ]
-        return CaseListExplorerColumns.get_value(self.request, self.domain)
 
     @property
     def headers(self):

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -36,11 +36,11 @@ class CaseListExplorer(CaseListReport):
     _is_exporting = False
 
     fields = [
+        XpathCaseSearchFilter,
+        CaseListExplorerColumns,
         CaseListFilter,
         CaseTypeFilter,
         SelectOpenCloseFilter,
-        XpathCaseSearchFilter,
-        CaseListExplorerColumns,
     ]
 
     def _build_query(self, sort=True):

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -87,10 +87,10 @@ class CaseListExplorer(CaseListReport):
     def columns(self):
         return [
             DataTablesColumn(
-                column['label'],
-                prop_name=column['name'],
-                visible=(not column.get('hidden')),
-                sortable=column['name'] not in CASE_COMPUTED_METADATA,
+                column,
+                prop_name=column,
+                visible=column not in CaseListExplorerColumns.HIDDEN_COLUMNS,
+                sortable=column not in CASE_COMPUTED_METADATA,
             )
             for column in self._columns
         ]

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -17,6 +17,10 @@ from corehq.util.dates import iso_string_to_datetime
 from corehq.util.view_utils import absolute_reverse
 from corehq.util.quickcache import quickcache
 from memoized import memoized
+from corehq.apps.case_search.const import (
+    CASE_COMPUTED_METADATA,
+    SPECIAL_CASE_PROPERTIES,
+)
 
 
 class CaseInfo(object):
@@ -243,12 +247,11 @@ class SafeCaseDisplay(object):
         self.case = case
         self.report = report
 
-    def get(self, column):
-        name = column['name']
-        if name == '_link':
+    def get(self, name):
+        if name == 'View Case':
             return self._link
 
-        if column.get('meta_type') == 'info':
+        if name in (SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA):
             return getattr(CaseDisplay(self.report, self.case), name.replace('@', ''))
 
         return self.case.get(name)

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -259,4 +259,6 @@ class SafeCaseDisplay(object):
             link = absolute_reverse('case_data', args=[self.report.domain, self.case.get('_id')])
         except NoReverseMatch:
             return _("No link found")
-        return html.mark_safe("<a class='ajax_dialog' href='{}' target='_blank'>{}</a>".format(link, _("Link")))
+        return html.mark_safe(
+            "<a class='ajax_dialog' href='{}' target='_blank'>{}</a>".format(link, _("View Case"))
+        )

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -39,6 +39,7 @@ class CaseInfo(object):
     @property
     def case_name(self):
         return self.case['name']
+    name = case_name
 
     @property
     def case_name_display(self):
@@ -248,7 +249,7 @@ class SafeCaseDisplay(object):
         self.report = report
 
     def get(self, name):
-        if name == 'View Case':
+        if name == '_link':
             return self._link
 
         if name in (SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA):

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -52,7 +52,7 @@ class XpathCaseSearchFilter(BaseSimpleFilter):
         ]
         operators = [
             {'name': prop, 'case_type': None, 'meta_type': 'operator'}
-            for prop in ['=', '!=', '>=', '<=', '>', '<']
+            for prop in ['=', '!=', '>=', '<=', '>', '<', 'and', 'or']
         ]
         return case_properties + special_case_properties + operators
 

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -41,7 +41,7 @@ class XpathCaseSearchFilter(BaseSimpleFilter):
         return context
 
     def get_suggestions(self):
-        case_properties = get_flattened_case_properties(self.domain)
+        case_properties = get_flattened_case_properties(self.domain, include_parent_properties=True)
         special_case_properties = [
             {'name': prop, 'case_type': None, 'meta_type': 'info'}
             for prop in SPECIAL_CASE_PROPERTIES
@@ -98,7 +98,7 @@ class CaseListExplorerColumns(BaseSimpleFilter):
         return context
 
     def get_column_suggestions(self):
-        case_properties = get_flattened_case_properties(self.domain)
+        case_properties = get_flattened_case_properties(self.domain, include_parent_properties=False)
         special_properties = [
             {'name': prop, 'case_type': None, 'meta_type': 'info'}
             for prop in SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA
@@ -111,8 +111,11 @@ class CaseListExplorerColumns(BaseSimpleFilter):
         return json.loads(value or "[]")
 
 
-def get_flattened_case_properties(domain):
-    all_properties_by_type = all_case_properties_by_domain(domain, include_parent_properties=False)
+def get_flattened_case_properties(domain, include_parent_properties=False):
+    all_properties_by_type = all_case_properties_by_domain(
+        domain,
+        include_parent_properties=include_parent_properties
+    )
     all_properties = [
         {'name': value, 'case_type': case_type}
         for case_type, values in six.iteritems(all_properties_by_type)

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -1,16 +1,20 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
+from collections import Counter
 
-from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy, ugettext as _
 import six
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy
 
 from corehq.apps.app_manager.app_schemas.case_properties import (
     all_case_properties_by_domain,
 )
-from corehq.apps.case_search.const import SPECIAL_CASE_PROPERTIES, CASE_COMPUTED_METADATA
+from corehq.apps.case_search.const import (
+    CASE_COMPUTED_METADATA,
+    SPECIAL_CASE_PROPERTIES,
+)
 from corehq.apps.reports.filters.base import BaseSimpleFilter
 
 
@@ -111,8 +115,9 @@ def get_flattened_case_properties(domain, include_parent_properties=False):
         domain,
         include_parent_properties=include_parent_properties
     )
+    property_counts = Counter(item for sublist in all_properties_by_type.values() for item in sublist)
     all_properties = [
-        {'name': value, 'case_type': case_type}
+        {'name': value, 'case_type': case_type, 'count': property_counts[value]}
         for case_type, values in six.iteritems(all_properties_by_type)
         for value in values
     ]

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -5,7 +5,6 @@ from collections import Counter
 
 import six
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
 from corehq.apps.app_manager.app_schemas.case_properties import (
@@ -61,33 +60,31 @@ class CaseListExplorerColumns(BaseSimpleFilter):
     slug = 'explorer_columns'
     label = ugettext_lazy("Columns")
     template = "reports/filters/explorer_columns.html"
-    PERSISTENT_COLUMNS = [      # all of these are hidden from exports
+    HIDDEN_COLUMNS = ['last_modified']
+    PERSISTENT_COLUMNS = [
         # hidden from view, but used for sorting when no sort column is provided
-        {'name': 'last_modified', 'label': 'Last Modified Date', 'hidden': True, 'editable': False},
+        'last_modified',
         # shown, but unremovable so there is always at least one column
-        {'name': '_link', 'label': _('View Case'), 'editable': False},
+        'View Case'
     ]
 
     EXPORT_PERSISTENT_COLUMNS = [  # these are always shown in exports
-        {'name': '_id', 'label': 'case_id'},
+        'case_id'
     ]
 
-    DEFAULT_COLUMNS = [
-        {'name': '@case_type', 'label': _('Case Type')},
-        {'name': 'case_name', 'label': _('Case Name')},
-    ]
+    DEFAULT_COLUMNS = ['@case_type', 'case_name']
 
     @property
     def filter_context(self):
         context = super(CaseListExplorerColumns, self).filter_context
         initial_values = self.get_value(self.request, self.domain) or []
 
-        user_value_names = [v['name'] for v in initial_values]
+        user_value_names = [v for v in initial_values]
         if not user_value_names:
             initial_values = self.DEFAULT_COLUMNS
 
         for persistent_column in reversed(self.PERSISTENT_COLUMNS):
-            if persistent_column['name'] not in user_value_names:
+            if persistent_column not in user_value_names:
                 initial_values = [persistent_column] + initial_values
 
         context.update({

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -61,7 +61,7 @@ class CaseListExplorerColumns(BaseSimpleFilter):
         # hidden from view, but used for sorting when no sort column is provided
         {'name': 'last_modified', 'label': 'Last Modified Date', 'hidden': True, 'editable': False},
         # shown, but unremovable so there is always at least one column
-        {'name': '_link', 'label': _('Link'), 'editable': False},
+        {'name': '_link', 'label': _('View Case'), 'editable': False},
     ]
 
     EXPORT_PERSISTENT_COLUMNS = [  # these are always shown in exports
@@ -71,11 +71,6 @@ class CaseListExplorerColumns(BaseSimpleFilter):
     DEFAULT_COLUMNS = [
         {'name': '@case_type', 'label': _('Case Type')},
         {'name': 'case_name', 'label': _('Case Name')},
-        {'name': 'owner_name', 'label': _('Owner Name')},
-        {'name': 'date_opened', 'label': _('Date Opened')},
-        {'name': 'opened_by_username', 'label': _('Opened By Username')},
-        {'name': 'last_modified', 'label': _('Last Modified')},
-        {'name': '@status', 'label': _('Status')},
     ]
 
     @property

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -60,32 +60,15 @@ class CaseListExplorerColumns(BaseSimpleFilter):
     slug = 'explorer_columns'
     label = ugettext_lazy("Columns")
     template = "reports/filters/explorer_columns.html"
-    HIDDEN_COLUMNS = ['last_modified']
-    PERSISTENT_COLUMNS = [
-        # hidden from view, but used for sorting when no sort column is provided
-        'last_modified',
-        # shown, but unremovable so there is always at least one column
-        'View Case'
-    ]
-
-    EXPORT_PERSISTENT_COLUMNS = [  # these are always shown in exports
-        'case_id'
-    ]
-
     DEFAULT_COLUMNS = ['@case_type', 'case_name']
 
     @property
     def filter_context(self):
         context = super(CaseListExplorerColumns, self).filter_context
-        initial_values = self.get_value(self.request, self.domain) or []
 
-        user_value_names = [v for v in initial_values]
-        if not user_value_names:
+        initial_values = self.get_value(self.request, self.domain)
+        if not initial_values:
             initial_values = self.DEFAULT_COLUMNS
-
-        for persistent_column in reversed(self.PERSISTENT_COLUMNS):
-            if persistent_column not in user_value_names:
-                initial_values = [persistent_column] + initial_values
 
         context.update({
             'initial_value': json.dumps(initial_values),

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -32,21 +32,9 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         });
     };
 
-    var Property = function ($parent, name, label, editable, hidden) {
+    var Property = function ($parent, name, editable, hidden) {
         var self = {};
         self.name = ko.observable(name).trimmed();
-
-        self.label = ko.observable(label || name).trimmed();
-
-        self.name.subscribe(function(newValue){
-            // Set the label value to the value of the name if it isn't otherwise set
-            if (!self.label() && newValue !== 'undefined'){ // atwho sometimes sets the value to the string 'undefined'
-                var val = newValue.replace('@', '').replace(/_/g, ' ').replace(/\w\S*/g, function(txt){
-                    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-                });
-                self.label(val);
-            }
-        });
 
         self.meta_type = ko.computed(function(){
             var value = _.find($parent.allSuggestions, function(prop){
@@ -72,11 +60,11 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         self.properties = ko.observableArray();
         for (var i = 0; i < initialColumns.length; i++){
             var initialColumn = initialColumns[i];
-            self.properties.push(Property(self, initialColumn.name, initialColumn.label, initialColumn.editable, initialColumn.hidden));
+            self.properties.push(Property(self, initialColumn));
         }
 
         self.addProperty = function () {
-            self.properties.push(Property(self, '', ''));
+            self.properties.push(Property(self, ''));
         };
 
         self.removeProperty = function (property) {
@@ -88,14 +76,7 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
 
             return JSON.stringify(
                 _.map(self.properties(), function(property){
-                    var pertinent_props = {name: property.name(), label: property.label()};
-                    if (property.hidden()){
-                        pertinent_props.hidden = property.hidden();
-                    }
-                    if (property.meta_type()){
-                        pertinent_props.meta_type = property.meta_type();
-                    }
-                    return pertinent_props;
+                    return property.name();
                 })
             );
         });

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -11,7 +11,20 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
 
         self.suggestedProperties = ko.computed(function(){
             if (self.currentCaseType() === ''){
-                return allSuggestions;
+                var filteredProperties = [];
+                for (var i = 0; i < allSuggestions.length; i++){
+                    var suggestion = Object.assign({}, allSuggestions[i]);
+                    if (suggestion.count === 1){
+                        filteredProperties.push(suggestion);
+                    }
+                    else if (_.findWhere(filteredProperties, {name: suggestion.name}) === undefined){
+                        if (suggestion.count !== undefined){
+                            suggestion.case_type = suggestion.count + " " + gettext("case types");
+                        }
+                        filteredProperties.push(suggestion);
+                    }
+                }
+                return filteredProperties;
             }
             return _.filter(allSuggestions, function(prop){
                 return prop['case_type'] === self.currentCaseType() || prop['case_type'] === null;

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -32,7 +32,7 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         });
     };
 
-    var Property = function ($parent, name, editable, hidden) {
+    var Property = function ($parent, name) {
         var self = {};
         self.name = ko.observable(name).trimmed();
 
@@ -45,8 +45,6 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
             }
             return null;
         });
-        self.editable = ko.observable(editable === undefined ? true : editable);
-        self.hidden = ko.observable(hidden || false);
 
         return self;
     };

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -72,7 +72,19 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         };
 
         self.allProperties = ko.computed(function(){
-            return JSON.stringify(ko.toJS(self.properties()));
+
+            return JSON.stringify(
+                _.map(self.properties(), function(property){
+                    var pertinent_props = {name: property.name(), label: property.label()};
+                    if (property.hidden()){
+                        pertinent_props.hidden = property.hidden();
+                    }
+                    if (property.meta_type()){
+                        pertinent_props.meta_type = property.meta_type();
+                    }
+                    return pertinent_props;
+                })
+            );
         });
 
         return self;

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -60,6 +60,10 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
             var initialColumn = initialColumns[i];
             self.properties.push(Property(self, initialColumn));
         }
+        self.properties.subscribe(function(newValue){
+            // When reordering properties, trigger a change to enable the "Apply" button
+            $('#fieldset_explorer_columns').trigger('change');
+        });
 
         self.addProperty = function () {
             self.properties.push(Property(self, ''));

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -89,6 +89,7 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
     var caseSearchXpathViewModel = function(allSuggestions){
         var self = {};
         applySuggestions.call(self, allSuggestions);
+        self.query = ko.observable();
         return self;
     };
 

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -60,7 +60,7 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
             var initialColumn = initialColumns[i];
             self.properties.push(Property(self, initialColumn));
         }
-        self.properties.subscribe(function(newValue){
+        self.properties.subscribe(function() {
             // When reordering properties, trigger a change to enable the "Apply" button
             $('#fieldset_explorer_columns').trigger('change');
         });

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
@@ -1,41 +1,43 @@
-hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', 'knockout', 'hqwebapp/js/atwho'], function($, ko, atwho) {
+hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', 'knockout', 'hqwebapp/js/atwho', 'ace-builds/src-min-noconflict/ace'], function($, ko, atwho) {
 
     ko.bindingHandlers.xPathAutocomplete = {
-        init: function(element) {
-            var $element = $(element);
-            if (!$element.atwho) {
-                throw new Error("The typeahead binding requires Atwho.js and Caret.js");
-            }
-
-            atwho.init($element, {
-                atwhoOptions: {
-                    displayTpl: function(item){
-                        if (item.case_type){
-                            return '<li><span class="label label-default">${case_type}</span> ${name}</li>';
-                        }
-                        var labelClass = item.meta_type === 'info' ? 'label-primary' : 'label-info';
-                        return '<li><span class="label ' + labelClass +'">${meta_type}</span> ${name}</li>';
-                    },
-                    callbacks: {},
-                },
-                afterInsert: function() {
-                    $element.trigger('textchange');
-                },
-                replaceValue: false,
+        init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+            var $element = $(element),
+                editor = ace.edit(
+                    element,
+                    {
+                        enableLiveAutocompletion: true,
+                        showPrintMargin: false,
+                        showLineNumbers: false,
+                        showFoldWidgets: false,
+                        showGutter: false,
+                        highlightGutterLine: false,
+                        highlightActiveLine: false,
+                        maxLines: 30,
+                        minLines: 3,
+                        fontSize: 14,
+                        wrap: true,
+                        useWorker: false, // enable the worker to show syntax errors
+                    }
+                );
+            editor.session.setMode('ace/mode/xquery'); // does reasonable syntax highlighting for XPath
+            editor.on('change', function(){
+                viewModel.query(editor.getValue());
+                $element.parent().trigger('change');
             });
-
-            $element.on("textchange", function() {
-                if ($element.val()) {
-                    $element.change();
+        },
+        update: function(element, valueAccessor){
+            var casePropertyAutocomplete = {
+                getCompletions: function(editor, session, pos, prefix, callback){
+                    var data = ko.utils.unwrapObservable(valueAccessor());
+                    callback(null, _.map(data, function(suggestion){
+                        return {name: suggestion.name, value: suggestion.name, meta: suggestion.case_type || suggestion.meta_type};
+                    }));
                 }
-            });
-        },
-
-        update: function(element, valueAccessor) {
-            $(element).atwho('load', '', ko.utils.unwrapObservable(valueAccessor()));
-        },
+            };
+            ace.require("ace/ext/language_tools").setCompleters([casePropertyAutocomplete]);
+        }
     };
-
 
     ko.bindingHandlers.explorerColumnsAutocomplete = {
         init: function(element) {

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
@@ -21,10 +21,15 @@ hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', '
                     }
                 );
             editor.session.setMode('ace/mode/xquery'); // does reasonable syntax highlighting for XPath
-            editor.on('change', function(){
+
+            var updateKOModel = function(){
                 viewModel.query(editor.getValue());
                 $element.parent().trigger('change');
+            };
+            editor.on('change', function(){
+                updateKOModel();
             });
+            updateKOModel();
 
             // Set placeholder
             function update() {
@@ -50,7 +55,11 @@ hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', '
                 getCompletions: function(editor, session, pos, prefix, callback){
                     var data = ko.utils.unwrapObservable(valueAccessor());
                     callback(null, _.map(data, function(suggestion){
-                        return {name: suggestion.name, value: suggestion.name, meta: suggestion.case_type || suggestion.meta_type};
+                        return {
+                            name: suggestion.name,
+                            value: suggestion.name,
+                            meta: suggestion.case_type || suggestion.meta_type,
+                        };
                     }));
                 }
             };

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
@@ -25,6 +25,25 @@ hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', '
                 viewModel.query(editor.getValue());
                 $element.parent().trigger('change');
             });
+
+            // Set placeholder
+            function update() {
+                // https://stackoverflow.com/a/26700324/2957657
+                var shouldShow = !editor.session.getValue().length,
+                    node = editor.renderer.emptyMessageNode;
+                if (!shouldShow && node) {
+                    editor.renderer.scroller.removeChild(editor.renderer.emptyMessageNode);
+                    editor.renderer.emptyMessageNode = null;
+                } else if (shouldShow && !node) {
+                    node = editor.renderer.emptyMessageNode = document.createElement("div");
+                    node.textContent = gettext("e.g. (dob <= '2017-02-01' and initial_home_visit_completed = 'yes') ");
+                    node.className = "ace_invisible ace_emptyMessage";
+                    node.style.padding = "0 9px";
+                    editor.renderer.scroller.appendChild(node);
+                }
+            }
+            editor.on("input", update);
+            setTimeout(update, 100);
         },
         update: function(element, valueAccessor){
             var casePropertyAutocomplete = {

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
@@ -1,7 +1,7 @@
-hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', 'knockout', 'hqwebapp/js/atwho', 'ace-builds/src-min-noconflict/ace'], function($, ko, atwho) {
+hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', 'knockout', 'hqwebapp/js/atwho', 'ace-builds/src-min-noconflict/ace'], function($, ko, atwho, ace) {
 
     ko.bindingHandlers.xPathAutocomplete = {
-        init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        init: function(element, valueAccessor, allBindings, viewModel) {
             var $element = $(element),
                 editor = ace.edit(
                     element,
@@ -61,10 +61,10 @@ hqDefine("reports/js/filters/case_list_explorer_knockout_bindings", ['jquery', '
                             meta: suggestion.case_type || suggestion.meta_type,
                         };
                     }));
-                }
+                },
             };
             ace.require("ace/ext/language_tools").setCompleters([casePropertyAutocomplete]);
-        }
+        },
     };
 
     ko.bindingHandlers.explorerColumnsAutocomplete = {

--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -177,9 +177,6 @@ hqDefine("reports/js/filters/main", [
             var model = caseListExplorer.caseSearchXpath(data.suggestions);
             $el.koApplyBindings(model);
         });
-        $xpathTextarea.on('keyup', function(){
-            $('#fieldset_search_xpath').trigger('change');
-        });
 
         $('[name=selected_group]').each(function(i, el) {
             $(el).select2({

--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -150,7 +150,8 @@ hqDefine("reports/js/filters/main", [
             $el.koApplyBindings(model);
         });
 
-        var $casePropertyColumns = $(".report-filter-case-property-columns");
+        var $casePropertyColumns = $(".report-filter-case-property-columns"),
+            $fieldsetExplorerColumns = $("#fieldset_explorer_columns");
         $casePropertyColumns.each(function (i, el) {
             var $el = $(el),
                 data = $el.data();
@@ -158,7 +159,10 @@ hqDefine("reports/js/filters/main", [
             $el.koApplyBindings(model);
         });
         $casePropertyColumns.on('keyup', function(){
-            $('#fieldset_explorer_columns').trigger('change');
+            $fieldsetExplorerColumns.trigger('change');
+        });
+        $fieldsetExplorerColumns.on('hidden.bs.collapse show.bs.collapse', function(e){
+            e.stopPropagation();
         });
 
         var $xpathTextarea = $(".report-filter-xpath-textarea");

--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -161,7 +161,12 @@ hqDefine("reports/js/filters/main", [
         $casePropertyColumns.on('keyup', function(){
             $fieldsetExplorerColumns.trigger('change');
         });
-        $fieldsetExplorerColumns.on('hidden.bs.collapse show.bs.collapse', function(e){
+        $fieldsetExplorerColumns.on('hidden.bs.collapse', function(e){
+            $fieldsetExplorerColumns.find("#panel-chevron i").removeClass('fa-chevron-up').addClass('fa-chevron-down');
+            e.stopPropagation();
+        });
+        $fieldsetExplorerColumns.on('show.bs.collapse', function(e){
+            $fieldsetExplorerColumns.find("#panel-chevron i").removeClass('fa-chevron-down').addClass('fa-chevron-up');
             e.stopPropagation();
         });
 

--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -163,10 +163,14 @@ hqDefine("reports/js/filters/main", [
         });
         $fieldsetExplorerColumns.on('hidden.bs.collapse', function(e){
             $fieldsetExplorerColumns.find("#panel-chevron i").removeClass('fa-chevron-up').addClass('fa-chevron-down');
+            // this is a nested panel, so we stop propagation of this event to
+            // prevent the text from changing on the outside panel
             e.stopPropagation();
         });
         $fieldsetExplorerColumns.on('show.bs.collapse', function(e){
             $fieldsetExplorerColumns.find("#panel-chevron i").removeClass('fa-chevron-down').addClass('fa-chevron-up');
+            // this is a nested panel, so we stop propagation of this event to
+            // prevent the text from changing on the outside panel
             e.stopPropagation();
         });
 

--- a/corehq/apps/reports/templates/reports/filters/explorer_columns.html
+++ b/corehq/apps/reports/templates/reports/filters/explorer_columns.html
@@ -24,7 +24,7 @@
                                 <th>&nbsp;</th>
                             </thead>
                             <tbody data-bind="foreach: properties, sortableList: properties">
-                                <tr data-bind="visible: editable()">
+                                <tr>
                                     <td>
                                         <i class="grip fa fa-arrows-v icon-blue"></i>
                                     </td>

--- a/corehq/apps/reports/templates/reports/filters/explorer_columns.html
+++ b/corehq/apps/reports/templates/reports/filters/explorer_columns.html
@@ -2,57 +2,62 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% block filter_content %}
-    <div class="panel-group" id="case-list-explorer-columns" role="tablist" aria-multiselectable="true">
+    <div class="panel-group report-filter-case-property-columns"
+         id="case-list-explorer-columns"
+         role="tablist"
+         data-initialvalue="{{ initial_value }}"
+         data-columnsuggestions="{{ column_suggestions }}"
+    >
         <div class="panel panel-default">
             <div class="panel-heading" role="tab">
-                <a role="button" data-toggle="collapse" data-parent="#case-list-explorer-columns" href="#columns-editor">
-                    <h4 class="panel-title">
-                        {% trans "Edit Columns" %}
-                        <span class="pull-right" id="panel-chevron">
+                <h4 class="panel-title">
+                    <a role="button" data-toggle="collapse" data-parent="#case-list-explorer-columns" href="#columns-editor">
+                        <span id="panel-chevron">
                             <i class="fa fa-chevron-down"></i>
                         </span>
-                    </h4>
-                </a>
+                        {% trans "Edit Columns" %}
+                        <small>(</small><span data-bind="foreach: properties"><!--ko if: $index() != 0 && name() !=='' -->, <!--/ko--><small data-bind="text: name"></small></span><small>)</small>
+                    </a>
+
+                </h4>
             </div>
             <div id="columns-editor" class="collapse" role="tabpanel">
                 <div class="panel-body">
-                    <div class="report-filter-case-property-columns" data-initialvalue="{{ initial_value }}" data-columnsuggestions="{{ column_suggestions }}">
-                        <table class="table table-condensed">
-                            <thead>
-                                <th>&nbsp;</th>
-                                <th>{% trans "Property" %}</th>
-                                <th>&nbsp;</th>
-                            </thead>
-                            <tbody data-bind="foreach: properties, sortableList: properties">
-                                <tr>
-                                    <td>
-                                        <i class="grip fa fa-arrows-v icon-blue"></i>
-                                    </td>
-                                    <td>
-                                        <div class="has-feedback">
-                                            <input type="text" class="form-control" data-bind="
-                                                         value: name,
-                                                         explorerColumnsAutocomplete: $parent.suggestedProperties()"
-                                            />
-                                            <span class="form-control-feedback" data-bind="visible: meta_type">
-                                                <span class="label label-primary" data-bind="text: meta_type"></span>
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <i style="cursor: pointer;"
-                                           data-bind="click: $parent.removeProperty"
-                                           class="fa fa-remove"></i>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <button class="btn btn-default" data-bind="click: addProperty">
-                            <i class="fa fa-plus"></i>
-                            {% trans "Add Property" %}
-                        </button>
-                        <input type="hidden" data-bind="value: allProperties" name="{{ slug }}" />
-                    </div>
+                    <table class="table table-condensed">
+                        <thead>
+                            <th>&nbsp;</th>
+                            <th>{% trans "Property" %}</th>
+                            <th>&nbsp;</th>
+                        </thead>
+                        <tbody data-bind="foreach: properties, sortableList: properties">
+                            <tr>
+                                <td>
+                                    <i class="grip fa fa-arrows-v icon-blue"></i>
+                                </td>
+                                <td>
+                                    <div class="has-feedback">
+                                        <input type="text" class="form-control" data-bind="
+                                                     value: name,
+                                                     explorerColumnsAutocomplete: $parent.suggestedProperties()"
+                                        />
+                                        <span class="form-control-feedback" data-bind="visible: meta_type">
+                                            <span class="label label-primary" data-bind="text: meta_type"></span>
+                                        </span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <i style="cursor: pointer;"
+                                       data-bind="click: $parent.removeProperty"
+                                       class="fa fa-remove"></i>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <button class="btn btn-default" data-bind="click: addProperty">
+                        <i class="fa fa-plus"></i>
+                        {% trans "Add Property" %}
+                    </button>
+                    <input type="hidden" data-bind="value: allProperties" name="{{ slug }}" />
                 </div>
             </div>
         </div>

--- a/corehq/apps/reports/templates/reports/filters/explorer_columns.html
+++ b/corehq/apps/reports/templates/reports/filters/explorer_columns.html
@@ -19,9 +19,8 @@
                     <div class="report-filter-case-property-columns" data-initialvalue="{{ initial_value }}" data-columnsuggestions="{{ column_suggestions }}">
                         <table class="table table-condensed">
                             <thead>
-                                <th></th>
+                                <th>&nbsp;</th>
                                 <th>{% trans "Property" %}</th>
-                                <th>{% trans "Display Text" %}</th>
                                 <th>&nbsp;</th>
                             </thead>
                             <tbody data-bind="foreach: properties, sortableList: properties">
@@ -41,12 +40,10 @@
                                         </div>
                                     </td>
                                     <td>
-                                        <input type="text" class="form-control" data-bind="value: label" /></td>
-                                        <td>
-                                            <i style="cursor: pointer;"
-                                               data-bind="click: $parent.removeProperty"
-                                               class="fa fa-remove"></i>
-                                        </td>
+                                        <i style="cursor: pointer;"
+                                           data-bind="click: $parent.removeProperty"
+                                           class="fa fa-remove"></i>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>

--- a/corehq/apps/reports/templates/reports/filters/explorer_columns.html
+++ b/corehq/apps/reports/templates/reports/filters/explorer_columns.html
@@ -5,11 +5,14 @@
     <div class="panel-group" id="case-list-explorer-columns" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">
             <div class="panel-heading" role="tab">
-                <h4 class="panel-title">
-                    <a role="button" data-toggle="collapse" data-parent="#case-list-explorer-columns" href="#columns-editor">
+                <a role="button" data-toggle="collapse" data-parent="#case-list-explorer-columns" href="#columns-editor">
+                    <h4 class="panel-title">
                         {% trans "Edit Columns" %}
-                    </a>
-                </h4>
+                        <span class="pull-right" id="panel-chevron">
+                            <i class="fa fa-chevron-down"></i>
+                        </span>
+                    </h4>
+                </a>
             </div>
             <div id="columns-editor" class="collapse" role="tabpanel">
                 <div class="panel-body">

--- a/corehq/apps/reports/templates/reports/filters/xpath_textarea.html
+++ b/corehq/apps/reports/templates/reports/filters/xpath_textarea.html
@@ -2,40 +2,7 @@
 {% load hq_shared_tags %}
 {% block filter_content %}
     <div class="report-filter-xpath-textarea" data-suggestions="{{ suggestions }}">
-    {% if help_title and help_content %}
-        <div class="row">
-            <div class="col-xs-11">
-    {% endif %}
-
-    <textarea
-        id="{{ css_id }}"
-        name="{{ slug }}"
-        type="text"
-        spellcheck="false"
-        style="resize: vertical; min-height: 60px;"
-        {% if required %}required="true"{% endif %}
-        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
-        class="form-control {% block input_css_class %}{% endblock %}"
-        value="{{ default }}"
-        data-bind="xPathAutocomplete: suggestedProperties",
-    >{{ text }}</textarea>
-
-    {% if help_inline %}
-        <p class="help-block">
-            <i class="fa fa-info-circle"></i>
-            {{ help_inline }}
-        </p>
-    {% endif %}
-    {% if help_title and help_content %}
-            </div>
-            <div class="col-xs-1">
-                <span class="hq-help-template"
-                      data-title="{{ help_title }}"
-                      data-content="{{ help_content }}"
-                      data-placement="left"
-                ></span>
-            </div>
-        </div>
-    {% endif %}
+        <pre data-bind="xPathAutocomplete: suggestedProperties">{{ default }}</pre>
+        <input type="hidden" data-bind="value: query" name="{{ slug }}" />
     </div>
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/filters/xpath_textarea.html
+++ b/corehq/apps/reports/templates/reports/filters/xpath_textarea.html
@@ -1,6 +1,10 @@
 {% extends 'reports/filters/base.html' %}
+{% load i18n %}
 {% load hq_shared_tags %}
 {% block filter_content %}
+    <div class="xpath-instructions">
+        <p>{% trans "Filter your cases by entering a search query in the box below." %}</p>
+    </div>
     <div class="report-filter-xpath-textarea" data-suggestions="{{ suggestions }}">
         <pre data-bind="xPathAutocomplete: suggestedProperties">{{ default }}</pre>
         <input type="hidden" data-bind="value: query" name="{{ slug }}" />

--- a/corehq/apps/reports/templates/reports/partials/filters_js.html
+++ b/corehq/apps/reports/templates/reports/partials/filters_js.html
@@ -8,6 +8,9 @@
 <script src="{% static 'reports/js/filters/phone_number.js' %}"></script>
 <script src="{% static 'reports/js/filters/schedule_instance.js' %}"></script>
 
+<script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+<script src="{% static 'ace-builds/src-min-noconflict/ext-language_tools.js' %}"></script>
+<script src="{% static 'ace-builds/src-min-noconflict/mode-xquery.js' %}"></script>
 <script src="{% static 'Caret.js/dist/jquery.caret.min.js' %}"></script>
 <script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
 <script src="{% static 'hqwebapp/js/atwho.js' %}"></script>


### PR DESCRIPTION
Now with syntax highlighting! 
I am adding a new JS dependency (ace editor) so that in the future I have more control over the autocomplete. For free this gives us syntax highlighting, and I imagine this (+ autocomplete) would be really fun to use in other places where we want you to write XPath queries. 

![screenshot from 2018-06-20 08-46-23](https://user-images.githubusercontent.com/146896/41659202-9678b2f6-7466-11e8-9248-07526c1546df.png)

:blowfish: / :blowfish: 