### PR TITLE
Further location download/upload improvements

### DIFF
--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -228,7 +228,7 @@ class LocationStub(object):
             any(old_metadata.get(k, '') != new_value
                 for k, new_value in new_metadata.items())
             # data is removed
-            or set(old_metadata.keys()) - set(new_metadata.keys())
+            or any(k not in new_metadata for k in old_metadata.keys())
         )
 
 

--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -207,8 +207,7 @@ class LocationStub(object):
                 # attributes are being updated
                 return True
 
-        if self.db_object.metadata != self.old_object.metadata:
-            # custom location data is being updated
+        if self._metadata_needs_save():
             return True
 
         if self.location_type != self.old_object.location_type.code:
@@ -220,6 +219,17 @@ class LocationStub(object):
         else:
             old_parent_code = ROOT_LOCATION_TYPE
         return old_parent_code != self.new_data.parent_code
+
+    def _metadata_needs_save(self):
+        # Save only for meaningful changes - not just to add empty fields
+        old_metadata, new_metadata = self.old_object.metadata, self.db_object.metadata
+        return (
+            # data is added or modified
+            any(old_metadata.get(k, '') != new_value
+                for k, new_value in new_metadata.items())
+            # data is removed
+            or set(old_metadata.keys()) - set(new_metadata.keys())
+        )
 
 
 class UnexpectedState(Exception):

--- a/corehq/apps/locations/bulk_management.py
+++ b/corehq/apps/locations/bulk_management.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import copy
 from collections import Counter, defaultdict
+from decimal import Decimal, InvalidOperation
 
 from attr import attrs, attrib
 from django.core.exceptions import ValidationError
@@ -110,8 +111,13 @@ def lowercase_string(val):
     return six.text_type(val).lower()
 
 
-def string_or_none(val):
-    return six.text_type(val) if val else None
+def maybe_decimal(val):
+    if not val:
+        return None
+    try:
+        return Decimal(val)
+    except InvalidOperation:
+        return val  # invalid - this will be caught later
 
 
 @attrs(frozen=True)
@@ -124,8 +130,8 @@ class LocationData(object):
     location_id = attrib(type=six.text_type)
     do_delete = attrib(type=bool, converter=to_boolean)
     external_id = attrib(type=six.text_type)
-    latitude = attrib(converter=string_or_none)
-    longitude = attrib(converter=string_or_none)
+    latitude = attrib(converter=maybe_decimal)
+    longitude = attrib(converter=maybe_decimal)
     # This can be a dict or 'NOT_PROVIDED_IN_EXCEL'
     custom_data = attrib()
     delete_uncategorized_data = attrib(type=bool, converter=to_boolean)
@@ -545,12 +551,8 @@ class LocationTreeValidator(object):
         errors = []
         for loc_stub in self.all_listed_locations:
             l = loc_stub.new_data
