### PR TITLE
Ce/more warehouse

### DIFF
--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -58,7 +58,7 @@ def run_query_across_partitioned_databases(model_class, q_expression, values=Non
             else:
                 qs = qs.values_list(*values)
 
-        for result in qs:
+        for result in qs.iterator():
             yield result
 
 

--- a/corehq/warehouse/transforms/sql/synclog_fact.sql
+++ b/corehq/warehouse/transforms/sql/synclog_fact.sql
@@ -9,21 +9,36 @@ INSERT INTO {{ synclog_fact }} (
     batch_id
 )
 SELECT
-    synclog_table.sync_log_id,
-    synclog_table.sync_date,
-    domain_table.domain,
-    domain_table.id,
-    user_table.id,
-    synclog_table.build_id,
-    synclog_table.duration,
+    sync_log_id,
+    sync_date,
+    domain,
+    domain_dim_id,
+    user_dim_id,
+    build_id,
+    duration,
     '{{ batch_id }}'
+FROM
+(
+SELECT
+    row_number() over wnd,
+    synclog_table.sync_log_id as sync_log_id,
+    synclog_table.sync_date as sync_date,
+    domain_table.domain as domain,
+    domain_table.id as domain_dim_id,
+    user_table.id as user_dim_id,
+    synclog_table.build_id as build_id,
+    synclog_table.duration as duration
 FROM
     {{ synclog_staging }} AS synclog_table
 LEFT JOIN {{ domain_dim }} AS domain_table ON synclog_table.domain = domain_table.domain
 LEFT JOIN {{ user_dim }} AS user_table ON synclog_table.user_id = user_table.user_id
 LEFT JOIN {{ synclog_fact }} AS synclog_fact ON user_table.id = synclog_fact.user_dim_id
 WHERE synclog_table.sync_date > synclog_fact.sync_date OR synclog_fact.sync_date IS NULL
-
+WINDOW wnd AS (
+       PARTITION BY user_table.id ORDER BY synclog_table.sync_date AT TIME ZONE 'UTC' DESC
+       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+) as sync_data where row_number=1
 ON CONFLICT (user_dim_id) DO UPDATE
 SET sync_log_id = EXCLUDED.sync_log_id,
     sync_date = EXCLUDED.sync_date,

--- a/corehq/warehouse/utils.py
+++ b/corehq/warehouse/utils.py
@@ -3,23 +3,26 @@ from __future__ import unicode_literals
 from django.db import connections
 from django.conf import settings
 
+from dimagi.utils.chunked import chunked
+
 from corehq.warehouse.const import DJANGO_MAX_BATCH_SIZE
 from corehq.sql_db.routers import db_for_read_write
 
 
 def django_batch_records(cls, record_iter, field_mapping, batch_id):
-    records = []
-    for index, raw_record in enumerate(record_iter):
-        record = {'batch_id': batch_id}
-        for source_key, destination_key in field_mapping:
-            if isinstance(raw_record, dict):
-                record[destination_key] = raw_record.get(source_key)
-            else:
-                record[destination_key] = getattr(raw_record, source_key, None)
+    for batch in chunked(record_iter, DJANGO_MAX_BATCH_SIZE):
+        records = []
+        for raw_record in batch:
+            record = {'batch_id': batch_id}
+            for source_key, destination_key in field_mapping:
+                if isinstance(raw_record, dict):
+                    record[destination_key] = raw_record.get(source_key)
+                else:
+                    record[destination_key] = getattr(raw_record, source_key, None)
 
-        records.append(cls(**record))
+            records.append(cls(**record))
 
-    cls.objects.bulk_create(records, batch_size=DJANGO_MAX_BATCH_SIZE)
+        cls.objects.bulk_create(records, batch_size=DJANGO_MAX_BATCH_SIZE)
 
 
 def truncate_records_for_cls(cls, cascade=False):


### PR DESCRIPTION
@snopoke @sravfeyn cc: @biyeun 
This fixes one bug in the sql that loads synclogs in instances where there are multiple synclogs per user, and makes the batched object creation not try to store all the elements in memory at once.

The last commit switches one of our db accessors to using a django queryset iterator because it felt to me like that was what the method called for and it is supposed to be far more memory efficient which I needed. Let me know if I am misinterpreting the intent @snopoke https://docs.djangoproject.com/en/2.0/ref/models/querysets/#iterator