### PR TITLE
keep static UCR configs in memeory

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -640,13 +640,16 @@ class ReportConfiguration(UnicodeMixIn, QuickCachedDocumentMixin, Document):
 STATIC_PREFIX = 'static-'
 CUSTOM_REPORT_PREFIX = 'custom-'
 
-StaticDataSourceMetadata = namedtuple('StaticDataSourceMetadata', 'id path domain')
-StaticReportMetadata = namedtuple('StaticReportMetadata', 'id path domain')
-
 
 class StaticDataSourceConfiguration(JsonObject):
     """
-    For custom data sources maintained in the repository
+    For custom data sources maintained in the repository.
+
+    This class keeps the full list of static data source configurations relevant to the
+    current environment in memory and upon requests builds a new data source configuration
+    from the static config.
+
+    See 0002-keep-static-ucr-configurations-in-memory.md
     """
     _datasource_id_prefix = STATIC_PREFIX
     domains = ListProperty(required=True)
@@ -658,63 +661,61 @@ class StaticDataSourceConfiguration(JsonObject):
         return '{}{}-{}'.format(cls._datasource_id_prefix, domain, table_id)
 
     @classmethod
-    @quickcache([], skip_arg='rebuild')
-    def by_id_mapping(cls, rebuild=False):
-        mapping = {}
-        for wrapped, path in cls._all():
-            for domain in wrapped.domains:
-                ds_id = cls.get_doc_id(domain, wrapped.config['table_id'])
-                mapping[ds_id] = StaticDataSourceMetadata(ds_id, path, domain)
-        return mapping
+    @memoized
+    def by_id_mapping(cls):
+        """Memoized method that maps domains to static data source config"""
+        return {
+            cls.get_doc_id(domain, wrapped.config['table_id']): (domain, wrapped)
+            for wrapped in cls._all()
+            for domain in wrapped.domains
+        }
 
     @classmethod
     def _all(cls):
-        for path_or_glob in settings.STATIC_DATA_SOURCES:
-            if os.path.isfile(path_or_glob):
-                yield _get_wrapped_object_from_file(path_or_glob, cls), path_or_glob
-            else:
-                files = glob.glob(path_or_glob)
-                for path in files:
-                    yield _get_wrapped_object_from_file(path, cls), path
+        """
+        :return: Generator of all wrapped configs read from disk
+        """
+        def __get_all():
+            for path_or_glob in settings.STATIC_DATA_SOURCES:
+                if os.path.isfile(path_or_glob):
+                    yield _get_wrapped_object_from_file(path_or_glob, cls)
+                else:
+                    files = glob.glob(path_or_glob)
+                    for path in files:
+                        yield _get_wrapped_object_from_file(path, cls)
 
-        for provider_path in settings.STATIC_DATA_SOURCE_PROVIDERS:
-            provider_fn = to_function(provider_path, failhard=True)
-            for wrapped, path in provider_fn():
-                yield wrapped, path
+            for provider_path in settings.STATIC_DATA_SOURCE_PROVIDERS:
+                provider_fn = to_function(provider_path, failhard=True)
+                for wrapped, path in provider_fn():
+                    yield wrapped
+
+        return __get_all() if settings.UNIT_TESTING else _filter_by_server_env(__get_all())
 
     @classmethod
-    def all(cls, use_server_filter=True):
-        for wrapped, path in cls._all():
-            if (use_server_filter and
-                    wrapped.server_environment and
-                    settings.SERVER_ENVIRONMENT not in wrapped.server_environment):
-                continue
-
+    def all(cls):
+        """Unoptimized method that get's all configs by re-reading from disk"""
+        for wrapped in cls._all():
             for domain in wrapped.domains:
                 yield cls._get_datasource_config(wrapped, domain)
 
     @classmethod
     def by_domain(cls, domain):
-        return [ds for ds in cls.all() if ds.domain == domain]
+        return [
+            cls._get_datasource_config(wrapped, dom)
+            for dom, wrapped in cls.by_id_mapping().values()
+            if domain == dom
+        ]
 
     @classmethod
     def by_id(cls, config_id):
-        mapping = cls.by_id_mapping()
-        if config_id not in mapping:
-            mapping = cls.by_id_mapping(rebuild=True)
-
-        metadata = mapping.get(config_id, None)
-        if not metadata:
+        try:
+            domain, wrapped = cls.by_id_mapping()[config_id]
+        except KeyError:
             raise StaticDataSourceConfigurationNotFoundError(_(
                 'The data source referenced by this report could not be found.'
             ))
 
