### PR TITLE
Reindex ICDS data by date

### DIFF
--- a/corehq/apps/es/management/commands/resave_failed_forms_and_cases.py
+++ b/corehq/apps/es/management/commands/resave_failed_forms_and_cases.py
@@ -60,7 +60,8 @@ class Command(BaseCommand):
 def perform_resave_on_xforms(domain, start_date, end_date):
     _, _, xform_ids_missing_in_es, _ = compare_xforms(domain, 'XFormInstance', start_date, end_date)
     print("%s Ids found for xforms missing in ES." % len(xform_ids_missing_in_es))
-    print(xform_ids_missing_in_es)
+    if len(xform_ids_missing_in_es) < 1000:
+        print(xform_ids_missing_in_es)
     ok = input("Type 'ok' to continue: ")
     if ok != "ok":
         print("No changes made")
@@ -81,7 +82,8 @@ def perform_resave_on_xforms(domain, start_date, end_date):
 def perform_resave_on_cases(domain, start_date, end_date):
     _, _, case_ids_missing_in_es, _ = compare_cases(domain, 'CommCareCase', start_date, end_date)
     print("%s Ids found for cases missing in ES." % len(case_ids_missing_in_es))
-    print(case_ids_missing_in_es)
+    if len(case_ids_missing_in_es) < 1000:
+        print(case_ids_missing_in_es)
     ok = input("Type 'ok' to continue: ")
     if ok != "ok":
         print("No changes made")

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -770,6 +770,8 @@ class CaseReindexAccessor(ReindexAccessor):
     def __init__(self, domain=None, limit_db_aliases=None, start_date=None, end_date=None):
         super(CaseReindexAccessor, self).__init__(limit_db_aliases=limit_db_aliases)
         self.domain = domain
+        self.start_date = start_date
+        self.end_date = end_date
 
     @property
     def model_class(self):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -767,7 +767,7 @@ class CaseReindexAccessor(ReindexAccessor):
     """
     :param: domain: If supplied the accessor will restrict results to only that domain
     """
-    def __init__(self, domain=None, limit_db_aliases=None):
+    def __init__(self, domain=None, limit_db_aliases=None, start_date=None, end_date=None):
         super(CaseReindexAccessor, self).__init__(limit_db_aliases=limit_db_aliases)
         self.domain = domain
 
@@ -789,6 +789,10 @@ class CaseReindexAccessor(ReindexAccessor):
         filters = [Q(deleted=False)]
         if self.domain:
             filters.append(Q(domain=self.domain))
+        if self.start_date is not None:
+            filters.append(Q(server_modified_on__gte=self.start_date))
+        if self.end_date is not None:
+            filters.append(Q(server_modified_on__lt=self.end_date))
         return filters
 
 

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -90,17 +90,24 @@ class SqlCaseReindexerFactory(ReindexerFactory):
         ReindexerFactory.elastic_reindexer_args,
         ReindexerFactory.limit_db_args,
         ReindexerFactory.domain_arg,
+        ReindexerFactory.server_modified_on_arg,
     ]
 
     def build(self):
         limit_to_db = self.options.pop('limit_to_db', None)
         domain = self.options.pop('domain', None)
-        iteration_key = "SqlCaseToElasticsearchPillow_{}_reindexer_{}_{}".format(
-            CASE_INDEX_INFO.index, limit_to_db or 'all', domain or 'all'
+        start_date = self.options.pop('start_date', None)
+        end_date = self.options.pop('end_date', None)
+        iteration_key = "SqlCaseToElasticsearchPillow_{}_reindexer_{}_{}_from_{}_until_{}".format(
+            CASE_INDEX_INFO.index, limit_to_db or 'all', domain or 'all',
+            start_date or 'beginning', end_date or 'current'
         )
         limit_db_aliases = [limit_to_db] if limit_to_db else None
 
-        reindex_accessor = CaseReindexAccessor(domain=domain, limit_db_aliases=limit_db_aliases)
+        reindex_accessor = CaseReindexAccessor(
+            domain=domain, limit_db_aliases=limit_db_aliases,
+            start_date=start_date, end_date=end_date
+        )
         doc_provider = SqlDocumentProvider(iteration_key, reindex_accessor)
         return ResumableBulkElasticPillowReindexer(
             doc_provider,


### PR DESCRIPTION
@dimagi/scale-team 

First commit is to add time filters to the case reindexer which I don't think we need because...

I found this old management that runs compare doc ids and resaves the form/case meaning it pushes it to kafka so it can get picked up by pillows. the last 3 commits fixes the management command and add date filtering.