### PR TITLE
Allow restarting messaging rules if they are stuck

### DIFF
--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -17,6 +17,7 @@
 {% block page_content %}
     {% registerurl 'conditional_alert_list' domain %}
     {% registerurl 'edit_conditional_alert' domain '---' %}
+    {% initial_page_data 'limit_rule_restarts' limit_rule_restarts %}
 
     <div class="btn-group">
         <a href="{% url 'create_conditional_alert' domain %}" class="btn btn-success">

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -581,7 +581,7 @@ class ConditionalAlertListView(BaseMessagingSectionView, DataTablesAJAXPaginatio
         # that is a standalone environment.
         return not (
             self.request.couch_user.is_superuser or
-            settings.SERVER_ENVIRONMENT in ('echis', 'pna', 'swiss')
+            settings.SERVER_ENVIRONMENT in settings.UNLIMITED_RULE_RESTART_ENVS
         )
 
     @property

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -16,10 +16,6 @@ class MessagingRuleProgressHelper(object):
         return 48 * 60 * 60
 
     @property
-    def in_progress_key(self):
-        return 'messaging-rule-processing-in-progress-%s' % self.rule_id
-
-    @property
     def current_key(self):
         return 'messaging-rule-case-count-current-%s' % self.rule_id
 
@@ -27,16 +23,31 @@ class MessagingRuleProgressHelper(object):
     def total_key(self):
         return 'messaging-rule-case-count-total-%s' % self.rule_id
 
+    @property
+    def rule_initiation_key(self):
+        return 'messaging-rule-run-initiated-%s' % self.rule_id
+
+    def set_rule_initiation_key(self):
+        self.client.set(self.rule_initiation_key, 1, timeout=2 * 60 * 60)
+
+    def clear_rule_initiation_key(self):
+        self.client.delete(self.rule_initiation_key)
+
+    def rule_initiation_key_is_set(self):
+        return self.client.get(self.rule_initiation_key) is not None
+
+    def rule_initiation_key_minutes_remaining(self):
+        return (self.client.ttl(self.rule_initiation_key) // 60) or 1
+
     def set_initial_progress(self):
         self.client.set(self.current_key, 0)
         self.client.set(self.total_key, 0)
-        self.client.set(self.in_progress_key, 1)
         self.client.expire(self.current_key, self.key_expiry)
         self.client.expire(self.total_key, self.key_expiry)
-        self.client.expire(self.in_progress_key, self.key_expiry)
+        self.set_rule_initiation_key()
 
     def set_rule_complete(self):
-        self.client.set(self.in_progress_key, 0)
+        self.clear_rule_initiation_key()
 
     def increment_current_case_count(self, fail_hard=False):
         try:

--- a/settings.py
+++ b/settings.py
@@ -495,6 +495,7 @@ EMAIL_SUBJECT_PREFIX = '[commcarehq] '
 
 SERVER_ENVIRONMENT = 'localdev'
 ICDS_ENVS = ('icds', 'icds-new')
+UNLIMITED_RULE_RESTART_ENVS = ('echis', 'pna', 'swiss')
 
 # minimum minutes between updates to user reporting metadata
 USER_REPORTING_METADATA_UPDATE_FREQUENCY = 15


### PR DESCRIPTION
For the new reminders framework, if a rule gets stuck because the rule running task encountered unexpected errors, this allows restarting the rule.

@millerdev @gbova 