-        return cls._get_from_metadata(metadata)
-
-    @classmethod
-    def _get_from_metadata(cls, metadata):
-        wrapped = _get_wrapped_object_from_file(metadata.path, cls)
-        return cls._get_datasource_config(wrapped, metadata.domain)
+        return cls._get_datasource_config(wrapped, domain)
 
     @classmethod
     def _get_datasource_config(cls, static_config, domain):
@@ -727,6 +728,12 @@ class StaticDataSourceConfiguration(JsonObject):
 class StaticReportConfiguration(JsonObject):
     """
     For statically defined reports based off of custom data sources
+
+    This class keeps the full list of static report configurations relevant to the
+    current environment in memory and upon requests builds a new report configuration
+    from the static report config.
+
+    See 0002-keep-static-ucr-configurations-in-memory.md
     """
     domains = ListProperty(required=True)
     report_id = StringProperty(validators=(_check_ids))
@@ -745,31 +752,30 @@ class StaticReportConfiguration(JsonObject):
 
     @classmethod
     def _all(cls):
-        for path_or_glob in settings.STATIC_UCR_REPORTS:
-            if os.path.isfile(path_or_glob):
-                yield _get_wrapped_object_from_file(path_or_glob, cls), path_or_glob
-            else:
-                files = glob.glob(path_or_glob)
-                for path in files:
-                    yield _get_wrapped_object_from_file(path, cls), path
+        def __get_all():
+            for path_or_glob in settings.STATIC_UCR_REPORTS:
+                if os.path.isfile(path_or_glob):
+                    yield _get_wrapped_object_from_file(path_or_glob, cls)
+                else:
+                    files = glob.glob(path_or_glob)
+                    for path in files:
+                        yield _get_wrapped_object_from_file(path, cls)
+
+        return __get_all() if settings.UNIT_TESTING else _filter_by_server_env(__get_all())
 
     @classmethod
-    @quickcache([], skip_arg='rebuild')
-    def by_id_mapping(cls, rebuild=False):
-        mapping = {}
-        for wrapped, path in StaticReportConfiguration._all():
-            for domain in wrapped.domains:
-                config_id = cls.get_doc_id(domain, wrapped.report_id, wrapped.custom_configurable_report)
-                mapping[config_id] = StaticReportMetadata(config_id, path, domain)
-        return mapping
+    @memoized
+    def by_id_mapping(cls):
+        return {
+            cls.get_doc_id(domain, wrapped.report_id, wrapped.custom_configurable_report): (domain, wrapped)
+            for wrapped in cls._all()
+            for domain in wrapped.domains
+        }
 
     @classmethod
-    def all(cls, ignore_server_environment=False):
-        for wrapped, path in StaticReportConfiguration._all():
-            if (not ignore_server_environment and wrapped.server_environment and
-                    settings.SERVER_ENVIRONMENT not in wrapped.server_environment):
-                continue
-
+    def all(cls):
+        """Only used in tests"""
+        for wrapped in StaticReportConfiguration._all():
             for domain in wrapped.domains:
                 yield cls._get_report_config(wrapped, domain)
 
@@ -778,7 +784,11 @@ class StaticReportConfiguration(JsonObject):
         """
         Returns a list of ReportConfiguration objects, NOT StaticReportConfigurations.
         """
-        return [ds for ds in cls.all() if ds.domain == domain]
+        return [
+            cls._get_report_config(wrapped, dom)
+            for dom, wrapped in cls.by_id_mapping().values()
+            if domain == dom
+        ]
 
     @classmethod
     def by_id(cls, config_id, domain=None):
