### PR TITLE
Catch BadSpecError in saved reports

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -189,7 +189,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     def has_viable_configuration(self):
         try:
             self.spec
-        except DocumentNotFound:
+        except (DocumentNotFound, BadSpecError):
             return False
         else:
             return True


### PR DESCRIPTION
Hi @emord ,

Fix for http://manage.dimagi.com/default.asp?281117#1520223
Prev PR: https://github.com/dimagi/commcare-hq/pull/21493

When I added the ```custom_configurable_report``` to vectorlink reports we are getting 500 error when we try open saved reports page. This occurs because in old reports we have in id prefix ```static``` but after my change, we have a prefix ```custom```

Please let me know if you have any questions.

Regards,
Łukasz