### PR TITLE
Ce/deleted app

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -13,6 +13,7 @@ import yaml
 from django.urls import reverse
 from couchdbkit.exceptions import DocTypeError
 from django.core.cache import cache
+from django.http import Http404
 from django.utils.translation import ugettext as _
 
 from corehq import toggles
@@ -663,7 +664,10 @@ def get_form_source_download_url(xform):
     if not xform.build_id:
         return None
 
-    app = get_app(xform.domain, xform.build_id)
+    try:
+        app = get_app(xform.domain, xform.build_id)
+    except Http404:
+        return None
     if app.is_remote_app():
         return None
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -1,17 +1,23 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from collections import namedtuple, OrderedDict
-from copy import deepcopy, copy
-from couchdbkit import ResourceNotFound
+
 import json
 import os
 import uuid
 import re
 import logging
-
 import yaml
-from django.urls import reverse
+import six
+from collections import namedtuple, OrderedDict
+from copy import deepcopy, copy
+from io import open
+
+
+from couchdbkit import ResourceNotFound
 from couchdbkit.exceptions import DocTypeError
+from memoized import memoized
+
+from django.urls import reverse
 from django.core.cache import cache
 from django.http import Http404
 from django.utils.translation import ugettext as _
@@ -35,10 +41,7 @@ from corehq.apps.app_manager.xform import XForm, XFormException, parse_xml
 from corehq.apps.users.models import CommCareUser
 from corehq.util.quickcache import quickcache
 from dimagi.utils.couch import CriticalSection
-from memoized import memoized
 from dimagi.utils.make_uuid import random_hex
-import six
-from io import open
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?280226#1514502

Handling of deleted apps stopped working when we switched to using `get_app`. This catches that case, and a few other places where `get_app` throws a 404 and allows the function to continue. The first commit is the actual change, the second one is an attempt to clean up imports.

@proteusvacuum @snopoke @orangejenny 