### PR TITLE
Remove angular from Automatically Close Cases

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -214,7 +214,7 @@ class AutomaticUpdateRule(models.Model):
             workflow=workflow,
             deleted=False,
             **additional_filters
-        )
+        ).order_by('name', 'id')
 
     @classmethod
     def domain_has_conditional_alerts(cls, domain):

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -214,7 +214,7 @@ class AutomaticUpdateRule(models.Model):
             workflow=workflow,
             deleted=False,
             **additional_filters
-        ).order_by('name', 'id')
+        )
 
     @classmethod
     def domain_has_conditional_alerts(cls, domain):

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/list_automatic_update_rules.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/list_automatic_update_rules.js
@@ -1,5 +1,44 @@
-hqDefine("data_interfaces/js/list_automatic_update_rules", function() {
-    'use strict';
+hqDefine("data_interfaces/js/list_automatic_update_rules", [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/crud_paginated_list',
+], function(
+    $,
+    ko,
+    _,
+    initialPageData,
+    CRUDPaginatedList
+) {
+    var ruleModel = function(itemSpec, initRow) {
+        return CRUDPaginatedList.PaginatedItem(itemSpec, function(rowElems, paginatedItem) {
+            initRow(rowElems, paginatedItem);
+
+            $(rowElems).find(".activate").click(function() {
+                console.log("activate me");
+            });
+
+            $(rowElems).find(".deactivate").click(function() {
+                console.log("deactivate me");
+            });
+        });
+    };
+
+    $(function () {
+        var paginatedListModel = CRUDPaginatedList.CRUDPaginatedListModel(
+            initialPageData.get('total'),
+            initialPageData.get('limit'),
+            initialPageData.get('page'), {
+                statusCodeText: initialPageData.get('status_codes'),
+                allowItemCreation: initialPageData.get('allow_item_creation'),
+                createItemForm: initialPageData.get('create_item_form'),
+            }, ruleModel);
+
+        ko.applyBindings(paginatedListModel, $('#editable-paginated-list').get(0));
+        paginatedListModel.init();
+    });
+    /*'use strict';
     var autoUpdateRuleApp = window.angular.module('autoUpdateRuleApp', ['hq.pagination']);
     autoUpdateRuleApp.config(['$httpProvider', function($httpProvider) {
         $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
@@ -68,5 +107,5 @@ hqDefine("data_interfaces/js/list_automatic_update_rules", function() {
         trackNewRule: function () {
             hqImport('analytix/js/google').track.event('Automatic Case Closure', 'Rules', 'Set Rule');
         },
-    });
+    });*/
 });

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/list_automatic_update_rules.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/list_automatic_update_rules.js
@@ -17,7 +17,7 @@ hqDefine("data_interfaces/js/list_automatic_update_rules", [
         var newItemData = _.extend({}, rule.itemData(), {
             action_error: error,
         });
-        rule.itemData(newItemData);
+        rule.updateItemSpec({itemData: newItemData});
     };
 
     var updateRule = function(action, rule) {
@@ -69,37 +69,4 @@ hqDefine("data_interfaces/js/list_automatic_update_rules", [
             googleAnalytics.track.event('Automatic Case Closure', 'Rules', 'Set Rule');
         });
     });
-    /*'use strict';
-    var autoUpdateRuleApp = window.angular.module('autoUpdateRuleApp', ['hq.pagination']);
-    autoUpdateRuleApp.config(['$httpProvider', function($httpProvider) {
-        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
-        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
-        $httpProvider.defaults.headers.common["X-CSRFToken"] = $("#csrfTokenContainer").val();
-    }]);
-
-    autoUpdateRuleApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
-        djangoRMIProvider.configure(hqImport("hqwebapp/js/initial_page_data").get("djng_current_rmi"));
-    }]);
-    autoUpdateRuleApp.constant('paginationLimitCookieName', '{{ pagination_limit_cookie_name }}');
-    autoUpdateRuleApp.constant('paginationCustomData', {
-        deleteRule: function (rule, djangoRMI, paginationController) {
-            $('#delete_' + rule.id).modal('hide');
-            djangoRMI.update_rule({
-                id: rule.id,
-                update_action: 'delete'
-            })
-            .success(function (data) {
-                if (data.success) {
-                    rule.action_error = '';
-                } else {
-                    rule.action_error = data.error;
-                }
-                paginationController.getData();
-            })
-            .error(function () {
-                rule.action_error = gettext("Issue communicating with server. Try again.");
-            });
-        },
-    });*/
 });

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/list_automatic_update_rules.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/list_automatic_update_rules.js
@@ -4,12 +4,14 @@ hqDefine("data_interfaces/js/list_automatic_update_rules", [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/crud_paginated_list',
+    'analytix/js/google',
 ], function(
     $,
     ko,
     _,
     initialPageData,
-    CRUDPaginatedList
+    CRUDPaginatedList,
+    googleAnalytics
 ) {
     var showActionError = function(rule, error) {
         var newItemData = _.extend({}, rule.itemData(), {
@@ -62,6 +64,10 @@ hqDefine("data_interfaces/js/list_automatic_update_rules", [
 
         ko.applyBindings(paginatedListModel, $('#editable-paginated-list').get(0));
         paginatedListModel.init();
+
+        $("#add-new").click(function() {
+            googleAnalytics.track.event('Automatic Case Closure', 'Rules', 'Set Rule');
+        });
     });
     /*'use strict';
     var autoUpdateRuleApp = window.angular.module('autoUpdateRuleApp', ['hq.pagination']);
@@ -94,9 +100,6 @@ hqDefine("data_interfaces/js/list_automatic_update_rules", [
             .error(function () {
                 rule.action_error = gettext("Issue communicating with server. Try again.");
             });
-        },
-        trackNewRule: function () {
-            hqImport('analytix/js/google').track.event('Automatic Case Closure', 'Rules', 'Set Rule');
         },
     });*/
 });

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -4,6 +4,19 @@
 
 {% requirejs_main 'data_interfaces/js/list_automatic_update_rules' %}
 
+{% block title %}{{ current_page.title }}{% endblock %}
+
+{% block page_breadcrumbs %}
+    <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
+        <li>
+            <a href="{% url "data_interfaces_default" domain %}"><strong>{% trans "Data" %}</strong></a>
+        </li>
+        <li class="active">
+            {% trans "Automatically Close Cases" %}
+        </li>
+    </ol>
+{% endblock %}
+
 {% block pagination_header %}
     <div class="row">
         <div class="col-sm-8">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -36,17 +36,17 @@
         <span class="label label-danger" data-bind="visible: !active">{% trans "Inactive" %}</span>
     </td>
     <td data-bind="text: last_run"></td>
-    <td>
-        <button type="button"
-                class="btn btn-default activate"
-                data-bind="visible: !active">
+    <td data-bind="css: {'has-error': action_error}">
+        <button type="button" class="btn btn-default" data-action="activate" data-bind="visible: !active">
             {% trans "Activate" %}
         </button>
-        <button type="button"
-                class="btn btn-default deactivate"
-                data-bind="visible: active">
+        <button type="button" class="btn btn-default" data-action="deactivate" data-bind="visible: active">
             {% trans "Deactivate" %}
         </button>
+        <p class="help-block" data-bind="visible: action_error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span data-bind="text: action_error"></span>
+        </p>
     </td>
 </script>
 {% endblock pagination_templates %}
@@ -125,10 +125,6 @@
                                     </form>
                                 </div>
                             </div>
-                            <p ng-show="!!rule.action_error">
-                                <i class="fa fa-exclamation-triangle"></i>
-                                {{ rule.action_error }}
-                            </p>
                         </td>
                         {% endangularjs %}
                     </tr>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -6,7 +6,18 @@
 
 {% block pagination_templates %}
 <script type="text/html" id="base-rule-template">
-    <td data-bind="text: name"></td>
+    <td>
+        <a data-bind="attr: {href: edit_url}">
+            <strong data-bind="text: name"></strong>
+        </a>
+    </td>
+    <td data-bind="text: case_type"></td>
+    <td>
+        <span class="label label-success" data-bind="visible: active">{% trans "Active" %}</span>
+        <span class="label label-danger" data-bind="visible: !active">{% trans "Inactive" %}</span>
+    </td>
+    <td data-bind="text: last_run"></td>
+    <td>TODO</td>
 </script>
 {% endblock %}
 
@@ -59,29 +70,9 @@
             <table class="table table-striped table-responsive"
                    style="margin-bottom: 0;"
                    ng-show="paginatedItems.length > 0">
-                <thead>
-                    <tr>
-                        <th class="col-xs-3">{% trans "Name" %}</th>
-                        <th class="col-xs-2">{% trans "Case Type" %}</th>
-                        <th class="col-xs-2">{% trans "Status" %}</th>
-                        <th class="col-xs-2">{% trans "Last Run" %}</th>
-                        <th class="col-xs-3">{% trans "Action" %}</th>
-                    </tr>
-                </thead>
                 <tbody>
                     <tr ng-repeat="rule in paginatedItems">
                         {% angularjs %}
-                        <td>
-                            <a href="{{ rule.edit_url }}">
-                                <strong>{{ rule.name }}</strong>
-                            </a>
-                        </td>
-                        <td>{{ rule.case_type }}</td>
-                        <td>
-                            <span class="label label-success" ng-show="rule.active">{% trans "Active" %}</span>
-                            <span class="label label-danger" ng-hide="rule.active">{% trans "Inactive" %}</span>
-                        </td>
-                        <td>{{ rule.last_run }}</td>
                         <td>
                             <button type="button"
                                     class="btn btn-default"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -4,6 +4,25 @@
 
 {% requirejs_main 'hqwebapp/js/crud_paginated_list_init' %}
 
+{% block pagination_header %}
+    <div class="row">
+        <div class="col-sm-8">
+            <p class="lead">
+                {% blocktrans %}
+                Automatically update and close cases from CommCareHQ
+                {% endblocktrans %}
+            </p>
+            <p>
+                {% blocktrans %}
+                Create rules for closing cases from CommCareHQ.
+                All rules run every day at midnight GMT.
+                For more information, see the <a href="{{ help_site_url }}">Help Site</a>.
+                {% endblocktrans %}
+            </p>
+        </div>
+    </div>
+{% endblock pagination_header %}
+
 {% block pagination_templates %}
 <script type="text/html" id="base-rule-template">
     <td>
@@ -19,7 +38,7 @@
     <td data-bind="text: last_run"></td>
     <td>TODO</td>
 </script>
-{% endblock %}
+{% endblock pagination_templates %}
 
 {% comment %}
 {% block js %}
@@ -39,22 +58,6 @@
                 <i class="fa fa-plus"></i> {% trans "Add Automatic Case Close Rule" %}
             </button>
         </a>
-    </div>
-    <div class="row">
-        <div class="col-sm-8">
-            <p class="lead">
-                {% blocktrans %}
-                Automatically update and close cases from CommCareHQ
-                {% endblocktrans %}
-            </p>
-            <p>
-                {% blocktrans %}
-                Create rules for closing cases from CommCareHQ.
-                All rules run every day at midnight GMT.
-                For more information, see the <a href="{{ help_site_url }}">Help Site</a>.
-                {% endblocktrans %}
-            </p>
-        </div>
     </div>
     <div class="panel panel-default"
          ng-cloak>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -50,88 +50,49 @@
         <button type="button" class="btn btn-default" data-action="deactivate" data-bind="visible: active">
             {% trans "Deactivate" %}
         </button>
+        <button type="button" data-toggle="modal" class="btn btn-danger"
+                data-bind="attr: { 'data-target': '#delete-rule-' + id }">
+            <i class="fa fa-remove"></i>
+            Delete
+        </button>
+        <div class="modal fade" data-bind="attr: { id: 'delete-rule-' + id }">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h3>{% trans "Delete this rule?" %}</h3>
+                    </div>
+                    <div class="modal-body">
+                        <p class="lead">
+                            {% blocktrans %}
+                                Are you sure you want to <strong>delete</strong> this rule?
+                            {% endblocktrans %}
+                        </p>
+                        <p class="lead"><strong data-bind="text: name"></strong></p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">
+                            {% trans "Cancel" %}
+                        </button>
+                        <button type="button" class="btn btn-danger delete-item-confirm"
+                                data-loading-text="Deleting Rule...">
+                            <i class="fa fa-remove"></i>
+                            {% trans "Delete Rule" %}
+                        </button>
+                </div>
+            </div>
+            </div>
+        </div>
         <p class="help-block" data-bind="visible: action_error">
             <i class="fa fa-exclamation-triangle"></i>
             <span data-bind="text: action_error"></span>
         </p>
     </td>
 </script>
+<script type="text/html" id="rule-deleted-template">
+    <td colspan="5">
+        <span data-bind="text: name"></span>
+        <span class="label label-default">{% trans 'Removed' %}</span>
+    </td>
+</script>
 {% endblock pagination_templates %}
-
-{% comment %}
-{% block page_content %}
-{% initial_page_data 'djng_current_rmi' djng_current_rmi %}
-<div ng-app="autoUpdateRuleApp" ng-controller="PaginatedListController as paginationController">
-    <div class="panel panel-default"
-         ng-cloak>
-        <div class="panel-heading">
-            <h3 class="panel-title">{% trans 'Automatic Case Close Rules' %}</h3>
-        </div>
-        <div class="panel-body">
-            <div class="alert alert-info" ng-hide="paginatedItems.length > 0 || notLoaded || hasError">
-                {% blocktrans %}
-                    <strong>There are currently no automatic update rules in this project.</strong>
-                {% endblocktrans %}
-            </div>
-            <table class="table table-striped table-responsive"
-                   style="margin-bottom: 0;"
-                   ng-show="paginatedItems.length > 0">
-                <tbody>
-                    <tr ng-repeat="rule in paginatedItems">
-                        {% angularjs %}
-                        <td>
-                            <button type="button"
-                                    class="btn btn-danger"
-                                    data-toggle="modal"
-                                    data-target="#delete_{{ rule.id }}">
-                                    {% trans "Delete" %}
-                            </button>
-                            <div id="delete_{{ rule.id }}" class="modal fade">
-                                <div class="modal-dialog">
-                                    <form class="modal-content"
-                                          method="post"
-                                          ng-submit="deleteRule(rule, djangoRMI, paginationController);">
-                                        {% csrf_token %}
-                                        <div class="modal-header">
-                                            <button type="button"
-                                                    class="close"
-                                                    data-dismiss="modal">
-                                                <span aria-hidden="true">&times;</span>
-                                                <span class="sr-only">{% trans "Close" %}</span>
-                                            </button>
-                                            <h4 class="modal-title">{% trans "Delete Rule" %}</h4>
-                                        </div>
-                                        <div class="modal-body">
-                                            <p class="lead">
-                                                {% blocktrans %}
-                                                    Are you sure you want to <strong>delete</strong> this rule?
-                                                {% endblocktrans %}
-                                            </p>
-                                            <p class="lead">
-                                                <strong>{{ rule.name }}</strong>
-                                            </p>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="button"
-                                                    class="btn btn-default"
-                                                    data-dismiss="modal">
-                                                {% trans "Cancel" %}
-                                            </button>
-                                            <button type="submit"
-                                                    class="btn btn-default btn-danger">
-                                                {% trans "Delete" %}
-                                            </button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-                        </td>
-                        {% endangularjs %}
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-</div>
-{% endblock %}
-{% endcomment %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -21,6 +21,13 @@
             </p>
         </div>
     </div>
+    <div class="btn-toolbar">
+        <a href="{% url "add_case_rule" domain %}">
+            <button type="button" class="btn btn-success" id="add-new">
+                <i class="fa fa-plus"></i> {% trans "Add Automatic Case Close Rule" %}
+            </button>
+        </a>
+    </div>
 {% endblock pagination_header %}
 
 {% block pagination_templates %}
@@ -55,13 +62,6 @@
 {% block page_content %}
 {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
 <div ng-app="autoUpdateRuleApp" ng-controller="PaginatedListController as paginationController">
-    <div class="btn-toolbar" style="margin-bottom: 20px;">
-        <a href="{% url "add_case_rule" domain %}">
-            <button type="button" class="btn btn-success" ng-click="trackNewRule();">
-                <i class="fa fa-plus"></i> {% trans "Add Automatic Case Close Rule" %}
-            </button>
-        </a>
-    </div>
     <div class="panel panel-default"
          ng-cloak>
         <div class="panel-heading">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -1,10 +1,18 @@
-{% extends 'hqwebapp/base_section.html' %}
+{% extends 'hqwebapp/base_paginated_crud.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% load djangular_tags %}
 
+{% requirejs_main 'hqwebapp/js/crud_paginated_list_init' %}
+
+{% block pagination_templates %}
+<script type="text/html" id="base-rule-template">
+    <td data-bind="text: name"></td>
+</script>
+{% endblock %}
+
+{% comment %}
 {% block js %}
-<script src="{% static 'hqwebapp/js/pagination.ng.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/pagination.ng.js' %}"></script>
 {% endblock %}
 
 {% block js-inline %}{{ block.super }}
@@ -167,3 +175,4 @@
     </div>
 </div>
 {% endblock %}
+{% endcomment %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -56,17 +56,6 @@
                     <strong>There are currently no automatic update rules in this project.</strong>
                 {% endblocktrans %}
             </div>
-            <div class="pull-right" style="clear: right;">
-                <pagination direction-links="true"
-                            total-items="total"
-                            items-per-page="limit"
-                            previous-text="&laquo;"
-                            next-text="&raquo;"
-                            max-size="maxSize"
-                            ng-model="currentPage"
-                            ng-change="pageChanged()"
-                            ng-show="paginatedItems.length > 0"></pagination>
-            </div>
             <table class="table table-striped table-responsive"
                    style="margin-bottom: 0;"
                    ng-show="paginatedItems.length > 0">
@@ -160,17 +149,6 @@
                     </tr>
                 </tbody>
             </table>
-            <div class="pull-right" style="clear: right;">
-                <pagination direction-links="true"
-                            total-items="total"
-                            items-per-page="limit"
-                            previous-text="&laquo;"
-                            next-text="&raquo;"
-                            max-size="maxSize"
-                            ng-model="currentPage"
-                            ng-change="pageChanged()"
-                            ng-show="paginatedItems.length > 0"></pagination>
-            </div>
         </div>
     </div>
 </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'hqwebapp/js/crud_paginated_list_init' %}
+{% requirejs_main 'data_interfaces/js/list_automatic_update_rules' %}
 
 {% block pagination_header %}
     <div class="row">
@@ -36,19 +36,22 @@
         <span class="label label-danger" data-bind="visible: !active">{% trans "Inactive" %}</span>
     </td>
     <td data-bind="text: last_run"></td>
-    <td>TODO</td>
+    <td>
+        <button type="button"
+                class="btn btn-default activate"
+                data-bind="visible: !active">
+            {% trans "Activate" %}
+        </button>
+        <button type="button"
+                class="btn btn-default deactivate"
+                data-bind="visible: active">
+            {% trans "Deactivate" %}
+        </button>
+    </td>
 </script>
 {% endblock pagination_templates %}
 
 {% comment %}
-{% block js %}
-    <script src="{% static 'hqwebapp/js/pagination.ng.js' %}"></script>
-{% endblock %}
-
-{% block js-inline %}{{ block.super }}
-    <script src="{% static "data_interfaces/js/list_automatic_update_rules.js" %}"></script>
-{% endblock %}
-
 {% block page_content %}
 {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
 <div ng-app="autoUpdateRuleApp" ng-controller="PaginatedListController as paginationController">
@@ -77,18 +80,6 @@
                     <tr ng-repeat="rule in paginatedItems">
                         {% angularjs %}
                         <td>
-                            <button type="button"
-                                    class="btn btn-default"
-                                    ng-hide="rule.active"
-                                    ng-click="activateRule(rule, djangoRMI);">
-                                {% trans "Activate" %}
-                            </button>
-                            <button type="button"
-                                    class="btn btn-default"
-                                    ng-show="rule.active"
-                                    ng-click="deactivateRule(rule, djangoRMI);">
-                                {% trans "Deactivate" %}
-                            </button>
                             <button type="button"
                                     class="btn btn-danger"
                                     data-toggle="modal"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -66,7 +66,7 @@
         <button type="button" data-toggle="modal" class="btn btn-danger"
                 data-bind="attr: { 'data-target': '#delete-rule-' + id }">
             <i class="fa fa-remove"></i>
-            Delete
+            {% trans "Delete" %}
         </button>
         <div class="modal fade" data-bind="attr: { id: 'delete-rule-' + id }">
             <div class="modal-dialog">

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -648,7 +648,7 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 
     @property
     def total(self):
-        return self._rules().count()
+        return len(self._rules())
 
     @property
     def column_names(self):
@@ -689,11 +689,11 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 
     @memoized
     def _rules(self):
-        return AutomaticUpdateRule.by_domain(
+        return sorted(AutomaticUpdateRule.by_domain(
             self.domain,
             AutomaticUpdateRule.WORKFLOW_CASE_UPDATE,
             active_only=False,
-        )
+        ), key=lambda rule: (rule.name, rule.id))
 
     def post(self, *args, **kwargs):
         return self.paginate_crud_response

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -648,7 +648,7 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 
     @property
     def total(self):
-        return len(self._rules())
+        return self._rules().count()
 
     @property
     def column_names(self):
@@ -689,11 +689,11 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 
     @memoized
     def _rules(self):
-        return sorted(AutomaticUpdateRule.by_domain(
+        return AutomaticUpdateRule.by_domain(
             self.domain,
             AutomaticUpdateRule.WORKFLOW_CASE_UPDATE,
             active_only=False,
-        ), key=lambda rule: (rule.name, rule.id))
+        ).order_by('name', 'id')
 
     def post(self, *args, **kwargs):
         return self.paginate_crud_response

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -681,7 +681,7 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 
     @property
     def paginated_list(self):
-        for rule in self._rules():
+        for rule in self._rules()[self.skip:self.skip + self.limit]:
             yield {
                 'itemData': self._format_rule(rule),
                 'template': 'base-rule-template',

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -636,8 +636,8 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
     @property
     def allowed_actions(self):
         actions = super(AutomaticUpdateRuleListView, self).allowed_actions
-        actions.append('activate')
-        actions.append('deactivate')
+        actions.append(self.ACTION_ACTIVATE)
+        actions.append(self.ACTION_DEACTIVATE)
         return actions
 
     @property

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -631,7 +631,9 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 
     @property
     def page_context(self):
-        return self.pagination_context
+        context = self.pagination_context
+        context['help_site_url'] = 'https://confluence.dimagi.com/display/commcarepublic/Automatically+Close+Cases'
+        return context
 
     @property
     def total(self):
@@ -685,15 +687,6 @@ class AutomaticUpdateRuleListView(HQJSONResponseMixin, DataInterfaceSection):
     ACTION_ACTIVATE = 'activate'
     ACTION_DEACTIVATE = 'deactivate'
     ACTION_DELETE = 'delete'
-
-    @property
-    def page_context(self):
-        return {
-            'pagination_limit_cookie_name': ('hq.pagination.limit'
-                                             '.automatic_update_rule_list.%s'
-                                             % self.domain),
-            'help_site_url': 'https://confluence.dimagi.com/display/commcarepublic/Automatically+Close+Cases',
-        }
 
     @allow_remote_invocation
     def update_rule(self, in_data):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -699,7 +699,6 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
         return self.paginate_crud_response
 
     def _get_rule(self, rule_id):
-        error = None
         if rule_id is None:
             return None, _("Please provide an id.")
 

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -666,10 +666,6 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
         )
 '''
 class AutomaticUpdateRuleListView(HQJSONResponseMixin, DataInterfaceSection):
-    template_name = 'data_interfaces/list_automatic_update_rules.html'
-    urlname = 'automatic_update_rule_list'
-    page_title = ugettext_lazy("Automatically Close Cases")
-
     ACTION_ACTIVATE = 'activate'
     ACTION_DEACTIVATE = 'deactivate'
     ACTION_DELETE = 'delete'
@@ -704,38 +700,6 @@ class AutomaticUpdateRuleListView(HQJSONResponseMixin, DataInterfaceSection):
                          .done()
                          .strftime(SERVER_DATETIME_FORMAT)) if rule.last_run else '-',
             'edit_url': reverse(EditCaseRuleView.urlname, args=[self.domain, rule.pk]),
-        }
-
-    @allow_remote_invocation
-    def get_pagination_data(self, in_data):
-        try:
-            limit = int(in_data['limit'])
-            page = int(in_data['page'])
-        except (TypeError, KeyError, ValueError):
-            return {
-                'success': False,
-                'error': _("Please provide pagination info."),
-            }
-
-        start = (page - 1) * limit
-        stop = limit * page
-
-        rules = AutomaticUpdateRule.by_domain(
-            self.domain,
-            AutomaticUpdateRule.WORKFLOW_CASE_UPDATE,
-            active_only=False,
-        )
-
-        rule_page = rules.order_by('name')[start:stop]
-        total = rules.count()
-
-        return {
-            'response': {
-                'itemList': list(map(self._format_rule, rule_page)),
-                'total': total,
-                'page': page,
-            },
-            'success': True,
         }
 
     @allow_remote_invocation

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/crud_paginated_list.js
@@ -18,7 +18,7 @@ hqDefine("hqwebapp/js/crud_paginated_list", [
         'use strict';
         options = options || {};
 
-        var self = this;
+        var self = {};
 
         self.PaginatedItem = paginatedItem || PaginatedItem;
 
@@ -109,7 +109,7 @@ hqDefine("hqwebapp/js/crud_paginated_list", [
                     self.paginatedList(_.map(
                         data.paginatedList,
                         function (listItem) {
-                            return new self.PaginatedItem(listItem, self.initRow);
+                            return self.PaginatedItem(listItem, self.initRow);
                         }
                     ));
                     self.deletedList([]);
@@ -160,7 +160,7 @@ hqDefine("hqwebapp/js/crud_paginated_list", [
                             if (data.newItem.error) {
                                 self.alertHtml(data.newItem.error);
                             } else {
-                                self.newList.push(new self.PaginatedItem(data.newItem, self.initRow));
+                                self.newList.push(self.PaginatedItem(data.newItem, self.initRow));
                             }
                         }
                     },
@@ -254,8 +254,7 @@ hqDefine("hqwebapp/js/crud_paginated_list", [
     };
 
     var PaginatedItem = function (itemSpec, initRow) {
-        'use strict';
-        var self = this;
+        var self = {};
         self.itemId = itemSpec.itemData.id;
         self.itemRowId = 'item-row-' + self.itemId;
         self.itemData = ko.observable(itemSpec.itemData);
@@ -363,5 +362,6 @@ hqDefine("hqwebapp/js/crud_paginated_list", [
 
     return {
         CRUDPaginatedListModel: CRUDPaginatedListModel,
+        PaginatedItem: PaginatedItem,
     };
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base_paginated_crud.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base_paginated_crud.html
@@ -50,20 +50,9 @@
                         hide: isLoadingVisible
                     }
                 ">
+
                 <div class="row" data-bind="visible: isPaginationActive">
-                    <div class="col-md-4">
-                        <div class="form-inline" style="margin: 1.6em 0;">
-                            <label for="pagination-limit">{% trans 'Show' %}</label>
-                            <select class="form-control" id="pagination-limit" data-bind="event: {change: updateListLimit}">
-                                {% for limit in pagination.limit_options %}
-                                    <option value="{{ limit }}">
-                                        {{ limit }} {{ pagination.text.limit }}
-                                    </option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                    </div>
-                    <div class="col-md-8">
+                    <div class="col-md-12">
                         {% include 'hqwebapp/partials/pagination.html' %}
                     </div>
                 </div>
@@ -159,11 +148,25 @@
                     </div>
                 </div>
             </div>
+
             <div class="row" data-bind="visible: isPaginationActive">
-                <div class="col-md-12">
+                <div class="col-md-4">
+                    <div class="form-inline" style="margin: 1.6em 0;">
+                        <label for="pagination-limit">{% trans 'Show' %}</label>
+                        <select class="form-control" id="pagination-limit" data-bind="event: {change: updateListLimit}">
+                            {% for limit in pagination.limit_options %}
+                                <option value="{{ limit }}">
+                                    {{ limit }} {{ pagination.text.limit }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div class="col-md-8">
                     {% include 'hqwebapp/partials/pagination.html' %}
                 </div>
             </div>
+
         </div>
     {% endblock %}
     {% block pagination_footer %}

--- a/docs/ui_helpers.rst
+++ b/docs/ui_helpers.rst
@@ -22,14 +22,14 @@ In its very basic form (a simple paginated view) it should look like:
 
 .. code-block:: python
 
-    class PuppiesCRUDView(BaseSectionView, CRUDPaginatedMixin):
+    class PuppiesCRUDView(BaseSectionView, CRUDPaginatedViewMixin):
         # your template should extend hqwebapp/base_paginated_crud.html
         template_name = 'puppyapp/paginated_puppies.html
 
         # all the user-visible text
         limit_text = "puppies per page"
         empty_notification = "you have no puppies"
-        loading_messagge = "loading_puppies"
+        loading_message = "loading_puppies"
 
         # required properties you must implement:
 
@@ -39,7 +39,7 @@ In its very basic form (a simple paginated view) it should look like:
             Specify a GET or POST from an HttpRequest object.
             """
             # Usually, something like:
-            return self.request.POST if self.request.method == 'post' else self.request.GET
+            return self.request.POST if self.request.method == 'POST' else self.request.GET
 
         @property
         def total(self):
@@ -54,6 +54,11 @@ In its very basic form (a simple paginated view) it should look like:
                 "Breed",
                 "Age",
             ]
+            
+        @property
+        def page_context(self):
+            # This should at least include the pagination_context that CRUDPaginatedViewMixin provides
+            return self.pagination_context
 
         @property
         def paginated_list(self):
@@ -81,7 +86,7 @@ In its very basic form (a simple paginated view) it should look like:
                 }
 
         def post(self, *args, **kwargs):
-            return self.paginated_crud_response
+            return self.paginate_crud_response
 
 The template should use `knockout templates <http://knockoutjs.com/documentation/template-binding.html>`_
 to render the data you pass back to the view. Each template will have access to
@@ -319,37 +324,41 @@ You should add the following to your `base-puppy-template` knockout template:
                         }
                     "
                     class="btn btn-danger">
-                <i class="icon-remove"></i> Delete Puppy
+                <i class="fa fa-remove"></i> Delete Puppy
             </button>
 
-            <div class="modal hide fade"
+            <div class="modal fade"
                  data-bind="
                     attr: {
                         id: 'delete-puppy-' + id
                     }
                  ">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h3>
-                       Delete puppy <strong data-bind="text: name"></strong>?
-                    </h3>
-                </div>
-                <div class="modal-body">
-                    <p>
-                        Yes, delete the puppy named <strong data-bind="text: name"></strong>.
-                    </p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button"
-                            class="btn"
-                            data-dismiss="modal">
-                        Cancel
-                    </button>
-                    <button type="button"
-                            class="btn btn-danger delete-item-confirm"
-                            data-loading-text="Deleting Puppy...">
-                        <i class="icon-remove"></i> Delete Puppy
-                    </button>
+                 <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h3>
+                               Delete puppy <strong data-bind="text: name"></strong>?
+                            </h3>
+                        </div>
+                        <div class="modal-body">
+                            <p class="lead">
+                                Yes, delete the puppy named <strong data-bind="text: name"></strong>.
+                            </p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button"
+                                    class="btn btn-default"
+                                    data-dismiss="modal">
+                                Cancel
+                            </button>
+                            <button type="button"
+                                    class="btn btn-danger delete-item-confirm"
+                                    data-loading-text="Deleting Puppy...">
+                                <i class="fa fa-remove"></i> Delete Puppy
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </td>


### PR DESCRIPTION
Replaces angular app with usage of the CRUD paginated mixin. 

@djmore9 Marked that as all-users because it makes some incidental UI changes, but nothing meaningful that needs to be announced.

before
![screen shot 2018-08-06 at 5 15 58 pm](https://user-images.githubusercontent.com/1486591/43741548-c6a69abe-999c-11e8-9366-4bac05a42ace.png)

after
![screen shot 2018-08-06 at 5 32 30 pm](https://user-images.githubusercontent.com/1486591/43742149-d65480aa-999e-11e8-9c4b-dd595938431c.png)

Review by commit.

@nickpell / @gcapalbo 