### PR TITLE
Revert ES index changes from PR #21106

### DIFF
--- a/corehq/pillows/mappings/reportcase_mapping.py
+++ b/corehq/pillows/mappings/reportcase_mapping.py
@@ -4,9 +4,9 @@ from corehq.util.elastic import es_index
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
 
-REPORT_CASE_INDEX = es_index("report_cases_201807050731")
+REPORT_CASE_INDEX = es_index("report_cases_czei39du507m9mmpqk3y01x72a3ux4p0")
 
-REPORT_CASE_MAPPING = {'_meta': {'comment': '2013-11-05 dmyung',
+REPORT_CASE_MAPPING={'_meta': {'comment': '2013-11-05 dmyung',
            'created': None},
  'date_detection': False,
  'date_formats': ['yyyy-MM-dd',
@@ -29,12 +29,15 @@ REPORT_CASE_MAPPING = {'_meta': {'comment': '2013-11-05 dmyung',
  'properties': {'actions': {'dynamic': True,
                             'properties': {'action_type': {'type': 'string'},
                                            'attachments': {'dynamic': False,
-                                                           'properties': {'attachment_name': {'type': 'string'},
-                                                                          'attachment_properties': {'dynamic': False,   # noqa: E501
-                                                                                                    'type': 'object'},  # noqa: E501
+                                                           'properties': {'attachment_from': {'type': 'string'},
+                                                                          'attachment_name': {'type': 'string'},
+                                                                          'attachment_properties': {'dynamic': False,
+                                                                                                    'type': 'object'},
                                                                           'attachment_size': {'type': 'long'},
+                                                                          'attachment_src': {'type': 'string'},
                                                                           'doc_type': {'index': 'not_analyzed',
                                                                                        'type': 'string'},
+                                                                          'identifier': {'type': 'string'},
                                                                           'server_md5': {'type': 'string'},
                                                                           'server_mime': {'type': 'string'}},
                                                            'type': 'object'},
@@ -62,12 +65,15 @@ REPORT_CASE_MAPPING = {'_meta': {'comment': '2013-11-05 dmyung',
                                            'xform_xmlns': {'type': 'string'}},
                             'type': 'nested'},
                 'case_attachments': {'dynamic': True,
-                                     'properties': {'attachment_name': {'type': 'string'},
+                                     'properties': {'attachment_from': {'type': 'string'},
+                                                    'attachment_name': {'type': 'string'},
                                                     'attachment_properties': {'dynamic': False,
                                                                               'type': 'object'},
                                                     'attachment_size': {'type': 'long'},
+                                                    'attachment_src': {'type': 'string'},
                                                     'doc_type': {'index': 'not_analyzed',
                                                                  'type': 'string'},
+                                                    'identifier': {'type': 'string'},
                                                     'server_md5': {'type': 'string'},
                                                     'server_mime': {'type': 'string'}},
                                      'type': 'object'},

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -219,7 +219,7 @@ EXPECTED_PROD_INDICES = [
     },
     {
         "alias": "report_cases",
-        "index": "test_report_cases_201807050731",
+        "index": "test_report_cases_czei39du507m9mmpqk3y01x72a3ux4p0",
         "type": "report_case",
         "meta": {
             "settings": {

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -114,7 +114,7 @@
     "ReportCaseToElasticsearchPillow": {
         "advertised_name": "ReportCaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "ReportCaseToElasticsearchPillow-test_report_cases_201807050731",
+        "checkpoint_id": "ReportCaseToElasticsearchPillow-test_report_cases_czei39du507m9mmpqk3y01x72a3ux4p0",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "ReportCaseToElasticsearchPillow"
     },


### PR DESCRIPTION
The changes in #21106 were not really necessary, and the rollout of this change was not handled correctly because I thought it would be done by the person doing the deploy.

@emord 