### PR TITLE
allow to maintain version free resources on transifex

### DIFF
--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -88,7 +88,10 @@ class POFileGenerator:
             )
 
     def _get_filename(self, sheet_name):
-        return sheet_name + '_v' + str(self.version)
+        if self.version:
+            return sheet_name + '_v' + str(self.version)
+        else:
+            return sheet_name
 
     def _get_header_index(self, sheet_name, column_name):
         for index, _column_name in enumerate(self.headers[sheet_name]):
@@ -151,8 +154,6 @@ class POFileGenerator:
         """
         from corehq.apps.app_manager.dbaccessors import get_current_app
         app = get_current_app(self.domain, self.app_id_to_build)
-        if self.version is None:
-            self.version = app.version
 
         rows = self._translation_data(app)
 

--- a/corehq/apps/app_manager/app_translations/parser.py
+++ b/corehq/apps/app_manager/app_translations/parser.py
@@ -40,7 +40,14 @@ class TranslationsParser(object):
         elif 'module' in sheet_name and 'form' in sheet_name:
             self._add_form_sheet(ws, po_entries)
         else:
-            raise Exception("Got unexpected sheet name %s" % sheet_name)
+            self._add_generic_sheet(ws, po_entries)
+
+    def _add_generic_sheet(self, ws, po_entries):
+        # add header
+        ws.append(["context", self.key_lang_str, self.source_lang_str])
+        # add rows
+        for po_entry in po_entries:
+            ws.append([po_entry.msgctxt, po_entry.msgid, po_entry.msgstr])
 
     def _add_module_and_form_sheet(self, ws, po_entries):
         context_regex = CONTEXT_REGEXS['module_and_forms_sheet']

--- a/custom/icds/translations/integrations/client.py
+++ b/custom/icds/translations/integrations/client.py
@@ -37,9 +37,13 @@ class TransifexApiClient(object):
         """
         :return: list of resource slugs corresponding to version
         """
-        return [r['name']
-                for r in self.list_resources().json()
-                if r['name'].endswith("v%s" % version)]
+        all_resources = self.list_resources().json()
+        if version:
+            return [r['slug']
+                    for r in all_resources
+                    if r['slug'].endswith("v%s" % version)]
+        else:
+            return [r['slug'] for r in all_resources]
 
     def lock_resource(self, resource_slug):
         """

--- a/custom/icds/translations/integrations/transifex.py
+++ b/custom/icds/translations/integrations/transifex.py
@@ -115,7 +115,8 @@ class Transifex(object):
         pull translations from transifex
         :return: dict of resource_slug mapped to POEntry objects
         """
-        self._ensure_resources_belong_to_version()
+        if self.version:
+            self._ensure_resources_belong_to_version()
         po_entries = {}
         for resource_slug in self.resource_slugs:
             po_entries[resource_slug] = self.client.get_translation(resource_slug, self.source_lang,


### PR DESCRIPTION
A critical but small tweak in the way we would want to maintain resources on transifex for ICDS app translations.
Currently the resources are maintained per version but we need to work to a way where it is not. I am guessing this would work simply like we handle translations for HQ.
I did some basic test and objective for the changed shared [here](https://docs.google.com/document/d/1h2QdZ0o3Bs_0L9kztKuiBTSmRZpoK3VOOzhsCZbWuxY/edit#)
