### PR TITLE
Simplify FIXTURE_GENERATORS

### DIFF
--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -10,8 +10,8 @@ from corehq.apps.cloudcare.views import (
     FormplayerPreviewSingleApp,
     PreviewAppView,
     LoginAsUsers,
-    form_context, get_cases,
-    get_fixtures, default,
+    form_context,
+    default,
 )
 
 app_urls = [
@@ -29,9 +29,6 @@ app_urls = [
 
 api_urls = [
     url(r'^login_as/users/$', LoginAsUsers.as_view(), name=LoginAsUsers.urlname),
-    url(r'^cases/$', get_cases, name='cloudcare_get_cases'),
-    url(r'^fixtures/(?P<user_id>[\w-]+)/(?P<fixture_id>[:\w-]+)$', get_fixtures,
-        name='cloudcare_get_fixtures'),
     url(r'^readable_questions/$', ReadableQuestions.as_view(), name=ReadableQuestions.urlname),
 ]
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -388,68 +388,6 @@ def form_context(request, domain, app_id, module_id, form_id):
 cloudcare_api = login_or_digest_ex(allow_cc_users=True)
 
 
-@cloudcare_api
-def get_cases(request, domain):
-    request_params = request.GET
-
-    if request.couch_user.is_commcare_user():
-        user_id = request.couch_user.get_id
-    else:
-        user_id = request_params.get("user_id", "")
-
-    if not user_id and not request.couch_user.is_web_user():
-        return HttpResponseBadRequest("Must specify user_id!")
-
-    ids_only = string_to_boolean(request_params.get("ids_only", "false"))
-    case_id = request_params.get("case_id", "")
-    footprint = string_to_boolean(request_params.get("footprint", "false"))
-    accessor = CaseAccessors(domain)
-
-    if case_id and not footprint:
-        # short circuit everything else and just return the case
-        # NOTE: this allows any user in the domain to access any case given
-        # they know its ID, which is slightly different from the previous
-        # behavior (can only access things you own + footprint). If we want to
-        # change this contract we would need to update this to check the
-        # owned case list + footprint
-        case = accessor.get_case(case_id)
-        assert case.domain == domain
-        cases = [CaseAPIResult(domain=domain, id=case_id, couch_doc=case, id_only=ids_only)]
-    else:
-        filters = get_filters_from_request_params(request_params)
-        status = api_closed_to_status(request_params.get('closed', 'false'))
-        case_type = filters.get('properties/case_type', None)
-        cases = get_filtered_cases(domain, status=status, case_type=case_type,
-                                   user_id=user_id, filters=filters,
-                                   footprint=footprint, ids_only=ids_only,
-                                   strip_history=True)
-    return json_response(cases)
-
-
-@cloudcare_api
-@cache_page(60 * 30)
-def get_fixtures(request, domain, user_id, fixture_id):
-    try:
-        user = CommCareUser.get_by_user_id(user_id)
-    except CouchUser.AccountTypeError:
-        err = ("You can't use case sharing or fixtures as a %s. "
-               "Login as a mobile worker and try again.") % settings.WEB_USER_TERM,
-        return HttpResponse(err, status=412, content_type="text/plain")
-
-    if not user:
-        raise Http404
-
-    assert user.is_member_of(domain)
-    restore_user = user.to_ota_restore_user()
-    fixture = generator.get_fixture_by_id(fixture_id, restore_user)
-    if not fixture:
-        raise Http404
-    assert len(fixture.getchildren()) == 1, 'fixture {} expected 1 child but found {}'.format(
-        fixture_id, len(fixture.getchildren())
-    )
-    return HttpResponse(ElementTree.tostring(fixture.getchildren()[0]), content_type="text/xml")
-
-
 class ReadableQuestions(View):
 
     urlname = 'readable_questions'

--- a/corehq/ex-submodules/casexml/apps/phone/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/fixtures.py
@@ -62,45 +62,7 @@ class FixtureGenerator(object):
         if not isinstance(user, OTARestoreUser):
             return []
 
-        if fixture_id:
-            full_id = fixture_id
-            prefix = fixture_id.split(':', 1)[0]
-
-            def provider_matches(provider):
-                # some providers generate fixtures with dynamic ID's e.g. item-list:my-item-list
-                # in which case provider.id is just the prefix.
-                return provider.id == full_id or provider.id == prefix
-
-            providers = [provider for provider in self._generator_providers if provider_matches(provider)]
-        else:
-            providers = self._generator_providers
-
-        return providers
-
-    def _get_fixtures(self, restore_user, fixture_id=None):
-        providers = self.get_providers(restore_user, fixture_id=fixture_id)
-        restore_state = _get_restore_state(restore_user)
-        return itertools.chain(*[
-            provider(restore_state)
-            for provider in providers
-        ])
-
-    def get_fixture_by_id(self, fixture_id, restore_user):
-        """
-        Only get fixtures with the specified ID.
-        """
-        fixtures = self._get_fixtures(restore_user, fixture_id)
-        for fixture in fixtures:
-            if isinstance(fixture, six.binary_type):
-                # could be bytes if it's coming from cache
-                cached_fixtures = ElementTree.fromstring(
-                    b"<cached-fixture>%s</cached-fixture>" % fixture
-                )
-                for fixture in cached_fixtures:
-                    if fixture.attrib.get("id") == fixture_id:
-                        return fixture
-            elif fixture.attrib.get("id") == fixture_id:
-                return fixture
+        return self._generator_providers
 
 
 generator = FixtureGenerator()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -77,22 +77,6 @@ class OtaFixtureTest(TestCase):
                 expected = _get_item_list_fixture(self.user.get_id, data_type.tag, data_item)
                 check_xml_line_by_line(self, expected, item_list_xml[0])
 
-    def test_fixtures_by_id(self):
-        fixture_xml = generator.get_fixture_by_id('user-groups', self.restore_user)
-        self._check_fixture([fixture_xml])
-
-        fixture_xml = generator.get_fixture_by_id('item-list:sa_provinces', self.restore_user)
-        self._check_fixture([fixture_xml], has_groups=False, item_lists=[SA_PROVINCES])
-
-        fixture_xml = generator.get_fixture_by_id('item-list:fr_provinces', self.restore_user)
-        self._check_fixture([fixture_xml], has_groups=False, item_lists=[FR_PROVINCES])
-
-        fixture_xml = generator.get_fixture_by_id('user-locations', self.restore_user)
-        self.assertIsNone(fixture_xml)
-
-        fixture_xml = generator.get_fixture_by_id('bad ID', self.restore_user)
-        self.assertIsNone(fixture_xml)
-
 
 @use_sql_backend
 class OtaFixtureTestSQL(OtaFixtureTest):

--- a/settings.py
+++ b/settings.py
@@ -512,30 +512,21 @@ PAGINATOR_OBJECTS_PER_PAGE = 15
 PAGINATOR_MAX_PAGE_LINKS = 5
 
 # OTA restore fixture generators
-FIXTURE_GENERATORS = {
-    # fixtures that may be sent to the phone independent of cases
-    'standalone': [
-        # core
-        "corehq.apps.users.fixturegenerators.user_groups",
-        "corehq.apps.fixtures.fixturegenerators.item_lists",
-        "corehq.apps.callcenter.fixturegenerators.indicators_fixture_generator",
-        "corehq.apps.products.fixtures.product_fixture_generator",
-        "corehq.apps.programs.fixtures.program_fixture_generator",
-        "corehq.apps.app_manager.fixtures.report_fixture_generator",
-        "corehq.apps.app_manager.fixtures.report_fixture_v2_generator",
-        "corehq.apps.calendar_fixture.fixture_provider.calendar_fixture_generator",
-        # custom
-        "custom.bihar.reports.indicators.fixtures.generator",
-        "custom.m4change.fixtures.report_fixtures.generator",
-        "custom.m4change.fixtures.location_fixtures.generator",
-
-    ],
-    # fixtures that must be sent along with the phones cases
-    'case': [
-        "corehq.apps.locations.fixtures.location_fixture_generator",
-        "corehq.apps.locations.fixtures.flat_location_fixture_generator",
-    ]
-}
+FIXTURE_GENERATORS = [
+    "corehq.apps.users.fixturegenerators.user_groups",
+    "corehq.apps.fixtures.fixturegenerators.item_lists",
+    "corehq.apps.callcenter.fixturegenerators.indicators_fixture_generator",
+    "corehq.apps.products.fixtures.product_fixture_generator",
+    "corehq.apps.programs.fixtures.program_fixture_generator",
+    "corehq.apps.app_manager.fixtures.report_fixture_generator",
+    "corehq.apps.app_manager.fixtures.report_fixture_v2_generator",
+    "corehq.apps.calendar_fixture.fixture_provider.calendar_fixture_generator",
+    "corehq.apps.locations.fixtures.location_fixture_generator",
+    "corehq.apps.locations.fixtures.flat_location_fixture_generator",
+    "custom.bihar.reports.indicators.fixtures.generator",
+    "custom.m4change.fixtures.report_fixtures.generator",
+    "custom.m4change.fixtures.location_fixtures.generator",
+]
 
 ### Shared drive settings ###
 # Also see section after localsettings import


### PR DESCRIPTION
Changes the dictionary to a list, and assumes that it's always there since it's in `settings.py`

It's possible these groupings made sense before, but I couldn't find anywhere where they were referenced previously.