### PR TITLE
allow viewing but not writing export-only

### DIFF
--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -216,33 +216,41 @@
         </fieldset>
         <div class="form-actions">
             <div class="col-sm-offset-4 col-md-offset-3 col-lg-offset-2 col-sm-8 col-md-9 col-lg-10 controls">
-                <button type="submit" class="btn btn-lg btn-primary" data-bind="
-                    click: save,
-                    disable: (saveState() === hqImport('export/js/const').SAVE_STATES.SAVING ||
-                              saveState() === hqImport('export/js/const').SAVE_STATES.SUCCESS ||
-                              ! isValid())
-                ">
-                    <span data-bind="
-                        visible: saveState() === hqImport('export/js/const').SAVE_STATES.READY,
-                        text: getSaveText()">
-                    </span>
-                    <span data-bind="visible: saveState() === hqImport('export/js/const').SAVE_STATES.SAVING">
-                        <i class="fa fa-refresh fa-spin"></i>
-                        {% trans "Saving" %}
-                    </span>
-                    <span data-bind="visible: saveState() === hqImport('export/js/const').SAVE_STATES.ERROR">
-                        {% trans "Try Again" %}
-                    </span>
-                    <span data-bind="visible: saveState() === hqImport('export/js/const').SAVE_STATES.SUCCESS">
-                        {% trans "Saved!" %}
-                    </span>
-                </button>
-                <a class="btn btn-default btn-lg" href="{{ export_home_url }}">{% trans "Cancel" %}</a>
-                {% if export_instance.get_id %}
-                <a class="btn btn-lg btn-danger pull-right" data-toggle="modal" href="#delete-export-modal-{{ export_instance.get_id }}">
-                    <i class="fa fa-remove fa-white"></i>
-                    {% trans "Delete this Export" %}
+                {% if can_edit %}
+                    <button type="submit" class="btn btn-lg btn-primary" data-bind="
+                        click: save,
+                        disable: (saveState() === hqImport('export/js/const').SAVE_STATES.SAVING ||
+                                  saveState() === hqImport('export/js/const').SAVE_STATES.SUCCESS ||
+                                  ! isValid())
+                    ">
+                        <span data-bind="
+                            visible: saveState() === hqImport('export/js/const').SAVE_STATES.READY,
+                            text: getSaveText()">
+                        </span>
+                        <span data-bind="visible: saveState() === hqImport('export/js/const').SAVE_STATES.SAVING">
+                            <i class="fa fa-refresh fa-spin"></i>
+                            {% trans "Saving" %}
+                        </span>
+                        <span data-bind="visible: saveState() === hqImport('export/js/const').SAVE_STATES.ERROR">
+                            {% trans "Try Again" %}
+                        </span>
+                        <span data-bind="visible: saveState() === hqImport('export/js/const').SAVE_STATES.SUCCESS">
+                            {% trans "Saved!" %}
+                        </span>
+                    </button>
+                {% endif %}
+                <a class="btn btn-default btn-lg" href="{{ export_home_url }}">
+                    {% if can_edit %}
+                        {% trans "Cancel" %}
+                    {% else %}
+                        {% trans "Back" %}
+                    {% endif %}
                 </a>
+                {% if export_instance.get_id and can_edit %}
+                    <a class="btn btn-lg btn-danger pull-right" data-toggle="modal" href="#delete-export-modal-{{ export_instance.get_id }}">
+                        <i class="fa fa-remove fa-white"></i>
+                        {% trans "Delete this Export" %}
+                    </a>
                 {% endif %}
                 <div class="text-danger" data-bind="if: !isValid()">
                     {% trans "There are errors with your configuration. Please fix them before creating the export." %}

--- a/corehq/apps/export/templates/export/partial/shared_exports_table.html
+++ b/corehq/apps/export/templates/export/partial/shared_exports_table.html
@@ -302,10 +302,9 @@
                 </div>
                 <div ng-if="!export.can_edit">
                     <div ng-if="isLocationSafeForUser(export)">
-                        <a class="btn btn-default disabled">
-                            <i class="fa fa-pencil"></i>
-                            <span ng-show="!export.isDailySaved">{% trans 'Edit' %}</span>
-                            <span ng-show="export.isDailySaved">{% trans 'Edit Columns' %}</span>
+                        <a href="{{ export.editUrl }}" class="btn btn-default">
+                            <span ng-show="!export.isDailySaved">{% trans 'View' %}</span>
+                            <span ng-show="export.isDailySaved">{% trans 'View Columns' %}</span>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
For read-only exports, include a "View" button:
<img width="1057" alt="screen shot 2018-06-25 at 1 43 30 pm" src="https://user-images.githubusercontent.com/1757035/41866539-7790770e-787e-11e8-9496-176cf1dc2b31.png">

And include a "Back" button:
<img width="1054" alt="screen shot 2018-06-25 at 1 43 40 pm" src="https://user-images.githubusercontent.com/1757035/41866545-7c68f2a6-787e-11e8-8ccc-67df57bd7de0.png">

instead of the options to save/delete (original below):
<img width="1055" alt="screen shot 2018-06-25 at 1 43 48 pm" src="https://user-images.githubusercontent.com/1757035/41866551-7f918cae-787e-11e8-8249-adcf34260e24.png">
