### PR TITLE
Exchange integration for new reminders framework

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -265,7 +265,7 @@ class AutomaticUpdateRule(models.Model):
         )
 
         if allow_custom_references:
-            allowed_recipient_types += (RECIPIENT_TYPE_CUSTOM, )
+            allowed_recipient_types += (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM, )
 
         for recipient_type, recipient_id in action_definition.recipients:
             if recipient_type not in allowed_recipient_types:
@@ -460,7 +460,7 @@ class AutomaticUpdateRule(models.Model):
                     event_and_content_objects,
                     total_iterations=schedule.total_iterations,
                     start_offset=schedule.start_offset,
-                    start_day_of_week=start_offset.start_day_of_week,
+                    start_day_of_week=schedule.start_day_of_week,
                     extra_options=extra_scheduling_options,
                     repeat_every=schedule.repeat_every,
                 )

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -213,6 +213,21 @@ class AutomaticUpdateRule(models.Model):
 
         return False
 
+    @classmethod
+    def get_referenced_form_unique_ids_from_sms_surveys(cls, domain):
+        """
+        Examines all of the scheduling rules in the given domain and returns
+        all form_unique_ids that are referenced from SMS Surveys.
+        """
+        result = []
+        for rule in cls.by_domain(domain, cls.WORKFLOW_SCHEDULING, active_only=False):
+            schedule = rule.get_messaging_rule_schedule()
+            for event in schedule.memoized_events:
+                if isinstance(event.content, SMSSurveyContent):
+                    result.append(event.content.form_unique_id)
+
+        return result
+
     def conditional_alert_can_be_copied(self, allow_sms_surveys=False, allow_custom_references=False):
         """
         Only scheduling rules (conditional alerts) are copied to the exchange now,

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -421,6 +421,9 @@ class AutomaticUpdateRule(models.Model):
                     repeat_every=schedule.repeat_every,
                 )
             elif schedule.ui_type == Schedule.UI_TYPE_WEEKLY:
+                if (schedule.repeat_every % 7) != 0 or schedule.repeat_every < 7:
+                    raise ValueError("Invalid schedule.repeat_every for a weekly schedule")
+
                 return TimedSchedule.create_simple_weekly_schedule(
                     to_domain,
                     model_event,
@@ -429,9 +432,12 @@ class AutomaticUpdateRule(models.Model):
                     schedule.start_day_of_week,
                     total_iterations=schedule.total_iterations,
                     extra_options=extra_scheduling_options,
-                    repeat_every=schedule.repeat_every,
+                    repeat_every=schedule.repeat_every // 7,
                 )
             elif schedule.ui_type == Schedule.UI_TYPE_MONTHLY:
+                if schedule.repeat_every >= 0:
+                    raise ValueError("Invalid schedule.repeat_every for a monthly schedule")
+
                 return TimedSchedule.create_simple_monthly_schedule(
                     to_domain,
                     model_event,
@@ -439,7 +445,7 @@ class AutomaticUpdateRule(models.Model):
                     model_content,
                     total_iterations=schedule.total_iterations,
                     extra_options=extra_scheduling_options,
-                    repeat_every=schedule.repeat_every,
+                    repeat_every=schedule.repeat_every * -1,
                 )
         elif schedule.ui_type in (
             Schedule.UI_TYPE_CUSTOM_DAILY,

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -226,7 +226,7 @@ class AutomaticUpdateRule(models.Model):
                 if isinstance(event.content, SMSSurveyContent):
                     result.append(event.content.form_unique_id)
 
-        return result
+        return list(set(result))
 
     def conditional_alert_can_be_copied(self, allow_sms_surveys=False, allow_custom_references=False):
         """

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -11,7 +11,9 @@ from six.moves.urllib.parse import urlparse, parse_qs
 from captcha.fields import CaptchaField
 
 from corehq.apps.callcenter.views import CallCenterOwnerOptionsView
+from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.users.models import CouchUser
+from corehq.messaging.util import project_is_on_new_reminders
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import StrictButton
@@ -246,8 +248,7 @@ class SnapshotSettingsForm(forms.Form):
         help_text=ugettext_noop("A brief description of your project (max. 200 characters)"))
     share_multimedia = BooleanField(label=ugettext_noop("Share all multimedia?"), required=False,
         help_text=ugettext_noop("This will allow any user to see and use all multimedia in this project"))
