### PR TITLE
adding error message to unretire/restore

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1754,6 +1754,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         - It will not restore the user's phone numbers
         - It will not restore reminders for cases
         """
+        by_username = self.get_db().view('users/by_username', key=self.username, reduce=False).first()
+        if by_username and by_username['id'] != self._id:
+            return False, "A user with the same username already exists in the system"
         if self.base_doc.endswith(DELETED_SUFFIX):
             self.base_doc = self.base_doc[:-len(DELETED_SUFFIX)]
 
@@ -1765,6 +1768,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
         undelete_system_forms.delay(self.domain, set(deleted_form_ids), set(deleted_case_ids))
         self.save()
+        return True, None
 
     def retire(self):
         suffix = DELETED_SUFFIX

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -366,8 +366,11 @@ def delete_commcare_user(request, domain, user_id):
 @require_POST
 def restore_commcare_user(request, domain, user_id):
     user = CommCareUser.get_by_user_id(user_id, domain)
-    user.unretire()
-    messages.success(request, "User %s and all their submissions have been restored" % user.username)
+    success, message = user.unretire()
+    if success:
+        messages.success(request, "User %s and all their submissions have been restored" % user.username)
+    else:
+        messages.error(request, message)
     return HttpResponseRedirect(reverse(EditCommCareUserView.urlname, args=[domain, user_id]))
 
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?d#1511393

Fixes an issue where a user was deleted, it's username recycled, and then there was an attempt to restore the original user.

This should make it so that it doesn't 500 with this [error]( https://sentry.io/dimagi/commcarehq/issues/601930957/events/24541975524/), but rather returns a nice error message

@snopoke 