@@ -788,55 +798,50 @@ class StaticReportConfiguration(JsonObject):
         :param domain: Optionally specify domain name to validate access.
                        Raises ``DocumentNotFound`` if domains don't match.
         """
-        mapping = cls.by_id_mapping()
-        if config_id not in mapping:
-            mapping = cls.by_id_mapping(rebuild=True)
-
-        metadata = mapping.get(config_id, None)
-        if not metadata:
+        try:
+            report_domain, wrapped = cls.by_id_mapping()[config_id]
+        except KeyError:
             raise BadSpecError(_('The report configuration referenced by this report could '
                                  'not be found: %(report_id)s') % {'report_id': config_id})
 
-        config = cls._get_from_metadata(metadata)
-        if domain and config.domain != domain:
+        if domain and report_domain != domain:
             raise DocumentNotFound("Document {} of class {} not in domain {}!".format(
                 config_id,
-                config.__class__.__name__,
+                ReportConfiguration.__class__.__name__,
                 domain,
             ))
-        return config
+        return cls._get_report_config(wrapped, domain)
 
     @classmethod
     def by_ids(cls, config_ids):
-        config_ids = set(config_ids)
         mapping = cls.by_id_mapping()
 
-        if not config_ids <= set(mapping.keys()):
-            mapping = cls.by_id_mapping(rebuild=True)
-
         return_configs = []
-        for config_id in config_ids:
-            metadata = mapping.get(config_id, None)
-            if not metadata:
+        for config_id in set(config_ids):
+            try:
+                domain, wrapped = mapping[config_id]
+            except KeyError:
                 raise ReportConfigurationNotFoundError(_(
                     "The following report configuration could not be found: {}".format(config_id)
                 ))
-            return_configs.append(cls._get_from_metadata(metadata))
+            return_configs.append(cls._get_report_config(wrapped, domain))
         return return_configs
 
     @classmethod
     def report_class_by_domain_and_id(cls, domain, config_id):
-        for wrapped, path in cls._all():
-            if cls.get_doc_id(domain, wrapped.report_id, wrapped.custom_configurable_report) == config_id:
-                return wrapped.custom_configurable_report
-        raise BadSpecError(_('The report configuration referenced by this report could '
-                             'not be found.'))
-
-    @classmethod
-    def _get_from_metadata(cls, metadata):
-        wrapped = _get_wrapped_object_from_file(metadata.path, cls)
-        domain = metadata.domain
-        return cls._get_report_config(wrapped, domain)
+        try:
+            report_domain, wrapped = cls.by_id_mapping()[config_id]
+        except KeyError:
+            raise BadSpecError(
+                _('The report configuration referenced by this report could not be found.')
+            )
+        if report_domain != domain:
+            raise DocumentNotFound("Document {} of class {} not in domain {}!".format(
+                config_id,
+                ReportConfiguration.__class__.__name__,
+                domain,
+            ))
+        return wrapped.custom_configurable_report
 
     @classmethod
     def _get_report_config(cls, static_config, domain):
@@ -1039,3 +1044,10 @@ def _get_wrapped_object_from_file(path, wrapper):
         msg = '{}: {}'.format(path, ex.args[0]) if ex.args else str(path)
         ex.args = (msg,) + ex.args[1:]
         raise
+
+
+def _filter_by_server_env(configs):
+    for wrapped in configs:
+        if wrapped.server_environment and settings.SERVER_ENVIRONMENT not in wrapped.server_environment:
+            continue
+        yield wrapped

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -594,7 +594,7 @@ class CustomConfigurableReportDispatcher(ReportDispatcher):
         report_config_id = subreport_slug
         try:
             report_class = self._report_class(domain, report_config_id)
-        except BadSpecError:
+        except (BadSpecError, DocumentNotFound):
             raise Http404
         return report_class.as_view()(request, domain=domain, subreport_slug=report_config_id, **kwargs)
 

--- a/corehq/apps/userreports/tests/test_get_report_configs.py
+++ b/corehq/apps/userreports/tests/test_get_report_configs.py
@@ -23,6 +23,10 @@ class TestGetReportConfigs(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'static_reports')
     root = os.path.dirname(__file__)
 
+    def setUp(self):
+        super(TestGetReportConfigs, self).setUp()
+        StaticReportConfiguration.by_id_mapping.reset_cache(StaticReportConfiguration.__class__)
+
     def test_static_reports(self):
         with override_settings(STATIC_UCR_REPORTS=[
             self.get_path('static_report_config', 'json'),

--- a/corehq/apps/userreports/tests/test_static_data_sources.py
+++ b/corehq/apps/userreports/tests/test_static_data_sources.py
@@ -24,7 +24,7 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     def test_get_all(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            all = list(StaticDataSourceConfiguration.all(use_server_filter=False))
+            all = list(StaticDataSourceConfiguration.all())
             self.assertEqual(2 + 3, len(all))
             example, dimagi = all[:2]
             self.assertEqual('example', example.domain)
@@ -37,12 +37,12 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     def test_is_static_positive_json(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            example = list(StaticDataSourceConfiguration.all(use_server_filter=False))[0]
+            example = list(StaticDataSourceConfiguration.all())[0]
             self.assertTrue(example.is_static)
 
     def test_is_static_positive_yaml(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'yaml')]):
-            example = list(StaticDataSourceConfiguration.all(use_server_filter=False))[0]
+            example = list(StaticDataSourceConfiguration.all())[0]
             self.assertTrue(example.is_static)
 
     def test_is_static_negative(self):
@@ -51,17 +51,17 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     def test_deactivate_noop(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            example = list(StaticDataSourceConfiguration.all(use_server_filter=False))[0]
+            example = list(StaticDataSourceConfiguration.all())[0]
             # since this is a SimpleTest, this should fail if the call actually hits the DB
             example.deactivate()
 
     def test_production_config(self):
-        for data_source in StaticDataSourceConfiguration.all(use_server_filter=False):
+        for data_source in StaticDataSourceConfiguration.all():
             data_source.validate()
 
     def test_for_table_id_conflicts(self):
         counts = Counter((ds.table_id, ds.domain) for ds in
-                         StaticDataSourceConfiguration.all(use_server_filter=False))
+                         StaticDataSourceConfiguration.all())
         duplicates = [k for k, v in counts.items() if v > 1]
         msg = "The following data source configs have duplicate table_ids on the same domains:\n{}".format(
             "\n".join("table_id: {}, domain: {}".format(table_id, domain) for table_id, domain in duplicates)

--- a/corehq/apps/userreports/tests/test_static_reports.py
+++ b/corehq/apps/userreports/tests/test_static_reports.py
@@ -42,12 +42,12 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
                 self.assertEqual('Custom Title', config.title)
 
     def test_production_config(self):
-        for report_config in StaticReportConfiguration.all(ignore_server_environment=True):
+        for report_config in StaticReportConfiguration.all():
             report_config.validate()
 
     def test_for_report_id_conflicts(self):
         counts = Counter(rc.get_id for rc in
-                         StaticReportConfiguration.all(ignore_server_environment=True))
+                         StaticReportConfiguration.all())
         duplicates = [k for k, v in counts.items() if v > 1]
         msg = "The following report configs have duplicate generated report_ids:\n{}".format(
             "\n".join("report_id: {}".format(report_id) for report_id in duplicates)
@@ -59,14 +59,14 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
     def test_data_sources_actually_exist(self):
 
         data_sources_on_domain = defaultdict(set)
-        for data_source in StaticDataSourceConfiguration.all(use_server_filter=False):
+        for data_source in StaticDataSourceConfiguration.all():
             data_sources_on_domain[data_source.domain].add(data_source.get_id)
 
         def has_no_data_source(report_config):
             available_data_sources = data_sources_on_domain[report_config.domain]
             return report_config.config_id not in available_data_sources
 
-        all_configs = StaticReportConfiguration.all(ignore_server_environment=True)
+        all_configs = StaticReportConfiguration.all()
         configs_missing_data_source = list(filter(has_no_data_source, all_configs))
 
         msg = ("There are {} report configs which reference data sources that "

--- a/corehq/apps/userreports/tests/test_static_reports.py
+++ b/corehq/apps/userreports/tests/test_static_reports.py
@@ -17,6 +17,10 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'static_reports')
     root = os.path.dirname(__file__)
 
+    def setUp(self):
+        super(TestStaticReportConfig, self).setUp()
+        StaticReportConfiguration.by_id_mapping.reset_cache(StaticReportConfiguration.__class__)
+
     def test_wrap(self):
         wrapped = StaticReportConfiguration.wrap(self.get_json('static_report_config'))
         self.assertEqual(["example", "dimagi"], wrapped.domains)

--- a/docs/decisions/0001-record-architecture-decisions.md
+++ b/docs/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2018-07-04
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/decisions/0002-keep-static-ucr-configurations-in-memory.md
+++ b/docs/decisions/0002-keep-static-ucr-configurations-in-memory.md
@@ -1,0 +1,51 @@
+# 2. Keep static UCR configurations in memory
+
+Date: 2018-07-04
+
+## Status
+
+Accepted
+
+## Context
+
+As part of the UCR framework configurations for data sources and reports
+may be stored in the database or as static files shipped with the code.
+
+These static files can apply to many different domains and even different
+server environments.
+
+When a data source or report configuraiton is requested the static configuration
+is read from disk and converted into the appropriate JsonObject class.
+
+During some performance testing on ICDS it was noted that the process or
+readying the static configuration files from disk and converting them
+to the JsonObject classes was taking up significant time (14% of restore
+time for ICDS).
+
+## Decision
+
+To improve the performance (primarily of restores) it was decided to maintain
+the list of configurations in memeory rather than re-read them from disk
+for each request.
+
+In order to keep the memory footprint to a minimum only the static configurations
+are kept in memory and not the generated classes. This also serves to ensure
+that any modifications that may get made to the classes do not persist.
+
+There are still some places that re-read the configurations from disk
+each time but these not called in places that require high performance. An
+example of this is the UCR pillow bootstrapping.
+
+## Consequences
+
+Although this may raise the memory usage of the processes (after the
+configurations have been loaded) it should be noted that even in the current
+setup all the configurations are loaded on first request in order to generate
+the list of available data sources / reports. It may be that memory get's
+released at some point after the initial load.
+
+In terms of actual memory footprint the figures are as follows:
+
+Base memory: 285Mb
+Data sources: 60Mb
+Report configs: 35Mb


### PR DESCRIPTION
replaces https://github.com/dimagi/commcare-hq/pull/21118

The only change between the two is that I decided it was easier to load ALL configs in unit tests to avoid having to mock the server environment and clear the cache the whole time.