### PR TITLE
Handle when error response is None

### DIFF
--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -92,6 +92,9 @@ def parse_request_exception(err):
         url=err.request.url,
         body=err.request.body
     ) if err.request.body else ' '.join((err.request.method, err.request.url))
-    err_content = pformat_json(err.response.content)  # pformat_json returns non-JSON values unchanged
-    err_response = '\n\n'.join((str(err), err_content))
+    if err.response:
+        err_content = pformat_json(err.response.content)  # pformat_json returns non-JSON values unchanged
+        err_response = '\n\n'.join((str(err), err_content))
+    else:
+        err_response = str(err)
     return err_request, err_response


### PR DESCRIPTION
When an OpenMRS server times out, the payload error was given as:

![timeout_error_before](https://user-images.githubusercontent.com/708421/43578985-e0ac83c8-9650-11e8-961e-4b3e540c4e9e.png)

This change returns the actual error message:

![timeout_error_after](https://user-images.githubusercontent.com/708421/43579000-ed280910-9650-11e8-81ed-fc9287553ba7.png)
