### PR TITLE
Single multimedia item for each language

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1491,6 +1491,10 @@ class NavMenuItemMediaMixin(DocumentSchema):
     media_audio = DictProperty(StringProperty)
     custom_icons = ListProperty(CustomIcon)
 
+    # When set to true, all languages use the specific media from the default language
+    media_image_languages_linked = BooleanProperty(default=False)
+    media_audio_languages_linked = BooleanProperty(default=False)
+
     @classmethod
     def wrap(cls, data):
         # Lazy migration from single-language media to localizable media
@@ -1526,6 +1530,11 @@ class NavMenuItemMediaMixin(DocumentSchema):
             to return first path in sorted lang->media-path list
         """
         assert media_attr in ('media_image', 'media_audio')
+
+        if self.media_image_languages_linked and media_attr == 'media_image':
+            lang = self.get_app().default_language
+        if self.media_audio_languages_linked and media_attr == 'media_audio':
+            lang = self.get_app().default_language
 
         media_dict = getattr(self, media_attr)
         if not media_dict:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1492,8 +1492,8 @@ class NavMenuItemMediaMixin(DocumentSchema):
     custom_icons = ListProperty(CustomIcon)
 
     # When set to true, all languages use the specific media from the default language
-    media_image_languages_linked = BooleanProperty(default=False)
-    media_audio_languages_linked = BooleanProperty(default=False)
+    use_default_image_for_all = BooleanProperty(default=False)
+    use_default_audio_for_all = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):
@@ -1531,9 +1531,9 @@ class NavMenuItemMediaMixin(DocumentSchema):
         """
         assert media_attr in ('media_image', 'media_audio')
 
-        if self.media_image_languages_linked and media_attr == 'media_image':
+        if self.use_default_image_for_all and media_attr == 'media_image':
             lang = self.get_app().default_language
