### PR TITLE
RN Correcting report filter

### DIFF
--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -436,7 +436,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         if instance._show_unknown:
             return True
         for param in params:
-            if param['slug'] == PARAM_SLUG_APP_ID:
+            if param['slug'] in [PARAM_SLUG_APP_ID, PARAM_SLUG_STATUS]:
                 return True
         return False
 


### PR DESCRIPTION
Filter was being applied only when specific app id is coming which was stoping the filters to get applied when not specific app is selected. 
Code change in this Pr allows applying the filter if the app id selected or not but the app type is selected.

http://manage.dimagi.com/default.asp?280807