### PR TITLE
Correctly call super setUpClass and tearDownClass

### DIFF
--- a/corehq/apps/userreports/tests/test_async_indicators.py
+++ b/corehq/apps/userreports/tests/test_async_indicators.py
@@ -81,6 +81,7 @@ class BulkAsyncIndicatorProcessingTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(BulkAsyncIndicatorProcessingTest, cls).setUpClass()
         domain_name = "bulk_async_indicator_processing"
         cls.domain = Domain.get_or_create_with_name(domain_name, is_active=True)
 
@@ -129,6 +130,7 @@ class BulkAsyncIndicatorProcessingTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.domain.delete()
+        super(BulkAsyncIndicatorProcessingTest, cls).tearDownClass()
 
     def _setup_docs_and_indicators(self):
         self.docs = [

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -27,11 +27,13 @@ class BaseTestCase(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(BaseTestCase, cls).setUpClass()
         cls.db = TemporaryFilesystemBlobDB()
 
     @classmethod
     def tearDownClass(cls):
         cls.db.close()
+        super(BaseTestCase, cls).tearDownClass()
 
     def make_doc(self, type_=None, id=None):
         if type_ is None:
@@ -499,6 +501,7 @@ class TestBlobMixinWithS3Backend(TestBlobMixin):
 
     @classmethod
     def setUpClass(cls):
+        super(TestBlobMixinWithS3Backend, cls).setUpClass()
         with trap_extra_setup(AttributeError, msg="S3_BLOB_DB_SETTINGS not configured"):
             config = settings.S3_BLOB_DB_SETTINGS
         cls.db = TemporaryS3BlobDB(config)

--- a/corehq/ex-submodules/toggle/tests.py
+++ b/corehq/ex-submodules/toggle/tests.py
@@ -205,6 +205,7 @@ class PredictablyRandomToggleTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(PredictablyRandomToggle, cls).setUpClass()
         cls.user_toggle = Toggle(
             slug='user_toggle',
             enabled_users=['arthur', 'diana'])
@@ -218,6 +219,7 @@ class PredictablyRandomToggleTests(TestCase):
     def tearDownClass(cls):
         cls.user_toggle.delete()
         cls.domain_toggle.delete()
+        super(PredictablyRandomToggle, cls).tearDownClass()
 
     @override_settings(DISABLE_RANDOM_TOGGLES=False)
     def test_user_namespace_disabled(self):
@@ -304,6 +306,7 @@ class DyanmicPredictablyRandomToggleTests(TestCase):
 class ShortcutTests(TestCase):
     @classmethod
     def setUpClass(cls):
+        super(ShortcutTests, cls).setUpClass()
         cls.users = ['arthur', 'diane']
         cls.user_toggle = Toggle(
             slug='user_toggle',
@@ -319,6 +322,7 @@ class ShortcutTests(TestCase):
     def tearDownClass(cls):
         cls.user_toggle.delete()
         cls.domain_toggle.delete()
+        super(ShortcutTests, cls).tearDownClass()
 
     def test_find_users_with_toggle_enabled(self):
         user_toggle = StaticToggle(

--- a/corehq/ex-submodules/toggle/tests.py
+++ b/corehq/ex-submodules/toggle/tests.py
@@ -205,7 +205,7 @@ class PredictablyRandomToggleTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(PredictablyRandomToggle, cls).setUpClass()
+        super(PredictablyRandomToggleTests, cls).setUpClass()
         cls.user_toggle = Toggle(
             slug='user_toggle',
             enabled_users=['arthur', 'diana'])
@@ -219,7 +219,7 @@ class PredictablyRandomToggleTests(TestCase):
     def tearDownClass(cls):
         cls.user_toggle.delete()
         cls.domain_toggle.delete()
-        super(PredictablyRandomToggle, cls).tearDownClass()
+        super(PredictablyRandomToggleTests, cls).tearDownClass()
 
     @override_settings(DISABLE_RANDOM_TOGGLES=False)
     def test_user_namespace_disabled(self):

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -179,6 +179,7 @@ class GetPatientByUuidTests(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(GetPatientByUuidTests, cls).setUpClass()
         cls.patient = {
             'uuid': 'c83d9989-585f-4db3-bf55-ca1d0ee7c0af',
             'display': 'Luis Safiana Bassilo'
@@ -187,10 +188,6 @@ class GetPatientByUuidTests(SimpleTestCase):
         response.json.return_value = cls.patient
         cls.requests = mock.Mock()
         cls.requests.get.return_value = response
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
 
     def test_none(self):
         patient = get_patient_by_uuid(self.requests, uuid=None)
@@ -235,11 +232,13 @@ class AllowedToForwardTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(AllowedToForwardTests, cls).setUpClass()
         cls.owner = CommCareUser.create(DOMAIN, 'chw@example.com', '123')
 
     @classmethod
     def tearDownClass(cls):
         cls.owner.delete()
+        super(AllowedToForwardTests, cls).tearDownClass()
 
     def test_update_from_openmrs(self):
         """

--- a/custom/intrahealth/tests/test_fluffs.py
+++ b/custom/intrahealth/tests/test_fluffs.py
@@ -44,10 +44,6 @@ class TestFluffs(IntraHealthTestCase):
                 )
             ).xform
 
-    @classmethod
-    def tearDownClass(cls):
-        super(TestFluffs, cls).tearDownClass()
-
     def test_taux_de_satifisfaction_fluff(self):
         with real_pillow_settings():
             management.call_command(


### PR DESCRIPTION
@nickpell I think we were talking about tests that didn't call these properly last week. I think these are all the instances of tests that never called them. I didn't go through any to make sure that they were called properly though (that was harder to automate)