### PR TITLE
[ICDS] Added colour translations for mpr 2bii report

### DIFF
--- a/custom/icds_reports/ucr/reports/mpr_2bii_child_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr_2bii_child_death_list.json
@@ -188,25 +188,45 @@
               "mar": "पांढरा",
               "tel": "తెలుపు",
               "hin": "सफेद",
-              "en": "White"
+              "en": "White",
+              "tam": "வெள்ளை",
+              "lus": "a var",
+              "pan": "ਚਿੱਟਾ",
+              "grt": "Gipok",
+              "kha": "lieh"
             },
             "green": {
               "mar": "हिरवा",
               "tel": "ఆకుపచ్చ",
               "hin": "हरा",
-              "en": "Green"
+              "en": "Green",
+              "tam": "பச்சை",
+              "lus": "a hring",
+              "pan": "ਹਰਾ",
+              "grt": "Tangsek",
+              "kha": "Jyrngam"
             },
             "red": {
               "mar": "लाल",
               "tel": "ఎరుపు",
               "hin": "लाल",
-              "en": "Red"
+              "en": "Red",
+              "tam": "சிவப்பு",
+              "lus": "a sen",
+              "pan": "ਲਾਲ",
+              "grt": "Gitchak",
+              "kha": "Saw"
             },
             "yellow": {
               "mar": "पिवळा",
               "tel": "పసుపు",
               "hin": "पीला",
-              "en": "Yellow"
+              "en": "Yellow",
+              "tam": "மஞ்சள்",
+              "lus": "Rimit",
+              "pan": "ਪੀਲਾ",
+              "grt": "Rimit",
+              "kha": "Stem"
             }
           }
         },


### PR DESCRIPTION
Hi @emord 

I added a missing translations for the colours in the 2bii report in ICDS UCR's.

CASE: https://manage.dimagi.com/default.asp?282142

Regards,
Łukasz