### PR TITLE
Create patient if case not found

### DIFF
--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -20,6 +20,7 @@ from corehq.motech.openmrs.const import PERSON_UUID_IDENTIFIER_TYPE_ID
 from corehq.motech.openmrs.jsonpath import Cmp
 from corehq.motech.value_source import recurse_subclasses
 from dimagi.ext.couchdbkit import (
+    BooleanProperty,
     DecimalProperty,
     DocumentSchema,
     ListProperty,
@@ -37,6 +38,9 @@ class PatientFinder(DocumentSchema):
 
     Subclasses must implement the `find_patients()` method.
     """
+
+    # If no patients are found, should a new one be created?
+    create_missing = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -548,14 +548,56 @@ def save_match_ids(case, case_config, patient):
     submit_case_blocks([case_block.as_string()], case.domain, xmlns=XMLNS_OPENMRS)
 
 
-def find_patient(requests, domain, case_id, openmrs_config):
-    case = CaseAccessors(domain).get_case(case_id)
+def create_person(requests, info, case_config):
+    name = {
+        property_: value_source.get_value(info)
+        for property_, value_source in case_config.person_preferred_name.items()
+        if property_ in NAME_PROPERTIES and value_source.get_value(info)
+    }
+    address = {
+        property_: value_source.get_value(info)
+        for property_, value_source in case_config.person_preferred_address.items()
+        if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
+    }
+    properties = {
+        property_: value_source.get_value(info)
+        for property_, value_source in case_config.person_properties.items()
+        if property_ in PERSON_PROPERTIES and value_source.get_value(info)
+    }
+    if name or address or properties:
+        person = {}
+        if name:
+            person['names'] = [serialize(name)]
+        if address:
+            person['addresses'] = [serialize(address)]
+        if properties:
+            person.update(serialize(properties))
+        response = requests.post(
+            '/ws/rest/v1/person/',
+            json=person,
+            raise_for_status=True,
+        )
+        return response.json()
+
+
+def find_patient(requests, domain, info, openmrs_config):
+    case = CaseAccessors(domain).get_case(info.case_id)
     patient_finder = PatientFinder.wrap(openmrs_config.case_config.patient_finder)
     patients = patient_finder.find_patients(requests, case, openmrs_config.case_config)
     if len(patients) == 1:
         patient, = patients
         save_match_ids(case, openmrs_config.case_config, patient)
         return patient
+    if not patients and patient_finder.create_missing:
+        person = create_person(requests, info, openmrs_config.case_config)
+        if person:
+            patient = {
+                'uuid': person['uuid'],
+                'identifiers': [],
+                'person': person
+            }
+            save_match_ids(case, openmrs_config.case_config, patient)
+            return patient
     # If PatientFinder can't narrow down the number of candidate
     # patients, don't guess. Just admit that we don't know.
     return None
@@ -574,7 +616,7 @@ def get_patient(requests, domain, info, openmrs_config):
         # Definitive IDs did not match a patient in OpenMRS.
         if openmrs_config.case_config.patient_finder:
             # Search for patients based on other case properties
-            patient = find_patient(requests, domain, info.case_id, openmrs_config)
+            patient = find_patient(requests, domain, info, openmrs_config)
 
     return patient
 


### PR DESCRIPTION
If a case is created in CommCare, and a corresponding patient is not found in OpenMRS, this change allows MOTECH to create a new patient for that case.

Default behaviour (don't create a new patient) is preserved.
