### PR TITLE
Fix tabs on My Saved Reports

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/sticky_tabs.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/sticky_tabs.js
@@ -20,8 +20,10 @@ hqDefine("hqwebapp/js/sticky_tabs", [
     $(function(){
         var tabSelector = "a[data-toggle='tab']",
             navSelector = ".nav.sticky-tabs",
-            $tabFromUrl = $("a[href='" + getHash() + "']");
-        if ($tabFromUrl.length) {
+            hash = getHash(),
+            $tabFromUrl = hash ? $("a[href='" + hash + "']") : undefined;
+
+        if ($tabFromUrl && $tabFromUrl.length) {
             $tabFromUrl.tab('show');
         } else {
             $(navSelector + ' ' + tabSelector).first().tab('show');


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/21173

When there was no hash in the url, sticky tabs would attempt to select any link on the page that doesn't have an href.

@pr33thi / @snopoke 