### PR TITLE
Include Mobile UCR v2 counts in admin restore view

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -59,21 +59,39 @@
                         </ul>
                     </div>
                 {% endif %}
+
                 <div>
-                    Number of reports in this restore: <strong>{{num_reports}}</strong>
+                    Number of V1 reports in this restore: <strong>{{ num_v1_reports }}</strong>
                 </div>
-                {% if report_row_counts %}
+                {% if v1_report_row_counts %}
                     <div>
                         Number of rows by report
                     </div>
                     <div>
                         <ul>
-                            {% for report_id, row_count in report_row_counts.items %}
-                                <li>{{report_id}}: {{row_count}}</li>
+                            {% for report_id, row_count in v1_report_row_counts.items %}
+                                <li>{{ report_id }}: <strong>{{ row_count }}</strong></li>
                             {% endfor %}
                         </ul>
                     </div>
                 {% endif %}
+
+                <div>
+                    Number of V2 reports in this restore: <strong>{{ num_v2_reports }}</strong>
+                </div>
+                {% if v2_report_row_counts %}
+                <div>
+                    Number of rows by report
+                </div>
+                <div>
+                    <ul>
+                        {% for report_id, row_count in v2_report_row_counts.items %}
+                        <li>{{ report_id }}: <strong>{{ row_count }}</strong></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endif %}
+
                 <div>
                     Number of ledger entries in this restore: <strong>{{ num_ledger_entries }}</strong>
                 </div>

--- a/corehq/apps/hqadmin/tests/data/restore.xml
+++ b/corehq/apps/hqadmin/tests/data/restore.xml
@@ -135,6 +135,82 @@
       </location>
     </locations>
   </fixture>
+  <fixture id="commcare:reports" user_id="0cf186bad6b44bb5afca9feb737290d9">
+    <reports last_sync="2018-08-22T16:34:24.326325+00:00">
+      <report id="e009c3dc89b0250a8accd09b9641c3250f4e38d0" report_id="0dc41ff3e342d3ac94c06bb5c6cdd416">
+        <filters/>
+        <rows>
+          <row index="0" is_total_row="False">
+            <column id="column_0">Andinet</column>
+            <column id="column_1">100</column>
+          </row>
+          <row index="1" is_total_row="False">
+            <column id="column_0">Meketa</column>
+            <column id="column_1">5</column>
+          </row>
+          <row index="2" is_total_row="False">
+            <column id="column_0">Melesa</column>
+            <column id="column_1">52</column>
+          </row>
+        </rows>
+      </report>
+      <report id="42dc83c562a474b7e5faba4fc3190ca37bd4777f" report_id="f1761733213601f7f77defc3bc2e2c87">
+        <filters/>
+        <rows>
+          <row index="0" is_total_row="False">
+            <column id="column_0">1</column>
+            <column id="column_1"/>
+          </row>
+          <row index="1" is_total_row="False">
+            <column id="column_0">3</column>
+            <column id="column_1"/>
+          </row>
+          <row index="2" is_total_row="False">
+            <column id="column_0">4</column>
+            <column id="column_1"/>
+          </row>
+        </rows>
+      </report>
+    </reports>
+  </fixture>
+  <fixture id="commcare-reports-filters:e009c3dc89b0250a8accd09b9641c3250f4e38d0">
+    <filters/>
+  </fixture>
+  <fixture id="commcare-reports:e009c3dc89b0250a8accd09b9641c3250f4e38d0" indexed="true" report_id="0dc41ff3e342d3ac94c06bb5c6cdd416" user_id="0cf186bad6b44bb5afca9feb737290d9">
+    <rows last_sync="2018-08-22T16:34:25.575930+00:00">
+      <row index="0" is_total_row="False">
+        <column_0>Andinet</column_0>
+        <column_1>100</column_1>
+      </row>
+      <row index="1" is_total_row="False">
+        <column_0>Meketa</column_0>
+        <column_1>5</column_1>
+      </row>
+      <row index="2" is_total_row="False">
+        <column_0>Melesa</column_0>
+        <column_1>52</column_1>
+      </row>
+    </rows>
+  </fixture>
+  <fixture id="commcare-reports-filters:42dc83c562a474b7e5faba4fc3190ca37bd4777f">
+    <filters/>
+  </fixture>
+  <fixture id="commcare-reports:42dc83c562a474b7e5faba4fc3190ca37bd4777f" indexed="true" report_id="f1761733213601f7f77defc3bc2e2c87" user_id="0cf186bad6b44bb5afca9feb737290d9">
+    <rows last_sync="2018-08-22T16:34:25.710505+00:00">
+      <row index="0" is_total_row="False">
+        <column_0>1</column_0>
+        <column_1/>
+      </row>
+      <row index="1" is_total_row="False">
+        <column_0>3</column_0>
+        <column_1/>
+      </row>
+      <row index="2" is_total_row="False">
+        <column_0>4</column_0>
+        <column_1/>
+      </row>
+    </rows>
+  </fixture>
   <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="b3861bab907c62de6a9c5932960e6cf8" date_modified="2016-10-31T20:05:16.423033Z" user_id="">
     <create>
       <case_type>person</case_type>

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -46,7 +46,8 @@ class AdminRestoreViewTests(TestXmlMixin, SimpleTestCase):
             'restore_id': None,
             'num_cases': 2,
             'num_locations': 7,
