### PR TITLE
30 day minimum subscription

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1733,7 +1733,7 @@ class Subscription(models.Model):
     def is_below_minimum_subscription(self):
         if self.is_trial:
             return False
-        elif self.date_start < datetime.date(2018, 9, 3):
+        elif self.date_start < datetime.date(2018, 9, 5):
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
         elif self.date_start + datetime.timedelta(days=MINIMUM_SUBSCRIPTION_LENGTH) >= datetime.date.today():

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1736,14 +1736,10 @@ class Subscription(models.Model):
         elif self.date_start < datetime.date(2018, 9, 3):
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
-        elif self.date_start + datetime.timedelta(days=self.minimum_subscription_length) >= datetime.date.today():
+        elif self.date_start + datetime.timedelta(days=MINIMUM_SUBSCRIPTION_LENGTH) >= datetime.date.today():
             return True
         else:
             return False
-
-    @property
-    def minimum_subscription_length(self):
-        return MINIMUM_SUBSCRIPTION_LENGTH
 
 
 class InvoiceBaseManager(models.Manager):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1730,7 +1730,7 @@ class Subscription(models.Model):
     def is_below_minimum_subscription(self):
         if self.is_trial:
             return False
-        elif self.date_start <= datetime.date(2018, 7, 30): # TODO: Set this date to be the date we launch this feature
+        elif self.date_start <= datetime.date(2018, 7, 1): # TODO: Set this date to be the date we launch this feature
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
         elif self.date_start >= datetime.date.today() - datetime.timedelta(days=2):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -79,6 +79,8 @@ SMALL_INVOICE_THRESHOLD = 100
 
 UNLIMITED_FEATURE_USAGE = -1
 