-    share_reminders = BooleanField(label=ugettext_noop("Share Reminders?"), required=False,
-        help_text=ugettext_noop("This will publish reminders along with this project"))
+    share_reminders = BooleanField(label=ugettext_noop("Share Conditional Alerts?"), required=False)
     image = forms.ImageField(label=ugettext_noop("Exchange image"), required=False,
         help_text=ugettext_noop("An optional image to show other users your logo or what your app looks like"))
     old_image = forms.BooleanField(required=False)
@@ -317,6 +318,25 @@ class SnapshotSettingsForm(forms.Form):
         self.fields['cda_confirmed'].help_text = \
             render_to_string('domain/partials/cda_modal.html')
 
+        self.fields['share_reminders'].help_text = render_to_string(
+            'domain/partials/share_reminders_help.html',
+            context={
+                'alerts_that_cannot_be_copied': self.get_conditional_alerts_that_cannot_be_copied(),
+            }
+        )
+
+    def get_conditional_alerts_that_cannot_be_copied(self):
+        result = []
+        for rule in AutomaticUpdateRule.by_domain(
+            self.dom.name,
+            AutomaticUpdateRule.WORKFLOW_SCHEDULING,
+            active_only=False,
+        ):
+            if not rule.conditional_alert_can_be_copied(allow_sms_surveys=True):
+                result.append(rule.name)
+
+        return result
+
     def clean_cda_confirmed(self):
         data_cda = self.cleaned_data['cda_confirmed']
         data_publish = self.data.get('publish_on_submit', "no") == "yes"
@@ -374,7 +394,11 @@ class SnapshotSettingsForm(forms.Form):
 
         sr = cleaned_data["share_reminders"]
         if sr:  # check that the forms referenced by the events in each reminders exist in the project
-            referenced_forms = CaseReminderHandler.get_referenced_forms(domain=self.dom.name)
+            if project_is_on_new_reminders(self.dom):
+                referenced_forms = AutomaticUpdateRule.get_referenced_form_unique_ids_from_sms_surveys(
+                    self.dom.name)
+            else:
+                referenced_forms = CaseReminderHandler.get_referenced_forms(domain=self.dom.name)
             if referenced_forms:
                 apps = [Application.get(app_id) for app_id in app_ids]
                 app_forms = [f.unique_id for forms in [app.get_forms() for app in apps] for f in forms]

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -764,6 +764,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 copy_data_items(doc_id, component._id)
 
             def convert_form_unique_id_function(form_unique_id):
+                from corehq.apps.app_manager.models import FormBase
                 form = FormBase.get_form(form_unique_id)
                 form_app = form.get_app()
                 m_index, f_index = form_app.get_form_location(form.unique_id)
@@ -801,7 +802,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 """
                 Change the form_unique_id to the proper form for each event in a newly copied CaseReminderHandler
                 """
-                from corehq.apps.app_manager.models import FormBase
                 for event in handler.events:
                     if not event.form_unique_id:
                         continue

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -17,6 +17,7 @@ from corehq.apps.tzmigration.api import set_tz_migration_complete
 from corehq.blobs.mixin import BlobMixin
 from corehq.dbaccessors.couchapps.all_docs import \
     get_all_doc_ids_for_domain_grouped_by_db
+from corehq.messaging.util import project_is_on_new_reminders
 from corehq.util.soft_assert import soft_assert
 from couchforms.analytics import domain_has_submission_in_last_30_days
 from dimagi.ext.couchdbkit import (
@@ -676,6 +677,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                   copy_by_id=None, share_reminders=True,
                   share_user_roles=True):
         from corehq.apps.app_manager.dbaccessors import get_app
+        from corehq.apps.data_interfaces.models import AutomaticUpdateRule
         from corehq.apps.reminders.models import CaseReminderHandler
         from corehq.apps.fixtures.models import FixtureDataItem
         from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
@@ -687,6 +689,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         new_id = db.copy_doc(self.get_id)['id']
         if new_domain_name is None:
             new_domain_name = new_id
+
+        uses_new_reminders = project_is_on_new_reminders(self)
 
         with CriticalSection(['request_domain_name_{}'.format(new_domain_name)]):
             new_domain_name = Domain.generate_name(new_domain_name)
@@ -759,10 +763,28 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                     'FixtureDataType', doc_id, new_domain_name, user=user)
                 copy_data_items(doc_id, component._id)
 
