### PR TITLE
Remove 'weekly' from phase 2 aww 1 content description

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1549,7 +1549,7 @@ AVAILABLE_CUSTOM_SCHEDULING_CONTENT = {
          "ICDS: Weekly AWC Submission Performance to LS"],
     "ICDS_PHASE2_AWW_1":
         ["custom.icds.messaging.custom_content.phase2_aww_1",
-         "ICDS: Weekly AWC VHND Performance to AWW"],
+         "ICDS: AWC VHND Performance to AWW"],
 }
 
 # Used by the old reminders framework


### PR DESCRIPTION
(The spec has us sending this monthly)

@millerdev 