+MINIMUM_SUBSCRIPTION_LENGTH = 30
+
 _soft_assert_domain_not_loaded = soft_assert(
     to='{}@{}'.format('npellegrino', 'dimagi.com'),
     exponential_backoff=False,
@@ -1734,10 +1736,14 @@ class Subscription(models.Model):
         elif self.date_start < datetime.date(2018, 9, 3):
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
-        elif self.date_start + datetime.timedelta(days=30) >= datetime.date.today():
+        elif self.date_start + datetime.timedelta(days=self.minimum_subscription_length) >= datetime.date.today():
             return True
         else:
             return False
+
+    @property
+    def minimum_subscription_length(self):
+        return MINIMUM_SUBSCRIPTION_LENGTH
 
 
 class InvoiceBaseManager(models.Manager):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1731,7 +1731,7 @@ class Subscription(models.Model):
     def is_below_minimum_subscription(self):
         if self.is_trial:
             return False
-        elif self.date_start <, datetime.date(2018, 9, 3):
+        elif self.date_start < datetime.date(2018, 9, 3):
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
         elif self.date_start + datetime.timedelta(days=30) >= datetime.date.today():

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1731,7 +1731,7 @@ class Subscription(models.Model):
     def is_below_minimum_subscription(self):
         if self.is_trial:
             return False
-        elif self.date_start <= datetime.date(2018, 7, 1): # TODO: Set this date to be the date we launch this feature
+        elif self.date_start <, datetime.date(2018, 9, 3):
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
         elif self.date_start + datetime.timedelta(days=30) >= datetime.date.today():

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1734,9 +1734,6 @@ class Subscription(models.Model):
         elif self.date_start <= datetime.date(2018, 7, 1): # TODO: Set this date to be the date we launch this feature
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
-        elif self.date_start >= datetime.date.today() - datetime.timedelta(days=2):
-            # 1-2 day grace period (because you cannot compare date and datetime)
-            return False
         elif self.date_start + datetime.timedelta(days=30) >= datetime.date.today():
             return True
         else:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1736,7 +1736,7 @@ class Subscription(models.Model):
         elif self.date_start >= datetime.date.today() - datetime.timedelta(days=2):
             # 1-2 day grace period (because you cannot compare date and datetime)
             return False
-        elif self.date_start + datetime.timedelta(days=3) >= datetime.date.today():
+        elif self.date_start + datetime.timedelta(days=30) >= datetime.date.today():
             return True
         else:
             return False

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1141,6 +1141,7 @@ class Subscription(models.Model):
         """
         assert date_start is not None
         for sub in Subscription.visible_objects.filter(
+            Q(date_end__isnull=True) | Q(date_end__gt=F('date_start')),
             subscriber=self.subscriber,
         ).exclude(
             id=self.id,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1726,6 +1726,21 @@ class Subscription(models.Model):
             last_subscription.plan_version.pk == plan_version.pk
         ), last_subscription
 
+    @property
+    def is_below_minimum_subscription(self):
+        if self.is_trial:
+            return False
+        elif self.date_start <= datetime.date(2018, 7, 30): # TODO: Set this date to be the date we launch this feature
+            # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
+            return False
+        elif self.date_start >= datetime.date.today() - datetime.timedelta(days=2):
+            # 1-2 day grace period (because you cannot compare date and datetime)
+            return False
+        elif self.date_start + datetime.timedelta(days=3) >= datetime.date.today():
+            return True
+        else:
+            return False
+
 
 class InvoiceBaseManager(models.Manager):
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1734,6 +1734,9 @@ class Subscription(models.Model):
         elif self.date_start <= datetime.date(2018, 7, 1): # TODO: Set this date to be the date we launch this feature
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
+        elif self.date_start >= datetime.date.today() - datetime.timedelta(days=2):
+            # 1-2 day grace period (because you cannot compare date and datetime)
+            return False
         elif self.date_start + datetime.timedelta(days=30) >= datetime.date.today():
             return True
         else:

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -71,8 +71,8 @@ hqDefine('accounting/js/confirm_plan', [
             initialPageData.get('new_plan')
         );
 
-        $('#confirm-plan').koApplyBindings(confirmPlanModel);
-        $('#modal-downgrade').koApplyBindings(confirmPlanModel);
+        $('#confirm-plan').koApplyBindings(confirmPlan);
+        $('#modal-downgrade').koApplyBindings(confirmPlan);
 
         confirmPlan.init();
     });

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -38,6 +38,14 @@ hqDefine('accounting/js/confirm_plan', function () {
             });
         };
 
+        var userAgreementCheckBox = document.getElementById('user-agreement');
+        var confirmPlanButton = document.getElementById('confirm-plan');
+        if (userAgreementCheckBox != null) {
+            userAgreementCheckBox.onchange = function () {
+                confirmPlanButton.disabled = !this.checked;
+            };
+        }
+
         return self;
     };
 

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -1,7 +1,18 @@
-hqDefine('accounting/js/confirm_plan', function () {
+hqDefine('accounting/js/confirm_plan', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data'
+], function (
+    $,
+    ko,
+    _,
+    initialPageData
+) {
     var confirmPlanModel = function (isUpgrade, currentPlan, newPlan) {
         'use strict';
         var self = {};
+
         self.isUpgrade = isUpgrade;
         self.currentPlan = currentPlan;
         self.newPlan = newPlan;
@@ -27,7 +38,7 @@ hqDefine('accounting/js/confirm_plan', function () {
             $button.disableButton();
             $.ajax({
                 method: "POST",
-                url: hqImport('hqwebapp/js/initial_page_data').reverse('email_on_downgrade'),
+                url: initialPageData.reverse('email_on_downgrade'),
                 data: {
                     old_plan: self.currentPlan.name,
                     new_plan: self.newPlan.name,
@@ -38,27 +49,31 @@ hqDefine('accounting/js/confirm_plan', function () {
             });
         };
 
-        var userAgreementCheckBox = document.getElementById('user-agreement');
-        var confirmPlanButton = document.getElementById('confirm-plan');
-        if (userAgreementCheckBox !== null) {
-            confirmPlanButton.disabled = true;
-            userAgreementCheckBox.onchange = function () {
-                confirmPlanButton.disabled = !this.checked;
-            };
-        }
+        self.init = function () {
+            var userAgreementCheckBox = document.getElementById('user-agreement');
+            var confirmPlanButton = document.getElementById('confirm-plan');
+            if (userAgreementCheckBox !== null) {
+                confirmPlanButton.disabled = true;
+                userAgreementCheckBox.onchange = function () {
+                    confirmPlanButton.disabled = !this.checked;
+                };
+            }
+        };
 
         return self;
     };
 
 
     $(function () {
-        var initialPageData = hqImport('hqwebapp/js/initial_page_data').get;
-        confirmPlanModel = confirmPlanModel(
-            initialPageData('is_upgrade'),
-            initialPageData('current_plan'),
-            initialPageData('new_plan')
+        var confirmPlan = confirmPlanModel(
+            initialPageData.get('is_upgrade'),
+            initialPageData.get('current_plan'),
+            initialPageData.get('new_plan')
         );
+
         $('#confirm-plan').koApplyBindings(confirmPlanModel);
         $('#modal-downgrade').koApplyBindings(confirmPlanModel);
-    }());
+
+        confirmPlan.init();
+    });
 });

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -68,7 +68,7 @@ hqDefine('accounting/js/confirm_plan', [
         var confirmPlan = confirmPlanModel(
             initialPageData.get('is_upgrade'),
             initialPageData.get('current_plan'),
-            initialPageData.get('new_plan')
+            initialPageData.get('new_plan_name')
         );
 
         $('#confirm-plan').koApplyBindings(confirmPlan);

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -34,7 +34,7 @@ hqDefine('accounting/js/confirm_plan', function () {
                     note: $button.closest(".modal").find("textarea").val(),
                 },
                 success: finish,
-                error: finish
+                error: finish,
             });
         };
 
@@ -43,11 +43,11 @@ hqDefine('accounting/js/confirm_plan', function () {
 
 
     $(function () {
-        var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get;
+        var initialPageData = hqImport('hqwebapp/js/initial_page_data').get;
         confirmPlanModel = confirmPlanModel(
-            initial_page_data('is_upgrade'),
-            initial_page_data('current_plan'),
-            initial_page_data('new_plan')
+            initialPageData('is_upgrade'),
+            initialPageData('current_plan'),
+            initialPageData('new_plan')
         );
         $('#confirm-plan').koApplyBindings(confirmPlanModel);
         $('#modal-downgrade').koApplyBindings(confirmPlanModel);

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -59,7 +59,7 @@ hqDefine('accounting/js/confirm_plan', [
                 };
             }
         };
-        
+
         return self;
     };
 

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -1,41 +1,59 @@
 hqDefine('accounting/js/confirm_plan', function () {
-    var confirmPlanModel = function (isUpgrade, nextInvoiceDate, currentPlan, isDowngradeBeforeMinimum,
+    var confirmPlanModel = function (isUpgrade, nextInvoiceDate, currentPlan, newPlan, isDowngradeBeforeMinimum,
                                      currentSubscriptionEndDate) {
-        debugger;
         'use strict';
         var self = {};
         self.isUpgrade = isUpgrade;
-        self.nextInvoiceDate = nextInvoiceDate;
+        self.nextInvoiceDate = nextInvoiceDate;                         // TODO: Delete if unnecessary
         self.currentPlan = currentPlan;
-        self.isDowngradeBeforeMinimum = isDowngradeBeforeMinimum;
-        self.currentSubscriptionEndDate = currentSubscriptionEndDate;
+        self.newPlan = newPlan;
+        self.isDowngradeBeforeMinimum = isDowngradeBeforeMinimum;       // TODO: Delete if unnecessary
+        self.currentSubscriptionEndDate = currentSubscriptionEndDate;   // TODO: Delete if unnecessary
 
-        self.openDowngradeModal = function() {
-            debugger;
-            // var editionSlugs = _.map(self.editions(), function(e) { return e.slug(); });
-            // self.form = $(e.currentTarget).closest("form");
-            // if (editionSlugs.indexOf(self.selected_edition()) < editionSlugs.indexOf(self.currentEdition)) {
-            //     var $modal = $("#modal-downgrade");
-            //     $modal.modal('show');
-            // } else {
-            //     self.form.submit();
-            // }
+        self.openDowngradeModal = function(confirmPlanModel) {
+            if (confirmPlanModel.isUpgrade) {
+                self.submitPlanChange();
+            } else {
+                var $modal = $("#modal-downgrade");
+                $modal.modal('show');
+            }
         };
-        self.submitDowngrade = function() {
-            debugger;
-            // var $button = $(e.currentTarget);
-            // $button.disableButton();
-            // $.ajax({
-            //     method: "POST",
-            //     url: hqImport('hqwebapp/js/initial_page_data').reverse('email_on_downgrade'),
-            //     data: {
-            //         old_plan: self.currentEdition,
-            //         new_plan: self.selected_edition(),
-            //         note: $button.closest(".modal").find("textarea").val(),
-            //     },
-            //     success: finish,
-            //     error: finish,
-            // });
+        self.submitDowngrade = function(pricingTable, e) {
+            var finish = function() {
+                self.submitPlanChange();
+            };
+
+            var $button = $(e.currentTarget);
+            $button.disableButton();
+            $.ajax({
+                method: "POST",
+                url: hqImport('hqwebapp/js/initial_page_data').reverse('email_on_downgrade'),
+                data: {
+                    old_plan: self.currentPlan.name,
+                    new_plan: self.newPlan.name,
+                    note: $button.closest(".modal").find("textarea").val(),
+                },
+                success: finish,
+                error: finish
+            });
+        };
+        self.submitPlanChange = function () {
+            var success = function () {
+                console.log("Success in confirm_billing_account_info");
+            };
+            var error = function () {
+                console.log("Error in confirm_billing_account_info");
+            };
+
+            $.ajax({
+                method: "POST",
+                class: "form",
+                // data: {plan_edition: self.newPlan.edition},
+                data: new FormData($(this)),
+                url: hqImport('hqwebapp/js/initial_page_data').reverse('confirm_billing_account_info'),
+                success: success,
+                error: error
+            });
         };
 
         return self;
@@ -48,9 +66,11 @@ hqDefine('accounting/js/confirm_plan', function () {
             initial_page_data('is_upgrade'),
             initial_page_data('next_invoice_date'),
             initial_page_data('current_plan'),
+            initial_page_data('new_plan'),
             initial_page_data('is_downgrade_before_minimum'),
             initial_page_data('current_subscription_end_date')
         );
+        $('#confirm-plan').koApplyBindings(confirmPlanModel);
         $('#modal-downgrade').koApplyBindings(confirmPlanModel);
     }());
 });

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -1,18 +1,16 @@
 hqDefine('accounting/js/confirm_plan', function () {
-    var confirmPlanModel = function (isUpgrade, nextInvoiceDate, currentPlan, newPlan, isDowngradeBeforeMinimum,
-                                     currentSubscriptionEndDate) {
+    var confirmPlanModel = function (isUpgrade, currentPlan, newPlan) {
         'use strict';
         var self = {};
         self.isUpgrade = isUpgrade;
-        self.nextInvoiceDate = nextInvoiceDate;                         // TODO: Delete if unnecessary
         self.currentPlan = currentPlan;
         self.newPlan = newPlan;
-        self.isDowngradeBeforeMinimum = isDowngradeBeforeMinimum;       // TODO: Delete if unnecessary
-        self.currentSubscriptionEndDate = currentSubscriptionEndDate;   // TODO: Delete if unnecessary
 
-        self.openDowngradeModal = function(confirmPlanModel) {
+        self.form = undefined;
+        self.openDowngradeModal = function(confirmPlanModel, e) {
+            self.form = $(e.currentTarget).closest("form");
             if (confirmPlanModel.isUpgrade) {
-                self.submitPlanChange();
+                self.form.submit();
             } else {
                 var $modal = $("#modal-downgrade");
                 $modal.modal('show');
@@ -20,7 +18,9 @@ hqDefine('accounting/js/confirm_plan', function () {
         };
         self.submitDowngrade = function(pricingTable, e) {
             var finish = function() {
-                self.submitPlanChange();
+                if (self.form) {
+                    self.form.submit();
+                }
             };
 
             var $button = $(e.currentTarget);
@@ -37,24 +37,6 @@ hqDefine('accounting/js/confirm_plan', function () {
                 error: finish
             });
         };
-        self.submitPlanChange = function () {
-            var success = function () {
-                console.log("Success in confirm_billing_account_info");
-            };
-            var error = function () {
-                console.log("Error in confirm_billing_account_info");
-            };
-
-            $.ajax({
-                method: "POST",
-                class: "form",
-                // data: {plan_edition: self.newPlan.edition},
-                data: new FormData($(this)),
-                url: hqImport('hqwebapp/js/initial_page_data').reverse('confirm_billing_account_info'),
-                success: success,
-                error: error
-            });
-        };
 
         return self;
     };
@@ -64,11 +46,8 @@ hqDefine('accounting/js/confirm_plan', function () {
         var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get;
         confirmPlanModel = confirmPlanModel(
             initial_page_data('is_upgrade'),
-            initial_page_data('next_invoice_date'),
             initial_page_data('current_plan'),
-            initial_page_data('new_plan'),
-            initial_page_data('is_downgrade_before_minimum'),
-            initial_page_data('current_subscription_end_date')
+            initial_page_data('new_plan')
         );
         $('#confirm-plan').koApplyBindings(confirmPlanModel);
         $('#modal-downgrade').koApplyBindings(confirmPlanModel);

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -1,0 +1,56 @@
+hqDefine('accounting/js/confirm_plan', function () {
+    var confirmPlanModel = function (isUpgrade, nextInvoiceDate, currentPlan, isDowngradeBeforeMinimum,
+                                     currentSubscriptionEndDate) {
+        debugger;
+        'use strict';
+        var self = {};
+        self.isUpgrade = isUpgrade;
+        self.nextInvoiceDate = nextInvoiceDate;
+        self.currentPlan = currentPlan;
+        self.isDowngradeBeforeMinimum = isDowngradeBeforeMinimum;
+        self.currentSubscriptionEndDate = currentSubscriptionEndDate;
+
+        self.openDowngradeModal = function() {
+            debugger;
+            // var editionSlugs = _.map(self.editions(), function(e) { return e.slug(); });
+            // self.form = $(e.currentTarget).closest("form");
+            // if (editionSlugs.indexOf(self.selected_edition()) < editionSlugs.indexOf(self.currentEdition)) {
+            //     var $modal = $("#modal-downgrade");
+            //     $modal.modal('show');
+            // } else {
+            //     self.form.submit();
+            // }
+        };
+        self.submitDowngrade = function() {
+            debugger;
+            // var $button = $(e.currentTarget);
+            // $button.disableButton();
+            // $.ajax({
+            //     method: "POST",
+            //     url: hqImport('hqwebapp/js/initial_page_data').reverse('email_on_downgrade'),
+            //     data: {
+            //         old_plan: self.currentEdition,
+            //         new_plan: self.selected_edition(),
+            //         note: $button.closest(".modal").find("textarea").val(),
+            //     },
+            //     success: finish,
+            //     error: finish,
+            // });
+        };
+
+        return self;
+    };
+
+
+    $(function () {
+        var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get;
+        confirmPlanModel = confirmPlanModel(
+            initial_page_data('is_upgrade'),
+            initial_page_data('next_invoice_date'),
+            initial_page_data('current_plan'),
+            initial_page_data('is_downgrade_before_minimum'),
+            initial_page_data('current_subscription_end_date')
+        );
+        $('#modal-downgrade').koApplyBindings(confirmPlanModel);
+    }());
+});

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -63,7 +63,7 @@ hqDefine('accounting/js/confirm_plan', [
             initialPageData.get('new_plan_name')
         );
 
-        $('#hq-content').koApplyBindings(confirmPlan);
+        $('#confirm-plan-content').koApplyBindings(confirmPlan);
         $('#modal-downgrade').koApplyBindings(confirmPlan);
     });
 });

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -41,6 +41,7 @@ hqDefine('accounting/js/confirm_plan', function () {
         var userAgreementCheckBox = document.getElementById('user-agreement');
         var confirmPlanButton = document.getElementById('confirm-plan');
         if (userAgreementCheckBox !== null) {
+            confirmPlanButton.disabled = true;
             userAgreementCheckBox.onchange = function () {
                 confirmPlanButton.disabled = !this.checked;
             };

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -17,6 +17,9 @@ hqDefine('accounting/js/confirm_plan', [
         self.currentPlan = currentPlan;
         self.newPlan = newPlan;
 
+        // If the user is upgrading, don't let them continue until they have agreed to the therms
+        self.userAgreementSigned = ko.observable(!isUpgrade);
+
         self.form = undefined;
         self.openDowngradeModal = function(confirmPlanModel, e) {
             self.form = $(e.currentTarget).closest("form");
@@ -49,17 +52,6 @@ hqDefine('accounting/js/confirm_plan', [
             });
         };
 
-        self.init = function () {
-            var userAgreementCheckBox = document.getElementById('user-agreement');
-            var confirmPlanButton = document.getElementById('confirm-plan');
-            if (userAgreementCheckBox !== null) {
-                confirmPlanButton.disabled = true;
-                userAgreementCheckBox.onchange = function () {
-                    confirmPlanButton.disabled = !this.checked;
-                };
-            }
-        };
-
         return self;
     };
 
@@ -71,9 +63,7 @@ hqDefine('accounting/js/confirm_plan', [
             initialPageData.get('new_plan_name')
         );
 
-        $('#confirm-plan').koApplyBindings(confirmPlan);
+        $('#hq-content').koApplyBindings(confirmPlan);
         $('#modal-downgrade').koApplyBindings(confirmPlan);
-
-        confirmPlan.init();
     });
 });

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -2,7 +2,7 @@ hqDefine('accounting/js/confirm_plan', [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/initial_page_data'
+    'hqwebapp/js/initial_page_data',
 ], function (
     $,
     ko,

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -40,7 +40,7 @@ hqDefine('accounting/js/confirm_plan', function () {
 
         var userAgreementCheckBox = document.getElementById('user-agreement');
         var confirmPlanButton = document.getElementById('confirm-plan');
-        if (userAgreementCheckBox != null) {
+        if (userAgreementCheckBox !== null) {
             userAgreementCheckBox.onchange = function () {
                 confirmPlanButton.disabled = !this.checked;
             };

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -59,7 +59,7 @@ hqDefine('accounting/js/confirm_plan', [
                 };
             }
         };
-
+        
         return self;
     };
 

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -77,17 +77,19 @@ hqDefine('accounting/js/pricing_table', [
             if (self.isDowngrade(self.currentEdition, self.selected_edition()) && self.subscriptionBelowMinimum) {
                 var oldPlan = utils.capitalize(self.currentEdition);
                 var newPlan = utils.capitalize(self.selected_edition());
-                var newStartDate = self.startDateAfterMinimumSubscription;
+                var newStartDate = "<strong>" + self.startDateAfterMinimumSubscription + "</strong>";
 
                 var message = "";
                 if (self.nextSubscriptionEdition) {
                     message = _.template(gettext(
-                        "All CommCare subscriptions require a 30 day minimum commitment. Your current " +
-                        "<%= oldPlan %> Edition Plan subscription is scheduled to be downgraded to the " +
-                        "<%= nextSubscription %> Edition Plan on <%= date %>. Continuing ahead will allow you " +
-                        "to schedule your current <%= oldPlan %> Edition Plan subscription to be downgraded to " +
-                        "the <%= newPlan %> Edition Plan on <%= date %>.  If you have questions or if you would " +
-                        "like to speak to us about your subscription, please reach out to <%= email %>."
+                        "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
+                        "<p>Your current <%= oldPlan %> Edition Plan subscription is scheduled to be downgraded " +
+                        "to the <%= nextSubscription %> Edition Plan on <%= date %>.</p>" +
+                        "<p>Continuing ahead will allow you to schedule your current <%= oldPlan %> Edition " +
+                        "Plan subscription to be downgraded to the <%= newPlan %> Edition Plan " +
+                        "on <%= date %>.</p>" +
+                        "<p>If you have questions or if you would like to speak to us about your subscription, " +
+                        "please reach out to <%= email %>.</p>"
                     ))({
                         oldPlan: oldPlan,
                         nextSubscription: self.nextSubscriptionEdition,
@@ -97,11 +99,12 @@ hqDefine('accounting/js/pricing_table', [
                     });
                 } else {
                     message = _.template(gettext(
-                        "All CommCare subscriptions require a 30 day minimum commitment. Continuing ahead will " +
-                        "allow you to schedule your current <%= oldPlan %> Edition Plan subscription to be " +
-                        "downgraded to the <%= newPlan %> Edition Plan on <%= date %>.  If you have questions " +
-                        "or if you would like to speak to us about your subscription, please reach out to " +
-                        "<%= email %>."
+                        "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
+                        "<p>Continuing ahead will allow you to schedule your current <%= oldPlan %> Edition " +
+                        "Plan subscription to be downgraded to the <%= newPlan %> Edition Plan " +
+                        "on <%= date %>.</p>" +
+                        "If you have questions or if you would like to speak to us about your subscription, " +
+                        "please reach out to <%= email %>."
                     ))({
                         oldPlan: oldPlan,
                         date: newStartDate,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -21,7 +21,7 @@ hqDefine('accounting/js/pricing_table', [
 
     var pricingTableModel = function (options) {
         assertProperties.assert(options, ['editions', 'currentEdition', 'isRenewal', 'startDateAfterMinimum',
-            'isSubscriptionBelowMin', 'nextSubscription']);
+            'isSubscriptionBelowMin', 'nextSubscription', 'invoicing_contact']);
 
         'use strict';
         var self = {};
@@ -31,6 +31,7 @@ hqDefine('accounting/js/pricing_table', [
         self.startDateAfterMinimumSubscription = options.startDateAfterMinimum;
         self.subscriptionBelowMinimum = options.isSubscriptionBelowMin;
         self.nextSubscription = options.nextSubscription;
+        self.invoicing_contact = options.invoicing_contact;
         self.editions = ko.observableArray(_.map(options.editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
         }));
@@ -72,7 +73,7 @@ hqDefine('accounting/js/pricing_table', [
         self.openMinimumSubscriptionModal = function (pricingTable, e) {
             self.form = $(e.currentTarget).closest("form");
 
-            var mailto = "<a href=\'mailto:billing-support@dimagi.com\'>billing-support@dimagi.com</a>";
+            var mailto = "<a href=\'mailto:" + self.invoicing_contact + "'>billing-support@dimagi.com</a>";
             if (self.isDowngrade(self.currentEdition, self.selected_edition()) && self.subscriptionBelowMinimum) {
                 var oldPlan = utils.capitalize(self.currentEdition);
                 var newPlan = utils.capitalize(self.selected_edition());
@@ -172,6 +173,7 @@ hqDefine('accounting/js/pricing_table', [
             startDateAfterMinimum: initialPageData.get('start_date_after_minimum_subscription'),
             isSubscriptionBelowMin: initialPageData.get('subscription_below_minimum'),
             nextSubscription: initialPageData.get('next_subscription'),
+            invoicing_contact: initialPageData.get('invoicing_contact_email')
         });
 
         // Applying bindings is a bit weird here, because we need logic in the modal,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -1,10 +1,10 @@
 hqDefine('accounting/js/pricing_table', function () {
-    var pricingTableModel = function (editions, current_edition, isRenewal,
-                                      startDateAfterMinimumSubscription, subscriptionBelowMinimum) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, startDateAfterMinimumSubscription,
+                                      subscriptionBelowMinimum) {
         'use strict';
         var self = {};
 
-        self.currentEdition = current_edition;
+        self.currentEdition = currentEdition;
         self.isRenewal = isRenewal;
         self.startDateAfterMinimumSubscription = startDateAfterMinimumSubscription;
         self.subscriptionBelowMinimum = subscriptionBelowMinimum;
@@ -12,7 +12,7 @@ hqDefine('accounting/js/pricing_table', function () {
             return pricingTableEditionModel(edition, self.currentEdition);
         }));
 
-        self.selected_edition = ko.observable(isRenewal ? current_edition : false);
+        self.selected_edition = ko.observable(isRenewal ? currentEdition : false);
         self.isSubmitVisible = ko.computed(function () {
             if (isRenewal){
                 return true;
@@ -29,20 +29,20 @@ hqDefine('accounting/js/pricing_table', function () {
             if (oldPlan === 'Enterprise') {
                 if (newPlan === 'Enterprise' || newPlan === 'Pro' ||
                     newPlan === 'Standard' || newPlan === 'Community') {
-                    return true
+                    return true;
                 }
             }
             else if (oldPlan === 'Advanced') {
                 if (newPlan === 'Pro' || newPlan === 'Standard' || newPlan === 'Community') {
-                    return true
+                    return true;
                 }
             } else if (oldPlan === 'Pro') {
                 if (newPlan === 'Standard' || newPlan === 'Community') {
-                    return true
+                    return true;
                 }
             } else if (oldPlan === 'Standard') {
                 if (newPlan === 'Community') {
-                    return true
+                    return true;
                 }
             }
             return false;
@@ -68,7 +68,7 @@ hqDefine('accounting/js/pricing_table', function () {
             }
         };
 
-        self.submitDowngradeForm = function (pricingTable, e) {
+        self.submitDowngradeForm = function (pricingTable) {
             if (self.form) {
                 self.form.submit();
             }
@@ -83,14 +83,14 @@ hqDefine('accounting/js/pricing_table', function () {
         return self;
     };
 
-    var pricingTableEditionModel = function (data, current_edition) {
+    var pricingTableEditionModel = function (data, currentEdition) {
         'use strict';
         var self = {};
 
         self.slug = ko.observable(data[0]);
         self.name = ko.observable(data[1].name);
         self.description = ko.observable(data[1].description);
-        self.currentEdition = ko.observable(data[0] === current_edition);
+        self.currentEdition = ko.observable(data[0] === currentEdition);
         self.notCurrentEdition = ko.computed(function (){
             return !self.currentEdition();
         });

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -36,7 +36,7 @@ hqDefine('accounting/js/pricing_table', [
         };
         self.isDowngrade = function (oldPlan, newPlan) {
             if (oldPlan === 'Enterprise') {
-                if (newPlan === 'Enterprise' || newPlan === 'Pro' ||
+                if (newPlan === 'Advanced' || newPlan === 'Pro' ||
                     newPlan === 'Standard' || newPlan === 'Community') {
                     return true;
                 }

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -4,7 +4,7 @@ hqDefine('accounting/js/pricing_table', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/main',
-    "hqwebapp/js/assert_properties"
+    "hqwebapp/js/assert_properties",
 ], function (
     $,
     ko,
@@ -171,7 +171,7 @@ hqDefine('accounting/js/pricing_table', [
             isRenewal: initialPageData.get('is_renewal'),
             startDateAfterMinimum: initialPageData.get('start_date_after_minimum_subscription'),
             isSubscriptionBelowMin: initialPageData.get('subscription_below_minimum'),
-            nextSubscription: initialPageData.get('next_subscription')
+            nextSubscription: initialPageData.get('next_subscription'),
         });
 
         // Applying bindings is a bit weird here, because we need logic in the modal,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -9,12 +9,13 @@ hqDefine('accounting/js/pricing_table', [
     _,
     initialPageData
 ) {
-    var pricingTableModel = function (editions, currentEdition, isRenewal, isSubscriptionBelowMin) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
         'use strict';
         var self = {};
 
         self.currentEdition = currentEdition;
         self.isRenewal = isRenewal;
+        self.startDateAfterMinimumSubscription = startDate;
         self.subscriptionBelowMinimum = isSubscriptionBelowMin;
         self.editions = ko.observableArray(_.map(editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
@@ -62,10 +63,22 @@ hqDefine('accounting/js/pricing_table', [
 
             var oldPlan = self.capitalizeString(self.currentEdition);
             var newPlan = self.capitalizeString(self.selected_edition());
+            var newStartDate = self.startDateAfterMinimumSubscription;
             if (self.isDowngrade(oldPlan, newPlan) && self.subscriptionBelowMinimum) {
                 var $modal = $("#modal-minimum-subscription");
+                $modal.find('.modal-body')[0].innerHTML =
+                    "CommCare is billed on a monthly basis. If you proceed, your subscription will downgrade " +
+                    "to the " + newPlan + " plan on " + newStartDate + ". You will still have full access " +
+                    "to your " + oldPlan + " subscription until " + newStartDate +
+                    ". Would you still like to schedule this downgrade?";
                 $modal.modal('show');
             } else {
+                self.form.submit();
+            }
+        };
+
+        self.submitDowngradeForm = function () {
+            if (self.form) {
                 self.form.submit();
             }
         };
@@ -117,6 +130,7 @@ hqDefine('accounting/js/pricing_table', [
             initialPageData.get('editions'),
             initialPageData.get('current_edition'),
             initialPageData.get('is_renewal'),
+            initialPageData.get('start_date_after_minimum_subscription'),
             initialPageData.get('subscription_below_minimum')
         );
 

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -9,12 +9,13 @@ hqDefine('accounting/js/pricing_table', [
     _,
     initialPageData
 ) {
-    var pricingTableModel = function (editions, currentEdition, isRenewal, isSubscriptionBelowMin) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
         'use strict';
         var self = {};
 
         self.currentEdition = currentEdition;
         self.isRenewal = isRenewal;
+        self.startDateAfterMinimumSubscription = startDate;
         self.subscriptionBelowMinimum = isSubscriptionBelowMin;
         self.editions = ko.observableArray(_.map(editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
@@ -77,6 +78,12 @@ hqDefine('accounting/js/pricing_table', [
             }
         };
 
+        self.submitDowngradeForm = function () {
+            if (self.form) {
+                self.form.submit();
+            }
+        };
+
         self.init = function () {
             $('.col-edition').click(function () {
                 self.selected_edition($(this).data('edition'));
@@ -124,6 +131,7 @@ hqDefine('accounting/js/pricing_table', [
             initialPageData.get('editions'),
             initialPageData.get('current_edition'),
             initialPageData.get('is_renewal'),
+            initialPageData.get('start_date_after_minimum_subscription'),
             initialPageData.get('subscription_below_minimum')
         );
 

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -9,13 +9,12 @@ hqDefine('accounting/js/pricing_table', [
     _,
     initialPageData
 ) {
-    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, isSubscriptionBelowMin) {
         'use strict';
         var self = {};
 
         self.currentEdition = currentEdition;
         self.isRenewal = isRenewal;
-        self.startDateAfterMinimumSubscription = startDate;
         self.subscriptionBelowMinimum = isSubscriptionBelowMin;
         self.editions = ko.observableArray(_.map(editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
@@ -78,12 +77,6 @@ hqDefine('accounting/js/pricing_table', [
             }
         };
 
-        self.submitDowngradeForm = function () {
-            if (self.form) {
-                self.form.submit();
-            }
-        };
-
         self.init = function () {
             $('.col-edition').click(function () {
                 self.selected_edition($(this).data('edition'));
@@ -131,7 +124,6 @@ hqDefine('accounting/js/pricing_table', [
             initialPageData.get('editions'),
             initialPageData.get('current_edition'),
             initialPageData.get('is_renewal'),
-            initialPageData.get('start_date_after_minimum_subscription'),
             initialPageData.get('subscription_below_minimum')
         );
 

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -9,7 +9,8 @@ hqDefine('accounting/js/pricing_table', [
     _,
     initialPageData
 ) {
-    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin,
+    nextSubscription) {
         'use strict';
         var self = {};
 
@@ -17,6 +18,7 @@ hqDefine('accounting/js/pricing_table', [
         self.isRenewal = isRenewal;
         self.startDateAfterMinimumSubscription = startDate;
         self.subscriptionBelowMinimum = isSubscriptionBelowMin;
+        self.nextSubscription = nextSubscription;
         self.editions = ko.observableArray(_.map(editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
         }));
@@ -66,12 +68,17 @@ hqDefine('accounting/js/pricing_table', [
             var newStartDate = self.startDateAfterMinimumSubscription;
             var mailto = "<a href=\'mailto:billing-support@dimagi.com\'>billing-support@dimagi.com</a>";
             if (self.isDowngrade(oldPlan, newPlan) && self.subscriptionBelowMinimum) {
+                var message = "All CommCare subscriptions require a 30 day minimum commitment.";
+                if (self.nextSubscription) {
+                    message += " Your current " + oldPlan + " Edition Plan subscription is scheduled to be " +
+                        "downgraded to the " + self.nextSubscription + " Edition Plan on " + newStartDate + ". ";
+                }
+                message += " Continuing ahead will allow you to schedule your current " + oldPlan + " Edition " +
+                    "Plan subscription to be downgraded to the " + newPlan + " Edition Plan on " + newStartDate +
+                    ". If you have questions or if you would like to speak to us about your subscription, " +
+                    "please reach out to " + mailto + ".";
                 var $modal = $("#modal-minimum-subscription");
-                $modal.find('.modal-body')[0].innerHTML =
-                    "All CommCare subscriptions require a 30 day minimum commitment. Your current subscription " +
-                    "will be downgraded to " + newPlan + " on " + newStartDate + ". If you have questions or if " +
-                    "you would like to speak to someone about your subscription, please reach out to "
-                    + mailto + ".";
+                $modal.find('.modal-body')[0].innerHTML = message;
                 $modal.modal('show');
             } else {
                 self.form.submit();
@@ -132,7 +139,8 @@ hqDefine('accounting/js/pricing_table', [
             initialPageData.get('current_edition'),
             initialPageData.get('is_renewal'),
             initialPageData.get('start_date_after_minimum_subscription'),
-            initialPageData.get('subscription_below_minimum')
+            initialPageData.get('subscription_below_minimum'),
+            initialPageData.get('next_subscription')
         );
 
         // Applying bindings is a bit weird here, because we need logic in the modal,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -1,4 +1,14 @@
-hqDefine('accounting/js/pricing_table', function () {
+hqDefine('accounting/js/pricing_table', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data'
+], function (
+    $,
+    ko,
+    _,
+    initialPageData
+) {
     var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
         'use strict';
         var self = {};
@@ -116,14 +126,13 @@ hqDefine('accounting/js/pricing_table', function () {
     };
 
     $(function () {
-        var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,
-            pricingTable = pricingTableModel(
-                initial_page_data('editions'),
-                initial_page_data('current_edition'),
-                initial_page_data('is_renewal'),
-                initial_page_data('start_date_after_minimum_subscription'),
-                initial_page_data('subscription_below_minimum')
-            );
+        var pricingTable = pricingTableModel(
+            initialPageData.get('editions'),
+            initialPageData.get('current_edition'),
+            initialPageData.get('is_renewal'),
+            initialPageData.get('start_date_after_minimum_subscription'),
+            initialPageData.get('subscription_below_minimum')
+        );
 
         // Applying bindings is a bit weird here, because we need logic in the modal,
         // but the only HTML ancestor the modal shares with the pricing table is <body>.
@@ -131,5 +140,5 @@ hqDefine('accounting/js/pricing_table', function () {
         $('#modal-minimum-subscription').koApplyBindings(pricingTable);
 
         pricingTable.init();
-    }());
+    });
 });

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -9,13 +9,12 @@ hqDefine('accounting/js/pricing_table', [
     _,
     initialPageData
 ) {
-    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, isSubscriptionBelowMin) {
         'use strict';
         var self = {};
 
         self.currentEdition = currentEdition;
         self.isRenewal = isRenewal;
-        self.startDateAfterMinimumSubscription = startDate;
         self.subscriptionBelowMinimum = isSubscriptionBelowMin;
         self.editions = ko.observableArray(_.map(editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
@@ -63,22 +62,10 @@ hqDefine('accounting/js/pricing_table', [
 
             var oldPlan = self.capitalizeString(self.currentEdition);
             var newPlan = self.capitalizeString(self.selected_edition());
-            var newStartDate = self.startDateAfterMinimumSubscription;
             if (self.isDowngrade(oldPlan, newPlan) && self.subscriptionBelowMinimum) {
                 var $modal = $("#modal-minimum-subscription");
-                $modal.find('.modal-body')[0].innerHTML =
-                    "CommCare is billed on a monthly basis. If you proceed, your subscription will downgrade " +
-                    "to the " + newPlan + " plan on " + newStartDate + ". You will still have full access " +
-                    "to your " + oldPlan + " subscription until " + newStartDate +
-                    ". Would you still like to schedule this downgrade?";
                 $modal.modal('show');
             } else {
-                self.form.submit();
-            }
-        };
-
-        self.submitDowngradeForm = function () {
-            if (self.form) {
                 self.form.submit();
             }
         };
@@ -130,7 +117,6 @@ hqDefine('accounting/js/pricing_table', [
             initialPageData.get('editions'),
             initialPageData.get('current_edition'),
             initialPageData.get('is_renewal'),
-            initialPageData.get('start_date_after_minimum_subscription'),
             initialPageData.get('subscription_below_minimum')
         );
 

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -1,13 +1,12 @@
 hqDefine('accounting/js/pricing_table', function () {
-    var pricingTableModel = function (editions, currentEdition, isRenewal, startDateAfterMinimumSubscription,
-                                      subscriptionBelowMinimum) {
+    var pricingTableModel = function (editions, currentEdition, isRenewal, startDate, isSubscriptionBelowMin) {
         'use strict';
         var self = {};
 
         self.currentEdition = currentEdition;
         self.isRenewal = isRenewal;
-        self.startDateAfterMinimumSubscription = startDateAfterMinimumSubscription;
-        self.subscriptionBelowMinimum = subscriptionBelowMinimum;
+        self.startDateAfterMinimumSubscription = startDate;
+        self.subscriptionBelowMinimum = isSubscriptionBelowMin;
         self.editions = ko.observableArray(_.map(editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
         }));
@@ -68,7 +67,7 @@ hqDefine('accounting/js/pricing_table', function () {
             }
         };
 
-        self.submitDowngradeForm = function (pricingTable) {
+        self.submitDowngradeForm = function () {
             if (self.form) {
                 self.form.submit();
             }

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -74,18 +74,36 @@ hqDefine('accounting/js/pricing_table', [
                 var newPlan = utils.capitalize(self.selected_edition());
                 var newStartDate = self.startDateAfterMinimumSubscription;
 
-                var message = _(gettext("All CommCare subscriptions require a 30 day minimum commitment."));
+                var message = "";
                 if (self.nextSubscription) {
-                    message += _.template(gettext(" Your current <%= oldPlan %> Edition Plan subscription is " +
-                        "scheduled to be downgraded to the <%= nextSubscription %> Edition Plan on <%= date %>."))
-                    ({oldPlan: oldPlan, nextSubscription: self.nextSubscription, date: newStartDate});
+                    message = _.template(gettext(
+                        "All CommCare subscriptions require a 30 day minimum commitment. Your current " +
+                        "<%= oldPlan %> Edition Plan subscription is scheduled to be downgraded to the " +
+                        "<%= nextSubscription %> Edition Plan on <%= date %>. Continuing ahead will allow you " +
+                        "to schedule your current <%= oldPlan %> Edition Plan subscription to be downgraded to " +
+                        "the <%= newPlan %> Edition Plan on <%= date %>.  If you have questions or if you would " +
+                        "like to speak to us about your subscription, please reach out to <%= email %>."
+                    ))({
+                        oldPlan: oldPlan,
+                        nextSubscription: self.nextSubscription,
+                        date: newStartDate,
+                        newPlan: newPlan,
+                        email: mailto
+                    });
+                } else {
+                    message = _.template(gettext(
+                        "All CommCare subscriptions require a 30 day minimum commitment. Continuing ahead will " +
+                        "allow you to schedule your current <%= oldPlan %> Edition Plan subscription to be " +
+                        "downgraded to the <%= newPlan %> Edition Plan on <%= date %>.  If you have questions " +
+                        "or if you would like to speak to us about your subscription, please reach out to " +
+                        "<%= email %>."
+                    ))({
+                        oldPlan: oldPlan,
+                        date: newStartDate,
+                        newPlan: newPlan,
+                        email: mailto
+                    });
                 }
-                message += _.template(gettext(" Continuing ahead will allow you to schedule your current " +
-                    "<%= oldPlan %> Edition Plan subscription to be downgraded to the <%= newPlan %> Edition " +
-                    "Plan on <%= date %>.  If you have questions or if you would like to speak to us about your " +
-                    "subscription, please reach out to "))
-                ({oldPlan: oldPlan, newPlan: newPlan, date: newStartDate});
-                message += mailto + " .";
                 var $modal = $("#modal-minimum-subscription");
                 $modal.find('.modal-body')[0].innerHTML = message;
                 $modal.modal('show');

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -69,7 +69,7 @@ hqDefine('accounting/js/pricing_table', [
                 var $modal = $("#modal-minimum-subscription");
                 $modal.find('.modal-body')[0].innerHTML =
                     "All CommCare subscriptions require a 30 day minimum commitment. Your current subscription " +
-                    "will be downgraded to " + newPlan + " on " + newStartDate + ".If you have questions or if " +
+                    "will be downgraded to " + newPlan + " on " + newStartDate + ". If you have questions or if " +
                     "you would like to speak to someone about your subscription, please reach out to "
                     + mailto + ".";
                 $modal.modal('show');

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -64,13 +64,14 @@ hqDefine('accounting/js/pricing_table', [
             var oldPlan = self.capitalizeString(self.currentEdition);
             var newPlan = self.capitalizeString(self.selected_edition());
             var newStartDate = self.startDateAfterMinimumSubscription;
+            var mailto = "<a href=\'mailto:billing-support@dimagi.com\'>billing-support@dimagi.com</a>";
             if (self.isDowngrade(oldPlan, newPlan) && self.subscriptionBelowMinimum) {
                 var $modal = $("#modal-minimum-subscription");
                 $modal.find('.modal-body')[0].innerHTML =
-                    "CommCare is billed on a monthly basis. If you proceed, your subscription will downgrade " +
-                    "to the " + newPlan + " plan on " + newStartDate + ". You will still have full access " +
-                    "to your " + oldPlan + " subscription until " + newStartDate +
-                    ". Would you still like to schedule this downgrade?";
+                    "All CommCare subscriptions require a 30 day minimum commitment. Your current subscription " +
+                    "will be downgraded to " + newPlan + " on " + newStartDate + ".If you have questions or if " +
+                    "you would like to speak to someone about your subscription, please reach out to "
+                    + mailto + ".";
                 $modal.modal('show');
             } else {
                 self.form.submit();

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -56,7 +56,6 @@ hqDefine('accounting/js/pricing_table', function () {
             var newPlan = self.capitalizeString(self.selected_edition());
             var newStartDate = self.startDateAfterMinimumSubscription;
             if (self.isDowngrade(oldPlan, newPlan) && self.subscriptionBelowMinimum) {
-                debugger;
                 var $modal = $("#modal-minimum-subscription");
                 $modal.find('.modal-body')[0].innerHTML =
                     "CommCare bills on a monthly basis. If you cancel now, your subscription will downgrade to " +
@@ -69,26 +68,10 @@ hqDefine('accounting/js/pricing_table', function () {
             }
         };
 
-        self.submitDowngrade = function(pricingTable, e) {
-            var finish = function() {
-                if (self.form) {
-                    self.form.submit();
-                }
-            };
-
-            var $button = $(e.currentTarget);
-            $button.disableButton();
-            $.ajax({
-                method: "POST",
-                url: hqImport('hqwebapp/js/initial_page_data').reverse('email_on_downgrade'),
-                data: {
-                    old_plan: self.currentEdition,
-                    new_plan: self.selected_edition(),
-                    note: $button.closest(".modal").find("textarea").val(),
-                },
-                success: finish,
-                error: finish,
-            });
+        self.submitDowngradeForm = function (pricingTable, e) {
+            if (self.form) {
+                self.form.submit();
+            }
         };
 
         self.init = function () {

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -2,7 +2,7 @@ hqDefine('accounting/js/pricing_table', [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/initial_page_data'
+    'hqwebapp/js/initial_page_data',
 ], function (
     $,
     ko,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -57,10 +57,10 @@ hqDefine('accounting/js/pricing_table', function () {
             if (self.isDowngrade(oldPlan, newPlan) && self.subscriptionBelowMinimum) {
                 var $modal = $("#modal-minimum-subscription");
                 $modal.find('.modal-body')[0].innerHTML =
-                    "CommCare bills on a monthly basis. If you cancel now, your subscription will downgrade to " +
-                    "the " + newPlan + " plan on " + newStartDate + ". Would you still like to schedule this " +
-                    "downgrade? You will still have full access to your " + oldPlan + " subscription until " +
-                    newStartDate + ".";
+                    "CommCare is billed on a monthly basis. If you proceed, your subscription will downgrade " +
+                    "to the " + newPlan + " plan on " + newStartDate + ". You will still have full access " +
+                    "to your " + oldPlan + " subscription until " + newStartDate +
+                    ". Would you still like to schedule this downgrade?";
                 $modal.modal('show');
             } else {
                 self.form.submit();

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -173,7 +173,7 @@ hqDefine('accounting/js/pricing_table', [
             startDateAfterMinimum: initialPageData.get('start_date_after_minimum_subscription'),
             isSubscriptionBelowMin: initialPageData.get('subscription_below_minimum'),
             nextSubscription: initialPageData.get('next_subscription'),
-            invoicing_contact: initialPageData.get('invoicing_contact_email')
+            invoicing_contact: initialPageData.get('invoicing_contact_email'),
         });
 
         // Applying bindings is a bit weird here, because we need logic in the modal,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -21,7 +21,7 @@ hqDefine('accounting/js/pricing_table', [
 
     var pricingTableModel = function (options) {
         assertProperties.assert(options, ['editions', 'currentEdition', 'isRenewal', 'startDateAfterMinimum',
-            'isSubscriptionBelowMin', 'nextSubscription', 'invoicing_contact']);
+            'isSubscriptionBelowMin', 'nextSubscriptionEdition', 'invoicing_contact']);
 
         'use strict';
         var self = {};
@@ -30,7 +30,7 @@ hqDefine('accounting/js/pricing_table', [
         self.isRenewal = options.isRenewal;
         self.startDateAfterMinimumSubscription = options.startDateAfterMinimum;
         self.subscriptionBelowMinimum = options.isSubscriptionBelowMin;
-        self.nextSubscription = options.nextSubscription;
+        self.nextSubscriptionEdition = options.nextSubscriptionEdition;
         self.invoicing_contact = options.invoicing_contact;
         self.editions = ko.observableArray(_.map(options.editions, function (edition) {
             return pricingTableEditionModel(edition, self.currentEdition);
@@ -80,7 +80,7 @@ hqDefine('accounting/js/pricing_table', [
                 var newStartDate = self.startDateAfterMinimumSubscription;
 
                 var message = "";
-                if (self.nextSubscription) {
+                if (self.nextSubscriptionEdition) {
                     message = _.template(gettext(
                         "All CommCare subscriptions require a 30 day minimum commitment. Your current " +
                         "<%= oldPlan %> Edition Plan subscription is scheduled to be downgraded to the " +
@@ -90,7 +90,7 @@ hqDefine('accounting/js/pricing_table', [
                         "like to speak to us about your subscription, please reach out to <%= email %>."
                     ))({
                         oldPlan: oldPlan,
-                        nextSubscription: self.nextSubscription,
+                        nextSubscription: self.nextSubscriptionEdition,
                         date: newStartDate,
                         newPlan: newPlan,
                         email: mailto,
@@ -172,7 +172,7 @@ hqDefine('accounting/js/pricing_table', [
             isRenewal: initialPageData.get('is_renewal'),
             startDateAfterMinimum: initialPageData.get('start_date_after_minimum_subscription'),
             isSubscriptionBelowMin: initialPageData.get('subscription_below_minimum'),
-            nextSubscription: initialPageData.get('next_subscription'),
+            nextSubscriptionEdition: initialPageData.get('next_subscription_edition'),
             invoicing_contact: initialPageData.get('invoicing_contact_email'),
         });
 

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -350,7 +350,7 @@ def get_account_name_from_default_name(default_name):
         )
 
 
-def cancel_future_subscriptions(domain_name, from_date, web_user, hide=False):
+def cancel_future_subscriptions(domain_name, from_date, web_user):
     from corehq.apps.accounting.models import (
         Subscription,
         SubscriptionAdjustment,
@@ -361,7 +361,6 @@ def cancel_future_subscriptions(domain_name, from_date, web_user, hide=False):
         date_start__gt=from_date,
     ).order_by('date_start').all():
         later_subscription.date_end = later_subscription.date_start
-        later_subscription.is_hidden_to_ops = hide
         later_subscription.save()
         SubscriptionAdjustment.record_adjustment(
             later_subscription,

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -368,3 +368,20 @@ def cancel_future_subscriptions(domain_name, from_date, web_user):
             web_user=web_user,
             note="Cancelled due to changing subscription",
         )
+
+
+def is_downgrade(current_edition, next_edition):
+    if current_edition == 'Enterprise':
+        if next_edition == 'Advanced' or next_edition == 'Pro' or \
+                next_edition == 'Standard' or next_edition == 'Community':
+            return True
+    if current_edition == 'Advanced':
+        if next_edition == 'Pro' or next_edition == 'Standard' or next_edition == 'Community':
+            return True
+    if current_edition == 'Pro':
+        if next_edition == 'Standard' or next_edition == 'Community':
+            return True
+    if current_edition == 'Standard':
+        if next_edition == 'Community':
+            return True
+    return False

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -350,7 +350,7 @@ def get_account_name_from_default_name(default_name):
         )
 
 
-def cancel_future_subscriptions(domain_name, from_date, web_user):
+def cancel_future_subscriptions(domain_name, from_date, web_user, hide=False):
     from corehq.apps.accounting.models import (
         Subscription,
         SubscriptionAdjustment,
@@ -361,6 +361,7 @@ def cancel_future_subscriptions(domain_name, from_date, web_user):
         date_start__gt=from_date,
     ).order_by('date_start').all():
         later_subscription.date_end = later_subscription.date_start
+        later_subscription.is_hidden_to_ops = hide
         later_subscription.save()
         SubscriptionAdjustment.record_adjustment(
             later_subscription,

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -371,17 +371,6 @@ def cancel_future_subscriptions(domain_name, from_date, web_user):
 
 
 def is_downgrade(current_edition, next_edition):
-    if current_edition == 'Enterprise':
-        if next_edition == 'Advanced' or next_edition == 'Pro' or \
-                next_edition == 'Standard' or next_edition == 'Community':
-            return True
-    if current_edition == 'Advanced':
-        if next_edition == 'Pro' or next_edition == 'Standard' or next_edition == 'Community':
-            return True
-    if current_edition == 'Pro':
-        if next_edition == 'Standard' or next_edition == 'Community':
-            return True
-    if current_edition == 'Standard':
-        if next_edition == 'Community':
-            return True
-    return False
+    from corehq.apps.accounting.models import SoftwarePlanEdition
+    plans = SoftwarePlanEdition.SELF_SERVICE_ORDER + [SoftwarePlanEdition.ENTERPRISE]
+    return plans.index(current_edition) > plans.index(next_edition)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1621,7 +1621,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 if not account_save_success:
                     return False
 
-                cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
+                cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user, hide=True)
                 if self.current_subscription is not None:
                     if self.is_downgrade() and self.current_subscription.is_below_minimum_subscription:
                         self.current_subscription.update_subscription(

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1621,7 +1621,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 if not account_save_success:
                     return False
 
-                cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user, hide=True)
+                cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
                 if self.current_subscription is not None:
                     if self.is_downgrade() and self.current_subscription.is_below_minimum_subscription:
                         self.current_subscription.update_subscription(

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -69,6 +69,7 @@ from corehq.apps.accounting.utils import (
     get_account_name_from_default_name,
     get_privileges,
     log_accounting_error,
+    is_downgrade
 )
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.app_manager.models import Application, FormBase, RemoteApp
@@ -1670,20 +1671,11 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
     def is_downgrade(self):
         if self.current_subscription is None:
             return False
-
-        current_edition = self.current_subscription.plan_version.plan.edition
-        new_edition = self.plan_version.plan.edition
-
-        if current_edition == 'Advanced':
-            if new_edition == 'Pro' or new_edition == 'Standard' or new_edition == 'Community':
-                return True
-        if current_edition == 'Pro':
-            if new_edition == 'Standard' or new_edition == 'Community':
-                return True
-        if current_edition == 'Standard':
-            if new_edition == 'Community':
-                return True
-        return False
+        else:
+            is_downgrade(
+                current_edition=self.current_subscription.plan_version.plan.edition,
+                next_edition=self.plan_version.plan.edition
+            )
 
 
 class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1623,32 +1623,15 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
 
                 cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
                 if self.current_subscription is not None:
-                    if self.is_downgrade() and self.current_subscription.is_below_minimum_subscription:
-                        self.current_subscription.update_subscription(
-                            date_start=self.current_subscription.date_start,
-                            date_end=self.current_subscription.date_start + datetime.timedelta(days=30)
-                        )
-                        Subscription.new_domain_subscription(
-                            account=self.account,
-                            domain=self.domain,
-                            plan_version=self.plan_version,
-                            date_start=self.current_subscription.date_start + datetime.timedelta(days=31),
-                            web_user=self.creating_user,
-                            adjustment_method=SubscriptionAdjustmentMethod.USER,
-                            service_type=SubscriptionType.PRODUCT,
-                            pro_bono_status=ProBonoStatus.NO,
-                            funding_source=FundingSource.CLIENT,
-                        )
-                    else:
-                        self.current_subscription.change_plan(
-                            self.plan_version,
-                            web_user=self.creating_user,
-                            adjustment_method=SubscriptionAdjustmentMethod.USER,
-                            service_type=SubscriptionType.PRODUCT,
-                            pro_bono_status=ProBonoStatus.NO,
-                            do_not_invoice=False,
-                            no_invoice_reason='',
-                        )
+                    self.current_subscription.change_plan(
+                        self.plan_version,
+                        web_user=self.creating_user,
+                        adjustment_method=SubscriptionAdjustmentMethod.USER,
+                        service_type=SubscriptionType.PRODUCT,
+                        pro_bono_status=ProBonoStatus.NO,
+                        do_not_invoice=False,
+                        no_invoice_reason='',
+                    )
                 else:
                     Subscription.new_domain_subscription(
                         self.account, self.domain, self.plan_version,
@@ -1666,24 +1649,6 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 show_stack_trace=True,
             )
             return False
-
-    def is_downgrade(self):
-        if self.current_subscription is None:
-            return False
-
-        current_edition = self.current_subscription.plan_version.plan.edition
-        new_edition = self.plan_version.plan.edition
-
-        if current_edition == 'Advanced':
-            if new_edition == 'Pro' or new_edition == 'Standard' or new_edition == 'Community':
-                return True
-        if current_edition == 'Pro':
-            if new_edition == 'Standard' or new_edition == 'Community':
-                return True
-        if current_edition == 'Standard':
-            if new_edition == 'Community':
-                return True
-        return False
 
 
 class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1623,15 +1623,32 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
 
                 cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
                 if self.current_subscription is not None:
-                    self.current_subscription.change_plan(
-                        self.plan_version,
-                        web_user=self.creating_user,
-                        adjustment_method=SubscriptionAdjustmentMethod.USER,
-                        service_type=SubscriptionType.PRODUCT,
-                        pro_bono_status=ProBonoStatus.NO,
-                        do_not_invoice=False,
-                        no_invoice_reason='',
-                    )
+                    if self.is_downgrade() and self.current_subscription.is_below_minimum_subscription:
+                        self.current_subscription.update_subscription(
+                            date_start=self.current_subscription.date_start,
+                            date_end=self.current_subscription.date_start + datetime.timedelta(days=30)
+                        )
+                        Subscription.new_domain_subscription(
+                            account=self.account,
+                            domain=self.domain,
+                            plan_version=self.plan_version,
+                            date_start=self.current_subscription.date_start + datetime.timedelta(days=31),
+                            web_user=self.creating_user,
+                            adjustment_method=SubscriptionAdjustmentMethod.USER,
+                            service_type=SubscriptionType.PRODUCT,
+                            pro_bono_status=ProBonoStatus.NO,
+                            funding_source=FundingSource.CLIENT,
+                        )
+                    else:
+                        self.current_subscription.change_plan(
+                            self.plan_version,
+                            web_user=self.creating_user,
+                            adjustment_method=SubscriptionAdjustmentMethod.USER,
+                            service_type=SubscriptionType.PRODUCT,
+                            pro_bono_status=ProBonoStatus.NO,
+                            do_not_invoice=False,
+                            no_invoice_reason='',
+                        )
                 else:
                     Subscription.new_domain_subscription(
                         self.account, self.domain, self.plan_version,
@@ -1649,6 +1666,24 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 show_stack_trace=True,
             )
             return False
+
+    def is_downgrade(self):
+        if self.current_subscription is None:
+            return False
+
+        current_edition = self.current_subscription.plan_version.plan.edition
+        new_edition = self.plan_version.plan.edition
+
+        if current_edition == 'Advanced':
+            if new_edition == 'Pro' or new_edition == 'Standard' or new_edition == 'Community':
+                return True
+        if current_edition == 'Pro':
+            if new_edition == 'Standard' or new_edition == 'Community':
+                return True
+        if current_edition == 'Standard':
+            if new_edition == 'Community':
+                return True
+        return False
 
 
 class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1633,7 +1633,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                             account=self.account,
                             domain=self.domain,
                             plan_version=self.plan_version,
-                            date_start=self.current_subscription.date_start + datetime.timedelta(days=31),
+                            date_start=self.current_subscription.date_start + datetime.timedelta(days=30),
                             web_user=self.creating_user,
                             adjustment_method=SubscriptionAdjustmentMethod.USER,
                             service_type=SubscriptionType.PRODUCT,

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -48,9 +48,9 @@
         <div class="alert alert-danger">
             {% blocktrans with next_invoice_date as invoice_date %}
             <h4>Note: Continuing will change your current subscription.</h4>
-            <p>CommCare bills on a monthly basis, and all subscriptions require a 30 day minimum commitment. You
-                should expect your first invoice on {{ invoice_date }}, or you can prepay for your subscription
-                by following the instructions
+            <p>CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
+                You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
+                subscription by following the instructions
                 <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
             </p>
             {% endblocktrans %}
@@ -61,10 +61,7 @@
             {% blocktrans with current_plan.name as p %}
             <h4>Note: Continuing will change your current subscription.</h4>
             <p>We’re sorry to see you go! You’ll have access to the features on your
-                <strong>{{ p }} Software Plan </strong></p> through {{ current_subscription_end_date }}.
-                If you’d like to continue using CommCare’s paid features, you can
-                <a href="https://www.commcarehq.org/a/project-space/settings/project/subscription/change/">renew</a>
-                your subscription at any time before {{ current_subscription_end_date }}.
+            <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>
         {% else %}
@@ -111,14 +108,14 @@
         <hr />
         <p>
             {% blocktrans %}
-            Clicking the 'Select this Plan' button below will bring you to a page where you can enter basic billing information.
+            Clicking the 'Confirm Plan' button below will bring you to a page where you can enter basic billing information.
             {% endblocktrans %}
         </p>
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
                 <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
-                    {% trans 'Select this Plan' %}
+                    {% trans 'Confirm Plan' %}
                 </button>
             </div>
         </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -111,7 +111,7 @@
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
+                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal" disabled>
                     {% trans 'Confirm Plan' %}
                 </button>
             </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -2,7 +2,17 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
+{% block js %}{{ block.super }}
+    <script src="{% static 'accounting/js/confirm_plan.js' %}"></script>
+{% endblock %}
+
 {% block form_content %}
+{% initial_page_data 'isUpgrade' isUpgrade %}
+{% initial_page_data 'nextInvoiceDate' nextInvoiceDate %}
+{% initial_page_data 'currentPlan' currentPlan %}
+{% initial_page_data 'isDowngradeBeforeMinimum' isDowngradeBeforeMinimum|BOOL %}
+{% initial_page_data 'currentSubscriptionEndDate' currentSubscriptionEndDate %}
+{% registerurl 'email_on_downgrade' domain %}
     <p class="lead">
         {% blocktrans with plan.name as p %}
         You have selected the <strong>{{ p }} Software Plan</strong>.
@@ -43,17 +53,16 @@
             </p>
             {% endblocktrans %}
         </div>
-        {% endif %}
-        {% if is_downgrade_before_minimum %}
+        {% elif is_downgrade_before_minimum %}
         <hr />
         <div class="alert alert-danger">
             {% blocktrans with current_plan.name as p %}
             <h4>Note: Continuing will change your current subscription.</h4>
             <p>We’re sorry to see you go! You’ll have access to the features on your
-                <strong>{{ p }} Software Plan </strong></p> through {{ new_subscription_start_date }}.
+                <strong>{{ p }} Software Plan </strong></p> through {{ current_subscription_end_date }}.
                 If you’d like to continue using CommCare’s paid features, you can
                 <a href="https://www.commcarehq.org/a/project-space/settings/project/subscription/change/">renew</a>
-                your subscription at any time before {{ new_subscription_start_date }}.
+                your subscription at any time before {{ current_subscription_end_date }}.
             {% endblocktrans %}
         </div>
         {% else %}
@@ -106,11 +115,38 @@
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button type="submit" class="btn btn-primary">
+                <button class="btn btn-primary" data-bind="click: openDowngradeModal">
                     {% trans 'Select this Plan' %}
                 </button>
             </div>
         </div>
     </form>
     {% endif %}
+{% endblock %}
+
+{% block modals %}{{ block.super }}
+<div class="modal fade" id="modal-downgrade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">{% trans "Close" %}</span>
+                </button>
+                <h4 class="modal-title">Downgrading?</h4>
+            </div>
+            <div class="modal-body">
+                {% blocktrans %}
+                    We'd love to make CommCare work better for you.
+                    Let us know what we can do to improve, or why you're downgrading.
+                {% endblocktrans %}
+                <br><br>
+                <textarea class="form-control"></textarea>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade">{% trans "OK" %}</button>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -8,6 +8,8 @@
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
 {% initial_page_data 'new_plan' plan.name %}
+{% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
+{% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
     <p class="lead">
@@ -131,7 +133,7 @@
             </div>
             <div class="modal-body">
                 {% blocktrans %}
-                    We're sorry to see you go! We'd love to make CommCare work better for you.
+                    We'd love to make CommCare work better for you.
                     Let us know what we can do to improve, or why you're downgrading.
                 {% endblocktrans %}
                 <br><br>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -115,7 +115,7 @@
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal" disabled>
+                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
                     {% trans 'Confirm Plan' %}
                 </button>
             </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -61,17 +61,16 @@
             <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>
-        {% endif %}
-        {% if is_downgrade_before_minimum %}
+        {% elif is_downgrade_before_minimum %}
         <hr />
         <div class="alert alert-danger">
             {% blocktrans with current_plan.name as p %}
             <h4>Note: Continuing will change your current subscription.</h4>
             <p>We’re sorry to see you go! You’ll have access to the features on your
-                <strong>{{ p }} Software Plan </strong></p> through {{ new_subscription_start_date }}.
+                <strong>{{ p }} Software Plan </strong></p> through {{ current_subscription_end_date }}.
                 If you’d like to continue using CommCare’s paid features, you can
                 <a href="https://www.commcarehq.org/a/project-space/settings/project/subscription/change/">renew</a>
-                your subscription at any time before {{ new_subscription_start_date }}.
+                your subscription at any time before {{ current_subscription_end_date }}.
             {% endblocktrans %}
         </div>
         {% else %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -31,13 +31,27 @@
     </p>
     {% endif %}
     {% if current_plan %}
-    <hr />
-    <div class="alert alert-danger">
-        {% blocktrans with current_plan.name as p %}
-        <h4>Note: Continuing will change your current subscription.</h4>
-        <p>You are currently subscribed to the <strong>{{ p }} Software Plan</strong></p>
-        {% endblocktrans %}
-    </div>
+        {% if is_upgrade %}
+        <hr />
+        <div class="alert alert-danger">
+            {% blocktrans with next_invoice_date as invoice_date %}
+            <h4>Note: Continuing will change your current subscription.</h4>
+            <p>CommCare bills on a monthly basis, and all subscriptions require a 30 day minimum commitment. You
+                should expect your first invoice on {{ invoice_date }}, or you can prepay for your subscription
+                by following the instructions
+                <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>
+            </p>
+            {% endblocktrans %}
+        </div>
+        {% else %}
+        <hr />
+        <div class="alert alert-danger">
+            {% blocktrans with current_plan.name as p %}
+            <h4>Note: Continuing will change your current subscription.</h4>
+            <p>You are currently subscribed to the <strong>{{ p }} Software Plan</strong></p>
+            {% endblocktrans %}
+        </div>
+        {% endif %}
     {% endif %}
 
     {% if downgrade_messages %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -57,8 +57,7 @@
         <hr />
         <div class="alert alert-danger">
             {% blocktrans with current_plan.name as p %}
-            <h4>Note: Continuing will change your current subscription.</h4>
-            <p>We’re sorry to see you go! You’ll have access to the features on your
+            <p>We’re sorry to see you downgrade. You’ll have access to the features on your
             <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -99,6 +99,7 @@
         <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
     </div>
     {% else %}
+    <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
         {% csrf_token %}
         <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
         <hr />
@@ -115,7 +116,7 @@
                 </button>
             </div>
         </div>
-    </div>
+    </form>
     {% endif %}
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -8,6 +8,8 @@
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
 {% initial_page_data 'new_plan' plan.name %}
+{% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
+{% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
     <p class="lead">
@@ -49,6 +51,15 @@
                 <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
             </p>
             <input type="checkbox" id="user-agreement" value="True"> I understand and wish to continue.<br>
+            {% endblocktrans %}
+        </div>
+        {% elif is_downgrade_before_minimum %}
+        <hr />
+        <div class="alert alert-danger">
+            {% blocktrans with current_plan.name as p %}
+            <h4>Note: Continuing will change your current subscription.</h4>
+            <p>We’re sorry to see you go! You’ll have access to the features on your
+            <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>
         {% else %}
@@ -123,7 +134,7 @@
             </div>
             <div class="modal-body">
                 {% blocktrans %}
-                    We're sorry to see you go! We'd love to make CommCare work better for you.
+                    We'd love to make CommCare work better for you.
                     Let us know what we can do to improve, or why you're downgrading.
                 {% endblocktrans %}
                 <br><br>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -7,12 +7,14 @@
 {% endblock %}
 
 {% block form_content %}
-{% initial_page_data 'isUpgrade' isUpgrade %}
-{% initial_page_data 'nextInvoiceDate' nextInvoiceDate %}
-{% initial_page_data 'currentPlan' currentPlan %}
-{% initial_page_data 'isDowngradeBeforeMinimum' isDowngradeBeforeMinimum|BOOL %}
-{% initial_page_data 'currentSubscriptionEndDate' currentSubscriptionEndDate %}
+{% initial_page_data 'is_upgrade' is_upgrade|BOOL %}
+{% initial_page_data 'next_invoice_date' next_invoice_date %}
+{% initial_page_data 'current_plan' current_plan %}
+{% initial_page_data 'new_plan' plan.name %}
+{% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
+{% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
 {% registerurl 'email_on_downgrade' domain %}
+{% registerurl 'confirm_billing_account_info' domain %}
     <p class="lead">
         {% blocktrans with plan.name as p %}
         You have selected the <strong>{{ p }} Software Plan</strong>.
@@ -49,7 +51,7 @@
             <p>CommCare bills on a monthly basis, and all subscriptions require a 30 day minimum commitment. You
                 should expect your first invoice on {{ invoice_date }}, or you can prepay for your subscription
                 by following the instructions
-                <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>
+                <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
             </p>
             {% endblocktrans %}
         </div>
@@ -103,7 +105,6 @@
         <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
     </div>
     {% else %}
-    <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
         {% csrf_token %}
         <hr />
         <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
@@ -112,15 +113,22 @@
             Clicking the 'Select this Plan' button below will bring you to a page where you can enter basic billing information.
             {% endblocktrans %}
         </p>
-        <div class="form-actions">
-            <div class="col-sm-6">
-                <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button class="btn btn-primary" data-bind="click: openDowngradeModal">
-                    {% trans 'Select this Plan' %}
-                </button>
-            </div>
+    {% csrf_token %}
+    <hr />
+    <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
+    <p>
+        {% blocktrans %}
+        Clicking the 'Select this Plan' button below will bring you to a page where you can enter basic billing information.
+        {% endblocktrans %}
+    </p>
+    <div class="form-actions">
+        <div class="col-sm-6">
+            <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
+            <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
+                {% trans 'Select this Plan' %}
+            </button>
         </div>
-    </form>
+    </div>
     {% endif %}
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -8,8 +8,6 @@
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
 {% initial_page_data 'new_plan' plan.name %}
-{% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
-{% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
     <p class="lead">
@@ -133,7 +131,7 @@
             </div>
             <div class="modal-body">
                 {% blocktrans %}
-                    We'd love to make CommCare work better for you.
+                    We're sorry to see you go! We'd love to make CommCare work better for you.
                     Let us know what we can do to improve, or why you're downgrading.
                 {% endblocktrans %}
                 <br><br>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -8,8 +8,6 @@
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
 {% initial_page_data 'new_plan' plan.name %}
-{% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
-{% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
     <p class="lead">
@@ -51,15 +49,6 @@
                 <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
             </p>
             <input type="checkbox" id="user-agreement" value="True"> I understand and wish to continue.<br>
-            {% endblocktrans %}
-        </div>
-        {% elif is_downgrade_before_minimum %}
-        <hr />
-        <div class="alert alert-danger">
-            {% blocktrans with current_plan.name as p %}
-            <h4>Note: Continuing will change your current subscription.</h4>
-            <p>We’re sorry to see you go! You’ll have access to the features on your
-            <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>
         {% else %}
@@ -134,7 +123,7 @@
             </div>
             <div class="modal-body">
                 {% blocktrans %}
-                    We'd love to make CommCare work better for you.
+                    We're sorry to see you go! We'd love to make CommCare work better for you.
                     Let us know what we can do to improve, or why you're downgrading.
                 {% endblocktrans %}
                 <br><br>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -105,30 +105,24 @@
         <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
     </div>
     {% else %}
+    <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
         {% csrf_token %}
-        <hr />
         <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
+        <hr />
         <p>
             {% blocktrans %}
             Clicking the 'Select this Plan' button below will bring you to a page where you can enter basic billing information.
             {% endblocktrans %}
         </p>
-    {% csrf_token %}
-    <hr />
-    <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
-    <p>
-        {% blocktrans %}
-        Clicking the 'Select this Plan' button below will bring you to a page where you can enter basic billing information.
-        {% endblocktrans %}
-    </p>
-    <div class="form-actions">
-        <div class="col-sm-6">
-            <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-            <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
-                {% trans 'Select this Plan' %}
-            </button>
+        <div class="form-actions">
+            <div class="col-sm-6">
+                <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
+                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
+                    {% trans 'Select this Plan' %}
+                </button>
+            </div>
         </div>
-    </div>
+    </form>
     {% endif %}
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -43,6 +43,19 @@
             </p>
             {% endblocktrans %}
         </div>
+        {% endif %}
+        {% if is_downgrade_before_minimum %}
+        <hr />
+        <div class="alert alert-danger">
+            {% blocktrans with current_plan.name as p %}
+            <h4>Note: Continuing will change your current subscription.</h4>
+            <p>We’re sorry to see you go! You’ll have access to the features on your
+                <strong>{{ p }} Software Plan </strong></p> through {{ new_subscription_start_date }}.
+                If you’d like to continue using CommCare’s paid features, you can
+                <a href="https://www.commcarehq.org/a/project-space/settings/project/subscription/change/">renew</a>
+                your subscription at any time before {{ new_subscription_start_date }}.
+            {% endblocktrans %}
+        </div>
         {% else %}
         <hr />
         <div class="alert alert-danger">

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -59,18 +59,20 @@
         <hr />
         <div class="alert alert-danger">
             {% blocktrans with current_plan as p %}
-            <p>You’ll have access to the features on your <strong>{{ p }} Edition Software Plan </strong>
-            through {{ current_subscription_end_date }}. On {{ start_date_after_minimum_subscription }} your
-            current subscription will be downgraded to the {{ new_plan_edition }} Edition Software Plan.
+            <p>We're sorry to see you downgrade! You’ll have access to the features on your
+            <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.
+            On {{ start_date_after_minimum_subscription }} your current subscription will be downgraded
+            to the {{ new_plan_edition }} Edition Software Plan.
             </p>
             {% endblocktrans %}
         </div>
         {% else %}
         <hr />
         <div class="alert alert-danger">
-            {% blocktrans with current_plan.name as p %}
+            {% blocktrans with current_plan as p %}
             <h4>Note: Continuing will change your current subscription.</h4>
-            <p>You are currently subscribed to the <strong>{{ p }} Software Plan</strong></p>
+            <p>We're sorry to see you downgrade! You are currently subscribed to the
+            <strong>{{ p }} Software Plan</strong></p>
             {% endblocktrans %}
         </div>
         {% endif %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -14,6 +14,7 @@
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
+<div class="container" id="hq-content">
     <p class="lead">
         {% blocktrans with plan.name as p %}
         You have selected the <strong>{{ p }} Software Plan</strong>.
@@ -52,7 +53,7 @@
                 subscription by following the instructions
                 <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
             </p>
-            <input type="checkbox" id="user-agreement" value="True"> I understand and wish to continue.<br>
+            <input type="checkbox" data-bind="checked: userAgreementSigned"> I understand and wish to continue.<br>
             {% endblocktrans %}
         </div>
         {% elif is_downgrade_before_minimum %}
@@ -96,7 +97,7 @@
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
+                <button class="btn btn-primary" data-bind="enable: userAgreementSigned, click: openDowngradeModal">
                     {% trans 'Confirm Plan' %}
                 </button>
             </div>
@@ -104,6 +105,7 @@
     </form>
     {% endif %}
 {% endblock %}
+</div>
 
 {% block modals %}{{ block.super }}
 <div class="modal fade" id="modal-downgrade">

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -61,18 +61,6 @@
             <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>
-        {% elif is_downgrade_before_minimum %}
-        <hr />
-        <div class="alert alert-danger">
-            {% blocktrans with current_plan.name as p %}
-            <h4>Note: Continuing will change your current subscription.</h4>
-            <p>We’re sorry to see you go! You’ll have access to the features on your
-                <strong>{{ p }} Software Plan </strong></p> through {{ current_subscription_end_date }}.
-                If you’d like to continue using CommCare’s paid features, you can
-                <a href="https://www.commcarehq.org/a/project-space/settings/project/subscription/change/">renew</a>
-                your subscription at any time before {{ current_subscription_end_date }}.
-            {% endblocktrans %}
-        </div>
         {% else %}
         <hr />
         <div class="alert alert-danger">
@@ -111,13 +99,12 @@
         <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
     </div>
     {% else %}
-    <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
         {% csrf_token %}
         <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
         <hr />
         <p>
             {% blocktrans %}
-            Clicking the 'Confirm Plan' button below will bring you to a page where you can enter basic billing information.
+            Clicking the 'Confirm Plan' button below will bring you to a page where you can confirm your billing information.
             {% endblocktrans %}
         </p>
         <div class="form-actions">
@@ -128,7 +115,7 @@
                 </button>
             </div>
         </div>
-    </form>
+    </div>
     {% endif %}
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -4,7 +4,7 @@
 {% requirejs_main 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
-{% initial_page_data 'is_upgrade' is_upgrade|BOOL %}
+{% initial_page_data 'is_upgrade' is_upgrade %}
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
 {% initial_page_data 'new_plan_edition' new_plan_edition %}
@@ -112,7 +112,7 @@
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only">{% trans "Close" %}</span>
                 </button>
-                <h4 class="modal-title">Downgrading?</h4>
+                <h4 class="modal-title">{% trans 'Downgrading?' %}</h4>
             </div>
             <div class="modal-body">
                 {% blocktrans %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -1,10 +1,7 @@
 {% extends "domain/base_change_plan.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-
-{% block js %}{{ block.super }}
-    <script src="{% static 'accounting/js/confirm_plan.js' %}"></script>
-{% endblock %}
+{% requirejs_main 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
 {% initial_page_data 'is_upgrade' is_upgrade|BOOL %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -111,7 +111,7 @@
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal" disabled>
+                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
                     {% trans 'Confirm Plan' %}
                 </button>
             </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -14,7 +14,7 @@
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
-<div class="container" id="hq-content">
+<div class="container" id="confirm-plan-content">
     <p class="lead">
         {% blocktrans with plan.name as p %}
         You have selected the <strong>{{ p }} Software Plan</strong>.

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -53,6 +53,7 @@
                 subscription by following the instructions
                 <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
             </p>
+            <input type="checkbox" id="user-agreement" value="True"> I understand and wish to continue.<br>
             {% endblocktrans %}
         </div>
         {% elif is_downgrade_before_minimum %}
@@ -114,7 +115,7 @@
         <div class="form-actions">
             <div class="col-sm-6">
                 <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal">
+                <button class="btn btn-primary" id="confirm-plan" data-bind="click: openDowngradeModal" disabled>
                     {% trans 'Confirm Plan' %}
                 </button>
             </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -61,6 +61,19 @@
             <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
             {% endblocktrans %}
         </div>
+        {% endif %}
+        {% if is_downgrade_before_minimum %}
+        <hr />
+        <div class="alert alert-danger">
+            {% blocktrans with current_plan.name as p %}
+            <h4>Note: Continuing will change your current subscription.</h4>
+            <p>We’re sorry to see you go! You’ll have access to the features on your
+                <strong>{{ p }} Software Plan </strong></p> through {{ new_subscription_start_date }}.
+                If you’d like to continue using CommCare’s paid features, you can
+                <a href="https://www.commcarehq.org/a/project-space/settings/project/subscription/change/">renew</a>
+                your subscription at any time before {{ new_subscription_start_date }}.
+            {% endblocktrans %}
+        </div>
         {% else %}
         <hr />
         <div class="alert alert-danger">

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -7,9 +7,11 @@
 {% initial_page_data 'is_upgrade' is_upgrade|BOOL %}
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
-{% initial_page_data 'new_plan' plan.name %}
+{% initial_page_data 'new_plan_edition' new_plan_edition %}
+{% initial_page_data 'new_plan_name' plan.name %}
 {% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
 {% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
+{% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
 {% registerurl 'email_on_downgrade' domain %}
 {% registerurl 'confirm_billing_account_info' domain %}
     <p class="lead">
@@ -56,9 +58,11 @@
         {% elif is_downgrade_before_minimum %}
         <hr />
         <div class="alert alert-danger">
-            {% blocktrans with current_plan.name as p %}
-            <p>We’re sorry to see you downgrade. You’ll have access to the features on your
-            <strong>{{ p }} Software Plan </strong> through {{ current_subscription_end_date }}.</p>
+            {% blocktrans with current_plan as p %}
+            <p>You’ll have access to the features on your <strong>{{ p }} Edition Software Plan </strong>
+            through {{ current_subscription_end_date }}. On {{ start_date_after_minimum_subscription }} your
+            current subscription will be downgraded to the {{ new_plan_edition }} Edition Software Plan.
+            </p>
             {% endblocktrans %}
         </div>
         {% else %}
@@ -72,27 +76,6 @@
         {% endif %}
     {% endif %}
 
-    {% if downgrade_messages %}
-    <hr />
-    <h4>
-        {% if show_community_notice %}
-        {% trans 'Note: If you do not upgrade from the Community Plan the following changes will take place.' %}
-        {% else %}
-        {% trans 'Note: Selecting this plan will result in the following changes to your project.' %}
-        {% endif %}
-    </h4>
-    {% endif %}
-
-    {% for message in downgrade_messages %}
-        <div class="alert alert-warning">
-            {{ message.message }}
-            <ul>
-            {% for detail in message.details %}
-                <li>{{ detail|safe }}</li>
-            {% endfor %}
-            </ul>
-        </div>
-    {% endfor %}
     {% if show_community_notice %}
     <div class="form-actions">
         <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -121,7 +121,7 @@
                 <br><br>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary pull-left" data-dismiss="modal">{% trans "Dismiss" %}</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Dismiss" %}</button>
                 <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
             </div>
         </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -20,9 +20,7 @@
 {% endif %}
 {% endblock %}
 
-{% block js %}{{ block.super }}
-    <script src="{% static 'accounting/js/pricing_table.js' %}"></script>
-{% endblock %}
+{% requirejs_main 'accounting/js/pricing_table' %}
 
 {% block form_content %}
 {% initial_page_data 'editions' editions %}

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -28,6 +28,7 @@
 {% initial_page_data 'is_renewal' is_renewal|BOOL %}
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
 {% initial_page_data 'subscription_below_minimum' subscription_below_minimum|BOOL %}
+{% initial_page_data 'next_subscription' next_subscription %}
 {% registerurl 'email_on_downgrade' domain %}
 <p class="lead">
     {{ lead_text|safe }}
@@ -120,7 +121,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" data-dismiss="modal" style="float: left;">{% trans "Dismiss" %}</button>
-                <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Schedule Downgrade" %}</button>
+                <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -28,6 +28,8 @@
 {% initial_page_data 'editions' editions %}
 {% initial_page_data 'current_edition' current_edition %}
 {% initial_page_data 'is_renewal' is_renewal|BOOL %}
+{% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
+{% initial_page_data 'subscription_below_minimum' subscription_below_minimum|BOOL %}
 {% registerurl 'email_on_downgrade' domain %}
 <p class="lead">
     {{ lead_text|safe }}
@@ -60,7 +62,7 @@
 
             <div class="form-actions" data-bind="visible: isSubmitVisible">
                 <div class="col-xs-offset-2">
-                    <button type="submit" class="btn btn-primary btn-lg" data-bind="click: openDowngradeModal">{% trans 'Next' %}</button>
+                    <button type="submit" class="btn btn-primary btn-lg" data-bind="click: openMinimumSubscriptionModal">{% trans 'Next' %}</button>
                 </div>
             </div>
         </form>
@@ -105,7 +107,7 @@
 {% endblock %}
 
 {% block modals %}{{ block.super }}
-<div class="modal fade" id="modal-downgrade">
+<div class="modal fade" id="modal-minimum-subscription">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -116,17 +118,13 @@
                 <h4 class="modal-title">Downgrading?</h4>
             </div>
             <div class="modal-body">
-                {% blocktrans %}
-                    We'd love to make CommCare work better for you.
-                    Let us know what we can do to improve, or why you're downgrading.
-                {% endblocktrans %}
                 <br><br>
-                <textarea class="form-control"></textarea>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade">{% trans "OK" %}</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal" style="float: left;">{% trans "Dismiss" %}</button>
+                <button type="button" class="btn btn-danger" data-bind="click: submitDowngrade">{% trans "Schedule Downgrade" %}</button>
             </div>
         </div>
     </div>
-</script>
+</div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -25,9 +25,9 @@
 {% block form_content %}
 {% initial_page_data 'editions' editions %}
 {% initial_page_data 'current_edition' current_edition %}
-{% initial_page_data 'is_renewal' is_renewal|BOOL %}
+{% initial_page_data 'is_renewal' is_renewal %}
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
-{% initial_page_data 'subscription_below_minimum' subscription_below_minimum|BOOL %}
+{% initial_page_data 'subscription_below_minimum' subscription_below_minimum %}
 {% initial_page_data 'next_subscription' next_subscription %}
 {% registerurl 'email_on_downgrade' domain %}
 <p class="lead">

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -122,7 +122,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" data-dismiss="modal" style="float: left;">{% trans "Dismiss" %}</button>
-                <button type="button" class="btn btn-danger" data-bind="click: submitDowngrade">{% trans "Schedule Downgrade" %}</button>
+                <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Schedule Downgrade" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -116,11 +116,14 @@
                 <h4 class="modal-title">Downgrading?</h4>
             </div>
             <div class="modal-body">
-                <br><br>
+                <br>All CommCare subscriptions require a 30 day minimum commitment. Your current subscription may
+                not be downgraded until {{  start_date_after_minimum_subscription }}. If you have questions or if
+                you would like to speak to someone about your subscription, please reach out to
+                <a href='mailto:billing-support@dimagi.com'>billing-support@dimagi.com</a>.
+                <br>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" data-dismiss="modal" style="float: left;">{% trans "Dismiss" %}</button>
-                <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Schedule Downgrade" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -116,14 +116,11 @@
                 <h4 class="modal-title">Downgrading?</h4>
             </div>
             <div class="modal-body">
-                <br>All CommCare subscriptions require a 30 day minimum commitment. Your current subscription may
-                not be downgraded until {{  start_date_after_minimum_subscription }}. If you have questions or if
-                you would like to speak to someone about your subscription, please reach out to
-                <a href='mailto:billing-support@dimagi.com'>billing-support@dimagi.com</a>.
-                <br>
+                <br><br>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" data-dismiss="modal" style="float: left;">{% trans "Dismiss" %}</button>
+                <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Schedule Downgrade" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -28,7 +28,7 @@
 {% initial_page_data 'is_renewal' is_renewal %}
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
 {% initial_page_data 'subscription_below_minimum' subscription_below_minimum %}
-{% initial_page_data 'next_subscription' next_subscription %}
+{% initial_page_data 'next_subscription_edition' next_subscription_edition %}
 {% initial_page_data 'invoicing_contact_email' invoicing_contact_email %}
 {% registerurl 'email_on_downgrade' domain %}
 <p class="lead">

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -29,6 +29,7 @@
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
 {% initial_page_data 'subscription_below_minimum' subscription_below_minimum %}
 {% initial_page_data 'next_subscription' next_subscription %}
+{% initial_page_data 'invoicing_contact_email' invoicing_contact_email %}
 {% registerurl 'email_on_downgrade' domain %}
 <p class="lead">
     {{ lead_text|safe }}
@@ -120,7 +121,7 @@
                 <br><br>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal" style="float: left;">{% trans "Dismiss" %}</button>
+                <button type="button" class="btn btn-primary pull-left" data-dismiss="modal">{% trans "Dismiss" %}</button>
                 <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
             </div>
         </div>

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1467,6 +1467,8 @@ class ConfirmSelectedPlanView(SelectPlanView):
     def is_upgrade(self):
         if self.current_subscription.is_trial:
             return True
+        elif self.current_subscription.plan_version.plan.edition == self.edition:
+            return False
         else:
             return not is_downgrade(
                 current_edition=self.current_subscription.plan_version.plan.edition,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1621,10 +1621,6 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     # You have successfully scheduled your current Advanced Edition Plan
                     # subscription to downgrade to the Pro Edition Plan on Sep 19, 2018.
                     message = _(
-                        "You have successfully scheduled a subscription to the %s Software Plan, "
-                        "set to start on %s."
-                    ) % (software_plan_name, start_date)
-                    message = _(
                         "You have successfully scheduled your current %s Edition Plan subscription to "
                         "downgrade to the %s Edition Plan on %s."
                     ) % (current_subscription, software_plan_name, start_date)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1467,8 +1467,6 @@ class ConfirmSelectedPlanView(SelectPlanView):
     def is_upgrade(self):
         if self.current_subscription.is_trial:
             return True
-        elif self.current_subscription.plan_version.plan.edition == self.edition:
-            return False
         else:
             return not is_downgrade(
                 current_edition=self.current_subscription.plan_version.plan.edition,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1465,8 +1465,6 @@ class ConfirmSelectedPlanView(SelectPlanView):
         elif current_edition == 'Pro':
             if new_edition == "Advanced":
                 return True
-        elif current_edition == "Enterprise":
-            return True
         return False
 
     @property
@@ -1610,12 +1608,12 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             is_saved = self.billing_account_info_form.save()
             software_plan_name = DESC_BY_EDITION[self.selected_plan_version.plan.edition]['name']
             if not is_saved:
+                downgrade_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
                 messages.error(
                     request, _(
-                        "It appears there was an issue subscribing your project to the %s Software Plan. You "
-                        "may try resubmitting, but if that doesn't work, rest assured someone will be "
-                        "contacting you shortly."
-                    ) % software_plan_name
+                        "You have already scheduled a downgrade to the %s Software Plan on %s. If this is a "
+                        "mistake, please reach out to billing-support@dimagi.com."
+                    ) % (software_plan_name, downgrade_date)
                 )
             else:
                 if self.current_subscription.next_subscription is not None:

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1495,9 +1495,9 @@ class ConfirmSelectedPlanView(SelectPlanView):
             return False
 
     @property
-    def new_subscription_start_date(self):
+    def current_subscription_end_date(self):
         if self.is_downgrade_before_minimum:
-            return self.current_subscription.date_start + datetime.timedelta(days=31)
+            return self.current_subscription.date_start + datetime.timedelta(days=30)
         else:
             return datetime.date.today()
 
@@ -1529,7 +1529,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
             'show_community_notice': (self.edition == SoftwarePlanEdition.COMMUNITY
                                       and self.current_subscription is None),
             'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
-            'new_subscription_start_date': self.new_subscription_start_date.strftime(USER_DATE_FORMAT)
+            'current_subscription_end_date': self.current_subscription_end_date.strftime(USER_DATE_FORMAT)
         }
 
     @property

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1473,7 +1473,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
             return False
         elif self.current_subscription is None or self.current_subscription.is_trial:
             return False
-        elif self.current_subscription.date_start + datetime.timedelta(days=30) >= datetime.date.today():
+        elif self.current_subscription.is_below_minimum_subscription:
             return True
         else:
             return False
@@ -1617,11 +1617,11 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                 )
             else:
                 if self.is_downgrade_before_minimum:
-                    start_date = self.current_subscription.date_start + datetime.timedelta(days=31)
+                    start_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
                     message = _(
                         "You have successfully scheduled a subscription to the %s Software Plan, "
                         "set to start on %s."
-                    ) % (software_plan_name, start_date.strftime(USER_DATE_FORMAT))
+                    ) % (software_plan_name, start_date)
                 else:
                     message = _(
                         "Your project has been successfully subscribed to the %s Software Plan."

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1468,24 +1468,6 @@ class ConfirmSelectedPlanView(SelectPlanView):
         return False
 
     @property
-    def is_downgrade_before_minimum(self):
-        if self.is_upgrade:
-            return False
-        elif self.current_subscription is None or self.current_subscription.is_trial:
-            return False
-        elif self.current_subscription.is_below_minimum_subscription:
-            return True
-        else:
-            return False
-
-    @property
-    def current_subscription_end_date(self):
-        if self.is_downgrade_before_minimum:
-            return self.current_subscription.date_start + datetime.timedelta(days=30)
-        else:
-            return datetime.date.today()
-
-    @property
     def next_invoice_date(self):
         # Next invoice date is the first day of the next month
         return datetime.date.today().replace(day=1) + dateutil.relativedelta.relativedelta(months=1)
@@ -1511,9 +1493,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
             'current_plan': (self.current_subscription.plan_version.user_facing_description
                              if self.current_subscription is not None else None),
             'show_community_notice': (self.edition == SoftwarePlanEdition.COMMUNITY
-                                      and self.current_subscription is None),
-            'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
-            'current_subscription_end_date': self.current_subscription_end_date.strftime(USER_DATE_FORMAT)
+                                      and self.current_subscription is None)
         }
 
     @property
@@ -1627,8 +1607,6 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     message = _(
                         "Your project has been successfully subscribed to the %s Software Plan."
                     ) % software_plan_name
-                messages.success(
-                    request, message
                 )
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
         return super(ConfirmBillingAccountInfoView, self).post(request, *args, **kwargs)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1465,6 +1465,8 @@ class ConfirmSelectedPlanView(SelectPlanView):
         elif current_edition == 'Pro':
             if new_edition == "Advanced":
                 return True
+        elif current_edition == "Enterprise":
+            return True
         return False
 
     @property

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1273,6 +1273,30 @@ class SelectPlanView(DomainAccountingSettings):
     lead_text = ugettext_lazy("Please select a plan below that fits your organization's needs.")
 
     @property
+    def subscription_below_minimum(self):
+        if self.current_subscription is None:
+            return False
+        elif self.current_subscription.is_trial:
+            return False
+        elif self.current_subscription.date_start <= datetime.date(2018, 7, 30): # TODO: Set this date to be the date we launch this feature
+            # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
+            return False
+        elif self.current_subscription.date_start + datetime.timedelta(days=30) >= datetime.date.today():
+            return True
+        else:
+            return False
+
+    @property
+    def start_date_after_minimum_subscription(self):
+        if self.current_subscription is None:
+            return ""
+        elif self.current_subscription.is_trial:
+            return ""
+        else:
+            new_start_date = self.current_subscription.date_start + datetime.timedelta(days=30)
+            return new_start_date.strftime("%B %d")
+
+    @property
     def edition_name(self):
         if self.edition:
             return DESC_BY_EDITION[self.edition]['name']
@@ -1325,6 +1349,8 @@ class SelectPlanView(DomainAccountingSettings):
                                 if self.current_subscription is not None
                                 and not self.current_subscription.is_trial
                                 else ""),
+            'start_date_after_minimum_subscription': self.start_date_after_minimum_subscription,
+            'subscription_below_minimum': self.subscription_below_minimum
         }
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1281,6 +1281,9 @@ class SelectPlanView(DomainAccountingSettings):
         elif self.current_subscription.date_start <= datetime.date(2018, 7, 30): # TODO: Set this date to be the date we launch this feature
             # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
             return False
+        elif self.current_subscription.date_start >= datetime.date.today() - datetime.timedelta(days=2):
+            # 1-2 day grace period (because you cannot compare date and datetime)
+            return False
         elif self.current_subscription.date_start + datetime.timedelta(days=30) >= datetime.date.today():
             return True
         else:

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1280,7 +1280,7 @@ class SelectPlanView(DomainAccountingSettings):
             return ""
         else:
             new_start_date = self.current_subscription.date_start + \
-                             datetime.timedelta(days=self.current_subscription.minimum_subscription_length + 1)
+                datetime.timedelta(days=self.current_subscription.minimum_subscription_length + 1)
             return new_start_date.strftime(USER_DATE_FORMAT)
 
     @property
@@ -1488,7 +1488,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
     def current_subscription_end_date(self):
         if self.is_downgrade_before_minimum:
             return self.current_subscription.date_start + \
-                   datetime.timedelta(days=self.current_subscription.minimum_subscription_length)
+                datetime.timedelta(days=self.current_subscription.minimum_subscription_length)
         else:
             return datetime.date.today()
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1468,24 +1468,6 @@ class ConfirmSelectedPlanView(SelectPlanView):
         return False
 
     @property
-    def is_downgrade_before_minimum(self):
-        if self.is_upgrade:
-            return False
-        elif self.current_subscription is None or self.current_subscription.is_trial:
-            return False
-        elif self.current_subscription.is_below_minimum_subscription:
-            return True
-        else:
-            return False
-
-    @property
-    def current_subscription_end_date(self):
-        if self.is_downgrade_before_minimum:
-            return self.current_subscription.date_start + datetime.timedelta(days=30)
-        else:
-            return datetime.date.today()
-
-    @property
     def next_invoice_date(self):
         # Next invoice date is the first day of the next month
         return datetime.date.today().replace(day=1) + dateutil.relativedelta.relativedelta(months=1)
@@ -1511,9 +1493,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
             'current_plan': (self.current_subscription.plan_version.user_facing_description
                              if self.current_subscription is not None else None),
             'show_community_notice': (self.edition == SoftwarePlanEdition.COMMUNITY
-                                      and self.current_subscription is None),
-            'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
-            'current_subscription_end_date': self.current_subscription_end_date.strftime(USER_DATE_FORMAT)
+                                      and self.current_subscription is None)
         }
 
     @property
@@ -1616,18 +1596,10 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     ) % software_plan_name
                 )
             else:
-                if self.is_downgrade_before_minimum:
-                    start_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
-                    message = _(
-                        "You have successfully scheduled a subscription to the %s Software Plan, "
-                        "set to start on %s."
-                    ) % (software_plan_name, start_date)
-                else:
-                    message = _(
+                messages.success(
+                    request, _(
                         "Your project has been successfully subscribed to the %s Software Plan."
                     ) % software_plan_name
-                messages.success(
-                    request, message
                 )
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
         return super(ConfirmBillingAccountInfoView, self).post(request, *args, **kwargs)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1465,8 +1465,6 @@ class ConfirmSelectedPlanView(SelectPlanView):
         elif current_edition == 'Pro':
             if new_edition == "Advanced":
                 return True
-        elif current_edition == "Enterprise":
-            return True
         return False
 
     @property

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1616,7 +1616,8 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     ) % software_plan_name
                 )
             else:
-                if self.is_downgrade_before_minimum:
+                if self.current_subscription.next_subscription is not None:
+                    # New subscription has been scheduled for the future
                     start_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
                     message = _(
                         "You have successfully scheduled a subscription to the %s Software Plan, "

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1468,6 +1468,24 @@ class ConfirmSelectedPlanView(SelectPlanView):
         return False
 
     @property
+    def is_downgrade_before_minimum(self):
+        if self.is_upgrade:
+            return False
+        elif self.current_subscription is None or self.current_subscription.is_trial:
+            return False
+        elif self.current_subscription.is_below_minimum_subscription:
+            return True
+        else:
+            return False
+
+    @property
+    def current_subscription_end_date(self):
+        if self.is_downgrade_before_minimum:
+            return self.current_subscription.date_start + datetime.timedelta(days=30)
+        else:
+            return datetime.date.today()
+
+    @property
     def next_invoice_date(self):
         # Next invoice date is the first day of the next month
         return datetime.date.today().replace(day=1) + dateutil.relativedelta.relativedelta(months=1)
@@ -1493,7 +1511,9 @@ class ConfirmSelectedPlanView(SelectPlanView):
             'current_plan': (self.current_subscription.plan_version.user_facing_description
                              if self.current_subscription is not None else None),
             'show_community_notice': (self.edition == SoftwarePlanEdition.COMMUNITY
-                                      and self.current_subscription is None)
+                                      and self.current_subscription is None),
+            'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
+            'current_subscription_end_date': self.current_subscription_end_date.strftime(USER_DATE_FORMAT)
         }
 
     @property
@@ -1596,10 +1616,18 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     ) % software_plan_name
                 )
             else:
-                messages.success(
-                    request, _(
+                if self.is_downgrade_before_minimum:
+                    start_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
+                    message = _(
+                        "You have successfully scheduled a subscription to the %s Software Plan, "
+                        "set to start on %s."
+                    ) % (software_plan_name, start_date)
+                else:
+                    message = _(
                         "Your project has been successfully subscribed to the %s Software Plan."
                     ) % software_plan_name
+                messages.success(
+                    request, message
                 )
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
         return super(ConfirmBillingAccountInfoView, self).post(request, *args, **kwargs)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1273,23 +1273,6 @@ class SelectPlanView(DomainAccountingSettings):
     lead_text = ugettext_lazy("Please select a plan below that fits your organization's needs.")
 
     @property
-    def subscription_below_minimum(self):
-        if self.current_subscription is None:
-            return False
-        elif self.current_subscription.is_trial:
-            return False
-        elif self.current_subscription.date_start <= datetime.date(2018, 7, 30): # TODO: Set this date to be the date we launch this feature
-            # Only block upgrades for subscriptions created after the date we launched the 30-Day Minimum
-            return False
-        elif self.current_subscription.date_start >= datetime.date.today() - datetime.timedelta(days=2):
-            # 1-2 day grace period (because you cannot compare date and datetime)
-            return False
-        elif self.current_subscription.date_start + datetime.timedelta(days=30) >= datetime.date.today():
-            return True
-        else:
-            return False
-
-    @property
     def start_date_after_minimum_subscription(self):
         if self.current_subscription is None:
             return ""
@@ -1353,7 +1336,8 @@ class SelectPlanView(DomainAccountingSettings):
                                 and not self.current_subscription.is_trial
                                 else ""),
             'start_date_after_minimum_subscription': self.start_date_after_minimum_subscription,
-            'subscription_below_minimum': self.subscription_below_minimum
+            'subscription_below_minimum': (self.current_subscription.is_below_minimum_subscription
+                                           if self.current_subscription is not None else False)
         }
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1616,10 +1616,18 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     ) % software_plan_name
                 )
             else:
-                messages.success(
-                    request, _(
+                if self.is_downgrade_before_minimum:
+                    start_date = self.current_subscription.date_start + datetime.timedelta(days=31)
+                    message = _(
+                        "You have successfully scheduled a subscription to the %s Software Plan, "
+                        "set to start on %s."
+                    ) % (software_plan_name, start_date.strftime(USER_DATE_FORMAT))
+                else:
+                    message = _(
                         "Your project has been successfully subscribed to the %s Software Plan."
                     ) % software_plan_name
+                messages.success(
+                    request, message
                 )
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
         return super(ConfirmBillingAccountInfoView, self).post(request, *args, **kwargs)


### PR DESCRIPTION
This PR blocks users from downgrading any subscription before 30 days after their current subscription's start date (there's a 1-2 day grace period). If a user does downgrade early, the current subscription's end date is set to `current_subscription.date_start + 30 days`, a new subscription is scheduled to start the day _after_ the current subscription ends.

Specs:
https://docs.google.com/document/d/1NP28XAqNrdrRFgBPr2gBQVLKZpPRAp_GgYzgTPxNx70/edit?usp=sharing