### PR TITLE
[ICDS] Make columns available for in-form filtering

### DIFF
--- a/custom/icds_reports/ucr/reports/mpr_10a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_10a_person_cases.json
@@ -282,6 +282,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "other_child_reached_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "last_referral_date",
+        "field": "last_referral_date",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "last_referral_date"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_10b_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_10b_person_cases.json
@@ -258,6 +258,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "other_reached_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "last_referral_date",
+        "field": "last_referral_date",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "last_referral_date"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_11_visitor_book_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr_11_visitor_book_forms.json
@@ -234,6 +234,18 @@
         "calculate_total": false,
         "type": "field",
         "display": "visitor_other"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "submitted_on",
+        "field": "submitted_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "submitted_on"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_2a_3_child_delivery_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr_2a_3_child_delivery_forms.json
@@ -315,6 +315,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "lbw_M_migrant_birth_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "submitted_on",
+        "field": "submitted_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "submitted_on"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_2a_person_cases.json
@@ -354,6 +354,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "dead_pnc_migrant_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "date_death",
+        "field": "date_death",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "date_death"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_3i_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_3i_person_cases.json
@@ -138,6 +138,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "pregnant_migrant_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "opened_on",
+        "field": "opened_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "opened_on"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_3ii_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_3ii_person_cases.json
@@ -180,6 +180,30 @@
         "calculate_total": true,
         "type": "field",
         "display": "M_migrant_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_at_reg",
+        "field": "age_at_reg",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "age_at_reg"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "opened_on",
+        "field": "opened_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "opened_on"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_4a_6_pse.json
+++ b/custom/icds_reports/ucr/reports/mpr_4a_6_pse.json
@@ -198,6 +198,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "open_one_acts_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "submitted_on",
+        "field": "submitted_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "submitted_on"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_4b_infra_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr_4b_infra_forms.json
@@ -123,6 +123,18 @@
         "calculate_total": false,
         "type": "field",
         "display": "use_salt"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "submitted_on",
+        "field": "submitted_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "submitted_on"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_5_ccs_record_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr_5_ccs_record_cases_v2.json
@@ -347,6 +347,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "thr_total_rations_lactating"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "month",
+        "field": "month",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "month"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_5_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr_5_child_health_cases_v2.json
@@ -354,6 +354,30 @@
         "field": "thr_total_rations_male",
         "calculate_total": true,
         "type": "field"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_in_months",
+        "field": "age_in_months",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "age_in_months"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "month",
+        "field": "month",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "month"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_6ac_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr_6ac_child_health_cases_v2.json
@@ -306,6 +306,30 @@
         "field": "pse_partial_male",
         "calculate_total": true,
         "type": "field"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_in_months",
+        "field": "age_in_months",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "age_in_months"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "month",
+        "field": "month",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "month"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_6b_child_health_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_6b_child_health_cases.json
@@ -154,6 +154,30 @@
         "calculate_total": true,
         "type": "field",
         "display": "pse_daily_attendance_female"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_in_months",
+        "field": "age_in_months",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "age_in_months"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "month",
+        "field": "month",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "month"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_6b_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr_6b_child_health_cases_v2.json
@@ -154,6 +154,30 @@
         "calculate_total": true,
         "type": "field",
         "display": "pse_daily_attendance_female"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_in_months",
+        "field": "age_in_months",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "age_in_months"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "month",
+        "field": "month",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "month"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_7_growth_monitoring_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr_7_growth_monitoring_forms.json
@@ -204,6 +204,30 @@
         "calculate_total": true,
         "type": "field",
         "display": "F_sev_resident_weighed_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_in_months",
+        "field": "age_in_months",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "age_in_months"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "last_date_gmp",
+        "field": "last_date_gmp",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "last_date_gmp"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_8_tasks_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr_8_tasks_cases.json
@@ -138,6 +138,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "open_child_1yr_immun_complete"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "date_turns_one_yr",
+        "field": "date_turns_one_yr",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "date_turns_one_yr"
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr_9_vhnd_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr_9_vhnd_forms.json
@@ -306,6 +306,18 @@
         "calculate_total": true,
         "type": "field",
         "display": "due_list_prep_antenatal_checkup"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "submitted_on",
+        "field": "submitted_on",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "submitted_on"
       }
     ],
     "sort_expression": [],


### PR DESCRIPTION
There are several dozen mobile reports configured in the LS app (and I believe more in the AWW app) which apply filters to reference a subset of report data. The app then dynamically selects which report config to use based on user input. This dynamism isn't really possible with mobile UCR v2 (at least, not simply).

For example, there are 6 reports based on the report "MPR - 6b - Child Health cases (Static) v2":

    child cases age 36-48 months, current month
    child cases age 48-60 months, current month
    child cases age 60-72 months, current month
    child cases age 36-48 months, previous month
    child cases age 48-60 months, previous month
    child cases age 60-72 months, previous month

The approach we're looking at is to deduplicate these reports by making the requisite columns available in the restore, so they may be filtered within the app.

Tagging "do not merge" while I get validation that this is the best approach.  My understanding is that adding these columns wouldn't have any user-facing changes, since these report modules are hidden from the user.