### PR TITLE
Remove formplayer-inline from case data page and pact reports

### DIFF
--- a/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
+++ b/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
@@ -22,11 +22,6 @@
     {% block patient_content %}
         <div class="col-sm-11">
             <div class="row">
-                {% if not request|toggle_enabled:"CASE_DATA_FORMPLAYER_EXCLUDE" %}
-                    {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
-                    {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
-                    {% include 'cloudcare/includes/formplayer-inline.html' %}
-                {% endif %}
                 {% include "case/partials/case_hierarchy.html" %}
             </div>
         </div>

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -12,11 +12,6 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    {% if not request|toggle_enabled:"CASE_DATA_FORMPLAYER_EXCLUDE" %}
-        {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
-        {# import error: http://manage.dimagi.com/default.asp?223100 #}
-        {% include 'cloudcare/includes/formplayer-inline.html' %}
-    {% endif %}
     <script src="{% static "hqwebapp/js/lib/bootstrap-tab-hashes.js" %}"></script>
     <script src="{% static "jquery-memoized-ajax/jquery.memoized.ajax.min.js" %}"></script>
     <script src="{% static "jquery-treetable/jquery.treetable.js" %}"></script>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1606,10 +1606,3 @@ AGGREGATE_UCRS = StaticToggle(
     TAG_INTERNAL,  # this might change in the future
     namespaces=[NAMESPACE_DOMAIN]
 )
-
-CASE_DATA_FORMPLAYER_EXCLUDE = StaticToggle(
-    'case_data_formplayer_exclude',
-    'Do not include formplayer on case data page or custom reports',
-    TAG_INTERNAL,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER],
-)

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
@@ -16,11 +16,6 @@
 </script>
 
 <div class="row">
-    {% if not request|toggle_enabled:"CASE_DATA_FORMPLAYER_EXCLUDE" %}
-        {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
-        {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
-        {% include 'cloudcare/includes/formplayer-inline.html' %}
-    {% endif %}
     {% include "case/partials/case_hierarchy.html" %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/21108 - deployed, clicked around, and didn't find any difference on the case data page or custom reports when formplayer was excluded.

@nickpell 