### PR TITLE
Ignore empty string in the device log user filter

### DIFF
--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -97,7 +97,7 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
     @property
     @memoized
     def device_log_users(self):
-        return set([_f for _f in DeviceLogUsersFilter.get_value(self.request, self.domain)])
+        return set([_f for _f in DeviceLogUsersFilter.get_value(self.request, self.domain) if _f])
 
     @property
     @memoized


### PR DESCRIPTION
Now this follows the same pattern as the other properties below it