### PR TITLE
handle export status when no task exists

### DIFF
--- a/corehq/apps/export/exceptions.py
+++ b/corehq/apps/export/exceptions.py
@@ -19,3 +19,7 @@ class ExportFormValidationException(Exception):
 
 class ExportAsyncException(Exception):
     pass
+
+
+class NoSavedExportTask(Exception):
+    pass

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -9,6 +9,7 @@ from soil import DownloadBase
 from soil.progress import get_task_status
 
 from corehq.apps.data_dictionary.util import add_properties_to_data_dictionary
+from corehq.apps.export.exceptions import NoSavedExportTask
 from corehq.apps.reports.models import HQGroupExportConfiguration
 from corehq.apps.users.models import CouchUser
 from corehq.blobs import CODES, get_blob_db
@@ -141,6 +142,8 @@ def get_saved_export_task_status(export_instance_id):
     rebuilds in progress for a single export instance)
     """
     download_data = _get_saved_export_download_data(export_instance_id)
+    if not download_data.task_id:
+        raise NoSavedExportTask('No existing task for export %s' % export_instance_id)
     return get_task_status(download_data.task)
 
 

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -59,6 +59,7 @@ from corehq.apps.export.exceptions import (
     BadExportConfiguration,
     ExportFormValidationException,
     ExportAsyncException,
+    NoSavedExportTask,
 )
 from corehq.apps.export.forms import (
     FilterFormCouchExportDownloadForm,
@@ -976,7 +977,14 @@ class BaseExportListView(ExportsPermissionsMixin, HQJSONResponseMixin, BaseProje
 
     @staticmethod
     def _get_task_status_json(export_instance_id):
-        status = get_saved_export_task_status(export_instance_id)
+        try:
+            status = get_saved_export_task_status(export_instance_id)
+        except NoSavedExportTask:
+            return {
+                'percentComplete': 0,
+                'inProgress': False,
+                'success': False,
+            }
         return {
             'percentComplete': status.progress.percent or 0,
             'inProgress': status.started(),


### PR DESCRIPTION
Fixes https://sentry.io/dimagi/commcarehq/issues/659332830/?environment=__all_environments__ and https://sentry.io/dimagi/commcarehq/issues/659334093/?environment=__all_environments__ when running celery 4.x