### PR TITLE
fix bug in form export schema with subcases in repeats

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1378,6 +1378,11 @@ class CaseInferredSchema(InferredSchema):
 
 
 class FormInferredSchema(InferredSchema):
+    """This was used during the migratoin from the old models to capture
+    export items that could not be found in the current apps.
+
+    See https://github.com/dimagi/commcare-hq/blob/34a9459462271cf2dcd7562b36cc86e300d343b8/corehq/apps/export/utils.py#L246-L265
+    """
     xmlns = StringProperty(required=True)
     app_id = StringProperty()
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1676,13 +1676,21 @@ class FormExportDataSchema(ExportDataSchema):
         )
 
         schemas = [current_schema, xform_schema]
-        schemas.extend(cls._add_export_items_for_cases(app, xform_schema, forms, xform))
+        repeats = cls._get_repeat_paths(xform, app.langs)
+        schemas.extend(cls._add_export_items_for_cases(xform_schema.group_schemas[0], forms, repeats))
 
         return cls._merge_schemas(*schemas)
 
     @classmethod
-    def _add_export_items_for_cases(cls, app, xform_schema, forms, xform):
-        root_group_schema = xform_schema.group_schemas[0]
+    def _add_export_items_for_cases(cls, root_group_schema, forms, repeats):
+        """Updates the root_group_schema in place and also returns a new schema for subcases
+        in repeats (if any).
+
+        :param root_group_schema:
+        :param forms: List of forms. Assume all have the same XMLNS
+        :param repeats: List of repeat paths in the form.
+        :return: FormDataExportSchema containing one group schema for each
+        """
         assert root_group_schema.path == []
 
         case_updates = OrderedSet()
@@ -1706,13 +1714,13 @@ class FormExportDataSchema(ExportDataSchema):
 
                 cls._add_export_items_for_case(
                     root_group_schema, '/data', case_properties,
-                    'case', None, [], create='open_case' in actions, close='close_case' in actions
+                    'case', repeats=[], create='open_case' in actions, close='close_case' in actions
                 )
 
                 if 'usercase_update' in actions and actions['usercase_update'].update:
                     cls._add_export_items_for_case(
                         root_group_schema, '/data/commcare_usercase', actions['usercase_update'].update,
-                        'case', None, [], create='open_case' in actions, close='close_case' in actions
+                        'case', repeats=[], create='open_case' in actions, close='close_case' in actions
                     )
             else:
                 all_actions = [form.actions]
@@ -1723,7 +1731,7 @@ class FormExportDataSchema(ExportDataSchema):
                     for action in actions.load_update_cases:
                         cls._add_export_items_for_case(
                             root_group_schema, '/data/{}'.format(action.form_element_name),
-                            action.case_properties, action.case_tag, None, [],
+                            action.case_properties, action.case_tag, repeats=[],
                             create=False, close=action.close_condition.is_active()
                         )
 
@@ -1731,12 +1739,11 @@ class FormExportDataSchema(ExportDataSchema):
                         if not action.is_subcase:
                             cls._add_export_items_for_case(
                                 root_group_schema, '/data/{}'.format(action.form_element_name),
-                                action.case_properties, action.case_tag, None, [],
+                                action.case_properties, action.case_tag, repeats=[],
                                 create=True, close=action.close_condition.is_active()
                             )
 
-        repeats_with_subcases = []
-        non_repeating_subcases = []
+        subcase_schema = cls()
         for form in forms:
             if isinstance(form.actions, AdvancedFormActions):
                 actions = list(form.actions.get_open_subcase_actions())
@@ -1745,28 +1752,23 @@ class FormExportDataSchema(ExportDataSchema):
 
             repeat_context_count = form.actions.count_subcases_per_repeat_context()
 
-            for action in actions:
-                if action.repeat_context:
-                    action.nest = repeat_context_count[action.repeat_context] > 1
-                    repeats_with_subcases.append(action)
+            for subcase_action in actions:
+                if subcase_action.repeat_context:
+                    root_path = subcase_action.repeat_context
+                    if repeat_context_count[subcase_action.repeat_context] > 1:
+                        root_path = '{}/{}'.format(root_path, subcase_action.form_element_name)
+
+                    group_schema = ExportGroupSchema(
+                        path=_question_path_to_path_nodes(root_path, repeats),
+                        last_occurrences=root_group_schema.last_occurrences,
+                    )
+                    subcase_schema.group_schemas.append(group_schema)
+                    cls._add_export_items_from_subcase_action(group_schema, root_path, subcase_action, repeats)
                 else:
-                    non_repeating_subcases.append(action)
+                    root_path = "/data/{}".format(subcase_action.form_element_name)  # always nest in root
+                    cls._add_export_items_from_subcase_action(root_group_schema, root_path, subcase_action, [])
 
