### PR TITLE
Only check uses_new_reminders in specific environments

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -29,6 +29,7 @@ from corehq.messaging.scheduling.models import (
     TimedSchedule,
 )
 from corehq.messaging.scheduling.tasks import refresh_alert_schedule_instances, refresh_timed_schedule_instances
+from corehq.messaging.util import project_is_on_new_reminders
 from django.db import transaction
 
 
@@ -202,7 +203,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         Reminder rules will be deactivated.
         """
         try:
-            if domain.uses_new_reminders:
+            if project_is_on_new_reminders(domain):
                 _deactivate_schedules(domain)
             else:
                 for reminder in _active_reminders(domain):
@@ -222,7 +223,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         All Reminder rules utilizing "survey" will be deactivated.
         """
         try:
-            if domain.uses_new_reminders:
+            if project_is_on_new_reminders(domain):
                 _deactivate_schedules(domain, survey_only=True)
             else:
                 surveys = [x for x in _active_reminders(domain)
@@ -531,7 +532,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         Reminder rules will be deactivated.
         """
-        if domain.uses_new_reminders:
+        if project_is_on_new_reminders(domain):
             num_active = (
                 len(_get_active_immediate_broadcasts(domain)) +
                 len(_get_active_scheduled_broadcasts(domain)) +
@@ -557,7 +558,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         All Reminder rules utilizing "survey" will be deactivated.
         """
-        if domain.uses_new_reminders:
+        if project_is_on_new_reminders(domain):
             num_survey = (
                 len(_get_active_immediate_broadcasts(domain, survey_only=True)) +
                 len(_get_active_scheduled_broadcasts(domain, survey_only=True)) +

--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -66,6 +66,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseTimedScheduleInstance,
 )
 from corehq.messaging.tasks import initiate_messaging_rule_run
+from corehq.messaging.util import project_is_on_new_reminders
 from corehq.sql_db.util import run_query_across_partitioned_databases
 from corehq.toggles import REMINDERS_MIGRATION_IN_PROGRESS
 from datetime import time, datetime, timedelta
@@ -932,7 +933,7 @@ class Command(BaseCommand):
         return handler.reminder_type in (REMINDER_TYPE_KEYWORD_INITIATED, REMINDER_TYPE_SURVEY_MANAGEMENT)
 
     def migration_already_done(self, domain_obj):
-        if domain_obj.uses_new_reminders:
+        if project_is_on_new_reminders(domain_obj):
             log("'%s' already uses new reminders, nothing to do" % domain_obj.name)
             return True
 

--- a/corehq/apps/reminders/util.py
+++ b/corehq/apps/reminders/util.py
@@ -18,6 +18,7 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.sms.mixin import apply_leniency, CommCareMobileContactMixin, InvalidFormatException
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.form_processor.utils import is_commcarecase
+from corehq.messaging.util import project_is_on_new_reminders
 from corehq.util.quickcache import quickcache
 from django_prbac.utils import has_privilege
 
@@ -256,7 +257,7 @@ def requires_old_reminder_framework():
                 return fn(request, *args, **kwargs)
             if not hasattr(request, 'project'):
                 request.project = Domain.get_by_name(request.domain)
-            if not request.project.uses_new_reminders:
+            if not project_is_on_new_reminders(request.project):
                 return fn(request, *args, **kwargs)
             raise Http404()
         return wrapped

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -69,6 +69,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseAlertScheduleInstance,
     CaseTimedScheduleInstance,
 )
+from corehq.messaging.util import project_is_on_new_reminders
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from django.core.exceptions import ObjectDoesNotExist
 import six
