### PR TITLE
don't make data source id required

### DIFF
--- a/corehq/apps/userreports/examples/examples.md
+++ b/corehq/apps/userreports/examples/examples.md
@@ -327,7 +327,7 @@ In the example below, the indicator is inside a form group question called "impa
             "property_name": "_id"
         }
     },
-    "column_id": "district",
+    "column_id": "district"
 }
 ```
 
@@ -345,7 +345,7 @@ In the example below, the indicator is inside a form group question called "impa
             "property_name": "location_id"
         }
     },
-    "column_id": "parent_location",
+    "column_id": "parent_location"
 }
 ```
 

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -137,7 +137,7 @@ DOC_TYPE_CHOICES = (
 
 class ConfigurableDataSourceEditForm(DocumentFormBase):
 
-    _id = forms.CharField(disabled=True, label=_('Data Source ID'),
+    _id = forms.CharField(required=False, disabled=True, label=_('Data Source ID'),
                           help_text=help_text.DATA_SOURCE_ID)
     table_id = forms.CharField(label=_("Table ID"),
                                help_text=help_text.TABLE_ID)


### PR DESCRIPTION
i can't create data sources on prod or locally.

is it possible this has been broken since https://github.com/dimagi/commcare-hq/pull/20742 / https://github.com/dimagi/commcare-hq/pull/20648?