### PR TITLE
[UP-NRHM] disable default ordering in datatables

### DIFF
--- a/custom/up_nrhm/reports/asha_reports.py
+++ b/custom/up_nrhm/reports/asha_reports.py
@@ -36,6 +36,7 @@ class ASHAReports(GenericTabularReport, NRHMDatespanMixin, CustomProjectReport, 
     show_all_rows = True
     default_rows = 20
     printable = True
+    sortable = False
     report_template_path = "up_nrhm/asha_report.html"
     extra_context_providers = [total_rows]
     no_value = '--'


### PR DESCRIPTION
Hi,

I disabled default ordering for datatables in UP-NRHM reports.
CASE: http://manage.dimagi.com/default.asp?280016

Please let me know if you have any questions.

Regards,
Łukasz