### PR TITLE
explicitly pickle / unpickle objects in celery tasks

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 import csv342 as csv
 import os
+import pickle
 
 import math
 from celery.schedules import crontab
@@ -338,7 +339,7 @@ def send_hubspot_form(form_id, request, user=None, extra_fields=None):
     if request and user and user.is_web_user():
         meta = get_meta(request)
         send_hubspot_form_task_v2.delay(
-            form_id, user, request.COOKIES.get(HUBSPOT_COOKIE),
+            form_id, pickle.dumps(user), request.COOKIES.get(HUBSPOT_COOKIE),
             meta, extra_fields=extra_fields
         )
 
@@ -351,8 +352,9 @@ def send_hubspot_form_task(form_id, web_user, hubspot_cookie, meta,
 
 
 @analytics_task()
-def send_hubspot_form_task_v2(form_id, web_user, hubspot_cookie, meta,
+def send_hubspot_form_task_v2(form_id, pickled_web_user, hubspot_cookie, meta,
                               extra_fields=None):
+    web_user = pickle.loads(web_user)
     _send_form_to_hubspot(form_id, web_user, hubspot_cookie, meta,
                           extra_fields=extra_fields)
 

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 import contextlib
+import pickle
 import time
 import sys
 from collections import Counter
@@ -285,8 +286,8 @@ def get_export_download(export_instances, filters, filename=None):
 
     download = DownloadBase()
     download.set_task(populate_export_download_task.delay(
-        export_instances,
-        filters,
+        pickle.dumps(export_instances),
+        pickle.dumps(filters),
         download.download_id,
         filename=filename
     ))

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -213,7 +213,8 @@ def _cached_add_inferred_export_properties(sender, domain, case_type, properties
 
 
 @task(queue='background_queue', bind=True)
-def generate_schema_for_all_builds(self, schema_cls, domain, app_id, identifier):
+def generate_schema_for_all_builds(self, pickled_schema_cls, domain, app_id, identifier):
+    schema_cls = pickle.loads(pickled_schema_cls)
     schema_cls.generate_schema_from_builds(
         domain,
         app_id,

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime, timedelta
 import logging
+import pickle
 from celery.schedules import crontab
 from celery.task import task, periodic_task
 from django.conf import settings
@@ -37,10 +38,12 @@ logger = logging.getLogger('export_migration')
 
 
 @task(queue=EXPORT_DOWNLOAD_QUEUE)
-def populate_export_download_task(export_instances, filters, download_id, filename=None, expiry=10 * 60):
+def populate_export_download_task(pickled_export_instances, pickled_filters, download_id, filename=None, expiry=10 * 60):
     """
     :param expiry:  Time period for the export to be available for download in minutes
     """
+    export_instances = pickle.loads(pickled_export_instances)
+    filters = pickle.loads(pickled_filters)
     domain = export_instances[0].domain
     with TransientTempfile() as temp_path, datadog_track_errors('populate_export_download_task'):
         export_file = get_export_file(

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from __future__ import division
 from __future__ import unicode_literals
+
+import pickle
 from datetime import datetime, date, timedelta
 
 from couchdbkit import ResourceNotFound
@@ -2262,7 +2264,7 @@ class GenerateSchemaFromAllBuildsView(View):
         assert type_ in [CASE_EXPORT, FORM_EXPORT], 'Unrecogized export type {}'.format(type_)
         download = DownloadBase()
         download.set_task(generate_schema_for_all_builds.delay(
-            self.export_cls(type_),
+            pickle.dumps(self.export_cls(type_)),
             request.domain,
             request.POST.get('app_id'),
             request.POST.get('identifier'),


### PR DESCRIPTION
Celery 4 does not use the pickle serializer by default, so we either have to:
(1) pickle / unpickle objects ourselves
(2) pass only JSON-serializable objects.

This PR does (1), since it's an easy fix, and validates that we can use this approach if these types of errors aren't caught during testing on staging.

Better long-term fixes would include passing IDs instead of objects wherever possible, and using JSON-serialization elsewhere.