### PR TITLE
check for media_path in all_media_paths before removing

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1593,6 +1593,7 @@ class NavMenuItemMediaMixin(DocumentSchema):
         app = self.get_app()
         if old_value and not media_path:
             # expire all_media_paths before checking for media path used in Application
+            app.all_media.reset_cache(app)
             app.all_media_paths.reset_cache(app)
             if old_value not in app.all_media_paths():
                 app.multimedia_map.pop(old_value, None)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1585,14 +1585,17 @@ class NavMenuItemMediaMixin(DocumentSchema):
 
         media_dict = getattr(self, media_attr) or {}
         old_value = media_dict.get(lang)
+        media_dict[lang] = media_path or ''
+        setattr(self, media_attr, media_dict)
         # remove the entry from app multimedia mappings if media is being removed now
         # This does not remove the multimedia but just it's reference in mapping
         # Added it here to ensure it's always set instead of getting it only when needed
         app = self.get_app()
         if old_value and not media_path:
-            app.multimedia_map.pop(old_value, None)
-        media_dict[lang] = media_path or ''
-        setattr(self, media_attr, media_dict)
+            # expire all_media_paths before checking for media path used in Application
+            app.all_media_paths.reset_cache(app)
+            if old_value not in app.all_media_paths():
+                app.multimedia_map.pop(old_value, None)
 
     def set_icon(self, lang, icon_path):
         self._set_media('media_image', lang, icon_path)

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -46,7 +46,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
         should_contain_media = [image_path.format(num) for num in [1, 2, 3, 4]] + \
                                [audio_path.format(num) for num in [1, 2, 3, 4]]
         self.assertTrue(app.get_module(0).uses_media())
-        self.assertEqual(app.all_media_paths, set(should_contain_media))
+        self.assertEqual(app.all_media_paths(), set(should_contain_media))
         self.assertEqual(set(app.multimedia_map.keys()), set(should_contain_media))
 
         # test multimedia removed
@@ -66,7 +66,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
         app = Application.wrap(self.get_json('app_video_inline'))
 
         self.assertTrue(app.get_module(0).uses_media())
-        self.assertEqual(app.all_media_paths, set([inline_video_path]))
+        self.assertEqual(app.all_media_paths(), set([inline_video_path]))
 
     @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
     def test_all_media_paths_with_expanded_audio(self, mock):
@@ -74,7 +74,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
         app = Application.wrap(self.get_json('app_expanded_audio'))
 
         self.assertTrue(app.get_module(0).uses_media())
-        self.assertEqual(app.all_media_paths, set([inline_video_path]))
+        self.assertEqual(app.all_media_paths(), set([inline_video_path]))
 
     @override_settings(BASE_ADDRESS='192.cc.hq.1')
     def test_case_list_media(self):

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -21,7 +21,8 @@ import commcare_translations
 class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
-    def test_all_media_paths(self):
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_all_media_paths(self, mock):
         image_path = 'jr://file/commcare/image{}.jpg'
         audio_path = 'jr://file/commcare/audio{}.mp3'
         app = Application.wrap(self.get_json('app'))
@@ -146,7 +147,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
         app.get_module(0).media_audio.update({'en': audio_path})
 
         self.assertTrue(app.get_module(0).uses_media())
-        self.assertEqual(len(app.all_media), 2)
+        self.assertEqual(len(app.all_media()), 2)
 
 
 class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -541,7 +541,6 @@ class HQMediaMixin(Document):
 
     archived_media = DictProperty()  # where we store references to the old logos (or other multimedia) on a downgrade, so that information is not lost
 
-    @property
     @memoized
     def all_media(self):
         """
@@ -699,11 +698,11 @@ class HQMediaMixin(Document):
 
     @memoized
     def all_media_paths(self):
-        return set([m.path for m in self.all_media])
+        return set([m.path for m in self.all_media()])
 
     @memoized
     def get_all_paths_of_type(self, media_class_name):
-        return set([m.path for m in self.all_media if m.media_class.__name__ == media_class_name])
+        return set([m.path for m in self.all_media() if m.media_class.__name__ == media_class_name])
 
     def get_media_ref_kwargs(self, module, module_index, form=None,
                              form_index=None, is_menu_media=False):
@@ -794,7 +793,7 @@ class HQMediaMixin(Document):
         """
             Used for the multimedia controller.
         """
-        return [m.as_dict(lang) for m in self.all_media]
+        return [m.as_dict(lang) for m in self.all_media()]
 
     def get_object_map(self):
         object_map = {}
@@ -832,14 +831,14 @@ class HQMediaMixin(Document):
     def check_media_state(self):
         has_missing_refs = False
 
-        for media in self.all_media:
+        for media in self.all_media():
             try:
                 self.multimedia_map[media.path]
             except KeyError:
                 has_missing_refs = True
 
         return {
-            "has_media": bool(self.all_media),
+            "has_media": bool(self.all_media()),
             "has_form_errors": self.media_form_errors,
             "has_missing_refs": has_missing_refs,
         }

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -697,7 +697,6 @@ class HQMediaMixin(Document):
         menu_media['audio'] = audio_ref
         return menu_media
 
-    @property
     @memoized
     def all_media_paths(self):
         return set([m.path for m in self.all_media])
@@ -732,7 +731,7 @@ class HQMediaMixin(Document):
         if self.check_media_state()['has_form_errors']:
             return
         paths = list(self.multimedia_map) if self.multimedia_map else []
-        permitted_paths = self.all_media_paths | self.logo_paths
+        permitted_paths = self.all_media_paths() | self.logo_paths
         for path in paths:
             if path not in permitted_paths:
                 map_changed = True


### PR DESCRIPTION
Possibly edge case introduced https://github.com/dimagi/commcare-hq/pull/20694/files#diff-535390eb5c83a4cd3449f82afd1fa9fbR1592

Steps to replicate
1. upload an icon for say en under module settings. Copy its media path
2. change the language, use the copied media path for the same module setting
3. remove the media for the previous language now.. that will remove the media path from multimedia_map

eventually resulting in missing multimedia, scenario generated [here](https://www.commcarehq.org/a/firsttestproject-1/apps/b40dc444f4620d2e0f251120bf3bf8ee/multimedia/map/)

can also been seen in [App Doc](https://www.commcarehq.org/hq/admin/raw_doc/?id=b40dc444f4620d2e0f251120bf3bf8ee&db_name=) for `jr://file/commcare/image/module0_en.jpg` missing in multimedia_map which eventually results error when installing the app.