### PR TITLE
remove duplicate teardown

### DIFF
--- a/custom/ilsgateway/tests/test_reminders2.py
+++ b/custom/ilsgateway/tests/test_reminders2.py
@@ -47,11 +47,6 @@ class RemindersTest(ILSTestScript):
 
     @classmethod
     def tearDownClass(cls):
-        delete_domain_phone_numbers(TEST_DOMAIN)
-        if cls.sms_backend_mapping.id is not None:
-            cls.sms_backend_mapping.delete()
-        cls.sms_backend.delete()
-        cls.domain.delete()
         super(RemindersTest, cls).tearDownClass()
 
 

--- a/custom/ilsgateway/tests/test_reminders2.py
+++ b/custom/ilsgateway/tests/test_reminders2.py
@@ -45,10 +45,6 @@ class RemindersTest(ILSTestScript):
         SupplyPointStatus.objects.all().delete()
         super(RemindersTest, self).tearDown()
 
-    @classmethod
-    def tearDownClass(cls):
-        super(RemindersTest, cls).tearDownClass()
-
 
 class TestStockOnHandReminders(RemindersTest):
 


### PR DESCRIPTION
This was causing an issue becuase `domain.delete()` bulk deletes
docs and doesn't clear caches. Then the super method
tries to delete users which it fetches from cache.

```
======================================================================
ERROR: test suite for <class 'custom.ilsgateway.tests.test_reminders2.TestRandRReminder'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vendor/lib/python2.7/site-packages/nose/suite.py", line 228, in run
    self.tearDown()
  File "/vendor/lib/python2.7/site-packages/nose/suite.py", line 351, in tearDown
    self.teardownContext(ancestor)
  File "/vendor/lib/python2.7/site-packages/nose/suite.py", line 367, in teardownContext
    try_run(context, names)
  File "/vendor/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/mnt/commcare-hq-ro/custom/ilsgateway/tests/test_reminders2.py", line 55, in tearDownClass
    super(RemindersTest, cls).tearDownClass()
  File "/mnt/commcare-hq-ro/custom/ilsgateway/tests/handlers/utils.py", line 128, in tearDownClass
    user.delete()
  File "/mnt/commcare-hq-ro/corehq/apps/users/models.py", line 1652, in delete
    super(CommCareUser, self).delete()
  File "/mnt/commcare-hq-ro/corehq/apps/users/models.py", line 1128, in delete
    super(CouchUser, self).delete() # Call the "real" delete() method.
  File "/vendor/lib/python2.7/site-packages/couchdbkit/schema/base.py", line 217, in delete
    db.delete_doc(self._id)
  File "/vendor/lib/python2.7/site-packages/couchdbkit/client.py", line 662, in delete_doc
    rev = self.get_rev(doc1)
  File "/vendor/lib/python2.7/site-packages/couchdbkit/client.py", line 483, in get_rev
    response = self.res.head(resource.escape_docid(docid))
  File "/vendor/lib/python2.7/site-packages/restkit/resource.py", line 122, in head
    params_dict=params_dict, **params)
  File "/vendor/lib/python2.7/site-packages/couchdbkit/resource.py", line 137, in request
    response=e.response)
ResourceNotFound: {'msg': '', 'status_int': 404, 'response': <couchdbkit.resource.CouchDBResponse object at 0x7f2e67317a90>}
```