### PR TITLE
Remove redundant validation on custom content handler

### DIFF
--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1495,10 +1495,6 @@ class CaseReminderHandler(Document):
                     "must send to all child cases if child case recipients are chosen"
                 )
 
-        if (self.custom_content_handler and self.custom_content_handler not in
-            settings.ALLOWED_CUSTOM_CONTENT_HANDLERS):
-            raise IllegalModelStateException("unknown custom_content_handler")
-
         self.check_min_tick()
 
     def check_min_tick(self, minutes=60):


### PR DESCRIPTION
This was a redundant check in the old framework (it's also done in the ui), but it's going to prevent me from properly dealing with the old enikshay reminders on the india server, so am going to remove it.

@orangejenny @jmtroth0 