### PR TITLE
Fix Periodic Analytics Task

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -254,7 +254,6 @@ def track_web_user_registration_hubspot(request, web_user, properties):
         'created_account_in_hq': True,
         'is_a_commcare_user': True,
         'lifecyclestage': 'lead',
-        'date_created': web_user.date_joined.isoformat(),
     }
     env = get_instance_string()
     tracking_info['{}date_created'.format(env)] = web_user.date_joined.isoformat()

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -95,13 +95,14 @@ def get_form_exports_by_domain(domain, has_deid_permissions):
 def get_export_count_by_domain(domain):
     from .models import ExportInstance
 
-    return ExportInstance.get_db().view(
+    export_result = ExportInstance.get_db().view(
         'export_instances_by_domain/view',
         startkey=[domain],
         endkey=[domain, {}],
         include_docs=False,
         reduce=True,
-    ).one()['value']
+    ).one()
+    return 0 if export_result is None else export_result['value']
 
 
 def get_deid_export_count(domain):


### PR DESCRIPTION
hubspot analytics has not been working properly since July 3rd, and I traced it down to this commit:
https://github.com/dimagi/commcare-hq/commit/bf661bfa9132333c66acdaae24f29671ad57b091

if no results are returned, calling `one()` on the view (under `get_export_count_by_domain`) returns `None` and then trying to grab `['value']` from it will throw an error.

`get_export_count_by_domain` is used in the analytics task here: 
https://github.com/dimagi/commcare-hq/blob/517f68324093a7a30ef000dbaffb1f44d73af06d/corehq/apps/analytics/tasks.py#L469
https://github.com/dimagi/commcare-hq/blob/517f68324093a7a30ef000dbaffb1f44d73af06d/corehq/apps/analytics/tasks.py#L404-L408

I also discovered that `www_` is not actually prepended to to the analytics properties due to 
https://github.com/dimagi/commcare-hq/blob/f706c263d49350779fd6a9c89813f7f4c9d4bfda/corehq/apps/analytics/utils.py#L21
so i removed the extra `date_created` from the registration data, as it will already be sent as `date_created` in production in the following line:
https://github.com/dimagi/commcare-hq/blob/517f68324093a7a30ef000dbaffb1f44d73af06d/corehq/apps/analytics/tasks.py#L259

@orangejenny @esoergel cc @dannyroberts 