### PR TITLE
Add generic custom recipients to new reminders framework

### DIFF
--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -77,7 +77,11 @@ from time import sleep
 from io import open
 
 
-ABT_CUSTOM_RECIPIENT = 'CASE_OWNER_LOCATION_PARENT'
+CUSTOM_RECIPIENTS = (
+    'CASE_OWNER_LOCATION_PARENT',
+    'HOST_CASE_OWNER_LOCATION',
+    'HOST_CASE_OWNER_LOCATION_PARENT',
+)
 
 
 def log(message):
@@ -453,8 +457,8 @@ def get_rule_recipients(handler):
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE, None)]
     elif handler.recipient == RECIPIENT_USER_GROUP:
         return [(ScheduleInstance.RECIPIENT_TYPE_USER_GROUP, handler.user_group_id)]
-    elif handler.recipient == ABT_CUSTOM_RECIPIENT:
-        return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM, ABT_CUSTOM_RECIPIENT)]
+    elif handler.recipient in CUSTOM_RECIPIENTS:
+        return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM, handler.recipient)]
     else:
         raise ValueError("Unexpected recipient: '%s'" % handler.recipient)
 
@@ -735,14 +739,13 @@ class Command(BaseCommand):
             except ValueError:
                 return None
 
-        if handler.recipient not in (
+        if handler.recipient not in (CUSTOM_RECIPIENTS + (
             RECIPIENT_OWNER,
             RECIPIENT_CASE,
             RECIPIENT_USER_GROUP,
             RECIPIENT_USER,
             RECIPIENT_PARENT_CASE,
-            ABT_CUSTOM_RECIPIENT,
-        ):
+        )):
             return None
 
         if handler.recipient == RECIPIENT_USER_GROUP and not handler.user_group_id:

--- a/corehq/messaging/scheduling/custom_recipients.py
+++ b/corehq/messaging/scheduling/custom_recipients.py
@@ -42,5 +42,6 @@ def host_case_owner_location_parent_from_case(domain, case):
 def host_case_owner_location(case_schedule_instance):
     return host_case_owner_location_from_case(case_schedule_instance.domain, case_schedule_instance.case)
 
+
 def host_case_owner_location_parent(case_schedule_instance):
     return host_case_owner_location_parent_from_case(case_schedule_instance.domain, case_schedule_instance.case)

--- a/corehq/messaging/scheduling/custom_recipients.py
+++ b/corehq/messaging/scheduling/custom_recipients.py
@@ -37,3 +37,10 @@ def host_case_owner_location_parent_from_case(domain, case):
         return None
 
     return parent_location
+
+
+def host_case_owner_location(case_schedule_instance):
+    return host_case_owner_location_from_case(case_schedule_instance.domain, case_schedule_instance.case)
+
+def host_case_owner_location_parent(case_schedule_instance):
+    return host_case_owner_location_parent_from_case(case_schedule_instance.domain, case_schedule_instance.case)

--- a/corehq/messaging/scheduling/custom_recipients.py
+++ b/corehq/messaging/scheduling/custom_recipients.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+from corehq.apps.locations.models import SQLLocation
+from corehq.form_processor.exceptions import CaseNotFound
+from couchdbkit.exceptions import ResourceNotFound
+
+
+def host_case_owner_location_from_case(domain, case):
+    if not case:
+        return None
+
+    try:
+        host = case.host
+    except (CaseNotFound, ResourceNotFound):
+        return None
+
+    if not host:
+        return None
+
+    location_id = host.owner_id
+    if not location_id:
+        return None
+
+    location = SQLLocation.by_location_id(location_id)
+    if not location or location.is_archived or location.domain != domain:
+        return None
+
+    return location
+
+
+def host_case_owner_location_parent_from_case(domain, case):
+    result = host_case_owner_location_from_case(domain, case)
+    if not result:
+        return None
+
+    parent_location = result.parent
+    if not parent_location:
+        return None
+
+    return parent_location

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -242,6 +242,111 @@ class SchedulingRecipientTest(TestCase):
                 recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE)
             self.assertEqual(instance.recipient.case_id, parent.case_id)
 
