### PR TITLE
Fix releases page when a new build happens

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -409,7 +409,7 @@ hqDefine('app_manager/js/releases/releases', function () {
                     $('#build-errors-wrapper').html(data.error_html);
                     if (data.saved_app) {
                         var app = savedAppModel(data.saved_app, self);
-                        self.addSavedApp(app, true);
+                        self.savedApps.unshift(app);
                     }
                     self.buildState('');
                     self.buildErrorCode('');


### PR DESCRIPTION
Product note: Fixes issue with releases page hanging after creating a new app.

https://manage.dimagi.com/default.asp?281888#

https://github.com/dimagi/commcare-hq/pull/21506/ caused the release page to hang when creating a new build because it remove `addSavedApp`

The fix I chose was to add this was to add the saved app to the list currently displayed. Since this new list is backed of elasticsearch, if we chose to make a new request to reload apps there's a non-zero chance that the new app build hasn't been picked up by the pillow yet.