### PR TITLE
Fix false error in form filters

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3128,9 +3128,14 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             ))
 
         if self.form_filter:
+            # Replace any dots with #case, which doesn't make for valid xpath
+            # but will trigger any appropriate validation errors
+            interpolated_form_filter = interpolate_xpath(self.form_filter, case_xpath="#case",
+                    module=self.get_module(), form=self)
+
             form_filter_references_case = (
-                xpath_references_case(self.form_filter) or
-                xpath_references_user_case(self.form_filter)
+                xpath_references_case(interpolated_form_filter) or
+                xpath_references_user_case(interpolated_form_filter)
             )
 
             if form_filter_references_case:

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -5,16 +5,12 @@ hqDefine("app_manager/js/forms/form_view", function() {
     appManagerUtils.setAppendedPageTitle(gettext("Form Settings"));
     appManagerUtils.updatePageTitle(initialPageData("form_name"));
 
-    function formFilterMatches(filter, patternMatches, substringMatches) {
+    function formFilterMatches(filter, substringMatches) {
         if (typeof(filter) !== 'string') {
             return false;
         }
 
         var result = false;
-        $.each(patternMatches, function(index, pattern) {
-            result = result || filter.match(pattern);
-        });
-
         $.each(substringMatches, function(index, sub) {
             result = result || filter.indexOf(sub) !== -1;
         });
@@ -42,7 +38,7 @@ hqDefine("app_manager/js/forms/form_view", function() {
                     filter = filter.replace(sub, '');
                 });
 
-                if (formFilterMatches(filter, patterns.case, patterns.case_substring)) {
+                if (formFilterMatches(filter, patterns.case_substring)) {
                     return true;
                 }
             }
@@ -51,7 +47,7 @@ hqDefine("app_manager/js/forms/form_view", function() {
 
         self.userCaseReferenceNotAllowed = ko.computed(function() {
             return !initialPageData('is_usercase_in_use') && formFilterMatches(
-                self.formFilter(), patterns.usercase, patterns.usercase_substring
+                self.formFilter(), patterns.usercase_substring
             );
         });
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -42,10 +42,6 @@ from io import open
 
 logger = logging.getLogger(__name__)
 
-CASE_XPATH_PATTERN_MATCHES = [
-    DOT_INTERPOLATE_PATTERN
-]
-
 CASE_XPATH_SUBSTRING_MATCHES = [
     "instance('casedb')",
     'session/data/case_id',
@@ -53,9 +49,6 @@ CASE_XPATH_SUBSTRING_MATCHES = [
     "#parent",
     "#host",
 ]
-
-
-USER_CASE_XPATH_PATTERN_MATCHES = []
 
 USER_CASE_XPATH_SUBSTRING_MATCHES = [
     "#user",

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -99,21 +99,21 @@ def xpath_references_case(xpath):
     # We want to determine here if the xpath references any cases other
     # than the user case. To determine if the xpath references the user
     # case, see xpath_references_user_case()
+    # Assumes xpath has already been dot interpolated as needed.
     for substring in USER_CASE_XPATH_SUBSTRING_MATCHES:
         xpath = xpath.replace(substring, '')
 
     return _check_xpath_for_matches(
         xpath,
         substring_matches=CASE_XPATH_SUBSTRING_MATCHES,
-        pattern_matches=CASE_XPATH_PATTERN_MATCHES
     )
 
 
 def xpath_references_user_case(xpath):
+    # Assumes xpath has already been dot interpolated as needed.
     return _check_xpath_for_matches(
         xpath,
         substring_matches=USER_CASE_XPATH_SUBSTRING_MATCHES,
-        pattern_matches=USER_CASE_XPATH_PATTERN_MATCHES,
     )
 
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -43,9 +43,7 @@ from corehq.apps.app_manager.util import (
     enable_usercase,
     actions_use_usercase,
     advanced_actions_use_usercase,
-    CASE_XPATH_PATTERN_MATCHES,
     CASE_XPATH_SUBSTRING_MATCHES,
-    USER_CASE_XPATH_PATTERN_MATCHES,
     USER_CASE_XPATH_SUBSTRING_MATCHES,
 )
 from corehq.apps.app_manager.xform import (
@@ -678,9 +676,7 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
         'is_case_list_form': form.is_case_list_form,
         'edit_name_url': reverse('edit_form_attr', args=[app.domain, app.id, form.unique_id, 'name']),
         'form_filter_patterns': {
-            'case': CASE_XPATH_PATTERN_MATCHES,
             'case_substring': CASE_XPATH_SUBSTRING_MATCHES,
-            'usercase': USER_CASE_XPATH_PATTERN_MATCHES,
             'usercase_substring': USER_CASE_XPATH_SUBSTRING_MATCHES,
         },
         'custom_instances': [


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?277612

This was displaying a false error on both the server and client side when a filter contained a dot that was *not* meant to be substituted with a case expression.

On the server side, fix by making sure dot interpolation happens before validation, and then removing the part of validation that checks for dots.

On the client side, just remove the validation that looks for dots. Given that we should be pushing people to use `#case`, etc instead of just `.`, and that any dot-related errors will still be caught on the server side, I think this isn't a big deal and is preferable to duplicating a bunch of dot interpolation logic in javascript.

@nickpell 