### PR TITLE
Skip SSL certificate verification

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -67,7 +67,7 @@ class Dhis2Repeater(FormRepeater):
         for form_config in self.dhis2_config.form_configs:
             if form_config.xmlns == payload['form']['@xmlns']:
                 return send_data_to_dhis2(
-                    Requests(self.domain, self.url, self.username, self.password),
+                    Requests(self.domain, self.url, self.username, self.password, verify=self.verify),
                     form_config,
                     payload,
                 )

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -63,7 +63,7 @@ class Dhis2Repeater(FormRepeater):
         payload = super(Dhis2Repeater, self).get_payload(repeat_record)
         return json.loads(payload)
 
-    def send_request(self, repeat_record, payload, verify=None):
+    def send_request(self, repeat_record, payload):
         for form_config in self.dhis2_config.form_configs:
             if form_config.xmlns == payload['form']['@xmlns']:
                 return send_data_to_dhis2(

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -109,7 +109,7 @@ class OpenmrsRepeater(CaseRepeater):
         form_question_values = get_form_question_values(payload)
 
         return send_openmrs_data(
-            Requests(self.domain, self.url, self.username, self.password),
+            Requests(self.domain, self.url, self.username, self.password, verify=self.verify),
             self.domain,
             payload,
             self.openmrs_config,

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -101,7 +101,7 @@ class OpenmrsRepeater(CaseRepeater):
         payload = super(OpenmrsRepeater, self).get_payload(repeat_record)
         return json.loads(payload)
 
-    def send_request(self, repeat_record, payload, verify=None):
+    def send_request(self, repeat_record, payload):
         case_trigger_infos = get_relevant_case_updates_from_form_json(
             self.domain, payload, case_types=self.white_listed_case_types,
             extra_fields=[identifier.case_property

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -109,7 +109,7 @@ class GenericRepeaterForm(forms.Form):
             self.special_crispy_fields["auth_type"],
             "username",
             "password",
-            "skip_cert_verify",
+            self.special_crispy_fields["skip_cert_verify"],
         ])
         return form_fields
 
@@ -136,6 +136,7 @@ class GenericRepeaterForm(forms.Form):
                 css_class='form-group'
             ),
             "auth_type": twbscrispy.PrependedText('auth_type', ''),
+            "skip_cert_verify": twbscrispy.PrependedText('skip_cert_verify', ''),
         }
 
     def clean(self):

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -47,6 +47,11 @@ class GenericRepeaterForm(forms.Form):
         label='Password',
         widget=forms.PasswordInput()
     )
+    skip_cert_verify = forms.BooleanField(
+        label=_('Skip SSL certificate verification'),
+        required=False,
+        help_text=_('FOR TESTING ONLY: DO NOT ENABLE THIS FOR PRODUCTION INTEGRATIONS'),
+    )
 
     def __init__(self, *args, **kwargs):
         self.domain = kwargs.pop('domain')
@@ -103,7 +108,8 @@ class GenericRepeaterForm(forms.Form):
             self.special_crispy_fields["test_link"],
             self.special_crispy_fields["auth_type"],
             "username",
-            "password"
+            "password",
+            "skip_cert_verify",
         ])
         return form_fields
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -89,6 +89,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     auth_type = StringProperty(choices=(BASIC_AUTH, DIGEST_AUTH, OAUTH1), required=False)
     username = StringProperty()
     password = StringProperty()
+    skip_cert_verify = BooleanProperty(default=False)
     friendly_name = _("Data")
     paused = BooleanProperty(default=False)
 
@@ -262,9 +263,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
 
     @property
     def verify(self):
-        # overwrite to skip certificate verification when sending request
-        # to https urls
-        return True
+        return not self.skip_cert_verify
 
     def send_request(self, repeat_record, payload, verify=None):
         headers = self.get_headers(repeat_record)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -20,7 +20,16 @@ from corehq.form_processor.exceptions import XFormNotFound
 from corehq.util.datadog.metrics import REPEATER_ERROR_COUNT, REPEATER_SUCCESS_COUNT
 from corehq.util.datadog.gauges import datadog_counter
 from corehq.util.quickcache import quickcache
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import (
+    BooleanProperty,
+    DateTimeProperty,
+    Document,
+    DocumentSchema,
+    IntegerProperty,
+    ListProperty,
+    StringListProperty,
+    StringProperty,
+)
 from casexml.apps.case.xml import V2, LEGAL_VERSIONS
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
 from couchforms.const import DEVICE_LOG_XMLNS

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -265,7 +265,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     def verify(self):
         return not self.skip_cert_verify
 
