### PR TITLE
Add knockout bindings as dependency to case search

### DIFF
--- a/corehq/apps/domain/static/domain/js/case_search_main.js
+++ b/corehq/apps/domain/static/domain/js/case_search_main.js
@@ -2,6 +2,7 @@ hqDefine('domain/js/case_search_main', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'domain/js/case_search',
+    'hqwebapp/js/knockout_bindings.ko',     // save button
 ], function(
     $,
     initialPageData,


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?281796

@nickpell usually when some interaction wholly missing from the page it's because there's a dependency missing - kncokout_bindings, select2, something like that.