### PR TITLE
Handle custom content in reminders migration

### DIFF
--- a/custom/ucla/api.py
+++ b/custom/ucla/api.py
@@ -49,6 +49,37 @@ def _generic_message_bank_content(fixture_name, reminder, handler, recipient):
     )
 
 
+def general_health_message_bank_content_new(recipient, schedule_instance):
+    return _get_message_bank_content_new_framework('general_health', recipient, schedule_instance)
+
+
+def mental_health_message_bank_content_new(recipient, schedule_instance):
+    return _get_message_bank_content_new_framework('mental_health', recipient, schedule_instance)
+
+
+def sexual_health_message_bank_content_new(recipient, schedule_instance):
+    return _get_message_bank_content_new_framework('sexual_health', recipient, schedule_instance)
+
+
+def med_adherence_message_bank_content_new(recipient, schedule_instance):
+    return _get_message_bank_content_new_framework('med_adherence', recipient, schedule_instance)
+
+
+def substance_use_message_bank_content_new(recipient, schedule_instance):
+    return _get_message_bank_content_new_framework('substance_use', recipient, schedule_instance)
+
+
+def _get_message_bank_content_new_framework(fixture_name, recipient, schedule_instance):
+    return _get_message_bank_content(
+        fixture_name,
+        schedule_instance.domain,
+        schedule_instance.schedule_iteration_num,
+        schedule_instance.current_event_num,
+        len(schedule_instance.memoized_schedule.memoized_events),
+        recipient
+    )
+
+
 def _get_message_bank_content(fixture_name, domain, schedule_iteration_num, current_event_num, num_events,
         recipient):
     message_bank = FixtureDataType.by_domain_tag(domain, fixture_name).first()

--- a/custom/ucla/api.py
+++ b/custom/ucla/api.py
@@ -70,7 +70,7 @@ def substance_use_message_bank_content_new(recipient, schedule_instance):
 
 
 def _get_message_bank_content_new_framework(fixture_name, recipient, schedule_instance):
