### PR TITLE
skip when passed no translation

### DIFF
--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -625,6 +625,11 @@ def update_form_translations(sheet, rows, missing_cols, app):
         old_trans = etree.tostring(value_node_.xml, method="text", encoding="unicode").strip()
         return _looks_like_markdown(old_trans) and not had_markdown(text_node_)
 
+    def has_translation(row_, langs):
+        for lang_ in langs:
+            if row_.get(_get_col_key('default', lang_)):
+                return True
+
     # Aggregate Markdown vetoes, and translations that currently have Markdown
     vetoes = defaultdict(lambda: False)  # By default, Markdown is not vetoed for a label
     markdowns = defaultdict(lambda: False)  # By default, Markdown is not in use
@@ -640,10 +645,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
     # skip labels that have no translation provided
     skip_label = set()
     for row in rows:
-        for lang in app.langs:
-            if row.get(_get_col_key('default', lang)):
-                break
-        else:  # https://stackoverflow.com/a/654002
+        if not has_translation(row, app.langs):
             skip_label.add(row['label'])
     for label in skip_label:
         msgs.append((

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -645,15 +645,16 @@ def update_form_translations(sheet, rows, missing_cols, app):
             markdowns[label_id] = markdowns[label_id] or had_markdown(text_node)
     # skip labels that have no translation provided
     skip_label = set()
-    for row in rows:
-        if not has_translation(row, app.langs):
-            skip_label.add(row['label'])
-    for label in skip_label:
-        msgs.append((
-            messages.error,
-            "You must provide at least one translation" +
-            " for the label '%s' in sheet '%s'" % (label, sheet.worksheet.title)
-        ))
+    if form.is_registration_form():
+        for row in rows:
+            if not has_translation(row, app.langs):
+                skip_label.add(row['label'])
+        for label in skip_label:
+            msgs.append((
+                messages.error,
+                "You must provide at least one translation" +
+                " for the label '%s' in sheet '%s'" % (label, sheet.worksheet.title)
+            ))
     # Update the translations
     for lang in app.langs:
         translation_node = itext.find("./{f}translation[@lang='%s']" % lang)

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -627,8 +627,9 @@ def update_form_translations(sheet, rows, missing_cols, app):
 
     def has_translation(row_, langs):
         for lang_ in langs:
-            if row_.get(_get_col_key('default', lang_)):
-                return True
+            for trans_type_ in ['default', 'audio', 'image', 'video']:
+                if row_.get(_get_col_key(trans_type_, lang_)):
+                    return True
 
     # Aggregate Markdown vetoes, and translations that currently have Markdown
     vetoes = defaultdict(lambda: False)  # By default, Markdown is not vetoed for a label

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -258,9 +258,8 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
           ('question7-label', 'question7', 'question7', '', '', '', '', '', ''),
           ('add_markdown-label', 'add_markdown', 'add_markdown', '', '', '', '', '', ''),
           ('update_markdown-label', '# update_markdown', '# update_markdown', '', '', '', '', '', ''),
-          (
-          'vetoed_markdown-label', '*i just happen to like stars*', '*i just happen to like stars*', '', '', '', '', '',
-          ''),
+          ('vetoed_markdown-label', '*i just happen to like stars*', '*i just happen to like stars*', '',
+           '', '', '', '', ''),
           ))
     )
 

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -226,6 +226,43 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
         ))
      )
 
