### PR TITLE
[VECTOR-LINK] property name typo

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -71,7 +71,7 @@ class AbtExpressionSpec(JsonObject):
 
     @classmethod
     def _get_form_name(cls, item):
-        form = cls._get_form(item['api_id'], item['xmlns'])
+        form = cls._get_form(item['app_id'], item['xmlns'])
         lang = cls._get_language(item)
         if lang in form.name:
             return form.name[lang]


### PR DESCRIPTION
Hi @calellowitz 

I found a typo in the property name. 

Please let me know if you have any questions.

Regards,
Łukasz