### PR TITLE
Cleanup knockout bindings & animate app summary

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -43,7 +43,7 @@
     <div class="row">
         <div class="col-sm-12">
             <!-- ko foreach: caseTypes -->
-                <div class="panel panel-appmanager" data-bind="visible: isVisible">
+                <div class="panel panel-appmanager" data-bind="slideVisible: isVisible">
                     <div class="panel-heading">
                         <h4 class="panel-title panel-title-nolink">
                             <i class="fcc fcc-fd-external-case"></i>
@@ -97,7 +97,7 @@
                             </thead>
                             <tbody data-bind="foreach: properties">
                                 <!-- ko foreach: forms -->
-                                    <tr data-bind="attr: {id: $parents[1].name + ':' + $parent.name}, css: {'danger': $parent.has_errors}, visible: $parent.isVisible">
+                                    <tr data-bind="attr: {id: $parents[1].name + ':' + $parent.name}, css: {'danger': $parent.has_errors}, slideVisible: $parent.isVisible">
                                         <!-- ko if: !$index() -->
                                         <td data-bind="attr: {rowspan: $parent.forms.length}, text: $parent.name"></td>
                                         <td data-bind="attr: {rowspan: $parent.forms.length}, text: $parent.description"></td>
@@ -131,7 +131,7 @@
             <li>
                 <span data-bind="html: $root.moduleFormReference(formId)"></span>
                 <!-- ko: if: conditions -->
-                    <ul class="fa-ul" data-bind="visible: $root.showConditions, foreach: conditions">
+                    <ul class="fa-ul" data-bind="slideVisible: $root.showConditions, foreach: conditions">
                         <li>
                             <i class="fa fa-sitemap"></i>
                             <span data-bind="text: question"></span>
@@ -155,7 +155,7 @@
                     <li data-bind="visible: $root.showIds, text: value"></li>
                     <li data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></li>
                 </ul>
-                <ul class="fa-ul" data-bind="if: condition, visible: $root.showConditions">
+                <ul class="fa-ul" data-bind="if: condition, slideVisible: $root.showConditions">
                     <li>
                         <i class="fa-li fa fa-sitemap text-muted"></i>
                         <span data-bind="text: condition.question"></span>
@@ -163,7 +163,7 @@
                         <span data-bind="text: condition.answer"></span>
                     </li>
                 </ul>
-                <ul class="fa-ul" data-bind="if: question.calculate, visible: $root.showCalculations">
+                <ul class="fa-ul" data-bind="if: question.calculate, slideVisible: $root.showCalculations">
                     <li>
                         <i class="fa-li fa fa-calculator text-muted"></i>
                         <span data-bind="text: question.calculate"></span>

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -53,7 +53,7 @@
     <!-- /ko -->
 
     <ul class="fa-ul" data-bind="foreach: modules">
-        <li data-bind="visible: isVisible">
+        <li data-bind="slideVisible: isVisible">
             <h4>
                 <a data-bind="ifnot: $root.readOnly, attr: { href: url }">
                     <i data-bind="attr: { 'class': icon }"></i>
@@ -63,10 +63,10 @@
                     <i data-bind="attr: { 'class': icon }"></i>
                     <span data-bind="text: $root.translate(name)"></span>
                 </div>
-                <span class="text-muted" data-bind="visible: $root.showComments"> &nbsp; <span data-bind="text: short_comment"</span>
+                <span class="text-muted" data-bind="slideVisible: $root.showComments"> &nbsp; <span data-bind="text: short_comment"</span>
             </h4>
             <ul class="fa-ul" data-bind="foreach: forms">
-                <li data-bind="visible: isVisible">
+                <li data-bind="slideVisible: isVisible">
                     <h5>
                         <a data-bind="ifnot: $root.readOnly, attr: { href: url }">
                             <i data-bind="attr: { 'class': icon }"></i>
@@ -76,15 +76,15 @@
                             <i data-bind="attr: { 'class': icon }"></i>
                             <span data-bind="text: $root.translate(name)"></span>
                         </div>
-                        <span class="text-muted" data-bind="visible: $root.showComments"> &nbsp; <span data-bind="text: short_comment"</span>
+                        <span class="text-muted" data-bind="slideVisible: $root.showComments"> &nbsp; <span data-bind="text: short_comment"</span>
                     </h5>
                     <ol data-bind="foreach: questions">
-                        <li data-bind="visible: isVisible">
+                        <li data-bind="slideVisible: isVisible">
                             <i data-bind="attr: { 'class': $root.questionIcon($data) }" title="type"></i>
                             <span data-bind="visible: $root.showIds, text: value"></span>
                             <span data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></span>
                             <span data-bind="visible: required" title="{% trans "This question is required"|escapejs %}">*</span>
