### PR TITLE
Migrate analytics tasks to a new gevent queue

### DIFF
--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -6,7 +6,7 @@ from corehq.apps.accounting.utils import ensure_domain_instance
 from corehq.apps.analytics.tasks import (
     track_user_sign_in_on_hubspot,
     HUBSPOT_COOKIE,
-    update_hubspot_properties,
+    update_hubspot_properties_v2,
 )
 from corehq.apps.analytics.utils import get_meta
 from corehq.apps.registration.views import ProcessRegistrationView
@@ -47,7 +47,7 @@ def user_save_callback(sender, **kwargs):
         properties.update(get_subscription_properties_by_user(couch_user))
         properties.update(get_domain_membership_properties(couch_user))
         identify.delay(couch_user.username, properties)
-        update_hubspot_properties(couch_user, properties)
+        update_hubspot_properties_v2(couch_user, properties)
 
 
 @receiver(commcare_domain_post_save)
@@ -61,7 +61,7 @@ def domain_save_callback(sender, domain, **kwargs):
 def update_subscription_properties_by_user(couch_user):
     properties = get_subscription_properties_by_user(couch_user)
     identify.delay(couch_user.username, properties)
-    update_hubspot_properties(couch_user, properties)
+    update_hubspot_properties_v2(couch_user, properties)
 
 
 def get_subscription_properties_by_user(couch_user):

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.auth.signals import user_logged_in
 from corehq.apps.accounting.utils import ensure_domain_instance
 from corehq.apps.analytics.tasks import (
-    track_user_sign_in_on_hubspot,
+    track_user_sign_in_on_hubspot_v2,
     HUBSPOT_COOKIE,
     update_hubspot_properties_v2,
 )
@@ -164,4 +164,4 @@ def track_user_login(sender, request, user, **kwargs):
                 return
 
         meta = get_meta(request)
-        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta, request.path)
+        track_user_sign_in_on_hubspot_v2.delay(couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta, request.path)

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -7,12 +7,12 @@ from corehq.apps.analytics.tasks import (
     track_user_sign_in_on_hubspot_v2,
     HUBSPOT_COOKIE,
     update_hubspot_properties_v2,
+    identify_v2,
 )
 from corehq.apps.analytics.utils import get_meta
 from corehq.apps.registration.views import ProcessRegistrationView
 from corehq.util.decorators import handle_uncaught_exceptions
 from corehq.util.soft_assert import soft_assert
-from .tasks import identify
 
 from django.dispatch import receiver
 from django.urls import reverse
@@ -46,7 +46,7 @@ def user_save_callback(sender, **kwargs):
         properties = {}
         properties.update(get_subscription_properties_by_user(couch_user))
         properties.update(get_domain_membership_properties(couch_user))
-        identify.delay(couch_user.username, properties)
+        identify_v2.delay(couch_user.username, properties)
         update_hubspot_properties_v2(couch_user, properties)
 
 
@@ -60,7 +60,7 @@ def domain_save_callback(sender, domain, **kwargs):
 
 def update_subscription_properties_by_user(couch_user):
     properties = get_subscription_properties_by_user(couch_user)
-    identify.delay(couch_user.username, properties)
+    identify_v2.delay(couch_user.username, properties)
     update_hubspot_properties_v2(couch_user, properties)
 
 

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -309,6 +309,11 @@ def track_built_app_on_hubspot_v2(webuser):
 
 @old_analytics_task()
 def track_confirmed_account_on_hubspot(webuser):
+    track_confirmed_account_on_hubspot_v2(webuser)
+
+
+@analytics_task()
+def track_confirmed_account_on_hubspot_v2(webuser):
     vid = _get_user_hubspot_id(webuser)
     if vid:
         # Only track the property if the contact already exists.

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -25,7 +25,7 @@ import logging
 from django.conf import settings
 from email_validator import validate_email, EmailNotValidError
 from corehq.toggles import deterministic_random
