### PR TITLE
change column birth_weight from decimal to integer

### DIFF
--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -553,7 +553,7 @@
       {
         "display_name": null,
         "property_path": [],
-        "datatype": "decimal",
+        "datatype": "integer",
         "is_primary_key": false,
         "is_nullable": true,
         "column_id": "birth_weight",


### PR DESCRIPTION
this is showing up in the app with 9 digits to the right of the decimal.  App builders requested this change from decimal to integer

trello here: https://trello.com/c/9LRIrG5F/238-aww-mpr-lists-birth-weight-in-mpr-2ci-child-birth-list-needs-to-have-a-limit-on-the-number-of-digits-displayed

Fogbugz here: https://manage.dimagi.com/default.asp?280924#edit_0_280924