-                            <span class="text-muted" data-bind="visible: $root.showComments">
+                            <span class="text-muted" data-bind="slideVisible: $root.showComments">
                                 &nbsp; <span data-bind="text: comment"></span>
                             </span>
                             <!-- ko template: {name: 'question-attribute', data: { attribute: calculate, icon: 'fa-calculator',
@@ -108,7 +108,7 @@
 
     {# Button to toggle question attribute #}
     <script type="text/html" id="question-attribute">
-        <ul class="fa-ul" data-bind="if: attribute, visible: visibleObs">
+        <ul class="fa-ul" data-bind="if: attribute, slideVisible: visibleObs">
             <li>
                 <i data-bind="attr: {'class': 'fa-li fa text-muted ' + icon}"></i>
                 <span data-bind="text: attribute"></span>

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -26,7 +26,7 @@
             </div>
             <!-- /ko -->
         </legend>
-        <div class="col-sm-12" data-bind="visibleFade: table.selected">
+        <div class="col-sm-12" data-bind="slideVisible: table.selected">
             <div class="form-group">
                 <label class="col-sm-4 col-md-3 col-lg-2 control-label">{% trans "Sheet Name" %}</label>
                 <div class="col-sm-9 col-md-8 col-lg-6">

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -473,38 +473,6 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", ['jquery', 'knockout', 'jquery-ui/u
         },
     };
 
-    ko.bindingHandlers.starred = {
-        init: function(element) {
-            $(element).addClass('icon fa');
-        },
-        update: function(element, valueAccessor) {
-            var value = ko.utils.unwrapObservable(valueAccessor()),
-                $element = $(element);
-            value = value + '';
-            $element.addClass('icon pointer');
-
-            var unselected = 'icon-star-empty fa-star-o';
-            var selected = 'icon-star icon-large fa-star released';
-            var pending = 'icon-refresh icon-spin fa-spin fa-spinner';
-            var error = 'icon-ban-circle';
-
-            var suffix = error;
-            if (value === 'false') {
-                suffix = unselected;
-            } else if (value === 'true') {
-                suffix = selected;
-            } else if (value === 'pending') {
-                suffix = pending;
-            }
-
-            $element.removeClass(unselected);
-            $element.removeClass(selected);
-            $element.removeClass(pending);
-            $element.removeClass(error);
-            $element.addClass(suffix);
-        },
-    };
-
     ko.bindingHandlers.bootstrapTabs = {
         init: function(element) {
             var tabLinkSelector = 'ul.nav > li > a';

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -462,7 +462,7 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", ['jquery', 'knockout', 'jquery-ui/u
         },
     };
 
-    ko.bindingHandlers.visibleFade = {
+    ko.bindingHandlers.slideVisible = {
         'update': function(element, valueAccessor) {
             var value = ko.utils.unwrapObservable(valueAccessor());
             if (value) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -568,35 +568,6 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", ['jquery', 'knockout', 'jquery-ui/u
         },
     };
 
-    ko.bindingHandlers.edit = {
-        update: function(element, valueAccessor) {
-            var editable = ko.utils.unwrapObservable(valueAccessor());
-
-            function getValue(e) {
-                if ($(e).is('select')) {
-                    return $('option[value="' + $(e).val() + '"]', e).text() || $(e).val();
-                }
-                return $(e).val();
-            }
-            if (editable) {
-                $(element).show();
-                $(element).next('.ko-no-edit').hide();
-            } else {
-                $(element).hide();
-                var no_edit = $(element).next('.ko-no-edit');
-                if (!no_edit.length) {
-                    if ($(element).hasClass('code')) {
-                        no_edit = $('<code></code>');
-                    } else {
-                        no_edit = $('<span></span>');
-                    }
-                    no_edit.addClass('ko-no-edit').insertAfter(element);
-                }
-                no_edit.text(getValue(element)).removeClass().addClass($(element).attr('class')).addClass('ko-no-edit').addClass('ko-no-edit-' + element.tagName.toLowerCase());
-            }
-        },
-    };
-
     /**
      * Converts the bound element to a select2 widget. The value of the binding is
      * a list of strings, or a list of objects with the keys 'id' and 'text' used

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -617,7 +617,7 @@
                                                     {% trans "Select which reports the role can view:" %}
                                                 </div>
                                                 <div class="panel-body"
-                                                     data-bind="foreach: reportPermissions.specific, visibleFade: !reportPermissions.all()">
+                                                     data-bind="foreach: reportPermissions.specific, slideVisible: !reportPermissions.all()">
                                                     <div class="checkbox">
                                                         <label>
                                                             <input type="checkbox" data-bind="checked: value"/>
@@ -654,7 +654,7 @@
                                                         {% trans "Select which Web Apps the role can view:" %}
                                                     </div>
                                                     <div class="panel-body"
-                                                         data-bind="foreach: webAppsPermissions.specific, visibleFade: !webAppsPermissions.all()">
+                                                         data-bind="foreach: webAppsPermissions.specific, slideVisible: !webAppsPermissions.all()">
                                                         <div class="checkbox">
                                                             <label>
                                                                 <input type="checkbox" data-bind="checked: value"/>


### PR DESCRIPTION
Noticed some unused bindings while working on https://github.com/dimagi/commcare-hq/pull/21553

Then I discovered `fadeVisible` and `slideVisible` and wanted to use them somewhere - it's easier for people to perceive changes on the page when they're animated (though it isn't always a good idea, some of the things that app/disappear on app summary looked weird when animated so i left those alone).

@pr33thi / @snopoke / @proteusvacuum 