+    upload_empty_translations = (
+        (MODULES_AND_FORMS_SHEET_NAME,
+         (('Module', 'module1', 'My & awesome module', '', '', '', '', '', '8f4f7085a93506cba4295eab9beae8723c0cee2a'),
+          ('Form', 'module1_form1', '', '', '', '', '', '', '', '', '93ea2a40df57d8f33b472f5b2b023882281722d4'))),
+        ('module1',
+         (('name', 'list', '', ''),
+          ('name', 'detail', 'Name', ''),
+          ('other-prop (ID Mapping Text)', 'detail', 'Other Prop', 'Autre Prop'),
+          ('foo (ID Mapping Value)', 'detail', 'bar', ''),
+          ('baz (ID Mapping Value)', 'detail', 'quz', ''),
+          ('mood (ID Mapping Text)', 'detail', 'Other Prop', ''),
+          ('. < 3 (ID Mapping Value)', 'detail', ':(', ':-('),
+          ('. >= 3 (ID Mapping Value)', 'detail', ':)', ':-)'),
+          ('energy (ID Mapping Text)', 'detail', 'Other Prop', ''),
+          ('. < 3 (ID Mapping Value)', 'detail',
+           'jr://file/commcare/image/module1_list_icon_energy_high.jpg',
+           'jr://file/commcare/image/module1_list_icon_energy_high_french.jpg'),
+          ('. >= 3 (ID Mapping Value)', 'detail',
+           'jr://file/commcare/image/module1_list_icon_energy_low.jpg',
+           'jr://file/commcare/image/module1_list_icon_energy_low_french.jpg'))),
+        ('module1_form1',
+         (('question1-label', '', '', '', '', '', '', '', ''),
+          ('question2-label', 'question2', 'question2', '', '', '', '', '', ''),
+          ('question2-item1-label', 'item1', 'item1', '', '', '', '', '', ''),
+          ('question2-item2-label', 'item2', 'item2', '', '', '', '', '', ''),
+          ('question3-label', 'question3', 'question3', '', '', '', '', '', ''),
+          ('question3/question4-label', 'question4', 'question4', '', '', '', '', '', ''),
+          ('question3/question5-label', 'question5', 'question5', '', '', '', '', '', ''),
+          ('question7-label', 'question7', 'question7', '', '', '', '', '', ''),
+          ('add_markdown-label', 'add_markdown', 'add_markdown', '', '', '', '', '', ''),
+          ('update_markdown-label', '# update_markdown', '# update_markdown', '', '', '', '', '', ''),
+          (
+          'vetoed_markdown-label', '*i just happen to like stars*', '*i just happen to like stars*', '', '', '', '', '',
+          ''),
+          ))
+    )
+
     def test_set_up(self):
         self._shared_test_initial_set_up()
 
@@ -324,6 +361,41 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
 
                 'Sheet "module1_form1" has unrecognized columns. Sheet will '
                 'be processed but ignoring the following columns: default-fra',
+
+                'App Translations Updated!'
+            ]
+        )
+
+    def test_empty_translations(self):
+        self.upload_raw_excel_translations(
+            self.upload_headers_bad_column,
+            self.upload_empty_translations,
+            expected_messages=[
+                'Sheet "{}" has fewer columns than expected. Sheet '
+                'will be processed but the following translations will be '
+                'unchanged: default_fra'.format(MODULES_AND_FORMS_SHEET_NAME),
+
+                'Sheet "{}" has unrecognized columns. Sheet will '
+                'be processed but ignoring the following columns: default-fra'.format(
+                    MODULES_AND_FORMS_SHEET_NAME),
+
+                'Sheet "module1" has fewer columns than expected. Sheet '
+                'will be processed but the following translations will be '
+                'unchanged: default_fra',
+
+                'Sheet "module1" has unrecognized columns. Sheet will '
+                'be processed but ignoring the following columns: default-fra',
+                "You must provide at least one translation of the case property 'name'",
+
+                'Sheet "module1_form1" has fewer columns than expected. Sheet '
+                'will be processed but the following translations will be '
+                'unchanged: default_fra',
+
+                'Sheet "module1_form1" has unrecognized columns. Sheet will '
+                'be processed but ignoring the following columns: default-fra',
+
+                "You must provide at least one translation for the label 'question1-label' "
+                "in sheet 'module1_form1'",
 
                 'App Translations Updated!'
             ]

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -367,6 +367,8 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
         )
 
     def test_empty_translations(self):
+        # make the form a registration form
+        self.app.modules[0].forms[0].actions.open_case.condition.type = 'always'
         self.upload_raw_excel_translations(
             self.upload_headers_bad_column,
             self.upload_empty_translations,

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -228,7 +228,8 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
 
     upload_empty_translations = (
         (MODULES_AND_FORMS_SHEET_NAME,
-         (('Module', 'module1', 'My & awesome module', '', '', '', '', '', '8f4f7085a93506cba4295eab9beae8723c0cee2a'),
+         (('Module', 'module1', 'My & awesome module', '', '', '', '', '',
+           '8f4f7085a93506cba4295eab9beae8723c0cee2a'),
           ('Form', 'module1_form1', '', '', '', '', '', '', '', '', '93ea2a40df57d8f33b472f5b2b023882281722d4'))),
         ('module1',
          (('name', 'list', '', ''),


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?277877#1505929

Just like we ensure at least one translation for [case properties](https://github.com/dimagi/commcare-hq/blob/d0067647e5872b7bf59bb1d2bfc05917a45354eb/corehq/apps/app_manager/app_translations/app_translations.py#L876), 
just added a check to ensure at least one translation for form labels for registration forms only.
