### PR TITLE
allow to maintain version free resources on transifex

### DIFF
--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -88,7 +88,10 @@ class POFileGenerator:
             )
 
     def _get_filename(self, sheet_name):
-        return sheet_name + '_v' + str(self.version)
+        if self.version:
+            return sheet_name + '_v' + str(self.version)
+        else:
+            return sheet_name
 
     def _get_header_index(self, sheet_name, column_name):
         for index, _column_name in enumerate(self.headers[sheet_name]):
@@ -151,8 +154,6 @@ class POFileGenerator:
         """
         from corehq.apps.app_manager.dbaccessors import get_current_app
         app = get_current_app(self.domain, self.app_id_to_build)
-        if self.version is None:
-            self.version = app.version
 
         rows = self._translation_data(app)
 

--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -16,7 +16,7 @@ Unique_ID = namedtuple('UniqueID', 'type id')
 
 class POFileGenerator:
     def __init__(self, domain, app_id, version, key_lang, source_lang, lang_prefix,
-                 exclude_if_default=False):
+                 exclude_if_default=False, use_version_postfix=True):
         """
         Generates PO files for source/default lang files and also for translated files
         :param domain: domain name
@@ -29,6 +29,7 @@ class POFileGenerator:
         :param lang_prefix: usually default_
         :param exclude_if_default: set this to skip adding msgstr in case its same as the
         default language. For details: https://github.com/dimagi/commcare-hq/pull/20706
+        :param use_version_postfix: use version number at the end of resource slugs
         """
         if key_lang == source_lang and exclude_if_default:
             raise Exception("Looks like you are setting up the file for default language "
@@ -42,6 +43,7 @@ class POFileGenerator:
         self.exclude_if_default = exclude_if_default
         self.translations = OrderedDict()
         self.version = version
+        self.use_version_postfix = use_version_postfix
         self.headers = dict()  # headers for each sheet name
         self.generated_files = list()  # list of tuples (filename, filepath)
         self.sheet_name_to_module_or_form_type_and_id = dict()
@@ -88,7 +90,7 @@ class POFileGenerator:
             )
 
     def _get_filename(self, sheet_name):
-        if self.version:
+        if self.version and self.use_version_postfix:
             return sheet_name + '_v' + str(self.version)
         else:
             return sheet_name
@@ -155,6 +157,8 @@ class POFileGenerator:
         from corehq.apps.app_manager.dbaccessors import get_current_app
         app = get_current_app(self.domain, self.app_id_to_build)
 
+        if self.version is None:
+            self.version = app.version
         rows = self._translation_data(app)
 
         for sheet_name in rows:

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -197,12 +197,11 @@ def download_raw_jar(request, domain, app_id):
 class DownloadCCZ(DownloadMultimediaZip):
     name = 'download_ccz'
     compress_zip = True
+    include_index_files = True
 
     @property
     def zip_name(self):
         return 'commcare_v{}.ccz'.format(self.app.version)
-
-    include_index_files = True
 
     def check_before_zipping(self):
         if self.app.is_remote_app():

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -640,7 +640,8 @@ def url_replace(context, field, value):
 
 @register.filter
 def view_pdb(element):
-    import ipdb; ipdb.sset_trace()
+    import ipdb
+    ipdb.sset_trace()
     return element
 
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -640,7 +640,7 @@ def url_replace(context, field, value):
 
 @register.filter
 def view_pdb(element):
-    import ipdb; ipdb.set_trace()
+    import ipdb; ipdb.sset_trace()
     return element
 
 

--- a/custom/icds/tasks.py
+++ b/custom/icds/tasks.py
@@ -59,7 +59,8 @@ def delete_resources_on_transifex(domain, data, email):
                           data.get('app_id'),
                           data.get('target_lang') or data.get('source_lang'),
                           data.get('transifex_project_slug'),
-                          version,)
+                          version,
+                          use_version_postfix='yes' in data['use_version_postfix'])
     delete_status = transifex.delete_resources()
     result_note = "Hi,\nThe request to delete resources for app {app_id}(version {version}), " \
                   "was completed on project {transifex_project_slug} on transifex. " \
@@ -85,13 +86,17 @@ def push_translation_files_to_transifex(domain, data, email):
                                   data.get('transifex_project_slug'),
                                   data.get('version'),
                                   is_source_file=False,
-                                  exclude_if_default=True).send_translation_files()
+                                  exclude_if_default=True,
+                                  use_version_postfix='yes' in data['use_version_postfix']
+                                  ).send_translation_files()
     elif data.get('source_lang'):
         upload_status = Transifex(domain,
                                   data.get('app_id'),
                                   data.get('source_lang'),
                                   data.get('transifex_project_slug'),
-                                  data.get('version')).send_translation_files()
+                                  data.get('version'),
+                                  use_version_postfix='yes' in data['use_version_postfix']
+                                  ).send_translation_files()
     if upload_status:
         result_note = "Hi,\nThe upload for app {app_id}(version {version}), " \
                       "with source language '{source_lang}' and target lang '{target_lang}' " \
@@ -116,7 +121,8 @@ def pull_translation_files_from_transifex(domain, data, email=None):
                           data.get('target_lang') or data.get('source_lang'),
                           data.get('transifex_project_slug'),
                           version,
-                          lock_translations=data.get('lock_translations'),)
+                          lock_translations=data.get('lock_translations'),
+                          use_version_postfix='yes' in data['use_version_postfix'])
     translation_file = None
     try:
         translation_file, filename = transifex.generate_excel_file()

--- a/custom/icds/translations/integrations/client.py
+++ b/custom/icds/translations/integrations/client.py
@@ -37,9 +37,13 @@ class TransifexApiClient(object):
         """
         :return: list of resource slugs corresponding to version
         """
-        return [r['name']
-                for r in self.list_resources().json()
-                if r['name'].endswith("v%s" % version)]
+        all_resources = self.list_resources().json()
+        if version:
+            return [r['slug']
+                    for r in self.list_resources().json()
+                    if r['slug'].endswith("v%s" % version)]
+        else:
+            return [r['slug'] for r in all_resources]
 
     def lock_resource(self, resource_slug):
         """

