### PR TITLE
Add commands to import and export conditional alerts

### DIFF
--- a/corehq/messaging/management/commands/export_conditional_alerts.py
+++ b/corehq/messaging/management/commands/export_conditional_alerts.py
@@ -55,7 +55,7 @@ class ExtraSchedulingOptions(jsonobject.JsonObject):
 
 class SimpleSMSDailyScheduleWithTime(jsonobject.JsonObject):
     schedule_type = SIMPLE_SMS_DAILY_SCHEDULE_WITH_TIME
-    time = jsonobject.TimeProperty(exact=True)
+    time = jsonobject.TimeProperty()
     message = jsonobject.DictProperty(six.text_type)
     total_iterations = jsonobject.IntegerProperty()
     start_offset = jsonobject.IntegerProperty()

--- a/corehq/messaging/management/commands/export_conditional_alerts.py
+++ b/corehq/messaging/management/commands/export_conditional_alerts.py
@@ -16,6 +16,7 @@ from corehq.messaging.scheduling.models import (
 )
 from corehq.messaging.scheduling.scheduling_partitioned.models import CaseScheduleInstanceMixin
 from django.core.management.base import BaseCommand, CommandError
+from io import open as io_open
 import copy
 import json
 import jsonobject
@@ -68,6 +69,14 @@ class SimpleSMSAlertSchedule(jsonobject.JsonObject):
     schedule_type = SIMPLE_SMS_ALERT_SCHEDULE
     message = jsonobject.DictProperty(six.text_type)
     extra_options = jsonobject.ObjectProperty(ExtraSchedulingOptions)
+
+
+def open_for_json_write(path):
+    # json.dumps returns bytes in python2, but unicode in python3
+    if six.PY2:
+        return open(path, 'wb')
+
+    return io_open(path, 'w', encoding='utf-8')
 
 
 class Command(BaseCommand):
@@ -201,7 +210,7 @@ class Command(BaseCommand):
                 'schedule': json_schedule.to_json(),
             }))
 
-        with open('conditional_alerts_for_%s.txt' % domain, 'wb') as f:
+        with open_for_json_write('conditional_alerts_for_%s.txt' % domain) as f:
             for line in result:
                 f.write(line)
                 f.write('\n')

--- a/corehq/messaging/management/commands/export_conditional_alerts.py
+++ b/corehq/messaging/management/commands/export_conditional_alerts.py
@@ -16,7 +16,7 @@ from corehq.messaging.scheduling.models import (
 )
 from corehq.messaging.scheduling.scheduling_partitioned.models import CaseScheduleInstanceMixin
 from django.core.management.base import BaseCommand, CommandError
-from io import open as io_open
+from io import open
 import copy
 import json
 import jsonobject
@@ -76,7 +76,7 @@ def open_for_json_write(path):
     if six.PY2:
         return open(path, 'wb')
 
-    return io_open(path, 'w', encoding='utf-8')
+    return open(path, 'w', encoding='utf-8')
 
 
 class Command(BaseCommand):

