### PR TITLE
Update requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -18,5 +18,6 @@ transifex-client==0.12.4
 modernize==0.6
 Fabric==1.14.0
 readline==6.2.4.1
+pip-tools==2.0.2
 
 --requirement=test-requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ cython==0.27.3
 restkit==4.2.2
 iso8601==0.1.11
 jsonobject==0.9.1
-jsonobject-couchdbkit==0.9.1
+jsonobject-couchdbkit==0.9.2
 celery==3.1.18
 # required by django-digest
 decorator==4.0.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ jinja2==2.8
 jmespath==0.9.3           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.1
+jsonobject-couchdbkit==0.9.2
 jsonobject==0.9.1
 jsonpath-rw==1.4.0
 kafka-python==0.9.5


### PR DESCRIPTION
- Point to the latest jsobject-couchdbkit
- Include pip-tools in dev-requirements (which includes pip-compile, which is used to generate the docs)