### PR TITLE
ICDS Reports | Decode Url in location service upon loading page

### DIFF
--- a/custom/icds_reports/static/js/icds_app.js
+++ b/custom/icds_reports/static/js/icds_app.js
@@ -10,6 +10,16 @@ function MainController($scope, $route, $routeParams, $location, $uibModal, $win
     $scope.healthCollapsed = true;
     $scope.isWebUser = isWebUser;
 
+    var locationParams = $location.search();
+    var newKey;
+    for (var key in locationParams) {
+        newKey = key;
+        if (newKey.startsWith('amp;')) {
+            newKey = newKey.slice(4);
+            $location.search(newKey, locationParams[key]).search(key, null);
+        }
+    }
+
     $scope.showInfoMessage = function() {
         var selected_month = parseInt($location.search()['month']) || new Date().getMonth() + 1;
         var selected_year = parseInt($location.search()['year']) || new Date().getFullYear();


### PR DESCRIPTION
Hi @emord,
I have added to the main controller in ICDS app a behaviour to parse URL with `&amp;` to one with only `&` as it causes issues as variables that we are looking to work with do not exist eg. `location_id` can be `amp;location_id`. This causes images section in preschool education to not load.
Regards, Dawid.