### PR TITLE
Allow run arbitrary django command against test db

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -73,7 +73,8 @@ def _should_patch_gevent(args, gevent_commands):
 
 
 def set_default_settings_path(argv):
-    if len(argv) > 1 and argv[1] == 'test':
+    if len(argv) > 1 and argv[1] == 'test' or os.environ.get('CCHQ_TESTING') == '1':
+        os.environ.setdefault('CCHQ_TESTING', '1')
         module = 'testsettings'
     else:
         module = 'settings'

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -15,7 +15,7 @@ from raven import fetch_git_sha
 
 
 def is_testing():
-    return len(sys.argv) > 1 and sys.argv[1] == "test"
+    return os.environ.get("CCHQ_TESTING") == "1"
 
 
 class SharedDriveConfiguration(object):


### PR DESCRIPTION
Useful for running and debugging migrations on test db:

```
$ CCHQ_TESTING=1 ./manage.py migrate
```

@mkangia @proteusvacuum 