-from corehq.util.decorators import old_analytics_task
+from corehq.util.decorators import old_analytics_task, analytics_task
 from corehq.util.soft_assert import soft_assert
 from corehq.util.datadog.utils import (
     count_by_response_code,
@@ -243,6 +243,11 @@ def _send_hubspot_form_request(url, data):
 
 @old_analytics_task()
 def update_hubspot_properties(webuser, properties):
+    update_hubspot_properties_v2(webuser, properties)
+
+
+@analytics_task()
+def update_hubspot_properties_v2(webuser, properties):
     vid = _get_user_hubspot_id(webuser)
     if vid:
         _track_on_hubspot(webuser, properties)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -337,7 +337,7 @@ def send_hubspot_form(form_id, request, user=None, extra_fields=None):
         user = getattr(request, 'couch_user', None)
     if request and user and user.is_web_user():
         meta = get_meta(request)
-        send_hubspot_form_task.delay(
+        send_hubspot_form_task_v2.delay(
             form_id, user, request.COOKIES.get(HUBSPOT_COOKIE),
             meta, extra_fields=extra_fields
         )
@@ -350,8 +350,20 @@ def send_hubspot_form_task(form_id, web_user, hubspot_cookie, meta,
                           extra_fields=extra_fields)
 
 
+@analytics_task()
+def send_hubspot_form_task_v2(form_id, web_user, hubspot_cookie, meta,
+                              extra_fields=None):
+    _send_form_to_hubspot(form_id, web_user, hubspot_cookie, meta,
+                          extra_fields=extra_fields)
+
+
 @old_analytics_task()
 def track_clicked_deploy_on_hubspot(webuser, hubspot_cookie, meta):
+    track_clicked_deploy_on_hubspot_v2(webuser, hubspot_cookie, meta)
+
+
+@analytics_task()
+def track_clicked_deploy_on_hubspot_v2(webuser, hubspot_cookie, meta):
     ab = {
         'a_b_variable_deploy': 'A' if deterministic_random(webuser.username + 'a_b_variable_deploy') > 0.5 else 'B',
     }
@@ -360,6 +372,11 @@ def track_clicked_deploy_on_hubspot(webuser, hubspot_cookie, meta):
 
 @old_analytics_task()
 def track_job_candidate_on_hubspot(user_email):
+    track_job_candidate_on_hubspot_v2(user_email)
+
+
+@analytics_task()
+def track_job_candidate_on_hubspot_v2(user_email):
     properties = {
         'job_candidate': True
     }
@@ -368,6 +385,11 @@ def track_job_candidate_on_hubspot(user_email):
 
 @old_analytics_task()
 def track_clicked_signup_on_hubspot(email, hubspot_cookie, meta):
+    track_clicked_signup_on_hubspot_v2(email, hubspot_cookie, meta)
+
+
+@analytics_task()
+def track_clicked_signup_on_hubspot_v2(email, hubspot_cookie, meta):
     data = {'lifecyclestage': 'subscriber'}
     number = deterministic_random(email + 'a_b_test_variable_newsletter')
     if number < 0.33:
@@ -393,11 +415,16 @@ def track_workflow(email, event, properties=None):
     """
     if analytics_enabled_for_email(email):
         timestamp = unix_time(datetime.utcnow())   # Dimagi KISSmetrics account uses UTC
-        _track_workflow_task.delay(email, event, properties, timestamp)
+        _track_workflow_task_v2.delay(email, event, properties, timestamp)
 
 
 @old_analytics_task()
 def _track_workflow_task(email, event, properties=None, timestamp=0):
+    _track_workflow_task_v2(email, event, properties, timestamp)
+
+
+@analytics_task()
+def _track_workflow_task_v2(email, event, properties=None, timestamp=0):
     api_key = settings.ANALYTICS_IDS.get("KISSMETRICS_KEY", None)
     if api_key:
         km = KISSmetrics.Client(key=api_key)
@@ -409,6 +436,11 @@ def _track_workflow_task(email, event, properties=None, timestamp=0):
 
 @old_analytics_task()
 def identify(email, properties):
+    identify_v2(email, properties)
+
+
+@analytics_task()
+def identify_v2(email, properties):
     """
     Set the given properties on a KISSmetrics user.
     :param email: The email address by which to identify the user.

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -289,6 +289,11 @@ def track_user_sign_in_on_hubspot(webuser, hubspot_cookie, meta, path):
     _send_form_to_hubspot(HUBSPOT_SIGNIN_FORM_ID, webuser, hubspot_cookie, meta)
 
 
+@analytics_task()
+def track_user_sign_in_on_hubspot_v2(webuser, hubspot_cookie, meta, path):
+    _send_form_to_hubspot(HUBSPOT_SIGNIN_FORM_ID, webuser, hubspot_cookie, meta)
+
+
 @old_analytics_task()
 def track_built_app_on_hubspot(webuser):
     vid = _get_user_hubspot_id(webuser)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -296,6 +296,11 @@ def track_user_sign_in_on_hubspot_v2(webuser, hubspot_cookie, meta, path):
 
 @old_analytics_task()
 def track_built_app_on_hubspot(webuser):
+    track_built_app_on_hubspot_v2(webuser)
+
+
+@analytics_task()
+def track_built_app_on_hubspot_v2(webuser):
     vid = _get_user_hubspot_id(webuser)
     if vid:
         # Only track the property if the contact already exists.

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -11,7 +11,7 @@ from django.views.generic import View
 from django.conf import settings
 
 from corehq.apps.analytics.tasks import (
-    track_clicked_deploy_on_hubspot, track_job_candidate_on_hubspot, HUBSPOT_COOKIE
+    track_clicked_deploy_on_hubspot_v2, track_job_candidate_on_hubspot_v2, HUBSPOT_COOKIE
 )
 from corehq.apps.analytics.utils import get_meta
 
@@ -21,7 +21,7 @@ class HubspotClickDeployView(View):
 
     def post(self, request, *args, **kwargs):
         meta = get_meta(request)
-        track_clicked_deploy_on_hubspot.delay(request.couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
+        track_clicked_deploy_on_hubspot_v2.delay(request.couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
         return HttpResponse()
 
 
@@ -51,7 +51,7 @@ class GreenhouseCandidateView(View):
             try:
                 user_emails = data["payload"]["application"]["candidate"]["email_addresses"]
                 for user_email in user_emails:
-                    track_job_candidate_on_hubspot.delay(user_email["value"])
+                    track_job_candidate_on_hubspot_v2.delay(user_email["value"])
             except KeyError:
                 pass
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -27,7 +27,7 @@ from phonelog.models import UserErrorEntry
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.analytics.tasks import track_built_app_on_hubspot
+from corehq.apps.analytics.tasks import track_built_app_on_hubspot_v2
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
 from corehq.apps.domain.decorators import login_or_api_key
@@ -208,7 +208,7 @@ def save_copy(request, domain, app_id):
     See VersionedDoc.save_copy
 
     """
-    track_built_app_on_hubspot.delay(request.couch_user)
+    track_built_app_on_hubspot_v2.delay(request.couch_user)
     comment = request.POST.get('comment')
     app = get_app(domain, app_id)
     try:

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -20,7 +20,7 @@ from djangular.views.mixins import allow_remote_invocation, JSONResponseMixin
 from corehq.apps.analytics import ab_tests
 from corehq.apps.analytics.tasks import (
     track_workflow,
-    track_confirmed_account_on_hubspot,
+    track_confirmed_account_on_hubspot_v2,
     track_clicked_signup_on_hubspot,
     HUBSPOT_COOKIE,
     track_web_user_registration_hubspot,
@@ -411,7 +411,7 @@ def confirm_domain(request, guid=None):
             'the time to confirm your email address: %s.'
         % (requesting_user.username))
     track_workflow(requesting_user.email, "Confirmed new project")
-    track_confirmed_account_on_hubspot.delay(requesting_user)
+    track_confirmed_account_on_hubspot_v2.delay(requesting_user)
     request.session['CONFIRM'] = True
     return HttpResponseRedirect(reverse(view_name, args=view_args))
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -21,7 +21,7 @@ from corehq.apps.analytics import ab_tests
 from corehq.apps.analytics.tasks import (
     track_workflow,
     track_confirmed_account_on_hubspot_v2,
-    track_clicked_signup_on_hubspot,
+    track_clicked_signup_on_hubspot_v2,
     HUBSPOT_COOKIE,
     track_web_user_registration_hubspot,
 )
@@ -187,7 +187,8 @@ class UserRegistrationView(BasePageView):
     def post(self, request, *args, **kwargs):
         if self.prefilled_email:
             meta = get_meta(request)
-            track_clicked_signup_on_hubspot.delay(self.prefilled_email, request.COOKIES.get(HUBSPOT_COOKIE), meta)
+            track_clicked_signup_on_hubspot_v2.delay(
+                self.prefilled_email, request.COOKIES.get(HUBSPOT_COOKIE), meta)
         return super(UserRegistrationView, self).get(request, *args, **kwargs)
 
     @property

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -25,7 +25,7 @@ from sqlalchemy import types, exc
 from sqlalchemy.exc import ProgrammingError
 
 from corehq.apps.accounting.models import Subscription
-from corehq.apps.analytics.tasks import update_hubspot_properties, send_hubspot_form, HUBSPOT_SAVED_UCR_FORM_ID
+from corehq.apps.analytics.tasks import update_hubspot_properties_v2, send_hubspot_form, HUBSPOT_SAVED_UCR_FORM_ID
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -369,7 +369,7 @@ class ReportBuilderPaywallActivatingSubscription(ReportBuilderPaywallBase):
             settings.DEFAULT_FROM_EMAIL,
             [settings.REPORT_BUILDER_ADD_ON_EMAIL],
         )
-        update_hubspot_properties.delay(request.couch_user, {'report_builder_subscription_request': 'yes'})
+        update_hubspot_properties_v2.delay(request.couch_user, {'report_builder_subscription_request': 'yes'})
         return self.get(request, domain, *args, **kwargs)
 
 

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -26,36 +26,36 @@ from pillowtop.es_utils import initialize_index_and_mapping
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock)
 class TestUserSignals(SimpleTestCase):
 
-    @patch('corehq.apps.analytics.signals.update_hubspot_properties')
+    @patch('corehq.apps.analytics.signals.update_hubspot_properties_v2')
     @patch('corehq.apps.callcenter.signals.sync_call_center_user_case')
     @patch('corehq.apps.cachehq.signals.invalidate_document')
     @patch('corehq.apps.users.signals.send_to_elasticsearch')
     def test_commcareuser_save(self, send_to_es, invalidate, sync_call_center,
-                               update_hubspot_properties):
+                               update_hubspot_properties_v2):
         CommCareUser(username='test').save()
 
         self.assertTrue(send_to_es.called)
         self.assertTrue(invalidate.called)
         self.assertTrue(sync_call_center.called)
-        self.assertFalse(update_hubspot_properties.called)
+        self.assertFalse(update_hubspot_properties_v2.called)
 
-    @patch('corehq.apps.analytics.signals.update_hubspot_properties')
+    @patch('corehq.apps.analytics.signals.update_hubspot_properties_v2')
     @patch('corehq.apps.callcenter.signals.sync_call_center_user_case')
     @patch('corehq.apps.cachehq.signals.invalidate_document')
     @patch('corehq.apps.users.signals.send_to_elasticsearch')
     def test_webuser_save(self, send_to_es, invalidate, sync_call_center,
-                          update_hubspot_properties):
+                          update_hubspot_properties_v2):
         WebUser().save()
 
         self.assertTrue(send_to_es.called)
         self.assertTrue(invalidate.called)
         self.assertFalse(sync_call_center.called)
-        self.assertTrue(update_hubspot_properties.called)
+        self.assertTrue(update_hubspot_properties_v2.called)
 
 
 @mock_out_couch()
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock)
-@patch('corehq.apps.analytics.signals.update_hubspot_properties')
+@patch('corehq.apps.analytics.signals.update_hubspot_properties_v2')
 @patch('corehq.apps.callcenter.signals.sync_call_center_user_case')
 @patch('corehq.apps.cachehq.signals.invalidate_document')
 class TestUserSyncToEs(SimpleTestCase):
@@ -97,8 +97,8 @@ class TestUserSyncToEs(SimpleTestCase):
     def check_user(self, user):
         self.es.indices.refresh(USER_INDEX_INFO.index)
         results = get_user_stubs([user._id])
-        self.assertEquals(len(results), 1)
-        self.assertEquals(results[0], {
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0], {
             '_id': user._id,
             'username': user.username,
             'is_active': True,

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -147,6 +147,10 @@ def serial_task(unique_key, default_retry_delay=30, timeout=5*60, max_retries=3,
 
 
 def old_analytics_task(default_retry_delay=10, max_retries=3, queue='background_queue'):
+    return analytics_task(default_retry_delay, max_retries, queue)
+
+
+def analytics_task(default_retry_delay=10, max_retries=3, queue='analytics_queue'):
     '''
         defines a task that posts data to one of our analytics endpoints. It retries the task
         up to 3 times if the post returns with a status code indicating an error with the post

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -146,7 +146,7 @@ def serial_task(unique_key, default_retry_delay=30, timeout=5*60, max_retries=3,
     return decorator
 
 
-def analytics_task(default_retry_delay=10, max_retries=3, queue='background_queue'):
+def old_analytics_task(default_retry_delay=10, max_retries=3, queue='background_queue'):
     '''
         defines a task that posts data to one of our analytics endpoints. It retries the task
         up to 3 times if the post returns with a status code indicating an error with the post


### PR DESCRIPTION
Noticed that the background queue creates tons of tasks on prod, but the background queue is specified as  using prefork pooling and max task per child is one. From what I can tell all of these analytics tasks are just sending some information to an external party via HTTP, which is a much better fit for high concurrency and gevent pooling. 

I have introduced a new queue for this here: https://github.com/dimagi/commcare-cloud/pull/2025

This PR will move all new tasks to using the new queue, while still keeping the old task around to process any tasks that are still in a queue. I'll have an upcoming PR to clean this up, to be deployed next week.

Some assumptions I'd like verified:

- We only care about these tasks on staging/softlayer/production
- The tasks are expected to be very I/O bound

Guessing the analytics knowledge to answer these is somewhere between @biyeun @orangejenny and @calellowitz 