### PR TITLE
start migrating CommCareBuild attachments to blob storage

### DIFF
--- a/corehq/apps/app_manager/management/commands/secure_submissions_all_apps.py
+++ b/corehq/apps/app_manager/management/commands/secure_submissions_all_apps.py
@@ -6,7 +6,7 @@ from distutils.version import LooseVersion
 from django.core.management import BaseCommand
 from corehq.apps.app_manager.const import APP_V1
 from corehq.apps.app_manager.util import all_apps_by_domain
-from corehq.apps.builds import get_default_build_spec
+from corehq.apps.builds.utils import get_default_build_spec
 
 
 def turn_on_secure_submissions_for_all_apps(domain):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -85,7 +85,7 @@ from corehq.apps.app_manager.xpath import (
     interpolate_xpath,
     LocationXpath,
 )
-from corehq.apps.builds import get_default_build_spec
+from corehq.apps.builds.utils import get_default_build_spec
 from dimagi.utils.couch.undo import DeleteRecord, DELETED_SUFFIX
 from dimagi.utils.dates import DateSpan
 from memoized import memoized

--- a/corehq/apps/builds/__init__.py
+++ b/corehq/apps/builds/__init__.py
@@ -1,2 +1,1 @@
 from __future__ import absolute_import
-from corehq.apps.builds.utils import get_default_build_spec

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -7,6 +7,7 @@ from corehq.apps.app_manager.const import APP_V2
 from dimagi.ext.couchdbkit import *
 from corehq.apps.builds.fixtures import commcare_build_config
 from corehq.apps.builds.jadjar import JadJar
+from corehq.blobs.mixin import BlobMixin
 from corehq.util.quickcache import quickcache
 from itertools import groupby
 from distutils.version import StrictVersion
@@ -28,7 +29,7 @@ class SemanticVersionProperty(StringProperty):
         return value
 
 
-class CommCareBuild(Document):
+class CommCareBuild(BlobMixin, Document):
     """
     #python manage.py shell
     #>>> from corehq.apps.builds.models import CommCareBuild
@@ -40,6 +41,8 @@ class CommCareBuild(Document):
     version = SemanticVersionProperty()
     time = DateTimeProperty()
     j2me_enabled = BooleanProperty(default=True)
+
+    _migrating_blobs_from_couch = True
 
     def put_file(self, payload, path, filename=None):
         """

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -80,6 +80,7 @@ from tempfile import mkdtemp
 from django.conf import settings
 
 from corehq.apps.accounting.models import InvoicePdf
+from corehq.apps.builds.models import CommCareBuild
 from corehq.apps.export import models as exports
 from corehq.apps.ota.models import DemoUserRestore
 from corehq.blobs import get_blob_db, DEFAULT_BUCKET, BlobInfo
@@ -648,6 +649,7 @@ class SqlModelMigrator(Migrator):
 
 
 MIGRATIONS = {m.slug: m for m in [
+    Migrator('commcare_builds', [CommCareBuild], CouchAttachmentMigrator),
     Migrator('invoice_pdfs', [InvoicePdf], CouchAttachmentMigrator),
     Migrator("saved_exports", [SavedBasicExport], CouchAttachmentMigrator),
     Migrator("applications", [


### PR DESCRIPTION
Following instructions [here](https://github.com/dimagi/commcare-hq/blob/1ba28da8fb45c2c3e5b9394fe2445fe6625eefd3/corehq/blobs/migrate.py#L18)

Noticed that ```CommCareBuild``` still uses Couch attachments in https://github.com/dimagi/commcare-hq/pull/21232