### PR TITLE
Show module/form indices on source files page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/source_files.html
@@ -26,54 +26,38 @@
     <h2>Resource Files</h2>
 
     <table class="table table-condensed">
-        {% for file in files %}
-            <tr>
-                <td class="col-sm-3">
-                    {% if file.source %}
-                        <a class="toggle-next" href="#">{{ file.name }}</a>
-                    {% else %}
-                        {{ file.name }}
-                    {% endif %}
-                </td>
-                <td class="col-sm-9">
-                    {% block file_description %}{% endblock %}
-                </td>
-            </tr>
-
-            {% if file.source %}
-                <tr class="hide">
-                    <td colspan="2">
-                    {% block file_source %}{% endblock %}
+        {% for section, files in files.items %}
+            {% if section %}<tr><th>{{ section }}</th></tr>{% endif %}
+            {% for file in files %}
+                <tr>
+                    <td class="col-sm-3">
+                        {% if file.source %}
+                            <a class="toggle-next" href="#">{{ file.name }}</a>
+                        {% else %}
+                            {{ file.name }}
+                        {% endif %}
+                        {% if file.readable_name != file.name and file.readable_name%}
+                            {{ file.readable_name }}
+                        {% endif %}
+                    </td>
+                    <td class="col-sm-9">
+                        {% block file_description %}{% endblock %}
                     </td>
                 </tr>
-            {% endif %}
+
+                {% if file.source %}
+                    <tr class="hide">
+                        <td colspan="2">
+                            {% block file_source %}{% endblock %}
+                        </td>
+                    </tr>
+                {% endif %}
+            {% endfor %}
         {% empty %}
             <tr><th>No Files</th></tr>
         {% endfor %}
     </table>
     {% block post_files %}{% endblock %}
-
-    <h2>Module/Form Mapping</h2>
-    <ul>
-    {% for module in app.modules %}
-        <li><strong>m{{ module.id }}</strong>:
-            {% for lang, name in module.name.items %}
-                {% if module.name|length > 1 %}<span class="label label-default">{{ lang }}</span>{% endif %}
-                {{ name }}
-            {% endfor %}
-        </li>
-        {% for form in module.forms %}
-            <ul>
-                <li><strong>f{{form.id}}</strong>:
-                    {% for lang, name in form.name.items %}
-                        {% if form.name|length > 1 %}<span class="label label-default">{{ lang }}</span>{% endif %}
-                        {{ name }}
-                    {% endfor %}
-                </li>
-            </ul>
-        {% endfor %}
-    {% endfor %}
-    </ul>
 {% endblock page_content %}
 
 {% block js %}{{ block.super }}

--- a/corehq/apps/app_manager/templates/app_manager/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/source_files.html
@@ -52,6 +52,28 @@
         {% endfor %}
     </table>
     {% block post_files %}{% endblock %}
+
+    <h2>Module/Form Mapping</h2>
+    <ul>
+    {% for module in app.modules %}
+        <li><strong>m{{ module.id }}</strong>:
+            {% for lang, name in module.name.items %}
+                {% if module.name|length > 1 %}<span class="label label-default">{{ lang }}</span>{% endif %}
+                {{ name }}
+            {% endfor %}
+        </li>
+        {% for form in module.forms %}
+            <ul>
+                <li><strong>f{{form.id}}</strong>:
+                    {% for lang, name in form.name.items %}
+                        {% if form.name|length > 1 %}<span class="label label-default">{{ lang }}</span>{% endif %}
+                        {{ name }}
+                    {% endfor %}
+                </li>
+            </ul>
+        {% endfor %}
+    {% endfor %}
+    </ul>
 {% endblock page_content %}
 
 {% block js %}{{ block.super }}

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -383,7 +383,7 @@ def download_index(request, domain, app_id):
                 section_name = "m{} - {}".format(
                     module_id,
                     ", ".join(["({}) {}".format(lang, name)
-                               for lang, name in module.name.iteritems()])
+                               for lang, name in six.iteritems(module.name)])
                 )
                 files[section_name].append({
                     'name': file_[0],
@@ -391,7 +391,7 @@ def download_index(request, domain, app_id):
                     'readable_name': "f{} - {}".format(
                         form_id,
                         ", ".join(["({}) {}".format(lang, name)
-                                   for lang, name in form.name.iteritems()])
+                                   for lang, name in six.iteritems(form.name)])
                     ),
                 })
             else:
@@ -414,7 +414,7 @@ def download_index(request, domain, app_id):
     built_versions = get_all_built_app_ids_and_versions(domain, request.app.copy_of)
     return render(request, "app_manager/download_index.html", {
         'app': request.app,
-        'files': OrderedDict(sorted(files.iteritems(), key=lambda x: x[0])),
+        'files': OrderedDict(sorted(six.iteritems(files), key=lambda x: x[0])),
         'supports_j2me': request.app.build_spec.supports_j2me(),
         'built_versions': [{
             'app_id': app_id,

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
+import re
+from collections import defaultdict, OrderedDict
 
 from couchdbkit import ResourceConflict, ResourceNotFound
 from django.contrib import messages
@@ -370,9 +372,34 @@ def download_index(request, domain, app_id):
     all the resource files that will end up zipped into the jar.
 
     """
-    files = []
+    files = defaultdict(list)
     try:
-        files = source_files(request.app)
+        for file_ in source_files(request.app):
+            form_filename = re.search('modules-(\d+)\/forms-(\d+)', file_[0])
+            if form_filename:
+                module_id, form_id = form_filename.groups()
+                module = request.app.get_module(module_id)
+                form = module.get_form(form_id)
+                section_name = "m{} - {}".format(
+                    module_id,
+                    ", ".join(["({}) {}".format(lang, name)
+                               for lang, name in module.name.iteritems()])
+                )
+                files[section_name].append({
+                    'name': file_[0],
+                    'source': file_[1],
+                    'readable_name': "f{} - {}".format(
+                        form_id,
+                        ", ".join(["({}) {}".format(lang, name)
+                                   for lang, name in form.name.iteritems()])
+                    ),
+                })
+            else:
+                files[None].append({
+                    'name': file_[0],
+                    'source': file_[1],
+                    'readable_name': None,
+                })
     except Exception:
         messages.error(
             request,
@@ -387,7 +414,7 @@ def download_index(request, domain, app_id):
     built_versions = get_all_built_app_ids_and_versions(domain, request.app.copy_of)
     return render(request, "app_manager/download_index.html", {
         'app': request.app,
-        'files': [{'name': f[0], 'source': f[1]} for f in files],
+        'files': OrderedDict(sorted(files.iteritems(), key=lambda x: x[0])),
         'supports_j2me': request.app.build_spec.supports_j2me(),
         'built_versions': [{
             'app_id': app_id,

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -479,7 +479,7 @@ class AppDiffView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
         return {
             "app": self.first_app,
             "other_app": self.second_app,
-            "files": self.app_diffs
+            "files": {None: self.app_diffs},
         }
 
     @property


### PR DESCRIPTION
https://trello.com/c/ZfPJqpZI/35-reveal-internally-assigned-ids

![screenshot from 2018-08-16 15-42-02](https://user-images.githubusercontent.com/146896/44231082-f000f500-a16a-11e8-9893-b01cbe99ed66.png)

Product Note: This page isn't technically behind a FF (it doesn't even need a login!), but there's only a link to it when you have the `support` toggle enabled. 