### PR TITLE
Data cleaning forms: better handle nodes that can't be cleaned

### DIFF
--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -543,10 +543,14 @@ def get_data_cleaning_data(form_data, instance):
                 if question.repeat:
                     value = "{}[{}]{}".format(question.repeat, repeat_index + 1,
                                               re.sub(r'^' + question.repeat, '', question.value))
+
+                # Limit data cleaning to nodes that can be found in the response submission.
+                # form_data may contain other data that shouldn't be clean-able, like subcase attributes.
                 try:
-                    node = get_node(instance.get_xml_element(), value, instance.xmlns)
+                    get_node(instance.get_xml_element(), value, instance.xmlns)
                 except XFormQuestionValueNotFound:
                     continue
+
                 question_response_map[value] = {
                     'label': question.label,
                     'icon': question.icon,

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -5,6 +5,8 @@ from pydoc import html
 from django.http import Http404
 from django.utils.safestring import mark_safe
 from corehq.apps.app_manager.exceptions import XFormException
+from corehq.form_processor.utils.xform import get_node
+from corehq.form_processor.exceptions import XFormQuestionValueNotFound
 from corehq.util.timezones.conversions import PhoneTime
 from corehq.util.timezones.utils import get_timezone_for_request
 from dimagi.ext.jsonobject import *
@@ -527,7 +529,7 @@ def questions_in_hierarchy(questions):
     return question_lists_by_group[None]
 
 
-def build_data_cleaning_questions_and_responses(form_data):
+def get_data_cleaning_data(form_data, instance):
     question_response_map = {}
     ordered_question_values = []
 
@@ -541,6 +543,10 @@ def build_data_cleaning_questions_and_responses(form_data):
                 if question.repeat:
                     value = "{}[{}]{}".format(question.repeat, repeat_index + 1,
                                               re.sub(r'^' + question.repeat, '', question.value))
+                try:
+                    node = get_node(instance.get_xml_element(), value, instance.xmlns)
+                except XFormQuestionValueNotFound:
+                    continue
                 question_response_map[value] = {
                     'label': question.label,
                     'icon': question.icon,

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -203,9 +203,11 @@ hqDefine("reports/js/data_corrections", [
             $button.disableButton();
             $.post({
                 url: options.saveUrl,
-                data: _.mapObject(self.properties, function(model) {
-                    return model.value();
-                }),
+                data: {
+                    properties: _.mapObject(self.properties, function(model) {
+                        return model.value();
+                    }),
+                },
                 success: function() {
                     window.location.reload();
                 },

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -204,9 +204,9 @@ hqDefine("reports/js/data_corrections", [
             $.post({
                 url: options.saveUrl,
                 data: {
-                    properties: _.mapObject(self.properties, function(model) {
+                    properties: JSON.stringify(_.mapObject(self.properties, function(model) {
                         return model.value();
-                    }),
+                    })),
                 },
                 success: function() {
                     window.location.reload();

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1593,7 +1593,7 @@ def edit_case_view(request, domain, case_id):
     # User may also update external_id; see CaseDisplayWrapper.dynamic_properties
     if 'external_id' in updates:
         if updates['external_id'] != case.external_id:
-            case_block_kwargs['external_id'] = properties['external_id']
+            case_block_kwargs['external_id'] = updates['external_id']
         updates.pop('external_id')
 
     if updates:

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1586,21 +1586,22 @@ def edit_case_view(request, domain, case_id):
 
     update = {}
     old_properties = case.dynamic_case_properties()
-    for name in request.POST:
+    properties = request.POST['properties']
+    for name in properties:
         if name != 'external_id':       # handled separately below
             if name in old_properties:  # updating property
-                if old_properties[name] != request.POST[name]:
-                    update[name] = request.POST[name]
-            elif request.POST[name]:    # new property
-                update[name] = request.POST[name]
+                if old_properties[name] != properties[name]:
+                    update[name] = properties[name]
+            elif properties[name]:    # new property
+                update[name] = properties[name]
 
     case_block_kwargs = {}
     if update:
         case_block_kwargs['update'] = update
 
     # User may also update external_id; see CaseDisplayWrapper.dynamic_properties
-    if 'external_id' in request.POST and request.POST['external_id'] != case.external_id:
-        case_block_kwargs['external_id'] = request.POST['external_id']
+    if 'external_id' in properties and properties['external_id'] != case.external_id:
+        case_block_kwargs['external_id'] = properties['external_id']
 
     if case_block_kwargs:
         submit_case_blocks([CaseBlock(case_id=case_id, **case_block_kwargs).as_string()],
@@ -2421,9 +2422,10 @@ def edit_form(request, domain, instance_id):
     assert instance.domain == domain
 
     form_data, question_list_not_found = get_readable_data_for_submission(instance)
-    old_values, dummy = get_data_cleaning_data(form_data, instance)
-    updates = {name: request.POST[name] for name in request.POST
-            if name in old_values and old_values[name] != request.POST[name]}
+    old_properties, dummy = get_data_cleaning_data(form_data, instance)
+    properties = request.POST['properties']
+    updates = {name: properties[name] for name in properties
+            if name in old_properties and old_properties[name] != properties[name]}
 
     if updates:
         errors = FormProcessorInterface(domain).update_responses(instance, updates, request.couch_user.get_id)

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -14,6 +14,10 @@ class XFormNotFound(ResourceNotFound, ObjectDoesNotExist):
     pass
 
 
+class XFormQuestionValueNotFound(Exception):
+    pass
+
+
 class LedgerValueNotFound(Exception):
     pass
 

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -143,6 +143,10 @@ class FormProcessorInterface(object):
         return self.processor.xformerror_from_xform_instance(instance, error_message, with_new_id=with_new_id)
 
     def update_responses(self, xform, value_responses_map, user_id):
+        '''
+        Update a set of question responses. Returns a list of any
+        questions that were not found in the xform.
+        '''
         from corehq.form_processor.utils.xform import update_response
         errors = []
 

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -10,6 +10,7 @@ from lxml import etree
 from redis.exceptions import RedisError
 
 from casexml.apps.case.exceptions import IllegalCaseId
+from corehq.form_processor.exceptions import XFormQuestionValueNotFound
 from memoized import memoized
 from ..utils import should_use_sql_backend
 import six
@@ -143,30 +144,30 @@ class FormProcessorInterface(object):
 
     def update_responses(self, xform, value_responses_map, user_id):
         from corehq.form_processor.utils.xform import update_response
+        errors = []
 
         xml = xform.get_xml_element()
-        dirty = False
         for question, response in six.iteritems(value_responses_map):
-            if update_response(xml, question, response, xmlns=xform.xmlns):
-                dirty = True
+            try:
+                update_response(xml, question, response, xmlns=xform.xmlns)
+            except XFormQuestionValueNotFound:
+                errors.append(question)
 
-        if dirty:
-            from couchforms.const import ATTACHMENT_NAME
-            from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-            from corehq.form_processor.models import Attachment
+        from couchforms.const import ATTACHMENT_NAME
+        from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+        from corehq.form_processor.models import Attachment
 
-            existing_form = FormAccessors(xform.domain).get_with_attachments(xform.get_id)
-            existing_form, new_form = self.processor.new_form_from_old(existing_form, xml,
-                                                                       value_responses_map, user_id)
-            new_xml = etree.tostring(xml)
-            interface = FormProcessorInterface(xform.domain)
-            interface.store_attachments(new_form, [
-                Attachment(name=ATTACHMENT_NAME, raw_content=new_xml, content_type='text/xml')
-            ])
-            interface.save_processed_models([new_form, existing_form])
-            return True
+        existing_form = FormAccessors(xform.domain).get_with_attachments(xform.get_id)
+        existing_form, new_form = self.processor.new_form_from_old(existing_form, xml,
+                                                                   value_responses_map, user_id)
+        new_xml = etree.tostring(xml)
+        interface = FormProcessorInterface(xform.domain)
+        interface.store_attachments(new_form, [
+            Attachment(name=ATTACHMENT_NAME, raw_content=new_xml, content_type='text/xml')
+        ])
+        interface.save_processed_models([new_form, existing_form])
 
-        return False
+        return errors
 
     def save_processed_models(self, forms, cases=None, stock_result=None):
         forms = _list_to_processed_forms_tuple(forms)

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -424,10 +424,23 @@ class FormAccessorsTests(TestCase):
         xform = submit_form_locally(formxml, DOMAIN).xform
 
         updates = {'breakfast': 'fruit'}
-        FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
+        errors = FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
         form = FormAccessors(DOMAIN).get_form(xform.form_id)
+        self.assertEqual(0, len(errors))
         self.assertEqual('fruit', form.form_data['breakfast'])
         self.assertEqual('sandwich', form.form_data['lunch'])
+
+    def test_update_responses_error(self):
+        formxml = FormSubmissionBuilder(
+            form_id='123',
+            form_properties={'nine': 'nueve'}
+        ).as_xml_string()
+        xform = submit_form_locally(formxml, DOMAIN).xform
+
+        updates = {'eight': 'ocho'}
+        errors = FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
+        self.assertEqual(1, len(errors))
+        self.assertEqual('eight', errors[0])
 
 
 @use_sql_backend

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -439,8 +439,7 @@ class FormAccessorsTests(TestCase):
 
         updates = {'eight': 'ocho'}
         errors = FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
-        self.assertEqual(1, len(errors))
-        self.assertEqual('eight', errors[0])
+        self.assertEqual(['eight'], errors)
 
 
 @use_sql_backend

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -225,8 +225,13 @@ def resave_form(domain, form):
         XFormInstance.get_db().save_doc(form.to_json())
 
 
-def get_node(xml, question, xmlns=None):
-    node = xml
+def get_node(root, question, xmlns=None):
+    '''
+    Given an xml element, find the node corresponding to a question path.
+    See XFormQuestionValueIterator for question path format.
+    Throws XFormQuestionValueNotFound if question is not present.
+    '''
+    node = root
     i = XFormQuestionValueIterator(question)
     for (qid, index) in i:
         try:
@@ -239,12 +244,12 @@ def get_node(xml, question, xmlns=None):
     return node
 
 
-def update_response(xml, question, response, xmlns=None):
+def update_response(root, question, response, xmlns=None):
     '''
-    Given a form submission's xml element, updates the response for an individual question.
+    Given a form submission's xml root, updates the response for an individual question.
     Question and response are both strings; see XFormQuestionValueIterator for question format.
     '''
-    node = get_node(xml, question, xmlns)
+    node = get_node(root, question, xmlns)
     if node.text != response:
         node.text = response
         return True


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?278868 and https://manage.dimagi.com/default.asp?279298

https://github.com/dimagi/commcare-hq/pull/21096 updated data cleaning to allow editing of unrecognized data. I didn't realize that while sometimes unrecognized data does appear in the submission and should be clean-able (like /data/fund-group-calendar-month-of-service [here](https://www.commcarehq.org/a/epm-thai/reports/form_data/3fc0a1a3-e70c-4ac1-89aa-68dcc37a9c31/)) but other times it's data that shouldn't show in data cleaning (like all of the subcase updates in that same form).

This PR makes it so that non-cleanable data doesn't appear in the data cleaning popup, and any non-cleanable data encountered during save throws an error but doesn't kill the whole save.

@millerdev / @emord 