### PR TITLE
Put a wall in front of messaging pages

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1063,6 +1063,11 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         required=False,
         min_value=1000,
     )
+    granted_messaging_access = forms.BooleanField(
+        label="Enable Messaging",
+        required=False,
+        help_text="Check this box to enable messaging.",  # TODO through non-test gateways
+    )
 
     def __init__(self, domain, can_edit_eula, *args, **kwargs):
         super(DomainInternalForm, self).__init__(*args, **kwargs)
@@ -1133,6 +1138,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
                     crispy.Field('auto_case_update_limit'),
                     data_bind="visible: use_custom_auto_case_update_limit() === 'Y'",
                 ),
+                'granted_messaging_access',
             ),
             crispy.Fieldset(
                 _("Salesforce Details"),
@@ -1208,6 +1214,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         )
         domain.is_test = self.cleaned_data['is_test']
         domain.auto_case_update_limit = self.cleaned_data['auto_case_update_limit']
+        domain.granted_messaging_access = self.cleaned_data['granted_messaging_access']
         domain.update_internal(
             sf_contract_id=self.cleaned_data['sf_contract_id'],
             sf_account_id=self.cleaned_data['sf_account_id'],

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -709,6 +709,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
             new_domain.creating_user = user.username if user else None
             new_domain.date_created = datetime.utcnow()
             new_domain.use_sql_backend = True
+            new_domain.granted_messaging_access = False
 
             for field in self._dirty_fields:
                 if hasattr(new_domain, field):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -321,6 +321,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     enable_registration_welcome_sms_for_mobile_worker = BooleanProperty(default=False)
     sms_survey_date_format = StringProperty()
 
+    granted_messaging_access = BooleanProperty(default=False)
+
     # Allowed outbound SMS per day
     # If this is None, then the default is applied. See get_daily_outbound_sms_limit()
     custom_daily_outbound_sms_limit = IntegerProperty()
@@ -420,6 +422,10 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         # remove this after everything's hunky-dory in production.  2015-03-06
         if 'location_types' in data:
             data['obsolete_location_types'] = data.pop('location_types')
+
+        if 'granted_messaging_access' not in data:
+            # enable messaging for domains created before this flag was added
+            data['granted_messaging_access'] = True
 
         self = super(Domain, cls).wrap(data)
         if self.deployment is None:

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2254,6 +2254,7 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
             'is_test': self.domain_object.is_test,
             'use_custom_auto_case_update_limit': 'Y' if self.domain_object.auto_case_update_limit else 'N',
             'auto_case_update_limit': self.domain_object.auto_case_update_limit,
+            'granted_messaging_access': self.domain_object.granted_messaging_access,
         }
         internal_attrs = [
             'sf_contract_id',

--- a/corehq/apps/sms/templates/sms/wall.html
+++ b/corehq/apps/sms/templates/sms/wall.html
@@ -6,9 +6,8 @@
     <p>
     {% blocktrans with next_plan.name as p_name%}
         To enable messaging features, please request access by sending an email
-        to <a href="mailto:sales@dimagi.com">sales@dimagi.com</a> from an email
-        address within your organization that contains the following
-        information:
+        to <a href="mailto:sales@dimagi.com">sales@dimagi.com</a> from your work
+        email address containing the following information:
     {% endblocktrans %}
     </p>
     <ul>

--- a/corehq/apps/sms/templates/sms/wall.html
+++ b/corehq/apps/sms/templates/sms/wall.html
@@ -1,0 +1,18 @@
+{% extends 'hqwebapp/base_section.html' %}
+{% load i18n %}
+
+{% block page_content %}
+    <h2>{% trans "Request Access to Messaging Features" %}</h2>
+    <p>
+    {% blocktrans with next_plan.name as p_name%}
+        To enable messaging features, please request access by sending an email
+        to <a href="mailto:sales@dimagi.com">sales@dimagi.com</a> from an email
+        address within your organization that contains the following
+        information:
+    {% endblocktrans %}
+    </p>
+    <ul>
+        <li>{% trans 'Your full name' %}</li>
+        <li>{% trans 'The organization you work for' %}</li>
+    </ul>
+{% endblock %}

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -139,8 +139,10 @@ class BaseMessagingSectionView(BaseDomainView):
 
     @method_decorator(require_privilege_but_override_for_migrator(privileges.OUTBOUND_SMS))
     @method_decorator(require_permission(Permissions.edit_data))
-    def dispatch(self, *args, **kwargs):
-        return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        if not (settings.ENTERPRISE_MODE or self.domain_object.granted_messaging_access):
+            return render(request, "sms/wall.html", self.main_context)
+        return super(BaseMessagingSectionView, self).dispatch(request, *args, **kwargs)
 
     @property
     def section_url(self):


### PR DESCRIPTION
Adds new setting in Project Settings > Internal Data (Dimagi Only) > Project Information

![screenshot 2018-07-25 14 45 58](https://user-images.githubusercontent.com/464726/43221093-cbcb7816-9019-11e8-84cc-6955fdec3071.png)

When this setting is turned off (default for all new domains) the messaging pages display a message as their main content:

![screenshot 2018-07-25 14 47 20](https://user-images.githubusercontent.com/464726/43221150-fcc2719a-9019-11e8-873c-e5ec4973bdfc.png)

@gcapalbo @orangejenny @dimagi/product 