### PR TITLE
Ability to search CommCare data by de-activated users.

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -259,7 +259,12 @@ class MobileWorkersOptionsView(EmwfOptionsView):
         ]
 
     def user_es_query(self, query):
-        query = super(MobileWorkersOptionsView, self).user_es_query(query)
+        # Do not include inactive users in this query.
+        search_fields = ["first_name", "last_name", "base_username"]
+        query = (UserES()
+                 .domain(self.domain)
+                 .search_string_query(query, default_fields=search_fields))
+
         return query.mobile_users()
 
 

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -159,6 +159,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
     def user_es_query(self, query):
         search_fields = ["first_name", "last_name", "base_username"]
         return (UserES()
+                .show_inactive()
                 .domain(self.domain)
                 .search_string_query(query, default_fields=search_fields))
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -334,7 +334,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         if HQUserType.DEMO_USER in user_types:
             user_type_filters.append(user_es.demo_users())
 
-        q = user_es.UserES().domain(domain)
+        q = user_es.UserES().show_inactive().domain(domain)
         if not request_user.has_permission(domain, 'access_all_locations'):
             cls._verify_users_are_accessible(domain, request_user, user_ids)
             return q.OR(


### PR DESCRIPTION
Include deactivated users in the emwf, which should show up in:
1. Submit History Search
2. Case List Search
3. Download Case Export
4. Download Form Export

(All that same info is here: https://trello.com/c/0IyuFW37/53-ability-to-search-commcare-data-by-de-activated-users)


I tested this out manually and it seemed to do it, but am unsure if it would affect more parts of the code than intended.

(Can review commit by commit)