### PR TITLE
Fix behavior for zero-row saved exports

### DIFF
--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -54,7 +54,11 @@ def get_task_progress(task):
         else:
             current = info.get('current')
             total = info.get('total')
-            percent = current * 100 // total if total and current is not None else 0
+            if total == 0:
+                percent = 100
+            else:
+                percent = current * 100 // total if total and current is not None else 0
+
     return TaskProgress(
         current=current,
         total=total,


### PR DESCRIPTION
previously they would hang at zero progress forever

Tested locally that both newly triggered saved export builds as well as export builds triggered on the old code behave well on the new code