-            'num_reports': 2,
+            'num_v1_reports': 2,
+            'num_v2_reports': 2,
             'case_type_counts': {},
             'location_type_counts': {
                 'country': 1,
@@ -55,7 +56,11 @@ class AdminRestoreViewTests(TestXmlMixin, SimpleTestCase):
                 'city': 1,
                 'neighborhood': 3,
             },
-            'report_row_counts': {
+            'v1_report_row_counts': {
+                '0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
+                'f1761733213601f7f77defc3bc2e2c87': 3,
+            },
+            'v2_report_row_counts': {
                 '0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
                 'f1761733213601f7f77defc3bc2e2c87': 3,
             },

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -14,6 +14,7 @@ from corehq.apps.hqadmin.views.users import AdminRestoreView
 class AdminRestoreViewTests(TestXmlMixin, SimpleTestCase):
     root = os.path.dirname(__file__)
     file_path = ['data']
+    maxDiff = None
 
     def test_bad_restore(self):
         user = Mock()
@@ -45,7 +46,7 @@ class AdminRestoreViewTests(TestXmlMixin, SimpleTestCase):
             'restore_id': None,
             'num_cases': 2,
             'num_locations': 7,
-            'num_reports': 0,
+            'num_reports': 2,
             'case_type_counts': {},
             'location_type_counts': {
                 'country': 1,
@@ -54,6 +55,9 @@ class AdminRestoreViewTests(TestXmlMixin, SimpleTestCase):
                 'city': 1,
                 'neighborhood': 3,
             },
-            'report_row_counts': {},
+            'report_row_counts': {
+                '0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
+                'f1761733213601f7f77defc3bc2e2c87': 3,
+            },
             'num_ledger_entries': 0,
         })

--- a/corehq/apps/ota/management/commands/time_restore.py
+++ b/corehq/apps/ota/management/commands/time_restore.py
@@ -68,7 +68,8 @@ def _get_headers_and_rows(domain, users, app_id):
             'total_duration': timing_dict['duration'],
             'num_cases': stats['num_cases'],
             'num_locations': stats['num_locations'],
-            'num_reports': stats['num_reports'],
+            'num_v1_reports': stats['num_v1_reports'],
+            'num_v2_reports': stats['num_v2_reports'],
             'num_ledger_entries': stats['num_ledger_entries'],
         }
         for provider in timing_dict['subs']:
@@ -87,7 +88,8 @@ def _get_headers_and_rows(domain, users, app_id):
         'total_duration',
         'num_cases',
         'num_locations',
-        'num_reports',
+        'num_v1_reports',
+        'num_v2_reports',
         'num_ledger_entries',
         'RegistrationElementProvider',
         'CasePayloadProvider',


### PR DESCRIPTION
The admin restore only shows info for "reports", without distinguishing between v1 and v2.  This counts each of them, separately.

Note that this is being PR'd against https://github.com/dimagi/commcare-hq/pull/21530, since there's a lot of overlap and I didn't want conflicts.  Once that's merged, I'll switch this to master.