### PR TITLE
use SumWhen to reduce number of queries

### DIFF
--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -637,6 +637,13 @@ def get_age_filters(beta):
     ]
 
 
+def get_age_condition(beta):
+    if beta:
+        return "age_tranche != :age_72"
+    else:
+        return "age_tranche != :age_0 AND age_tranche != :age_6 AND age_tranche != :age_72"
+
+
 def track_time(func):
     """A decorator to track the duration an aggregation script takes to execute"""
     from custom.icds_reports.models import AggregateSQLProfile


### PR DESCRIPTION
In sql-agg each new combination of `table + filters + group_by` will be executed as a separate query.

BUT sql-agg support generating case statements which makes it possible to generate this export in a single query instead of 20: https://github.com/dimagi/sql-agg#conditional--case-columns

@lwyszomi FYI the same pattern can be applied to other reports

SQLAlachemy docs on `case` here: http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.case