### PR TITLE
Various items for parity with old reminders framework

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -125,6 +125,11 @@ def _deactivate_schedules(domain, survey_only=False):
         )
 
     for rule in _get_active_scheduling_rules(domain, survey_only=survey_only):
+        """
+        Deactivating a scheduling rule involves only deactivating the schedule, and
+        leaving the rule active. See ConditionalAlertListView.get_activate_ajax_response
+        for more information.
+        """
         with transaction.atomic():
             schedule = rule.get_messaging_rule_schedule()
             if isinstance(schedule, AlertSchedule):

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -202,7 +202,8 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
             if domain.uses_new_reminders:
                 _deactivate_schedules(domain, survey_only=True)
             else:
-                surveys = [x for x in _active_reminders(domain) if x.method in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY]]
+                surveys = [x for x in _active_reminders(domain)
+                           if x.method in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY]]
                 for survey in surveys:
                     survey.active = False
                     survey.save()
@@ -534,7 +535,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         All Reminder rules utilizing "survey" will be deactivated.
         """
         if domain.uses_new_reminders:
-            num_active = (
+            num_survey = (
                 len(_get_active_immediate_broadcasts(domain, survey_only=True)) +
                 len(_get_active_scheduled_broadcasts(domain, survey_only=True)) +
                 len(_get_active_scheduling_rules(domain, survey_only=True))

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -97,11 +97,13 @@ def _get_active_scheduled_broadcasts(domain, survey_only=False):
 
 
 def _get_active_scheduling_rules(domain, survey_only=False):
-    result = list(
-        AutomaticUpdateRule.by_domain(domain.name, AutomaticUpdateRule.WORKFLOW_SCHEDULING, active_only=False)
-    )
-    if survey_only:
-        result = [rule for rule in result if rule.get_messaging_rule_schedule().memoized_uses_sms_survey]
+    rules = AutomaticUpdateRule.by_domain(domain.name, AutomaticUpdateRule.WORKFLOW_SCHEDULING, active_only=False)
+
+    result = []
+    for rule in rules:
+        schedule = rule.get_messaging_rule_schedule()
+        if schedule.active and (not survey_only or schedule.memoized_uses_sms_survey):
+            result.append(rule)
 
     return result
 

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -24,6 +24,14 @@ from corehq.apps.reminders.models import METHOD_SMS_SURVEY, METHOD_IVR_SURVEY
 from corehq.apps.users.models import CommCareUser, UserRole
 from corehq.apps.userreports.exceptions import DataSourceConfigurationNotFoundError
 from corehq.const import USER_DATE_FORMAT
+from corehq.messaging.scheduling.models import (
+    ImmediateBroadcast,
+    ScheduledBroadcast,
+    AlertSchedule,
+    TimedSchedule,
+)
+from corehq.messaging.scheduling.tasks import refresh_alert_schedule_instances, refresh_timed_schedule_instances
+from django.db import transaction
 
 
 class BaseModifySubscriptionHandler(object):
@@ -68,9 +76,65 @@ class BaseModifySubscriptionActionHandler(BaseModifySubscriptionHandler):
         return all(response)
 
 
-# TODO - cache
 def _active_reminders(domain):
     return get_active_reminders_by_domain_name(domain.name)
+
+
+def _get_active_immediate_broadcasts(domain, survey_only=False):
+    result = list(ImmediateBroadcast.objects.filter(domain=domain.name, deleted=False, schedule__active=True))
+    if survey_only:
+        result = [broadcast for broadcast in result if broadcast.schedule.memoized_uses_sms_survey]
+
+    return result
+
+
+def _get_active_scheduled_broadcasts(domain, survey_only=False):
+    result = list(ScheduledBroadcast.objects.filter(domain=domain.name, deleted=False, schedule__active=True))
+    if survey_only:
+        result = [broadcast for broadcast in result if broadcast.schedule.memoized_uses_sms_survey]
+
+    return result
+
+
+def _get_active_scheduling_rules(domain, survey_only=False):
+    result = list(
+        AutomaticUpdateRule.by_domain(domain.name, AutomaticUpdateRule.WORKFLOW_SCHEDULING, active_only=False)
+    )
+    if survey_only:
+        result = [rule for rule in result if rule.get_messaging_rule_schedule().memoized_uses_sms_survey]
+
+    return result
+
+
+def _deactivate_schedules(domain, survey_only=False):
+    from corehq.messaging.tasks import initiate_messaging_rule_run
+
+    for broadcast in _get_active_immediate_broadcasts(domain, survey_only=survey_only):
+        AlertSchedule.objects.filter(schedule_id=broadcast.schedule_id).update(active=False)
+        refresh_alert_schedule_instances.delay(
+            broadcast.schedule_id,
+            broadcast.recipients,
+        )
+
+    for broadcast in _get_active_scheduled_broadcasts(domain, survey_only=survey_only):
+        TimedSchedule.objects.filter(schedule_id=broadcast.schedule_id).update(active=False)
+        refresh_timed_schedule_instances.delay(
+            broadcast.schedule_id,
+            broadcast.recipients,
+            start_date=broadcast.start_date
+        )
+
+    for rule in _get_active_scheduling_rules(domain, survey_only=survey_only):
+        with transaction.atomic():
+            schedule = rule.get_messaging_rule_schedule()
+            if isinstance(schedule, AlertSchedule):
+                AlertSchedule.objects.filter(schedule_id=schedule.schedule_id).update(active=False)
+            elif isinstance(schedule, TimedSchedule):
+                TimedSchedule.objects.filter(schedule_id=schedule.schedule_id).update(active=False)
+            else:
+                raise TypeError("Expected AlertSchedule or TimedSchedule")
+
+            initiate_messaging_rule_run(domain.name, rule.pk)
 
 
 class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
@@ -110,9 +174,12 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         Reminder rules will be deactivated.
         """
         try:
