### PR TITLE
Add created_from_template to brief apps

### DIFF
--- a/corehq/apps/app_manager/_design/views/applications_brief/map.js
+++ b/corehq/apps/app_manager/_design/views/applications_brief/map.js
@@ -12,7 +12,8 @@ function(doc){
             cached_properties: doc.cached_properties,
             case_sharing: doc.case_sharing,
             cloudcare_enabled: doc.cloudcare_enabled,
-            mobile_ucr_sync_interval: doc.mobile_ucr_sync_interval
+            mobile_ucr_sync_interval: doc.mobile_ucr_sync_interval,
+            created_from_template: doc.created_from_template            // temporary for APPCUES_TEMPLATE_APP_AB_TEST
         });
     }
 }


### PR DESCRIPTION
Part of the upcoming new appcues test, which isn't yet done, but I'd like to get this merged and do the preindex this weekend.

The test will involve creating a sample app from a template and having an appcues flow tailored to that app. `created_from_template` needs to be added here so that when HQ's top nav is generated, the code can identify these sample apps and add a GET param to their urls, which is how the appcues flow will get triggered.

@nickpell / @jmtroth0 