### PR TITLE
ICDS Reports | Height info fix in wasting

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -1032,7 +1032,8 @@ def get_awc_report_beneficiary(start, length, draw, order, awc_id, month, two_be
             current_month_wasting=get_status(
                 getattr(row_data, current_month_wasting_column(icds_features_flag)),
                 'wasted',
-                'Normal weight for height'
+                'Normal weight for height',
+                data_entered=True if row_data.recorded_height and row_data.recorded_weight else False
             ),
             pse_days_attended=row_data.pse_days_attended
         )

--- a/custom/icds_reports/static/icds_reports/js/spec/awc-reports.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/awc-reports.directive.spec.js
@@ -94,7 +94,7 @@ describe('AWC Reports Directive', function () {
     });
 
     it('tests get popover content', function () {
-        var expected = "<div>Weight: 50.00 kg</div><div>Height: 150.00 cm</div><div>Age: 40 months</div>";
+        var expected = "<div>Weight: 50.00 kg</div><div>Height: Data Not Valid</div><div>Age: 40 months</div>";
         var result = controller.getPopoverContent(50, 150, 40, 'both');
         assert.equal(expected, result);
     });

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -1872,7 +1872,7 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             recordedWeight = d3.format(".2f")(weightRecorded) + ' kg';
         }
         if (heightRecorded && parseInt(heightRecorded) !== 0) {
-            if (type === 'height' && (parseInt(heightRecorded) <= 45 || parseInt(heightRecorded) >= 120)) {
+            if (parseInt(heightRecorded) <= 45 || parseInt(heightRecorded) >= 120) {
                 recordedHeight = 'Data Not Valid';
             } else {
                 recordedHeight = d3.format(".2f")(heightRecorded) + ' cm';


### PR DESCRIPTION
Hi @emord,
I have fixed issue with height info in the beneficiary child list. Change in the python file is responsible for showing 'Data not Valid' in the table if values are not between 45 and 120 cm in wasting column, while javascript does this same for wasting column popover height info.
Regards, Dawid.