-            for reminder in _active_reminders(domain):
-                reminder.active = False
-                reminder.save()
+            if domain.uses_new_reminders:
+                _deactivate_schedules(domain)
+            else:
+                for reminder in _active_reminders(domain):
+                    reminder.active = False
+                    reminder.save()
         except Exception:
             log_accounting_error(
                 "Failed to downgrade outbound sms for domain %s."
@@ -127,10 +194,13 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         All Reminder rules utilizing "survey" will be deactivated.
         """
         try:
-            surveys = [x for x in _active_reminders(domain) if x.method in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY]]
-            for survey in surveys:
-                survey.active = False
-                survey.save()
+            if domain.uses_new_reminders:
+                _deactivate_schedules(domain, survey_only=True)
+            else:
+                surveys = [x for x in _active_reminders(domain) if x.method in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY]]
+                for survey in surveys:
+                    survey.active = False
+                    survey.save()
         except Exception:
             log_accounting_error(
                 "Failed to downgrade inbound sms for domain %s."
@@ -309,7 +379,6 @@ class DomainUpgradeActionHandler(BaseModifySubscriptionActionHandler):
         return True
 
 
-# TODO - cache
 def _active_reminder_methods(domain):
     reminder_rules = get_active_reminders_by_domain_name(domain.name)
     return [reminder.method for reminder in reminder_rules]
@@ -433,14 +502,21 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         Reminder rules will be deactivated.
         """
-        num_active = len(_active_reminder_methods(domain))
+        if domain.uses_new_reminders:
+            num_active = (
+                len(_get_active_immediate_broadcasts(domain)) +
+                len(_get_active_scheduled_broadcasts(domain)) +
+                len(_get_active_scheduling_rules(domain))
+            )
+        else:
+            num_active = len(_active_reminder_methods(domain))
         if num_active > 0:
             return _fmt_alert(
                 ungettext(
-                    "You have %(num_active)d active Reminder Rule. Selecting "
-                    "this plan will deactivate this rule.",
-                    "You have %(num_active)d active Reminder Rules. Selecting "
-                    "this plan will deactivate these rules.",
+                    "You have %(num_active)d active Reminder Rule or Broadcast. Selecting "
+                    "this plan will deactivate it.",
+                    "You have %(num_active)d active Reminder Rules and Broadcasts. Selecting "
+                    "this plan will deactivate them.",
                     num_active
                 ) % {
                     'num_active': num_active,
@@ -452,15 +528,22 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         All Reminder rules utilizing "survey" will be deactivated.
         """
-        surveys = [x for x in _active_reminder_methods(domain) if x in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY]]
-        num_survey = len(surveys)
+        if domain.uses_new_reminders:
+            num_active = (
+                len(_get_active_immediate_broadcasts(domain, survey_only=True)) +
+                len(_get_active_scheduled_broadcasts(domain, survey_only=True)) +
+                len(_get_active_scheduling_rules(domain, survey_only=True))
+            )
+        else:
+            surveys = [x for x in _active_reminder_methods(domain) if x in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY]]
+            num_survey = len(surveys)
         if num_survey > 0:
             return _fmt_alert(
                 ungettext(
-                    "You have %(num_active)d active Reminder Rule for a Survey. "
-                    "Selecting this plan will deactivate this rule.",
-                    "You have %(num_active)d active Reminder Rules for a Survey. "
-                    "Selecting this plan will deactivate these rules.",
+                    "You have %(num_active)d active Reminder Rule or Broadcast which uses a Survey. "
+                    "Selecting this plan will deactivate it.",
+                    "You have %(num_active)d active Reminder Rules and Broadcasts which use a Survey. "
+                    "Selecting this plan will deactivate them.",
                     num_survey
                 ) % {
                     'num_active': num_survey,

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TransactionTestCase
 from mock import patch, Mock, call
 
 from corehq.apps.accounting.models import (
@@ -258,7 +258,7 @@ class TestSoftwarePlanChanges(BaseAccountingTest):
         self.assertRaises(SubscriptionAdjustmentError, lambda: sub2.change_plan(self.advanced_plan))
 
 
-class DeactivateScheduleTest(TestCase):
+class DeactivateScheduleTest(TransactionTestCase):
 
     def setUp(self):
         super(DeactivateScheduleTest, self).setUp()

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -215,7 +215,7 @@ class AutomaticUpdateRule(models.Model):
 
     @classmethod
     def domain_has_conditional_alerts(cls, domain):
-        return cls.by_domain(domain, cls.WORKFLOW_SCHEDULING, active_only=False).count() > 0
+        return cls.by_domain(domain, cls.WORKFLOW_SCHEDULING, active_only=False).exists()
 
     @classmethod
     @quickcache(['domain', 'workflow', 'active_only'], timeout=30 * 60)

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -214,6 +214,10 @@ class AutomaticUpdateRule(models.Model):
         )
 
     @classmethod
+    def domain_has_conditional_alerts(cls, domain):
+        return cls.by_domain(domain, cls.WORKFLOW_SCHEDULING, active_only=False).count() > 0
+
+    @classmethod
     @quickcache(['domain', 'workflow', 'active_only'], timeout=30 * 60)
     def by_domain_cached(cls, domain, workflow, active_only=True):
         result = cls.by_domain(domain, workflow, active_only=active_only)

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -23,7 +23,6 @@ from couchforms.analytics import get_number_of_forms_in_domain, \
     get_last_form_submission_received
 
 from corehq.apps.domain.models import Domain
-from corehq.apps.reminders.models import CaseReminderHandler
 from corehq.apps.users.models import CouchUser
 from corehq.elastic import es_query, ADD_TO_ES_FILTER
 from dimagi.utils.parsing import json_format_datetime
@@ -36,6 +35,7 @@ from corehq.motech.repeaters.models import Repeater
 from corehq.apps.export.dbaccessors import get_form_exports_by_domain, get_case_exports_by_domain
 from corehq.apps.fixtures.models import FixtureDataType
 from corehq.apps.hqmedia.models import HQMediaMixin
+from corehq.messaging.scheduling.util import domain_has_reminders
 
 def num_web_users(domain, *args):
     return get_web_user_count(domain, include_inactive=False)
@@ -240,8 +240,7 @@ def app_list(domain, *args):
 
 
 def uses_reminders(domain, *args):
-    handlers = CaseReminderHandler.get_handlers(domain)
-    return len(handlers) > 0
+    return domain_has_reminders(domain)
 
 
 def not_implemented(domain, *args):

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -95,10 +95,12 @@ def bulk_download_users_async(domain, download_id, user_filters):
 def tag_cases_as_deleted_and_remove_indices(domain, case_ids, deletion_id, deletion_date):
     from corehq.apps.sms.tasks import delete_phone_numbers_for_owners
     from corehq.apps.reminders.tasks import delete_reminders_for_cases
+    from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
     CaseAccessors(domain).soft_delete_cases(list(case_ids), deletion_date, deletion_id)
     _remove_indices_from_deleted_cases_task.delay(domain, case_ids)
     delete_phone_numbers_for_owners.delay(case_ids)
     delete_reminders_for_cases.delay(domain, case_ids)
+    delete_schedule_instances_for_cases.delay(domain, case_ids)
 
 
 @task(rate_limit=2, queue='background_queue', ignore_result=True, acks_late=True)

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -15,7 +15,6 @@ from corehq.apps.hqwebapp.decorators import (
 from django_prbac.utils import has_privilege
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.users import UserES

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -22,7 +22,6 @@ from corehq.apps.es.users import UserES
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.sms.models import Keyword
-from corehq.apps.reminders.models import CaseReminderHandler
 from corehq.apps.reports.util import get_simplified_users
 from corehq.apps.sms.verify import (
     initiate_sms_verification_workflow,
@@ -34,7 +33,7 @@ from corehq.apps.sms.verify import (
 from corehq.apps.users.forms import GroupMembershipForm
 from corehq.apps.users.decorators import require_can_edit_commcare_users
 from corehq.apps.users.views import BaseUserSettingsView
-from corehq.messaging.scheduling.models import ScheduledBroadcast, ImmediateBroadcast
+from corehq.messaging.scheduling.util import domain_has_reminders
 from corehq import privileges
 from corehq.util.workbook_json.excel import alphanumeric_sort_key
 from memoized import memoized
@@ -211,10 +210,7 @@ class EditGroupMembersView(BaseGroupsView):
     @property
     def page_context(self):
         domain_has_reminders_or_keywords = (
-            AutomaticUpdateRule.domain_has_conditional_alerts(self.domain) or
-            ScheduledBroadcast.domain_has_broadcasts(self.domain) or
-            ImmediateBroadcast.domain_has_broadcasts(self.domain) or
-            CaseReminderHandler.domain_has_reminders(self.domain) or
+            domain_has_reminders(self.domain) or
             Keyword.domain_has_keywords(self.domain)
         )
         bulk_sms_verification_enabled = (

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -15,6 +15,7 @@ from corehq.apps.hqwebapp.decorators import (
 from django_prbac.utils import has_privilege
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.users import UserES
@@ -33,6 +34,7 @@ from corehq.apps.sms.verify import (
 from corehq.apps.users.forms import GroupMembershipForm
 from corehq.apps.users.decorators import require_can_edit_commcare_users
 from corehq.apps.users.views import BaseUserSettingsView
+from corehq.messaging.scheduling.models import ScheduledBroadcast, ImmediateBroadcast
 from corehq import privileges
 from corehq.util.workbook_json.excel import alphanumeric_sort_key
 from memoized import memoized
@@ -209,6 +211,9 @@ class EditGroupMembersView(BaseGroupsView):
     @property
     def page_context(self):
         domain_has_reminders_or_keywords = (
+            AutomaticUpdateRule.domain_has_conditional_alerts(self.domain) or
+            ScheduledBroadcast.domain_has_broadcasts(self.domain) or
+            ImmediateBroadcast.domain_has_broadcasts(self.domain) or
             CaseReminderHandler.domain_has_reminders(self.domain) or
             Keyword.domain_has_keywords(self.domain)
         )

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -385,3 +385,7 @@ class Broadcast(models.Model):
 
     def soft_delete(self):
         raise NotImplementedError()
+
+    @classmethod
+    def domain_has_broadcasts(cls, domain):
+        return cls.objects.filter(domain=domain, deleted=False).count() > 0

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -388,4 +388,4 @@ class Broadcast(models.Model):
 
     @classmethod
     def domain_has_broadcasts(cls, domain):
-        return cls.objects.filter(domain=domain, deleted=False).count() > 0
+        return cls.objects.filter(domain=domain, deleted=False).exists()

--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -257,3 +257,14 @@ def delete_timed_schedule_instances_for_schedule(cls, schedule_id):
 
     for db_name in get_db_aliases_for_partitioned_query():
         cls.objects.using(db_name).filter(timed_schedule_id=schedule_id).delete()
+
+
+def delete_schedule_instances_by_case_id(domain, case_id):
+    from corehq.messaging.scheduling.scheduling_partitioned.models import (
+        CaseTimedScheduleInstance,
+        CaseAlertScheduleInstance,
+    )
+
+    for cls in (CaseAlertScheduleInstance, CaseTimedScheduleInstance):
+        for db_name in get_db_aliases_for_partitioned_query():
+            cls.objects.using(db_name).filter(domain=domain, case_id=case_id).delete()

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -69,7 +69,7 @@ class ScheduleInstance(PartitionedModel):
         if self.recipient_type == self.RECIPIENT_TYPE_CASE:
             try:
                 case = CaseAccessors(self.domain).get_case(self.recipient_id)
-            except (CaseNotFound, ResourceNotFound):
+            except CaseNotFound:
                 return None
 
             if case.domain != self.domain:
@@ -461,7 +461,7 @@ class CaseScheduleInstanceMixin(object):
     def case(self):
         try:
             return CaseAccessors(self.domain).get_case(self.case_id)
-        except (CaseNotFound, ResourceNotFound):
+        except CaseNotFound:
             return None
 
     @property

--- a/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_both.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_both.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from corehq.form_processor.tests.utils import partitioned
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseScheduleInstanceMixin,

--- a/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_both.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_both.py
@@ -1,0 +1,81 @@
+from corehq.form_processor.tests.utils import partitioned
+from corehq.messaging.scheduling.scheduling_partitioned.models import (
+    CaseScheduleInstanceMixin,
+    CaseAlertScheduleInstance,
+    CaseTimedScheduleInstance,
+)
+from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
+from corehq.sql_db.util import run_query_across_partitioned_databases
+from datetime import datetime, date
+from django.db.models import Q
+from django.test import TestCase
+import uuid
+
+
+@partitioned
+class SchedulingDBAccessorsTest(TestCase):
+
+    domain = 'scheduling-dbaccessors-test'
+    domain_2 = domain + '-x'
+
+    def create_case_alert_schedule_instance(self, domain, case_id):
+        instance = CaseAlertScheduleInstance(
+            domain=domain,
+            recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
+            current_event_num=0,
+            schedule_iteration_num=1,
+            next_event_due=datetime(2018, 7, 1),
+            active=True,
+            alert_schedule_id=uuid.uuid4(),
+            case_id=case_id,
+            rule_id=1,
+        )
+        instance.save()
+        self.addCleanup(instance.delete)
+
+    def create_case_timed_schedule_instance(self, domain, case_id):
+        instance = CaseTimedScheduleInstance(
+            domain=domain,
+            recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
+            current_event_num=0,
+            schedule_iteration_num=1,
+            next_event_due=datetime(2018, 7, 1),
+            active=True,
+            timed_schedule_id=uuid.uuid4(),
+            start_date=date(2018, 7, 1),
+            case_id=case_id,
+            rule_id=1,
+        )
+        instance.save()
+        self.addCleanup(instance.delete)
+
+    def get_case_schedule_instances_for_domain(self, domain):
+        instances = list(run_query_across_partitioned_databases(CaseAlertScheduleInstance, Q(domain=domain)))
+        instances.extend(run_query_across_partitioned_databases(CaseTimedScheduleInstance, Q(domain=domain)))
+        return instances
+
+    def test_delete_schedule_instances_for_cases(self):
+        case_id_1 = uuid.uuid4().hex
+        case_id_2 = uuid.uuid4().hex
+        case_id_3 = uuid.uuid4().hex
+        case_id_4 = uuid.uuid4().hex
+
+        for domain, case_id in (
+            (self.domain, case_id_1),
+            (self.domain, case_id_2),
+            (self.domain, case_id_3),
+            (self.domain_2, case_id_4),
+        ):
+            self.create_case_alert_schedule_instance(domain, case_id)
+            self.create_case_timed_schedule_instance(domain, case_id)
+
+        self.assertEqual(len(self.get_case_schedule_instances_for_domain(self.domain)), 6)
+        self.assertEqual(len(self.get_case_schedule_instances_for_domain(self.domain_2)), 2)
+
+        delete_schedule_instances_for_cases(self.domain, [case_id_1, case_id_2])
+
+        self.assertEqual(len(self.get_case_schedule_instances_for_domain(self.domain)), 2)
+        self.assertEqual(len(self.get_case_schedule_instances_for_domain(self.domain_2)), 2)
+
+        for instance in self.get_case_schedule_instances_for_domain(self.domain):
+            self.assertEqual(instance.case_id, case_id_3)

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -12,6 +12,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     TimedScheduleInstance,
     CaseAlertScheduleInstance,
     CaseTimedScheduleInstance,
+    CaseScheduleInstanceMixin,
 )
 from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
     delete_alert_schedule_instance,
@@ -424,7 +425,10 @@ def _handle_schedule_instance(instance, save_function):
     """
     :return: True if the event was handled, otherwise False
     """
-    if instance.memoized_schedule.deleted:
+    if (
+        instance.memoized_schedule.deleted or
+        (isinstance(instance, CaseScheduleInstanceMixin) and (instance.case is None or instance.case.is_deleted))
+    ):
         instance.delete()
         return False
 

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -29,6 +29,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
     delete_case_schedule_instance,
     delete_alert_schedule_instances_for_schedule,
     delete_timed_schedule_instances_for_schedule,
+    delete_schedule_instances_by_case_id,
 )
 from corehq.util.celery_utils import no_result_task
 from datetime import datetime
@@ -484,3 +485,9 @@ def handle_case_timed_schedule_instance(case_id, schedule_instance_id):
             return
 
         _handle_schedule_instance(instance, save_case_schedule_instance)
+
+
+@no_result_task(queue='background_queue', acks_late=True)
+def delete_schedule_instances_for_cases(domain, case_ids):
+    for case_id in case_ids:
+        delete_schedule_instances_by_case_id(domain, case_id)

--- a/corehq/messaging/scheduling/tests/test_util.py
+++ b/corehq/messaging/scheduling/tests/test_util.py
@@ -7,6 +7,7 @@ from corehq.messaging.scheduling.models import (
     TimedSchedule,
     AlertSchedule,
 )
+from corehq.messaging.scheduling.util import domain_has_reminders
 from datetime import date
 from django.test import TestCase
 
@@ -17,14 +18,17 @@ class TestMessagingModelLookups(TestCase):
 
     def test_domain_has_conditional_alerts(self):
         self.assertFalse(AutomaticUpdateRule.domain_has_conditional_alerts(self.domain))
+        self.assertFalse(domain_has_reminders(self.domain))
 
         rule = create_empty_rule(self.domain, AutomaticUpdateRule.WORKFLOW_SCHEDULING)
         self.addCleanup(rule.delete)
 
         self.assertTrue(AutomaticUpdateRule.domain_has_conditional_alerts(self.domain))
+        self.assertTrue(domain_has_reminders(self.domain))
 
     def test_domain_has_scheduled_broadcasts(self):
         self.assertFalse(ScheduledBroadcast.domain_has_broadcasts(self.domain))
+        self.assertFalse(domain_has_reminders(self.domain))
 
         schedule = TimedSchedule.objects.create(domain=self.domain, repeat_every=1, total_iterations=1)
         self.addCleanup(schedule.delete)
@@ -34,9 +38,11 @@ class TestMessagingModelLookups(TestCase):
         self.addCleanup(broadcast.delete)
 
         self.assertTrue(ScheduledBroadcast.domain_has_broadcasts(self.domain))
+        self.assertTrue(domain_has_reminders(self.domain))
 
     def test_domain_has_immediate_broadcasts(self):
         self.assertFalse(ImmediateBroadcast.domain_has_broadcasts(self.domain))
+        self.assertFalse(domain_has_reminders(self.domain))
 
         schedule = AlertSchedule.objects.create(domain=self.domain)
         self.addCleanup(schedule.delete)
@@ -45,3 +51,4 @@ class TestMessagingModelLookups(TestCase):
         self.addCleanup(broadcast.delete)
 
         self.assertTrue(ImmediateBroadcast.domain_has_broadcasts(self.domain))
+        self.assertTrue(domain_has_reminders(self.domain))

--- a/corehq/messaging/scheduling/tests/test_util.py
+++ b/corehq/messaging/scheduling/tests/test_util.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from corehq.apps.data_interfaces.models import AutomaticUpdateRule
+from corehq.apps.data_interfaces.tests.util import create_empty_rule
+from corehq.messaging.scheduling.models import (
+    ScheduledBroadcast,
+    ImmediateBroadcast,
+    TimedSchedule,
+    AlertSchedule,
+)
+from datetime import date
+from django.test import TestCase
+
+
+class TestMessagingModelLookups(TestCase):
+
+    domain = 'messaging-lookup-test'
+
+    def test_domain_has_conditional_alerts(self):
+        self.assertFalse(AutomaticUpdateRule.domain_has_conditional_alerts(self.domain))
+
+        rule = create_empty_rule(self.domain, AutomaticUpdateRule.WORKFLOW_SCHEDULING)
+        self.addCleanup(rule.delete)
+
+        self.assertTrue(AutomaticUpdateRule.domain_has_conditional_alerts(self.domain))
+
+    def test_domain_has_scheduled_broadcasts(self):
+        self.assertFalse(ScheduledBroadcast.domain_has_broadcasts(self.domain))
+
+        schedule = TimedSchedule.objects.create(domain=self.domain, repeat_every=1, total_iterations=1)
+        self.addCleanup(schedule.delete)
+
+        broadcast = ScheduledBroadcast.objects.create(domain=self.domain, name='', schedule=schedule,
+            start_date=date(2018, 7, 1))
+        self.addCleanup(broadcast.delete)
+
+        self.assertTrue(ScheduledBroadcast.domain_has_broadcasts(self.domain))
+
+    def test_domain_has_immediate_broadcasts(self):
+        self.assertFalse(ImmediateBroadcast.domain_has_broadcasts(self.domain))
+
+        schedule = AlertSchedule.objects.create(domain=self.domain)
+        self.addCleanup(schedule.delete)
+
+        broadcast = ImmediateBroadcast.objects.create(domain=self.domain, name='', schedule=schedule)
+        self.addCleanup(broadcast.delete)
+
+        self.assertTrue(ImmediateBroadcast.domain_has_broadcasts(self.domain))

--- a/corehq/messaging/scheduling/util.py
+++ b/corehq/messaging/scheduling/util.py
@@ -8,3 +8,16 @@ def utcnow():
     Defined here to do patching in tests.
     """
     return datetime.utcnow()
+
+
+def domain_has_reminders(domain):
+    from corehq.apps.data_interfaces.models import AutomaticUpdateRule
+    from corehq.apps.reminders.models import CaseReminderHandler
+    from corehq.messaging.scheduling.models import ScheduledBroadcast, ImmediateBroadcast
+
+    return (
+        AutomaticUpdateRule.domain_has_conditional_alerts(domain) or
+        ScheduledBroadcast.domain_has_broadcasts(domain) or
+        ImmediateBroadcast.domain_has_broadcasts(domain) or
+        CaseReminderHandler.domain_has_reminders(domain)
+    )

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -17,6 +17,7 @@ from corehq.util.celery_utils import no_result_task
 from dimagi.utils.couch import CriticalSection
 from django.conf import settings
 from django.db.models import Q
+from django.db import transaction
 
 
 def get_sync_key(case_id):
@@ -100,7 +101,7 @@ def _sync_case_for_messaging_rule(domain, case_id, rule_id):
 def initiate_messaging_rule_run(domain, rule_id):
     MessagingRuleProgressHelper(rule_id).set_initial_progress()
     AutomaticUpdateRule.objects.filter(pk=rule_id).update(locked_for_editing=True)
-    run_messaging_rule.delay(domain, rule_id)
+    transaction.on_commit(lambda: run_messaging_rule.delay(domain, rule_id))
 
 
 def get_case_ids_for_messaging_rule(domain, case_type):

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -55,9 +55,9 @@ def _sync_case_for_messaging(domain, case_id):
         case = None
 
     if case is None or case.is_deleted:
-        sms_tasks.delete_phone_numbers_for_owners([case.case_id])
-        reminders_tasks.delete_reminders_for_cases(domain, [case.case_id])
-        delete_schedule_instances_for_cases(domain, [case.case_id])
+        sms_tasks.delete_phone_numbers_for_owners([case_id])
+        reminders_tasks.delete_reminders_for_cases(domain, [case_id])
+        delete_schedule_instances_for_cases(domain, [case_id])
         return
 
     if use_phone_entries():

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -447,6 +447,7 @@ def create_test_case(domain, case_type, case_name, case_properties=None, drop_si
     from corehq.apps.reminders.tasks import delete_reminders_for_cases
     from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
     from corehq.form_processor.utils.general import should_use_sql_backend
+    from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import delete_schedule_instances_by_case_id
 
     case = create_and_save_a_case(domain, case_id or uuid.uuid4().hex, case_name,
         case_properties=case_properties, case_type=case_type, drop_signals=drop_signals,
@@ -456,6 +457,7 @@ def create_test_case(domain, case_type, case_name, case_properties=None, drop_si
     finally:
         delete_phone_numbers_for_owners([case.case_id])
         delete_reminders_for_cases(domain, [case.case_id])
+        delete_schedule_instances_by_case_id(domain, case.case_id)
         if should_use_sql_backend(domain):
             CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
         else:


### PR DESCRIPTION
This PR implements various backend tasks in the new reminders framework that are also present in the old. Most importantly, deleted cases are handled properly (any associated schedule instances are deleted), and configurations in the new reminders framework are deactivated on subscription downgrade appropriately.

@millerdev @gbova 

@nickpell Could you have a look at commit https://github.com/dimagi/commcare-hq/commit/8f7590108168959c6b7ab4c45881ac2bbc21e37d?w=1 and let me know if there's any other places I might need to deactivate configurations on subscription downgrade? From what I can tell that's all that was done to deactivate reminder configurations in the old framework, and I just replicated that for the new one.