+            def convert_form_unique_id_function(form_unique_id):
+                form = FormBase.get_form(form_unique_id)
+                form_app = form.get_app()
+                m_index, f_index = form_app.get_form_location(form.unique_id)
+                form_copy = new_app_components[form_app._id].get_module(m_index).get_form(f_index)
+                return form_copy.unique_id
+
             if share_reminders:
-                for doc_id in get_doc_ids_in_domain_by_class(self.name, CaseReminderHandler):
-                    self.copy_component(
-                        'CaseReminderHandler', doc_id, new_domain_name, user=user)
+                if uses_new_reminders:
+                    for rule in AutomaticUpdateRule.by_domain(
+                        self.name,
+                        AutomaticUpdateRule.WORKFLOW_SCHEDULING,
+                        active_only=False,
+                    ):
+                        rule.copy_conditional_alert(
+                            new_domain_name,
+                            convert_form_unique_id_function=convert_form_unique_id_function,
+                        )
+                else:
+                    for doc_id in get_doc_ids_in_domain_by_class(self.name, CaseReminderHandler):
+                        self.copy_component(
+                            'CaseReminderHandler', doc_id, new_domain_name, user=user)
             if share_user_roles:
                 for doc_id in get_doc_ids_in_domain_by_class(self.name, UserRole):
                     self.copy_component('UserRole', doc_id, new_domain_name, user=user)
@@ -772,27 +794,26 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 user.add_domain_membership(new_domain_name, is_admin=True)
             apply_update(user, add_dom_to_user)
 
-        def update_events(handler):
-            """
-            Change the form_unique_id to the proper form for each event in a newly copied CaseReminderHandler
-            """
-            from corehq.apps.app_manager.models import FormBase
-            for event in handler.events:
-                if not event.form_unique_id:
-                    continue
-                form = FormBase.get_form(event.form_unique_id)
-                form_app = form.get_app()
-                m_index, f_index = form_app.get_form_location(form.unique_id)
-                form_copy = new_app_components[form_app._id].get_module(m_index).get_form(f_index)
-                event.form_unique_id = form_copy.unique_id
+        if not uses_new_reminders:
+            # When uses_new_reminders is True, all of this is already taken care of
+            # in the copy process
+            def update_events(handler):
+                """
+                Change the form_unique_id to the proper form for each event in a newly copied CaseReminderHandler
+                """
+                from corehq.apps.app_manager.models import FormBase
+                for event in handler.events:
+                    if not event.form_unique_id:
+                        continue
+                    event.form_unique_id = convert_form_unique_id_function(event.form_unique_id)
 
-        def update_for_copy(handler):
-            handler.active = False
-            update_events(handler)
+            def update_for_copy(handler):
+                handler.active = False
+                update_events(handler)
 
-        if share_reminders:
-            for handler in CaseReminderHandler.get_handlers(new_domain_name):
-                apply_update(handler, update_for_copy)
+            if share_reminders:
+                for handler in CaseReminderHandler.get_handlers(new_domain_name):
+                    apply_update(handler, update_for_copy)
 
         return new_domain
 

--- a/corehq/apps/domain/templates/domain/partials/share_reminders_help.html
+++ b/corehq/apps/domain/templates/domain/partials/share_reminders_help.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+
+{% blocktrans %}
+If selected, all conditional alerts in this project that are able to be published
+will be published.
+{% endblocktrans %}
+
+{% if alerts_that_cannot_be_copied %}
+<p>
+    <i class="fa fa-info-circle"></i>
+    {% blocktrans %}
+    The following conditional alerts reference project-specific recipients or custom
+    features that cannot be published:
+    {% endblocktrans %}
+    <ul>
+    {% for name in alerts_that_cannot_be_copied %}
+        <li>{{ name }}</li>
+    {% endfor %}
+    </ul>
+</p>
+{% else %}
+<p>
+    <i class="fa fa-info-circle"></i>
+    {% blocktrans %}
+    All conditional alerts in this project can be published.
+    {% endblocktrans %}
+</p>
+{% endif %}

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1184,8 +1184,7 @@ class ScheduleForm(Form):
         initial['send_frequency'] = self.SEND_DAILY
 
     def add_initial_for_weekly_schedule(self, initial):
-        weekdays = [(self.initial_schedule.start_day_of_week + e.day) % 7
-                    for e in self.initial_schedule.memoized_events]
+        weekdays = self.initial_schedule.get_weekdays()
         initial['send_frequency'] = self.SEND_WEEKLY
         initial['weekdays'] = [six.text_type(day) for day in weekdays]
 

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -279,6 +279,16 @@ class Event(ContentForeignKeyMixin):
     class Meta(object):
         abstract = True
 
