### PR TITLE
Stop adding js script when Select2Ajax is used

### DIFF
--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -97,12 +97,6 @@ class Select2Ajax(forms.TextInput):
     The url is not specified in the form class definition because in most cases the url will be dependent on the
     domain of the request.
     """
-    class Media(object):
-        css = {
-            'all': ('select2-3.5.2-legacy/select2.css', 'select2-3.5.2-legacy/select2-bootstrap.css')
-        }
-        js = ('select2-3.5.2-legacy/select2.js',)
-
     def __init__(self, attrs=None, page_size=20, multiple=False):
         self.page_size = page_size
         self.multiple = multiple

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -646,6 +646,7 @@ class EditLocationView(NewLocationView):
     creates_new_location = False
 
     @method_decorator(can_edit_location)
+    @use_select2
     def dispatch(self, request, *args, **kwargs):
         return super(EditLocationView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext as _, ugettext_noop
 from corehq.apps.reports.filters.api import MobileWorkersOptionsView
 from corehq.apps.hqwebapp.decorators import (
     use_multiselect,
+    use_select2,
 )
 from django_prbac.utils import has_privilege
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
@@ -125,6 +126,7 @@ class BaseGroupsView(BaseUserSettingsView):
 
     @method_decorator(require_can_edit_commcare_users)
     @use_multiselect
+    @use_select2
     def dispatch(self, request, *args, **kwargs):
         return super(BaseGroupsView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Found the various usages of Select2Ajax and either verified that the related view uses @use_select2 or added it in.

@gcapalbo 