### PR TITLE
Feature flag to exclude formplayer-inline from case data and custom r…

### DIFF
--- a/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
+++ b/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
@@ -22,10 +22,12 @@
     {% block patient_content %}
         <div class="col-sm-11">
             <div class="row">
-                {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
-                {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
-                {% include 'cloudcare/includes/formplayer-inline.html' %}
-                {% include "case/partials/case_hierarchy.html" %}
+                {% if not request|toggle_enabled:"CASE_DATA_FORMPLAYER_EXCLUDE" %}
+                    {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
+                    {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
+                    {% include 'cloudcare/includes/formplayer-inline.html' %}
+                    {% include "case/partials/case_hierarchy.html" %}
+                {% endif %}
             </div>
         </div>
     {% endblock patient_content %}

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -12,9 +12,11 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
-    {# import error: http://manage.dimagi.com/default.asp?223100 #}
-    {% include 'cloudcare/includes/formplayer-inline.html' %}
+    {% if not request|toggle_enabled:"CASE_DATA_FORMPLAYER_EXCLUDE" %}
+        {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
+        {# import error: http://manage.dimagi.com/default.asp?223100 #}
+        {% include 'cloudcare/includes/formplayer-inline.html' %}
+    {% endif %}
     <script src="{% static "hqwebapp/js/lib/bootstrap-tab-hashes.js" %}"></script>
     <script src="{% static "jquery-memoized-ajax/jquery.memoized.ajax.min.js" %}"></script>
     <script src="{% static "jquery-treetable/jquery.treetable.js" %}"></script>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1606,3 +1606,10 @@ AGGREGATE_UCRS = StaticToggle(
     TAG_INTERNAL,  # this might change in the future
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+CASE_DATA_FORMPLAYER_EXCLUDE = StaticToggle(
+    'case_data_formplayer_exclude',
+    'Do not include formplayer on case data page or custom reports',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN, NAMESPACE_USER],
+)

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
@@ -16,9 +16,11 @@
 </script>
 
 <div class="row">
-    {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
-    {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
-    {% include 'cloudcare/includes/formplayer-inline.html' %}
-    {% include "case/partials/case_hierarchy.html" %}
+    {% if not request|toggle_enabled:"CASE_DATA_FORMPLAYER_EXCLUDE" %}
+        {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
+        {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
+        {% include 'cloudcare/includes/formplayer-inline.html' %}
+        {% include "case/partials/case_hierarchy.html" %}
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
…eports

So far as I can tell based on git history and clicking through patient cases, the `formplayer-inline.html` include can be removed from `case_data.html`. The inline case editing seems to be gone from pact, with just some (possibly broken) links to web apps remaining. But [the last time](http://manage.dimagi.com/default.asp?223100) we tried removing it things got rather messy. Planning to release this, poke around at the pact domain a bit to see if it breaks anything, and if not remove the include altogether.

@czue / @snopoke 