@@ -1646,7 +1647,7 @@ class ScheduleInstanceReport(ProjectReport, ProjectReportParametersMixin, Generi
 
         return (
             (user and toggles.NEW_REMINDERS_MIGRATOR.enabled(user.username)) or
-            (project and project.uses_new_reminders)
+            (project and project_is_on_new_reminders(project))
         )
 
     @property

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -22,6 +22,7 @@ from corehq.messaging.scheduling.models import (
     SMSContent,
 )
 from corehq.messaging.tasks import initiate_messaging_rule_run
+from corehq.messaging.util import project_is_on_new_reminders
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from io import open
@@ -56,7 +57,7 @@ class Command(BaseCommand):
         if domain_obj is None:
             raise CommandError("Project space '%s' not found" % domain)
 
-        if not domain_obj.uses_new_reminders:
+        if not project_is_on_new_reminders(domain_obj):
             raise CommandError("Project space '%s' does not have new reminders enabled" % domain)
 
         json_rules = []

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -51,7 +51,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
 )
 from corehq.messaging.scheduling.tasks import refresh_alert_schedule_instances, refresh_timed_schedule_instances
 from corehq.messaging.tasks import initiate_messaging_rule_run
-from corehq.messaging.util import MessagingRuleProgressHelper
+from corehq.messaging.util import MessagingRuleProgressHelper, project_is_on_new_reminders
 from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -80,7 +80,7 @@ def _requires_new_reminder_framework():
                 return fn(request, *args, **kwargs)
             if not hasattr(request, 'project'):
                 request.project = Domain.get_by_name(request.domain)
-            if request.project.uses_new_reminders:
+            if project_is_on_new_reminders(request.project):
                 return fn(request, *args, **kwargs)
             raise Http404()
         return wrapped
@@ -119,7 +119,7 @@ class MessagingDashboardView(BaseMessagingSectionView):
             MessagingEventsReport,
         )
 
-        if self.domain_object.uses_new_reminders:
+        if project_is_on_new_reminders(self.domain_object):
             scheduled_events_url = reverse(ScheduleInstanceReport.dispatcher.name(), args=[],
                 kwargs={'domain': self.domain, 'report_slug': ScheduleInstanceReport.slug})
         else:
@@ -176,7 +176,7 @@ class MessagingDashboardView(BaseMessagingSectionView):
         })
 
     def add_reminder_status_info(self, result):
-        if self.domain_object.uses_new_reminders:
+        if project_is_on_new_reminders(self.domain_object):
             events_pending = get_count_of_active_schedule_instances_due(self.domain, datetime.utcnow())
         else:
             events_pending = len(CaseReminderHandler.get_all_reminders(

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -88,6 +88,13 @@ def use_phone_entries():
     return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
 
 
+def project_is_on_new_reminders(domain_obj):
+    if settings.SERVER_ENVIRONMENT in ('production', 'softlayer', 'staging'):
+        return domain_obj.uses_new_reminders
+
+    return True
+
+
 def show_messaging_dashboard(domain, couch_user):
     return (
         not toggles.HIDE_MESSAGING_DASHBOARD_FROM_NON_SUPERUSERS.enabled(domain) or

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -58,7 +58,7 @@ from corehq.messaging.scheduling.views import (
     CreateConditionalAlertView,
     EditConditionalAlertView,
 )
-from corehq.messaging.util import show_messaging_dashboard
+from corehq.messaging.util import show_messaging_dashboard, project_is_on_new_reminders
 from corehq.motech.dhis2.view import Dhis2ConnectionView, DataSetMapView
 from corehq.motech.views import MotechLogListView
 from corehq.motech.openmrs.views import OpenmrsImporterView
@@ -966,7 +966,7 @@ class MessagingTab(UITab):
     @memoized
     def show_new_reminders_pages(self):
         return (
-            self.project.uses_new_reminders or
+            project_is_on_new_reminders(self.project) or
             toggles.NEW_REMINDERS_MIGRATOR.enabled(self.couch_user.username)
         )
 
@@ -974,7 +974,7 @@ class MessagingTab(UITab):
     @memoized
     def show_old_reminders_pages(self):
         return (
-            not self.project.uses_new_reminders or
+            not project_is_on_new_reminders(self.project) or
             toggles.NEW_REMINDERS_MIGRATOR.enabled(self.couch_user.username)
         )
 


### PR DESCRIPTION
Makes it so that the new reminders framework is automatically enabled in environments that have been either completely migrated to the new framework already, or that don't have any reminders yet.

@millerdev @pr33thi 