### PR TITLE
ReportExport and VectorLink reports

### DIFF
--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -41,21 +41,15 @@ class ReportExport(object):
     """Export all the rows of a UCR report
     """
 
-    def __init__(self, domain, title, report_config, lang, filter_values):
-        self.domain = domain
-        self.title = title
-        self.report_config = report_config
-        self.lang = lang
-        self.filter_values = filter_values
+    def __init__(self, report):
+        self.report = report
 
     @property
     @memoized
     def data_source(self):
-        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
-        data_source = ConfigurableReportDataSource.from_spec(self.report_config, include_prefilters=True)
-        data_source.lang = self.lang
-        data_source.set_filter_values(self.filter_values)
-        data_source.set_order_by([(o['field'], o['order']) for o in self.report_config.sort_expression])
+        data_source = self.report.data_source
+        data_source.set_filter_values(self.report.filter_values)
+        data_source.set_order_by([(o['field'], o['order']) for o in self.report.spec.sort_expression])
         return data_source
 
     def create_export(self, file_path, format_):
@@ -79,7 +73,7 @@ class ReportExport(object):
             self.data_source.config
         )
         column_ids = []
-        for column in self.report_config.report_columns:
+        for column in self.report.spec.report_columns:
             if column.visible:
                 column_ids.extend(column_id_to_expanded_column_ids.get(column.column_id, [column.column_id]))
 
@@ -88,19 +82,19 @@ class ReportExport(object):
 
         export_table = [
             [
-                self.title,
+                self.report.title,
                 [headers] + rows + total_rows
             ]
         ]
 
-        if INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS.enabled(self.domain):
-            time_zone = get_timezone_for_domain(self.domain)
+        if INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS.enabled(self.report.domain):
+            time_zone = get_timezone_for_domain(self.report.domain)
             export_table.append([
                 'metadata',
                 [
-                    [_('Report Name'), self.title],
+                    [_('Report Name'), self.report.title],
                     [_('Generated On'), datetime.now(time_zone).strftime('%Y-%m-%d %H:%M')],
-                ] + list(self._get_filter_values())
+                ] + list(self.report._get_filter_values())
             ])
 
         return export_table

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -513,7 +513,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def report_export(self):
-        return ReportExport(self.domain, self.title, self.spec, self.lang, self.filter_values)
+        return ReportExport(self)
 
     @property
     def export_table(self):

--- a/custom/abt/reports/views.py
+++ b/custom/abt/reports/views.py
@@ -4,6 +4,7 @@ import io
 import json
 
 from django.http import HttpResponse
+from memoized import memoized
 
 import openpyxl
 from openpyxl.formatting.rule import CellIsRule
@@ -185,17 +186,11 @@ class CombinedDataSource(object):
         self.original_data_source = original_data_source
         self.filters_data = filter_values
 
-    def get_data(self, start, limit):
+    def get_data(self, start=None, limit=None):
         original_data = self.original_data_source.get_data(start, limit)
         unique_sops = UniqueSOPSumDataSource(self.original_data_source.domain, self.filters_data).get_data()
         group_columns = tuple(self.original_data_source.group_by[:-1])
         unique = {}
-
-        def get_loc_names(row, loc_levels):
-            locs = []
-            for loc in loc_levels:
-                locs.append(row[loc])
-            return tuple(locs)
 
         for row in unique_sops:
             loc_names = tuple(row[x] for x in group_columns)
@@ -244,10 +239,19 @@ class CombinedDataSource(object):
     def get_total_row(self):
         return self.original_data_source.get_total_row()
 
+    @property
+    def top_level_columns(self):
+        return self.original_data_source.top_level_columns
+
+    @property
+    def config(self):
+        return self.original_data_source.config
+
 
 class FormattedSprayProgressReport(CustomConfigurableReport):
 
     @property
+    @memoized
     def data_source(self):
         original_data_source = super(FormattedSprayProgressReport, self).data_source
         return CombinedDataSource(original_data_source, self.filter_values)


### PR DESCRIPTION
Hi,

I changed the ```ReportExport``` class to use the data from the report which should be exported. We had a problem with the VectorLink report that UI reports work correctly but emailed reports not. This occurred because in ```ReportExport``` class we getting once again data source configuration from the database, I think we should use this from Report. In VectorLink reports, we using ```custom_configurable_report``` where in the class we override ```datasource``` function

Please let me know if you have any questions.

Regards,
Łukasz