### PR TITLE
Fix 280549: export scalar question that was previously a repeat

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -304,7 +304,18 @@ class ExportColumn(DocumentSchema):
             value = MISSING_VALUE
 
         if isinstance(value, list):
-            value = ' '.join(value)
+            def _serialize(str_or_dict):
+                """
+                Serialize old data for scalar questions that were previously a repeat
+
+                This is a total edge case. See https://manage.dimagi.com/default.asp?280549.
+                """
+                if isinstance(str_or_dict, dict):
+                    return ','.join('{}={}'.format(k, v) for k, v in str_or_dict.items())
+                else:
+                    return str_or_dict
+
+            value = ' '.join(_serialize(elem) for elem in value)
         return value
 
     @staticmethod


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?280549

This prevents a 500 and just serializes the question dict as q1=v1,q2=v2