+    def create_copy(self):
+        """
+        The point of this method is to create a copy of this object with no
+        primary keys set or references to other objects. It's used in the
+        process of copying schedules to a different project in the copy
+        conditional alert workflow, so there should also not be any
+        unresolved project-specific references in the returned copy.
+        """
+        raise NotImplementedError()
+
 
 class Content(models.Model):
     # If this this content is being invoked in the context of a case,
@@ -291,6 +301,16 @@ class Content(models.Model):
 
     class Meta(object):
         abstract = True
+
+    def create_copy(self):
+        """
+        The point of this method is to create a copy of this object with no
+        primary keys set or references to other objects. It's used in the
+        process of copying schedules to a different project in the copy
+        conditional alert workflow, so there should also not be any
+        unresolved project-specific references in the returned copy.
+        """
+        raise NotImplementedError()
 
     def set_context(self, case=None, schedule_instance=None):
         if case:

--- a/corehq/messaging/scheduling/models/alert_schedule.py
+++ b/corehq/messaging/scheduling/models/alert_schedule.py
@@ -104,6 +104,14 @@ class AlertEvent(Event):
     schedule = models.ForeignKey('scheduling.AlertSchedule', on_delete=models.CASCADE)
     minutes_to_wait = models.IntegerField()
 
+    def create_copy(self):
+        """
+        See Event.create_copy() for docstring.
+        """
+        return AlertEvent(
+            minutes_to_wait=self.minutes_to_wait,
+        )
+
 
 class ImmediateBroadcast(Broadcast):
     schedule = models.ForeignKey('scheduling.AlertSchedule', on_delete=models.CASCADE)

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 import jsonfield as old_jsonfield
+from copy import deepcopy
 from corehq.apps.accounting.utils import domain_is_on_trial
 from corehq.apps.app_manager.exceptions import XFormIdNotUnique
 from corehq.apps.app_manager.models import Form
@@ -32,6 +33,14 @@ from corehq.apps.formplayer_api.smsforms.api import TouchformsError
 
 class SMSContent(Content):
     message = old_jsonfield.JSONField(default=dict)
+
+    def create_copy(self):
+        """
+        See Content.create_copy() for docstring
+        """
+        return SMSContent(
+            message=deepcopy(self.message),
+        )
 
     def render_message(self, message, recipient, logged_subevent):
         if not message:
@@ -73,6 +82,15 @@ class EmailContent(Content):
     message = old_jsonfield.JSONField(default=dict)
 
     TRIAL_MAX_EMAILS = 50
+
+    def create_copy(self):
+        """
+        See Content.create_copy() for docstring
+        """
+        return EmailContent(
+            subject=deepcopy(self.subject),
+            message=deepcopy(self.message),
+        )
 
     def render_subject_and_message(self, subject, message, recipient):
         renderer = self.get_template_renderer(recipient)
@@ -134,6 +152,18 @@ class SMSSurveyContent(Content):
     reminder_intervals = JSONField(default=list)
     submit_partially_completed_forms = models.BooleanField(default=False)
     include_case_updates_in_partial_submissions = models.BooleanField(default=False)
+
+    def create_copy(self):
+        """
+        See Content.create_copy() for docstring
+        """
+        return SMSSurveyContent(
+            form_unique_id=None,
+            expire_after=self.expire_after,
+            reminder_intervals=deepcopy(self.reminder_intervals),
+            submit_partially_completed_forms=self.submit_partially_completed_forms,
+            include_case_updates_in_partial_submissions=self.include_case_updates_in_partial_submissions,
+        )
 
     @memoized
     def get_memoized_app_module_form(self, domain):

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -407,6 +407,14 @@ class CustomContent(Content):
     # messsages to send to the recipient.
     custom_content_id = models.CharField(max_length=126)
 
+    def create_copy(self):
+        """
+        See Content.create_copy() for docstring
+        """
+        return CustomContent(
+            custom_content_id=self.custom_content_id,
+        )
+
     def get_list_of_messages(self, recipient):
         if not self.schedule_instance:
             raise ValueError(


### PR DESCRIPTION
Adds some utilities for copying conditional alerts, and then uses them to replicate the same behavior with publishing to the exchange as existed in the old reminders framework.

Best reviewed by commit and with `?w=1`

@orangejenny @jmtroth0 