### PR TITLE
Allow EWS and ILS to circumvent restrictions for web users

### DIFF
--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -283,8 +283,16 @@ def conditionally_location_safe(conditional_function):
 
     """
     def _inner(view_fn):
-        if isinstance(view_fn, type) and issubclass(view_fn, GenericReportView):
-            CONDITIONALLY_LOCATION_SAFE_HQ_REPORTS[view_fn.slug] = conditional_function
+        if isinstance(view_fn, type):
+
+            # Django class-based views
+            if issubclass(view_fn, View):
+                view_fn.dispatch.__func__._conditionally_location_safe_function = conditional_function
+
+            # HQ report classes
+            if issubclass(view_fn, GenericReportView):
+                CONDITIONALLY_LOCATION_SAFE_HQ_REPORTS[view_fn.slug] = conditional_function
+
         else:
             view_fn._conditionally_location_safe_function = conditional_function
         return view_fn

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1352,6 +1352,8 @@ LOCATION_SAFETY_EXEMPTION = StaticToggle(
         "for backwards compatibility and should not be enabled for any other "
         "project."
     ),
+    relevant_environments={'production'},
+    always_enabled={'ews-ghana', 'ils-gateway'},
 )
 
 SORT_CALCULATION_IN_CASE_LIST = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1340,6 +1340,20 @@ LOCATION_USERS = StaticToggle(
     ),
 )
 
+LOCATION_SAFETY_EXEMPTION = StaticToggle(
+    'location_safety_exemption',
+    'Exemption from location restrictions for EWS and ILS',
+    TAG_DEPRECATED,
+    [NAMESPACE_DOMAIN],
+    description=(
+        "ewsghana and ilsgateway do some custom location permissions stuff. "
+        "This feature flag grants them access to the web user pages, but it does "
+        "not actually restrict their access at all. This is implemented strictly "
+        "for backwards compatibility and should not be enabled for any other "
+        "project."
+    ),
+)
+
 SORT_CALCULATION_IN_CASE_LIST = StaticToggle(
     'sort_calculation_in_case_list',
     'Configure a custom xpath calculation for Sort Property in Case Lists',

--- a/custom/ewsghana/views.py
+++ b/custom/ewsghana/views.py
@@ -17,7 +17,7 @@ from corehq.apps.domain.decorators import (
     login_and_domain_required,
 )
 from corehq.apps.domain.views import BaseDomainView
-from corehq.apps.locations.permissions import locations_access_required, user_can_edit_any_location
+from corehq.apps.locations.permissions import locations_access_required, user_can_edit_any_location, location_safe
 from corehq.apps.products.models import Product
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import WebUser
@@ -35,12 +35,14 @@ from dimagi.utils.web import json_handler, json_response
 from six.moves import map
 
 
+@location_safe
 class EWSGlobalStats(GlobalStats):
     template_name = "ewsghana/global_stats.html"
     show_supply_point_types = True
     root_name = 'Country'
 
 
+@location_safe
 class InputStockView(BaseDomainView):
     section_name = 'Input stock data'
     section_url = ""
@@ -133,6 +135,7 @@ class InputStockView(BaseDomainView):
         return context
 
 
+@location_safe
 class EWSUserExtensionView(BaseCommTrackManageView):
 
     template_name = 'ewsghana/user_extension.html'
@@ -169,6 +172,7 @@ class EWSUserExtensionView(BaseCommTrackManageView):
 
 
 @require_GET
+@location_safe
 def inventory_management(request, domain):
 
     inventory_management_ds = InventoryManagementData(
@@ -186,6 +190,7 @@ def inventory_management(request, domain):
 
 
 @require_GET
+@location_safe
 def stockouts_product(request, domain):
 
     stockout_graph = StockoutsProduct(
@@ -203,6 +208,7 @@ def stockouts_product(request, domain):
 
 
 @require_POST
+@location_safe
 def configure_in_charge(request, domain):
     in_charge_ids = request.POST.getlist('users[]')
     location_id = request.POST.get('location_id')
@@ -218,6 +224,7 @@ def loc_to_payload(loc):
 
 
 @locations_access_required
+@location_safe
 def non_administrative_locations_for_select2(request, domain):
     id = request.GET.get('id')
     query = request.GET.get('name', '').lower()
@@ -250,6 +257,7 @@ def non_administrative_locations_for_select2(request, domain):
     return json_response(list(map(loc_to_payload, locs[:10])))
 
 
+@location_safe
 class DashboardPageView(RedirectView):
 
     def get_redirect_url(self, *args, **kwargs):

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -16,6 +16,7 @@ from corehq.apps.commtrack.models import StockState
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.domain.views import BaseDomainView, DomainViewMixin
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.sms.models import SMS, INCOMING, OUTGOING
 from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.users.models import CommCareUser, WebUser, UserRole
@@ -39,6 +40,7 @@ from custom.ilsgateway.tasks import report_run
 from custom.logistics.views import BaseConfigView
 
 
+@location_safe
 class GlobalStats(BaseDomainView):
     section_name = 'Global Stats'
     section_url = ""
@@ -101,6 +103,7 @@ class GlobalStats(BaseDomainView):
         return main_context
 
 
+@location_safe
 class ILSConfigView(BaseConfigView):
     config = ILSGatewayConfig
     urlname = 'ils_config'
@@ -138,6 +141,7 @@ class ILSConfigView(BaseConfigView):
         return self.get(request, *args, **kwargs)
 
 
+@location_safe
 class SupervisionDocumentListView(BaseDomainView):
     section_name = 'Supervision Documents'
     section_url = ""
@@ -202,6 +206,7 @@ class SupervisionDocumentListView(BaseDomainView):
         return main_context
 
 
+@location_safe
 class SupervisionDocumentView(TemplateView):
 
     def dispatch(self, request, *args, **kwargs):
@@ -221,6 +226,7 @@ class SupervisionDocumentView(TemplateView):
         return response
 
 
+@location_safe
 class SupervisionDocumentDeleteView(TemplateView, DomainViewMixin):
 
     @method_decorator(domain_admin_required)
@@ -260,6 +266,7 @@ def end_report_run(request, domain):
 
 
 @require_POST
+@location_safe
 def save_ils_note(request, domain):
     post_data = request.POST
     user = request.couch_user
@@ -286,6 +293,7 @@ def save_ils_note(request, domain):
     return HttpResponse(json.dumps(data), content_type='application/json')
 
 
+@location_safe
 class ReportRunListView(ListView, DomainViewMixin):
     context_object_name = 'runs'
     template_name = 'ilsgateway/report_run_list.html'
@@ -299,6 +307,7 @@ class ReportRunListView(ListView, DomainViewMixin):
         return ReportRun.objects.filter(domain=self.domain).order_by('pk')
 
 
+@location_safe
 class PendingRecalculationsListView(ListView, DomainViewMixin):
     context_object_name = 'recalculations'
     template_name = 'ilsgateway/pending_recalculations.html'
@@ -313,6 +322,7 @@ class PendingRecalculationsListView(ListView, DomainViewMixin):
         return PendingReportingDataRecalculation.objects.filter(domain=self.domain).order_by('pk')
 
 
+@location_safe
 class ReportRunDeleteView(DeleteView, DomainViewMixin):
     model = ReportRun
     template_name = 'ilsgateway/confirm_delete.html'
@@ -326,6 +336,7 @@ class ReportRunDeleteView(DeleteView, DomainViewMixin):
         return reverse_lazy('report_run_list', args=[self.domain])
 
 
+@location_safe
 class DashboardPageRedirect(RedirectView):
 
     @method_decorator(login_and_domain_required)


### PR DESCRIPTION
These two projects are the sole reason we have a lot of old location permissions code still around.  I'm going to attempt to switch them to the standard way of handling location permissions.  I spoke with MikeO about this, and it looks like the only blocker is that they need access to the web user pages, which are not currently location safe.  One option would be to _make_ that page safe, but that'd require a little more thought than I'd like to do at this time, since we'd need to make sure restricted users can't do anything there that would allow them to violate their restriction.  Instead, I'm just giving them this exemption.

I feel reasonably confident in making this change, since as-is, their users can all access these pages anyways.  Making these pages location-safe will effectively cancel out changing the user roles to be location-restricted, at least with respect to the custom views.

If we are able to get those two projects off the old permissions and on to the new, then we can delete a lot of confusing code:
https://github.com/dimagi/commcare-hq/compare/es/rm-old-loc-permissions?expand=1

@czue