### PR TITLE
Use ace editor for admin restore page

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
@@ -2,5 +2,20 @@
 hqDefine('hqadmin/js/admin_restore', function () {
     $(function() {
         $("#timingTable").treetable();
+        var element = document.getElementById("payload");
+        var editor = ace.edit(
+                element,
+                {
+                    showPrintMargin: false,
+                    maxLines: 40,
+                    minLines: 3,
+                    fontSize: 14,
+                    wrap: true,
+                    useWorker: false, // enable the worker to show syntax errors
+                }
+            );
+        editor.session.setMode('ace/mode/xml');
+        editor.setReadOnly(true);
+        editor.session.setValue($("#payload").data('payload'));
     });
 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
@@ -1,19 +1,19 @@
-/* globals hqDefine */
+/* globals hqDefine ace */
 hqDefine('hqadmin/js/admin_restore', function () {
     $(function() {
         $("#timingTable").treetable();
         var element = document.getElementById("payload");
         var editor = ace.edit(
-                element,
-                {
-                    showPrintMargin: false,
-                    maxLines: 40,
-                    minLines: 3,
-                    fontSize: 14,
-                    wrap: true,
-                    useWorker: false, // enable the worker to show syntax errors
-                }
-            );
+            element,
+            {
+                showPrintMargin: false,
+                maxLines: 40,
+                minLines: 3,
+                fontSize: 14,
+                wrap: true,
+                useWorker: false, // enable the worker to show syntax errors
+            }
+        );
         editor.session.setMode('ace/mode/xml');
         editor.setReadOnly(true);
         editor.session.setValue($("#payload").data('payload'));

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -86,7 +86,7 @@
                         <div class="tab-content">
                             <div role="tabpanel" class="tab-pane active" id="payload-tab">
                                 {% if not hide_xml %}
-                                    <pre id="payload" data-payload="{{ payload }}"></pre>
+                                    <pre id="payload" data-payload="{% html_attr payload %}"></pre>
                                 {% else %}
                                     XML is hidden
                                 {% endif %}

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -10,6 +10,9 @@
         {% javascript_libraries %}
         {% compress js %}
             <script src="{% static 'jquery-treetable/jquery.treetable.js' %}"></script>
+            <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+            <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
+            <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
             <script src="{% static 'hqadmin/js/admin_restore.js' %}"></script>
         {% endcompress %}
 
@@ -83,7 +86,7 @@
                         <div class="tab-content">
                             <div role="tabpanel" class="tab-pane active" id="payload-tab">
                                 {% if not hide_xml %}
-                                    <pre id="payload">{{ payload }}</pre>
+                                    <pre id="payload" data-payload="{{ payload }}"></pre>
                                 {% else %}
                                     XML is hidden
                                 {% endif %}


### PR DESCRIPTION
Uses the ace editor on the admin restore page so that it doesn't try and render all the XML at once. This rendered a 20MB restore file for me immediately, and comes with its own search box.

Previous attempts at making this page usable are: `hide_xml`, and `download=true`. This is a combination of all of them! 

