### PR TITLE
add app_id filter for form ucr datasources created via report builder

### DIFF
--- a/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
+++ b/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
@@ -206,7 +206,7 @@ class UCRAggregationTest(TestCase, AggregationBaseTestMixin):
             case_blocks=[caseblock],
             form_properties=properties,
         )
-        submit_form_locally(form_builder.as_xml_string(), cls.domain, received_on=received_on)
+        submit_form_locally(form_builder.as_xml_string(), cls.domain, received_on=received_on, app_id=cls.app._id)
         return form_id
 
     @classmethod

--- a/corehq/apps/userreports/app_manager/data_source_meta.py
+++ b/corehq/apps/userreports/app_manager/data_source_meta.py
@@ -35,15 +35,29 @@ def make_case_data_source_filter(case_type):
     }
 
 
-def make_form_data_source_filter(xmlns):
+def make_form_data_source_filter(xmlns, app_id):
     return {
-        "type": "boolean_expression",
-        "operator": "eq",
-        "expression": {
-            "type": "property_name",
-            "property_name": "xmlns"
-        },
-        "property_value": xmlns,
+        "type": "and",
+        "filters": [
+            {
+                "type": "boolean_expression",
+                "operator": "eq",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "xmlns"
+                },
+                "property_value": xmlns,
+            },
+            {
+                "type": "boolean_expression",
+                "operator": "eq",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "app_id"
+                },
+                "property_value": app_id,
+            }
+        ]
     }
 
 
@@ -94,7 +108,8 @@ class FormDataSourceMeta(AppDataSourceMeta):
         self.source_xform = XForm(self.source_form.source)
 
     def get_filter(self):
-        return make_form_data_source_filter(self.source_xform.data_node.tag_xmlns)
+        return make_form_data_source_filter(
+            self.source_xform.data_node.tag_xmlns, self.source_form.get_app().get_id)
 
 
 def make_form_question_indicator(question, column_id=None, data_type=None, root_doc=False):

--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -76,7 +76,7 @@ def get_form_data_source(app, form):
         referenced_doc_type='XFormInstance',
         table_id=clean_table_name(app.domain, form_name),
         display_name=form_name,
-        configured_filter=make_form_data_source_filter(xform.data_node.tag_xmlns),
+        configured_filter=make_form_data_source_filter(xform.data_node.tag_xmlns, app.get_id),
         configured_indicators=meta_properties + dynamic_properties + _get_shared_indicators(),
     )
 

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -49,13 +49,27 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_FORM, self.form.unique_id)
         self.assertEqual('XFormInstance', builder.source_doc_type)
         expected_filter = {
-            "operator": "eq",
-            "expression": {
-                "type": "property_name",
-                "property_name": "xmlns"
-            },
-            "type": "boolean_expression",
-            "property_value": self.form.xmlns
+            "type": "and",
+            "filters": [
+                {
+                    "type": "boolean_expression",
+                    "operator": "eq",
+                    "expression": {
+                        "type": "property_name",
+                        "property_name": "xmlns"
+                    },
+                    "property_value": self.form.xmlns,
+                },
+                {
+                    "type": "boolean_expression",
+                    "operator": "eq",
+                    "expression": {
+                        "type": "property_name",
+                        "property_name": "app_id"
+                    },
+                    "property_value": self.app.get_id,
+                }
+            ]
         }
         self.assertEqual(expected_filter, builder.filter)
 


### PR DESCRIPTION
Addresses a ucr data filtering issue found in the ticket https://manage.dimagi.com/default.asp?278999#1517058

If apps are copied across, the form `xmlns` stays same. So, when a form-based report (built using the report builder with a form from one of these apps as the datasource) is run submissions for both the apps are returned. This happens because the `xmlns` stays same. This PR adds the `app_id` filter to the datasources built via report builder, so that users see what they expect in the UCR report data. 

We wouldn't have to do this, if we were to set new `xmlns` for new forms when an app is copied. Due to xmlns being same, this kind of data issue pops in export-tool and other reports as well. Examples of some [older](https://manage.dimagi.com/default.asp?266493) [tickets](https://manage.dimagi.com/default.asp?268082). Is there a strong reason for not doing this? @snopoke 

 
cc @jmtroth0 
