### PR TITLE
fix first submission date for inactive awws

### DIFF
--- a/custom/icds_reports/management/commands/recalculate_inactive_aww.py
+++ b/custom/icds_reports/management/commands/recalculate_inactive_aww.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, print_function
+
+from __future__ import unicode_literals
+import datetime
+
+from django.core.management.base import BaseCommand
+
+from custom.icds_reports.models import AggregateInactiveAWW
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        start_date = datetime.date(2017, 3, 1)
+        AggregateInactiveAWW.aggregate(start_date)

--- a/custom/icds_reports/utils/aggregation.py
+++ b/custom/icds_reports/utils/aggregation.py
@@ -931,7 +931,11 @@ class InactiveAwwsAggregationHelper(BaseICDSAggregationHelper):
                 FIRST_VALUE(form_date) OVER forms as first_submission,
                 LAST_VALUE(form_date) OVER forms as last_submission
             FROM "{ucr_tablename}"
-            WHERE inserted_at >= %(last_sync)s AND form_date <= %(now)s
+            WHERE awc_id IN (
+              SELECT DISTINCT awc_id 
+              from "{ucr_tablename}"
+              where inserted_at >= %(last_sync)s AND form_date <= %(now)s
+            )
             WINDOW forms AS (
               PARTITION BY awc_id
               ORDER BY form_date ASC RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/custom/icds_reports/utils/aggregation.py
+++ b/custom/icds_reports/utils/aggregation.py
@@ -932,9 +932,9 @@ class InactiveAwwsAggregationHelper(BaseICDSAggregationHelper):
                 LAST_VALUE(form_date) OVER forms as last_submission
             FROM "{ucr_tablename}"
             WHERE awc_id IN (
-              SELECT DISTINCT awc_id 
-              from "{ucr_tablename}"
-              where inserted_at >= %(last_sync)s AND form_date <= %(now)s
+                SELECT DISTINCT awc_id
+                FROM "{ucr_tablename}"
+                WHERE inserted_at >= %(last_sync)s AND form_date <= %(now)s
             )
             WINDOW forms AS (
               PARTITION BY awc_id

--- a/custom/icds_reports/utils/aggregation.py
+++ b/custom/icds_reports/utils/aggregation.py
@@ -931,11 +931,7 @@ class InactiveAwwsAggregationHelper(BaseICDSAggregationHelper):
                 FIRST_VALUE(form_date) OVER forms as first_submission,
                 LAST_VALUE(form_date) OVER forms as last_submission
             FROM "{ucr_tablename}"
-            WHERE awc_id IN (
-                SELECT DISTINCT awc_id
-                FROM "{ucr_tablename}"
-                WHERE inserted_at >= %(last_sync)s AND form_date <= %(now)s
-            )
+            WHERE inserted_at >= %(last_sync)s AND form_date <= %(now)s
             WINDOW forms AS (
               PARTITION BY awc_id
               ORDER BY form_date ASC RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
@@ -979,7 +975,7 @@ class InactiveAwwsAggregationHelper(BaseICDSAggregationHelper):
         ucr_query, params = self.data_from_ucr_query()
         return """
             UPDATE "{table_name}" AS agg_table SET
-                first_submission = ut.first_submission,
+                first_submission = LEAST(ut.first_submission, ut.first_submission)
                 last_submission = ut.last_submission
             FROM (
               SELECT


### PR DESCRIPTION
Hi @emord,

I fixed a problem with the first submission date for inactive AWW's, it occurs because we take into consideration only the forms between the last sync and now. I changed this and now to calculate both dates we get all the forms, but only for AWC's which sent new forms.
Also, I added a management command to recalculate the whole table.

CASE: http://manage.dimagi.com/default.asp?276618#1512071

Please let me know if you have any questions.

Regards,
Łukasz