### PR TITLE
What's old is new again

### DIFF
--- a/custom/icds_reports/ucr/data_sources/dashboard/birth_preparedness_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/birth_preparedness_forms.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-dashboard_birth_preparedness_forms",

--- a/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-child_tasks_cases",

--- a/custom/icds_reports/ucr/data_sources/dashboard/commcare_user_cases.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/commcare_user_cases.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-commcare_user_cases",

--- a/custom/icds_reports/ucr/data_sources/dashboard/complementary_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/complementary_feeding_forms.json
@@ -6,7 +6,7 @@
   "server_environment": [
     "softlayer",
     "icds-new",
-    "localdev"
+    "icds"
   ],
   "config": {
     "table_id": "static-complementary_feeding_forms",

--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "dashboard_child_health_daily_feeding_forms",

--- a/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
@@ -6,7 +6,7 @@
   "server_environment": [
     "softlayer",
     "icds-new",
-    "localdev"
+    "icds"
   ],
   "config": {
     "table_id": "static-dashboard_growth_monitoring_forms",

--- a/custom/icds_reports/ucr/data_sources/dashboard/delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/delivery_forms.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-dashboard_delivery_forms",

--- a/custom/icds_reports/ucr/data_sources/dashboard/postnatal_care_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/postnatal_care_forms.json
@@ -6,7 +6,7 @@
   "server_environment": [
     "softlayer",
     "icds-new",
-    "localdev"
+    "icds"
   ],
   "config": {
     "table_id": "static-postnatal_care_forms",

--- a/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-pregnant-tasks_cases",

--- a/custom/icds_reports/ucr/data_sources/dashboard/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/thr_forms.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-dashboard_thr_forms",

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-infrastructure_form",

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form_v2.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form_v2.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-infrastructure_form_v2",

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "config": {
     "table_id": "static-thr_forms_v2",

--- a/custom/icds_reports/ucr/reports/custom_mpr_5_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/custom_mpr_5_child_health_cases_v2.json
@@ -6,7 +6,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "report_id": "static-custom_mpr_5_child_health_cases_v2",
   "data_source_table": "static-child_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/custom_mpr_6ac_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/custom_mpr_6ac_child_health_cases_v2.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "report_id": "static-custom_mpr_6ac_child_health_cases_v2",
   "data_source_table": "static-child_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/custom_mpr_6b_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/custom_mpr_6b_child_health_cases_v2.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "report_id": "static-custom_sql_mpr_6b_child_health_cases_v2",
   "data_source_table": "static-child_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/custom_sql_mpr_2a_person_cases.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "report_id": "static-custom_sql_mpr_2a_person_cases",
   "data_source_table": "static-person_cases_v2",

--- a/custom/icds_reports/ucr/reports/mobile_mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/mobile_mpr_2a_deaths.json
@@ -5,7 +5,8 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds-new",
+    "icds"
   ],
   "report_id": "static-mobile_mpr_2a_deaths",
   "data_source_table": "static-person_cases_v2",


### PR DESCRIPTION
@dimagi/scale-team This should get hotfixed to the new cluster before any performance testing since it includes some of the newer UCR data sources. The old ones still had the old cluster name icds in it.