### PR TITLE
Kissmetrics and Hubspot analytics improvements on login

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -305,7 +305,7 @@ def track_confirmed_account_on_hubspot(webuser):
         })
 
 
-def send_hubspot_form(form_id, request, user=None):
+def send_hubspot_form(form_id, request, user=None, extra_fields=None):
     """
     pulls out relevant info from request object before sending to celery since
     requests cannot be pickled
@@ -314,12 +314,17 @@ def send_hubspot_form(form_id, request, user=None):
         user = getattr(request, 'couch_user', None)
     if request and user and user.is_web_user():
         meta = get_meta(request)
-        send_hubspot_form_task.delay(form_id, user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
+        send_hubspot_form_task.delay(
+            form_id, user, request.COOKIES.get(HUBSPOT_COOKIE),
+            meta, extra_fields=extra_fields
+        )
 
 
 @analytics_task()
-def send_hubspot_form_task(form_id, web_user, hubspot_cookie, meta):
-    _send_form_to_hubspot(form_id, web_user, hubspot_cookie, meta)
+def send_hubspot_form_task(form_id, web_user, hubspot_cookie, meta,
+                           extra_fields=None):
+    _send_form_to_hubspot(form_id, web_user, hubspot_cookie, meta,
+                          extra_fields=extra_fields)
 
 @analytics_task()
 def track_clicked_deploy_on_hubspot(webuser, hubspot_cookie, meta):

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -246,8 +246,7 @@ def update_hubspot_properties(webuser, properties):
         _track_on_hubspot(webuser, properties)
 
 
-@analytics_task()
-def track_web_user_registration_hubspot(web_user, properties):
+def track_web_user_registration_hubspot(request, web_user, properties):
     if not settings.ANALYTICS_IDS.get('HUBSPOT_API_ID'):
         return
 
@@ -269,16 +268,12 @@ def track_web_user_registration_hubspot(web_user, properties):
 
     tracking_info.update(get_ab_test_properties(web_user))
     tracking_info.update(properties)
-    _track_on_hubspot(web_user, tracking_info)
+
+    send_hubspot_form(HUBSPOT_SIGNUP_FORM_ID, request, user=web_user)
 
 
 @analytics_task()
 def track_user_sign_in_on_hubspot(webuser, hubspot_cookie, meta, path):
-    from corehq.apps.registration.views import ProcessRegistrationView
-    if path.startswith(reverse(ProcessRegistrationView.urlname)):
-        # registration view - only track the form itself here.
-        # use track_web_user_registration_hubspot to track properties on signup
-        _send_form_to_hubspot(HUBSPOT_SIGNUP_FORM_ID, webuser, hubspot_cookie, meta)
     _send_form_to_hubspot(HUBSPOT_SIGNIN_FORM_ID, webuser, hubspot_cookie, meta)
 
 

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -222,9 +222,10 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
             'hs_context': json.dumps({"hutk": hubspot_cookie, "ipAddress": _get_client_ip(meta)}),
         }
         if webuser:
-            data.update({'firstname': webuser.first_name,
-                         'lastname': webuser.last_name,
-                         })
+            data.update({
+                'firstname': webuser.first_name,
+                'lastname': webuser.last_name,
+            })
         if extra_fields:
             data.update(extra_fields)
 

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -235,7 +235,9 @@ class RegisterWebUserForm(forms.Form):
             # sync django user
             duplicate.save()
         if User.objects.filter(username__iexact=data).count() > 0 or duplicate:
-            raise forms.ValidationError('Username already taken; please try another')
+            raise forms.ValidationError(
+                ugettext("Username already taken. Please try another.")
+            )
         return data
 
     def clean_password(self):
@@ -244,10 +246,29 @@ class RegisterWebUserForm(forms.Form):
     def clean_eula_confirmed(self):
         data = self.cleaned_data['eula_confirmed']
         if data is not True:
-            raise forms.ValidationError(
-                "You must agree to our Terms of Service and Business Agreement in order "
-                "to register an account."
-            )
+            raise forms.ValidationError(ugettext(
+                "You must agree to our Terms of Service and Business Agreement "
+                "in order to register an account."
+            ))
+        return data
+
+    def clean_persona(self):
+        data = self.cleaned_data['persona'].strip()
+        if not data and settings.IS_SAAS_ENVIRONMENT:
+            raise forms.ValidationError(ugettext(
+                "Please specify how you plan to use CommCare so we know how to "
+                "best help you."
+            ))
+        return data
+
+    def clean_persona_other(self):
+        data = self.cleaned_data['persona_other'].strip().lower()
+        persona = self.data['persona'].strip()
+        if persona == 'Other' and not data and settings.IS_SAAS_ENVIRONMENT:
+            raise forms.ValidationError(ugettext(
+                "Please specify how you plan to use CommCare so we know how to "
+                "best help you."
+            ))
         return data
 
     def clean(self):

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
@@ -9,7 +9,7 @@
     {% endblocktrans %}
   </p>
   <ul data-bind="foreach: submitErrors">
-    <li><strong data-bind="text: fieldName"></strong> &mdash; <span data-bind="text:errors"></span></li>
+    <li><span data-bind="text:errors"></span></li>
   </ul>
   <button type="button"
           class="btn btn-lg btn-primary-dark"

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -44,6 +44,8 @@ from corehq.apps.hqwebapp.decorators import use_jquery_ui, \
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq import toggles
 from django.contrib.auth.models import User
+
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.couch.resource_conflict import retry_resource
 from memoized import memoized
 from dimagi.utils.web import get_ip
@@ -157,10 +159,12 @@ class ProcessRegistrationView(JSONResponseMixin, NewUserNumberAbTestMixin, View)
                 }
             )
             if not persona or (persona == 'Other' and not persona_other):
-                logging.error(
-                    "Persona fields from the login form were submitted without "
-                    "data. Please alert product as this should not be "
-                    "happening. User: {}".format(email)
+                # There shouldn't be many instances of this.
+                _assert = soft_assert('@'.join(['bbuczyk', 'dimagi.com']), exponential_backoff=False)
+                _assert(
+                    False,
+                    "[BAD PERSONA DATA] Persona fields during "
+                    "login submitted empty. User: {}".format(email)
                 )
 
         login(self.request, new_user)


### PR DESCRIPTION
Make sure that persona field / persona other can never be empty when sent to hubspot and kissmetrics

Send the new user hubspot form directly upon completing user registration. Make sure all persona data is coupled with it.

@orangejenny cc @calellowitz 