### PR TITLE
bump jsonobject-couchdbkit to 0.9.5

### DIFF
--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -94,7 +94,7 @@ jinja2==2.8
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.4
+jsonobject-couchdbkit==0.9.5
 jsonobject==0.9.3
 jsonpath-rw==1.4.0
 kafka-python==0.9.5

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ cython==0.27.3
 restkit==4.2.2
 iso8601==0.1.11
 jsonobject==0.9.3
-jsonobject-couchdbkit==0.9.4
+jsonobject-couchdbkit==0.9.5
 celery==3.1.18
 # required by django-digest
 decorator==4.0.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ jinja2==2.8
 jmespath==0.9.3           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.4
+jsonobject-couchdbkit==0.9.5
 jsonobject==0.9.3
 jsonpath-rw==1.4.0
 kafka-python==0.9.5


### PR DESCRIPTION
Removes several functions believed to be unused.