### PR TITLE
Speed up ICDS releases page

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -440,7 +440,7 @@ def get_all_built_app_results(domain, app_id=None):
         'app_manager/saved_app',
         startkey=startkey,
         endkey=endkey,
-        include_docs=True,
+        include_docs=False,
     ).all()
 
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?267409

There are only [two](https://github.com/dimagi/commcare-hq/blob/7c2f92aafa34025b97f1d86f04f3513ab5a48c37/corehq/apps/api/resources/v0_4.py#L405-L414) [usages](https://github.com/dimagi/commcare-hq/blob/2c7cfec3d29e763aaff3142b81602d9968c64261/corehq/apps/app_manager/dbaccessors.py#L422-L428) of this function, and neither of them use the doc. With include_docs set to false, [this line](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/forms.py#L135) run on the CAS app in a shell on the ICDS server drops from ~2 minutes to instantaneous.

Marked feature flag because the issue is in the heartbeat / prompted updates feature.

@nickpell / @dannyroberts 