--- a/corehq/messaging/management/commands/export_conditional_alerts.py
+++ b/corehq/messaging/management/commands/export_conditional_alerts.py
@@ -1,0 +1,209 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from corehq.apps.data_interfaces.models import (
+    AutomaticUpdateRule,
+    MatchPropertyDefinition,
+    CreateScheduleInstanceActionDefinition,
+)
+from corehq.messaging.scheduling.models import (
+    Schedule,
+    AlertSchedule,
+    TimedSchedule,
+    TimedEvent,
+    SMSContent,
+)
+from corehq.messaging.scheduling.scheduling_partitioned.models import CaseScheduleInstanceMixin
+from django.core.management.base import BaseCommand, CommandError
+import copy
+import json
+import jsonobject
+import six
+
+
+SIMPLE_SMS_DAILY_SCHEDULE_WITH_TIME = 1
+SIMPLE_SMS_ALERT_SCHEDULE = 2
+
+
+class MatchPropertyCriterion(jsonobject.JsonObject):
+    property_name = jsonobject.StringProperty()
+    property_value = jsonobject.StringProperty()
+    match_type = jsonobject.StringProperty()
+
+
+class SimpleSchedulingRule(jsonobject.JsonObject):
+    name = jsonobject.StringProperty()
+    case_type = jsonobject.StringProperty()
+    criteria = jsonobject.ListProperty(MatchPropertyCriterion)
+    recipients = jsonobject.ListProperty(jsonobject.ListProperty(jsonobject.StringProperty(required=False)))
+    reset_case_property_name = jsonobject.StringProperty()
+    start_date_case_property = jsonobject.StringProperty()
+    specific_start_date = jsonobject.DateProperty()
+    scheduler_module_info = jsonobject.ObjectProperty(CreateScheduleInstanceActionDefinition.SchedulerModuleInfo)
+
+
+class ExtraSchedulingOptions(jsonobject.JsonObject):
+    active = jsonobject.BooleanProperty()
+    include_descendant_locations = jsonobject.BooleanProperty()
+    default_language_code = jsonobject.StringProperty()
+    custom_metadata = jsonobject.DictProperty(six.text_type)
+    use_utc_as_default_timezone = jsonobject.BooleanProperty()
+    user_data_filter = jsonobject.DictProperty(jsonobject.ListProperty(six.text_type))
+    stop_date_case_property_name = jsonobject.StringProperty()
+
+
+class SimpleSMSDailyScheduleWithTime(jsonobject.JsonObject):
+    schedule_type = SIMPLE_SMS_DAILY_SCHEDULE_WITH_TIME
+    time = jsonobject.TimeProperty(exact=True)
+    message = jsonobject.DictProperty(six.text_type)
+    total_iterations = jsonobject.IntegerProperty()
+    start_offset = jsonobject.IntegerProperty()
+    start_day_of_week = jsonobject.IntegerProperty()
+    extra_options = jsonobject.ObjectProperty(ExtraSchedulingOptions)
+    repeat_every = jsonobject.IntegerProperty()
+
+
+class SimpleSMSAlertSchedule(jsonobject.JsonObject):
+    schedule_type = SIMPLE_SMS_ALERT_SCHEDULE
+    message = jsonobject.DictProperty(six.text_type)
+    extra_options = jsonobject.ObjectProperty(ExtraSchedulingOptions)
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+
+    def get_json_rule(self, rule):
+        json_rule = SimpleSchedulingRule(
+            name=rule.name,
+            case_type=rule.case_type,
+        )
+
+        for criterion in rule.memoized_criteria:
+            definition = criterion.definition
+            if not isinstance(definition, MatchPropertyDefinition):
+                raise CommandError(
+                    "Rule %s references currently unsupported criterion definition for export." % rule.pk
+                )
+
+            json_rule.criteria.append(MatchPropertyCriterion(
+                property_name=definition.property_name,
+                property_value=definition.property_value,
+                match_type=definition.match_type,
+            ))
+
+        if len(rule.memoized_actions) != 1:
+            raise CommandError("Expected exactly one action for rule %s" % rule.pk)
+
+        action = rule.memoized_actions[0].definition
+        if not isinstance(action, CreateScheduleInstanceActionDefinition):
+            raise CommandError("Expected CreateScheduleInstanceActionDefinition")
+
+        for recipient_type, recipient_id in action.recipients:
+            if recipient_type not in (
+                CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
+                CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
+                CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
+                CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE,
+                CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
+            ):
+                raise CommandError("Unexpected recipient_type in rule %s" % rule.pk)
+
+        if action.get_scheduler_module_info().enabled:
+            raise CommandError("Expected scheduler module integration to be disabled")
+
+        json_rule.recipients = copy.deepcopy(action.recipients)
+        reset_case_property_name = action.reset_case_property_name
+        start_date_case_property = action.start_date_case_property
+        specific_start_date = action.specific_start_date
+        scheduler_module_info = CreateScheduleInstanceActionDefinition.SchedulerModuleInfo(enabled=False)
+
+        return json_rule
+
+    def get_json_scheduling_options(self, schedule):
+        return ExtraSchedulingOptions(
+            active=schedule.active,
+            include_descendant_locations=schedule.include_descendant_locations,
+            default_language_code=schedule.default_language_code,
+            custom_metadata=copy.deepcopy(schedule.custom_metadata),
+            use_utc_as_default_timezone=schedule.use_utc_as_default_timezone,
+            user_data_filter=copy.deepcopy(schedule.user_data_filter),
+            stop_date_case_property_name=schedule.stop_date_case_property_name,
+        )
+
+    def get_json_timed_schedule(self, schedule):
+        if schedule.ui_type != Schedule.UI_TYPE_DAILY:
+            raise CommandError("Expected simple daily schedule")
+
+        json_schedule = SimpleSMSDailyScheduleWithTime(
+            total_iterations=schedule.total_iterations,
+            start_offset=schedule.start_offset,
+            start_day_of_week=schedule.start_day_of_week,
+            repeat_every=schedule.repeat_every,
+            extra_options=self.get_json_scheduling_options(schedule),
+        )
+
+        event = schedule.memoized_events[0]
+        if not isinstance(event, TimedEvent):
+            raise CommandError("Expected TimedEvent")
+
+        json_schedule.time = event.time
+
+        content = event.content
+        if not isinstance(content, SMSContent):
+            raise CommandError("Expected SMSContent")
+
+        json_schedule.message = copy.deepcopy(content.message)
+
+        return json_schedule
+
+    def get_json_alert_schedule(self, schedule):
+        if schedule.ui_type != Schedule.UI_TYPE_IMMEDIATE:
+            raise CommandError("Expected simple immediate schedule")
+
+        json_schedule = SimpleSMSAlertSchedule(
+            extra_options=self.get_json_scheduling_options(schedule),
+        )
+
+        event = schedule.memoized_events[0]
+        content = event.content
+        if not isinstance(content, SMSContent):
+            raise CommandError("Expected SMSContent")
+
+        json_schedule.message = copy.deepcopy(content.message)
+
+        return json_schedule
+
+    def handle(self, domain, **options):
+        result = []
+        for rule in AutomaticUpdateRule.by_domain(
+            domain,
+            AutomaticUpdateRule.WORKFLOW_SCHEDULING,
+            active_only=False,
+        ):
+            json_rule = self.get_json_rule(rule)
+
+            action = rule.memoized_actions[0].definition
+            if action.schedule.location_type_filter:
+                raise CommandError("Expected location_type_filter to be empty for rule %s" % rule.pk)
+
+            if isinstance(action.schedule, TimedSchedule):
+                json_schedule = self.get_json_timed_schedule(action.schedule)
+            elif isinstance(action.schedule, AlertSchedule):
+                json_schedule = self.get_json_alert_schedule(action.schedule)
+            else:
+                raise CommandError("Unexpected Schedule type for rule %s" % rule.pk)
+
+            result.append(json.dumps({
+                'rule': json_rule.to_json(),
+                'schedule': json_schedule.to_json(),
+            }))
+
+        with open('conditional_alerts_for_%s.txt' % domain, 'wb') as f:
+            for line in result:
+                f.write(line)
+                f.write('\n')
+
+        print("Done")

