### PR TITLE
Fix case list formats when / in a calculated property

### DIFF
--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -237,6 +237,8 @@ class AppCaseMetadata(JsonObject):
         return prop
 
     def add_property_detail(self, detail_type, root_case_type, module_id, column):
+        if column.useXpathExpression:
+            return column.field
         prop = self.get_property(root_case_type, column.field)
         prop.add_detail(detail_type, module_id, column.header, column.format)
         return prop


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/650985403/

When a '/' in a  property it assumes that it is a parent property. When a calculated property has a '/' it tries to resolve the index type but that doesn't exist. doesn't look like there are any tests around these code paths