### PR TITLE
Add "last_sync" to "rows" element

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -369,11 +369,13 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         data_source.set_filter_values(filter_values)
         data_source.set_defer_fields([f.field for f in defer_filters])
         filter_options_by_field = defaultdict(set)
+        last_sync = _last_sync_time(domain, restore_user.user_id)
 
         rows_elem = ReportFixturesProviderV2._get_v2_report_elem(
             data_source,
             {f.field for f in defer_filters},
-            filter_options_by_field
+            filter_options_by_field,
+            last_sync,
         )
         filters_elem = BaseReportFixturesProvider._get_filters_elem(
             defer_filters, filter_options_by_field, restore_user._couch_user)
@@ -386,14 +388,14 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
 
         report_elem = E.fixture(
             id=ReportFixturesProviderV2._report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
-            report_id=report_config.report_id, last_sync=_last_sync_time(domain, restore_user.user_id),
+            report_id=report_config.report_id, last_sync=last_sync,
             indexed='true'
         )
         report_elem.append(rows_elem)
         return [report_filter_elem, report_elem]
 
     @staticmethod
-    def _get_v2_report_elem(data_source, deferred_fields, filter_options_by_field):
+    def _get_v2_report_elem(data_source, deferred_fields, filter_options_by_field, last_sync):
         def _row_to_row_elem(row, index, is_total_row=False):
             row_elem = E.row(index=str(index), is_total_row=str(is_total_row))
             for k in sorted(row.keys()):
@@ -403,7 +405,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
                     filter_options_by_field[k].add(value)
             return row_elem
 
-        rows_elem = E.rows()
+        rows_elem = E.rows(last_sync=last_sync)
         for i, row in enumerate(data_source.get_data()):
             rows_elem.append(_row_to_row_elem(row, i))
         if data_source.has_total_row:

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -369,13 +369,12 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         data_source.set_filter_values(filter_values)
         data_source.set_defer_fields([f.field for f in defer_filters])
         filter_options_by_field = defaultdict(set)
-        last_sync = _last_sync_time(domain, restore_user.user_id)
 
         rows_elem = ReportFixturesProviderV2._get_v2_report_elem(
             data_source,
             {f.field for f in defer_filters},
             filter_options_by_field,
-            last_sync,
+            _last_sync_time(domain, restore_user.user_id),
         )
         filters_elem = BaseReportFixturesProvider._get_filters_elem(
             defer_filters, filter_options_by_field, restore_user._couch_user)
@@ -388,8 +387,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
 
         report_elem = E.fixture(
             id=ReportFixturesProviderV2._report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
-            report_id=report_config.report_id, last_sync=last_sync,
-            indexed='true'
+            report_id=report_config.report_id, indexed='true'
         )
         report_elem.append(rows_elem)
         return [report_filter_elem, report_elem]

--- a/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report.xml
+++ b/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report.xml
@@ -2,7 +2,7 @@
   <fixture id="commcare-reports-filters:c0ffee">
 	  <filters />
   </fixture>
-  <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" last_sync="2017-09-11T06:35:20" indexed="true">
+  <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" indexed="true">
     <rows last_sync="2017-09-11T06:35:20">
       <row index="0" is_total_row="False">
         <bar>2</bar>

--- a/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report.xml
+++ b/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report.xml
@@ -3,7 +3,7 @@
 	  <filters />
   </fixture>
   <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" last_sync="2017-09-11T06:35:20" indexed="true">
-    <rows>
+    <rows last_sync="2017-09-11T06:35:20">
       <row index="0" is_total_row="False">
         <bar>2</bar>
         <baz>3</baz>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?280524
App builders cannot access attributes defined at the top level of an instance definition.  ICDS uses the "last_sync" attr on mobile UCR v1, so I'm making it available in v2 for the migration.

Product - the user-facing change here is that projects using mobile UCR v2 will now be able to access the timestamp of the last time each report fixture was updated.

@Rohit25negi @emord 