### PR TITLE
Revert "Ability to search CommCare data by de-activated users."

### DIFF
--- a/corehq/apps/callcenter/views.py
+++ b/corehq/apps/callcenter/views.py
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.es import UserES
 from corehq.apps.reports.filters.api import EmwfOptionsView
 from corehq.apps.reports.util import _report_user_dict
 from corehq.apps.users.cases import get_wrapped_owner
@@ -70,13 +69,8 @@ class CallCenterOwnerOptionsView(EmwfOptionsView):
         ]
 
     def user_es_query(self, query):
-        # Do not include inactive users in this query.
-        search_fields = ["first_name", "last_name", "base_username"]
-        query = (UserES()
-                 .domain(self.domain)
-                 .search_string_query(query, default_fields=search_fields))
-
-        return query.mobile_users()
+        q = super(CallCenterOwnerOptionsView, self).user_es_query(query)
+        return q.mobile_users()
 
     @staticmethod
     def convert_owner_id_to_select_choice(owner_id, domain):

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -159,7 +159,6 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
     def user_es_query(self, query):
         search_fields = ["first_name", "last_name", "base_username"]
         return (UserES()
-                .show_inactive()
                 .domain(self.domain)
                 .search_string_query(query, default_fields=search_fields))
 
@@ -259,12 +258,7 @@ class MobileWorkersOptionsView(EmwfOptionsView):
         ]
 
     def user_es_query(self, query):
-        # Do not include inactive users in this query.
-        search_fields = ["first_name", "last_name", "base_username"]
-        query = (UserES()
-                 .domain(self.domain)
-                 .search_string_query(query, default_fields=search_fields))
-
+        query = super(MobileWorkersOptionsView, self).user_es_query(query)
         return query.mobile_users()
 
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -334,7 +334,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         if HQUserType.DEMO_USER in user_types:
             user_type_filters.append(user_es.demo_users())
 
-        q = user_es.UserES().show_inactive().domain(domain)
+        q = user_es.UserES().domain(domain)
         if not request_user.has_permission(domain, 'access_all_locations'):
             cls._verify_users_are_accessible(domain, request_user, user_ids)
             return q.OR(


### PR DESCRIPTION
Dev added another item to this task (it should be clear that the user is deactivated when they appear in the dropdown), so I'll revert this until that's in.

Going to go ahead and revert it, just tagged you guys in this so you're aware.