### PR TITLE
Check new deid exports before downgrade

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -17,7 +17,6 @@ from corehq.apps.accounting.utils import (
 from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.domain.models import Domain
-from corehq.apps.export.dbaccessors import get_deid_export_count
 from corehq.apps.fixtures.models import FixtureDataType
 from corehq.apps.reminders.models import METHOD_SMS_SURVEY, METHOD_IVR_SURVEY
 from corehq.apps.users.models import CommCareUser, UserRole
@@ -585,6 +584,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         De-id exports will be hidden
         """
+        from corehq.apps.export.dbaccessors import get_deid_export_count
         num_deid_reports = get_deid_export_count(domain)
         if num_deid_reports > 0:
             return _fmt_alert(

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -100,12 +100,23 @@ def get_form_exports_by_domain(domain, has_deid_permissions):
 def get_export_count_by_domain(domain):
     from .models import ExportInstance
 
-    return len(ExportInstance.get_db().view(
+    return ExportInstance.get_db().view(
         'export_instances_by_domain/view',
         startkey=[domain],
         endkey=[domain, {}],
         include_docs=False,
-        reduce=False,
+        reduce=True,
+    ).one()['value']
+
+
+def get_deid_export_count(domain):
+    from .models import ExportInstance
+    return sum(res['value'] for res in ExportInstance.get_db().view(
+        'export_instances_by_domain/view',
+        keys=[[domain, 'FormExportInstance', True],
+              [domain, 'CaseExportInstance', True]],
+        include_docs=False,
+        group=True,
     ).all())
 
 

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -17,6 +17,7 @@ from corehq.apps.export.dbaccessors import (
     get_form_export_instances,
     get_case_export_instances,
     get_export_count_by_domain,
+    get_deid_export_count,
     get_all_daily_saved_export_instance_ids,
     get_properly_wrapped_export_instance,
     get_case_inferred_schema,
@@ -175,6 +176,12 @@ class TestExportInstanceDBAccessors(TestCase):
         self.assertEqual(
             get_export_count_by_domain(self.domain),
             4
+        )
+
+    def test_get_count_deid_export_instances(self):
+        self.assertEqual(
+            get_deid_export_count(self.domain),
+            2
         )
 
     def test_get_case_export_instances_wrong_domain(self):


### PR DESCRIPTION
Domain downgrade previously checked only old exports to warn about DEID usage, now it will check new exports.
@orangejenny @nickpell