### PR TITLE
change default for missing sort

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -565,13 +565,18 @@ class ElasticAPIQuerySet(object):
         for field in fields:
             if not field:
                 continue
-            
+
             direction = 'asc'
+            missing_dir = '_first'
             if field[0] == '-':
                 direction = 'desc'
+                missing_dir = '_last'
                 field = field[1:]
 
-            new_payload['sort'].append({field: direction})
+            new_payload['sort'].append({field: {
+                'order': direction,
+                "missing": missing_dir
+            }})
 
         return self.with_fields(payload=new_payload)
 

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -357,11 +357,11 @@ class TestXFormInstanceResource(APIResourceTest):
         # Runs *2* queries
         response = self._assert_auth_get_resource('%s?order_by=received_on' % self.list_endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(queries[0]['sort'], [{'received_on': 'asc'}])
+        self.assertEqual(queries[0]['sort'], [{'received_on': {'missing': '_first', 'order': 'asc'}}])
         # Runs *2* queries
         response = self._assert_auth_get_resource('%s?order_by=-received_on' % self.list_endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(queries[2]['sort'], [{'received_on': 'desc'}])
+        self.assertEqual(queries[2]['sort'], [{'received_on': {'missing': '_last', 'order': 'desc'}}])
 
     def test_get_list_archived(self):
         expected = [
@@ -1032,19 +1032,21 @@ class TestElasticAPIQuerySet(TestCase):
         es = FakeXFormES()
         for i in range(0, 1300):
             es.add_doc(i, {'i': i})
-        
+
         queryset = ElasticAPIQuerySet(es_client=es, payload={})
-        qs_asc = list(queryset.order_by('foo'))
-        self.assertEqual(es.queries[0]['sort'], [{'foo': 'asc'}])
+        list(queryset.order_by('foo'))
+        asc_ = {'missing': '_first', 'order': 'asc'}
+        desc_ = {'missing': '_last', 'order': 'desc'}
+        self.assertEqual(es.queries[0]['sort'], [{'foo': asc_}])
 
-        qs_desc = list(queryset.order_by('-foo'))
-        self.assertEqual(es.queries[1]['sort'], [{'foo': 'desc'}])
+        list(queryset.order_by('-foo'))
+        self.assertEqual(es.queries[1]['sort'], [{'foo': desc_}])
 
-        qs_overwrite = list(queryset.order_by('bizzle').order_by('-baz'))
-        self.assertEqual(es.queries[2]['sort'], [{'baz': 'desc'}])
+        list(queryset.order_by('bizzle').order_by('-baz'))
+        self.assertEqual(es.queries[2]['sort'], [{'baz': desc_}])
 
-        qs_multi = list(queryset.order_by('one', '-two', 'three'))
-        self.assertEqual(es.queries[3]['sort'], [{'one': 'asc'}, {'two': 'desc'}, {'three': 'asc'}])
+        list(queryset.order_by('one', '-two', 'three'))
+        self.assertEqual(es.queries[3]['sort'], [{'one': asc_}, {'two': desc_}, {'three': asc_}])
 
 
 class ToManySourceModel(object):


### PR DESCRIPTION
Sort missing values first when sorting in ascending order and last
when sorting in descending order.

ES default is to always sort them last.

This is to fix an issue with the Data Export Tool and legacy data that does not have a server_modified_on field. An alternative fix would be to reindex form data.

Marking this as `product/invisible` since it shouldn't have any impact on normal API users.