### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -433,7 +433,7 @@ class HQMediaMapItem(DocumentSchema):
 
     @classmethod
     def gen_unique_id(cls, m_id, path):
-        return hashlib.md5("%s: %s" % (path.encode('utf-8'), str(m_id))).hexdigest()
+        return hashlib.md5(b"%s: %s" % (path.encode('utf-8'), m_id.encode('utf-8'))).hexdigest()
 
 
 class ApplicationMediaReference(object):


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/633936618/

In py3, ```hashlib.md5``` only accepts bytes and byte-like objects (no unicode).

@calellowitz code buddy