### PR TITLE
Updated requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -13,7 +13,6 @@ alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
 appdirs==1.4.3
-appnope==0.1.0            # via ipython
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.1.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -9,7 +9,6 @@ alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
 appdirs==1.4.3
-appnope==0.1.0            # via ipython
 asn1crypto==0.24.0
 attrs==18.1.0
 babel==2.6.0


### PR DESCRIPTION
What you get when you 
```
$ make requirements
```

**appnope** no longer seems to be a requirement of **ipython**
