### PR TITLE
use text formatting for mobile users download

### DIFF
--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -730,7 +730,7 @@ def dump_users_and_groups(domain, download_id, user_filters):
 
         return group_memoizer
 
-    writer = Excel2007ExportWriter()
+    writer = Excel2007ExportWriter(format_as_text=True)
     group_memoizer = _load_memoizer(domain)
     location_cache = LocationIdToSiteCodeCache(domain)
 

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -20,6 +20,8 @@ import xlwt
 
 from couchexport.models import Format
 import six
+from openpyxl.styles import numbers
+from openpyxl.worksheet.write_only import WriteOnlyCell
 from six.moves import zip
 from six.moves import map
 
@@ -360,8 +362,14 @@ class Excel2007ExportWriter(ExportWriter):
     format = Format.XLS_2007
     max_table_name_size = 31
 
+    def __init__(self, format_as_text=False):
+        super(Excel2007ExportWriter, self).__init__()
+        self.format_as_text = format_as_text
+
     def _init(self):
+        # https://openpyxl.readthedocs.io/en/latest/optimized.html
         self.book = openpyxl.Workbook(write_only=True)
+
         self.tables = {}
         self.table_indices = {}
 
@@ -390,10 +398,11 @@ class Excel2007ExportWriter(ExportWriter):
                 value = ''
             return dirty_chars.sub('?', value)
 
-        # NOTE: don't touch this. changing anything like formatting in the
-        # row by referencing the cells will cause huge memory issues.
-        # see: http://openpyxl.readthedocs.org/en/latest/optimized.html
-        sheet.append(list(map(get_write_value, row)))
+        cells = [WriteOnlyCell(sheet, get_write_value(val)) for val in row]
+        if self.format_as_text:
+            for cell in cells:
+                cell.number_format = numbers.FORMAT_TEXT
+        sheet.append(cells)
 
     def _close(self):
         """


### PR DESCRIPTION
https://trello.com/c/RI2ekDJN/26-stop-removing-leading-0s-and-other-text-from-our-mobile-worker-uploads-ie-for-usernames-claire

Makes it easier for users to upload phone numbers with leading zeroes, by making the original downloaded Excel file in "Text" format (as opposed to default Excel format "General").