### PR TITLE
Revert "Fix js errors on My Saved Reports"

### DIFF
--- a/corehq/apps/reports/static/reports/js/saved_reports.js
+++ b/corehq/apps/reports/static/reports/js/saved_reports.js
@@ -1,7 +1,3 @@
-/**
- * This file handles the interaction for the "My Saved Reports" page
- * and also the modal used to save a report on standard reports pages.
- */
 var ReportConfig = function (data) {
     var self = ko.mapping.fromJS(data, {
         'copy': ['filters'],

--- a/corehq/apps/reports/templates/reports/reports_home.html
+++ b/corehq/apps/reports/templates/reports/reports_home.html
@@ -1,18 +1,12 @@
-{% extends "hqwebapp/base_section.html" %}
+{% extends "reports/base_template.html" %}
 {% load case_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load report_tags %}
 {% load compress %}
 
-{% block js %}{{ block.super }}
-    <script src="{% static 'reports/js/saved_reports.js' %}"></script>
-{% endblock %}
-
 {% block page_content %}
 {% initial_page_data 'configs' configs %}
-{% registerurl 'add_report_config' domain %}
-
 <ul class="nav nav-tabs sticky-tabs" style="margin-bottom: 10px;">
     <li><a href="#ko-report-config-list" data-toggle="tab">{% trans "My Saved Reports" %}</a></li>
     <li><a href="#scheduled-reports" data-toggle="tab">


### PR DESCRIPTION
Reverts dimagi/commcare-hq#21512

https://manage.dimagi.com/default.asp?281892

@orangejenny was this fixing a bug, or just some cleanup? It broke editing the form. I tried adding standard_hq_report.js to this page, but it looks like it requires some globals to be defined and there are an amazing amount of possible places they can be set in reports/base_template.html