### PR TITLE
Ce/aadhar sum

### DIFF
--- a/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
+++ b/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
@@ -113,7 +113,7 @@ BEGIN
     'wer_weighed = ut.wer_weighed, ' ||
     'wer_eligible = ut.wer_eligible, ' ||
     'cases_person_beneficiary_v2 = ut.cases_child_health, ' ||
-    'cases_person_has_aadhar_v2 = ut.child_has_aadhar ' ||
+    'cases_person_has_aadhaar_v2 = ut.child_has_aadhar ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
     'month, ' ||
@@ -133,7 +133,7 @@ BEGIN
     'cases_ccs_pregnant_all = ut.cases_ccs_pregnant_all, ' ||
     'cases_ccs_lactating_all = ut.cases_ccs_lactating_all, ' ||
     'cases_person_beneficiary_v2 = COALESCE(cases_person_beneficiary_v2, 0) + ut.cases_ccs_pregnant + ut.cases_ccs_lactating, ' ||
-    'cases_person_has_aadhar_v2 = COALESCE(cases_person_has_aadhar_v2, 0) + ut.ccs_has_aadhar ' ||
+    'cases_person_has_aadhaar_v2 = COALESCE(cases_person_has_aadhaar_v2, 0) + ut.ccs_has_aadhar ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
     'month, ' ||
@@ -184,8 +184,6 @@ BEGIN
     'num_children_immunized = ut.num_children_immunized ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
-    'sum(has_aadhar_id) as child_has_aadhar, ' ||
-    'count(*) as child_beneficiary, ' ||
     'sum(immunization_in_month) AS num_children_immunized ' ||
     'FROM ' || quote_ident(_child_health_monthly_tablename) || ' ' ||
     'WHERE valid_in_month = 1' ||

--- a/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
+++ b/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
@@ -133,7 +133,7 @@ BEGIN
     'cases_ccs_pregnant_all = ut.cases_ccs_pregnant_all, ' ||
     'cases_ccs_lactating_all = ut.cases_ccs_lactating_all, ' ||
     'cases_person_beneficiary_v2 = COALESCE(cases_person_beneficiary_v2, 0) + ut.cases_ccs_pregnant + ut.cases_ccs_lactating, ' ||
-    'cases_person_has_aadhar_v2 = COALSECE(cases_person_has_aadhar_v2, 0) + ut.ccs_has_aadhar ' ||
+    'cases_person_has_aadhar_v2 = COALESCE(cases_person_has_aadhar_v2, 0) + ut.ccs_has_aadhar ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
     'month, ' ||

--- a/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
+++ b/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
@@ -140,7 +140,7 @@ BEGIN
     'sum(pregnant) AS cases_ccs_pregnant, ' ||
     'sum(lactating) AS cases_ccs_lactating, ' ||
     'sum(pregnant_all) AS cases_ccs_pregnant_all, ' ||
-    'sum(lactating_all) AS cases_ccs_lactating_all ' ||
+    'sum(lactating_all) AS cases_ccs_lactating_all, ' ||
     'sum(has_aadhar_id) AS ccs_has_aadhar '
     'FROM ' || quote_ident(_ccs_record_tablename) || ' ' ||
     'WHERE month = ' || quote_literal(_start_date) || ' AND aggregation_level = 5 GROUP BY awc_id, month) ut ' ||

--- a/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
+++ b/custom/icds_reports/migrations/sql_templates/database_functions/aggregate_awc_data.sql
@@ -112,16 +112,14 @@ BEGIN
     'cases_child_health_all = ut.cases_child_health_all, ' ||
     'wer_weighed = ut.wer_weighed, ' ||
     'wer_eligible = ut.wer_eligible, ' ||
-    'cases_person_beneficiary_v2 = ut.cases_child_health, ' ||
-    'cases_person_has_aadhaar_v2 = ut.child_has_aadhar ' ||
+    'cases_person_beneficiary_v2 = ut.cases_child_health ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
     'month, ' ||
     'sum(valid_in_month) AS cases_child_health, ' ||
     'sum(valid_all_registered_in_month) AS cases_child_health_all, ' ||
     'sum(nutrition_status_weighed) AS wer_weighed, ' ||