-        if self.media_audio_languages_linked and media_attr == 'media_audio':
+        if self.use_default_audio_for_all and media_attr == 'media_audio':
             lang = self.get_app().default_language
 
         media_dict = getattr(self, media_attr)

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -3,8 +3,14 @@ hqDefine('app_manager/js/app_manager_media', function() {
         /* This interfaces the media reference for a form or module menu
         (as an icon or image) with the upload manager.*/
         'use strict';
-        var self = {};
+        var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
+            self = {
+                isDefaultLanguage: initial_page_data('current_language') === initial_page_data('default_language')
+            };
 
+        self.enabled = ko.observable(
+            o.ref.languages_linked ? self.isDefaultLanguage : true
+        );
         self.ref = ko.observable(new MenuMediaReference(o.ref));
         self.refHasPath = ko.computed(function() {
             return self.ref().path.length > 0;

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -3,9 +3,9 @@ hqDefine('app_manager/js/app_manager_media', function() {
         /* This interfaces the media reference for a form or module menu
         (as an icon or image) with the upload manager.*/
         'use strict';
-        var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
             self = {
-                isDefaultLanguage: initial_page_data('current_language') === initial_page_data('default_language')
+                isDefaultLanguage: initialPageData('current_language') === initialPageData('default_language'),
             };
 
         self.enabled = ko.observable(

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -9,7 +9,7 @@ hqDefine('app_manager/js/app_manager_media', function() {
             };
 
         self.enabled = ko.observable(
-            o.ref.languages_linked ? self.isDefaultLanguage : true
+            o.ref.use_default_media ? self.isDefaultLanguage : true
         );
         self.ref = ko.observable(new MenuMediaReference(o.ref));
         self.refHasPath = ko.computed(function() {
@@ -77,7 +77,7 @@ hqDefine('app_manager/js/app_manager_media', function() {
             }
         });
 
-        self.languagesLinked = ko.observable(o.ref.languages_linked);
+        self.languagesLinked = ko.observable(o.ref.use_default_media);
 
         self.setCustomPath = function() {
             self.useCustomPath(true);

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -71,6 +71,8 @@ hqDefine('app_manager/js/app_manager_media', function() {
             }
         });
 
+        self.languagesLinked = ko.observable(o.ref.languages_linked);
+
         self.setCustomPath = function() {
             self.useCustomPath(true);
             if (self.customPath().length === 0) {

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -144,6 +144,8 @@
     {% initial_page_data 'is_allowed_to_be_release_notes_form' is_allowed_to_be_release_notes_form %}
     {% initial_page_data 'is_training_module' is_training_module %}
     {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
+    {% initial_page_data 'default_language' app.default_language %}
+    {% initial_page_data 'current_language' lang %}
     {% if allow_form_copy and request|toggle_enabled:"COPY_FORM_TO_APP" %}
         {% initial_page_data 'apps_modules' apps_modules %}
     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -75,6 +75,8 @@
   {% initial_page_data 'shadow_module_options' shadow_module_options %}
   {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
   {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
+  {% initial_page_data 'default_language' app.default_language %}
+  {% initial_page_data 'current_language' lang %}
   {% registerurl "edit_module_detail_screens" domain app.id module.unique_id %}
   {% registerurl "hqmedia_remove_detail_print_template" domain app.id %}
   {% registerurl "validate_module_for_build" domain app.id module.unique_id %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view_report.html
@@ -32,6 +32,8 @@
     {% initial_page_data 'report_module_options' report_module_options %}
     {% initial_page_data 'static_data_options' static_data_options %}
     {% initial_page_data 'uuids_by_instance_id' uuids_by_instance_id %}
+    {% initial_page_data 'default_language' app.default_language %}
+    {% initial_page_data 'current_language' lang %}
     {% registerurl 'choice_list_api' domain 'report_id' 'filter_id' %}
     {% registerurl "edit_report_module" domain app.id module.unique_id %}
     {% registerurl "validate_module_for_build" domain app.id module.unique_id %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -87,7 +87,7 @@
                    name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
                    data-bind="value: savedPath" />
             <input type="hidden"
-                   name="{{type}}_languages_linked"
+                   name="use_default_{{type}}_for_all"
                    data-bind="value: languagesLinked" />
         </div>
         <div class="col-sm-1">

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -21,6 +21,7 @@
             {% endif %}
             <button type="button" class="btn btn-default" data-toggle="modal" data-target="#{{ slug }}"
                     data-bind="attr: { 'data-hqmediapath': currentPath },
+                               enable: enabled,
                                event: {
                                     mediaUploadComplete: uploadComplete,
                                     click: passToUploadController
@@ -32,6 +33,7 @@
             <button type="button" class="btn btn-danger"
                     data-bind="
                         visible: refHasPath,
+                        enable: enabled,
                         event: {
                             click: removeMedia
                         }
@@ -41,6 +43,7 @@
             <button type="button" class="btn btn-default pull-right"
                     data-bind="
                         visible: showDefaultPath,
+                        enable: enabled,
                         click: function () {
                             setCustomPath();
                             hqImport('analytix/js/google').track.event('App Builder', 'Click Show Path for a Form or Module', '{{ type }}');
@@ -58,11 +61,18 @@
                 {% endblocktrans %}
             </p>
             {% endif %}
-            <div>
+            <div data-bind="visible: isDefaultLanguage">
                 <label>
-                    Languages Linked:
-                    <input type="checkbox" data-bind="checked: languagesLinked" />
+                    {% blocktrans %}
+                        Use this {{ label }} for all languages
+                    {% endblocktrans %}:
+                    <input type="checkbox" data-bind="enable: enabled, checked: languagesLinked" />
                 </label>
+            </div>
+            <div data-bind="visible: languagesLinked() && !isDefaultLanguage">
+                {% blocktrans %}
+                    This {{ label }} is linked to the default language, and can only be modified there.
+                {% endblocktrans %}
             </div>
         </div>
     </div>
@@ -71,6 +81,7 @@
         <div class="col-sm-4">
             <input type="text" class="form-control"
                    data-bind="value: customPath,
+                              enable: enabled,
                               valueUpdate: 'textchange'" />
             <input type="hidden" class="jr-resource-field"
                    name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
@@ -83,6 +94,7 @@
             <button type="button" class="btn btn-default"
                     data-bind="
                         visible: showCustomPath,
+                        enable: enabled,
                         event: { click: setDefaultPath }
                     ">
                 <i class="fa fa-remove"></i>

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -61,19 +61,21 @@
                 {% endblocktrans %}
             </p>
             {% endif %}
-            <div data-bind="visible: isDefaultLanguage">
-                <label>
+            {% if app.langs|length > 1 %}
+                <div data-bind="visible: isDefaultLanguage">
+                    <label>
+                        {% blocktrans %}
+                            Use this {{ label }} for all languages
+                        {% endblocktrans %}:
+                        <input type="checkbox" data-bind="enable: enabled, checked: languagesLinked" />
+                    </label>
+                </div>
+                <div data-bind="visible: languagesLinked() && !isDefaultLanguage">
                     {% blocktrans %}
-                        Use this {{ label }} for all languages
-                    {% endblocktrans %}:
-                    <input type="checkbox" data-bind="enable: enabled, checked: languagesLinked" />
-                </label>
-            </div>
-            <div data-bind="visible: languagesLinked() && !isDefaultLanguage">
-                {% blocktrans %}
-                    This {{ label }} is linked to the default language, and can only be modified there.
-                {% endblocktrans %}
-            </div>
+                        This {{ label }} is linked to the default language, and can only be modified there.
+                    {% endblocktrans %}
+                </div>
+            {% endif %}
         </div>
     </div>
     <div class="form-group" data-bind="visible: showCustomPath">

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -58,6 +58,12 @@
                 {% endblocktrans %}
             </p>
             {% endif %}
+            <div>
+                <label>
+                    Languages Linked:
+                    <input type="checkbox" data-bind="checked: languagesLinked" />
+                </label>
+            </div>
         </div>
     </div>
     <div class="form-group" data-bind="visible: showCustomPath">
@@ -69,6 +75,9 @@
             <input type="hidden" class="jr-resource-field"
                    name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
                    data-bind="value: savedPath" />
+            <input type="hidden"
+                   name="{{type}}_languages_linked"
+                   data-bind="value: languagesLinked" />
         </div>
         <div class="col-sm-1">
             <button type="button" class="btn btn-default"

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -310,6 +310,20 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         self._test_correct_icon_translations(self.app, self.module.case_list, icon_locale)
         self._test_correct_audio_translations(self.app, self.module.case_list, audio_locale)
 
+    def test_linked_language_image(self):
+        self.module.media_image_languages_linked = True
+        self.module.media_audio_languages_linked = True
+
+        self.module.set_icon('en', self.image_path)
+        self.module.set_audio('en', self.audio_path)
+        self.module.set_icon('hin', 'jr://file/commcare/case_list_image_hin.jpg')
+        self.module.set_audio('hin', 'jr://file/commcare/case_list_audio_hin.mp3')
+
+        en_app_strings = commcare_translations.loads(self.app.create_app_strings('en'))
+        hin_app_strings = commcare_translations.loads(self.app.create_app_strings('hin'))
+        self.assertEqual(en_app_strings['modules.m0.icon'], hin_app_strings['modules.m0.icon'])
+        self.assertEqual(en_app_strings['modules.m0.audio'], hin_app_strings['modules.m0.audio'])
+
     def _assert_app_strings_available(self, app, lang):
         et = etree.XML(app.create_suite())
         locale_elems = et.findall(".//locale/[@id]")

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -310,9 +310,9 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         self._test_correct_icon_translations(self.app, self.module.case_list, icon_locale)
         self._test_correct_audio_translations(self.app, self.module.case_list, audio_locale)
 
-    def test_linked_language_image(self):
-        self.module.media_image_languages_linked = True
-        self.module.media_audio_languages_linked = True
+    def test_use_default_media(self):
+        self.module.use_default_image_for_all = True
+        self.module.use_default_audio_for_all = True
 
         self.module.set_icon('en', self.image_path)
         self.module.set_audio('en', self.audio_path)

--- a/corehq/apps/app_manager/views/media_utils.py
+++ b/corehq/apps/app_manager/views/media_utils.py
@@ -33,3 +33,8 @@ def handle_media_edits(request, item, should_edit, resp, lang):
         if should_edit(attribute):
             media_path = process_media_attribute(attribute, resp, request.POST.get(attribute))
             item._set_media(attribute, lang, media_path)
+
+    if should_edit('image_languages_linked'):
+        item.media_image_languages_linked = request.POST.get('image_languages_linked') == 'true'
+    if should_edit('audio_languages_linked'):
+        item.media_audio_languages_linked = request.POST.get('audio_languages_linked') == 'true'

--- a/corehq/apps/app_manager/views/media_utils.py
+++ b/corehq/apps/app_manager/views/media_utils.py
@@ -34,7 +34,7 @@ def handle_media_edits(request, item, should_edit, resp, lang):
             media_path = process_media_attribute(attribute, resp, request.POST.get(attribute))
             item._set_media(attribute, lang, media_path)
 
-    if should_edit('image_languages_linked'):
-        item.media_image_languages_linked = request.POST.get('image_languages_linked') == 'true'
-    if should_edit('audio_languages_linked'):
-        item.media_audio_languages_linked = request.POST.get('audio_languages_linked') == 'true'
+    if should_edit('use_default_image_for_all'):
+        item.use_default_image_for_all = request.POST.get('use_default_image_for_all') == 'true'
+    if should_edit('use_default_audio_for_all'):
+        item.use_default_audio_for_all = request.POST.get('use_default_audio_for_all') == 'true'

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -427,8 +427,8 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
         "custom_icon_form": None,
         "custom_icon_text_body": None,
         "custom_icon_xpath": None,
-        "image_languages_linked": None,
-        "audio_languages_linked": None,
+        "use_default_image_for_all": None,
+        "use_default_audio_for_all": None,
     }
 
     if attr not in attributes:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -427,6 +427,8 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
         "custom_icon_form": None,
         "custom_icon_text_body": None,
         "custom_icon_xpath": None,
+        "image_languages_linked": None,
+        "audio_languages_linked": None,
     }
 
     if attr not in attributes:

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -447,7 +447,7 @@ class ApplicationMediaReference(object):
 
     def __init__(self, path, module_id=None, module_name=None, form_id=None,
                  form_name=None, form_order=None, media_class=None,
-                 is_menu_media=False, app_lang=None, languages_linked=False):
+                 is_menu_media=False, app_lang=None, use_default_media=False):
 
         if not isinstance(path, six.string_types):
             path = ''
@@ -468,7 +468,7 @@ class ApplicationMediaReference(object):
 
         self.app_lang = app_lang or "en"
 
-        self.languages_linked = languages_linked
+        self.use_default_media = use_default_media
 
     def __str__(self):
         detailed_location = ""
@@ -498,7 +498,7 @@ class ApplicationMediaReference(object):
             'path': self.path,
             "icon_class": self.media_class.get_icon_class(),
             "media_type": self.media_class.get_nice_name(),
-            "languages_linked": self.languages_linked,
+            "use_default_media": self.use_default_media,
         }
 
     def _get_name(self, raw_name, lang=None):
@@ -684,7 +684,7 @@ class HQMediaMixin(Document):
         image_ref = ApplicationMediaReference(
             item.icon_by_language(to_language),
             media_class=CommCareImage,
-            languages_linked=item.media_image_languages_linked,
+            use_default_media=item.use_default_image_for_all,
             **media_kwargs
         )
         image_ref = image_ref.as_dict()
@@ -693,7 +693,7 @@ class HQMediaMixin(Document):
         audio_ref = ApplicationMediaReference(
             item.audio_by_language(to_language),
             media_class=CommCareAudio,
-            languages_linked=item.media_audio_languages_linked,
+            use_default_media=item.use_default_audio_for_all,
             **media_kwargs
         )
         audio_ref = audio_ref.as_dict()

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -445,10 +445,9 @@ class ApplicationMediaReference(object):
         Useful info for user-facing things.
     """
 
-    def __init__(self, path,
-                 module_id=None, module_name=None,
-                 form_id=None, form_name=None, form_order=None,
-                 media_class=None, is_menu_media=False, app_lang=None):
+    def __init__(self, path, module_id=None, module_name=None, form_id=None,
+                 form_name=None, form_order=None, media_class=None,
+                 is_menu_media=False, app_lang=None, languages_linked=False):
 
         if not isinstance(path, six.string_types):
             path = ''
@@ -468,6 +467,8 @@ class ApplicationMediaReference(object):
         self.is_menu_media = is_menu_media
 
         self.app_lang = app_lang or "en"
+
+        self.languages_linked = languages_linked
 
     def __str__(self):
         detailed_location = ""
@@ -497,6 +498,7 @@ class ApplicationMediaReference(object):
             'path': self.path,
             "icon_class": self.media_class.get_icon_class(),
             "media_type": self.media_class.get_nice_name(),
+            "languages_linked": self.languages_linked,
         }
 
     def _get_name(self, raw_name, lang=None):
@@ -682,6 +684,7 @@ class HQMediaMixin(Document):
         image_ref = ApplicationMediaReference(
             item.icon_by_language(to_language),
             media_class=CommCareImage,
+            languages_linked=item.media_image_languages_linked,
             **media_kwargs
         )
         image_ref = image_ref.as_dict()
@@ -690,6 +693,7 @@ class HQMediaMixin(Document):
         audio_ref = ApplicationMediaReference(
             item.audio_by_language(to_language),
             media_class=CommCareAudio,
+            languages_linked=item.media_audio_languages_linked,
             **media_kwargs
         )
         audio_ref = audio_ref.as_dict()


### PR DESCRIPTION
https://trello.com/c/Rg254qKR/22-better-handle-multimedia-for-multiple-languages-enable-having-a-single-multimedia-item-for-all-languages-jen

Adds a toggle to link multimedia to the default language. More info about why this is useful in the trello card. 

### Default language page
![screenshot from 2018-08-03 13-43-15](https://user-images.githubusercontent.com/146896/43657356-92a0e4f2-9723-11e8-9f1f-3beccb7e2899.png)

### Other language page
![screenshot from 2018-08-03 13-43-24](https://user-images.githubusercontent.com/146896/43657379-9fced666-9723-11e8-864a-32e9a84c15d1.png)

Pinging @dimagi/product to see if this is something we want behind a flag or if it should be generally available. Also @dimagi/ux for messaging / UI thoughts!

Product Note: Feature Flag: `language_linked_multimedia`