### PR TITLE
CodeMirror -> Ace

### DIFF
--- a/corehq/motech/openmrs/templates/openmrs/edit_config.html
+++ b/corehq/motech/openmrs/templates/openmrs/edit_config.html
@@ -1,26 +1,12 @@
 {% extends 'hqwebapp/two_column.html' %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
-{# todo: this was just copied from userreports/userreports_base.html #}
 {% block title %}Edit Config : OpenMRS :: {% endblock %}
 {% block js %}{{ block.super }}
-    <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
-    <script src="{% static 'codemirror/mode/javascript/javascript.js' %}"></script>
-    <script src="{% static 'codemirror/addon/fold/foldcode.js' %}"></script>
-    <script src="{% static 'codemirror/addon/fold/foldgutter.js' %}"></script>
-    <script src="{% static 'codemirror/addon/fold/brace-fold.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
     <script src="{% static 'userreports/js/base.js' %}"></script>
-{% endblock %}
-{% block stylesheets %}{{ block.super }}
-    <link rel="stylesheet" href="{% static 'codemirror/lib/codemirror.css' %}" />
-    <link rel="stylesheet" href="{% static 'codemirror/addon/fold/foldgutter.css' %}"/>
-    <style>
-        .CodeMirror {
-            border: 1px solid #ccc;
-            height: auto;
-            max-width: 800px;
-        }
-    </style>
 {% endblock %}
 
 {% block page_content %}


### PR DESCRIPTION
OpenMRS configuration (re)uses userreports/js/base.js to render its JSON editor.

This is not a great dependency. I'm open to suggestions on how to keep this DRY without the dependency on UCRs. But for now, this fixes a broken editor, and upgrades to Ace.

@snopoke cc @dannyroberts @proteusvacuum 