### PR TITLE
Revert "Add urllib3[secure] to prod-requirements.txt"

### DIFF
--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -7,3 +7,10 @@ uWSGI==2.0.11.2
 ipython==5.2.2
 ndg-httpsclient==0.5.0
 pyasn1==0.4.3
+
+# ssl issue
+# https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification-in-python-2
+pyOpenSSL==18.0.0
+cryptography==2.3
+idna==2.6
+certifi==2018.4.16

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -7,4 +7,3 @@ uWSGI==2.0.11.2
 ipython==5.2.2
 ndg-httpsclient==0.5.0
 pyasn1==0.4.3
-urllib3[secure]==1.23


### PR DESCRIPTION
Reverts dimagi/commcare-hq#21236

Simply typing `pip` in a release that's has tried (and failed) to update to this version gives
```
Traceback (most recent call last):
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/bin/pip", line 7, in <module>
    from pip import main
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/pip/__init__.py", line 16, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/pip/download.py", line 39, in <module>
    from pip._vendor import requests, six
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py", line 53, in <module>
    from .packages.urllib3.contrib import pyopenssl
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/contrib/pyopenssl.py", line 54, in <module>
    import OpenSSL.SSL
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "/home/cchq/www/staging/releases/2018-07-18_19.48/python_env/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 124, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: 'module' object has no attribute 'SSL_ST_INIT'
```

My guess is that it's because `urllib3[secure]` vendorizes pyopenssl
which seems to conflict with our currently installed version of pyopenssl

I don’t fully understand it but I can see enough to know it’s a bit of a cluster eff bomb