### PR TITLE
Skip creating pg hashlib extension (on shards)

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -104,7 +104,7 @@ class ShardAccessor(object):
     hash_key = b'\x00' * 16
 
     @staticmethod
-    def hash_doc_ids_sql(doc_ids):
+    def hash_doc_ids_sql_for_testing(doc_ids):
         """Get HASH for each doc_id from PostgreSQL
 
         This is used to ensure the python version is consistent with what's
@@ -123,7 +123,7 @@ class ShardAccessor(object):
             return {row.doc_id: row.hash for row in rows}
 
     @staticmethod
-    def hash_doc_uuid_sql(doc_uuid):
+    def hash_doc_uuid_sql_for_testing(doc_uuid):
         """Get the hash for a UUID from PostgreSQL
 
         This is used to ensure the python version is consistent with what's

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -148,7 +148,7 @@ class ShardAccessorTests(TestCase):
     def test_hash_doc_ids(self):
         N = 1001
         doc_ids = [str(i) for i in range(N)]
-        hashes = ShardAccessor.hash_doc_ids_sql(doc_ids)
+        hashes = ShardAccessor.hash_doc_ids_sql_for_testing(doc_ids)
         self.assertEquals(len(hashes), N)
         self.assertTrue(all(isinstance(hash_, int) for hash_ in hashes.values()))
 
@@ -175,7 +175,7 @@ class ShardAccessorTests(TestCase):
         N = 2048
         doc_ids = [str(i) for i in range(N)]
 
-        sql_hashes = ShardAccessor.hash_doc_ids_sql(doc_ids)
+        sql_hashes = ShardAccessor.hash_doc_ids_sql_for_testing(doc_ids)
 
         csiphash_hashes = ShardAccessor.hash_doc_ids_python(doc_ids)
         self.assertEquals(len(csiphash_hashes), N)
@@ -192,4 +192,4 @@ class ShardAccessorTests(TestCase):
     def test_hash_uuid(self):
         uuid = UUID('403724ef9fe141f2908363918c62c2ff')
         self.assertEqual(ShardAccessor.hash_doc_id_python(uuid), 1415444857)
-        self.assertEqual(ShardAccessor.hash_doc_uuid_sql(uuid), 1415444857)
+        self.assertEqual(ShardAccessor.hash_doc_uuid_sql_for_testing(uuid), 1415444857)

--- a/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
+++ b/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
@@ -17,6 +17,8 @@ class Migration(migrations.Migration):
         # this originally installed the hashlib extension in production as well
         # but commcare-cloud does that where possible already
         # and Amazon RDS doesn't allow it
+        # Todo: Move this to testing harness, doesn't really belong here.
+        # See https://github.com/dimagi/commcare-hq/pull/21627#pullrequestreview-149807976
         HqRunSQL(
             'CREATE EXTENSION IF NOT EXISTS hashlib',
             'DROP EXTENSION hashlib'

--- a/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
+++ b/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations
-from corehq.sql_db.operations import HqRunSQL
+from corehq.sql_db.operations import noop_migration
 
 
 class Migration(migrations.Migration):
@@ -13,8 +13,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        HqRunSQL(
-            'CREATE EXTENSION IF NOT EXISTS hashlib',
-            'DROP EXTENSION hashlib'
-        ),
+        # this originally installed the hashlib extension
+        # but commcare-cloud does that where possible already
+        # and Amazon RDS doesn't allow it
+        noop_migration()
     ]

--- a/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
+++ b/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations
-from corehq.sql_db.operations import noop_migration
+from django.conf import settings
+from corehq.sql_db.operations import HqRunSQL, noop_migration
 
 
 class Migration(migrations.Migration):
@@ -13,8 +14,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # this originally installed the hashlib extension
+        # this originally installed the hashlib extension in production as well
         # but commcare-cloud does that where possible already
         # and Amazon RDS doesn't allow it
-        noop_migration()
+        HqRunSQL(
+            'CREATE EXTENSION IF NOT EXISTS hashlib',
+            'DROP EXTENSION hashlib'
+        )
+        if settings.UNIT_TESTING else noop_migration()
     ]

