### PR TITLE
Fix case attachment deletion bug

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -18,7 +18,6 @@ from casexml.apps.case.xml import V2
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.blobs import get_blob_db
 from corehq.blobs.tests.util import TemporaryS3BlobDB
-from corehq.form_processor.exceptions import AttachmentNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
@@ -218,8 +217,6 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         if getattr(settings, 'TESTS_SHOULD_USE_SQL_BACKEND', False):
             self.assertEqual(case.case_attachments, {})
-            with self.assertRaises(AttachmentNotFound):
-                attachment_sql.read_content()
         else:
             attach_actions = [x for x in case.actions if x['action_type'] == 'attachment']
             self.assertEqual(2, len(attach_actions))

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -1032,8 +1032,6 @@ class CaseAccessorSQL(AbstractCaseAccessor):
                     attachment.save()
 
                 CaseAttachmentSQL.objects.using(case.db).filter(id__in=attachment_ids_to_delete).delete()
-                for attachment in case.get_tracked_models_to_delete(CaseAttachmentSQL):
-                    attachment.delete_content()
 
                 case.clear_tracked_models()
         except InternalError as e:


### PR DESCRIPTION
Discovered while working on blob metadata refactor.

Case attachments reference form attachments, and therefore are not sole the owner of the attachment content (blob). The form is the primary owner, and attachment content should not be deleted when a case attachment is deleted unless the form attachment is also being deleted.

@snopoke @orangejenny 