-    def send_request(self, repeat_record, payload, verify=None):
+    def send_request(self, repeat_record, payload):
         headers = self.get_headers(repeat_record)
         auth = self.get_auth()
         url = self.get_url(repeat_record)

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -55,6 +55,7 @@ hqDefine("repeaters/js/add_form_repeater", [
                 auth_type: $('#id_auth_type').val(),
                 username: $('#id_username').val(),
                 password: $('#id_password').val(),
+                skip_cert_verify: $('#id_skip_cert_verify').prop('checked'),
             };
             $testLinkButton.disableButton();
 

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -380,6 +380,7 @@ def test_repeater(request, domain):
 
         username = request.POST.get('username')
         password = request.POST.get('password')
+        verify = not request.POST.get('skip_cert_verify') == 'true'
         if auth_type == BASIC_AUTH:
             auth = HTTPBasicAuth(username, password)
         elif auth_type == DIGEST_AUTH:
@@ -388,7 +389,7 @@ def test_repeater(request, domain):
             auth = None
 
         try:
-            resp = simple_post(fake_post, url, headers=headers, auth=auth)
+            resp = simple_post(fake_post, url, headers=headers, auth=auth, verify=verify)
             if 200 <= resp.status_code < 300:
                 return HttpResponse(json.dumps({"success": True,
                                                 "response": resp.content,

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -40,15 +40,18 @@ def log_request(func):
 
 
 class Requests(object):
-    def __init__(self, domain_name, base_url, username, password):
+    def __init__(self, domain_name, base_url, username, password, verify=True):
         self.domain_name = domain_name
         self.base_url = base_url
         self.username = username
         self.password = password
+        self.verify = verify
 
     @log_request
     def send_request(self, method_func, *args, **kwargs):
         raise_for_status = kwargs.pop('raise_for_status', False)
+        if not self.verify:
+            kwargs['verify'] = False
         try:
             response = method_func(*args, **kwargs)
             if raise_for_status:

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -68,3 +68,16 @@ class RequestsTests(SimpleTestCase):
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json()['status'], 'SUCCESS')
             self.assertEqual(response.json()['importCount']['imported'], 2)
+
+    def test_verify_ssl(self):
+        with patch('corehq.motech.requests.RequestLog', Mock()), \
+                patch('corehq.motech.requests.requests') as requests_mock:
+
+            requests = Requests(TEST_DOMAIN, TEST_API_URL, TEST_API_USERNAME, TEST_API_PASSWORD, verify=False)
+            requests.get('me')
+            requests_mock.get.assert_called_with(
+                TEST_API_URL + 'me',
+                headers={'Accept': 'application/json'},
+                auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
+                verify=False
+            )

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -61,9 +61,6 @@ import six
 class BaseNikshayRepeater(CaseRepeater):
     @property
     def verify(self):
-        # Never verify SSL certificates when sending requests to https urls
-        # 2018-08-03 (Norman): Left this as False to maintain current behaviour
-        #     instead of using self.skip_cert_verify like base class
         return False
 
     @classmethod
@@ -285,9 +282,6 @@ class NikshayHealthEstablishmentRepeater(SOAPRepeaterMixin, LocationRepeater):
 
     @property
     def verify(self):
-        # Never verify SSL certificates when sending requests to https urls
-        # 2018-08-03 (Norman): Left this as False to maintain current behaviour
-        #     instead of using self.skip_cert_verify
         return False
 
     @classmethod

--- a/custom/enikshay/integrations/nikshay/repeaters.py
+++ b/custom/enikshay/integrations/nikshay/repeaters.py
@@ -61,6 +61,9 @@ import six
 class BaseNikshayRepeater(CaseRepeater):
     @property
     def verify(self):
+        # Never verify SSL certificates when sending requests to https urls
+        # 2018-08-03 (Norman): Left this as False to maintain current behaviour
+        #     instead of using self.skip_cert_verify like base class
         return False
 
     @classmethod
@@ -282,6 +285,9 @@ class NikshayHealthEstablishmentRepeater(SOAPRepeaterMixin, LocationRepeater):
 
     @property
     def verify(self):
+        # Never verify SSL certificates when sending requests to https urls
+        # 2018-08-03 (Norman): Left this as False to maintain current behaviour
+        #     instead of using self.skip_cert_verify
         return False
 
     @classmethod


### PR DESCRIPTION
This makes SSL verification for Repeaters configurable. Multiple projects have now required this.

Because this is a bad idea, the warning given in the help text tries to be sufficiently dire.

NikshayRepeater SSL verification behaviour (i.e. don't ever verify) is kept as-is.

:hotel: / :blowfish: 

cc @mkangia 