### PR TITLE
Add child case recipients to new reminders framework

### DIFF
--- a/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
+++ b/corehq/apps/reminders/management/commands/migrate_to_new_reminders.py
@@ -502,6 +502,8 @@ def get_rule_recipients(handler):
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, None)]
     elif handler.recipient == RECIPIENT_PARENT_CASE:
         return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE, None)]
+    elif handler.recipient == RECIPIENT_SUBCASE:
+        return [(CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES, None)]
     elif handler.recipient == RECIPIENT_USER_GROUP:
         return [(ScheduleInstance.RECIPIENT_TYPE_USER_GROUP, handler.user_group_id)]
     elif handler.recipient in CUSTOM_RECIPIENTS:
@@ -795,7 +797,14 @@ class Command(BaseCommand):
             RECIPIENT_USER_GROUP,
             RECIPIENT_USER,
             RECIPIENT_PARENT_CASE,
+            RECIPIENT_SUBCASE,
         )):
+            return None
+
+        if handler.recipient == RECIPIENT_SUBCASE and not (
+            handler.recipient_case_match_property == '_id' and
+            handler.recipient_case_match_type == MATCH_ANY_VALUE
+        ):
             return None
 
         if handler.recipient == RECIPIENT_USER_GROUP and not handler.user_group_id:

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1484,10 +1484,10 @@ class CaseReminderHandler(Document):
                     "non-negative")
 
         if self.recipient == RECIPIENT_SUBCASE:
-            check_attr("recipient_case_match_property")
-            check_attr("recipient_case_match_type")
-            if self.recipient_case_match_type != MATCH_ANY_VALUE:
-                check_attr("recipient_case_match_value")
+            if self.recipient_case_match_property != '_id' or self.recipient_case_match_type != MATCH_ANY_VALUE:
+                raise IllegalModelStateException(
+                    "must send to all child cases if child case recipients are chosen"
+                )
 
         if (self.custom_content_handler and self.custom_content_handler not in
             settings.ALLOWED_CUSTOM_CONTENT_HANDLERS):

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2867,6 +2867,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER, _("The Case's Owner")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, _("The Case's Last Submitting User")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE, _("The Case's Parent Case")),
+            (CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES, _("The Case's Child Cases")),
         ]
         new_choices.extend(self.fields['recipient_types'].choices)
 
@@ -3414,6 +3415,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE,
+            CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES,
         ):
             if recipient_type_without_id in recipient_types:
                 result.append((recipient_type_without_id, None))

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -9,6 +9,7 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.sms.models import MessagingEvent
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
 from corehq.apps.users.models import CommCareUser, WebUser, CouchUser
+from corehq.form_processor.abstract_models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.utils import is_commcarecase
@@ -499,7 +500,7 @@ class CaseScheduleInstanceMixin(object):
     RECIPIENT_TYPE_CASE_OWNER = 'Owner'
     RECIPIENT_TYPE_LAST_SUBMITTING_USER = 'LastSubmittingUser'
     RECIPIENT_TYPE_PARENT_CASE = 'ParentCase'
-    RECIPIENT_TYPE_CHILD_CASE = 'SubCase'
+    RECIPIENT_TYPE_ALL_CHILD_CASES = 'AllChildCases'
     RECIPIENT_TYPE_CUSTOM = 'CustomRecipient'
 
     @property
@@ -565,7 +566,10 @@ class CaseScheduleInstanceMixin(object):
                 return self.case.parent
 
             return None
-        elif self.recipient_type == self.RECIPIENT_TYPE_CHILD_CASE:
+        elif self.recipient_type == self.RECIPIENT_TYPE_ALL_CHILD_CASES:
+            if self.case:
+                return list(self.case.get_subcases(index_identifier=DEFAULT_PARENT_IDENTIFIER))
+
             return None
         elif self.recipient_type == self.RECIPIENT_TYPE_CUSTOM:
             custom_function = to_function(

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -270,6 +270,27 @@ class SchedulingRecipientTest(TestCase):
             self.assertEqual(instance.recipient.case_id, parent.case_id)
 
     @run_with_all_backends
+    def test_child_case_recipient(self):
+        with create_case(self.domain, 'person') as child_1, \
+                create_case(self.domain, 'person') as child_2, \
+                create_case(self.domain, 'person') as parent:
+
+            instance = CaseTimedScheduleInstance(domain=self.domain, case_id=parent.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES)
+            self.assertIsInstance(instance.recipient, list)
+            self.assertEqual(len(instance.recipient), 0)
+
+            set_parent_case(self.domain, child_1, parent, relationship='child', identifier='parent')
+            set_parent_case(self.domain, child_2, parent, relationship='child', identifier='parent')
+
+            instance = CaseTimedScheduleInstance(domain=self.domain, case_id=parent.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES)
+
+            self.assertIsInstance(instance.recipient, list)
+            self.assertEqual(len(instance.recipient), 2)
+            self.assertItemsEqual([c.case_id for c in instance.recipient], [child_1.case_id, child_2.case_id])
+
+    @run_with_all_backends
     def test_host_case_owner_location(self):
         with create_test_case(self.domain, 'test-extension-case', 'name') as extension_case:
             with create_test_case(self.domain, 'test-host-case', 'name') as host_case:


### PR DESCRIPTION
Adds an option to send to all child cases from a conditional alert, for parity with the old framework.

@millerdev @orangejenny @jmtroth0 