### PR TITLE
remove unused 'strict' arg

### DIFF
--- a/corehq/apps/domain/shortcuts.py
+++ b/corehq/apps/domain/shortcuts.py
@@ -25,7 +25,7 @@ def create_user(username, password, is_staff=False, is_superuser=False, is_activ
     else:
         user.password = password
 
-    # at this stage in the process there is no couch user so it's pointless 
+    # at this stage in the process there is no couch user so it's pointless
     # trying to update it.
     user.DO_NOT_SAVE_COUCH_USER = True
     user.save()

--- a/corehq/apps/domain/shortcuts.py
+++ b/corehq/apps/domain/shortcuts.py
@@ -25,6 +25,8 @@ def create_user(username, password, is_staff=False, is_superuser=False, is_activ
     else:
         user.password = password
 
+    # at this stage in the process there is no couch user so it's pointless 
+    # trying to update it.
     user.DO_NOT_SAVE_COUCH_USER = True
     user.save()
     return user

--- a/corehq/apps/domain/shortcuts.py
+++ b/corehq/apps/domain/shortcuts.py
@@ -25,6 +25,7 @@ def create_user(username, password, is_staff=False, is_superuser=False, is_activ
     else:
         user.password = password
 
+    user.DO_NOT_SAVE_COUCH_USER = True
     user.save()
     return user
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1469,7 +1469,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
             if by_username and by_username['id'] != self._id:
                 raise self.Inconsistent("CouchUser with username %s already exists" % self.username)
 
-            if not self.to_be_deleted():
+            if self._rev and not self.to_be_deleted():
                 django_user = self.sync_to_django_user()
                 django_user.save()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1450,6 +1450,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
     @classmethod
     def save_docs(cls, docs, **kwargs):
+        # this won't clear the caches, lets check if it's used anywhere before disallowing it's use
+        _assert = soft_assert('@'.join(['skelly', 'dimagi.com']), exponential_backoff=False)
+        _assert(False, "bulk save called on user class")
         utcnow = datetime.utcnow()
         for doc in docs:
             doc['last_modified'] = utcnow

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1492,12 +1492,14 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
                 try:
                     # avoid triggering cyclical sync
                     super(CouchUser, couch_user).save(**get_safe_write_kwargs())
-                    couch_user.clear_quickcache_for_user()
                 except ResourceConflict:
                     if max_tries > 0:
+                        couch_user.clear_quickcache_for_user()
                         cls.django_user_post_save_signal(sender, django_user, created, max_tries - 1)
                     else:
                         raise
+
+                couch_user.clear_quickcache_for_user()
 
     def is_deleted(self):
         return self.base_doc.endswith(DELETED_SUFFIX)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1491,7 +1491,10 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
                     super(CouchUser, couch_user).save(**get_safe_write_kwargs())
                     couch_user.clear_quickcache_for_user()
                 except ResourceConflict:
-                    cls.django_user_post_save_signal(sender, django_user, created, max_tries - 1)
+                    if max_tries > 0:
+                        cls.django_user_post_save_signal(sender, django_user, created, max_tries - 1)
+                    else:
+                        raise
 
     def is_deleted(self):
         return self.base_doc.endswith(DELETED_SUFFIX)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1339,7 +1339,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         }[doc_type].wrap(source)
 
     @classmethod
-    @quickcache(['username'], skip_arg='strict')
+    @quickcache(['username'])
     def get_by_username(cls, username, strict=True):
         if not username:
             return None

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1489,6 +1489,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
                 try:
                     # avoid triggering cyclical sync
                     super(CouchUser, couch_user).save(**get_safe_write_kwargs())
+                    couch_user.clear_quickcache_for_user()
                 except ResourceConflict:
                     cls.django_user_post_save_signal(sender, django_user, created, max_tries - 1)
 

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -7,6 +7,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, DeviceAppMeta
 from corehq.form_processor.utils import get_simple_wrapped_form, TestFormMetadata
 from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
+from corehq.util.test_utils import softer_assert
 
 
 class UserModelTest(TestCase):
@@ -45,6 +46,7 @@ class UserModelTest(TestCase):
         user = CommCareUser.get(self.user._id)
         self.assertGreater(user.last_modified, lm)
 
+    @softer_assert()
     def test_last_modified_bulk(self):
         lm = self.user.last_modified
         CommCareUser.save_docs([self.user])

--- a/corehq/apps/zapier/views.py
+++ b/corehq/apps/zapier/views.py
@@ -120,7 +120,7 @@ class ZapierCreateCase(View):
         if not case_type or not owner_id or not domain or not case_name:
             return HttpResponseForbidden('Please fill in all required fields')
 
-        couch_user = CommCareUser.get_by_username(user_name, domain)
+        couch_user = CommCareUser.get_by_username(user_name)
         if not couch_user.is_member_of(domain):
             return HttpResponseForbidden("This user does not have access to this domain.")
 
@@ -156,7 +156,7 @@ class ZapierUpdateCase(View):
 
         properties.pop('case_id')
 
-        couch_user = CommCareUser.get_by_username(user_name, domain)
+        couch_user = CommCareUser.get_by_username(user_name)
         if not couch_user.is_member_of(domain):
             return HttpResponseForbidden("This user does not have access to this domain.")
 


### PR DESCRIPTION
I originally noticed this because the default value of `strict` was `True` - since the `strict` arg is also used to skip cache this resulted in always skipping the cache.

This has been like this since 02913388706f6c7e9063f8289de6817a8652d57b

Quick test to double check: https://github.com/dimagi/commcare-hq/compare/sk/quickcache-skip?expand=1