### PR TITLE
Revert "Adapt blob downloads to new blob metadata API "

### DIFF
--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -20,7 +20,7 @@ from corehq.apps.es import DomainES
 
 from dimagi.utils.django.email import send_HTML_email
 
-from soil.util import expose_zipped_blob_download
+from soil.util import ExposeBlobDownload
 from couchexport.models import Format
 from io import open
 
@@ -168,12 +168,7 @@ def send_repeater_payloads(repeater_id, payload_ids, email_id):
 
     headers = populate_payloads(headers)
     temp_file_path = create_result_file()
-    download_url = expose_zipped_blob_download(
-        temp_file_path,
-        result_file_name,
-        Format.CSV,
-        repeater.domain,
-    )
+    download_url = ExposeBlobDownload().get_link(temp_file_path, result_file_name, Format.CSV)
     email_result(download_url)
 
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -11,7 +11,7 @@ from soil.progress import get_task_status
 from corehq.apps.data_dictionary.util import add_properties_to_data_dictionary
 from corehq.apps.reports.models import HQGroupExportConfiguration
 from corehq.apps.users.models import CouchUser
-from corehq.blobs import CODES, get_blob_db
+from corehq.blobs import get_blob_db
 from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
 from corehq.util.datadog.gauges import datadog_track_errors
 from corehq.util.decorators import serial_task
