### PR TITLE
add check for number of languages

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/supported_languages.js
+++ b/corehq/apps/app_manager/static/app_manager/js/supported_languages.js
@@ -97,10 +97,6 @@ hqDefine('app_manager/js/supported_languages', function () {
             self.saveButton.fire('change');
         };
         var smartLangDisplayEnabled = hqImport("hqwebapp/js/initial_page_data").get("smart_lang_display_enabled");
-        // If user has not set any preference yet for this app, default to true
-        if(smartLangDisplayEnabled === null) {
-            smartLangDisplayEnabled = true;
-        }
         this.smartLangDisplay = ko.observable(smartLangDisplayEnabled);
         this.smartLangDisplay.subscribe(changeSaveButton);
 

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -211,7 +211,7 @@ def _get_base_vellum_options(request, domain, app, displayLang):
         'javaRosa': {
             'langs': app.langs,
             'displayLanguage': displayLang,
-            'showOnlyCurrentLang': (app.smart_lang_display and len(app.langs) > 2),
+            'showOnlyCurrentLang': (app.smart_lang_display and (len(app.langs) > 2)),
         },
         'uploader': {
             'uploadUrls': {

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -211,7 +211,7 @@ def _get_base_vellum_options(request, domain, app, displayLang):
         'javaRosa': {
             'langs': app.langs,
             'displayLanguage': displayLang,
-            'showOnlyCurrentLang': (app.smart_lang_display & len(app.langs) > 2),
+            'showOnlyCurrentLang': (app.smart_lang_display and len(app.langs) > 2),
         },
         'uploader': {
             'uploadUrls': {

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -211,7 +211,7 @@ def _get_base_vellum_options(request, domain, app, displayLang):
         'javaRosa': {
             'langs': app.langs,
             'displayLanguage': displayLang,
-            'showOnlyCurrentLang': app.smart_lang_display,
+            'showOnlyCurrentLang': (app.smart_lang_display & len(app.langs) > 2),
         },
         'uploader': {
             'uploadUrls': {


### PR DESCRIPTION
since smart_lang_display is enabled by default we need to also check if the app has more than 2 languages.

introduced #20705

https://manage.dimagi.com/default.asp?279453

Plus,
Don't enable it by default as concluded in discussion with @djmore9 to avoid confusion when people miss it.