### PR TITLE
Externalize JS: icds_reports

### DIFF
--- a/custom/icds_reports/reports/__init__.py
+++ b/custom/icds_reports/reports/__init__.py
@@ -13,6 +13,7 @@ from corehq.util.dates import get_first_last_days
 class IcdsBaseReport(CustomProjectReport, ProjectReportParametersMixin, MonthYearMixin, GenericTabularReport):
 
     report_template_path = "icds_reports/multi_report.html"
+    base_template = 'icds_reports/base.html'
     flush_layout = True
     exportable = True
 

--- a/custom/icds_reports/static/icds_reports/js/base.js
+++ b/custom/icds_reports/static/icds_reports/js/base.js
@@ -1,2 +1,14 @@
 hqDefine("icds_reports/js/base", function() {
+    $(function() {
+        $('#fieldset_location_async').on('change', 'select', function(e) {
+            e.stopPropagation();
+            var state = $('select.form-control')[0].selectedIndex;
+            var applyBtn = $('#apply-filters');
+            if (state == 0) {
+                applyBtn.disableButtonNoSpinner();
+            } else {
+                applyBtn.enableButton();
+            }
+        })
+    })
 });

--- a/custom/icds_reports/static/icds_reports/js/base.js
+++ b/custom/icds_reports/static/icds_reports/js/base.js
@@ -1,6 +1,6 @@
 hqDefine("icds_reports/js/base", function() {
     $(function() {
-        $('#fieldset_location_async').on('change', 'select', function(e) {
+        $(document).on('change', '#fieldset_location_async select', function(e) {
             e.stopPropagation();
             var state = $('select.form-control')[0].selectedIndex;
             var applyBtn = $('#apply-filters');
@@ -9,6 +9,6 @@ hqDefine("icds_reports/js/base", function() {
             } else {
                 applyBtn.enableButton();
             }
-        })
-    })
+        });
+    });
 });

--- a/custom/icds_reports/static/icds_reports/js/base.js
+++ b/custom/icds_reports/static/icds_reports/js/base.js
@@ -1,0 +1,2 @@
+hqDefine("icds_reports/js/base", function() {
+});

--- a/custom/icds_reports/templates/icds_reports/base.html
+++ b/custom/icds_reports/templates/icds_reports/base.html
@@ -1,0 +1,6 @@
+{% extends "reports/base_template.html" %}
+{% load hq_shared_tags %}
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'icds_reports/js/base.js' %}"></script>
+{% endblock %}

--- a/custom/icds_reports/templates/icds_reports/multi_report.html
+++ b/custom/icds_reports/templates/icds_reports/multi_report.html
@@ -52,20 +52,3 @@
 {% endblock %}
 {% block posttable %}{% endblock %}
 {% endblock %}
-
-{% block js-inline %} {{ block.super }}
-    <script>
-        $(function() {
-            $('#fieldset_location_async').on('change', 'select', function(e) {
-                e.stopPropagation();
-                var state = $('select.form-control')[0].selectedIndex;
-                var applyBtn = $('#apply-filters');
-                if (state == 0) {
-                    applyBtn.disableButtonNoSpinner();
-                } else {
-                    applyBtn.enableButton();
-                }
-            })
-        })
-    </script>
-{% endblock %}


### PR DESCRIPTION
Couldn't find any references to a `fieldset_location_async` element either in the code or in a couple of MPR/ASR reports on india's `icds-test` domain, but this seem straightforward enough to migrate.

@nickpell / @emord 