### PR TITLE
Remove type='text/javascript' from script tags

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/domain_faceted_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/domain_faceted_report.html
@@ -26,9 +26,9 @@
 {% compress js %}
 <script src="{% static 'hqwebapp/js/lib/history-1.7.1.js' %}"></script>
 <script src="{% static 'hqwebapp/js/hash-tab.js' %}"></script>
-<script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}' type='text/javascript'></script>
-<script src='{% static 'hqadmin/js/visualizations.js' %}' type='text/javascript'></script>
-<script src='{% static 'hqadmin/js/domain_faceted_report.js' %}' type='text/javascript'></script>
+<script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}'></script>
+<script src='{% static 'hqadmin/js/visualizations.js' %}'></script>
+<script src='{% static 'hqadmin/js/domain_faceted_report.js' %}'></script>
 {% endcompress %}
 {% endblock %}
 

--- a/corehq/apps/hqadmin/templates/hqadmin/indicator_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/indicator_report.html
@@ -5,10 +5,10 @@
 
 {% block js %}{{ block.super }}
     {% compress js %}
-        <script src="{% static 'hqwebapp/js/lib/history-1.7.1.js' %}" type='text/javascript'></script>
-        <script src="{% static 'hqwebapp/js/hash-tab.js' %}" type='text/javascript'></script>
-        <script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}' type='text/javascript'></script>
-        <script src='{% static 'hqadmin/js/visualizations.js' %}' type='text/javascript'></script>
+        <script src="{% static 'hqwebapp/js/lib/history-1.7.1.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/hash-tab.js' %}"></script>
+        <script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}'></script>
+        <script src='{% static 'hqadmin/js/visualizations.js' %}'></script>
     {% endcompress %}
     <script src="{% static 'hqadmin/js/indicator_report.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/hqadmin/templates/hqadmin/mass_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/mass_email.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% block title %}Mass Email Users{% endblock %}
 {% block js-inline %} {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function () {
                 $('#real_email').click(function(e) {
                     if($(this).prop('checked')) {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -361,7 +361,7 @@
             <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
             <script src="{% static 'hqwebapp/js/requirejs_config.js' %}"></script>
             <script src="{% static 'hqwebapp/js/resource_versions.js' %}"></script>
-            <script type="text/javascript">
+            <script>
                 requirejs.config({
                     deps: ['knockout', 'ko.mapping'],
                     callback: function (ko, mapping) {
@@ -522,9 +522,9 @@
             </div>
           </div>
           <!--[if lte IE 8]>
-          <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+          <script charset="utf-8" src="//js.hsforms.net/forms/v2-legacy.js"></script>
           <![endif]-->
-          <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+          <script charset="utf-8" src="//js.hsforms.net/forms/v2.js"></script>
           <script>
             hbspt.forms.create({
               portalId: "{{ ANALYTICS_IDS.HUBSPOT_API_ID }}",

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -39,7 +39,7 @@
     {% endcompress %}
     {% if is_saas_environment %}
       <!-- Google Code for Destination Lead Conversion Page -->
-      <script type="text/javascript">
+      <script>
       /* <![CDATA[ */
       var google_conversion_id = 941515958;
       var google_conversion_language = "en";
@@ -49,7 +49,7 @@
       var google_remarketing_only = false;
       /* ]]> */
       </script>
-      <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js"></script>
+      <script src="//www.googleadservices.com/pagead/conversion.js"></script>
       <noscript>
         <div style="display:inline;">
           <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/941515958/?label=glkzCMmv73UQtsn5wAM&amp;guid=ON&amp;script=0"/>
@@ -57,9 +57,9 @@
       </noscript>
 
       <!-- linked in -->
-      <script type="text/javascript">
+      <script>
       _linkedin_data_partner_id = "63907";
-      </script><script type="text/javascript">
+      </script><script>
       (function(){var s = document.getElementsByTagName("script")[0];
       var b = document.createElement("script");
       b.type = "text/javascript";b.async = true;

--- a/custom/_legacy/mvp/templates/mvp/reports/chw_report.html
+++ b/custom/_legacy/mvp/templates/mvp/reports/chw_report.html
@@ -12,12 +12,12 @@
     {% endfor %}
 {% endblock %}
 {% block js %} {{ block.super }}
-    <script type="text/javascript" src="{% static 'mvp/js/mvp.indicatorQueue.js' %}"></script>
-    <script type="text/javascript" src="{% static 'mvp/ko/mvp.async_table.js' %}"></script>
+    <script src="{% static 'mvp/js/mvp.indicatorQueue.js' %}"></script>
+    <script src="{% static 'mvp/ko/mvp.async_table.js' %}"></script>
 {% endblock %}
 {% block js-inline %} {{ block.super }}
 {% if not report.needs_filters %}
-<script type="text/javascript">
+<script>
     $(function () {
         var indicator_table = new CHWIndicatorTable({
             indicators: {{ indicators|JSON }}

--- a/custom/_legacy/mvp/templates/mvp/reports/fancy_report.html
+++ b/custom/_legacy/mvp/templates/mvp/reports/fancy_report.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 {% block js-inline %} {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $.when(
             $.getScript("{% static 'mvp/js/mvp.indicatorQueue.js' %}"),
             $.getScript("{% static 'mvp/ko/mvp.async_indicators.js' %}")

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_edit.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_edit.html
@@ -23,7 +23,7 @@
         </div>
     </div>
 
-    <script type="text/javascript">
+    <script>
             $("#submit_button").click(function() {
                 // validate and process form here
                 var form_data = $("#pt_edit_form").serialize();

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_providers.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_providers.html
@@ -92,7 +92,7 @@
     </div>
 
 
-    <script type="text/javascript">
+    <script>
         function ProviderModel(data) {
             this.id = ko.observable(data.id);
             this.first_name = ko.observable(data.first_name);

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_schedule.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_schedule.html
@@ -42,7 +42,7 @@
             <button id="btn_schedule_submit" type="submit" class="btn btn-primary">Save</button>
         </form>
     </div>
-    <script type="text/javascript">
+    <script>
         function format_date(isodatestring) {
             if (isodatestring == "" || isodatestring == null) {
                 return 'present';

--- a/custom/apps/crs_reports/templates/crs_reports/base_template.html
+++ b/custom/apps/crs_reports/templates/crs_reports/base_template.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block js-inline %}
-    <script type="text/javascript">
+    <script>
         $("#render_to_pdf").click(function() {
            $.get("{{ report.slug }}/to_pdf")
         })

--- a/custom/bihar/templates/bihar/reports/report.html
+++ b/custom/bihar/templates/bihar/reports/report.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 {% block js-inline %} {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function () {
             var reportContent = $('#report-content');
 

--- a/custom/care_pathways/templates/care_pathways/adoption_disaggregated_report.html
+++ b/custom/care_pathways/templates/care_pathways/adoption_disaggregated_report.html
@@ -15,7 +15,7 @@
 
 {% block js-inline %}
     <link href="{% static 'care_pathways/css/care_pathways.css' %}" rel="stylesheet"/>
-    <script type="text/javascript">
+    <script>
         $(function() {
             var filter_section = $('<section id="filters"></section>');
             var group_section = $('<section id="groups"></section>');

--- a/custom/care_pathways/templates/care_pathways/filters/drilldown_options.html
+++ b/custom/care_pathways/templates/care_pathways/filters/drilldown_options.html
@@ -35,7 +35,7 @@
 </div>
 
 {% block filter_js %}
-<script type="text/javascript">
+<script>
     $.getScript("{% static 'care_pathways/ko/report_filter.drilldown_options.js' %}", function () {
        $('#{{ css_id }}').drilldownOptionFilter({
            selected: {{ selected|JSON }},

--- a/custom/care_pathways/templates/care_pathways/filters/single_option_with_helper.html
+++ b/custom/care_pathways/templates/care_pathways/filters/single_option_with_helper.html
@@ -3,7 +3,7 @@
 {% block filter_js %}
     {{ block.super }}
 
-    <script type="text/javascript">
+    <script>
     $(function () {
         $("fieldset .help-block").each( function (index, data) {
             $(this).parents('.form-group').find("label:first").append('<span class="hq-help-template" data-placement="top" data-content="' + data.textContent + '"></span>');

--- a/custom/care_pathways/templates/care_pathways/partials/multi_bar_chart.html
+++ b/custom/care_pathways/templates/care_pathways/partials/multi_bar_chart.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-<script type="text/javascript">
+<script>
     function wrap(text, width) {
         //http://bl.ocks.org/mbostock/7555321
         text.each(function () {

--- a/custom/care_pathways/templates/care_pathways/partials/report_table.html
+++ b/custom/care_pathways/templates/care_pathways/partials/report_table.html
@@ -60,7 +60,7 @@
     {% endif %}
 </table>
 
-<script type="text/javascript">
+<script>
    $(function () {
         {% if report_table and report_table.datatables %}
         var reportTables = hqImport("reports/js/config.dataTables.bootstrap").HQReportDataTables({

--- a/custom/care_pathways/templates/care_pathways/table_card_report.html
+++ b/custom/care_pathways/templates/care_pathways/table_card_report.html
@@ -67,7 +67,7 @@
             {% endwith %}
         {% endfor %}
     {% endfor %}
-    <script type="text/javascript">
+    <script>
         $(function() {
             var filter_section = $('<section id="filters"></section>');
             var group_section = $('<section id="groups"></section>');

--- a/custom/champ/templates/champ/knockout/base_template.html
+++ b/custom/champ/templates/champ/knockout/base_template.html
@@ -4,12 +4,12 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script type="text/javascript" src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'nvd3/nv.d3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'champ/js/knockout/select2-binding.js' %}"></script>
-    <script type="text/javascript" src="{% static 'champ/js/knockout/prevision_vs_achievement_graph.js' %}"></script>
-    <script type="text/javascript" src="{% static 'champ/js/knockout/prevision_vs_achievement_table.js' %}"></script>
-    <script type="text/javascript" src="{% static 'champ/js/knockout/service_uptake.js' %}"></script>
+    <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
+    <script src="{% static 'nvd3/nv.d3.js' %}"></script>
+    <script src="{% static 'champ/js/knockout/select2-binding.js' %}"></script>
+    <script src="{% static 'champ/js/knockout/prevision_vs_achievement_graph.js' %}"></script>
+    <script src="{% static 'champ/js/knockout/prevision_vs_achievement_table.js' %}"></script>
+    <script src="{% static 'champ/js/knockout/service_uptake.js' %}"></script>
     <script>
         $(document).ready(function () {
             $('#reportFiltersAccordion').css('display', 'none');

--- a/custom/champ/templates/champ/spec/mocha.html
+++ b/custom/champ/templates/champ/spec/mocha.html
@@ -3,10 +3,10 @@
 
 {% block core_libraries %}{{ block.super }}
     <script src="{% static 'moment/moment.js' %}"></script>
-    <script type="text/javascript" src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'nvd3/nv.d3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'bower_components/bootstrap-daterangepicker/daterangepicker.js' %}"></script>
-    <script type="text/javascript" src="{% static 'champ/js/knockout/select2-binding.js' %}"></script>
+    <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
+    <script src="{% static 'nvd3/nv.d3.js' %}"></script>
+    <script src="{% static 'bower_components/bootstrap-daterangepicker/daterangepicker.js' %}"></script>
+    <script src="{% static 'champ/js/knockout/select2-binding.js' %}"></script>
 {% endblock %}
 
 {% block dependencies %}

--- a/custom/common/templates/common/drilldown_options.html
+++ b/custom/common/templates/common/drilldown_options.html
@@ -31,7 +31,7 @@
 </div>
 
 {% block filter_js %}
-<script type="text/javascript">
+<script>
     $.getScript("{% static 'reports/js/filters/drilldown_options.js' %}").done(function(){
         $.getScript("{% static 'common/ko/report_filter.drilldown_options.js' %}").done(function () {
             $('#{{ css_id }}').drilldownOptionFilter({

--- a/custom/common/templates/common/line_chart.html
+++ b/custom/common/templates/common/line_chart.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-<script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}' type='text/javascript'></script>
+<script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}'></script>
 <script>
     nv.addGraph(function() {
         var chart_config = {{ chart.config_dict|JSON }};

--- a/custom/enikshay/templates/enikshay/data_dumps_task.html
+++ b/custom/enikshay/templates/enikshay/data_dumps_task.html
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <script type="text/javascript">
+        <script>
             $(function () {
                 var form = $('#data-dump-task-form');
                 form.submit(function () {

--- a/custom/enikshay/templates/enikshay/reconciliation_tasks.html
+++ b/custom/enikshay/templates/enikshay/reconciliation_tasks.html
@@ -22,7 +22,7 @@
             </div>
         </div>
 
-        <script type="text/javascript">
+        <script>
             $(function() {
                 var frm = $('#reconciliation-task-form');
                 frm.submit(function () {

--- a/custom/ewsghana/templates/ewsghana/base_template.html
+++ b/custom/ewsghana/templates/ewsghana/base_template.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% block js %}{{ block.super }}
-    <script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}' type='text/javascript'></script>
+    <script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}'></script>
     <script src="{% static 'ewsghana/report_links.js' %}"></script>
     <script src="{% static 'hqwebapp/js/daterangepicker.config.js' %}"></script>
     <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>

--- a/custom/ewsghana/templates/ewsghana/dashboard_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/dashboard_print_report.html
@@ -14,7 +14,7 @@
 
 {% block js-inline %}
     {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function() {
             if (!document.hidden) {
                 setTimeout(function() {

--- a/custom/ewsghana/templates/ewsghana/datespan.html
+++ b/custom/ewsghana/templates/ewsghana/datespan.html
@@ -45,7 +45,7 @@
 
 {% endblock %}
 {% block filter_js %}
-<script type="text/javascript">
+<script>
     $(function () {
         ko.bindingHandlers.select2 = {
             init: function(element, valueAccessor) {

--- a/custom/ewsghana/templates/ewsghana/drilldown_options.html
+++ b/custom/ewsghana/templates/ewsghana/drilldown_options.html
@@ -31,7 +31,7 @@
 </div>
 
 {% block filter_js %}
-<script type="text/javascript">
+<script>
     $.when(
         $.getScript("{% static 'reports/js/filters/drilldown_options.js' %}"),
         $.getScript("{% static 'ewsghana/ko/ews_filter.drilldown_options.js' %}")

--- a/custom/ewsghana/templates/ewsghana/facility_page_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/facility_page_print_report.html
@@ -15,7 +15,7 @@
 
 {% block js-inline %}
     {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function() {
             if (!document.hidden) {
                 setTimeout(function() {

--- a/custom/ewsghana/templates/ewsghana/partials/ews_line_chart.html
+++ b/custom/ewsghana/templates/ewsghana/partials/ews_line_chart.html
@@ -1,6 +1,6 @@
 {% load hq_shared_tags %}
 
-<script type="text/javascript">
+<script>
     var line_chart_data;
     var line_chart_id;
     var line_chart;

--- a/custom/ewsghana/templates/ewsghana/partials/ews_multibar_chart.html
+++ b/custom/ewsghana/templates/ewsghana/partials/ews_multibar_chart.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-<script type="text/javascript">
+<script>
     var codeProductMap = {{ chart.product_code_map|JSON }};
     nv.addGraph(function() {
         var chart_config = {{ chart.config_dict|JSON }};

--- a/custom/ewsghana/templates/ewsghana/partials/ews_pie_chart.html
+++ b/custom/ewsghana/templates/ewsghana/partials/ews_pie_chart.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-<script type="text/javascript">
+<script>
 
     var moveLegend = function (chart_id) {
         var x = ($(chart_id).width() / 2) - 20;

--- a/custom/ewsghana/templates/ewsghana/partials/report_table.html
+++ b/custom/ewsghana/templates/ewsghana/partials/report_table.html
@@ -62,7 +62,7 @@
     </table>
 {% endif %}
 
-<script type="text/javascript">
+<script>
     {% if report_table and report_table.use_datatables %}
         var dataTablesDom = "frt<'row dataTables_control'<'col-sm-5'il><'col-sm-7'p>>";
 

--- a/custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html
@@ -14,7 +14,7 @@
 
 {% block js-inline %}
     {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function() {
             if (!document.hidden) {
                 setTimeout(function() {

--- a/custom/ewsghana/templates/ewsghana/stock_status_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/stock_status_print_report.html
@@ -14,7 +14,7 @@
 
 {% block js-inline %}
     {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function() {
             if (!document.hidden) {
                 setTimeout(function() {

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -23,94 +23,94 @@
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'css/icds_dashboard.css' %}"/>
         {% include 'analytics/google.html' %}
         {% javascript_libraries underscore=True hq=True %}
-        <script type="text/javascript" src="{% static 'd3-3.5.17/d3.js' %}"></script>
-        <script type="text/javascript" src="{% static 'datatables/media/js/jquery.dataTables.min.js'%}"></script>
-        <script type="text/javascript" src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js'%}"></script>
-        <script type="text/javascript" src="{% static 'datatables-fixedheader/js/dataTables.fixedHeader.js'%}"></script>
-        <script type="text/javascript" src="{% static 'leaflet/dist/leaflet.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular/angular.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-datatables/dist/angular-datatables.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-datatables/dist/plugins/fixedcolumns/angular-datatables.fixedcolumns.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-datatables/dist/plugins/fixedheader/angular-datatables.fixedheader.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-route/angular-route.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-busy/dist/angular-busy.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'ui-select/dist/select.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-sanitize/angular-sanitize.js' %}"></script>
-        <script type="text/javascript" src="{% static 'nvd3-1.8.6/build/nv.d3.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-nvd3/dist/angular-nvd3.js' %}"></script>
-        <script type="text/javascript" src="{% static 'moment/min/moment-with-locales.min.js' %}"> </script>
-        <script type="text/javascript" src="{% static 'angular-leaflet-directive/dist/angular-leaflet-directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'perfect-scrollbar/js/perfect-scrollbar.jquery.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-perfect-scrollbar/src/angular-perfect-scrollbar.js' %}"></script>
+        <script src="{% static 'd3-3.5.17/d3.js' %}"></script>
+        <script src="{% static 'datatables/media/js/jquery.dataTables.min.js'%}"></script>
+        <script src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js'%}"></script>
+        <script src="{% static 'datatables-fixedheader/js/dataTables.fixedHeader.js'%}"></script>
+        <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
+        <script src="{% static 'angular/angular.js' %}"></script>
+        <script src="{% static 'angular-datatables/dist/angular-datatables.min.js' %}"></script>
+        <script src="{% static 'angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.min.js' %}"></script>
+        <script src="{% static 'angular-datatables/dist/plugins/fixedcolumns/angular-datatables.fixedcolumns.js' %}"></script>
+        <script src="{% static 'angular-datatables/dist/plugins/fixedheader/angular-datatables.fixedheader.js' %}"></script>
+        <script src="{% static 'angular-route/angular-route.js' %}"></script>
+        <script src="{% static 'angular-busy/dist/angular-busy.min.js' %}"></script>
+        <script src="{% static 'ui-select/dist/select.js' %}"></script>
+        <script src="{% static 'angular-sanitize/angular-sanitize.js' %}"></script>
+        <script src="{% static 'nvd3-1.8.6/build/nv.d3.js' %}"></script>
+        <script src="{% static 'angular-nvd3/dist/angular-nvd3.js' %}"></script>
+        <script src="{% static 'moment/min/moment-with-locales.min.js' %}"> </script>
+        <script src="{% static 'angular-leaflet-directive/dist/angular-leaflet-directive.js' %}"></script>
+        <script src="{% static 'perfect-scrollbar/js/perfect-scrollbar.jquery.min.js' %}"></script>
+        <script src="{% static 'angular-perfect-scrollbar/src/angular-perfect-scrollbar.js' %}"></script>
 
-        <script type="text/javascript" src="{% static 'topojson/topojson.js' %}"></script>
-        <script type="text/javascript" src="{% static 'datamaps/dist/datamaps.ind.js' %}"></script>
+        <script src="{% static 'topojson/topojson.js' %}"></script>
+        <script src="{% static 'datamaps/dist/datamaps.ind.js' %}"></script>
     {% if have_access_to_features %}
-        <script type="text/javascript" src="{% static 'js/topojsons/states_v2.topojson.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/topojsons/districts_v2.topojson.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/topojsons/blocks_v3.topojson.js' %}"></script>
+        <script src="{% static 'js/topojsons/states_v2.topojson.js' %}"></script>
+        <script src="{% static 'js/topojsons/districts_v2.topojson.js' %}"></script>
+        <script src="{% static 'js/topojsons/blocks_v3.topojson.js' %}"></script>
     {% else %}
-        <script type="text/javascript" src="{% static 'js/topojsons/states.topojson.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/topojsons/district.topojson.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/topojsons/block_v2.topojson.js' %}"></script>
+        <script src="{% static 'js/topojsons/states.topojson.js' %}"></script>
+        <script src="{% static 'js/topojsons/district.topojson.js' %}"></script>
+        <script src="{% static 'js/topojsons/block_v2.topojson.js' %}"></script>
     {% endif %}
-        <script type="text/javascript" src="{% static 'angular-datamaps/dist/angular-datamaps.js' %}"></script>
-        <script type="text/javascript" src="{% static 'angular-bootstrap/ui-bootstrap-tpls.min.js' %}"></script>
+        <script src="{% static 'angular-datamaps/dist/angular-datamaps.js' %}"></script>
+        <script src="{% static 'angular-bootstrap/ui-bootstrap-tpls.min.js' %}"></script>
 
-        <script type="text/javascript" src="{% static 'js/icds_app.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/filters/property-filter/property.filter.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/filters/india-numbers/india-numbers.filter.js' %}"></script>
+        <script src="{% static 'js/icds_app.js' %}"></script>
+        <script src="{% static 'js/filters/property-filter/property.filter.js' %}"></script>
+        <script src="{% static 'js/filters/india-numbers/india-numbers.filter.js' %}"></script>
 
-        <script type="text/javascript" src="{% static 'js/angular-services/maternal-child.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/system-usage.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/locations.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/progress-report.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/storage.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/icds-cas-reach.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/demographics.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/infrastructure.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/issnip.service.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/angular-services/baseControllers.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/maternal-child.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/system-usage.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/locations.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/progress-report.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/storage.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/icds-cas-reach.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/demographics.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/infrastructure.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/issnip.service.js' %}"></script>
+        <script src="{% static 'js/angular-services/baseControllers.service.js' %}"></script>
 
-        <script type="text/javascript" src="{% static 'js/directives/filters/filters.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/kpi/kpi.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/location-filter/location-filter.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/month-filter/month-filter.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/additional-filter/additional-filter.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/system-usage/system-usage.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/navigation/navigation.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/dot-link/dot-link.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/awc-opened-yesterday/awc-opened-yesterday.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/underweight-children-report/underweight-children-report.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/awc-reports/awc-reports.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/indie-map/indie-map.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/map-or-sector-view/map-or-sector-view.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/download/download.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/progress-report/progress-report.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/print/print.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/children-initiated/children-initiated.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/institutional-deliveries/institutional-deliveries.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/immunization_coverage/immunization_coverage.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/awc-daily-status/awc-daily-status.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/awcs-covered/awcs-covered.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/registered-household/registered-household.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/enrolled-children/enrolled-children.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/enrolled-women/enrolled-women.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/lactating-enrolled-women/lactating-enrolled-women.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/adolescent-girls/adolescent-girls.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/clean-water/clean-water.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/functional-toilet/functional-toilet.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/medicine-kit/medicine-kit.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/infants-weight-scale/infants-weight-scale.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/adult-weight-scale/adult-weight-scale.directive.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/directives/access-denied/access-denied.directive.js' %}"></script>
+        <script src="{% static 'js/directives/filters/filters.directive.js' %}"></script>
+        <script src="{% static 'js/directives/kpi/kpi.directive.js' %}"></script>
+        <script src="{% static 'js/directives/location-filter/location-filter.directive.js' %}"></script>
+        <script src="{% static 'js/directives/month-filter/month-filter.directive.js' %}"></script>
+        <script src="{% static 'js/directives/additional-filter/additional-filter.directive.js' %}"></script>
+        <script src="{% static 'js/directives/system-usage/system-usage.directive.js' %}"></script>
+        <script src="{% static 'js/directives/navigation/navigation.directive.js' %}"></script>
+        <script src="{% static 'js/directives/dot-link/dot-link.directive.js' %}"></script>
+        <script src="{% static 'js/directives/awc-opened-yesterday/awc-opened-yesterday.directive.js' %}"></script>
+        <script src="{% static 'js/directives/underweight-children-report/underweight-children-report.directive.js' %}"></script>
+        <script src="{% static 'js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js' %}"></script>
+        <script src="{% static 'js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js' %}"></script>
+        <script src="{% static 'js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js' %}"></script>
+        <script src="{% static 'js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js' %}"></script>
+        <script src="{% static 'js/directives/awc-reports/awc-reports.directive.js' %}"></script>
+        <script src="{% static 'js/directives/indie-map/indie-map.directive.js' %}"></script>
+        <script src="{% static 'js/directives/map-or-sector-view/map-or-sector-view.directive.js' %}"></script>
+        <script src="{% static 'js/directives/download/download.directive.js' %}"></script>
+        <script src="{% static 'js/directives/progress-report/progress-report.directive.js' %}"></script>
+        <script src="{% static 'js/directives/print/print.directive.js' %}"></script>
+        <script src="{% static 'js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js' %}"></script>
+        <script src="{% static 'js/directives/children-initiated/children-initiated.directive.js' %}"></script>
+        <script src="{% static 'js/directives/institutional-deliveries/institutional-deliveries.directive.js' %}"></script>
+        <script src="{% static 'js/directives/immunization_coverage/immunization_coverage.directive.js' %}"></script>
+        <script src="{% static 'js/directives/awc-daily-status/awc-daily-status.directive.js' %}"></script>
+        <script src="{% static 'js/directives/awcs-covered/awcs-covered.directive.js' %}"></script>
+        <script src="{% static 'js/directives/registered-household/registered-household.directive.js' %}"></script>
+        <script src="{% static 'js/directives/enrolled-children/enrolled-children.directive.js' %}"></script>
+        <script src="{% static 'js/directives/enrolled-women/enrolled-women.directive.js' %}"></script>
+        <script src="{% static 'js/directives/lactating-enrolled-women/lactating-enrolled-women.directive.js' %}"></script>
+        <script src="{% static 'js/directives/adolescent-girls/adolescent-girls.directive.js' %}"></script>
+        <script src="{% static 'js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js' %}"></script>
+        <script src="{% static 'js/directives/clean-water/clean-water.directive.js' %}"></script>
+        <script src="{% static 'js/directives/functional-toilet/functional-toilet.directive.js' %}"></script>
+        <script src="{% static 'js/directives/medicine-kit/medicine-kit.directive.js' %}"></script>
+        <script src="{% static 'js/directives/infants-weight-scale/infants-weight-scale.directive.js' %}"></script>
+        <script src="{% static 'js/directives/adult-weight-scale/adult-weight-scale.directive.js' %}"></script>
+        <script src="{% static 'js/directives/access-denied/access-denied.directive.js' %}"></script>
 </head>
 <body>
 <div id="app" ng-cloak>
@@ -274,7 +274,7 @@
         </div>
     </script>
     {% include 'hqwebapp/includes/modal_report_issue.html' %}
-    <script type="text/javascript" src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>
     <script>
         var $modal = $('#modalReportIssue');
         $modal.find('.modal-title').text('Report an Issue with ICDS-CAS Dashboard');

--- a/custom/icds_reports/templates/icds_reports/multi_report.html
+++ b/custom/icds_reports/templates/icds_reports/multi_report.html
@@ -54,7 +54,7 @@
 {% endblock %}
 
 {% block js-inline %} {{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function() {
             $('#fieldset_location_async').on('change', 'select', function(e) {
                 e.stopPropagation();

--- a/custom/icds_reports/templates/icds_reports/spec/mocha.html
+++ b/custom/icds_reports/templates/icds_reports/spec/mocha.html
@@ -8,48 +8,48 @@
 
 {% block dependencies %}
 
-    <script type="text/javascript" src="{% static 'd3-3.5.17/d3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'datatables/media/js/jquery.dataTables.min.js'%}"></script>
-    <script type="text/javascript" src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js'%}"></script>
-    <script type="text/javascript" src="{% static 'datatables-fixedheader/js/dataTables.fixedHeader.js'%}"></script>
-    <script type="text/javascript" src="{% static 'leaflet/dist/leaflet.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-datatables/dist/angular-datatables.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-datatables/dist/plugins/fixedcolumns/angular-datatables.fixedcolumns.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-datatables/dist/plugins/fixedheader/angular-datatables.fixedheader.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-route/angular-route.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-busy/dist/angular-busy.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'ui-select/dist/select.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-sanitize/angular-sanitize.js' %}"></script>
-    <script type="text/javascript" src="{% static 'nvd3-1.8.6/build/nv.d3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-nvd3/dist/angular-nvd3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'moment/min/moment-with-locales.min.js' %}"> </script>
-    <script type="text/javascript" src="{% static 'angular-leaflet-directive/dist/angular-leaflet-directive.js' %}"></script>
-    <script type="text/javascript" src="{% static 'perfect-scrollbar/js/perfect-scrollbar.jquery.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-perfect-scrollbar/src/angular-perfect-scrollbar.js' %}"></script>
+    <script src="{% static 'd3-3.5.17/d3.js' %}"></script>
+    <script src="{% static 'datatables/media/js/jquery.dataTables.min.js'%}"></script>
+    <script src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js'%}"></script>
+    <script src="{% static 'datatables-fixedheader/js/dataTables.fixedHeader.js'%}"></script>
+    <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
+    <script src="{% static 'angular-datatables/dist/angular-datatables.min.js' %}"></script>
+    <script src="{% static 'angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.min.js' %}"></script>
+    <script src="{% static 'angular-datatables/dist/plugins/fixedcolumns/angular-datatables.fixedcolumns.js' %}"></script>
+    <script src="{% static 'angular-datatables/dist/plugins/fixedheader/angular-datatables.fixedheader.js' %}"></script>
+    <script src="{% static 'angular-route/angular-route.js' %}"></script>
+    <script src="{% static 'angular-busy/dist/angular-busy.min.js' %}"></script>
+    <script src="{% static 'ui-select/dist/select.js' %}"></script>
+    <script src="{% static 'angular-sanitize/angular-sanitize.js' %}"></script>
+    <script src="{% static 'nvd3-1.8.6/build/nv.d3.js' %}"></script>
+    <script src="{% static 'angular-nvd3/dist/angular-nvd3.js' %}"></script>
+    <script src="{% static 'moment/min/moment-with-locales.min.js' %}"> </script>
+    <script src="{% static 'angular-leaflet-directive/dist/angular-leaflet-directive.js' %}"></script>
+    <script src="{% static 'perfect-scrollbar/js/perfect-scrollbar.jquery.min.js' %}"></script>
+    <script src="{% static 'angular-perfect-scrollbar/src/angular-perfect-scrollbar.js' %}"></script>
 
-    <script type="text/javascript" src="{% static 'topojson/topojson.js' %}"></script>
-    <script type="text/javascript" src="{% static 'datamaps/dist/datamaps.ind.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/topojsons/states.topojson.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/topojsons/district.topojson.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/topojsons/block_v2.topojson.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-datamaps/dist/angular-datamaps.js' %}"></script>
-    <script type="text/javascript" src="{% static 'angular-bootstrap/ui-bootstrap-tpls.min.js' %}"></script>
+    <script src="{% static 'topojson/topojson.js' %}"></script>
+    <script src="{% static 'datamaps/dist/datamaps.ind.js' %}"></script>
+    <script src="{% static 'js/topojsons/states.topojson.js' %}"></script>
+    <script src="{% static 'js/topojsons/district.topojson.js' %}"></script>
+    <script src="{% static 'js/topojsons/block_v2.topojson.js' %}"></script>
+    <script src="{% static 'angular-datamaps/dist/angular-datamaps.js' %}"></script>
+    <script src="{% static 'angular-bootstrap/ui-bootstrap-tpls.min.js' %}"></script>
 
     <script src="{% static 'js/icds_app.js' %}"></script>
 
-    <script type="text/javascript" src="{% static 'js/angular-services/maternal-child.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/system-usage.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/locations.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/progress-report.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/storage.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/icds-cas-reach.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/demographics.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/infrastructure.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/issnip.service.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/angular-services/baseControllers.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/maternal-child.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/system-usage.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/locations.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/progress-report.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/storage.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/icds-cas-reach.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/demographics.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/infrastructure.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/issnip.service.js' %}"></script>
+    <script src="{% static 'js/angular-services/baseControllers.service.js' %}"></script>
 
-    <script type="text/javascript" src="{% static 'js/filters/india-numbers/india-numbers.filter.js' %}"></script>
+    <script src="{% static 'js/filters/india-numbers/india-numbers.filter.js' %}"></script>
 
     <script src="{% static 'js/directives/adolescent-girls/adolescent-girls.directive.js' %}"></script>
     <script src="{% static 'js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js' %}"></script>

--- a/custom/icds_reports/templates/icds_reports/tableau.html
+++ b/custom/icds_reports/templates/icds_reports/tableau.html
@@ -58,9 +58,9 @@
         }
     </style>
     {% javascript_libraries underscore=True ko=True hq=True %}
-    <script type="text/javascript" src="{% static 'tableau.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'select2/dist/js/select2.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'tableau_app.js' %}"></script>
+    <script src="{% static 'tableau.min.js' %}"></script>
+    <script src="{% static 'select2/dist/js/select2.min.js' %}"></script>
+    <script src="{% static 'tableau_app.js' %}"></script>
 </head>
 <body>
     <input id="csrfTokenContainer" type="hidden" value="{{ csrf_token }}">

--- a/custom/ilsgateway/templates/ilsgateway/datespan.html
+++ b/custom/ilsgateway/templates/ilsgateway/datespan.html
@@ -40,7 +40,7 @@
 
 {% endblock %}
 {% block filter_js %}
-<script type="text/javascript">
+<script>
     $(function () {
         ko.bindingHandlers.select2 = {
             init: function(element, valueAccessor) {

--- a/custom/ilsgateway/templates/ilsgateway/location_async.html
+++ b/custom/ilsgateway/templates/ilsgateway/location_async.html
@@ -33,7 +33,7 @@
 </div>
 <input name="location_id" type="hidden" data-bind="value: selected_locid" />
 
-<script type="text/javascript">
+<script>
 
   $.getScript("{% static 'locations/js/location_drilldown.js' %}", function() {
 

--- a/custom/ilsgateway/templates/ilsgateway/partials/ils_multibar_chart.html
+++ b/custom/ilsgateway/templates/ilsgateway/partials/ils_multibar_chart.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-<script type="text/javascript">
+<script>
     nv.addGraph(function() {
         var chart_config = {{ chart.config_dict|JSON }};
         multibar_chart_data = {{ chart.data|JSON }};

--- a/custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html
+++ b/custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html
@@ -78,7 +78,7 @@
 {% endif %}
 
 {% block js-inline %}
-    <script type="text/javascript">
+    <script>
 
         {% if report_table.slug == 'ils_notes' %}
             $('#save_note').on('click', function() {

--- a/custom/ilsgateway/templates/ilsgateway/slab/edit_location.html
+++ b/custom/ilsgateway/templates/ilsgateway/slab/edit_location.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block js-inline %}{{ block.super }}
-    <script type="text/javascript">
+    <script>
         $(function () {
             var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
             multiselect_utils.createFullMultiselectWidget(

--- a/custom/intrahealth/templates/intrahealth/location_filter.html
+++ b/custom/intrahealth/templates/intrahealth/location_filter.html
@@ -10,7 +10,7 @@
 </div>
 <input name="location_id" type="hidden" data-bind="value: selected_locid" />
 
-<script type="text/javascript">
+<script>
 
     var REQUIRED = {{ required }}
 

--- a/custom/intrahealth/templates/intrahealth/partials/report_table.html
+++ b/custom/intrahealth/templates/intrahealth/partials/report_table.html
@@ -60,7 +60,7 @@
     {% endif %}
 </table>
 
-<script type="text/javascript">
+<script>
    {% if report_table and report_table.datatables %}
    $(function() {
         var reportTables = hqImport("reports/js/config.dataTables.bootstrap").HQReportDataTables({

--- a/custom/intrahealth/templates/yeksi_naa/location_filter.html
+++ b/custom/intrahealth/templates/yeksi_naa/location_filter.html
@@ -16,7 +16,7 @@
 </div>
 <input name="location_id" type="hidden" data-bind="value: selected_locid"/>
 
-<script type="text/javascript">
+<script>
     var REQUIRED = 0;
 
     $.when(

--- a/custom/intrahealth/templates/yeksi_naa/partials/report_table.html
+++ b/custom/intrahealth/templates/yeksi_naa/partials/report_table.html
@@ -49,7 +49,7 @@
     {% endif %}
 </table>
 
-<script type="text/javascript">
+<script>
    {% if report_table and report_table.datatables %}
    $(function() {
         var reportTables = hqImport("reports/js/config.dataTables.bootstrap").HQReportDataTables({

--- a/custom/m4change/templates/m4change/fields/daterange.html
+++ b/custom/m4change/templates/m4change/fields/daterange.html
@@ -30,7 +30,7 @@
     </div>
 {% endblock %}
 {% block filter_js %}
-    <script type="text/javascript">
+    <script>
         $.getScript("{% static 'm4change/javascripts/daterangepicker.js' %}", function () {
             var separator = '{{ separator }}';
             var report_labels = JSON.parse('{{ report_labels|safe }}');

--- a/custom/m4change/templates/m4change/selectTemplate.html
+++ b/custom/m4change/templates/m4change/selectTemplate.html
@@ -4,13 +4,13 @@
 {% load i18n %}
 
 {% block js %} {{ block.super }}
-    <script type="text/javascript" src="{% static 'case/js/cheapxml.js' %}"></script>
-    <script type="text/javascript" src="{% static 'case/js/casexml.js' %}"></script>
-    <script type="text/javascript" src="{% static 'm4change/javascripts/mcct_project_review_page_management.js' %}"></script>
+    <script src="{% static 'case/js/cheapxml.js' %}"></script>
+    <script src="{% static 'case/js/casexml.js' %}"></script>
+    <script src="{% static 'm4change/javascripts/mcct_project_review_page_management.js' %}"></script>
 {% endblock %}
 
 {% block js-inline %} {{ block.super }}
-    <script type="text/javascript">
+    <script>
     (function () {
         var OPTIONS = {
             users: {{ users|JSON }},
@@ -63,7 +63,7 @@
     <div id="mcct_project_review_page_management">
         {{ block.super }}
     </div>
-    <script type="text/javascript">
+    <script>
         $(function () {
             $('.hq-help-template').each(function () {
                 hqImport("hqwebapp/js/main").transformHelpTemplate($(this), true);

--- a/custom/succeed/templates/patient_submissions.html
+++ b/custom/succeed/templates/patient_submissions.html
@@ -43,7 +43,7 @@
 {% endblock reportcontent %}
 
 {% block js-inline %} {{ block.super }}
-<script type="text/javascript">
+<script>
     $(function() {
         if ($('#paramSelectorForm').find('#patient_id_field').length == 0) {
             $('<input>').attr({id: 'patient_id_field', type: 'hidden', name: 'patient_id', value: '{{ patient_id }}' }).appendTo('#paramSelectorForm');

--- a/custom/succeed/templates/succeed/base_template.html
+++ b/custom/succeed/templates/succeed/base_template.html
@@ -2,5 +2,5 @@
 {% load static %}
 
 {% block js %}{{ block.super }}
-    <script type="text/javascript" src="{% static 'hqwebapp/js/bootstrap-popout.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap-popout.js' %}"></script>
 {% endblock %}

--- a/custom/succeed/templates/succeed/report.html
+++ b/custom/succeed/templates/succeed/report.html
@@ -1,6 +1,6 @@
 {% include "reports/async/filters.html" %}
 
-<script type="text/javascript">
+<script>
 
     $('#group_search_query').hide();
 

--- a/custom/succeed/templates/succeed/ucla_table.html
+++ b/custom/succeed/templates/succeed/ucla_table.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 
 {% block js-inline %}
-    <script type="text/javascript">
+    <script>
 
         $(function() {
         {% if report_table and report_table.datatables %}

--- a/custom/up_nrhm/templates/up_nrhm/datespan.html
+++ b/custom/up_nrhm/templates/up_nrhm/datespan.html
@@ -4,7 +4,7 @@
 {% block init_filter %}{% endblock %}
 {% block filter_js %}
 {% ifequal slug 'datespan'  %}
-    <script type="text/javascript">
+    <script>
         $(function () {
             var separator = '{{ separator }}';
             var report_labels = JSON.parse('{{ report_labels_json|safe }}');

--- a/custom/world_vision/templates/world_vision/datespan.html
+++ b/custom/world_vision/templates/world_vision/datespan.html
@@ -49,7 +49,7 @@
 
 {% block filter_js %}
 {% ifequal slug 'datespan'  %}
-<script type="text/javascript">
+<script>
     $(function () {
         var standardHQReport = hqImport("reports/js/standard_hq_report").getStandardHQReport();
         $(standardHQReport.filterAccordion).trigger('hqreport.filter.datespan.startdate', '');

--- a/custom/world_vision/templates/world_vision/location_filter.html
+++ b/custom/world_vision/templates/world_vision/location_filter.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block filter_js %}
-<script type="text/javascript">
+<script>
     $.getScript("{% static 'world_vision/ko/report_filter.drilldown_options.js' %}", function() {
        $('#{{ css_id }}').drilldownOptionFilter({
            drilldown_map: {{ option_map|JSON }},

--- a/custom/world_vision/templates/world_vision/multi_report.html
+++ b/custom/world_vision/templates/world_vision/multi_report.html
@@ -54,7 +54,7 @@
             </div>
         </div>
     </script>
-    <script type="text/javascript">
+    <script>
             $(function() {
         {% if report_table and report_table.datatables %}
             var reportTables = hqImport("reports/js/config.dataTables.bootstrap").HQReportDataTables({

--- a/custom/world_vision/templates/world_vision/partials/report_table_script.html
+++ b/custom/world_vision/templates/world_vision/partials/report_table_script.html
@@ -1,5 +1,5 @@
 {% if rendered_as != "print" %}
-    <script type="text/javascript">
+    <script>
         $(function () {
             $('.hq-help-template').each(function () {
                 hqImport("hqwebapp/js/main").transformHelpTemplate($(this), true);

--- a/custom/world_vision/templates/world_vision/print_report.html
+++ b/custom/world_vision/templates/world_vision/print_report.html
@@ -10,8 +10,8 @@
 {% block reportcontent %}
     <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
     <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script type="text/javascript" src="{% static 'd3/d3.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'nvd3/nv.d3.min.js' %}"></script>
+    <script src="{% static 'd3/d3.min.js' %}"></script>
+    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
 
     <link rel="stylesheet" href="{% static "world_vision/css/world_vision_print.css" %}">
     <link type="text/css" rel="stylesheet" href="{% static 'nvd3/src/nv.d3.css' %}" />


### PR DESCRIPTION
Purely mechanical. Having the type complicates the requirejs metrics script.

@nickpell 
or @dannyroberts since you did https://github.com/dimagi/commcare-hq/pull/12632