### PR TITLE
remove celery.utils.mail.ErrorMail

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -16,7 +16,6 @@ from corehq import toggles
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import UserArchivedRebuild
-from corehq.util.log import SensitiveErrorMail
 from couchforms.exceptions import UnexpectedDeletedXForm
 from corehq.apps.domain.models import Domain
 from django.utils.html import format_html
@@ -30,7 +29,7 @@ from six.moves import map
 logger = get_task_logger(__name__)
 
 
-@task(ErrorMail=SensitiveErrorMail)
+@task
 def bulk_upload_async(domain, user_specs, group_specs):
     from corehq.apps.users.bulkupload import create_or_update_users_and_groups
     task = bulk_upload_async

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -14,7 +14,6 @@ from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
 
-from celery.utils.mail import ErrorMail
 from dimagi.utils.django.email import send_HTML_email as _send_HTML_email
 from django.core import mail
 from django.http import HttpRequest
@@ -192,18 +191,6 @@ class NotifyExceptionEmailer(HqAdminEmailHandler):
         context = super(NotifyExceptionEmailer, self).get_context(record)
         context['subject'] = record.getMessage()
         return context
-
-
-class SensitiveErrorMail(ErrorMail):
-    """
-    Extends Celery's ErrorMail class to prevents task args and kwargs from being printed in error emails.
-    """
-    replacement = '(excluded due to sensitive nature)'
-
-    def format_body(self, context):
-        context['args'] = self.replacement
-        context['kwargs'] = self.replacement
-        return self.body.strip() % context
 
 
 class HQRequestFilter(Filter):

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -233,7 +233,6 @@ if os.environ.get("COMMCAREHQ_BOOTSTRAP") == "yes":
     UNIT_TESTING = False
     ADMINS = (('Admin', 'admin@example.com'),)
 
-    CELERY_SEND_TASK_ERROR_EMAILS = True
     LESS_DEBUG = True
     COMPRESS_OFFLINE = False
 

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -119,7 +119,6 @@ DJANGO_LOG_FILE = "/tmp/commcare-hq.django.log"
 LOG_FILE = "/tmp/commcare-hq.log"
 SHARED_DRIVE_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sharedfiles")
 
-CELERY_SEND_TASK_ERROR_EMAILS = True
 CELERY_PERIODIC_QUEUE = 'celery' # change this to something else if you want a different queue for periodic tasks
 CELERY_FLOWER_URL = 'http://127.0.0.1:5555'
 


### PR DESCRIPTION
```SensitiveErrorMail``` should be obsolete because we don't send emails for celery errors.

```ErrorMail``` is no longer supported in celery 4.