### PR TITLE
py3 docker image doesn't need dev-requirements.txt

### DIFF
--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -16,7 +16,6 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jdk
 
 COPY requirements/requirements.txt \
-     requirements/dev-requirements.txt \
      requirements/test-requirements.txt \
      package.json \
      /vendor/
@@ -26,7 +25,7 @@ RUN git config --global url."https://".insteadOf git:// \
  && pip install --upgrade pip \
  && pip install \
     -r /vendor/requirements.txt \
-    -r /vendor/dev-requirements.txt \
+    -r /vendor/test-requirements.txt \
     --user --upgrade \
  && rm -rf /root/.cache/pip
 


### PR DESCRIPTION
Include the changes from 093b983035b5f7a3742fa140f5aec3c72058dffd in the python 3 Dockerfile.