### PR TITLE
catch HTTPError, not Unauthorized

### DIFF
--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -9,12 +9,7 @@ from collections import defaultdict, namedtuple
 import requests
 from django.conf import settings
 from django.http import (
-    HttpResponseRedirect,
     HttpResponse,
-    HttpResponseBadRequest,
-    HttpResponseNotFound,
-    JsonResponse,
-    StreamingHttpResponse,
 )
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
@@ -23,14 +18,10 @@ from django.views.decorators.http import require_POST
 from restkit.errors import Unauthorized
 
 from corehq.apps.domain.decorators import (
-    require_superuser, require_superuser_or_contractor,
-    login_or_basic, domain_admin_required,
-    check_lockout)
+    require_superuser, require_superuser_or_contractor)
 from corehq.apps.hqadmin.service_checks import run_checks
 from corehq.apps.hqwebapp.decorators import use_datatables, use_jquery_ui, \
     use_nvd3_v3
-from corehq.form_processor.serializers import XFormInstanceSQLRawDocSerializer, \
-    CommCareCaseSQLRawDocSerializer
 from corehq.toggles import any_toggle_enabled, SUPPORT
 from corehq.util.supervisord.api import (
     PillowtopSupervisorApi,
@@ -44,10 +35,6 @@ from dimagi.utils.web import json_response
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.utils import get_all_pillows_json, get_pillow_json, get_pillow_config_by_name
 from corehq.apps.hqadmin import service_checks, escheck
-from corehq.apps.hqadmin.forms import (
-    AuthenticateAsForm, BrokenBuildsForm, EmailForm, SuperuserManagementForm,
-    ReprocessMessagingCaseUpdatesForm,
-    DisableTwoFactorForm, DisableUserForm)
 from corehq.apps.hqadmin.history import get_recent_changes, download_changes
 from corehq.apps.hqadmin.models import HqDeploy
 from corehq.apps.hqadmin.utils import get_celery_stats


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/605989965/?environment=__all_environments__

```active_tasks()``` already raises an ```HTTPError```, not ```Unauthorized```