### PR TITLE
Remove unnecessary caching

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -304,12 +304,6 @@ def _queue_indicators(indicators):
         _queue_chunk(to_queue)
 
 
-@quickcache(['config_id'])
-def _get_config(config_id):
-    # performance optimization for save_document. don't use elsewhere
-    return _get_config_by_id(config_id)
-
-
 @task(queue=UCR_INDICATOR_CELERY_QUEUE, ignore_result=True, acks_late=True)
 def save_document(doc_ids):
     lock_keys = []
@@ -379,7 +373,7 @@ def _save_document_helper(indicator, doc):
     configs = dict()
     for config_id in indicator.indicator_config_ids:
         try:
-            configs[config_id] = _get_config(config_id)
+            configs[config_id] = _get_config_by_id(config_id)
         except (ResourceNotFound, StaticDataSourceConfigurationNotFoundError):
             celery_task_logger.info("{} no longer exists, skipping".format(config_id))
             configs_to_remove.append(config_id)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -445,7 +445,7 @@ class AsyncIndicatorTest(TestCase):
             self.assertEqual(errors.count(), 0)
             self.assertEqual(indicators.count(), 0)
 
-    @patch('corehq.apps.userreports.tasks._get_config')
+    @patch('corehq.apps.userreports.tasks._get_config_by_id')
     def test_async_save_fails(self, config):
         # process_changes will generate an exception when trying to use this config
         config.return_value = None


### PR DESCRIPTION
I think when I was first implementing this I was also thinking about non-static data sources needing to be cached, but that never really happened. Since static data sources are stored in memory once they're loaded, I'm pretty sure this will only slow things down.