### PR TITLE
Add option to use existing rule during reminders migration

### DIFF
--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -704,9 +704,6 @@ class Command(BaseCommand):
         if handler.active and handler.uses_parent_case_property:
             return None
 
-        if handler.active and handler.start_date and handler.use_today_if_start_date_is_blank:
-            return None
-
         return migrate_rule
 
     def get_rule_schedule_migration_function(self, handler):

--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -282,6 +282,28 @@ class CaseReminderHandlerMigrator(BaseMigrator):
         initiate_messaging_rule_run(self.rule.domain, self.rule.pk)
 
 
+class ManualCaseReminderHandlerMigrator(CaseReminderHandlerMigrator):
+
+    def __init__(self, handler, rule_id):
+        self.handler = handler
+        self.source_duplicate_count = 0
+
+        try:
+            self.rule = AutomaticUpdateRule.objects.get(
+                pk=rule_id,
+                domain=handler.domain,
+                workflow=AutomaticUpdateRule.WORKFLOW_SCHEDULING,
+                deleted=False,
+            )
+        except AutomaticUpdateRule.DoesNotExist:
+            raise ValueError("Invalid rule_id given: %s" % rule_id)
+
+        self.schedule = self.rule.get_messaging_rule_schedule()
+
+    def migrate(self):
+        pass
+
+
 class BroadcastMigrator(BaseMigrator):
 
     def __init__(self, handler, broadcast_migration_function):
@@ -920,6 +942,12 @@ class Command(BaseCommand):
             if rule_migration_function and schedule_migration_function:
                 return CaseReminderHandlerMigrator(handler, rule_migration_function, schedule_migration_function,
                     until_references_timestamp)
+
+            if self.confirm(
+                "A suitable migrator could not be found for %s. Use manual migrator? y/n " % handler._id
+            ):
+                rule_id = self.get_int("Enter rule id for %s: " % handler._id)
+                return ManualCaseReminderHandlerMigrator(handler, rule_id)
 
             return None
         elif handler.reminder_type == REMINDER_TYPE_ONE_TIME:

--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -898,7 +898,10 @@ class Command(BaseCommand):
             return None
 
         if handler.use_today_if_start_date_is_blank and handler.active and handler.start_date:
-            return None
+            if not self.confirm(
+                "Ok to treat use_today_if_start_date_is_blank as False for %s? y/n " % handler._id
+            ):
+                return None
 
         if handler.reminder_type == REMINDER_TYPE_DEFAULT:
             for event in handler.events:

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2670,9 +2670,15 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         required=False,
     )
 
+    skip_running_rule_post_save = BooleanField(
+        required=False,
+        label=ugettext_lazy("Skip running rule post save"),
+    )
+
     allow_custom_immediate_schedule = True
 
     def __init__(self, domain, schedule, can_use_sms_surveys, rule, criteria_form, *args, **kwargs):
+        self.new_reminders_migrator = kwargs.pop('new_reminders_migrator', False)
         self.initial_rule = rule
         self.criteria_form = criteria_form
         super(ConditionalAlertScheduleForm, self).__init__(domain, schedule, can_use_sms_surveys, *args, **kwargs)
@@ -3027,6 +3033,9 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                     data_bind="visible: capture_custom_metadata_item() === 'Y'",
                 ),
             ])
+
+        if self.new_reminders_migrator:
+            result.append(crispy.Field('skip_running_rule_post_save'))
 
         return result
 


### PR DESCRIPTION
This isn't needed often but for some of the edge cases that the old framework allowed you to create it's easier to just recreate those configurations in the new UI manually and then let the migration take over using the existing rule.

@millerdev @pr33thi 