-        for subcase_action in non_repeating_subcases:
-            root_path = "/data/{}".format(subcase_action.form_element_name)  # always nest in root
-            cls._add_export_items_from_subcase_action(root_group_schema, root_path, subcase_action, [])
-
-        subcase_schemas = []
-        if repeats_with_subcases:
-            repeat_case_schema = cls._generate_schema_from_repeat_subcases(
-                xform,
-                repeats_with_subcases,
-                app.langs,
-                app.master_id,
-                app.version,
-            )
-            subcase_schemas.append(repeat_case_schema)
-        return subcase_schemas
+        return [subcase_schema] if subcase_schema.group_schemas else []
 
     @classmethod
     def _add_export_items_from_subcase_action(cls, group_schema, root_path, subcase_action, repeats):
@@ -1782,12 +1784,12 @@ class FormExportDataSchema(ExportDataSchema):
 
         cls._add_export_items_for_case(
             group_schema, root_path, subcase_action.case_properties,
-            label_prefix, subcase_action.repeat_context, repeats, case_indices=index_relationships
+            label_prefix, repeats, case_indices=index_relationships
         )
 
     @classmethod
     def _add_export_items_for_case(cls, group_schema, root_path, case_properties, label_prefix,
-                                   repeat_context, repeats, case_indices=None, create=True, close=False):
+                                   repeats, case_indices=None, create=True, close=False):
         def _add_to_group_schema(path, label, transform=None, datatype=None):
             group_schema.items.append(ExportItem(
                 path=_question_path_to_path_nodes(path, repeats),
@@ -1829,37 +1831,6 @@ class FormExportDataSchema(ExportDataSchema):
                     identifier = index.reference_id or 'parent'
                     path = '{}/case/index/{}/{}'.format(root_path, identifier, prop)
                     _add_to_group_schema(path, 'index.{}'.format(prop))
-
-    @classmethod
-    def _generate_schema_from_repeat_subcases(cls, xform, repeats_with_subcases, langs, app_id, app_version):
-        """
-        This generates a FormExportDataSchema for repeat groups that generate subcases.
-
-        :param xform: An XForm instance
-        :param repeats_with_subcases: A list of OpenSubCaseAction classes that have a
-            repeat_context.
-        :param langs: An array of application languages
-        :param app_id: The app_id of the corresponding app
-        :param app_version: The build number of the app
-        :returns: An instance of a FormExportDataSchema
-        """
-
-        repeats = cls._get_repeat_paths(xform, langs)
-        schema = cls()
-
-        for subcase_action in repeats_with_subcases:
-            root_path = subcase_action.repeat_context
-            if subcase_action.nest:
-                root_path = '{}/{}'.format(root_path, subcase_action.form_element_name)
-
-            group_schema = ExportGroupSchema(
-                path=_question_path_to_path_nodes(root_path, repeats),
-                last_occurrences={app_id: app_version},
-            )
-            cls._add_export_items_from_subcase_action(group_schema, root_path, subcase_action, repeats)
-
-            schema.group_schemas.append(group_schema)
-        return schema
 
     @staticmethod
     def _get_repeat_paths(xform, langs):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -145,7 +145,13 @@ class PathNode(DocumentSchema):
         return hash(self.__key())
 
 
-class ExportItem(DocumentSchema):
+class ReadablePathMixin(object):
+    @property
+    def readable_path(self):
+        return '.'.join([node.name for node in self.path])
+
+
+class ExportItem(DocumentSchema, ReadablePathMixin):
     """
     An item for export.
     path: A question path like [PathNode(name=("my_group"), PathNode(name="q1")]
@@ -222,10 +228,6 @@ class ExportItem(DocumentSchema):
         item.inferred = one.inferred or two.inferred
         item.inferred_from |= two.inferred_from
         return item
-
-    @property
-    def readable_path(self):
-        return '.'.join([node.name for node in self.path])
 
 
 class ExportColumn(DocumentSchema):
@@ -1277,7 +1279,7 @@ class MultipleChoiceItem(ExportItem):
         return item
 
 
-class ExportGroupSchema(DocumentSchema):
+class ExportGroupSchema(DocumentSchema, ReadablePathMixin):
     """
     An object representing the `ExportItem`s that would appear in a single export table, such as all the
     questions in a particular repeat group, or all the questions not in any repeat group.

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1805,18 +1805,7 @@ class FormExportDataSchema(ExportDataSchema):
 
         # Add case updates
         for case_property, case_path in six.iteritems(case_properties):
-            if repeat_context:
-                # This removes the repeat part of the path. For example, if inside
-                # a repeat group that has the following path:
-                #
-                # /data/repeat/other_group/question
-                #
-                # We want to create a path that looks like:
-                #
-                # /data/repeat/case/update/other_group/question
-                path_suffix = case_path[len(repeat_context) + 1:]
-            else:
-                path_suffix = case_property
+            path_suffix = case_property
             path = '{}/case/update/{}'.format(root_path, path_suffix)
             _add_to_group_schema(path, 'update.{}'.format(case_property))
 

--- a/corehq/apps/export/tests/data/app_with_subcases.json
+++ b/corehq/apps/export/tests/data/app_with_subcases.json
@@ -482,7 +482,8 @@
                             {
                                 "case_name": "/data/babies/whats_the_babys_name",
                                 "case_properties": {
-                                    "eye_color": "/data/babies/eye_color"
+                                    "eye_color": "/data/babies/eye_color",
+                                    "facility_name": "/data/facility_name"
                                 },
                                 "case_type": "baby",
                                 "close_condition": {

--- a/corehq/apps/export/tests/data/app_with_subcases_form.xml
+++ b/corehq/apps/export/tests/data/app_with_subcases_form.xml
@@ -8,6 +8,7 @@
 					<how_are_you_today/>
 					<is_this_a_delivery/>
 					<how_many_babies/>
+					<facility_name/>
 					<babies jr:template="">
 						<whats_the_babys_name/>
 						<eye_color/>

--- a/corehq/apps/export/tests/data/app_with_subcases_submission.json
+++ b/corehq/apps/export/tests/data/app_with_subcases_submission.json
@@ -62,7 +62,8 @@
                         }
                     },
                     "update": {
-                        "eye_color": "brown"
+                        "eye_color": "brown",
+                        "facility_name": "test"
                     }
                 },
                 "eye_color": "brown",
@@ -86,7 +87,8 @@
                         }
                     },
                     "update": {
-                        "eye_color": "blue"
+                        "eye_color": "blue",
+                        "facility_name": "test"
                     }
                 },
                 "eye_color": "blue",