--- a/corehq/sql_db/management/commands/print_database_shard_data.py
+++ b/corehq/sql_db/management/commands/print_database_shard_data.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
-from corehq.sql_db.shard_data_management import get_database_shard_info
+from corehq.sql_db.shard_data_management import get_database_shard_info_for_testing
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
 
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         for database in get_db_aliases_for_partitioned_query():
             if verbose:
                 print('Checking database {}...'.format(database))
-            shard_info = get_database_shard_info(database)
+            shard_info = get_database_shard_info_for_testing(database)
             if options['csv']:
                 print(shard_info.to_csv())
             else:

--- a/corehq/sql_db/tests/test_shard_management.py
+++ b/corehq/sql_db/tests/test_shard_management.py
@@ -14,8 +14,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.tests.test_dbaccessors_p
     BaseSchedulingPartitionedDBAccessorsTest
 from corehq.sql_db.config import partition_config
 from corehq.sql_db.models import PartitionedModel
-from corehq.sql_db.shard_data_management import get_count_of_unmatched_models_by_shard, \
-    get_count_of_models_by_shard_for_testing
+from corehq.sql_db.shard_data_management import get_count_of_unmatched_models_by_shard
 from corehq.sql_db.tests.utils import DefaultShardingTestConfigMixIn
 
 
@@ -43,6 +42,7 @@ class ShardManagementTest(DefaultShardingTestConfigMixIn, TestCase):
         self.assertEqual(ShardAccessor.get_database_for_doc(self.p2_uuid), self.db2)
 
     def test_uuid_partitioning_correct(self):
+        from corehq.sql_db.shard_data_management import get_count_of_models_by_shard_for_testing
         instance = BaseSchedulingPartitionedDBAccessorsTest.make_alert_schedule_instance(
             self.p1_uuid, domain=self.domain
         )
@@ -65,6 +65,7 @@ class ShardManagementTest(DefaultShardingTestConfigMixIn, TestCase):
         self.assertEqual((0, 1), matches[0])
 
     def test_text_partitioning_correct(self):
+        from corehq.sql_db.shard_data_management import get_count_of_models_by_shard_for_testing
         form = self._make_form_instance(str(self.p2_uuid))
         form.save()
         self.assertEqual(XFormInstanceSQL.objects.using(self.db2).count(), 1)

--- a/corehq/sql_db/tests/test_shard_management.py
+++ b/corehq/sql_db/tests/test_shard_management.py
@@ -15,7 +15,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.tests.test_dbaccessors_p
 from corehq.sql_db.config import partition_config
 from corehq.sql_db.models import PartitionedModel
 from corehq.sql_db.shard_data_management import get_count_of_unmatched_models_by_shard, \
-    get_count_of_models_by_shard
+    get_count_of_models_by_shard_for_testing
 from corehq.sql_db.tests.utils import DefaultShardingTestConfigMixIn
 
 
@@ -50,7 +50,7 @@ class ShardManagementTest(DefaultShardingTestConfigMixIn, TestCase):
         self.assertEqual(AlertScheduleInstance.objects.using(self.db1).count(), 1)
         matches = get_count_of_unmatched_models_by_shard(self.db1, AlertScheduleInstance)
         self.assertEqual(0, len(matches))
-        all_data = get_count_of_models_by_shard(self.db1, AlertScheduleInstance)
+        all_data = get_count_of_models_by_shard_for_testing(self.db1, AlertScheduleInstance)
         self.assertEqual(1, len(all_data))
         self.assertEqual((0, 1), all_data[0])
 
@@ -70,7 +70,7 @@ class ShardManagementTest(DefaultShardingTestConfigMixIn, TestCase):
         self.assertEqual(XFormInstanceSQL.objects.using(self.db2).count(), 1)
         matches = get_count_of_unmatched_models_by_shard(self.db2, XFormInstanceSQL)
         self.assertEqual(0, len(matches))
-        all_data = get_count_of_models_by_shard(self.db2, XFormInstanceSQL)
+        all_data = get_count_of_models_by_shard_for_testing(self.db2, XFormInstanceSQL)
         self.assertEqual(1, len(all_data))
         self.assertEqual((2, 1), all_data[0])
 


### PR DESCRIPTION
- commcare-cloud already does it where possible
- Amazon RDS doesn't allow it