### PR TITLE
prevent sorted rows from disappearing when send to top/bottom is clic…

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -311,13 +311,9 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", ['jquery', 'knockout', 'jquery-ui/u
                         i = parseInt(element.children[cur].attributes['data-order'].value);
                         newList.push(list()[i]);
                     }
-                    list().splice(0, list().length);
+                    list.splice(0, list().length);
                     for (i = 0; i < newList.length; i++) {
-                        list().push(newList[i]);
-                    }
-
-                    for (cur = 0; cur < element.children.length; cur++) {
-                        element.children[cur].attributes['data-order'].value = cur;
+                        list.push(newList[i]);
                     }
                 },
             });


### PR DESCRIPTION
…ked on another row

Ensures that KO stays in sync with the UI, by operating on the observable array ```list```, not the array ```list()```.

@kaapstorm Getting this working solved a bug!