### PR TITLE
Fix js errors on My Saved Reports

### DIFF
--- a/corehq/apps/reports/static/reports/js/saved_reports.js
+++ b/corehq/apps/reports/static/reports/js/saved_reports.js
@@ -1,3 +1,7 @@
+/**
+ * This file handles the interaction for the "My Saved Reports" page
+ * and also the modal used to save a report on standard reports pages.
+ */
 var ReportConfig = function (data) {
     var self = ko.mapping.fromJS(data, {
         'copy': ['filters'],

--- a/corehq/apps/reports/templates/reports/reports_home.html
+++ b/corehq/apps/reports/templates/reports/reports_home.html
@@ -1,12 +1,18 @@
-{% extends "reports/base_template.html" %}
+{% extends "hqwebapp/base_section.html" %}
 {% load case_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load report_tags %}
 {% load compress %}
 
+{% block js %}{{ block.super }}
+    <script src="{% static 'reports/js/saved_reports.js' %}"></script>
+{% endblock %}
+
 {% block page_content %}
 {% initial_page_data 'configs' configs %}
+{% registerurl 'add_report_config' domain %}
+
 <ul class="nav nav-tabs sticky-tabs" style="margin-bottom: 10px;">
     <li><a href="#ko-report-config-list" data-toggle="tab">{% trans "My Saved Reports" %}</a></li>
     <li><a href="#scheduled-reports" data-toggle="tab">


### PR DESCRIPTION
JavaScript errors are popping up on prod:
![screen shot 2018-08-12 at 12 41 25 pm](https://user-images.githubusercontent.com/1486591/44004319-c0cde0e8-9e2e-11e8-9092-b4c58304f5d2.png)

I'm not sure why these are just coming up now and haven't been able to reproduce locally...but they're coming out of tabular.js, which doesn't need to be on this page at all. Rejiggered this page so it doesn't descend from the other reports templates, which are for rendering actual report data.

Verified you can still create saved reports.

@pr33thi / @snopoke 