### PR TITLE
change data not entered in AWC Infrastructure Report

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -895,8 +895,8 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
     }
 
 
-@quickcache(['domain', 'config', 'month', 'show_test'], timeout=30 * 60)
-def get_awc_report_infrastructure(domain, config, month, show_test=False):
+@quickcache(['domain', 'config', 'month', 'show_test', 'beta'], timeout=30 * 60)
+def get_awc_report_infrastructure(domain, config, month, show_test=False, beta=False):
     selected_month = datetime(*month)
 
     def get_data_for_kpi(filters, date):
@@ -909,14 +909,18 @@ def get_awc_report_infrastructure(domain, config, month, show_test=False):
             functional_toilet=Sum('infra_functional_toilet'),
             medicine_kits=Sum('infra_medicine_kits'),
             infant_weighing_scale=Sum('infra_infant_weighing_scale'),
-            adult_weighing_scale=Sum('infra_adult_weighing_scale')
+            adult_weighing_scale=Sum('infra_adult_weighing_scale'),
+            num_awc_infra_last_update=Sum('num_awc_infra_last_update'),
         )
         if not show_test:
             queryset = apply_exclude(domain, queryset)
         return queryset
 
     def get_infa_value(data, prop):
-        value = (data[0][prop] or None) if data else None
+        if beta:
+            value = data[0][prop] if data[0]['num_awc_infra_last_update'] else None
+        else:
+            value = (data[0][prop] or None) if data else None
         if value is not None:
             if value == 1:
                 return _("Available")

--- a/custom/icds_reports/sqldata/exports/awc_infrastructure.py
+++ b/custom/icds_reports/sqldata/exports/awc_infrastructure.py
@@ -6,7 +6,7 @@ from sqlagg.base import AliasColumn
 from sqlagg.columns import SumColumn, SimpleColumn
 
 from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn, AggregateColumn
-from custom.icds_reports.utils import percent
+from custom.icds_reports.utils import percent, percent_or_not_entered
 from custom.icds_reports.utils.mixins import ExportableMixin
 
 
@@ -32,10 +32,11 @@ class AWCInfrastructureExport(ExportableMixin, SqlData):
     @property
     def columns(self):
         columns = self.get_columns_by_loc_level
+        percent_function = percent_or_not_entered if self.beta else percent
         agg_columns = [
             AggregateColumn(
                 'Percentage AWCs reported clean drinking water',
-                percent,
+                percent_function,
                 [
                     SumColumn('infra_clean_water'),
                     SumColumn('num_awc_infra_last_update', alias='awcs')
@@ -44,7 +45,7 @@ class AWCInfrastructureExport(ExportableMixin, SqlData):
             ),
             AggregateColumn(
                 'Percentage AWCs reported functional toilet',
-                percent,
+                percent_function,
                 [
                     SumColumn('infra_functional_toilet'),
                     AliasColumn('awcs')
@@ -53,7 +54,7 @@ class AWCInfrastructureExport(ExportableMixin, SqlData):
             ),
             AggregateColumn(
                 'Percentage AWCs reported medicine kit',
-                percent,
+                percent_function,
                 [
                     SumColumn('infra_medicine_kits'),
                     AliasColumn('awcs')
@@ -62,7 +63,7 @@ class AWCInfrastructureExport(ExportableMixin, SqlData):
             ),
             AggregateColumn(
                 'Percentage AWCs reported weighing scale: infants',
-                percent,
+                percent_function,
                 [
                     SumColumn('infra_infant_weighing_scale'),
                     AliasColumn('awcs')
@@ -71,7 +72,7 @@ class AWCInfrastructureExport(ExportableMixin, SqlData):
             ),
             AggregateColumn(
                 'Percentage AWCs reported weighing scale: mother and child',
-                percent,
+                percent_function,
                 [
                     SumColumn('infra_adult_weighing_scale'),
                     AliasColumn('awcs')

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -569,7 +569,8 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
         excel_data = AWCInfrastructureExport(
             config=config,
             loc_level=aggregation_level,
-            show_test=include_test
+            show_test=include_test,
+            beta=beta,
         ).get_excel_data(location)
     elif indicator == BENEFICIARY_LIST_EXPORT:
         # this report doesn't use this configuration

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -663,7 +663,7 @@ def percent(x, y):
 
 
 def percent_or_not_entered(x, y):
-    return percent(x, y) if y else 'data not entered'
+    return percent(x, y) if y else DATA_NOT_ENTERED
 
 
 class ICDSDatabaseColumn(DatabaseColumn):

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -662,6 +662,10 @@ def percent(x, y):
     return "%.2f %%" % (percent_num(x, y))
 
 
+def percent_or_not_entered(x, y):
+    return percent(x, y) if y else 'data not entered'
+
+
 class ICDSDatabaseColumn(DatabaseColumn):
     def get_raw_value(self, row):
         return (self.view.get_value(row) or '') if row else ''

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -584,7 +584,8 @@ class AwcReportsView(BaseReportView):
                 domain,
                 config,
                 tuple(current_month.timetuple())[:3],
-                include_test
+                include_test,
+                beta=icds_pre_release_features(request.couch_user)
             )
         elif step == 'beneficiary':
             if 'awc_id' in config:


### PR DESCRIPTION
Hi @emord,
this changes in AWC Reports -> AWC Infrastructure Report (`custom/icds_reports/reports/awc_reports.py`) show either all 'Data not entered' when `num_awc_infra_last_update` for this AWC is not 1 or 'Available' / 'Not available' when it is 1.
Currently, if `num_awc_infra_last_update` is 1 and eg. infra_clean_water is 0 rather than showing 'Not available' for clean water, it shows 'Data not entered'. 'Not available' is never shown in AWC Reports -> AWC Infrastructure Report right now.

The changes in other files introduce to Tabular Report -> AWC Infrastructure viewed by (aggregated by) AWC to put the value of 'data not entered' in the cells of AWC row for which `num_awc_infra_last_update != 1`, rather than current '0.00%'

All of the changes are behind a feature flag.

Let me know if You have any questions.

Regards, Dawid