### PR TITLE
Fix calling popup function by providing correct values per column

### DIFF
--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -1768,14 +1768,14 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
     function renderHeightForAgeStatus(data, type, full) {
         return '<span ng-class="row.stunning.color" class="pointer" uib-popover-html="$ctrl.getPopoverContent(\''
             + full.recorded_weight + '\',\'' + full.recorded_height + '\',\'' + full.age_in_months
-            + '\', \'both\')" popover-placement="right" popover-trigger="\'mouseenter\'">'
+            + '\', \'height\')" popover-placement="right" popover-trigger="\'mouseenter\'">'
             + full.current_month_stunting.value + '</span>';
     }
 
     function renderWeightForHeightStatus(data, type, full) {
         return '<span ng-class="row.wasting.color" class="pointer" uib-popover-html="$ctrl.getPopoverContent(\''
             + full.recorded_weight + '\',\'' + full.recorded_height + '\',\'' + full.age_in_months
-            + '\', \'height\')" popover-placement="right" popover-trigger="\'mouseenter\'">'
+            + '\', \'both\')" popover-placement="right" popover-trigger="\'mouseenter\'">'
             + full.current_month_wasting.value + '</span>';
     }
 


### PR DESCRIPTION
Hi @emord, @lwyszomi 
I have fixed wrong data in a popup in the awc reports child beneficiary list.
HeightForAge was marked as both and WeightForHeight as height.
Regards, Dawid.