### PR TITLE
ICDS: Less noisy notify exception

### DIFF
--- a/custom/icds/case_relationships.py
+++ b/custom/icds/case_relationships.py
@@ -17,13 +17,15 @@ def _get_exactly_one_parent_case(case, identifier, relationship, expected_parent
     if len(related) != 1:
         raise CaseRelationshipError(
             "Expected exactly one parent for %s, relationship %s/%s" %
-            (case.case_id, identifier, relationship)
+            (case.case_id, identifier, relationship),
+            case.case_id, case.type, identifier, relationship, len(related)
         )
 
     parent_case = related[0]
     if parent_case.type != expected_parent_case_type:
         raise CaseRelationshipError(
-            "Expected case type of '%s' for %s" % (expected_parent_case_type, parent_case.case_id)
+            "Expected case type of '%s' for %s" % (expected_parent_case_type, parent_case.case_id),
+            case.case_id, case.type, identifier, relationship, len(related)
         )
 
     return parent_case

--- a/custom/icds/exceptions.py
+++ b/custom/icds/exceptions.py
@@ -1,4 +1,12 @@
 
 
 class CaseRelationshipError(Exception):
-    pass
+
+    def __init__(self, message, child_case_id, child_case_type, identifier, relationship, num_related_found):
+        self.child_case_id = child_case_id
+        self.child_case_type = child_case_type
+        self.identifier = identifier
+        self.relationship = relationship
+        self.num_related_found = num_related_found
+
+        super(CaseRelationshipError, self).__init__(message)

--- a/custom/icds/messaging/custom_recipients.py
+++ b/custom/icds/messaging/custom_recipients.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from corehq.apps.locations.models import SQLLocation
+from corehq.form_processor.models import CommCareCaseIndexSQL
 from custom.icds.case_relationships import (
     mother_person_case_from_ccs_record_case,
     mother_person_case_from_child_health_case,
@@ -8,6 +9,7 @@ from custom.icds.case_relationships import (
 )
 from custom.icds.const import SUPERVISOR_LOCATION_TYPE_CODE
 from custom.icds.exceptions import CaseRelationshipError
+from datetime import datetime
 from dimagi.utils.logging import notify_exception
 
 
@@ -24,11 +26,28 @@ def skip_notifying_missing_mother_person_case(e):
     )
 
 
+def skip_notifying_missing_ccs_record_parent(e):
+    # https://manage.dimagi.com/default.asp?277600
+    # This is an open issue so it probably doesn't make sense to keep notifying
+    # these unless it gets resolved. Going to make these start notifying at a
+    # later date so this can be revisited.
+
+    return (
+        datetime.utcnow() < datetime(2018, 8, 1) and
+        e.child_case_type = 'ccs_record' and
+        e.identifier == 'parent' and
+        e.relationship == CommCareCaseIndexSQL.CHILD and
+        e.num_related_found == 0
+    )
+
+
 def recipient_mother_person_case_from_ccs_record_case(case_schedule_instance):
     try:
         return mother_person_case_from_ccs_record_case(case_schedule_instance.case)
-    except CaseRelationshipError:
-        notify_exception(None, message="ICDS ccs_record relationship error")
+    except CaseRelationshipError as e:
+        if not skip_notifying_missing_ccs_record_parent(e):
+            notify_exception(None, message="ICDS ccs_record relationship error")
+
         return None
 
 

--- a/custom/icds/messaging/custom_recipients.py
+++ b/custom/icds/messaging/custom_recipients.py
@@ -19,7 +19,7 @@ def skip_notifying_missing_mother_person_case(e):
     # so we don't notify when that's the lookup that fails.
 
     return (
-        e.child_case_type = 'person' and
+        e.child_case_type == 'person' and
         e.identifier == 'mother' and
         e.relationship == CommCareCaseIndexSQL.CHILD and
         e.num_related_found == 0
@@ -34,7 +34,7 @@ def skip_notifying_missing_ccs_record_parent(e):
 
     return (
         datetime.utcnow() < datetime(2018, 8, 1) and
-        e.child_case_type = 'ccs_record' and
+        e.child_case_type == 'ccs_record' and
         e.identifier == 'parent' and
         e.relationship == CommCareCaseIndexSQL.CHILD and
         e.num_related_found == 0

--- a/custom/icds/tests/test_case_relationships.py
+++ b/custom/icds/tests/test_case_relationships.py
@@ -10,6 +10,7 @@ from custom.icds.case_relationships import (
     child_person_case_from_tasks_case,
 )
 from custom.icds.exceptions import CaseRelationshipError
+from custom.icds.messaging.custom_recipients import skip_notifying_missing_mother_person_case
 from custom.icds.tests.base import BaseICDSTest
 
 
@@ -75,8 +76,10 @@ class CaseRelationshipTest(BaseICDSTest):
         with self.assertRaises(CaseRelationshipError):
             child_person_case_from_child_health_case(self.lone_child_health_case)
 
-        with self.assertRaises(CaseRelationshipError):
+        with self.assertRaises(CaseRelationshipError) as raises:
             mother_person_case_from_child_person_case(self.lone_child_person_case)
+
+        self.assertTrue(skip_notifying_missing_mother_person_case(raises.exception))
 
         with self.assertRaises(CaseRelationshipError):
             mother_person_case_from_ccs_record_case(self.lone_ccs_record_case)


### PR DESCRIPTION
This stops notifying for known issues so that going forward all notifies from messaging are actionable.

@millerdev 