### PR TITLE
Stop creating views every day

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -155,7 +155,6 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2):
     if db_alias:
         with connections[db_alias].cursor() as cursor:
             _create_aggregate_functions(cursor)
-            _create_views(cursor)
             _update_aggregate_locations_tables(cursor)
 
         state_ids = (SQLLocation.objects
@@ -215,7 +214,7 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2):
         ).delay()
 
 
-def _create_views(cursor):
+def create_views(cursor):
     try:
         celery_task_logger.info("Starting icds reports create_sql_views")
         for sql_view_path in SQL_VIEWS_PATHS:

--- a/custom/icds_reports/tests/__init__.py
+++ b/custom/icds_reports/tests/__init__.py
@@ -9,6 +9,7 @@ import postgres_copy
 import sqlalchemy
 
 from django.conf import settings
+from django.db import connections
 from django.test.utils import override_settings
 
 from corehq.apps.domain.models import Domain
@@ -18,6 +19,7 @@ from corehq.apps.userreports.models import StaticDataSourceConfiguration
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.sql_db.connections import connection_manager, ICDS_UCR_ENGINE_ID
 from custom.icds_reports.tasks import (
+    create_views,
     move_ucr_data_into_aggregation_tables,
     _aggregate_child_health_pnc_forms)
 from io import open
@@ -128,6 +130,9 @@ def setUpModule():
             raise
         finally:
             _call_center_domain_mock.stop()
+
+        with connections['icds-ucr'].cursor() as cursor:
+            create_views(cursor)
 
 
 def tearDownModule():


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/618930437/?environment=icds-new

Deadlocks started intermittently occurring the other day. This seems kind of hacky anyways as views should only need to be recreated whenever we change them which is not very often

@lwyszomi @dmydlo @calellowitz fyi for dashboard