--- a/custom/icds/translations/integrations/client.py
+++ b/custom/icds/translations/integrations/client.py
@@ -16,11 +16,12 @@ from io import open
 
 
 class TransifexApiClient(object):
-    def __init__(self, token, organization, project):
+    def __init__(self, token, organization, project, use_version_postfix=True):
         self.username = API_USER
         self.token = token
         self.organization = organization
         self.project = project
+        self.use_version_postfix = use_version_postfix
 
     @property
     def _auth(self):
@@ -38,7 +39,7 @@ class TransifexApiClient(object):
         :return: list of resource slugs corresponding to version
         """
         all_resources = self.list_resources().json()
-        if version:
+        if version and self.use_version_postfix:
             return [r['slug']
                     for r in self.list_resources().json()
                     if r['slug'].endswith("v%s" % version)]

--- a/custom/icds/translations/integrations/transifex.py
+++ b/custom/icds/translations/integrations/transifex.py
@@ -15,7 +15,8 @@ from custom.icds.translations.integrations.client import TransifexApiClient
 
 class Transifex(object):
     def __init__(self, domain, app_id, source_lang, project_slug, version=None, lang_prefix='default_',
-                 resource_slugs=None, is_source_file=True, exclude_if_default=False, lock_translations=False):
+                 resource_slugs=None, is_source_file=True, exclude_if_default=False, lock_translations=False,
+                 use_version_postfix=True):
         """
         :param domain: domain name
         :param app_id: id of the app to be used
@@ -25,6 +26,7 @@ class Transifex(object):
         :param lang_prefix: prefix if other than "default_"
         :param resource_slugs: resource slugs
         :param is_source_file: upload as source language file(True) or translation(False)
+        :param use_version_postfix: use version number at the end of resource slugs
         """
         if version:
             version = int(version)
@@ -36,8 +38,9 @@ class Transifex(object):
         self.is_source_file = is_source_file
         self.source_lang = source_lang
         self.lock_translations = lock_translations
+        self.use_version_postfix = use_version_postfix
         self.po_file_generator = POFileGenerator(domain, app_id, version, self.key_lang, source_lang, lang_prefix,
-                                                 exclude_if_default)
+                                                 exclude_if_default, use_version_postfix)
 
     def send_translation_files(self):
         """
