### PR TITLE
Fully release phone number on signup

### DIFF
--- a/corehq/apps/analytics/ab_tests.py
+++ b/corehq/apps/analytics/ab_tests.py
@@ -41,14 +41,3 @@ class ABTest(object):
             'name': self.name,
             'version': self.version,
         }
-
-
-NEW_USER_NUMBER_OPTION_SHOW_NUM = 'show_number'
-NEW_USER_NUMBER_OPTION_HIDE_NUM = 'hide_number'
-
-
-NEW_USER_NUMBER = ABTestConfig(
-    'New User Phone Number',
-    'new_phone_may2018',
-    (NEW_USER_NUMBER_OPTION_SHOW_NUM, NEW_USER_NUMBER_OPTION_HIDE_NUM)
-)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -77,20 +77,7 @@ class RegisterWebUserForm(forms.Form):
     is_mobile = forms.BooleanField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, *args, **kwargs):
-        self.show_phone_number = kwargs.pop('show_number', False)
         super(RegisterWebUserForm, self).__init__(*args, **kwargs)
-        if not self.show_phone_number:
-            del self.fields['phone_number']
-            phone_number_fields = []
-        else:
-            phone_number_fields = [
-                hqcrispy.InlineField(
-                    'phone_number',
-                    css_class="input-lg",
-                    data_bind="value: phoneNumber, "
-                              "valueUpdate: 'keyup'"
-                ),
-            ]
 
         persona_fields = []
         if settings.IS_SAAS_ENVIRONMENT:
@@ -163,7 +150,12 @@ class RegisterWebUserForm(forms.Form):
                                   "}",
                     ),
                     hqcrispy.ValidationMessage('passwordDelayed'),
-                    crispy.Div(*phone_number_fields),
+                    hqcrispy.InlineField(
+                        'phone_number',
+                        css_class="input-lg",
+                        data_bind="value: phoneNumber, "
+                                  "valueUpdate: 'keyup'"
+                    ),
                     hqcrispy.InlineField('atypical_user'),
                     twbscrispy.StrictButton(
                         ugettext("Next"),

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -38,17 +38,10 @@ hqDefine('registration/js/new_user.ko', function () {
 
     // Can't set up analytics until the values for the A/B tests are ready
     _kissmetrics.whenReadyAlways(function() {
-        _private.isAbPhoneNumberShown = _kissmetrics.getAbTest('New User Phone Number') === 'show_number';
-        _kissmetrics.identifyTraits({
-            "Phone number field": _private.isAbPhoneNumberShown ? "Shown" : "Not shown",
-        });
         _kissmetrics.track.event("Viewed CommCare signup page");
 
         _private.submitSuccessAnalytics = function (data) {
             _kissmetrics.track.event("Account Creation was Successful");
-            if (_private.isAbPhoneNumberShown) {
-                _kissmetrics.track.event("Phone Number Field Filled Out");
-            }
 
             var appcuesEvent = "Assigned user to Appcues test",
                 appcuesData = {

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -40,33 +40,31 @@ $(function () {
     });
 
     // Handle phone number input
-    if (initial_page_data('show_number')) {
-        var $number = $('#id_phone_number');
-        $number.intlTelInput({
-            separateDialCode: true,
-            utilsScript: initial_page_data('number_utils_script'),
-        });
-        $number.keydown(function (e) {
-            // prevents non-numeric numbers from being entered.
-            // from http://stackoverflow.com/questions/995183/how-to-allow-only-numeric-0-9-in-html-inputbox-using-jquery
-            // Allow: backspace, delete, tab, escape, enter and .
-            if ($.inArray(e.keyCode, [46, 8, 9, 27, 13, 110, 190]) !== -1 ||
-                // Allow: Ctrl+A, Command+A
-                (e.keyCode === 65 && (e.ctrlKey === true || e.metaKey === true)) ||
-                // Allow: home, end, left, right, down, up
-                (e.keyCode >= 35 && e.keyCode <= 40)
-            ) {
-                // let it happen, don't do anything
-                return;
-            }
+    var $number = $('#id_phone_number');
+    $number.intlTelInput({
+        separateDialCode: true,
+        utilsScript: initial_page_data('number_utils_script'),
+    });
+    $number.keydown(function (e) {
+        // prevents non-numeric numbers from being entered.
+        // from http://stackoverflow.com/questions/995183/how-to-allow-only-numeric-0-9-in-html-inputbox-using-jquery
+        // Allow: backspace, delete, tab, escape, enter and .
+        if ($.inArray(e.keyCode, [46, 8, 9, 27, 13, 110, 190]) !== -1 ||
+            // Allow: Ctrl+A, Command+A
+            (e.keyCode === 65 && (e.ctrlKey === true || e.metaKey === true)) ||
+            // Allow: home, end, left, right, down, up
+            (e.keyCode >= 35 && e.keyCode <= 40)
+        ) {
+            // let it happen, don't do anything
+            return;
+        }
 
-            // Ensure that it is a number and stop the keypress
-            if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
-                e.preventDefault();
-            }
-        });
-        reg.setGetPhoneNumberFn(function () {
-            return $number.intlTelInput("getNumber");
-        });
-    }
+        // Ensure that it is a number and stop the keypress
+        if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
+            e.preventDefault();
+        }
+    });
+    reg.setGetPhoneNumberFn(function () {
+        return $number.intlTelInput("getNumber");
+    });
 });

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -75,18 +75,15 @@
 
 {% block content %}
 {% initial_page_data 'hide_password_feedback' hide_password_feedback %}
-{% initial_page_data 'show_number' show_number %}
 {% initial_page_data 'number_utils_script' 'intl-tel-input/build/js/utils.js'|static %}
 {% initial_page_data 'reg_form_defaults' reg_form_defaults %}
-
-{% analytics_ab_test 'kissmetrics.new_phone_jan2016' ab_show_number|JSON %}
 
 {% registerurl 'process_registration' %}
 <div class="container">
   <div class="row">
     <div class="col-xs-12">
       <div id="registration-form-container"
-           class="reg-form-container {% if show_number %}has-phonenumber{% endif %}">
+           class="reg-form-container">
         <ul class="form-step-progress">
           <li class="active">{% trans "Create Account" %}</li>
           <li data-bind="css: { active: currentStep() > 0 }">{% trans "Name Project" %}</li>


### PR DESCRIPTION
https://trello.com/c/bYNRYcQI/132-phone-number-on-hq-signup-a-b-test

I'm deleting this code entirely rather than just turning off the test with `NewUserNumberAbTestMixin__NoAbEnabled`...and hoping we're not going to want to run this test yet again.

@biyeun 
code buddies @emord / @millerdev 