### PR TITLE
Revert "run confirm_domain once at a time per guid"

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -48,7 +48,6 @@ from corehq import toggles
 from django.contrib.auth.models import User
 
 from corehq.util.soft_assert import soft_assert
-from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.resource_conflict import retry_resource
 from memoized import memoized
 from dimagi.utils.web import get_ip
@@ -378,64 +377,63 @@ def resend_confirmation(request):
 
 
 @transaction.atomic
-def confirm_domain(request, guid=''):
-    with CriticalSection('confirm_domain_' + guid):
-        error = None
-        # Did we get a guid?
-        if not guid:
-            error = _('An account activation key was not provided.  If you think this '
-                      'is an error, please contact the system administrator.')
+def confirm_domain(request, guid=None):
+    error = None
+    # Did we get a guid?
+    if guid is None:
+        error = _('An account activation key was not provided.  If you think this '
+                  'is an error, please contact the system administrator.')
 
-        # Does guid exist in the system?
+    # Does guid exist in the system?
+    else:
+        req = RegistrationRequest.get_by_guid(guid)
+        if not req:
+            error = _('The account activation key "%s" provided is invalid. If you '
+                      'think this is an error, please contact the system '
+                      'administrator.') % guid
+
+    if error is not None:
+        context = {
+            'message_body': error,
+            'current_page': {'page_name': 'Account Not Activated'},
+        }
+        return render(request, 'registration/confirmation_error.html', context)
+
+    requested_domain = Domain.get_by_name(req.domain)
+    view_name = "dashboard_default"
+    view_args = [requested_domain]
+    if not domain_has_apps(req.domain):
+        if ab_tests.appcues_template_app_test(request):
+            view_name = "app_from_template"
+            view_args.append("appcues")
         else:
-            req = RegistrationRequest.get_by_guid(guid)
-            if not req:
-                error = _('The account activation key "%s" provided is invalid. If you '
-                          'think this is an error, please contact the system '
-                          'administrator.') % guid
+            view_name = "default_new_app"
 
-        if error is not None:
-            context = {
-                'message_body': error,
-                'current_page': {'page_name': 'Account Not Activated'},
-            }
-            return render(request, 'registration/confirmation_error.html', context)
-
-        requested_domain = Domain.get_by_name(req.domain)
-        view_name = "dashboard_default"
-        view_args = [requested_domain]
-        if not domain_has_apps(req.domain):
-            if ab_tests.appcues_template_app_test(request):
-                view_name = "app_from_template"
-                view_args.append("appcues")
-            else:
-                view_name = "default_new_app"
-
-        # Has guid already been confirmed?
-        if requested_domain.is_active:
-            assert(req.confirm_time is not None and req.confirm_ip is not None)
-            messages.success(request, 'Your account %s has already been activated. '
-                'No further validation is required.' % req.new_user_username)
-            return HttpResponseRedirect(reverse(view_name, args=view_args))
-
-        # Set confirm time and IP; activate domain and new user who is in the
-        req.confirm_time = datetime.utcnow()
-        req.confirm_ip = get_ip(request)
-        req.save()
-        requested_domain.is_active = True
-        requested_domain.save()
-        requesting_user = WebUser.get_by_username(req.new_user_username)
-
-        send_new_request_update_email(requesting_user, get_ip(request), requested_domain.name, is_confirming=True)
-
-        messages.success(request,
-                'Your account has been successfully activated.  Thank you for taking '
-                'the time to confirm your email address: %s.'
-            % (requesting_user.username))
-        track_workflow(requesting_user.email, "Confirmed new project")
-        track_confirmed_account_on_hubspot_v2.delay(requesting_user)
-        request.session['CONFIRM'] = True
+    # Has guid already been confirmed?
+    if requested_domain.is_active:
+        assert(req.confirm_time is not None and req.confirm_ip is not None)
+        messages.success(request, 'Your account %s has already been activated. '
+            'No further validation is required.' % req.new_user_username)
         return HttpResponseRedirect(reverse(view_name, args=view_args))
+
+    # Set confirm time and IP; activate domain and new user who is in the
+    req.confirm_time = datetime.utcnow()
+    req.confirm_ip = get_ip(request)
+    req.save()
+    requested_domain.is_active = True
+    requested_domain.save()
+    requesting_user = WebUser.get_by_username(req.new_user_username)
+
+    send_new_request_update_email(requesting_user, get_ip(request), requested_domain.name, is_confirming=True)
+
+    messages.success(request,
+            'Your account has been successfully activated.  Thank you for taking '
+            'the time to confirm your email address: %s.'
+        % (requesting_user.username))
+    track_workflow(requesting_user.email, "Confirmed new project")
+    track_confirmed_account_on_hubspot_v2.delay(requesting_user)
+    request.session['CONFIRM'] = True
+    return HttpResponseRedirect(reverse(view_name, args=view_args))
 
 
 @retry_resource(3)


### PR DESCRIPTION
Reverts dimagi/commcare-hq#21619
Still investigating what the issue is, but this PR makes the registration confirmation page hang forever.  It's reproducible locally too.  Reverting until we can get to the bottom of it.