### PR TITLE
Log export tasks

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -97,6 +97,9 @@ EXPORT_DOWNLOAD_QUEUE = 'export_download_queue'
 # Used for automatically triggered exports
 SAVED_EXPORTS_QUEUE = 'saved_exports_queue'
 
+# If the queue contains this many tasks, log what's in it
+QUEUE_LENGTH_LOGGING_THRESHHOLD = 100
+
 # The maximum file size of one DataFile
 MAX_DATA_FILE_SIZE = 104857600  # 100 MB
 

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -97,9 +97,6 @@ EXPORT_DOWNLOAD_QUEUE = 'export_download_queue'
 # Used for automatically triggered exports
 SAVED_EXPORTS_QUEUE = 'saved_exports_queue'
 
-# If the queue contains this many tasks, log what's in it
-QUEUE_LENGTH_LOGGING_THRESHHOLD = 100
-
 # The maximum file size of one DataFile
 MAX_DATA_FILE_SIZE = 104857600  # 100 MB
 

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -419,6 +419,12 @@ def __record_datadog_export(duration, doc_bytes, n_rows, metric, tags):
             duration // n_rows,
             tags=tags,
         )
+    if not (doc_bytes or n_rows):
+        datadog_histogram(
+            metric,
+            duration,
+            tags=tags,
+        )
 
 
 def _get_base_query(export_instance):

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 import contextlib
-import logging
 import time
 import sys
 from collections import Counter
@@ -18,7 +17,6 @@ from couchexport.export import FormattedRow, get_writer
 from couchexport.models import Format
 from corehq.elastic import iter_es_docs_from_query
 from corehq.toggles import PAGINATED_EXPORTS
