### PR TITLE
One toggle for DHIS2

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from corehq.motech.repeaters.views.repeaters import AddDhis2RepeaterView
 from corehq.motech.requests import Requests
 from corehq.motech.dhis2.handler import send_data_to_dhis2
-from corehq.toggles import DHIS2_INTEGRATION, DHIS2_REPEATER_INTEGRATION
+from corehq.toggles import DHIS2_INTEGRATION
 from corehq.util import reverse
 
 
@@ -53,7 +53,7 @@ class Dhis2Repeater(FormRepeater):
 
     @classmethod
     def available_for_domain(cls, domain):
-        return DHIS2_REPEATER_INTEGRATION.enabled(domain) and DHIS2_INTEGRATION.enabled(domain)
+        return DHIS2_INTEGRATION.enabled(domain)
 
     @classmethod
     def get_custom_url(cls, domain):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -502,13 +502,6 @@ DHIS2_INTEGRATION = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-DHIS2_REPEATER_INTEGRATION = StaticToggle(
-    'dhis2_repeater_integration',
-    'DHIS2 Repeater Integration (Needed DHIS2 Integration enabled)',
-    TAG_SOLUTIONS,
-    [NAMESPACE_DOMAIN]
-)
-
 GRAPH_CREATION = StaticToggle(
     'graph-creation',
     'Case list/detail graph creation',


### PR DESCRIPTION
After chatting with Dev, it was decided that we should have one toggle for DHIS2 (and keep the one for OpenMRS).

Dropping "DHIS2 Repeater Integration". (Keeping "DHIS2 Integration" and "OpenMRS Integration".)
