### PR TITLE
assign_explicit_community_subscription should record a more specific …

### DIFF
--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -182,8 +182,10 @@ class CreatedSubAdjMethodFilter(BaseSingleOptionFilter):
     options = (
         (SubscriptionAdjustmentMethod.INTERNAL, "Operations Created"),
         (SubscriptionAdjustmentMethod.USER, "User Created"),
-        (SubscriptionAdjustmentMethod.TASK, "Created During Invoicing"),
+        (SubscriptionAdjustmentMethod.INVOICING, "Created During Invoicing"),
+        (SubscriptionAdjustmentMethod.TASK, "[Deprecated] Created During Invoicing"),
         (SubscriptionAdjustmentMethod.TRIAL, "30 Day Trial (default signup)"),
+        (SubscriptionAdjustmentMethod.DEFAULT_COMMUNITY, "Defaulted to Community"),
     )
 
 

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -412,7 +412,7 @@ def generate_invoice(subscription, invoice_start, invoice_end):
         # record that the subscription was created
         SubscriptionAdjustment.record_adjustment(
             subscription,
-            method=SubscriptionAdjustmentMethod.TASK,
+            method=SubscriptionAdjustmentMethod.INVOICING,
             invoice=invoice,
         )
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -199,12 +199,16 @@ class SubscriptionAdjustmentMethod(object):
     TASK = "TASK"
     TRIAL = "TRIAL"
     AUTOMATIC_DOWNGRADE = 'AUTOMATIC_DOWNGRADE'
+    DEFAULT_COMMUNITY = 'DEFAULT_COMMUNITY'
+    INVOICING = 'INVOICING'
     CHOICES = (
         (USER, "User"),
         (INTERNAL, "Ops"),
-        (TASK, "Task (Invoicing)"),
+        (TASK, "[Deprecated] Task (Invoicing)"),
         (TRIAL, "30 Day Trial"),
         (AUTOMATIC_DOWNGRADE, "Automatic Downgrade"),
+        (DEFAULT_COMMUNITY, 'Default to Community'),
+        (INVOICING, 'Invoicing')
     )
 
 

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -10,6 +10,7 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan,
     SoftwarePlanEdition,
     Subscription,
+    SubscriptionAdjustmentMethod,
 )
 from corehq.apps.accounting.tasks import ensure_explicit_community_subscription
 from corehq.apps.domain.models import Domain
@@ -111,7 +112,9 @@ class TestExplicitCommunitySubscriptions(TestCase):
         ))
 
     def _assign_community_subscriptions(self):
-        ensure_explicit_community_subscription(self.domain.name, self.from_date)
+        ensure_explicit_community_subscription(
+            self.domain.name, self.from_date, SubscriptionAdjustmentMethod.DEFAULT_COMMUNITY
+        )
 
     @property
     def _most_recently_created_community_plan_version(self):

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -20,6 +20,7 @@ from memoized import memoized
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.name_to_url import name_to_url
 
+from corehq.apps.accounting.models import SubscriptionAdjustmentMethod
 from corehq.apps.accounting.tasks import ensure_explicit_community_subscription
 from corehq.apps.app_manager.views.apps import clear_app_cache
 from corehq.apps.appstore.exceptions import CopiedFromDeletedException
@@ -359,7 +360,9 @@ def copy_snapshot(request, snapshot):
                                                user=user)
                     if new_domain.commtrack_enabled:
                         new_domain.convert_to_commtrack()
-                    ensure_explicit_community_subscription(new_domain.name, date.today())
+                    ensure_explicit_community_subscription(
+                        new_domain.name, date.today(), SubscriptionAdjustmentMethod.USER
+                    )
                 except NameUnavailableException:
                     messages.error(request, _("A project by that name already exists"))
                     return HttpResponseRedirect(reverse(ProjectInformationView.urlname, args=[snapshot]))

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -104,7 +104,9 @@ def request_new_domain(request, form, is_new_user=True):
         # domains with no subscription are equivalent to be on free Community plan
         create_30_day_advanced_trial(new_domain, current_user.username)
     else:
-        ensure_explicit_community_subscription(new_domain.name, date.today())
+        ensure_explicit_community_subscription(
+            new_domain.name, date.today(), SubscriptionAdjustmentMethod.USER
+        )
 
     UserRole.init_domain_with_presets(new_domain.name)
 


### PR DESCRIPTION
…adjustment method

Instead of always recording the same adjustment method, have assign_explicit_community_subscription use an adjustment method appropriate for where it is called.  This helps with debugging by providing a clearer record of why a subscription was created.