### PR TITLE
Externalize js: crs_reports

### DIFF
--- a/custom/apps/crs_reports/templates/crs_reports/base_template.html
+++ b/custom/apps/crs_reports/templates/crs_reports/base_template.html
@@ -15,14 +15,6 @@
     </style>
 {% endblock %}
 
-{% block js-inline %}
-    <script>
-        $("#render_to_pdf").click(function() {
-           $.get("{{ report.slug }}/to_pdf")
-        })
-    </script>
-{% endblock %}
-
 {% block page_breadcrumbs %}
      <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
         <li>


### PR DESCRIPTION
This was added back in https://github.com/dimagi/commcare-hq/pull/1225/and looks like it never did anything - there's no element with id `render_to_pdf` on the page. This report is barely used anymore (two page views in the past year) but crs-remind is still on an enterprise plan so I'm not going to look at deleting it right now.

@millerdev / @emord 