@@ -102,6 +104,7 @@
                 "last_status": "fine_thanks"
             }
         },
+        "facility_name": "test",
         "how_are_you_today": "fine_thanks",
         "how_many_babies": "2",
         "is_this_a_delivery": "yes",

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -193,7 +193,7 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
 
         update_items = list(set(group_schema.items) - set(create_items) - set(attribute_items) - set(index_items))
         self.assertEqual(len(update_items), 1)
-        self.assertEqual(update_items[0].readable_path, 'form.repeat.case.update.group.weight')
+        self.assertEqual(update_items[0].readable_path, 'form.repeat.case.update.weight')
 
     def test_xform_parsing_with_stock_questions(self):
         form_xml = self.get_xml('stock_form')

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -31,6 +31,10 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
     A "prescription" case can also be created using save-to-case.
         case_name is /data/prescription/prescription_name
         the save-to-case node is /data/prescription/prescription
+
+    SK Update 2018-07-30:
+      - http://manage.dimagi.com/default.asp?280515
+      - added case update tha references a question outside of the repeat group (facility_name)
     """
     file_path = ['data']
     root = os.path.dirname(__file__)
@@ -81,6 +85,7 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
                 ('form.add_a_prescription', 'Add a prescription?'),
                 ('form.voucher-name', '#form/voucher-name'),
                 ('form.is_this_a_delivery', 'Is this a delivery?'),
+                (u'form.facility_name', u'#form/facility_name'),
 
                 # Verify that the main parent case updates appear (case type "mom")
                 ('form.case.@case_id', 'case.@case_id'),
@@ -134,6 +139,7 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
                 ('form.babies.case.create.case_type', 'subcase_1.create.case_type'),
                 ('form.babies.case.create.owner_id', 'subcase_1.create.owner_id'),
                 ('form.babies.case.update.eye_color', 'subcase_1.update.eye_color'),
+                ('form.babies.case.update.facility_name', 'subcase_1.update.facility_name'),
                 ('form.babies.case.index.parent.#text', 'subcase_1.index.#text'),
                 ('form.babies.case.index.parent.@case_type', 'subcase_1.index.@case_type'),
                 ('form.babies.eye_color', 'Eye color?'),
@@ -197,7 +203,10 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
 
         }, get_form_data('Forms')[0])
 
-        self.assertDictContainsSubset({
+        self.assertDictEqual({
+            "number": "0.0",
+            "number__0": 0,
+            "number__1": 0,
 
             "form.babies.eye_color": "brown",
             "form.babies.whats_the_babys_name": "Bob",
@@ -214,5 +223,6 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
             "form.babies.case.index.parent.@case_type": "mom",
 
             "form.babies.case.update.eye_color": "brown",
+            "form.babies.case.update.facility_name": "test",
 
         }, get_form_data('Repeat- babies')[0])


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?280515

This will require rebuilding affected schemas. Migration for that not included in this PR. 

Actual bug fix is in this commit: https://github.com/dimagi/commcare-hq/pull/21384/commits/a9a1cdcbc572e8a8e804f8a190db72bffe57a705

The rest are tests / refactors.