### PR TITLE
Better error handling

### DIFF
--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json
+
+from django.urls import reverse
+from django.test import Client, TestCase
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.locations.exceptions import LocationConsistencyError
+from corehq.apps.locations.models import LocationType
+from corehq.apps.locations.views import LocationTypesView
+from corehq.apps.users.models import WebUser
+from django.contrib.messages import get_messages
+import mock
+
+
+OTHER_DETAILS = {
+    'has_user': False,
+    'expand_from': None,
+    'expand_to': None,
+    'expand_from_root': False,
+    'include_without_expanding': None,
+    'include_only': [],
+    'parent_type': '',
+    'administrative': '',
+    'shares_cases': False,
+    'view_descendants': False,
+}
+
+
+class LocationTypesViewTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(LocationTypesViewTest, cls).setUpClass()
+        cls.domain = "test-domain"
+        cls.project = create_domain(cls.domain)
+        cls.couch_user = WebUser.create(cls.domain, "test", "foobar")
+        cls.couch_user.add_domain_membership(cls.domain, is_admin=True)
+        cls.couch_user.set_role(cls.domain, "admin")
+        cls.couch_user.save()
+        cls.loc_type1 = LocationType(domain=cls.domain, name='type1', code='code1')
+        cls.loc_type1.save()
+        cls.loc_type2 = LocationType(domain=cls.domain, name='type2', code='code2')
+        cls.loc_type2.save()
+
+    def setUp(self):
+        self.url = reverse(LocationTypesView.urlname, args=[self.domain])
+        self.client = Client()
+        self.client.login(username='test', password='foobar')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.couch_user.delete()
+        cls.project.delete()
+        super(LocationTypesViewTest, cls).tearDownClass()
+
+    @mock.patch('django_prbac.decorators.has_privilege', return_value=True)
+    def send_request(self, data, _):
+        return self.client.post(self.url, {'json': json.dumps(data)})
+
+    def test_missing_property(self):
+        with self.assertRaises(LocationConsistencyError):
+            self.send_request({'loc_types': [{}]})
+
+    def test_swap_name(self):
+        loc_type1 = OTHER_DETAILS.copy()
+        loc_type2 = OTHER_DETAILS.copy()
+        loc_type1.update({'name': self.loc_type2.name, 'pk': self.loc_type1.pk})
+        loc_type2.update({'name': self.loc_type1.name, 'pk': self.loc_type2.pk})
+        data = {'loc_types': [loc_type1, loc_type2]}
+        response = self.send_request(data)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0].message),
+            u'Looks like you are assigning a location name/code to a different location in the same request. '
+            u'Please do this in two separate updates by using a temporary name to free up the name/code to be '
+            u're-assigned.'
+        )
+
+    def test_swap_code(self):
+        loc_type1 = OTHER_DETAILS.copy()
+        loc_type2 = OTHER_DETAILS.copy()
+        loc_type1.update({'name': self.loc_type1.name, 'pk': self.loc_type1.pk, 'code': self.loc_type2.code})
+        loc_type2.update({'name': self.loc_type2.name, 'pk': self.loc_type2.pk, 'code': self.loc_type1.code})
+        data = {'loc_types': [loc_type1, loc_type2]}
+        response = self.send_request(data)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0].message),
+            u'Looks like you are assigning a location name/code to a different location in the same request. '
+            u'Please do this in two separate updates by using a temporary name to free up the name/code to be '
+            u're-assigned.'
+        )
+
+    def test_valid_update(self):
+        loc_type1 = OTHER_DETAILS.copy()
+        loc_type2 = OTHER_DETAILS.copy()
+        loc_type1.update({'name': "new name", 'pk': self.loc_type1.pk, 'code': self.loc_type1.code})
+        loc_type2.update({'name': "new name 2", 'pk': self.loc_type2.pk, 'code': self.loc_type2.code})
+        data = {'loc_types': [loc_type1, loc_type2]}
+        response = self.send_request(data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -332,6 +332,21 @@ class LocationTypesView(BaseDomainView):
             sql_loc_types[pk] = loc_type
             loc_type.save()
 
+        def unique_name_and_code():
+            current_location_types = LocationType.objects.by_domain(request.domain)
+            for location_type in current_location_types:
+                if location_type.pk in payload_loc_type_name_by_pk:
+                    # to check if the name/code was swapped with another location by confirming if
+                    # either name/code has changed but the current name is still present in the names/codes passed
+                    if (
+                            (location_type.name != payload_loc_type_name_by_pk.get(location_type.pk) and
+                             location_type.name in names) or
+                            (location_type.code != payload_loc_type_code_by_pk.get(location_type.pk) and
+                             location_type.code in codes)
+                    ):
+                        return False
+            return True
+
         loc_types = payload['loc_types']
         pks = []
         payload_loc_type_name_by_pk = {}
@@ -345,7 +360,7 @@ class LocationTypesView(BaseDomainView):
             if not _is_fake_pk(pk):
                 pks.append(loc_type['pk'])
             payload_loc_type_name_by_pk[loc_type['pk']] = loc_type['name']
-            if loc_type['code']:
+            if loc_type.get('code'):
                 payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']
         names = payload_loc_type_name_by_pk.values()
         names_are_unique = len(names) == len(set(names))
@@ -354,23 +369,13 @@ class LocationTypesView(BaseDomainView):
         if not names_are_unique or not codes_are_unique:
             raise LocationConsistencyError("'name' and 'code' are supposed to be unique")
 
-        current_location_types = LocationType.objects.by_domain(request.domain)
-        for location_type in current_location_types:
-            if location_type.pk in payload_loc_type_name_by_pk:
-                # to check if the name/code was swapped with another location by confirming if
-                # either name/code has changed but the current name is still present in the names/codes passed
-                if (
-                        (location_type.name != payload_loc_type_name_by_pk.get(location_type.pk) and
-                         location_type.name in names) or
-                        (location_type.code != payload_loc_type_code_by_pk[location_type.pk] and
-                         location_type.code in codes)
-                ):
-                    messages.error(request, LocationConsistencyError(_(
-                        "Looks like you are assigning a location name/code to a different location "
-                        "in the same request. Please do this in two separate updates by using a "
-                        "temporary name to free up the name/code to be re-assigned."))
-                    )
-                    return self.get(request, *args, **kwargs)
+        if not unique_name_and_code():
+            messages.error(request, LocationConsistencyError(_(
+                "Looks like you are assigning a location name/code to a different location "
+                "in the same request. Please do this in two separate updates by using a "
+                "temporary name to free up the name/code to be re-assigned."))
+            )
+            return self.get(request, *args, **kwargs)
         hierarchy = self.get_hierarchy(loc_types)
 
         if not self.remove_old_location_types(pks):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -362,9 +362,9 @@ class LocationTypesView(BaseDomainView):
             payload_loc_type_name_by_pk[loc_type['pk']] = loc_type['name']
             if loc_type.get('code'):
                 payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']
-        names = payload_loc_type_name_by_pk.values()
+        names = list(payload_loc_type_name_by_pk.values())
         names_are_unique = len(names) == len(set(names))
-        codes = payload_loc_type_code_by_pk.values()
+        codes = list(payload_loc_type_code_by_pk.values())
         codes_are_unique = len(codes) == len(set(codes))
         if not names_are_unique or not codes_are_unique:
             raise LocationConsistencyError("'name' and 'code' are supposed to be unique")

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -334,6 +334,8 @@ class LocationTypesView(BaseDomainView):
 
         loc_types = payload['loc_types']
         pks = []
+        payload_loc_type_name_by_pk = {}
+        payload_loc_type_code_by_pk = {}
         for loc_type in loc_types:
             for prop in ['name', 'parent_type', 'administrative',
                          'shares_cases', 'view_descendants', 'pk']:
@@ -342,14 +344,33 @@ class LocationTypesView(BaseDomainView):
             pk = loc_type['pk']
             if not _is_fake_pk(pk):
                 pks.append(loc_type['pk'])
-
-        names = [lt['name'] for lt in loc_types]
+            payload_loc_type_name_by_pk[loc_type['pk']] = loc_type['name']
+            if loc_type['code']:
+                payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']
+        names = payload_loc_type_name_by_pk.values()
         names_are_unique = len(names) == len(set(names))
-        codes = [lt['code'] for lt in loc_types if lt['code']]
+        codes = payload_loc_type_code_by_pk.values()
         codes_are_unique = len(codes) == len(set(codes))
         if not names_are_unique or not codes_are_unique:
             raise LocationConsistencyError("'name' and 'code' are supposed to be unique")
 
+        current_location_types = LocationType.objects.by_domain(request.domain)
+        for location_type in current_location_types:
+            if location_type.pk in payload_loc_type_name_by_pk:
+                # to check if the name/code was swapped with another location by confirming if
+                # either name/code has changed but the current name is still present in the names/codes passed
+                if (
+                        (location_type.name != payload_loc_type_name_by_pk.get(location_type.pk) and
+                         location_type.name in names) or
+                        (location_type.code != payload_loc_type_code_by_pk[location_type.pk] and
+                         location_type.code in codes)
+                ):
+                    messages.error(request, LocationConsistencyError(_(
+                        "Looks like you are assigning a location name/code to a different location "
+                        "in the same request. Please do this in two separate updates by using a "
+                        "temporary name to free up the name/code to be re-assigned."))
+                    )
+                    return self.get(request, *args, **kwargs)
         hierarchy = self.get_hierarchy(loc_types)
 
         if not self.remove_old_location_types(pks):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?276927

Show error message to user 
```
Looks like you are assigning a location name/code to a different location in the same request. 
Please do this in two separate updates by using a temporary name to free up the name/code to be re-assigned.
```

if they are trying to swap names/codes for two locations or trying to use name/code for a location to another

Doing such an update in a single request results in IntegrityError at database due to unique constraint while the updates are being done sequentially.

fyi @emord @esoergel 