--- a/corehq/messaging/management/commands/export_conditional_alerts.py
+++ b/corehq/messaging/management/commands/export_conditional_alerts.py
@@ -80,9 +80,13 @@ def open_for_json_write(path):
 
 
 class Command(BaseCommand):
+    help = "Export conditional alerts to file."
 
     def add_arguments(self, parser):
-        parser.add_argument('domain')
+        parser.add_argument(
+            'domain',
+            help="The project space from which to export conditional alerts.",
+        )
 
     def get_json_rule(self, rule):
         json_rule = SimpleSchedulingRule(

--- a/corehq/messaging/management/commands/export_conditional_alerts.py
+++ b/corehq/messaging/management/commands/export_conditional_alerts.py
@@ -115,10 +115,10 @@ class Command(BaseCommand):
             raise CommandError("Expected scheduler module integration to be disabled")
 
         json_rule.recipients = copy.deepcopy(action.recipients)
-        reset_case_property_name = action.reset_case_property_name
-        start_date_case_property = action.start_date_case_property
-        specific_start_date = action.specific_start_date
-        scheduler_module_info = CreateScheduleInstanceActionDefinition.SchedulerModuleInfo(enabled=False)
+        json_rule.reset_case_property_name = action.reset_case_property_name
+        json_rule.start_date_case_property = action.start_date_case_property
+        json_rule.specific_start_date = action.specific_start_date
+        json_rule.scheduler_module_info = CreateScheduleInstanceActionDefinition.SchedulerModuleInfo(enabled=False)
 
         return json_rule
 

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -1,0 +1,115 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from corehq.apps.data_interfaces.models import (
+    AutomaticUpdateRule,
+    MatchPropertyDefinition,
+    CreateScheduleInstanceActionDefinition,
+)
+from corehq.apps.domain.models import Domain
+from corehq.messaging.management.commands.export_conditional_alerts import (
+    SimpleSchedulingRule,
+    SimpleSMSDailyScheduleWithTime,
+    SimpleSMSAlertSchedule,
+    SIMPLE_SMS_DAILY_SCHEDULE_WITH_TIME,
+    SIMPLE_SMS_ALERT_SCHEDULE,
+)
+from corehq.messaging.scheduling.models import (
+    AlertSchedule,
+    TimedSchedule,
+    TimedEvent,
+    SMSContent,
+)
+from corehq.messaging.tasks import initiate_messaging_rule_run
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+import json
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('filename')
+
+    def handle(self, domain, filename, **options):
+        domain_obj = Domain.get_by_name(domain)
+        if domain_obj is None:
+            raise CommandError("Project space '%s' not found" % domain)
+
+        if not domain_obj.uses_new_reminders:
+            raise CommandError("Project space '%s' does not have new reminders enabled" % domain)
+
+        json_rules = []
+        with open(filename, 'rb') as f:
+            for line in f:
+                json_rules.append(json.loads(line))
+
+        print("Importing %s rules..." % len(json_rules))
+
+        rules = []
+        with transaction.atomic():
+            for entry in json_rules:
+                json_rule = SimpleSchedulingRule(entry['rule'])
+
+                schedule_type = entry['schedule']['schedule_type']
+                if schedule_type == SIMPLE_SMS_DAILY_SCHEDULE_WITH_TIME:
+                    json_schedule = SimpleSMSDailyScheduleWithTime(entry['schedule'])
+                    schedule = TimedSchedule.create_simple_daily_schedule(
+                        domain,
+                        TimedEvent(time=json_schedule.time),
+                        SMSContent(message=json_schedule.message),
+                        total_iterations=json_schedule.total_iterations,
+                        start_offset=json_schedule.start_offset,
+                        start_day_of_week=json_schedule.start_day_of_week,
+                        extra_options=json_schedule.extra_options.to_json(),
+                        repeat_every=json_schedule.repeat_every,
+                    )
+                elif schedule_type == SIMPLE_SMS_ALERT_SCHEDULE:
+                    json_schedule = SimpleSMSAlertSchedule(entry['schedule'])
+                    schedule = AlertSchedule.create_simple_alert(
+                        domain,
+                        SMSContent(message=json_schedule.message),
+                        extra_options=json_schedule.extra_options.to_json(),
+                    )
+                else:
+                    raise CommandError("Unexpected schedule_type: %s" % schedule_type)
+
+                rule = AutomaticUpdateRule.objects.create(
+                    domain=domain,
+                    name=json_rule.name,
+                    case_type=json_rule.case_type,
+                    active=True,
+                    filter_on_server_modified=False,
+                    migrated=True,
+                    workflow=AutomaticUpdateRule.WORKFLOW_SCHEDULING,
+                )
+
+                for criterion in json_rule.criteria:
+                    rule.add_criteria(
+                        MatchPropertyDefinition,
+                        property_name=criterion.property_name,
+                        property_value=criterion.property_value,
+                        match_type=criterion.match_type,
+                    )
+
+                rule.add_action(
+                    CreateScheduleInstanceActionDefinition,
+                    alert_schedule_id=schedule.schedule_id if isinstance(schedule, AlertSchedule) else None,
+                    timed_schedule_id=schedule.schedule_id if isinstance(schedule, TimedSchedule) else None,
+                    recipients=json_rule.recipients,
+                    reset_case_property_name=json_rule.reset_case_property_name,
+                    start_date_case_property=json_rule.start_date_case_property,
+                    specific_start_date=json_rule.specific_start_date,
+                    scheduler_module_info=json_rule.scheduler_module_info.to_json(),
+                )
+
+                rules.append(rule)
+
+        print("Import complete. Starting instance refresh tasks...")
+
+        for rule in rules:
+            initiate_messaging_rule_run(rule.domain, rule.pk)
+
+        print("Done.")

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -24,7 +24,18 @@ from corehq.messaging.scheduling.models import (
 from corehq.messaging.tasks import initiate_messaging_rule_run
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from io import open as io_open
 import json
+import six
+
+
+def open_for_json_read(path):
+    # json.dumps returns bytes in python2, but unicode in python3
+    # this function mirrors open_for_json_write in export_conditional_alerts
+    if six.PY2:
+        return open(path, 'rb')
+
+    return io_open(path, 'r', encoding='utf-8')
 
 
 class Command(BaseCommand):
@@ -42,7 +53,7 @@ class Command(BaseCommand):
             raise CommandError("Project space '%s' does not have new reminders enabled" % domain)
 
         json_rules = []
-        with open(filename, 'rb') as f:
+        with open_for_json_read(filename) as f:
             for line in f:
                 json_rules.append(json.loads(line))
 

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -24,7 +24,7 @@ from corehq.messaging.scheduling.models import (
 from corehq.messaging.tasks import initiate_messaging_rule_run
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from io import open as io_open
+from io import open
 import json
 import six
 
@@ -35,7 +35,7 @@ def open_for_json_read(path):
     if six.PY2:
         return open(path, 'rb')
 
-    return io_open(path, 'r', encoding='utf-8')
+    return open(path, 'r', encoding='utf-8')
 
 
 class Command(BaseCommand):

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -39,10 +39,17 @@ def open_for_json_read(path):
 
 
 class Command(BaseCommand):
+    help = "Import conditional alerts from file."
 
     def add_arguments(self, parser):
-        parser.add_argument('domain')
-        parser.add_argument('filename')
+        parser.add_argument(
+            'domain',
+            help="The conditional alerts will be imported into this project space.",
+        )
+        parser.add_argument(
+            'filename',
+            help="The name of the file which holds the exported conditional alerts.",
+        )
 
     def handle(self, domain, filename, **options):
         domain_obj = Domain.get_by_name(domain)


### PR DESCRIPTION
This is to support moving conditional alerts from production to echis, so only the needed use cases are currently supported. If this were to be used for other efforts, these scripts might need to be updated based on the use cases in the alerts to be moved.

@pr33thi @millerdev 