### PR TITLE
Use device_id to identify cases imported from OpenMRS

### DIFF
--- a/corehq/motech/openmrs/const.py
+++ b/corehq/motech/openmrs/const.py
@@ -21,6 +21,10 @@ IMPORT_FREQUENCY_CHOICES = (
     (IMPORT_FREQUENCY_MONTHLY, _('Monthly')),
 )
 
+# device_id for cases added/updated by an OpenmrsImporter.
+# OpenmrsImporter ID is appended to this.
+OPENMRS_IMPORTER_DEVICE_ID = 'openmrs-importer-'
+
 # XMLNS to indicate that a form was imported from OpenMRS
 XMLNS_OPENMRS = 'http://commcarehq.org/openmrs-integration'
 

--- a/corehq/motech/openmrs/const.py
+++ b/corehq/motech/openmrs/const.py
@@ -23,7 +23,7 @@ IMPORT_FREQUENCY_CHOICES = (
 
 # device_id for cases added/updated by an OpenmrsImporter.
 # OpenmrsImporter ID is appended to this.
-OPENMRS_IMPORTER_DEVICE_ID = 'openmrs-importer-'
+OPENMRS_IMPORTER_DEVICE_ID_PREFIX = 'openmrs-importer-'
 
 # XMLNS to indicate that a form was imported from OpenMRS
 XMLNS_OPENMRS = 'http://commcarehq.org/openmrs-integration'

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -27,7 +27,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.motech.openmrs.const import (
     IMPORT_FREQUENCY_MONTHLY,
     IMPORT_FREQUENCY_WEEKLY,
-    OPENMRS_IMPORTER_DEVICE_ID,
+    OPENMRS_IMPORTER_DEVICE_ID_PREFIX,
     XMLNS_OPENMRS,
 )
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
@@ -149,7 +149,7 @@ def import_patients_of_owner(requests, importer, domain_name, owner, location=No
     submit_case_blocks(
         [cb.case.as_string() for cb in case_blocks],
         domain_name,
-        device_id=OPENMRS_IMPORTER_DEVICE_ID + importer.get_id,
+        device_id='{}{}'.format(OPENMRS_IMPORTER_DEVICE_ID_PREFIX, importer.get_id),
         user_id=owner.user_id,
         xmlns=XMLNS_OPENMRS,
     )

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -24,7 +24,12 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.dbaccessors import get_all_users_by_location
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.users.models import CommCareUser
-from corehq.motech.openmrs.const import IMPORT_FREQUENCY_WEEKLY, IMPORT_FREQUENCY_MONTHLY, XMLNS_OPENMRS
+from corehq.motech.openmrs.const import (
+    IMPORT_FREQUENCY_MONTHLY,
+    IMPORT_FREQUENCY_WEEKLY,
+    OPENMRS_IMPORTER_DEVICE_ID,
+    XMLNS_OPENMRS,
+)
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.models import POSIX_MILLISECONDS
@@ -144,7 +149,7 @@ def import_patients_of_owner(requests, importer, domain_name, owner, location=No
     submit_case_blocks(
         [cb.case.as_string() for cb in case_blocks],
         domain_name,
-        username=owner.username,
+        device_id=OPENMRS_IMPORTER_DEVICE_ID + importer.get_id,
         user_id=owner.user_id,
         xmlns=XMLNS_OPENMRS,
     )


### PR DESCRIPTION
This change should make it easy to see that the cases were imported, and not created by a user.

Feature flag: 'Enable OpenMRS integration'
