### PR TITLE
Add domain to notification email

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -79,9 +79,11 @@ def _build_indicators(config, document_store, relevant_ids):
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True)
 def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1):
     config = _get_config_by_id(indicator_config_id)
-    success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
-    failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
-    send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
+    send = False
+    if limit == -1:
+        success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
+        failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
+        send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         adapter = get_indicator_adapter(config, can_handle_laboratory=True)
         if not id_is_static(indicator_config_id):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -79,10 +79,10 @@ def _build_indicators(config, document_store, relevant_ids):
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True)
 def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1):
     config = _get_config_by_id(indicator_config_id)
+    success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
+    failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     send = False
     if limit == -1:
-        success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
-        failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
         send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         adapter = get_indicator_adapter(config, can_handle_laboratory=True)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -79,8 +79,8 @@ def _build_indicators(config, document_store, relevant_ids):
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True)
 def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1):
     config = _get_config_by_id(indicator_config_id)
-    success = _('Your UCR table {} has finished rebuilding').format(config.table_id)
-    failure = _('There was an error rebuilding Your UCR table {}.').format(config.table_id)
+    success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
+    failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         adapter = get_indicator_adapter(config, can_handle_laboratory=True)
@@ -99,8 +99,8 @@ def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1):
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True)
 def rebuild_indicators_in_place(indicator_config_id, initiated_by=None):
     config = _get_config_by_id(indicator_config_id)
-    success = _('Your UCR table {} has finished rebuilding').format(config.table_id)
-    failure = _('There was an error rebuilding Your UCR table {}.').format(config.table_id)
+    success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
+    failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         adapter = get_indicator_adapter(config, can_handle_laboratory=True)
@@ -117,8 +117,8 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None):
 @task(queue=UCR_CELERY_QUEUE, ignore_result=True, acks_late=True)
 def resume_building_indicators(indicator_config_id, initiated_by=None):
     config = _get_config_by_id(indicator_config_id)
-    success = _('Your UCR table {} has finished rebuilding').format(config.table_id)
-    failure = _('There was an error rebuilding Your UCR table {}.').format(config.table_id)
+    success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
+    failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         resume_helper = DataSourceResumeHelper(config)


### PR DESCRIPTION
Feature flag: "send UCR rebuild info"

Adds the domain to the notification emails subject so that it's a bit easier to track