-    'sum(wer_eligible) AS wer_eligible, ' ||
-    'sum(has_aadhar_id) AS child_has_aadhar ' ||
+    'sum(wer_eligible) AS wer_eligible ' ||
     'FROM ' || quote_ident(_child_health_tablename) || ' ' ||
     'WHERE month = ' || quote_literal(_start_date) || ' AND aggregation_level = 5 GROUP BY awc_id, month) ut ' ||
   'WHERE ut.month = agg_awc.month AND ut.awc_id = agg_awc.awc_id';
@@ -132,16 +130,14 @@ BEGIN
     'cases_ccs_lactating = ut.cases_ccs_lactating, ' ||
     'cases_ccs_pregnant_all = ut.cases_ccs_pregnant_all, ' ||
     'cases_ccs_lactating_all = ut.cases_ccs_lactating_all, ' ||
-    'cases_person_beneficiary_v2 = COALESCE(cases_person_beneficiary_v2, 0) + ut.cases_ccs_pregnant + ut.cases_ccs_lactating, ' ||
-    'cases_person_has_aadhaar_v2 = COALESCE(cases_person_has_aadhaar_v2, 0) + ut.ccs_has_aadhar ' ||
+    'cases_person_beneficiary_v2 = COALESCE(cases_person_beneficiary_v2, 0) + ut.cases_ccs_pregnant + ut.cases_ccs_lactating ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
     'month, ' ||
     'sum(pregnant) AS cases_ccs_pregnant, ' ||
     'sum(lactating) AS cases_ccs_lactating, ' ||
     'sum(pregnant_all) AS cases_ccs_pregnant_all, ' ||
-    'sum(lactating_all) AS cases_ccs_lactating_all, ' ||
-    'sum(has_aadhar_id) AS ccs_has_aadhar '
+    'sum(lactating_all) AS cases_ccs_lactating_all ' ||
     'FROM ' || quote_ident(_ccs_record_tablename) || ' ' ||
     'WHERE month = ' || quote_literal(_start_date) || ' AND aggregation_level = 5 GROUP BY awc_id, month) ut ' ||
   'WHERE ut.month = agg_awc.month AND ut.awc_id = agg_awc.awc_id';
@@ -181,9 +177,11 @@ BEGIN
 
   -- Update number of children immunized
   EXECUTE 'UPDATE ' || quote_ident(_tablename5) || ' agg_awc SET ' ||
+    'cases_person_has_aadhaar_v2 = ut.child_has_aadhar, ' ||
     'num_children_immunized = ut.num_children_immunized ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
+    'sum(has_aadhar_id) as child_has_aadhar, ' ||
     'sum(immunization_in_month) AS num_children_immunized ' ||
     'FROM ' || quote_ident(_child_health_monthly_tablename) || ' ' ||
     'WHERE valid_in_month = 1' ||
@@ -192,10 +190,12 @@ BEGIN
 
   -- Update number anc visits
   EXECUTE 'UPDATE ' || quote_ident(_tablename5) || ' agg_awc SET ' ||
-    'num_anc_visits = ut.num_anc_visits ' ||
+    'num_anc_visits = ut.num_anc_visits, ' ||
+    'cases_person_has_aadhaar_v2 = COALESCE(cases_person_has_aadhaar_v2, 0) + ut.ccs_has_aadhar ' ||
   'FROM (SELECT ' ||
     'awc_id, ' ||
-    'sum(anc_in_month) AS num_anc_visits ' ||
+    'sum(anc_in_month) AS num_anc_visits, ' ||
+    'sum(has_aadhar_id) AS ccs_has_aadhar ' ||
     'FROM ' || quote_ident(_ccs_record_monthly_tablename) || ' ' ||
     'WHERE pregnant = 1 OR lactating = 1 ' ||
     'GROUP BY awc_id) ut ' ||

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -269,8 +269,6 @@ def icds_aggregation_task(self, date, func):
     try:
         func(date)
     except Error as exc:
-        import ipdb; ipdb.set_trace()
-
         _dashboard_team_soft_assert(
             False,
             "{} aggregation failed on {} for {}. This task will be retried in 15 minutes".format(

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -269,6 +269,8 @@ def icds_aggregation_task(self, date, func):
     try:
         func(date)
     except Error as exc:
+        import ipdb; ipdb.set_trace()
+
         _dashboard_team_soft_assert(
             False,
             "{} aggregation failed on {} for {}. This task will be retried in 15 minutes".format(

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -627,6 +627,14 @@
                   },
                   "property_value": ["", null]
                 }
+              },
+              "expression_if_true": {
+                "type": "constant",
+                "constant": "yes"
+              },
+              "expression_if_false": {
+                "type": "constant",
+                "constant": "no"
               }
             }
           }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -615,17 +615,18 @@
               }
             },
             "expression_if_false": {
-            "type": "conditional",
-            "test": {
-              "type": "not",
-              "filter": {
-                "type": "boolean_expression",
-                "operator": "in",
-                "expression": {
-                  "type": "named",
-                  "name": "aadhar_number_from_forms"
-                },
-                "property_value": ["", null]
+              "type": "conditional",
+              "test": {
+                "type": "not",
+                "filter": {
+                  "type": "boolean_expression",
+                  "operator": "in",
+                  "expression": {
+                    "type": "named",
+                    "name": "aadhar_number_from_forms"
+                  },
+                  "property_value": ["", null]
+                }
               }
             }
           }

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_tableau2.json
@@ -615,8 +615,18 @@
               }
             },
             "expression_if_false": {
-              "type": "named",
-              "name": "has_aadhar_id_from_forms"
+            "type": "conditional",
+            "test": {
+              "type": "not",
+              "filter": {
+                "type": "boolean_expression",
+                "operator": "in",
+                "expression": {
+                  "type": "named",
+                  "name": "aadhar_number_from_forms"
+                },
+                "property_value": ["", null]
+              }
             }
           }
         },
@@ -2544,12 +2554,12 @@
           "constant": "no"
         }
       },
-      "has_aadhar_id_from_forms": {
+      "aadhar_number_from_forms": {
         "type": "icds_get_last_case_property_update",
         "case_id_expression": {
           "type": "icds_parent_id"
         },
-        "case_property": "has_aadhar",
+        "case_property": "aadhar_number",
         "end_date": {
           "type": "named",
           "name": "month_end"

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -630,6 +630,14 @@
                   },
                   "property_value": ["", null]
                 }
+              },
+              "expression_if_true": {
+                "type": "constant",
+                "constant": "yes"
+              },
+              "expression_if_false": {
+                "type": "constant",
+                "constant": "no"
               }
             }
           }

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -618,8 +618,18 @@
               }
             },
             "expression_if_false": {
-              "type": "named",
-              "name": "has_aadhar_id_from_forms"
+            "type": "conditional",
+            "test": {
+              "type": "not",
+              "filter": {
+                "type": "boolean_expression",
+                "operator": "in",
+                "expression": {
+                  "type": "named",
+                  "name": "aadhar_number_from_forms"
+                },
+                "property_value": ["", null]
+              }
             }
           }
         },
@@ -2608,12 +2618,12 @@
           "constant": "no"
         }
       },
-      "has_aadhar_id_from_forms": {
+      "aadhar_number_from_forms": {
         "type": "icds_get_last_case_property_update",
         "case_id_expression": {
           "type": "icds_parent_id"
         },
-        "case_property": "has_aadhar",
+        "case_property": "aadhar_number",
         "end_date": {
           "type": "named",
           "name": "month_end"

--- a/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases_monthly_tableau2.json
@@ -619,16 +619,17 @@
             },
             "expression_if_false": {
             "type": "conditional",
-            "test": {
-              "type": "not",
-              "filter": {
-                "type": "boolean_expression",
-                "operator": "in",
-                "expression": {
-                  "type": "named",
-                  "name": "aadhar_number_from_forms"
-                },
-                "property_value": ["", null]
+              "test": {
+                "type": "not",
+                "filter": {
+                  "type": "boolean_expression",
+                  "operator": "in",
+                  "expression": {
+                    "type": "named",
+                    "name": "aadhar_number_from_forms"
+                  },
+                  "property_value": ["", null]
+                }
               }
             }
           }


### PR DESCRIPTION
@emord 
This fixes two aadhar related tickets. First it ensures the total number of beneficiaries displayed is a strict sum of the numbers displayed for each of the 3 beneficiary categories (as opposed to calculating it later where it was subject to change by new form processing). Second it changes the aadhar caculation to fall back to `aadhar_number` instead of `has_aadhar` which is guaranteed to give correct answers.