### PR TITLE
Show full case hierarchy on case_data page

### DIFF
--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -51,9 +51,9 @@ class MigrationView(BaseMigrationView, FormView):
 
 
 def get_case_hierarchy_for_restore(case):
-    from corehq.apps.reports.view_helpers import get_case_hierarchy
+    from corehq.apps.reports.view_helpers import get_children
     return [
-        c for c in get_case_hierarchy(case, {})['case_list']
+        c for c in get_children(case)['case_list']
         if not c.closed
     ]
 

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -201,7 +201,7 @@ def get_case_hierarchy(case, type_info):
     accessor = CaseAccessors(case.domain)
     new_indices = {case.case_id}
     seen_indices = {case.case_id}
-    last_index = None
+    last_index = case.case_id
     while True:
         new_indices = accessor.get_indexed_case_ids(new_indices)
         if not set(new_indices) - seen_indices:

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from functools import partial
 import datetime
 import numbers
-import pytz
+from functools import partial
 
-from couchdbkit import ResourceNotFound
+import pytz
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from casexml.apps.case.views import get_wrapped_case
 from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=None):
@@ -21,34 +21,9 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
     columns = wrapped_case.related_cases_columns
     type_info = wrapped_case.related_type_info
 
-    descendent_case_list = get_flat_descendant_case_list(
+    case_list = get_flat_descendant_case_list(
         case, get_case_url, type_info=type_info
     )
-
-    parent_cases = []
-    if case.indices:
-        # has parent case(s)
-        # todo: handle duplicates in ancestor path (bubbling up of parent-child
-        # relationships)
-        for idx in case.indices:
-            try:
-                parent_cases.append(idx.referenced_case)
-            except ResourceNotFound:
-                parent_cases.append(None)
-        for parent_case in parent_cases:
-            if parent_case:
-                parent_case.edit_data = {
-                    'view_url': get_case_url(parent_case.case_id)
-                }
-                last_parent_id = parent_case.case_id
-            else:
-                last_parent_id = None
-
-        for c in descendent_case_list:
-            if not getattr(c, 'treetable_parent_node_id', None) and last_parent_id:
-                c.treetable_parent_node_id = last_parent_id
-
-    case_list = parent_cases + descendent_case_list
 
     for c in case_list:
         if not c:
@@ -179,17 +154,18 @@ def process_case_hierarchy(case_output, get_case_url, type_info):
     process_output(case_output)
 
 
-def get_case_hierarchy(case, type_info):
-    def get_children(case, referenced_type=None, seen=None):
+def get_children(case, type_info=None):
+    def _get_children(case, referenced_type=None, seen=None):
         seen = seen or set()
 
-        ignore_types = type_info.get(case.type, {}).get("ignore_relationship_types", [])
+        # only relevant for `pact`
+        ignore_types = type_info.get(case.type, {}).get("ignore_relationship_types", []) if type_info else []
         if referenced_type and referenced_type in ignore_types:
             return None
 
         seen.add(case.case_id)
         children = [
-            get_children(i.referenced_case, i.referenced_type, seen) for i in case.reverse_indices
+            _get_children(i.referenced_case, i.referenced_type, seen) for i in case.reverse_indices
             if i.referenced_id not in seen
         ]
 
@@ -218,8 +194,22 @@ def get_case_hierarchy(case, type_info):
             'descendant_types': list(set(descendant_types + [c['case'].type for c in children])),
             'case_list': [case] + child_cases
         }
+    return _get_children(case)
 
-    return get_children(case)
+
+def get_case_hierarchy(case, type_info):
+    accessor = CaseAccessors(case.domain)
+    new_indices = {case.case_id}
+    seen_indices = {case.case_id}
+    last_index = None
+    while True:
+        new_indices = accessor.get_indexed_case_ids(new_indices)
+        if not set(new_indices) - seen_indices:
+            break
+        last_index = new_indices[0]
+        seen_indices |= set(new_indices)
+
+    return get_children(CaseAccessors(case.domain).get_case(last_index), type_info)
 
 
 def get_flat_descendant_case_list(case, get_case_url, type_info=None):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -310,6 +310,27 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual(2, len(hierarchy['child_cases'][0]['case_list']))
         self.assertEqual(1, len(hierarchy['child_cases'][0]['child_cases']))
 
+    def test_full_ancestry(self):
+        """get_case_hierarchy should return the full parentage tree for any case
+        """
+        factory = CaseFactory('baggins-of-hobbiton')
+        bagginses = ['balbo', 'mungo', 'bungo', 'bilbo']
+        cases = {}
+        for level, baggins in enumerate(bagginses):
+            cases[baggins] = factory.create_or_update_case(
+                CaseStructure(
+                    case_id=baggins,
+                    attrs={
+                        'case_type': 'baggins',
+                        'update': {'name': baggins},
+                        'create': True},
+                    indices=[CaseIndex(CaseStructure(case_id=bagginses[level - 1]))] if level != 0 else None,
+                    walk_related=False,
+                )
+            )[0]
+        hierarchy = get_case_hierarchy(cases['bungo'], {})
+        self.assertEqual(4, len(hierarchy['case_list']))
+
 
 @use_sql_backend
 class TestCaseHierarchySQL(TestCaseHierarchy):


### PR DESCRIPTION
Shows the full case hierarchy in the case data page

## Before
![screenshot from 2018-08-06 17-04-08](https://user-images.githubusercontent.com/146896/43740953-c2024884-999a-11e8-829a-79495e5dcd81.png)

## After
![screenshot from 2018-08-06 17-03-12](https://user-images.githubusercontent.com/146896/43740913-ada5311c-999a-11e8-86bc-82bd9dbea922.png)