@@ -61,7 +64,8 @@ class Transifex(object):
             return TransifexApiClient(
                 transifex_account_details['token'],
                 transifex_account_details['organization'],
-                self.project_slug
+                self.project_slug,
+                self.use_version_postfix,
             )
         else:
             raise Exception(_("Transifex account details not available on this environment."))
@@ -115,7 +119,7 @@ class Transifex(object):
         pull translations from transifex
         :return: dict of resource_slug mapped to POEntry objects
         """
-        if self.version:
+        if self.version and self.use_version_postfix:
             self._ensure_resources_belong_to_version()
         po_entries = {}
         for resource_slug in self.resource_slugs:

--- a/custom/icds/translations/integrations/transifex.py
+++ b/custom/icds/translations/integrations/transifex.py
@@ -115,7 +115,8 @@ class Transifex(object):
         pull translations from transifex
         :return: dict of resource_slug mapped to POEntry objects
         """
-        self._ensure_resources_belong_to_version()
+        if self.version:
+            self._ensure_resources_belong_to_version()
         po_entries = {}
         for resource_slug in self.resource_slugs:
             po_entries[resource_slug] = self.client.get_translation(resource_slug, self.source_lang,

--- a/custom/icds_reports/forms.py
+++ b/custom/icds_reports/forms.py
@@ -17,6 +17,14 @@ class AppTranslationsForm(forms.Form):
     app_id = forms.ChoiceField(label=ugettext_lazy("App"), choices=(), required=True)
     version = forms.IntegerField(label=ugettext_lazy("Version"), required=False,
                                  help_text=ugettext_lazy("Leave blank to use current application state"))
+    use_version_postfix = forms.MultipleChoiceField(
+        choices=[
+            ('yes', 'Use Version Postfix in resources'),
+        ],
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+        initial='use_version_postfix',
+    )
     transifex_project_slug = forms.ChoiceField(label=ugettext_lazy("Trasifex project"), choices=(),
                                                required=True)
     source_lang = forms.ChoiceField(label=ugettext_lazy("Source Language"),
@@ -69,6 +77,7 @@ class AppTranslationsForm(forms.Form):
         self.helper.layout = Layout(
             'app_id',
             'version',
+            'use_version_postfix',
             'transifex_project_slug',
             'source_lang',
             'target_lang',

--- a/custom/icds_reports/forms.py
+++ b/custom/icds_reports/forms.py
@@ -23,7 +23,7 @@ class AppTranslationsForm(forms.Form):
         ],
         widget=forms.CheckboxSelectMultiple(),
         required=False,
-        initial='use_version_postfix',
+        initial='yes',
     )
     transifex_project_slug = forms.ChoiceField(label=ugettext_lazy("Trasifex project"), choices=(),
                                                required=True)

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -1623,7 +1623,8 @@ class ICDSAppTranslations(BaseDomainView):
         transifex_project_slug = form_data.get('transifex_project_slug')
         source_language_code = form_data.get('target_lang') or form_data.get('source_lang')
         return Transifex(domain, form_data['app_id'], source_language_code, transifex_project_slug,
-                         form_data['version'])
+                         form_data['version'],
+                         use_version_postfix='yes' in form_data['use_version_postfix'])
 
     def perform_push_request(self, request, form_data):
         if form_data['target_lang']:


### PR DESCRIPTION
A critical but small tweak in the way we would want to maintain resources on transifex for ICDS app translations.
Currently the resources are maintained per version but we need to work to a way where it is not. I am guessing this would work simply like we handle translations for HQ.
objective for the changed shared [here](https://docs.google.com/document/d/1h2QdZ0o3Bs_0L9kztKuiBTSmRZpoK3VOOzhsCZbWuxY/edit#) and some basics tests done included in the doc itself [here](https://docs.google.com/document/d/1h2QdZ0o3Bs_0L9kztKuiBTSmRZpoK3VOOzhsCZbWuxY/edit#bookmark=id.qc0atpadv401)