### PR TITLE
break early

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -51,7 +51,9 @@ class AbtExpressionSpec(JsonObject):
     @classmethod
     @quickcache(['app_id', 'xmlns'])
     def _get_form(cls, app_id, xmlns):
-        return [x for x in Application.get(app_id).get_forms() if x['xmlns'] == xmlns][0]
+        for form in Application.get(app_id).get_forms():
+            if form['xmlns'] == xmlns:
+                return form
 
     @classmethod
     @quickcache(['app_id', 'xmlns', 'lang'])


### PR DESCRIPTION
Dont need to fetch all matching forms, just return once found

Also this wont raise exception in case there are no matching forms now, but there would be an exception at the only place its being used so should not be an issue