### PR TITLE
Ce/warehouse scale

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -392,7 +392,7 @@ class FormAccessorSQL(AbstractFormAccessor):
 
         :returns: An iterator of XFormInstanceSQL objects
         '''
-        from corehq.sql_db.util import run_query_across_partitioned_databases
+        from corehq.sql_db.util import paginate_query_across_partitioned_databases
 
         annotate = {
             'last_modified': Greatest('received_on', 'edited_on', 'deleted_on'),

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -398,7 +398,7 @@ class FormAccessorSQL(AbstractFormAccessor):
             'last_modified': Greatest('received_on', 'edited_on', 'deleted_on'),
         }
 
-        return run_query_across_partitioned_databases(
+        return paginate_query_across_partitioned_databases(
             XFormInstanceSQL,
             Q(last_modified__gt=start_datetime),
             annotate=annotate,

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -81,24 +81,13 @@ def paginate_query_across_partitioned_databases(model_class, q_expression, annot
     """
     db_names = get_db_aliases_for_partitioned_query()
 
-    if values and not isinstance(values, (list, tuple)):
-        raise ValueError("Expected a list or tuple")
-
     for db_name in db_names:
         qs = model_class.objects.using(db_name)
         if annotate:
             qs = qs.annotate(**annotate)
 
         qs = qs.filter(q_expression)
-        if values:
-            if len(values) == 1:
-                flat_qs = True
-                qs = qs.values_list(*values, flat=True)
-            else:
-                qs = qs.values_list(*values)
-            sort_col = values[0]
-        else:
-            sort_col = 'pk'
+        sort_col = 'pk'
         value = 0
         last_value = qs.order_by('-{}'.format(sort_col)).values_list(sort_col, flat=True).first()
         if last_value is not None:

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -21,7 +21,7 @@ ACCEPTABLE_STANDBY_DELAY_SECONDS = 3
 STALE_CHECK_FREQUENCY = 30
 
 
-def run_query_across_partitioned_databases(model_class, q_expression, values=None, annotate=None, query_size=4000):
+def run_query_across_partitioned_databases(model_class, q_expression, values=None, annotate=None):
     """
     Runs a query across all partitioned databases and produces a generator
     with the results.

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -95,10 +95,7 @@ def paginate_query_across_partitioned_databases(model_class, q_expression, annot
             while value < last_value:
                 filter_expression = {'{}__gt'.format(sort_col): value}
                 for row in qs.filter(**filter_expression)[:query_size]:
-                    if flat_qs:
-                        value = row
-                    else:
-                        value = row.get(sort_col)
+                    value = row.pk
                     yield row
 
 

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import uuid
 from collections import defaultdict
 from numpy import random
-import itertools
 
 from django.conf import settings
 from django import db

--- a/corehq/warehouse/const.py
+++ b/corehq/warehouse/const.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-DJANGO_MAX_BATCH_SIZE = 2000
+DJANGO_MAX_BATCH_SIZE = 5000
 
 # Slugs
 

--- a/corehq/warehouse/const.py
+++ b/corehq/warehouse/const.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-DJANGO_MAX_BATCH_SIZE = 1000
+DJANGO_MAX_BATCH_SIZE = 2000
 
 # Slugs
 

--- a/corehq/warehouse/dbaccessors.py
+++ b/corehq/warehouse/dbaccessors.py
@@ -5,7 +5,6 @@ from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
 
-
 def get_group_ids_by_last_modified(start_datetime, end_datetime):
     '''
     Returns all group ids that have been modified within a time range. The start date is
@@ -71,15 +70,14 @@ def get_synclogs_by_date(start_datetime, end_datetime):
     '''
     from casexml.apps.phone.models import SyncLogSQL
 
-    return SyncLogSQL.objects.filter(date__gt=start_datetime, date__lte=end_datetime).defer('doc')
+    return SyncLogSQL.objects.filter(date__gt=start_datetime, date__lte=end_datetime).defer('doc').iterator()
 
 def get_forms_by_last_modified(start_datetime, end_datetime):
     '''
     Returns all form ids that have been modified within a time range. The start date is
     exclusive while the end date is inclusive (start_datetime, end_datetime].
     '''
-    for form in FormAccessorSQL.iter_forms_by_last_modified(start_datetime, end_datetime):
-        yield form
+    return FormAccessorSQL.iter_forms_by_last_modified(start_datetime, end_datetime)
 
     # TODO Couch forms
 

--- a/corehq/warehouse/transforms/sql/user_location_dim.sql
+++ b/corehq/warehouse/transforms/sql/user_location_dim.sql
@@ -62,14 +62,20 @@ SELECT
 FROM
 (
 	SELECT
+		user_location.user_dim_id as user_dim_id,
+		user_location.domain as domain,
+		location_dim.id as location_dim_id
+	FROM
+	(
+	SELECT
 		user_dim.id as user_dim_id,
 		user_staging.domain as domain,
-		UNNEST(user_staging.assigned_location_ids) AS location_id,
-		location_dim.id as location_dim_id
-FROM {{ user_staging }} AS user_staging
-LEFT JOIN {{ user_dim }} AS user_dim
-ON user_staging.user_id = user_dim.user_id
+		UNNEST(user_staging.assigned_location_ids) AS location_id
+	FROM {{ user_staging }} AS user_staging
+	LEFT JOIN {{ user_dim }} AS user_dim
+	ON user_staging.user_id = user_dim.user_id
+	WHERE user_staging.doc_type = 'CommCareUser'
+	) as user_location
 LEFT JOIN {{ location_dim }} AS location_dim
-ON location_id = location_dim.location_id
-WHERE user_staging.doc_type = 'CommCareUser'
+ON user_location.location_id = location_dim.location_id
 ) as mobileusers;


### PR DESCRIPTION
These were some final fixes I made for the warehouse on ICDS. The first commit is warehouse specific. The last two include a refactor of `run_query_across_partitioned_databases` based on https://djangosnippets.org/snippets/1949/ (as mentioned in the comment). This was to make the iteration actually use constant memory and batch the query as previous implementations loaded the whole queryset at once (either at the psycopg or django level depending on whether `.iterator()` was used. There are possible performance hits with this if it is pulling a list of values and the first one is not indexed, since it needs to sort the values to keep track of where it is in the result set.

I am open to moving this logic to its own dbaccessor but it seemed to implement the spirit of this method so I thought I would leave it here for now.

@snopoke @czue @emord @nickpell 