### PR TITLE
Don't verify cert on formplayer status check

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -194,7 +194,7 @@ def check_couch():
 
 def check_formplayer():
     try:
-        res = requests.get('{}/serverup'.format(get_formplayer_url()), timeout=5)
+        res = requests.get('{}/serverup'.format(get_formplayer_url()), timeout=5, verify=False)
     except requests.exceptions.ConnectTimeout:
         return ServiceStatus(False, "Could not establish a connection in time")
     except requests.ConnectionError:

--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -194,6 +194,8 @@ def check_couch():
 
 def check_formplayer():
     try:
+        # Setting verify=False in this request keeps this from failing for urls with unsigned certificates.
+        # Allowing this because the certificate will always be unsigned for the fullstack deploy.
         res = requests.get('{}/serverup'.format(get_formplayer_url()), timeout=5, verify=False)
     except requests.exceptions.ConnectTimeout:
         return ServiceStatus(False, "Could not establish a connection in time")

--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -194,8 +194,9 @@ def check_couch():
 
 def check_formplayer():
     try:
-        # Setting verify=False in this request keeps this from failing for urls with unsigned certificates.
-        # Allowing this because the certificate will always be unsigned for the fullstack deploy.
+        # Setting verify=False in this request keeps this from failing for urls with self-signed certificates.
+        # Allowing this because the certificate will always be self-signed in the "provable deploy"
+        # bootstrapping test in commcare-cloud.
         res = requests.get('{}/serverup'.format(get_formplayer_url()), timeout=5, verify=False)
     except requests.exceptions.ConnectTimeout:
         return ServiceStatus(False, "Could not establish a connection in time")


### PR DESCRIPTION
Reason: check-services was returning `FAILURE (Took   0.11s) formplayer     : Could not connect to formplayer` on the fullstack deploy because it uses a self signed certificate. All we want is to make sure that we get a response from this page, so a certificate isn't needed.