### PR TITLE
transform column birth_weight with format_string

### DIFF
--- a/custom/icds_reports/ucr/reports/mpr_2ci_child_birth_list.json
+++ b/custom/icds_reports/ucr/reports/mpr_2ci_child_birth_list.json
@@ -104,6 +104,10 @@
         "column_id": "birth_weight",
         "field": "birth_weight",
         "type": "field",
+        "transform": {
+          "format_string": "{0:.0f}", 
+          "type": "number_format"
+        }, 
         "display": {
           "mar": "मुलाचे जन्म वजन आहे",
           "tel": "బిడ్డ యొక్క బరువు",


### PR DESCRIPTION
@calellowitz per our discussion yesterday, moving this to a reports transform rather than changing the column in the data source.

set no digits to right of decimal point in column birth_weight using;

    "transform": {
      "format_string": "{0:.0f}", 
      "type": "number_format"
    }, 

tested here: https://india.commcarehq.org/a/icds-cas/configurable_reports/reports/edit/bd08b2eff770f959b9dcffb1ea14486a/#

trello here: https://trello.com/c/9LRIrG5F/238-aww-mpr-lists-birth-weight-in-mpr-2ci-child-birth-list-needs-to-have-a-limit-on-the-number-of-digits-displayed

fogbugz here: https://manage.dimagi.com/default.asp?280924#edit_0_280924