### PR TITLE
Fix permission denied error when opening builds in web apps from rele…

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -267,10 +267,11 @@ hqDefine('app_manager/js/releases/releases', function () {
             }
             return hqImport("hqwebapp/js/initial_page_data").reverse.apply(null, arguments);
         };
-        self.webAppsUrl = function(idObservable) {
+        self.webAppsUrl = function(idObservable, copyOf) {
             var url = hqImport("hqwebapp/js/initial_page_data").reverse("formplayer_main"),
                 data = {
                     appId: ko.utils.unwrapObservable(idObservable),
+                    copyOf: copyOf,
                 };
 
             return url + '#' + encodeURI(JSON.stringify(data));

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -189,7 +189,7 @@
                                    data-category="App Manager"
                                    data-action="Deploy Type"
                                    data-label="Open in Web Apps"
-                                   data-bind="attr: {href: $root.webAppsUrl(id)}">
+                                   data-bind="attr: {href: $root.webAppsUrl(id, '{{ app.id }}')}">
                                     <i class="fa fa-desktop"></i>
                                     {% trans 'Open in Web Apps' %}
                                 </a>

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -19,10 +19,10 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 menus;
 
             if (!params.preview) {
-                // Make sure the user has access to this app
+                // Make sure the user has access to the canonical (not a build) version of this app
                 var accessibleApps = hqImport("hqwebapp/js/initial_page_data").get("apps"),
-                    accessibleAppIds = _.pluck(accessibleApps, '_id');
-                if (!_.contains(accessibleAppIds, params.appId)) {
+                    accessibleAppIds = _.map(accessibleApps, function(a) { return a.copy_of || a._id; });
+                if (!_.contains(accessibleAppIds, params.appId) && !_.contains(accessibleAppIds, params.copyOf)) {
                     FormplayerFrontend.trigger(
                         'showError',
                         gettext("Permission Denied")

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -131,6 +131,7 @@ Util.pagesToShow = function(selectedPage, totalPages, limit) {
 
 Util.CloudcareUrl = function (options) {
     this.appId = options.appId;
+    this.copyOf = options.copyOf;
     this.sessionId = options.sessionId;
     this.steps = options.steps;
     this.page = options.page;
@@ -210,6 +211,7 @@ Util.CloudcareUrl.prototype.toJson = function () {
     var self = this;
     var dict = {
         appId: self.appId,
+        copyOf: self.copyOf,
         sessionId: self.sessionId,
         steps: self.steps,
         page: self.page,
@@ -226,6 +228,7 @@ Util.CloudcareUrl.fromJson = function (json) {
     var data = JSON.parse(json);
     var options = {
         'appId': data.appId,
+        'copyOf': data.copyOf,
         'sessionId': data.sessionId,
         'steps': data.steps,
         'page': data.page,


### PR DESCRIPTION
…ases page

https://manage.dimagi.com/default.asp?278241

Two changes:
- Make the accessible apps list always contain canonical app ids (instead of potentially containing build ids)
- When linking to web apps, pass along the canonical id (copy_of) so that is what gets checked against the accessible apps list

@nickpell / @esoergel 