### PR TITLE
Temporarily hide enterprise settings from menu

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1412,10 +1412,10 @@ class EnterpriseSettingsTab(UITab):
                 'title': _('Enterprise Dashboard'),
                 'url': reverse('enterprise_dashboard', args=[self.domain]),
             },
-            {
-                'title': _('Enterprise Settings'),
-                'url': reverse('enterprise_settings', args=[self.domain]),
-            },
+            #{
+            #    'title': _('Enterprise Settings'),
+            #    'url': reverse('enterprise_settings', args=[self.domain]),
+            #},
         ]))
         return items
 


### PR DESCRIPTION
Keep CRS from potentially using this while we make some UI changes to it.

@gcapalbo @jmtroth0 