### PR TITLE
Migrate Pillow Error Details page

### DIFF
--- a/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/single.js
+++ b/corehq/apps/hqpillow_retry/static/hqpillow_retry/js/single.js
@@ -1,4 +1,4 @@
-hqDefine("hqpillow_retry/js/single", function() {
+hqDefine("hqpillow_retry/js/single", ['jquery'], function($) {
     function performAction(action) {
         if (action === 'delete') {
             var r=confirm("Are you sure you want to delete this error log?");

--- a/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
+++ b/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
@@ -3,9 +3,7 @@
 {% load hq_shared_tags %}
 {% load compress %}
 
-{% block js %}{{ block.super }}
-    <script src="{% static "hqpillow_retry/js/single.js" %}"></script>
-{% endblock %}
+{% requirejs_main 'hqpillow_retry/js/single' %}
 
 {% block page_content %}
     <div class="row">


### PR DESCRIPTION
The other hqpillow_retry js file is used by reports, can't be migrated until reports are done.

@millerdev / @emord 