### PR TITLE
Ensure month filter values are integers

### DIFF
--- a/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
@@ -23,8 +23,8 @@ function MonthModalController($location, $uibModalInstance) {
         });
     }
 
-    vm.selectedMonth = $location.search()['month'] !== void(0) ? $location.search()['month'] : new Date().getMonth() + 1;
-    vm.selectedYear = $location.search()['year'] !== void(0) ? $location.search()['year'] : new Date().getFullYear();
+    vm.selectedMonth = $location.search()['month'] !== void(0) ? parseInt($location.search()['month']) : new Date().getMonth() + 1;
+    vm.selectedYear = $location.search()['year'] !== void(0) ? parseInt($location.search()['year']) : new Date().getFullYear();
 
     if (vm.selectedYear === new Date().getFullYear()) {
         vm.months = _.filter(vm.monthsCopy, function (month) {


### PR DESCRIPTION
Hi @emord @lwyszomi,
I have added parsing month and year values from location.search to integer as it sometimes returns a string and we need integers to show proper months in filter.
Regards, Dawid