### PR TITLE
Notify on feature flag changes

### DIFF
--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -192,7 +192,7 @@ class ToggleEditView(ToggleBaseView):
                 _clear_caches_for_dynamic_toggle(self.toggle_meta())
 
         elif save_randomness:
-            messages.error(request, _("The randomness value {} must be between 0 and 1".format(randomness)))
+            messages.error(request, "The randomness value {} must be between 0 and 1".format(randomness))
 
         toggle.save()
         self._notify_on_change(currently_enabled - previously_enabled)

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -9,7 +9,6 @@ from django.contrib import messages
 from django.urls import reverse
 from django.http.response import Http404, HttpResponse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster, \
     toggle_js_user_cachebuster
 from couchforms.analytics import get_last_form_submission_received
@@ -19,8 +18,16 @@ from corehq.apps.toggle_ui.utils import find_static_toggle
 from corehq.apps.users.models import CouchUser
 from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.toggles import (
-    ALL_NAMESPACES, ALL_TAGS, NAMESPACE_USER, NAMESPACE_DOMAIN, TAG_DEPRECATED,
-    DynamicallyPredictablyRandomToggle, PredictablyRandomToggle, all_toggles,
+    ALL_NAMESPACES,
+    ALL_TAGS,
+    NAMESPACE_USER,
+    NAMESPACE_DOMAIN,
+    TAG_CUSTOM,
+    TAG_DEPRECATED,
+    TAG_INTERNAL,
+    DynamicallyPredictablyRandomToggle,
+    PredictablyRandomToggle,
+    all_toggles,
 )
 from corehq.util.soft_assert import soft_assert
 from toggle.models import Toggle
@@ -208,7 +215,7 @@ class ToggleEditView(ToggleBaseView):
         return HttpResponse(json.dumps(data), content_type="application/json")
 
     def _notify_on_change(self, added_entries):
-        is_deprecated_toggle = (self.static_toggle.tag == TAG_DEPRECATED)
+        is_deprecated_toggle = (self.static_toggle.tag in (TAG_DEPRECATED, TAG_CUSTOM, TAG_INTERNAL))
         if added_entries and (self.static_toggle.notification_emails or is_deprecated_toggle):
             subject = "User {} added {} on {} in environment {}".format(
                 self.request.user.username, self.static_toggle.slug,

--- a/corehq/ex-submodules/toggle/models.py
+++ b/corehq/ex-submodules/toggle/models.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import (
+    Document, DateTimeProperty, ListProperty, StringProperty
+)
 
 
 TOGGLE_ID_PREFIX = 'hqFeatureToggle'

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -62,7 +62,8 @@ class StaticToggle(object):
     def __init__(self, slug, label, tag, namespaces=None, help_link=None,
                  description=None, save_fn=None, always_enabled=None,
                  always_disabled=None, enabled_for_new_domains_after=None,
-                 enabled_for_new_users_after=None, relevant_environments=None):
+                 enabled_for_new_users_after=None, relevant_environments=None,
+                 notification_emails=None):
         self.slug = slug
         self.label = label
         self.tag = tag
@@ -82,6 +83,7 @@ class StaticToggle(object):
             self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
         else:
             self.namespaces = [None]
+        self.notification_emails = notification_emails
 
     def enabled(self, item, namespace=Ellipsis):
         if self.relevant_environments and not (

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -548,6 +548,7 @@ USER_CONFIGURABLE_REPORTS = StaticToggle(
         "A feature which will allow your domain to create User Configurable Reports."
     ),
     help_link='https://confluence.dimagi.com/display/RD/User+Configurable+Reporting',
+    notification_emails=['jemord']
 )
 
 EXPORT_NO_SORT = StaticToggle(


### PR DESCRIPTION
@esoergel @orangejenny we talked about this last week. This notifies the team on any deprecated flag changes and you can also specify yourself on any you want to track yourself.

Also considered a thank you email for removed entries. maybe some positive reinforcement would be good?