### PR TITLE
Allow tracked CommCare.jad file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ submissions/
 /bower_components
 bad/
 *.log*
-CommCare.ja*
+/CommCare.ja*
 startover.sh
 celery.db
 tmp.sh


### PR DESCRIPTION
This has been around for ever, but the .gitignore just doesn't agree
with what's actually committed