### PR TITLE
fix end window date if there is some data that matches end date column

### DIFF
--- a/corehq/apps/aggregate_ucrs/ingestion.py
+++ b/corehq/apps/aggregate_ucrs/ingestion.py
@@ -75,12 +75,16 @@ def get_aggregation_start_period(aggregate_table_definition, last_update=None):
 
 
 def get_aggregation_end_period(aggregate_table_definition, last_update=None):
-    return _get_aggregation_from_primary_table(
+    value_from_db = _get_aggregation_from_primary_table(
         aggregate_table_definition=aggregate_table_definition,
         column_id=aggregate_table_definition.time_aggregation.end_column,
         sqlalchemy_agg_fn=sqlalchemy.func.max,
         last_update=last_update,
-    ) or datetime.utcnow()
+    )
+    if not value_from_db:
+        return datetime.utcnow()
+    else:
+        return max(value_from_db, datetime.utcnow())
 
 
 def _get_aggregation_from_primary_table(aggregate_table_definition, column_id, sqlalchemy_agg_fn, last_update):

--- a/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
+++ b/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
@@ -292,13 +292,13 @@ class UCRAggregationTest(TestCase, AggregationBaseTestMixin):
         aggregate_table_adapter.rebuild_table()
 
         populate_aggregate_table_data(aggregate_table_adapter)
-        self._check_results()
+        self._check_monthly_results()
 
         # confirm it's also idempotent
         populate_aggregate_table_data(aggregate_table_adapter)
-        self._check_results()
+        self._check_monthly_results()
 
-    def _check_results(self):
+    def _check_monthly_results(self):
         aggregate_table_adapter = AggregateIndicatorSqlAdapter(self.monthly_aggregate_table_definition)
         aggregate_table = aggregate_table_adapter.get_table()
         aggregate_query = aggregate_table_adapter.get_query_object()


### PR DESCRIPTION
this ensures that calculations will always run at least through the current date (which they should for anything that has a `null` value for the `end_column`