-            try:
-                if l.latitude:
-                    float(l.latitude)
-                if l.longitude:
-                    float(l.longitude)
-            except ValueError:
+            if (l.latitude and not isinstance(l.latitude, Decimal)
+                    or l.longitude and not isinstance(l.longitude, Decimal)):
                 errors.append(l)
         return [
             _("latitude/longitude 'lat-{lat}, lng-{lng}' for location in sheet '{type}' "

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -1048,6 +1048,8 @@ class TestBulkManagementWithInitialLocs(UploadTestUtils, LocationHierarchyPerTes
         self.locations['City111'].latitude = Decimal('42.36')
         self.locations['City111'].longitude = Decimal('71.06')
         self.locations['City111'].external_id = '123'
+        self.locations['County11'].metadata = {'favorite_color': 'purple',
+                                               'language': 'en'}
         self.locations['City111'].save()
 
         self.locations['County11'].external_id = '321'
@@ -1073,9 +1075,8 @@ class TestBulkManagementWithInitialLocs(UploadTestUtils, LocationHierarchyPerTes
 
         # The upload should succeed and not perform any updates
         assert_errors(result, [])
-        # TODO make these pass
-        # self.assertFalse(save_location.called)
-        # self.assertFalse(save_type.called)
+        self.assertFalse(save_location.called)
+        self.assertFalse(save_type.called)
 
 
 class TestRestrictedUserUpload(UploadTestUtils, LocationHierarchyPerTest):

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from collections import defaultdict
+from decimal import Decimal
 
 from django.test import SimpleTestCase, TestCase
 from django.utils.functional import cached_property
@@ -1044,8 +1045,8 @@ class TestBulkManagementWithInitialLocs(UploadTestUtils, LocationHierarchyPerTes
                              CustomDataField(slug='language')]
         loc_fields.save()
 
-        self.locations['City111'].latitude = 42.36
-        self.locations['City111'].longitude = 71.06
+        self.locations['City111'].latitude = Decimal('42.36')
+        self.locations['City111'].longitude = Decimal('71.06')
         self.locations['City111'].external_id = '123'
         self.locations['City111'].save()
 

--- a/corehq/apps/locations/tests/test_export.py
+++ b/corehq/apps/locations/tests/test_export.py
@@ -6,17 +6,8 @@ from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition, Cu
 
 from ..util import LocationExporter
 from ..views import LocationFieldsView
-from .util import LocationHierarchyTestCase
+from .util import LocationHierarchyTestCase, MockExportWriter
 from six.moves import zip
-
-
-class MockExportWriter(object):
-    def __init__(self):
-        self.data = {}
-
-    def write(self, document_table):
-        for table_index, table in document_table:
-            self.data[table_index] = list(table)
 
 
 class TestLocationsExport(LocationHierarchyTestCase):

--- a/corehq/apps/locations/tests/test_export.py
+++ b/corehq/apps/locations/tests/test_export.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from decimal import Decimal
 
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition, CustomDataField
 
@@ -43,6 +44,9 @@ class TestLocationsExport(LocationHierarchyTestCase):
         cls.boston.metadata = {
             field: '{}-试验'.format(field) for field in cls.custom_fields + ['不知道']
         }
+        cls.boston.external_id = 'external_id'
+        cls.boston.latitude = Decimal('42.36')
+        cls.boston.longitude = Decimal('71.06')
         cls.boston.save()
 
         exporter = LocationExporter(cls.domain)
@@ -52,6 +56,17 @@ class TestLocationsExport(LocationHierarchyTestCase):
         cls.headers = dict(exporter.get_headers())
         cls.city_headers = cls.headers['city'][0]
         cls.boston_data = [row for row in writer.data['city'] if row[0] == cls.boston.location_id][0]
+
+    def test_columns_and_headers_align(self):
+        boston = dict(zip(self.city_headers, self.boston_data))
+        self.assertEqual(boston['location_id'], self.boston.location_id)
+        self.assertEqual(boston['name'], self.boston.name)
+        self.assertEqual(boston['site_code'], self.boston.site_code)
+        self.assertEqual(boston['external_id'], self.boston.external_id)
+        self.assertEqual(boston['latitude'], self.boston.latitude)
+        self.assertEqual(boston['longitude'], self.boston.longitude)
+        for field in self.custom_fields:
+            self.assertEqual(boston['data: {}'.format(field)], self.boston.metadata[field])
 
     def test_consisent_header_order(self):
         # This intentionally checks both contents and order

--- a/corehq/apps/locations/tests/util.py
+++ b/corehq/apps/locations/tests/util.py
@@ -195,3 +195,12 @@ class LocationHierarchyPerTest(TestCase):
 
     def tearDown(self):
         self.domain_obj.delete()
+
+
+class MockExportWriter(object):
+    def __init__(self):
+        self.data = {}
+
+    def write(self, document_table):
+        for table_index, table in document_table:
+            self.data[table_index] = list(table)

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -11,7 +11,7 @@ from corehq.apps.consumption.shortcuts import get_loaded_default_monthly_consump
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.const import LOCATION_TYPE_SHEET_HEADERS, \
     LOCATION_SHEET_HEADERS_BASE, LOCATION_SHEET_HEADERS_OPTIONAL
-from corehq.apps.locations.models import SQLLocation
+from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.products.models import Product
 from corehq.blobs import get_blob_db
 from corehq.form_processor.interfaces.supply import SupplyInterface
@@ -139,7 +139,7 @@ class LocationExporter(object):
         self.headers_only = headers_only
         self.data_model = get_location_data_model(domain)
         self.administrative_types = {}
-        self.location_types = self.domain_obj.location_types
+        self.location_types = LocationType.objects.by_domain(domain)
         self.async_task = async_task
         self._location_count = None
         self._locations_exported = 0

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -235,16 +235,17 @@ class LocationExporter(object):
         def _row_generator(include_consumption=include_consumption):
             for loc in query:
                 model_data, uncategorized_data = self.data_model.get_model_and_uncategorized(loc.metadata)
-                row = [
-                    loc.location_id,
-                    loc.site_code,
-                    loc.name,
-                    loc.parent.site_code if loc.parent else '',
-                    loc.latitude or '',
-                    loc.longitude or '',
-                    loc.external_id,
-                    '',  # do delete
-                ]
+                row_data = {
+                    'location_id': loc.location_id,
+                    'site_code': loc.site_code,
+                    'name': loc.name,
+                    'parent_code': loc.parent.site_code if loc.parent else '',
+                    'external_id': loc.external_id,
+                    'latitude': loc.latitude or '',
+                    'longitude': loc.longitude or '',
+                    'do_delete': '',
+                }
+                row = [row_data[attr] for attr in LOCATION_SHEET_HEADERS_BASE.keys()]
                 for field in self.data_model.fields:
                     row.append(model_data.get(field.slug, ''))
 


### PR DESCRIPTION
This is a handful of things, somewhat disparate.  Commits are granular.  This PR is into https://github.com/dimagi/commcare-hq/pull/21092

@millerdev pointed out that the location sheets aren't ordered properly, so that's fixed, and that external_id and lat/long are scrambled - looks like the download has been broken for a while, this tests and fixes that too.  It also adds a test to download locations and reupload them, verifying that no changes are made.  This shows the external_id issue as well as two other instances where we were needlessly saving locations.