### PR TITLE
Delete pre-existing blobs when copying an export

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -971,6 +971,7 @@ class ExportInstance(BlobMixin, Document):
     def copy_export(self):
         export_json = self.to_json()
         del export_json['_id']
+        del export_json['external_blobs']
         export_json['name'] = '{} - Copy'.format(self.name)
         new_export = self.__class__.wrap(export_json)
         return new_export


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?281007#

Deletes the pre-existing export when copying over a daily saved export. 