### PR TITLE
Add obfuscation block to icds custom login

### DIFF
--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -67,6 +67,13 @@
 </div>
 {% endblock page_content %}
 
+{% block js %}
+  {{ block.super }}
+  {% if implement_password_obfuscation %}
+      {% include "nic_compliance/password_encoder.html" %}
+  {% endif %}
+{% endblock %}
+
 <!-- get rid of footer -->
 {% block footer %}
 {% endblock footer %}


### PR DESCRIPTION
Add the block from login_and_password/login.html to enable password obfuscation for icds login