-    return _get_message_bank_content(
+    result = _get_message_bank_content(
         fixture_name,
         schedule_instance.domain,
         schedule_instance.schedule_iteration_num,
@@ -78,6 +78,11 @@ def _get_message_bank_content_new_framework(fixture_name, recipient, schedule_in
         len(schedule_instance.memoized_schedule.memoized_events),
         recipient
     )
+
+    if result:
+        return [result]
+
+    return []
 
 
 def _get_message_bank_content(fixture_name, domain, schedule_iteration_num, current_event_num, num_events,

--- a/custom/ucla/api.py
+++ b/custom/ucla/api.py
@@ -39,7 +39,18 @@ def substance_use_message_bank_content(reminder, handler, recipient):
 
 
 def _generic_message_bank_content(fixture_name, reminder, handler, recipient):
-    domain = reminder.domain
+    return _get_message_bank_content(
+        fixture_name,
+        reminder.domain,
+        reminder.schedule_iteration_num,
+        reminder.current_event_sequence_num,
+        len(handler.events),
+        recipient
+    )
+
+
+def _get_message_bank_content(fixture_name, domain, schedule_iteration_num, current_event_num, num_events,
+        recipient):
     message_bank = FixtureDataType.by_domain_tag(domain, fixture_name).first()
 
     if not message_bank:
@@ -70,8 +81,8 @@ def _generic_message_bank_content(fixture_name, reminder, handler, recipient):
         return None
 
     current_message_seq_num = str(
-        ((reminder.schedule_iteration_num - 1) * len(handler.events)) +
-        reminder.current_event_sequence_num + 1
+        ((schedule_iteration_num - 1) * num_events) +
+        current_event_num + 1
     )
     custom_messages = FixtureDataItem.by_field_value(
         domain, message_bank, RISK_PROFILE_FIELD, risk_profile

--- a/custom/ucla/tests.py
+++ b/custom/ucla/tests.py
@@ -8,9 +8,16 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.fixtures.models import (
     FixtureDataType, FixtureTypeField, FixtureDataItem, FieldList, FixtureItemField
 )
+from corehq.messaging.scheduling.models import TimedSchedule, TimedEvent, CustomContent
+from corehq.messaging.scheduling.scheduling_partitioned.models import (
+    CaseScheduleInstanceMixin,
+    CaseTimedScheduleInstance,
+    ScheduleInstance,
+)
 from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import create_test_case
 from custom.ucla.api import general_health_message_bank_content
+from datetime import time
 
 Reminder = namedtuple('Reminder', ['domain', 'schedule_iteration_num', 'current_event_sequence_num'])
 Handler = namedtuple('Handler', ['events'])
@@ -29,12 +36,29 @@ class TestUCLACustomHandler(TestCase):
         email = 'dimagi@dimagi.com'
         cls.user = WebUser.create(cls.domain_name, email, '***', email=email)
         cls.user.save()
+        cls.schedule = TimedSchedule.create_simple_daily_schedule(
+            cls.domain_name,
+            TimedEvent(time=time(12, 0)),
+            CustomContent(custom_content_id='UCLA_GENERAL_HEALTH'),
+        )
 
     @classmethod
     def tearDownClass(cls):
+        cls.schedule.delete()
         cls.user.delete()
         cls.domain.delete()
         super(TestUCLACustomHandler, cls).tearDownClass()
+
+    def _schedule_instance(self, case, iteration_num=1):
+        return CaseTimedScheduleInstance(
+            domain=self.domain_name,
+            case_id=case.case_id,
+            recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
+            recipient_id=None,
+            schedule_iteration_num=iteration_num,
+            current_event_num=0,
+            timed_schedule_id=self.schedule.schedule_id,
+        )
 
     def _reminder(self, iteration_num=1):
         return Reminder(
@@ -105,6 +129,13 @@ class TestUCLACustomHandler(TestCase):
         data_item.save()
         self.addCleanup(data_item.delete)
 
+    def _get_current_event_messages(self, schedule_instance):
+        content = self.schedule.get_current_event_content(schedule_instance)
+        content.set_context(case=schedule_instance.case, schedule_instance=schedule_instance)
+        recipients = list(schedule_instance.expand_recipients())
+        self.assertEqual(len(recipients), 1)
+        return content.get_list_of_messages(recipients[0])
+
     def test_message_bank_doesnt_exist(self):
         with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
             self.assertRaises(
@@ -159,3 +190,63 @@ class TestUCLACustomHandler(TestCase):
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
             self.assertEqual(
                 general_health_message_bank_content(self._reminder(), self._handler(), case), 'message1')
+
+    def test_message_bank_doesnt_exist_new(self):
+        with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(self._schedule_instance(case))
+
+    def test_message_bank_doesnt_have_correct_properties_new(self):
+        data_type = FixtureDataType(
+            domain=self.domain_name,
+            tag=self.fixture_name,
+            fields=[],
+            item_attributes=[]
+        )
+        data_type.save()
+        self.addCleanup(data_type.delete)
+        with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(self._schedule_instance(case))
+
+    def test_not_passing_case_new(self):
+        self._setup_fixture_type()
+        with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
+            schedule_instance = self._schedule_instance(case)
+            schedule_instance.recipient_type = ScheduleInstance.RECIPIENT_TYPE_WEB_USER
+            schedule_instance.recipient_id = self.user.get_id
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(schedule_instance)
+
+    def test_passing_case_without_risk_profile_new(self):
+        self._setup_fixture_type()
+        with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(self._schedule_instance(case))
+
+    def test_no_relevant_message_invalid_risk_new(self):
+        self._setup_fixture_type()
+        with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk2'}) as case:
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(self._schedule_instance(case))
+
+    def test_no_relevant_message_invalid_seq_num_new(self):
+        self._setup_fixture_type()
+        with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(self._schedule_instance(case, iteration_num=2))
+
+    def test_multiple_relevant_messages_new(self):
+        self._setup_fixture_type()
+        self._setup_data_item('risk1', '1', 'message2')
+        with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
+            with self.assertRaises(AssertionError):
+                self._get_current_event_messages(self._schedule_instance(case))
+
+    def test_correct_message_new(self):
+        self._setup_fixture_type()
+        with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
+            self.assertEqual(
+                self._get_current_event_messages(self._schedule_instance(case)),
+                ['message1']
+            )

--- a/custom/ucla/tests.py
+++ b/custom/ucla/tests.py
@@ -193,8 +193,10 @@ class TestUCLACustomHandler(TestCase):
 
     def test_message_bank_doesnt_exist_new(self):
         with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(self._schedule_instance(case))
+
+            self.assertIn('Lookup Table general_health not found', str(e.exception))
 
     def test_message_bank_doesnt_have_correct_properties_new(self):
         data_type = FixtureDataType(
@@ -206,8 +208,10 @@ class TestUCLACustomHandler(TestCase):
         data_type.save()
         self.addCleanup(data_type.delete)
         with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(self._schedule_instance(case))
+
+            self.assertIn('must have', str(e.exception))
 
     def test_not_passing_case_new(self):
         self._setup_fixture_type()
@@ -215,33 +219,43 @@ class TestUCLACustomHandler(TestCase):
             schedule_instance = self._schedule_instance(case)
             schedule_instance.recipient_type = ScheduleInstance.RECIPIENT_TYPE_WEB_USER
             schedule_instance.recipient_id = self.user.get_id
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(schedule_instance)
+
+            self.assertIn('must be a case', str(e.exception))
 
     def test_passing_case_without_risk_profile_new(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case') as case:
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(self._schedule_instance(case))
+
+            self.assertIn('does not include risk_profile', str(e.exception))
 
     def test_no_relevant_message_invalid_risk_new(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk2'}) as case:
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(self._schedule_instance(case))
+
+            self.assertIn('No message for case', str(e.exception))
 
     def test_no_relevant_message_invalid_seq_num_new(self):
         self._setup_fixture_type()
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(self._schedule_instance(case, iteration_num=2))
+
+            self.assertIn('No message for case', str(e.exception))
 
     def test_multiple_relevant_messages_new(self):
         self._setup_fixture_type()
         self._setup_data_item('risk1', '1', 'message2')
         with create_test_case(self.domain_name, self.case_type, 'test-case', {'risk_profile': 'risk1'}) as case:
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(AssertionError) as e:
                 self._get_current_event_messages(self._schedule_instance(case))
+
+            self.assertIn('Multiple messages for case', str(e.exception))
 
     def test_correct_message_new(self):
         self._setup_fixture_type()

--- a/settings.py
+++ b/settings.py
@@ -1550,6 +1550,21 @@ AVAILABLE_CUSTOM_SCHEDULING_CONTENT = {
     "ICDS_PHASE2_AWW_1":
         ["custom.icds.messaging.custom_content.phase2_aww_1",
          "ICDS: AWC VHND Performance to AWW"],
+    "UCLA_GENERAL_HEALTH":
+        ["custom.ucla.api.general_health_message_bank_content_new",
+         "UCLA: General Health Message Bank"],
+    "UCLA_MENTAL_HEALTH":
+        ["custom.ucla.api.mental_health_message_bank_content_new",
+         "UCLA: Mental Health Message Bank"],
+    "UCLA_SEXUAL_HEALTH":
+        ["custom.ucla.api.sexual_health_message_bank_content_new",
+         "UCLA: Sexual Health Message Bank"],
+    "UCLA_MED_ADHERENCE":
+        ["custom.ucla.api.med_adherence_message_bank_content_new",
+         "UCLA: Med Adherence Message Bank"],
+    "UCLA_SUBSTANCE_USE":
+        ["custom.ucla.api.substance_use_message_bank_content_new",
+         "UCLA: Substance Use Message Bank"],
 }
 
 # Used by the old reminders framework


### PR DESCRIPTION
Updates existing custom content handlers, creating entry points for them in the new reminders framework, and then handles migrating reminders which use them in the migration script.

@orangejenny @jmtroth0 