### PR TITLE
rate limit on raw answer

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -97,7 +97,7 @@ EntrySingleAnswer = function(question, options) {
 
     if (options.enableAutoUpdate) {
         self.valueUpdate = 'keyup';
-        self.answer.extend({
+        self.rawAnswer.extend({
             rateLimit: {
                 timeout: Formplayer.Const.KO_ENTRY_TIMEOUT,
                 method: "notifyWhenChangesStop",

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -609,7 +609,7 @@ Formplayer.Const = {
     CONTROL_VIDEO_CAPTURE: 13,
 
     //knockout timeouts
-    KO_ENTRY_TIMEOUT: 500,
+    KO_ENTRY_TIMEOUT: 200,
 
 };
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?278199#1511824

it looks like commit https://github.com/dimagi/commcare-hq/commit/aa3c5d17f2435d413d06261af2762d76b0aafe89 changed the rate limit from being on `self.rawAnswer` to being on `self.answer`. if that was intentional, i can keep digging for something else, but I 100% have not been able to repro with it like this.

leaning towards this fix over the one in https://github.com/dimagi/commcare-hq/pull/21200

@orangejenny @snopoke @biyeun 

Also, 200 seemed fine for the throttling