### PR TITLE
Web Apps: Populate value for unsupported question types

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -132,7 +132,7 @@ function UnsupportedEntry(question, options) {
     var self = this;
     Entry.call(self, question, options);
     self.templateType = 'unsupported';
-    self.answer(gettext('Unsupported Question Type'));
+    self.answer('Not Supported by Web Entry');
 }
 UnsupportedEntry.prototype = Object.create(Entry.prototype);
 UnsupportedEntry.prototype.constructor = Entry;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -132,6 +132,7 @@ function UnsupportedEntry(question, options) {
     var self = this;
     Entry.call(self, question, options);
     self.templateType = 'unsupported';
+    self.answer(gettext('Unsupported Question Type'));
 }
 UnsupportedEntry.prototype = Object.create(Entry.prototype);
 UnsupportedEntry.prototype.constructor = Entry;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -299,6 +299,11 @@ function Form(json) {
             var container = $(event.currentTarget).closest(".caption");
             container.find(".modal").modal('show');
         });
+
+        $(".unsupported-question-type-trigger").click(function() {
+            var container = $(event.currentTarget).closest(".widget");
+            container.find(".modal").modal('show');
+        });
     };
 
     $.unsubscribe('session');

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -113,9 +113,8 @@
                 <!-- ko if: help() -->
                 <a
                     class="help-text-trigger"
-                    role="button">
-                    <i class="fa fa-info-circle"></i>
-                </a>
+                    role="button"
+                    ><i class="fa fa-info-circle"></i></a>
                 <div class="modal fade" role="dialog">
                     <div class="modal-dialog">
                         <div class="modal-content">
@@ -249,9 +248,27 @@
 </script>
 <script type="text/html" id="unsupported-entry-ko-template">
     <div class="unsupported alert alert-warning">
+        <a class="unsupported-question-type-trigger" role="button"
+            ><i class="fa fa-info-circle"></i></a>
         {% blocktrans %}
             Sorry, web entry cannot support this type of question.
         {% endblocktrans %}
+    </div>
+    <div class="modal fade" role="dialog" id="unsupported-question-type-modal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body">
+                    {% blocktrans %}
+                        This question will appear as follows in data exports.
+                    {% endblocktrans %}
+                    <br><br>
+                    <input type="text" class="form-control" data-bind="value: $data.answer" />
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-default" data-dismiss="modal">{% trans "OK" %}</button>
+                </div>
+            </div>
+        </div>
     </div>
 </script>
 <script type="text/html" id="geo-entry-ko-template">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -251,11 +251,6 @@
     <div class="unsupported alert alert-warning">
         {% blocktrans %}
             Sorry, web entry cannot support this type of question.
-            <br><br>
-            <small>
-                This question will appear as follows in data exports:
-                <strong data-bind="text: $data.answer"></strong>
-            </small>
         {% endblocktrans %}
     </div>
 </script>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -114,7 +114,7 @@
                 <a
                     class="help-text-trigger"
                     role="button"
-                    ><i class="fa fa-info-circle"></i></a>
+                    ><i class="fa fa-question-circle"></i></a>
                 <div class="modal fade" role="dialog">
                     <div class="modal-dialog">
                         <div class="modal-content">
@@ -249,7 +249,7 @@
 <script type="text/html" id="unsupported-entry-ko-template">
     <div class="unsupported alert alert-warning">
         <a class="unsupported-question-type-trigger" role="button"
-            ><i class="fa fa-info-circle"></i></a>
+            ><i class="fa fa-question-circle"></i></a>
         {% blocktrans %}
             Sorry, web entry cannot support this type of question.
         {% endblocktrans %}

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -248,9 +248,16 @@
     "></span>
 </script>
 <script type="text/html" id="unsupported-entry-ko-template">
-    <div class="unsupported alert alert-warning" data-bind="
-        text: 'Sorry, web entry cannot support this type of question ' + datatype
-    "></div>
+    <div class="unsupported alert alert-warning">
+        {% blocktrans %}
+            Sorry, web entry cannot support this type of question.
+            <br><br>
+            <small>
+                This question will appear as follows in data exports:
+                <strong data-bind="text: $data.answer"></strong>
+            </small>
+        {% endblocktrans %}
+    </div>
 </script>
 <script type="text/html" id="geo-entry-ko-template">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
@@ -7,6 +7,12 @@
   outline: 0;
 }
 
+.help-text-trigger, .unsupported-question-type-trigger {
+  float: right;
+  margin-bottom: 5px;
+  margin-left: 5px;
+}
+
 .atwho-view:after {
   text-align: center;
   content: attr(data-message);


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?249088

Give unsupported question types a default response so they don't block form submission in web apps / app preview if they're required.

@dimagi/product / @ctsims Does this approach seem reasonable? The other suggestion on the ticket (supply a text input) would be more flexible in terms of passing validation conditions and making reasonable fake output, but it's also potentially a good deal more confusing. I'd also appreciate feedback on whether or not to include the "This question will appear..." message or if it's just clutter.

App Preview:
<img width="297" alt="screen shot 2018-08-09 at 2 09 31 pm" src="https://user-images.githubusercontent.com/1486591/43917697-02c0da98-9bdf-11e8-82b1-f7acd12dcfa7.png">

Form Data:
<img width="1118" alt="screen shot 2018-08-09 at 2 09 55 pm" src="https://user-images.githubusercontent.com/1486591/43917723-0d853f14-9bdf-11e8-838f-17d1fa03dc8f.png">

code buddies @pr33thi @snopoke 
web apps @jmtroth0 