-from corehq.util.celery_utils import get_queue_length, get_queue_tasks, get_task_str
 from corehq.util.files import safe_filename, TransientTempfile
 from corehq.util.datadog.gauges import datadog_histogram, datadog_track_errors
 from corehq.apps.export.esaccessors import (
@@ -31,16 +29,9 @@ from corehq.apps.export.models.new import (
     FormExportInstance,
     SMSExportInstance,
 )
-from corehq.apps.export.const import (
-    MAX_EXPORTABLE_ROWS,
-    EXPORT_DOWNLOAD_QUEUE,
-    QUEUE_LENGTH_LOGGING_THRESHHOLD,
-)
+from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
 import six
 from io import open
-
-
-logger = logging.getLogger('export_tasks')
 
 
 class ExportFile(object):
@@ -291,15 +282,6 @@ def get_export_writer(export_instances, temp_path, allow_pagination=True):
 
 def get_export_download(export_instances, filters, filename=None):
     from corehq.apps.export.tasks import populate_export_download_task
-
-    queue_len = get_queue_length(EXPORT_DOWNLOAD_QUEUE)
-    if queue_len == QUEUE_LENGTH_LOGGING_THRESHHOLD:
-        # This makes the assumption that the task that is holding up the queue
-        # is still active.
-        logger.info('Queue {} at 100 tasks. Logging task data.'.format(EXPORT_DOWNLOAD_QUEUE))
-        for task in get_queue_tasks(EXPORT_DOWNLOAD_QUEUE):
-            task_str = get_task_str(task)
-            logger.info(task_str)
 
     download = DownloadBase()
     download.set_task(populate_export_download_task.delay(

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -285,7 +285,7 @@ def get_export_download(export_instances, filters, filename=None):
 
     download = DownloadBase()
     download.set_task(populate_export_download_task.delay(
-        export_instances,
+        [inst.to_json() for inst in export_instances],
         filters,
         download.download_id,
         filename=filename

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -9,6 +9,7 @@ from collections import Counter
 import datetime
 
 from couchdbkit import ResourceConflict
+from django.utils.text import slugify
 
 from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
@@ -378,7 +379,11 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
             DownloadBase.set_progress(progress_tracker, row_number + 1, documents.count)
 
     end = _time_in_milliseconds()
-    tags = ['format:{}'.format(writer.format)]
+    tags = [
+        'format:{}'.format(writer.format),
+        'domain:{}'.format(export_instance.domain),
+        'export:{}'.format(slugify(export_instance.name)),
+    ]
     _record_datadog_export_write_rows(write_total, total_bytes, total_rows, tags)
     _record_datadog_export_compute_rows(compute_total, total_bytes, total_rows, tags)
     _record_datadog_export_duration(end - start, total_bytes, total_rows, tags)

--- a/corehq/apps/export/filters.py
+++ b/corehq/apps/export/filters.py
@@ -30,6 +30,9 @@ class ExportFilter(object):
     Abstract base class for an export filter on a single case or form property
     """
 
+    def __repr__(self):
+        return repr(self.to_es_filter())
+
     def to_es_filter(self):
         """
         Return an ES filter representing this filter

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -27,6 +27,7 @@ from .dbaccessors import (
     get_case_inferred_schema,
     get_properly_wrapped_export_instance,
     get_all_daily_saved_export_instance_ids,
+    _properly_wrap_export_instance,
 )
 from .export import get_export_file, rebuild_export, should_rebuild_export
 from .models.new import EmailExportWhenDoneRequest
@@ -38,7 +39,8 @@ logger = logging.getLogger('export_migration')
 
 
 @task(queue=EXPORT_DOWNLOAD_QUEUE)
-def populate_export_download_task(export_instances, filters, download_id, filename=None, expiry=10 * 60 * 60):
+def populate_export_download_task(export_instances_json, filters, download_id, filename=None, expiry=10 * 60 * 60):
+    export_instances = [_properly_wrap_export_instance(doc) for doc in export_instances_json]
     with TransientTempfile() as temp_path, datadog_track_errors('populate_export_download_task'):
         export_file = get_export_file(
             export_instances,

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -126,8 +126,8 @@ def rebuild_saved_export(export_instance_id, last_access_cutoff=None, manual=Fal
         # This makes the assumption that the task that is holding up the queue
         # is still active.
         logger.info('Queue {} at 100 tasks. Logging task data.'.format(queue))
-        for task in get_queue_tasks(queue):
-            task_str = get_task_str(task)
+        for task_ in get_queue_tasks(queue):
+            task_str = get_task_str(task_)
             logger.info(task_str)
 
     # associate task with the export instance

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -273,19 +273,19 @@ def _get_workers(app, queue):
 
 def _get_queue_tasks(app, workers):
     inspect = app.control.inspect(workers)
-    for worker, tasks in six.iteritems(inspect.reserved()):
+    for worker, tasks in six.iteritems(inspect.active()):
         for task in tasks:
             # Don't use TaskInfo because we need the task's args and
             # kwargs to unpack what the task doing.
-            task['state'] = 'reserved'
+            task['state'] = 'active'
             yield task
     for worker, tasks in six.iteritems(inspect.scheduled()):
         for task in tasks:
             task['request']['state'] = 'scheduled'
             yield task['request']
-    for worker, tasks in six.iteritems(inspect.active()):
+    for worker, tasks in six.iteritems(inspect.reserved()):
         for task in tasks:
-            task['state'] = 'active'
+            task['state'] = 'reserved'
             yield task
 
 

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -274,19 +274,19 @@ def _get_workers(app, queue):
 def _get_queue_tasks(app, workers):
     inspect = app.control.inspect(workers)
     for worker, tasks in six.iteritems(inspect.active()):
-        for task in tasks:
+        for task_ in tasks:
             # Don't use TaskInfo because we need the task's args and
             # kwargs to unpack what the task doing.
-            task['state'] = 'active'
-            yield task
+            task_['state'] = 'active'
+            yield task_
     for worker, tasks in six.iteritems(inspect.scheduled()):
-        for task in tasks:
-            task['request']['state'] = 'scheduled'
-            yield task['request']
+        for task_ in tasks:
+            task_['request']['state'] = 'scheduled'
+            yield task_['request']
     for worker, tasks in six.iteritems(inspect.reserved()):
-        for task in tasks:
-            task['state'] = 'reserved'
-            yield task
+        for task_ in tasks:
+            task_['state'] = 'reserved'
+            yield task_
 
 
 def get_queue_length(queue):
@@ -302,13 +302,13 @@ def get_queue_tasks(queue):
     app.config_from_object(settings)
     workers = _get_workers(app, queue)
     if workers:
-        for task in _get_queue_tasks(app, workers):
-            task = _parse_args(task)
-            if 'time_start' in task:
-                task['time_start'] = TaskInfo.parse_timestamp(task['time_start'])
-            async_result = app.AsyncResult(task['id'])
-            task['status'] = get_task_status(async_result)
-            yield task
+        for task_ in _get_queue_tasks(app, workers):
+            task_ = _parse_args(task_)
+            if 'time_start' in task_:
+                task_['time_start'] = TaskInfo.parse_timestamp(task_['time_start'])
+            async_result = app.AsyncResult(task_['id'])
+            task_['status'] = get_task_status(async_result)
+            yield task_
 
 
 def get_task_str(task):

--- a/settings.py
+++ b/settings.py
@@ -113,6 +113,7 @@ COUCH_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.django.log")
 DJANGO_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.django.log")
 ACCOUNTING_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.accounting.log")
 ANALYTICS_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.analytics.log")
+EXPORT_TASKS_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.export_tasks.log")
 UCR_TIMING_FILE = "%s/%s" % (FILEPATH, "ucr.timing.log")
 UCR_DIFF_FILE = "%s/%s" % (FILEPATH, "ucr.diff.log")
 UCR_EXCEPTION_FILE = "%s/%s" % (FILEPATH, "ucr.exception.log")
@@ -1125,6 +1126,14 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 20  # Backup 200 MB of logs
         },
+        'export_tasks_handler': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'verbose',
+            'filename': EXPORT_TASKS_LOG_FILE,
+            'maxBytes': 10 * 1024 * 1024,  # 10 MB
+            'backupCount': 20  # Backup 200 MB of logs
+        },
         'formplayer_diff': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
@@ -1255,6 +1264,11 @@ LOGGING = {
         'elasticsearch': {
             'handlers': ['file'],
             'level': 'ERROR',
+            'propagate': True,
+        },
+        'export_tasks': {
+            'handlers': ['export_tasks_handler'],
+            'level': 'INFO',
             'propagate': True,
         },
         'formplayer_timing': {

--- a/settings.py
+++ b/settings.py
@@ -1274,12 +1274,12 @@ LOGGING = {
         'formplayer_timing': {
             'handlers': ['formplayer_timing'],
             'level': 'INFO',
-            'propogate': True,
+            'propagate': True,
         },
         'formplayer_diff': {
             'handlers': ['formplayer_diff'],
             'level': 'INFO',
-            'propogate': True,
+            'propagate': True,
         },
         'ucr_timing': {
             'handlers': ['ucr_timing'],

--- a/settings.py
+++ b/settings.py
@@ -113,7 +113,6 @@ COUCH_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.django.log")
 DJANGO_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.django.log")
 ACCOUNTING_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.accounting.log")
 ANALYTICS_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.analytics.log")
-EXPORT_TASKS_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.export_tasks.log")
 UCR_TIMING_FILE = "%s/%s" % (FILEPATH, "ucr.timing.log")
 UCR_DIFF_FILE = "%s/%s" % (FILEPATH, "ucr.diff.log")
 UCR_EXCEPTION_FILE = "%s/%s" % (FILEPATH, "ucr.exception.log")
@@ -1126,14 +1125,6 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 20  # Backup 200 MB of logs
         },
-        'export_tasks_handler': {
-            'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'formatter': 'verbose',
-            'filename': EXPORT_TASKS_LOG_FILE,
-            'maxBytes': 10 * 1024 * 1024,  # 10 MB
-            'backupCount': 20  # Backup 200 MB of logs
-        },
         'formplayer_diff': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
@@ -1264,11 +1255,6 @@ LOGGING = {
         'elasticsearch': {
             'handlers': ['file'],
             'level': 'ERROR',
-            'propagate': True,
-        },
-        'export_tasks': {
-            'handlers': ['export_tasks_handler'],
-            'level': 'INFO',
             'propagate': True,
         },
         'formplayer_timing': {


### PR DESCRIPTION
Recently a regular export download has blocked the queue for other users. This PR is to get more insight into the queued tasks when that happens. Adding workers seems to be a good approach, but we need to know if there is a project-specific issue here that resources won't fully address.

Context: [FB 279413](http://manage.dimagi.com/default.asp?279413)

:tropical_fish: might give more insight into the choices made -- specifically why we are passing parameters that can be evaluated from their string representations.

Labelling "do not merge": This code hasn't been fully tested yet.

@sravfeyn cc @esoergel @snopoke 
