### PR TITLE
Fixes language select in the app manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/menu.js
+++ b/corehq/apps/app_manager/static/app_manager/js/menu.js
@@ -10,8 +10,11 @@ hqDefine("app_manager/js/menu", function() {
 
     var initLangs = function () {
         $('#langs select').change(function () {
-            var lang = $(this).find('option:selected').attr('value');
-            $(document).attr('location', window.location.href + (window.location.search ? '&' : '?') + 'lang=' + lang);
+            var lang = $(this).find('option:selected').attr('value'),
+                loc = window.location,
+                baseUrl = loc.origin + loc.pathname,
+                querystring = loc.search + (loc.search ? '&' : '?') + "lang=" + lang;
+            $(document).attr('location', baseUrl + querystring + loc.hash);
         });
     };
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?281861

Product note: Fixes a bug in the language select in the app builder that caused a language to not be selected


Not-Product note: Ideally we'd either have a library for this sort of thing, or use https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams to reconstruct the params without duplicates, but this doesn't seem like the place to introduce another library or experimental api