+    @run_with_all_backends
+    def test_host_case_owner_location(self):
+        with create_test_case(self.domain, 'test-extension-case', 'name') as extension_case:
+            with create_test_case(self.domain, 'test-host-case', 'name') as host_case:
+
+                update_case(self.domain, host_case.case_id,
+                    case_properties={'owner_id': self.city_location.location_id})
+                set_parent_case(self.domain, extension_case, host_case, relationship='extension')
+
+                # Test the recipient is returned correctly
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=extension_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION',
+                )
+                self.assertIsInstance(instance.recipient, SQLLocation)
+                self.assertEqual(instance.recipient.location_id, self.city_location.location_id)
+
+                # Test location that does not exist
+                update_case(self.domain, host_case.case_id, case_properties={'owner_id': 'does-not-exist'})
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=extension_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION',
+                )
+                self.assertIsNone(instance.recipient)
+
+                # Test on a case that is not an extension case
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=host_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION',
+                )
+                self.assertIsNone(instance.recipient)
+
+                # Test with case id that doesn't exist
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id='does-not-exist',
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION',
+                )
+                self.assertIsNone(instance.recipient)
+
+    @run_with_all_backends
+    def test_host_case_owner_location_parent(self):
+        with create_test_case(self.domain, 'test-extension-case', 'name') as extension_case:
+            with create_test_case(self.domain, 'test-host-case', 'name') as host_case:
+
+                update_case(self.domain, host_case.case_id,
+                    case_properties={'owner_id': self.city_location.location_id})
+                set_parent_case(self.domain, extension_case, host_case, relationship='extension')
+
+                # Test the recipient is returned correctly
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=extension_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION_PARENT',
+                )
+                self.assertIsInstance(instance.recipient, SQLLocation)
+                self.assertEqual(instance.recipient.location_id, self.state_location.location_id)
+
+                # Test no parent location
+                update_case(self.domain, host_case.case_id,
+                    case_properties={'owner_id': self.country_location.location_id})
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=extension_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION_PARENT',
+                )
+                self.assertIsNone(instance.recipient)
+
+                # Test location that does not exist
+                update_case(self.domain, host_case.case_id, case_properties={'owner_id': 'does-not-exist'})
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=extension_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION_PARENT',
+                )
+                self.assertIsNone(instance.recipient)
+
+                # Test on a case that is not an extension case
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=host_case.case_id,
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION_PARENT',
+                )
+                self.assertIsNone(instance.recipient)
+
+                # Test with case id that doesn't exist
+                instance = CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id='does-not-exist',
+                    recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+                    recipient_id='HOST_CASE_OWNER_LOCATION_PARENT',
+                )
+                self.assertIsNone(instance.recipient)
+
     def test_expand_location_recipients_without_descendants(self):
         schedule = TimedSchedule.create_simple_daily_schedule(
             self.domain,

--- a/settings.py
+++ b/settings.py
@@ -1632,6 +1632,12 @@ AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS = {
     'ICDS_SUPERVISOR_FROM_AWC_OWNER':
         ['custom.icds.messaging.custom_recipients.supervisor_from_awc_owner',
          "ICDS: Supervisor Location from AWC Owner"],
+    'HOST_CASE_OWNER_LOCATION':
+        ['corehq.messaging.scheduling.custom_recipients.host_case_owner_location',
+         "Custom: Extension Case -> Host Case -> Owner (which is a location)"],
+    'HOST_CASE_OWNER_LOCATION_PARENT':
+        ['corehq.messaging.scheduling.custom_recipients.host_case_owner_location_parent',
+         "Custom: Extension Case -> Host Case -> Owner (which is a location) -> Parent location"],
     'CASE_OWNER_LOCATION_PARENT':
         ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_new_framework',
          "Abt: The case owner's location's parent location"],


### PR DESCRIPTION
There were a couple of generic custom recipients in use by projects that were supported in the old framework, and this adds them to the new one for parity.

@gbova @millerdev 