@@ -41,7 +41,6 @@ def populate_export_download_task(export_instances, filters, download_id, filena
     """
     :param expiry:  Time period for the export to be available for download in minutes
     """
-    domain = export_instances[0].domain
     with TransientTempfile() as temp_path, datadog_track_errors('populate_export_download_task'):
         export_file = get_export_file(
             export_instances,
@@ -57,14 +56,7 @@ def populate_export_download_task(export_instances, filters, download_id, filena
 
         with export_file as file_:
             db = get_blob_db()
-            db.put(
-                file_,
-                domain=domain,
-                parent_id=domain,
-                type_code=CODES.data_export,
-                key=download_id,
-                timeout=expiry,
-            )
+            db.put(file_, download_id, timeout=expiry)
 
             expose_blob_download(
                 download_id,
@@ -74,6 +66,7 @@ def populate_export_download_task(export_instances, filters, download_id, filena
                 download_id=download_id,
             )
 
+    domain = export_instances[0].domain
     email_requests = EmailExportWhenDoneRequest.objects.filter(
         domain=domain,
         download_id=download_id
@@ -97,8 +90,7 @@ def _start_export_task(export_instance_id, last_access_cutoff):
 
 
 def _get_saved_export_download_data(export_instance_id):
-    prefix = DownloadBase.new_id_prefix
-    download_id = '{}rebuild_export_tracker.{}'.format(prefix, export_instance_id)
+    download_id = 'rebuild_export_tracker.{}'.format(export_instance_id)
     download_data = DownloadBase.get(download_id)
     if download_data is None:
         download_data = DownloadBase(download_id=download_id)

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -13,7 +13,7 @@ from corehq.apps.locations.const import LOCATION_TYPE_SHEET_HEADERS, \
     LOCATION_SHEET_HEADERS_BASE, LOCATION_SHEET_HEADERS_OPTIONAL
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.products.models import Product
-from corehq.blobs import CODES, get_blob_db
+from corehq.blobs import get_blob_db
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.util.files import safe_filename_header
 from couchexport.models import Format
@@ -298,14 +298,7 @@ def dump_locations(domain, download_id, include_consumption, headers_only, task=
     with open(path, 'rb') as file_:
         db = get_blob_db()
         expiry_mins = 60
-        db.put(
-            file_,
-            domain=domain,
-            parent_id=domain,
-            type_code=CODES.tempfile,
-            key=download_id,
-            timeout=expiry_mins,
-        )
+        db.put(file_, download_id, timeout=expiry_mins)
 
         file_format = Format.from_format(Excel2007ExportWriter.format)
         expose_blob_download(

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -16,7 +16,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 
 from django_transfer import TransferHttpResponse
 from soil.progress import get_task_progress, get_multiple_task_progress
-from corehq.blobs import get_blob_db
+from corehq.blobs import DEFAULT_BUCKET, get_blob_db
 import six
 from io import open
 
@@ -38,30 +38,16 @@ class DownloadBase(object):
 
     has_file = False
 
-    # `new_id_prefix` adopted when implementing new blob metadata
-    # format. This needs to round-trip to the client and back so we can
-    # detect legacy download ids, which should never start with
-    # `new_id_prefix`. Previously blobs were saved in the blob db using
-    # `self.identifier` as the key, which could result in collisions.
-    # Can be removed after all legacy blob downloads have expired.
-    new_id_prefix = "dl-"  # not a valid uuid4 prefix
-
     def __init__(self, mimetype="text/plain",
                  content_disposition='attachment; filename="download.txt"',
                  transfer_encoding=None, extras=None, download_id=None,
                  cache_backend=SOIL_DEFAULT_CACHE, content_type=None,
                  suffix=None, message=None):
-
-        if download_id is None:
-            download_id = self.new_id_prefix + uuid.uuid4().hex
-        else:
-            assert download_id.startswith(self.new_id_prefix), download_id
-
         self.content_type = content_type if content_type else mimetype
         self.content_disposition = self.clean_content_disposition(content_disposition)
         self.transfer_encoding = transfer_encoding
         self.extras = extras or {}
-        self.download_id = download_id
+        self.download_id = download_id or uuid.uuid4().hex
         self.cache_backend = cache_backend
         # legacy default
         self.suffix = suffix or ''
@@ -270,8 +256,12 @@ class FileDownload(DownloadBase):
         return response
 
     @classmethod
-    def create(cls, payload, **kwargs):
-        raise NotImplementedError
+    def create(cls, path, **kwargs):
+        """
+        Create a FileDownload object from a payload, plus any
+        additional arguments to pass through to the constructor.
+        """
+        return cls(filename=path, **kwargs)
 
 
 class BlobDownload(DownloadBase):
@@ -282,9 +272,9 @@ class BlobDownload(DownloadBase):
 
     def __init__(self, identifier, mimetype="text/plain",
                  content_disposition='attachment; filename="download.txt"',
-                 transfer_encoding=None, extras=None, download_id=None,
-                 cache_backend=SOIL_DEFAULT_CACHE,
-                 content_type=None):
+                 transfer_encoding=None, extras=None, download_id=None, cache_backend=SOIL_DEFAULT_CACHE,
+                 content_type=None, bucket=DEFAULT_BUCKET):
+
         super(BlobDownload, self).__init__(
             mimetype=content_type if content_type else mimetype,
             content_disposition=content_disposition,
@@ -294,6 +284,7 @@ class BlobDownload(DownloadBase):
             cache_backend=cache_backend
         )
         self.identifier = identifier
+        self.bucket = bucket
 
     def get_filename(self):
         return self.identifier
@@ -302,14 +293,9 @@ class BlobDownload(DownloadBase):
         raise NotImplementedError
 
     def toHttpResponse(self):
-        if self.download_id.startswith(self.new_id_prefix):
-            blob_key = self.download_id
-        else:
-            # legacy key; remove after all legacy blob downloads have expired
-            blob_key = "_default/" + self.identifier
         blob_db = get_blob_db()
-        file_obj = blob_db.get(key=blob_key)
-        blob_size = blob_db.size(key=blob_key)
+        file_obj = blob_db.get(self.identifier, self.bucket)
+        blob_size = blob_db.size(self.identifier, self.bucket)
 
         response = StreamingHttpResponse(
             FileWrapper(file_obj, CHUNK_SIZE),
@@ -323,5 +309,9 @@ class BlobDownload(DownloadBase):
         return response
 
     @classmethod
-    def create(cls, payload, **kwargs):
-        raise NotImplementedError
+    def create(cls, identifier, **kwargs):
+        """
+        Create a BlobDownload object from a payload, plus any
+        additional arguments to pass through to the constructor.
+        """
+        return cls(identifier=identifier, **kwargs)

--- a/corehq/ex-submodules/soil/tests/test_download_base.py
+++ b/corehq/ex-submodules/soil/tests/test_download_base.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from io import BytesIO
-from uuid import uuid4
-from django.test import TestCase
+from io import StringIO
+from django.test import SimpleTestCase
 
 from soil import BlobDownload
 from soil.util import expose_blob_download
 
-from corehq.blobs.tests.util import new_meta, TemporaryFilesystemBlobDB
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
 
 
-class TestBlobDownload(TestCase):
+class TestBlobDownload(SimpleTestCase):
     identifier = 'identifier'
 
     @classmethod
@@ -24,26 +23,21 @@ class TestBlobDownload(TestCase):
         super(TestBlobDownload, cls).tearDownClass()
 
     def test_expose_blob_download(self):
-        ref = expose_blob_download(
+        content_disposition = 'text/xml'
+        download_id = 'abc123'
+
+        self.db.put(StringIO('content'), self.identifier)
+
+        expose_blob_download(
             self.identifier,
             expiry=60,
-            content_disposition='text/xml',
+            content_disposition=content_disposition,
+            download_id=download_id
         )
-        self.db.put(BytesIO(b'content'), meta=new_meta(key=ref.download_id))
 
-        response = BlobDownload.get(ref.download_id).toHttpResponse()
+        download = BlobDownload.get(download_id)
+
+        self.assertIsNotNone(download)
+
+        response = download.toHttpResponse()
         self.assertEqual(next(response.streaming_content), 'content')
-
-    def test_expose_blob_download_with_legacy_download_id(self):
-        self.db.put(BytesIO(b'legacy-blob'), self.identifier)
-
-        ref = BlobDownload(
-            self.identifier,
-            mimetype='text/plain',
-            content_disposition='text/xml',
-        )
-        ref.download_id = uuid4().hex  # old download id format
-        ref.save(60)
-
-        response = BlobDownload.get(ref.download_id).toHttpResponse()
-        self.assertEqual(next(response.streaming_content), 'legacy-blob')

--- a/corehq/ex-submodules/soil/util.py
+++ b/corehq/ex-submodules/soil/util.py
@@ -20,7 +20,7 @@ from soil.heartbeat import is_alive, heartbeat_enabled
 from soil.progress import get_task_status
 
 from corehq.util.view_utils import absolute_reverse
-from corehq.blobs import CODES, get_blob_db
+from corehq.blobs import get_blob_db
 from corehq.util.files import safe_filename_header
 
 from zipfile import ZipFile
@@ -45,7 +45,7 @@ def expose_file_download(path, expiry, **kwargs):
     """
     Expose a file download object that potentially uses the external drive
     """
-    ref = FileDownload(path, **kwargs)
+    ref = FileDownload.create(path, **kwargs)
     ref.save(expiry)
     return ref
 
@@ -59,8 +59,7 @@ def expose_blob_download(
     """
     Expose a blob object for download
     """
-    # TODO add file parameter and refactor blob_db.put(...) into this method
-    ref = BlobDownload(
+    ref = BlobDownload.create(
         identifier,
         mimetype=mimetype,
         content_disposition=content_disposition,
@@ -153,46 +152,61 @@ def expose_download(use_transfer, file_path, filename, download_id, file_type):
         )
 
 
-def expose_zipped_blob_download(data_path, filename, format, domain):
-    """Expose zipped file content as a blob download
-
-    :param data_path: Path to data file. Will be deleted.
-    :param filename: File name.
-    :param format: `couchexport.models.Format` constant.
-    :param domain: Domain name.
-    :returns: A link to download the file.
+class ExposeBlobDownload:
     """
-    try:
-        _, zip_temp_path = tempfile.mkstemp(".zip")
-        with ZipFile(zip_temp_path, 'w') as zip_file_:
-            zip_file_.write(data_path, filename)
-    finally:
-        os.remove(data_path)
+        Takes path to a file,
+        move its content to a ZipFile unless asked not to
+        stores it's contents in BlobDb
+        clean the input file after storing content to blobdb unless asked not to
+        returns a link to download the file
+    """
+    def __init__(self, zip_file=True, cleanup=True):
+        self.zip_file = zip_file
+        self.cleanup = cleanup
 
-    try:
+    @staticmethod
+    def save_dump_to_blob(data_file_path, data_file_name, result_file_format):
         expiry_mins = 60 * 24
-        file_format = Format.from_format(format)
-        file_name_header = safe_filename_header(filename, file_format.extension)
-        ref = expose_blob_download(
-            filename,
+        with open(data_file_path, 'rb') as file_:
+            blob_db = get_blob_db()
+            blob_db.put(
+                file_,
+                data_file_name,
+                timeout=expiry_mins)
+        file_format = Format.from_format(result_file_format)
+        file_name_header = safe_filename_header(
+            data_file_name, file_format.extension)
+        blob_dl_object = expose_blob_download(
+            data_file_name,
             expiry=expiry_mins * 60,
             mimetype=file_format.mimetype,
             content_disposition=file_name_header
         )
-        with open(zip_temp_path, 'rb') as file_:
-            get_blob_db().put(
-                file_,
-                domain=domain,
-                parent_id=domain,
-                type_code=CODES.tempfile,
-                key=ref.download_id,
-                timeout=expiry_mins
-            )
-    finally:
-        os.remove(zip_temp_path)
+        return blob_dl_object.download_id
 
-    return "%s%s?%s" % (
-        get_url_base(),
-        reverse('retrieve_download', kwargs={'download_id': ref.download_id}),
-        "get_file"  # download immediately rather than rendering page
-    )
+    @staticmethod
+    def zip_dump(data_file_path, data_file_name):
+        _, zip_temp_path = tempfile.mkstemp(".zip")
+        with ZipFile(zip_temp_path, 'w') as zip_file_:
+            zip_file_.write(data_file_path, data_file_name)
+
+        return zip_temp_path
+
+    @staticmethod
+    def clean_temp_files(*temp_file_paths):
+        for file_path in temp_file_paths:
+            os.remove(file_path)
+
+    def get_link(self, data_file_path, data_file_name, result_file_format):
+        if self.zip_file:
+            temp_zip_path = self.zip_dump(data_file_path, data_file_name)
+            download_id = self.save_dump_to_blob(temp_zip_path, data_file_name, result_file_format)
+            self.clean_temp_files(temp_zip_path)
+        else:
+            download_id = self.save_dump_to_blob(data_file_path, data_file_name, result_file_format)
+        if self.cleanup:
+            self.clean_temp_files(data_file_path)
+        url = "%s%s?%s" % (get_url_base(),
+                           reverse('retrieve_download', kwargs={'download_id': download_id}),
+                           "get_file")  # downloads immediately, rather than rendering page
+        return url


### PR DESCRIPTION
Reverts dimagi/commcare-hq#21606
The new ID format breaks download status views, which have a pattern like:
```python
    url(r'^commcare/download/status/(?P<download_id>[0-9a-fA-Z]{25,32})/$', DownloadUsersStatusView.as_view(),
        name=DownloadUsersStatusView.urlname),
```
The new format has prepends `dl-` to GUIDs, which doesn't match that regex.  I _think_ the fix is just to switch those to
```[-0-9a-fA-Z]{25,35})```
There are a lot of places where that download_id pattern is referenced, and I'm not confident I'd be able to fully test it, so I'm playing it safe and reverting instead.  I did verify that reverting fixes exports, users, and locations (which are reproducibly broken locally on latest master).