### PR TITLE
 Fix error with blank columns in case upload

### DIFF
--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -62,7 +62,6 @@ def store_task_result(upload_id):
 
 def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKSIZE,
               record_form_callback=None):
-    columns = spreadsheet.get_header_columns()
     match_count = created_count = too_many_matches = num_chunks = 0
     errors = importer_util.ImportErrorDetail()
 
@@ -121,7 +120,7 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
         return err
 
     row_count = spreadsheet.max_row
-    for i, row in enumerate(spreadsheet.iter_rows()):
+    for i, row in enumerate(spreadsheet.iter_row_dicts()):
         if task:
             set_task_progress(task, i, row_count)
 
@@ -129,9 +128,9 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
         if i == 0:
             continue
 
-        search_id = importer_util.parse_search_id(config, columns, row)
+        search_id = importer_util.parse_search_id(config, row)
 
-        fields_to_update = importer_util.populate_updated_fields(config, columns, row)
+        fields_to_update = importer_util.populate_updated_fields(config, row)
         if not any(fields_to_update.values()):
             # if the row was blank, just skip it, no errors
             continue

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -113,13 +113,12 @@ class WorksheetWrapper(object):
             return cls(workbook.worksheets[0])
 
     def get_header_columns(self):
-        if self.max_row > 1:
-            # remove None columns the library sometimes returns
-            return list(filter(None, next(self.iter_rows())))
+        try:
+            header_row = next(self.iter_rows())
+        except StopIteration:
+            header_row = []
 
-        # if max_row is 1, there may be either 0 or 1 rows in the sheet
-        rows = list(self.iter_rows())
-        header_row = rows[0] if rows else []
+        # remove None columns the library sometimes returns
         return list(filter(None, header_row))
 
     def _get_column_values(self, column_index):

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from contextlib import contextmanager
 import json
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, OrderedDict
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from couchdbkit import NoResultFound
 
@@ -112,22 +113,36 @@ class WorksheetWrapper(object):
         else:
             return cls(workbook.worksheets[0])
 
-    def get_header_columns(self):
+    @cached_property
+    def _headers_by_index(self):
         try:
-            header_row = next(self.iter_rows())
+            header_row = next(self._iter_rows())
         except StopIteration:
             header_row = []
 
-        # remove None columns the library sometimes returns
-        return list(filter(None, header_row))
+        return OrderedDict(
+            (i, header) for i, header in enumerate(header_row)
+            if header  # remove None columns the library sometimes returns
+        )
+
+    def get_header_columns(self):
+        return self._headers_by_index.values()
 
     @property
     def max_row(self):
         return self._worksheet.max_row
 
-    def iter_rows(self):
+    def _iter_rows(self):
         for row in self._worksheet.iter_rows():
             yield [cell.value for cell in row]
+
+    def iter_row_dicts(self):
+        for row in self._iter_rows():
+            yield {
+                self._headers_by_index[i]: value
+                for i, value in enumerate(row)
+                if i in self._headers_by_index
+            }
 
 
 def convert_custom_fields_to_struct(config):
@@ -229,14 +244,12 @@ def convert_field_value(value):
         return str(value)
 
 
-def parse_search_id(config, columns, row):
+def parse_search_id(config, row):
     """ Find and convert the search id in an excel row """
 
     # Find index of user specified search column
     search_column = config.search_column
-    search_column_index = columns.index(search_column)
-
-    search_id = row[search_column_index] or ''
+    search_id = row[search_column] or ''
 
     try:
         # if the spreadsheet gives a number, strip any decimals off
@@ -282,7 +295,7 @@ def lookup_case(search_field, search_id, domain, case_type):
         return (None, LookupErrors.NotFound)
 
 
-def populate_updated_fields(config, columns, row):
+def populate_updated_fields(config, row):
     """
     Returns a dict map of fields that were marked to be updated
     due to the import. This can be then used to pass to the CaseBlock
@@ -292,7 +305,7 @@ def populate_updated_fields(config, columns, row):
     fields_to_update = {}
     for key in field_map:
         try:
-            update_value = row[columns.index(key)]
+            update_value = row[key]
         except Exception:
             continue
 

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -121,16 +121,6 @@ class WorksheetWrapper(object):
         # remove None columns the library sometimes returns
         return list(filter(None, header_row))
 
-    def _get_column_values(self, column_index):
-        rows = self.iter_rows()
-        # skip first row (header row)
-        next(rows)
-        for row in rows:
-            yield row[column_index]
-
-    def get_unique_column_values(self, column_index):
-        return list(set(self._get_column_values(column_index)))
-
     @property
     def max_row(self):
         return self._worksheet.max_row


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?281992

The case upload code grabbed the first row of the spreadsheet and stripped any blank values, calling that "headers".  It would then grab each row, and compare indices of that row's values against the indices in the headers row to figure out what property each value corresponds to.  The problem is, any blank values in headers would shift everything to the right of it off by one, assigning values to the wrong property.  This would result in nonsensical case updates, but they could have easily gone unnoticed.  Case owner, however, has some validation on it, so if _that_ was one of the properties to the right of a blank column, you'd get an error for trying to assign your case to an owner with the ID "Male" or "Blue" or something meant to be in a property.

This change returns rows as key/value pairs rather than positional lists to avoid that type of issue.