### PR TITLE
Fix JS error for empty enterprise email list

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -185,8 +185,7 @@ class BillingAccountBasicForm(forms.Form):
                 crispy.Div(
                     crispy.Field(
                         'enterprise_admin_emails',
-                        css_class='input-xxlarge accounting-email-select2',
-                        data_bind='attr: {required: false}'
+                        css_class='input-xxlarge accounting-email-select2'
                     ),
                     data_bind='visible: is_customer_billing_account'
                 )

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -186,7 +186,7 @@ class BillingAccountBasicForm(forms.Form):
                     crispy.Field(
                         'enterprise_admin_emails',
                         css_class='input-xxlarge accounting-email-select2',
-                        data_bind='attr: {required: is_customer_billing_account}'
+                        data_bind='attr: {required: false}'
                     ),
                     data_bind='visible: is_customer_billing_account'
                 )

--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -10,12 +10,13 @@ hqDefine('accounting/js/billing_account_form', [
     ko,
     initialPageData
 ) {
-    var billingAccountFormModel = function (isActive, isCustomerBillingAccount) {
+    var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails) {
         'use strict';
         var self = {};
 
         self.is_active = ko.observable(isActive);
         self.is_customer_billing_account = ko.observable(isCustomerBillingAccount);
+        self.enterprise_admin_emails = ko.observable(enterpriseAdminEmails);
         self.showActiveAccounts = ko.computed(function () {
             return !self.is_active();
         });
@@ -25,7 +26,7 @@ hqDefine('accounting/js/billing_account_form', [
 
     $(function () {
         var baForm = billingAccountFormModel(initialPageData.get('account_form_is_active'),
-            initialPageData.get('is_customer_billing_account'));
+            initialPageData.get('is_customer_billing_account'), initialPageData.get('enterprise_admin_emails'));
         $('#account-form').koApplyBindings(baForm);
 
         $("#show_emails").click(function() {

--- a/corehq/apps/accounting/templates/accounting/accounts.html
+++ b/corehq/apps/accounting/templates/accounting/accounts.html
@@ -8,6 +8,7 @@
 {% block page_content %}
     {% initial_page_data 'account_form_is_active' basic_form.is_active.value %}
     {% initial_page_data 'is_customer_billing_account' basic_form.is_customer_billing_account.value %}
+    {% initial_page_data 'enterprise_admin_emails' basic_form.enterprise_admin_emails.value %}
 
     <ul class="nav nav-tabs" id="user-settings-tabs">
         <li><a href="#account" data-toggle="tab">{% trans "Account" %}</a></li>


### PR DESCRIPTION
Fixed a JS error that occurred when saving a customer account with new enterprise admin emails. Also, those emails shouldn't be required. _Now_ people should be able to set an account to the customer level without having to add enterprise admins.