### PR TITLE
Repeater passwords

### DIFF
--- a/corehq/motech/const.py
+++ b/corehq/motech/const.py
@@ -1,0 +1,3 @@
+PASSWORD_PLACEHOLDER = '*' * 16
+
+ALGO_AES = 'aes'

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -67,7 +67,7 @@ class Dhis2Repeater(FormRepeater):
         for form_config in self.dhis2_config.form_configs:
             if form_config.xmlns == payload['form']['@xmlns']:
                 return send_data_to_dhis2(
-                    Requests(self.domain, self.url, self.username, self.password, verify=self.verify),
+                    Requests(self.domain, self.url, self.username, self.plaintext_password, verify=self.verify),
                     form_config,
                     payload,
                 )

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -109,7 +109,7 @@ class OpenmrsRepeater(CaseRepeater):
         form_question_values = get_form_question_values(payload)
 
         return send_openmrs_data(
-            Requests(self.domain, self.url, self.username, self.password, verify=self.verify),
+            Requests(self.domain, self.url, self.username, self.plaintext_password, verify=self.verify),
             self.domain,
             payload,
             self.openmrs_config,

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -13,6 +13,7 @@ from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views import BaseProjectSettingsView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.motech.const import PASSWORD_PLACEHOLDER
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.models import OpenmrsImporter
 from corehq.motech.openmrs.tasks import import_patients_to_domain
@@ -31,9 +32,6 @@ from memoized import memoized
 from dimagi.utils.web import json_response
 from six.moves import map
 from six.moves import range
-
-
-PASSWORD_PLACEHOLDER = '*' * 16
 
 
 @login_and_domain_required

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -45,7 +45,7 @@ class GenericRepeaterForm(forms.Form):
     password = forms.CharField(
         required=False,
         label='Password',
-        widget=forms.PasswordInput()
+        widget=forms.PasswordInput(render_value=True)
     )
     skip_cert_verify = forms.BooleanField(
         label=_('Skip SSL certificate verification'),

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -13,7 +13,8 @@ from django.views.decorators.http import require_POST
 
 from memoized import memoized
 
-from corehq.motech.const import PASSWORD_PLACEHOLDER
+from corehq.motech.const import PASSWORD_PLACEHOLDER, ALGO_AES
+from corehq.motech.utils import b64_aes_encrypt
 from dimagi.utils.post import simple_post
 
 from corehq import toggles
@@ -131,7 +132,10 @@ class BaseRepeaterView(BaseAdminProjectSettingsView):
         repeater.auth_type = cleaned_data['auth_type'] or None
         repeater.username = cleaned_data['username']
         if cleaned_data['password'] != PASSWORD_PLACEHOLDER:
-            repeater.password = cleaned_data['password']
+            repeater.password = '${algo}${ciphertext}'.format(
+                algo=ALGO_AES,
+                ciphertext=b64_aes_encrypt(cleaned_data['password'])
+            )
         repeater.format = cleaned_data['format']
         repeater.skip_cert_verify = cleaned_data['skip_cert_verify']
         return repeater

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -12,6 +12,8 @@ from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.decorators.http import require_POST
 
 from memoized import memoized
+
+from corehq.motech.const import PASSWORD_PLACEHOLDER
 from dimagi.utils.post import simple_post
 
 from corehq import toggles
@@ -128,7 +130,8 @@ class BaseRepeaterView(BaseAdminProjectSettingsView):
         repeater.url = cleaned_data['url']
         repeater.auth_type = cleaned_data['auth_type'] or None
         repeater.username = cleaned_data['username']
-        repeater.password = cleaned_data['password']
+        if cleaned_data['password'] != PASSWORD_PLACEHOLDER:
+            repeater.password = cleaned_data['password']
         repeater.format = cleaned_data['format']
         repeater.skip_cert_verify = cleaned_data['skip_cert_verify']
         return repeater
@@ -275,10 +278,12 @@ class EditRepeaterView(BaseRepeaterView):
         else:
             repeater_id = self.kwargs['repeater_id']
             repeater = Repeater.get(repeater_id)
+            data = repeater.to_json()
+            data['password'] = PASSWORD_PLACEHOLDER
             return self.repeater_form_class(
                 domain=self.domain,
                 repeater_class=self.repeater_class,
-                data=repeater.to_json(),
+                data=data,
                 submit_btn_text=_("Update Repeater"),
             )
 


### PR DESCRIPTION
Repeaters haven't been great with passwords. Updating a repeater can save a blank password over the original one. And they are stored in plaintext. This addresses those two problems.
