### PR TITLE
Add datadog timing for requests to s3 blobdb

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -50,7 +50,7 @@ class S3BlobDB(AbstractBlobDB):
             original_stop(name)
             datadog_counter(
                 'commcare.blobs.requests.timing',
-                value=timer.duration * 1000,
+                value=timer.duration,
                 tags=[
                     'action:{}'.format(action),
                     's3_bucket_name:{}'.format(blobdb.s3_bucket_name)

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -10,6 +10,7 @@ from corehq.blobs.exceptions import BadName, NotFound
 from corehq.blobs.interface import AbstractBlobDB, SAFENAME
 from corehq.blobs.util import ClosingContextProxy, set_blob_expire_object
 from corehq.util.datadog.gauges import datadog_counter
+from corehq.util.timer import TimingContext
 
 from dimagi.utils.chunked import chunked
 
@@ -40,6 +41,24 @@ class S3BlobDB(AbstractBlobDB):
         # https://github.com/boto/boto3/issues/259
         self.db.meta.client.meta.events.unregister('before-sign.s3', fix_s3_host)
 
+    def report_timing(self, action):
+        blobdb = self
+        timer = TimingContext()
+        original_stop = timer.stop
+
+        def new_stop(timer, name=None):
+            original_stop(name)
+            datadog_counter(
+                'commcare.blobs.requests.timing',
+                value=timer.duration * 1000,
+                tags=[
+                    'action:{}'.format(action),
+                    's3_bucket_name:{}'.format(blobdb.s3_bucket_name)
+                ]
+            )
+        timer.stop = new_stop
+        return timer
+
     def put(self, content, identifier, bucket=DEFAULT_BUCKET, timeout=None):
         path = self.get_path(identifier, bucket)
         s3_bucket = self._s3_bucket(create=True)
@@ -52,7 +71,8 @@ class S3BlobDB(AbstractBlobDB):
         content.seek(0)
         content_md5 = get_content_md5(content)
         content_length = get_file_size(content)
-        s3_bucket.upload_fileobj(content, path)
+        with self.report_timing('put'):
+            s3_bucket.upload_fileobj(content, path)
         if timeout is not None:
             set_blob_expire_object(bucket, identifier, content_length, timeout)
         datadog_counter('commcare.blobs.added.count')
@@ -61,19 +81,22 @@ class S3BlobDB(AbstractBlobDB):
 
     def get(self, identifier, bucket=DEFAULT_BUCKET):
         path = self.get_path(identifier, bucket)
-        with maybe_not_found(throw=NotFound(identifier, bucket)):
+        with maybe_not_found(throw=NotFound(identifier, bucket)), \
+                self.report_timing('get'):
             resp = self._s3_bucket().Object(path).get()
         return BlobStream(resp["Body"], self, path)
 
     def size(self, identifier, bucket=DEFAULT_BUCKET):
         path = self.get_path(identifier, bucket)
-        with maybe_not_found(throw=NotFound(identifier, bucket)):
+        with maybe_not_found(throw=NotFound(identifier, bucket)), \
+                self.report_timing('size'):
             return self._s3_bucket().Object(path).content_length
 
     def exists(self, identifier, bucket=DEFAULT_BUCKET):
         path = self.get_path(identifier, bucket)
         try:
-            with maybe_not_found(throw=NotFound(identifier, bucket)):
+            with maybe_not_found(throw=NotFound(identifier, bucket)), \
+                    self.report_timing('exists'):
                 self._s3_bucket().Object(path).load()
             return True
         except NotFound:
@@ -127,7 +150,8 @@ class S3BlobDB(AbstractBlobDB):
     def copy_blob(self, content, info, bucket):
         self._s3_bucket(create=True)
         path = self.get_path(info.identifier, bucket)
-        self._s3_bucket().upload_fileobj(content, path)
+        with self.report_timing('copy_blobdb'):
+            self._s3_bucket().upload_fileobj(content, path)
 
     def _s3_bucket(self, create=False):
         if create and not self._s3_bucket_exists:

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -9,7 +9,7 @@ from corehq.blobs import BlobInfo, DEFAULT_BUCKET
 from corehq.blobs.exceptions import BadName, NotFound
 from corehq.blobs.interface import AbstractBlobDB, SAFENAME
 from corehq.blobs.util import ClosingContextProxy, set_blob_expire_object
-from corehq.util.datadog.gauges import datadog_bucket_timer
+from corehq.util.datadog.gauges import datadog_counter, datadog_bucket_timer
 
 from dimagi.utils.chunked import chunked
 

--- a/corehq/util/datadog/gauges.py
+++ b/corehq/util/datadog/gauges.py
@@ -57,6 +57,23 @@ def _datadog_record(fn, name, value, enforce_prefix='commcare', tags=None):
         datadog_logger.exception('Unable to record Datadog stats')
 
 
+def datadog_timer(metric, tags=None):
+    blobdb = self
+    timer = TimingContext()
+    original_stop = timer.stop
+
+    def new_stop(name=None):
+        original_stop(name)
+        datadog_gauge(
+            metric,
+            value=timer.duration,
+            tags=tags
+        )
+
+    timer.stop = new_stop
+    return timer
+
+
 class _DatadogGauge(object):
 
     def __init__(self, name, fn, run_every):

--- a/corehq/util/datadog/gauges.py
+++ b/corehq/util/datadog/gauges.py
@@ -60,6 +60,30 @@ def _datadog_record(fn, name, value, enforce_prefix='commcare', tags=None):
 
 
 def datadog_bucket_timer(metric, tags, timing_buckets):
+    """
+    create a context manager that times and reports to datadog using timing buckets
+
+    adds a 'duration' tag specifying which predefined timing bucket the timing fell into,
+    see the `bucket_value` function for more info.
+
+    Example Usage:
+
+        timer = datadog_bucket_timer('commcare.some.special.metric', tags=[
+            'type:{}'.format(type),
+        ], timing_buckets=(.001, .01, .1, 1, 10, 100))
+        with timer:
+            some_special_thing()
+
+    This will result it a datadog counter metric with a 'duration' tag, with the possible values
+    lt_0.001, lt_0.01, lt_0.1, lt_001, lt_010, lt_100, and over_100.
+
+    :param metric: Name of the datadog metric (must start with 'commcare.')
+    :param tags: Datadog tags to include
+    :param timing_buckets: sequence of numbers representing time thresholds, in seconds
+    :return: A context manager that will perform the specified timing
+             and send the specified metric
+
+    """
     timer = TimingContext()
     original_stop = timer.stop
 


### PR DESCRIPTION
Opening for review of the general tactic. (There are other things we could do like log to a file and read from the file, or log at the boto library HTTP request level with some monkey patching, but this seemed like this simplest.)

If we're happy with the general implementation, I'll test on staging and then we can roll this out.