### PR TITLE
Add test enforcing `make requirements` was run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TEST=python NOSE_DIVIDED_WE_RUN=05 JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=6a JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=bf JS_SETUP=yes
-    - TEST=python-sharded-and-javascript JS_SETUP=yes
+    - TEST=python-sharded-and-javascript JS_SETUP=yes TEST_MAKE_REQUIREMENTS=yes
   global:
     # TRAVIS_HQ_USERNAME
     - secure: "LuT0vvsY6RjlEX8Gje74Xl0jcuEfaiN/fOOXpfZd1tf8zC3Xd9E8mNn5vlup/3PBBBv1yIAUmw9LTc03ifWBGzaazqIVAgTfgBoW7XAd8G/lx0/eeZFqheSdpP8wSZwn72Z/XrIhQczFCreZRJHlZA9GopRv7Lfs1SfNEbnMoac="
@@ -33,6 +33,24 @@ script:
   - export TRAVIS_HQ_USERNAME=$TRAVIS_HQ_USERNAME
   - export TRAVIS_HQ_PASSWORD=$TRAVIS_HQ_PASSWORD
   - export DATADOG_API_KEY=$DATADOG_API_KEY
+  - |
+    function _test_make_requirements {
+        pip install pip-tools
+        make requirements
+        git diff
+        git update-index -q --refresh
+        if git diff-index --quiet HEAD --; then
+            # No changes
+            exit 0
+        else
+            # Changes
+            exit 1
+        fi
+    }
+    if [[ "$TEST_MAKE_REQUIREMENTS" == "yes" ]]
+    then
+      _test_make_requirements
+    fi
   - "scripts/docker test --noinput --stop --verbosity=2 --divide-depth=1 --with-timing --threshold=10"
 after_success:
   # create symlink so artifacts are available

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
         git update-index -q --refresh
         if git diff-index --quiet HEAD --; then
             # No changes
-            exit 0
+            echo "requirements ok"
         else
             # Changes
             exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,22 +34,9 @@ script:
   - export TRAVIS_HQ_PASSWORD=$TRAVIS_HQ_PASSWORD
   - export DATADOG_API_KEY=$DATADOG_API_KEY
   - |
-    function _test_make_requirements {
-        pip install pip-tools
-        make requirements
-        git diff
-        git update-index -q --refresh
-        if git diff-index --quiet HEAD --; then
-            # No changes
-            echo "requirements ok"
-        else
-            # Changes
-            exit 1
-        fi
-    }
     if [[ "$TEST_MAKE_REQUIREMENTS" == "yes" ]]
     then
-      _test_make_requirements
+      bash scripts/test-make-requirements.sh
     fi
   - "scripts/docker test --noinput --stop --verbosity=2 --divide-depth=1 --with-timing --threshold=10"
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ requirements: scripts/_vendor/pip-post-compile.sh
 	pip-compile -o requirements/test-requirements.txt requirements/test-requirements.in
 	pip-compile -o requirements/dev-requirements.txt requirements/dev-requirements.in
 	pip-compile -o requirements/docs-requirements.txt requirements/docs-requirements.in
-	bash scripts/_vendor/pip-post-compile.sh requirements/*requirements.txt
+	bash scripts/pip-post-compile.sh requirements/*requirements.txt
 
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade-requirements
 upgrade-requirements: scripts/_vendor/pip-post-compile.sh
@@ -21,4 +21,4 @@ upgrade-requirements: scripts/_vendor/pip-post-compile.sh
 	pip-compile --upgrade -o requirements/test-requirements.txt requirements/test-requirements.in
 	pip-compile --upgrade -o requirements/dev-requirements.txt requirements/dev-requirements.in
 	pip-compile --upgrade -o requirements/docs-requirements.txt requirements/docs-requirements.in
-	bash scripts/_vendor/pip-post-compile.sh requirements/*requirements.txt
+	bash scripts/pip-post-compile.sh requirements/*requirements.txt

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -13,7 +13,6 @@ alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
 appdirs==1.4.3
-appnope==0.1.0            # via ipython
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.1.0
@@ -56,6 +55,7 @@ django-debug-toolbar==1.8
 django-extensions==1.7.7
 django-formtools==2.0
 django-otp==0.3.13
+django-partial-index==0.4.0
 django-phonenumber-field==1.3.0
 django-prbac==0.0.7
 django-ranged-response==0.2.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -44,6 +44,7 @@ django-cte==1.1.4
 django-extensions==1.7.7
 django-formtools==2.0
 django-otp==0.3.13
+django-partial-index==0.4.0
 django-phonenumber-field==1.3.0
 django-prbac==0.0.7
 django-ranged-response==0.2.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -9,7 +9,6 @@ alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
 appdirs==1.4.3
-appnope==0.1.0            # via ipython
 asn1crypto==0.24.0
 attrs==18.1.0
 babel==2.6.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -46,6 +46,7 @@ django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.0
 django-otp==0.3.13
+django-partial-index==0.4.0
 django-phonenumber-field==1.3.0
 django-prbac==0.0.7
 django-ranged-response==0.2.0

--- a/scripts/pip-post-compile.sh
+++ b/scripts/pip-post-compile.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+bash scripts/_vendor/pip-post-compile.sh "$@"
+
+function clean_file {
+    FILE_PATH=$1
+    TEMP_FILE=${FILE_PATH}.tmp
+    grep -v '^appnope==' ${FILE_PATH} > ${TEMP_FILE}
+    mv ${TEMP_FILE} ${FILE_PATH}
+}
+
+for i in "$@"; do
+    case ${i} in
+        -h|--help)
+            exit 0
+            ;;
+        *)
+            clean_file ${i}
+            ;;
+    esac
+done

--- a/scripts/test-make-requirements.sh
+++ b/scripts/test-make-requirements.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+pip install pip-tools
+make requirements
+git diff
+git update-index -q --refresh
+if git diff-index --quiet HEAD --; then
+    # No changes
+    echo "requirements ok"
+else
+    # Changes
+    exit 1
+fi


### PR DESCRIPTION
and that running it again on linux does not produce a git diff

Pulled out from https://github.com/dimagi/commcare-hq/pull/21612 (which contained this as an unrelated change, and turned out to be hairier than I thought) and then squashed into one commit.

Update: I decide to solve the issue from https://github.com/dimagi/commcare-hq/pull/21612 in this PR as well, by simply post-processing requirements.txt files to remove lines that match `^appnope==`, thus matching the file that would be generated on Linux. So now fixes https://github.com/dimagi/commcare-hq/issues/21580.