### PR TITLE
OpenMRS API requests should fail early and loudly

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -137,7 +137,7 @@ class UpdatePersonAttributeTask(WorkflowTask):
                 'value': self.value,
                 'attributeType': self.attribute_type_uuid,
             },
-            raise_for_status = True,
+            raise_for_status=True,
         )
 
     def rollback(self):
@@ -149,7 +149,7 @@ class UpdatePersonAttributeTask(WorkflowTask):
                 'value': self.existing_value,
                 'attributeType': self.attribute_type_uuid,
             },
-            raise_for_status = True,
+            raise_for_status=True,
         )
 
 
@@ -200,7 +200,7 @@ class UpdatePatientIdentifierTask(WorkflowTask):
                 'identifier': self.identifier,
                 'identifierType': self.identifier_type_uuid,
             },
-            raise_for_status = True,
+            raise_for_status=True,
         )
 
     def rollback(self):
@@ -212,7 +212,7 @@ class UpdatePatientIdentifierTask(WorkflowTask):
                 'identifier': self.existing_identifier,
                 'identifierType': self.identifier_type_uuid,
             },
-            raise_for_status = True,
+            raise_for_status=True,
         )
 
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -103,6 +103,7 @@ class CreatePersonAttributeTask(WorkflowTask):
         response = self.requests.post(
             '/ws/rest/v1/person/{person_uuid}/attribute'.format(person_uuid=self.person_uuid),
             json={'attributeType': self.attribute_type_uuid, 'value': self.value},
+            raise_for_status=True,
         )
         self.attribute_uuid = response.json()['uuid']
 
@@ -135,7 +136,8 @@ class UpdatePersonAttributeTask(WorkflowTask):
             json={
                 'value': self.value,
                 'attributeType': self.attribute_type_uuid,
-            }
+            },
+            raise_for_status = True,
         )
 
     def rollback(self):
@@ -146,7 +148,8 @@ class UpdatePersonAttributeTask(WorkflowTask):
             json={
                 'value': self.existing_value,
                 'attributeType': self.attribute_type_uuid,
-            }
+            },
+            raise_for_status = True,
         )
 
 
@@ -163,6 +166,7 @@ class CreatePatientIdentifierTask(WorkflowTask):
         response = self.requests.post(
             '/ws/rest/v1/patient/{patient_uuid}/identifier'.format(patient_uuid=self.patient_uuid),
             json={'identifierType': self.identifier_type_uuid, 'identifier': self.identifier},
+            raise_for_status=True,
         )
         self.identifier_uuid = response.json()['uuid']
 
@@ -195,7 +199,8 @@ class UpdatePatientIdentifierTask(WorkflowTask):
             json={
                 'identifier': self.identifier,
                 'identifierType': self.identifier_type_uuid,
-            }
+            },
+            raise_for_status = True,
         )
 
     def rollback(self):
@@ -206,7 +211,8 @@ class UpdatePatientIdentifierTask(WorkflowTask):
             json={
                 'identifier': self.existing_identifier,
                 'identifierType': self.identifier_type_uuid,
-            }
+            },
+            raise_for_status = True,
         )
 
 


### PR DESCRIPTION
Using `raise_for_status=True` on all API requests allows integrators/administrators to see error messages that make more sense.

This resolves a bug where integrators/administrators were seeing error messages for side effects instead of the original cause.