### PR TITLE
Web Apps: support markdown in choices

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -25,6 +25,15 @@ md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
     return defaultRender(tokens, idx, options, env, self);
 };
 
+_.delay(function() {
+    ko.bindingHandlers.renderMarkdown = {
+        update: function(element, valueAccessor) {
+            var value = ko.unwrap(valueAccessor());
+            value = md.render(value || '');
+            $(element).html(value);
+        },
+    };
+});
 
 //if index is part of a repeat, return only the part beyond the deepest repeat
 function relativeIndex(ix) {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -298,7 +298,7 @@
                         class: 'group-' + $parent.entryId,
                     }
                 "/>
-                <span data-bind="text: $data"></span>
+                <span data-bind="renderMarkdown: $data"></span>
             </label>
         </div>
     </div>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?235137

This adds a knockout binding for rendering markdown and uses it on choices. It doesn't touch the way the markdown is rendered for question display text (`caption_markdown` in [fullform_ui.js](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js)) - I briefly looked at unifying them but didn't get far.

<img width="290" alt="screen shot 2018-08-09 at 3 08 54 pm" src="https://user-images.githubusercontent.com/1486591/43920262-6a8db806-9be6-11e8-8533-105b3a18a260.png">

@jmtroth0 
code buddies @pr33thi @snopoke 