### PR TITLE
update only when requested to

### DIFF
--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -509,8 +509,10 @@ def _process_modules_and_forms_sheet(rows, app):
         _update_translation_dict('default_', document.name, row, app.langs)
 
         for lang in app.langs:
-            document.set_icon(lang, row.get('icon_filepath_%s' % lang, ''))
-            document.set_audio(lang, row.get('audio_filepath_%s' % lang, ''))
+            if 'icon_filepath_%s' % lang in row:
+                document.set_icon(lang, row.get('icon_filepath_%s' % lang, ''))
+            if 'audio_filepath_%s' % lang in row:
+                document.set_audio(lang, row.get('audio_filepath_%s' % lang, ''))
 
     return msgs
 

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -509,10 +509,12 @@ def _process_modules_and_forms_sheet(rows, app):
         _update_translation_dict('default_', document.name, row, app.langs)
 
         for lang in app.langs:
-            if 'icon_filepath_%s' % lang in row:
-                document.set_icon(lang, row.get('icon_filepath_%s' % lang, ''))
-            if 'audio_filepath_%s' % lang in row:
-                document.set_audio(lang, row.get('audio_filepath_%s' % lang, ''))
+            icon_filepath = 'icon_filepath_%s' % lang
+            audio_filepath = 'audio_filepath_%s' % lang
+            if icon_filepath in row:
+                document.set_icon(lang, row[icon_filepath])
+            if audio_filepath in row:
+                document.set_audio(lang, row[audio_filepath])
 
     return msgs
 


### PR DESCRIPTION
We have a different behaviour when updating icons and audios on forms compared to what we do for the first "Modules_and_forms" sheet. There is no multimedia for modules sheets.

When updating form we skip missing columns [here](https://github.com/dimagi/commcare-hq/blob/eb85f57eced7879aee30a51f310bde3b9893f558/corehq/apps/app_manager/app_translations/app_translations.py#L676)
But for "Modules_and_forms" we clean the audio and icon even if the column is missing.

Looks like its better to keep it same and not remove anything if the column is missing in the excel sheet. 