### PR TITLE
When pruning apps, soft delete instead of hard

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -61,3 +61,4 @@ def prune_auto_generated_builds(domain, app_id):
         if not app.is_auto_generated or app.copy_of != app_id or app.id == last_build_id:
             raise SavedAppBuildException("Attempted to delete build that should not be deleted")
         app.delete_app()
+        app.save(increment_version=False)

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -60,4 +60,4 @@ def prune_auto_generated_builds(domain, app_id):
             continue
         if not app.is_auto_generated or app.copy_of != app_id or app.id == last_build_id:
             raise SavedAppBuildException("Attempted to delete build that should not be deleted")
-        app.delete()
+        app.delete_app()


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?282002

https://github.com/dimagi/commcare-hq/pull/21506 makes the releases page susceptible to 500ing when there are discrepancies between ES and couch. I suspect that [pruning auto-generated builds](https://github.com/dimagi/commcare-hq/pull/20829) is causing these discrepancies.

@gcapalbo / @jmtroth0 