### PR TITLE
Migration: copy blob metadata into BlobMeta table

### DIFF
--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -84,6 +84,7 @@ from django.conf import settings
 from corehq.apps.domain import SHARED_DOMAIN
 from corehq.blobs import get_blob_db
 from corehq.blobs.exceptions import NotFound
+from corehq.blobs.migrate_metadata import migrate_metadata
 from corehq.blobs.migratingdb import MigratingBlobDB
 from corehq.blobs.mixin import BlobHelper
 from corehq.blobs.models import BlobMeta, BlobMigrationState
@@ -448,6 +449,7 @@ class ExportByDomain(object):
 
 MIGRATIONS = {m.slug: m for m in [
     BackendMigrator("migrate_backend"),
+    migrate_metadata,
     # Kept for reference when writing new migrations.
     # Migrator("applications", [
     #    apps.Application,

--- a/corehq/blobs/migrate_metadata.py
+++ b/corehq/blobs/migrate_metadata.py
@@ -1,0 +1,323 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from functools import partial
+from itertools import groupby
+
+import six
+from django.db import connections
+
+from corehq.apps.domain import SHARED_DOMAIN, UNKNOWN_DOMAIN
+from corehq.blobs import CODES
+from corehq.blobs.mixin import BlobHelper, BlobMetaRef
+from corehq.blobs.models import BlobMigrationState
+from corehq.form_processor.backends.sql.dbaccessors import ReindexAccessor
+from corehq.sql_db.util import get_db_alias_for_partitioned_doc
+from corehq.util.doc_processor.sql import SqlDocumentProvider
+
+import corehq.apps.accounting.models as acct
+import corehq.apps.app_manager.models as apps
+import corehq.apps.hqmedia.models as hqmedia
+from corehq.apps.builds.models import CommCareBuild
+from corehq.apps.case_importer.tracking.models import CaseUploadFileMeta, CaseUploadRecord
+from corehq.apps.domain.models import Domain
+from corehq.apps.export import models as exports
+from corehq.apps.ota.models import DemoUserRestore
+from corehq.apps.users.models import CommCareUser
+
+import casexml.apps.case.models as cases
+import couchforms.models as xform
+from couchexport.models import SavedBasicExport
+from custom.icds_reports.models.helper import IcdsFile
+
+
+class MultiDbMigrator(object):
+
+    def __init__(self, slug, couch_types, sql_reindexers):
+
+        self.slug = slug
+        self.couch_types = couch_types
+        self.sql_reindexers = sql_reindexers
+
+    def iter_migrators(self):
+        from . import migrate as mod
+        SqlMigrator, BlobMetaMigrator = make_migrators(mod)
+        couch_migrator = partial(BlobMetaMigrator, blob_helper=couch_blob_helper)
+
+        def db_key(doc_type):
+            if isinstance(doc_type, tuple):
+                doc_type = doc_type[1]
+            return doc_type.get_db().dbname
+
+        for key, types in groupby(sorted(self.couch_types, key=db_key), key=db_key):
+            slug = "%s-%s" % (self.slug, key)
+            yield mod.Migrator(slug, list(types), couch_migrator)
+
+        for rex in self.sql_reindexers:
+            slug = "%s-%s" % (self.slug, rex.model_class.__name__)
+            yield SqlMigrator(slug, rex(), BlobMetaMigrator)
+
+    def migrate(self, filename, *args, **kw):
+        def filen(n):
+            return None if filename is None else "{}.{}".format(filename, n)
+        migrated = 0
+        skipped = 0
+        for n, item in enumerate(self.iter_migrators()):
+            one_migrated, one_skipped = item.migrate(filen(n), *args, **kw)
+            migrated += one_migrated
+            skipped += one_skipped
+            print("\n")
+        if not skipped:
+            BlobMigrationState.objects.get_or_create(slug=self.slug)[0].save()
+        return migrated, skipped
+
+
+def make_migrators(mod):
+    # defer class definitions to work around circular import
+
+    class BlobMetaMigrator(mod.BaseDocMigrator):
+        """Migrate blob metadata to BlobMeta model"""
+
+        def __init__(self, *args, **kw):
+            super(BlobMetaMigrator, self).__init__(*args, **kw)
+            self.total_blobs = 0
+
+        def _backup_doc(self, doc):
+            pass
+
+        def _do_migration(self, doc):
+            if not doc.get("external_blobs"):
+                return True
+            type_code = self.get_type_code(doc)
+            obj = self.blob_helper(doc, self.couchdb, type_code)
+            db = get_db_alias_for_partitioned_doc(doc["_id"])
+            with connections[db].cursor() as cursor:
+                for name, meta in six.iteritems(obj.blobs):
+                    if meta.blobmeta_id is not None:
+                        # blobmeta already saved
+                        continue
+                    if obj.domain is None:
+                        print("Unknown domain: {!r}".format(obj))
+                    cursor.execute("""
+                        INSERT INTO blobs_blobmeta (
+                            domain,
+                            type_code,
+                            parent_id,
+                            name,
+                            key,
+                            content_type,
+                            content_length,
+                            created_on
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, CLOCK_TIMESTAMP())
+                        ON CONFLICT (key) DO NOTHING
+                    """, params=[
+                        (UNKNOWN_DOMAIN if obj.domain is None else obj.domain),
+                        type_code,
+                        doc["_id"],
+                        name,
+                        meta.key,
+                        meta.content_type,
+                        meta.content_length or 0,
+                    ])
+                    self.total_blobs += 1
+            return True
+
+        def processing_complete(self, skipped):
+            # fake skipped to prevent writing BlobMigrationState
+            super(BlobMetaMigrator, self).processing_complete(1)
+
+    class SqlMigrator(mod.Migrator):
+
+        def __init__(self, slug, reindexer, doc_migrator_class):
+            types = [reindexer.model_class]
+
+            def doc_migrator(*args, **kw):
+                kw["blob_helper"] = reindexer.blob_helper
+                kw["get_type_code"] = reindexer.get_type_code
+                return doc_migrator_class(*args, **kw)
+
+            super(SqlMigrator, self).__init__(slug, types, doc_migrator)
+            self.reindexer = reindexer
+
+        def _get_document_provider(self):
+            return SqlDocumentProvider(self.iteration_key, self.reindexer)
+
+    return SqlMigrator, BlobMetaMigrator
+
+
+class SqlBlobHelper(object):
+    """Adapt a SQL model object to look like a BlobHelper
+
+    This is currently built on the assumtion that the SQL model only
+    references a single blob, and the blob name is not used.
+    """
+
+    def __init__(self, obj, key, domain, reindexer):
+        self.obj = obj
+        self.domain = domain
+        self.blobs = {"": BlobMetaRef(key=key, **reindexer.blob_kwargs(obj))}
+        self.external_blobs = self.blobs
+
+    @property
+    def _id(self):
+        return self.obj.id
+
+    @property
+    def doc_type(self):
+        return type(self.obj).__name__
+
+
+def sql_blob_helper(key_attr):
+
+    def blob_helper(self, doc, *ignored):
+        """This has the same signature as BlobHelper
+
+        :returns: Object having parts of BlobHelper interface needed
+        for blob migrations (currently only used by BlobMetaMigrator).
+        """
+        obj = doc["_obj_not_json"]
+        domain = self.get_domain(obj) or UNKNOWN_DOMAIN
+        return SqlBlobHelper(obj, getattr(obj, key_attr), domain, self)
+
+    return blob_helper
+
+
+class PkReindexAccessor(ReindexAccessor):
+    @property
+    def id_field(self):
+        return 'id'
+
+    def get_doc(self, *args, **kw):
+        # only used for retries; BlobMetaMigrator doesn't retry
+        raise NotImplementedError
+
+    def doc_to_json(self, obj, id):
+        return {"_id": id, "_obj_not_json": obj, "external_blobs": True}
+
+
+class CaseUploadFileMetaReindexAccessor(PkReindexAccessor):
+    model_class = CaseUploadFileMeta
+    blob_helper = sql_blob_helper("identifier")
+
+    def doc_to_json(self, obj):
+        return PkReindexAccessor.doc_to_json(self, obj, self.get_domain(obj))
+
+    @staticmethod
+    def get_type_code(doc):
+        return CODES.data_import
+
+    def get_domain(self, obj):
+        return CaseUploadRecord.objects.get(upload_file_meta_id=obj.id).domain
+
+    def blob_kwargs(self, obj):
+        return {"content_length": obj.length}
+
+
+class DemoUserRestoreReindexAccessor(PkReindexAccessor):
+    model_class = DemoUserRestore
+    blob_helper = sql_blob_helper("restore_blob_id")
+
+    def doc_to_json(self, obj):
+        return PkReindexAccessor.doc_to_json(
+            self, obj, obj.demo_user_id or "DemoUserRestore")
+
+    @staticmethod
+    def get_type_code(doc):
+        return CODES.demo_user_restore
+
+    def get_domain(self, obj):
+        return CommCareUser.get(obj.demo_user_id).domain
+
+    def blob_kwargs(self, obj):
+        return {"content_length": obj.content_length, "content_type": "text/xml"}
+
+
+class IcdsFileReindexAccessor(PkReindexAccessor):
+    model_class = IcdsFile
+    blob_helper = sql_blob_helper("blob_id")
+
+    def doc_to_json(self, obj):
+        return PkReindexAccessor.doc_to_json(self, obj, "IcdsFile")
+
+    @staticmethod
+    def get_type_code(doc):
+        return CODES.tempfile
+
+    def get_domain(self, obj):
+        return "icds-cas"
+
+    def blob_kwargs(self, obj):
+        return {"content_length": 0}  # unknown content length
+
+
+def couch_blob_helper(doc, *args, **kw):
+    obj = BlobHelper(doc, *args, **kw)
+    get_domain = DOMAIN_MAP.get(obj.doc_type)
+    if get_domain is not None:
+        assert not hasattr(obj, "domain"), obj
+        obj.domain = get_domain(doc)
+    assert hasattr(obj, "domain"), obj.doc_type
+    return obj
+
+
+def get_shared_domain(doc):
+    return SHARED_DOMAIN
+
+
+def get_invoice_domain(doc):
+    if doc.get("is_wire"):
+        return acct.WireInvoice.objects.get(int(doc["invoice_id"])).domain
+    # customer invoice has no domain
+    return UNKNOWN_DOMAIN
+
+
+DOMAIN_MAP = {
+    "InvoicePdf": get_invoice_domain,
+    "CommCareBuild": get_shared_domain,
+    "CommCareAudio": get_shared_domain,
+    "CommCareImage": get_shared_domain,
+    "CommCareVideo": get_shared_domain,
+    "CommCareMultimedia": get_shared_domain,
+    "SavedBasicExport": (lambda doc: UNKNOWN_DOMAIN),
+}
+
+
+migrate_metadata = MultiDbMigrator("migrate_metadata",
+    couch_types=[
+        apps.Application,
+        apps.LinkedApplication,
+        apps.RemoteApp,
+        ("Application-Deleted", apps.Application),
+        ("RemoteApp-Deleted", apps.RemoteApp),
+        apps.SavedAppBuild,
+        CommCareBuild,
+        SavedBasicExport,
+        Domain,
+        acct.InvoicePdf,
+        hqmedia.CommCareAudio,
+        hqmedia.CommCareImage,
+        hqmedia.CommCareVideo,
+        hqmedia.CommCareMultimedia,
+        xform.XFormInstance,
+        ("XFormInstance-Deleted", xform.XFormInstance),
+        xform.XFormArchived,
+        xform.XFormDeprecated,
+        xform.XFormDuplicate,
+        xform.XFormError,
+        xform.SubmissionErrorLog,
+        ("HQSubmission", xform.XFormInstance),
+        cases.CommCareCase,
+        ('CommCareCase-deleted', cases.CommCareCase),
+        ('CommCareCase-Deleted', cases.CommCareCase),
+        ('CommCareCase-Deleted-Deleted', cases.CommCareCase),
+        exports.CaseExportInstance,
+        exports.FormExportInstance,
+        exports.SMSExportInstance,
+    ],
+    sql_reindexers=[
+        CaseUploadFileMetaReindexAccessor,
+        DemoUserRestoreReindexAccessor,
+        IcdsFileReindexAccessor,
+    ],
+)

--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -335,6 +335,14 @@ class BlobHelper(object):
             BlobMetaRef._normalize_json(database.dbname, self._id, m.copy())
         ) for n, m in six.iteritems(doc.get("external_blobs", {}))}
 
+    def __repr__(self):
+        return "<%s %s domain=%s id=%s>" % (
+            type(self).__name__,
+            self.doc_type,
+            getattr(self, "domain", ""),
+            self._id,
+        )
+
     _atomic_blobs = None
 
     @property

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -105,10 +105,12 @@ class TestMigrateBackend(TestCase):
 def discard_migration_state(slug):
     migrator = mod.MIGRATIONS[slug]
     if hasattr(migrator, "migrators"):
-        providers = [m._get_document_provider() for m in migrator.migrators]
+        migrators = migrator.migrators
+    elif hasattr(migrator, "iter_migrators"):
+        migrators = migrator.iter_migrators()
     else:
-        providers = [migrator._get_document_provider()]
-    for provider in providers:
+        migrators = [migrator]
+    for provider in (m._get_document_provider() for m in migrators):
         provider.get_document_iterator(1).discard_state()
     mod.BlobMigrationState.objects.filter(slug=slug).delete()
 

--- a/corehq/blobs/tests/test_migrate_metadata.py
+++ b/corehq/blobs/tests/test_migrate_metadata.py
@@ -1,0 +1,269 @@
+# coding=utf-8
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+import uuid
+from itertools import chain
+from os.path import join
+
+import corehq.blobs.migrate as migrate
+import corehq.blobs.migrate_metadata as mod
+from corehq.blobs import CODES
+from corehq.blobs.migrate import MIGRATIONS
+from corehq.blobs.models import BlobMeta
+from corehq.blobs.tests.test_migrate import discard_migration_state
+
+from corehq.sql_db.util import get_db_alias_for_partitioned_doc
+
+import attr
+from dimagi.ext.couchdbkit import DocumentSchema, IntegerProperty, StringProperty
+from django.test import TestCase
+from testil import replattr, tempdir
+
+
+class TestMigrateBackend(TestCase):
+
+    longMessage = True
+    slug = "migrate_metadata"
+    couch_doc_types = {
+        "Application": mod.apps.Application,
+        "LinkedApplication": mod.apps.LinkedApplication,
+        "RemoteApp": mod.apps.RemoteApp,
+        "Application-Deleted": mod.apps.Application,
+        "RemoteApp-Deleted": mod.apps.RemoteApp,
+        "SavedAppBuild": mod.apps.SavedAppBuild,
+        "CommCareBuild": mod.CommCareBuild,
+        "SavedBasicExport": mod.SavedBasicExport,
+        "Domain": mod.Domain,
+        "InvoicePdf": mod.acct.InvoicePdf,
+        "CommCareAudio": mod.hqmedia.CommCareAudio,
+        "CommCareImage": mod.hqmedia.CommCareImage,
+        "CommCareVideo": mod.hqmedia.CommCareVideo,
+        "CommCareMultimedia": mod.hqmedia.CommCareMultimedia,
+        "XFormInstance": mod.xform.XFormInstance,
+        "XFormInstance-Deleted": mod.xform.XFormInstance,
+        "XFormArchived": mod.xform.XFormArchived,
+        "XFormDeprecated": mod.xform.XFormDeprecated,
+        "XFormDuplicate": mod.xform.XFormDuplicate,
+        "XFormError": mod.xform.XFormError,
+        "SubmissionErrorLog": mod.xform.SubmissionErrorLog,
+        "HQSubmission": mod.xform.XFormInstance,
+        "CommCareCase": mod.cases.CommCareCase,
+        'CommCareCase-deleted': mod.cases.CommCareCase,
+        'CommCareCase-Deleted': mod.cases.CommCareCase,
+        'CommCareCase-Deleted-Deleted': mod.cases.CommCareCase,
+        "CaseExportInstance": mod.exports.CaseExportInstance,
+        "FormExportInstance": mod.exports.FormExportInstance,
+        "SMSExportInstance": mod.exports.SMSExportInstance,
+    }
+    shared_domain_doc_types = {
+        "CommCareBuild",
+        "CommCareAudio",
+        "CommCareImage",
+        "CommCareVideo",
+        "CommCareMultimedia",
+    }
+    sql_reindex_accessors = [
+        mod.CaseUploadFileMetaReindexAccessor,
+        mod.DemoUserRestoreReindexAccessor,
+        mod.IcdsFileReindexAccessor,
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMigrateBackend, cls).setUpClass()
+        cls.user = mod.CommCareUser(username="testuser", domain="test")
+        cls.user.save()
+        assert cls.user._id, cls.user
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete()
+        super(TestMigrateBackend, cls).tearDownClass()
+
+    def CaseUploadFileMeta_save(self, obj, key):
+        obj.identifier = key
+        obj.filename = "file.txt"
+        obj.length = 15
+        obj.save()
+        mod.CaseUploadRecord.objects.create(
+            domain="test",
+            upload_id=uuid.uuid4(),
+            task_id=uuid.uuid4(),
+            couch_user_id=self.user._id,
+            case_type="test",
+            upload_file_meta=obj,
+        )
+        return SqlDoc(obj, "test", "test", CODES.data_import, None, 15)
+
+    def DemoUserRestore_save(self, obj, key):
+        obj.restore_blob_id = key
+        obj.demo_user_id = uid = self.user._id
+        obj.content_length = 87
+        obj.save()
+        code = CODES.demo_user_restore
+        return SqlDoc(obj, self.user.domain, uid, code, "text/xml", 87)
+
+    def IcdsFile_save(self, obj, key):
+        obj.blob_id = key
+        obj.data_type = "unknown"
+        obj.save()
+        return SqlDoc(obj, "icds-cas", "IcdsFile", CODES.tempfile, None, 0)
+
+    def setUp(self):
+        super(TestMigrateBackend, self).setUp()
+
+        self.not_founds = set()
+        self.couch_docs = []
+        for doc_type, doc_class in self.couch_doc_types.items():
+            obj = doc_class()
+            if hasattr(doc_class, "domain"):
+                domain = obj.domain = "test"
+            elif doc_class is mod.Domain:
+                domain = obj.name = "test"
+            elif doc_type in self.shared_domain_doc_types:
+                domain = mod.SHARED_DOMAIN
+            else:
+                domain = mod.UNKNOWN_DOMAIN
+            obj.doc_type = doc_type
+            doc = obj.to_json()
+            doc["external_blobs"] = {"blob": OldCouchBlobMeta(
+                id=doc_type.lower(),
+                content_type="text/plain",
+                content_length=7,
+            ).to_json()}
+            doc_class.get_db().save_doc(doc)
+            self.couch_docs.append(CouchDoc(doc_class, doc_type, domain, doc))
+
+        def create_sql_doc(rex):
+            key = uuid.uuid4().hex
+            obj = rex.model_class()
+            save_attr = rex.model_class.__name__ + "_save"
+            return getattr(self, save_attr)(obj, key)
+        self.sql_docs = []
+        for rex in (x() for x in self.sql_reindex_accessors):
+            self.sql_docs.append(create_sql_doc(rex))
+
+        self.test_size = len(self.couch_docs) + len(self.sql_docs)
+        discard_migration_state(self.slug)
+
+    def tearDown(self):
+        try:
+            for doc in self.couch_docs:
+                doc.class_.get_db().delete_doc(doc.id)
+            for doc in self.sql_docs:
+                doc.obj.delete()
+            discard_migration_state(self.slug)
+        finally:
+            super(TestMigrateBackend, self).tearDown()
+
+    def test_migrate_backend(self):
+        with tempdir() as tmp:
+            filename = join(tmp, "file.txt")
+            # do migration
+            migrated, skipped = MIGRATIONS[self.slug].migrate(filename)
+            self.assertGreaterEqual(migrated, self.test_size)
+
+            # verify: migration state recorded
+            mod.BlobMigrationState.objects.get(slug=self.slug)
+
+        # verify: metadata was saved in BlobMeta table
+
+        for doc in self.couch_docs:
+            obj = doc.class_.get(doc.id)
+            self.assertEqual(obj._rev, doc.data["_rev"])  # rev should not change
+            self.assertEqual(set(obj.blobs), set(doc.data["external_blobs"]))
+            db = get_db_alias_for_partitioned_doc(obj._id)
+            metas = {meta.name: meta
+                for meta in BlobMeta.objects.using(db).filter(parent_id=doc.id)}
+            for name, meta in obj.blobs.items():
+                blobmeta = metas[name]
+                dbname = doc.class_.get_db().dbname
+                key = "%s/%s/%s" % (dbname, obj._id, doc.doc_type.lower())
+                self.assertEqual(blobmeta.key, key, doc)
+                self.assertEqual(blobmeta.domain, doc.domain, doc)
+                self.assertEqual(blobmeta.content_type, meta.content_type, doc)
+                self.assertEqual(blobmeta.content_length, meta.content_length, doc)
+
+        for doc in self.sql_docs:
+            db = get_db_alias_for_partitioned_doc(doc.parent_id)
+            blobmeta = BlobMeta.objects.using(db).get(
+                parent_id=doc.parent_id,
+                type_code=doc.type_code,
+                name="",
+            )
+            self.assertEqual(blobmeta.domain, doc.domain, doc)
+            self.assertEqual(blobmeta.content_type, doc.content_type, doc)
+            self.assertEqual(blobmeta.content_length, doc.content_length, doc)
+
+    def test_resume_migration(self):
+
+        class IncompleteDPC(migrate.DocumentProcessorController):
+
+            def _processing_complete(self):
+                self.document_iterator.discard_state()
+
+        with tempdir() as tmp:
+            filename = join(tmp, "file.txt")
+            with replattr(migrate, "DocumentProcessorController", IncompleteDPC):
+                # interrupted migration
+                migrated1, skipped = MIGRATIONS[self.slug].migrate(filename)
+                self.assertGreaterEqual(migrated1, self.test_size)
+                self.assertFalse(skipped)
+
+            # resumed migration: all docs already migrated, so BlobMeta records
+            # exist, but should not cause errors on attempting to insert them
+            migrated2, skipped = MIGRATIONS[self.slug].migrate(filename)
+            self.assertEqual(migrated1, migrated2)
+            self.assertFalse(skipped)
+
+            mod.BlobMigrationState.objects.get(slug=self.slug)
+
+        parent_ids = chain(
+            (doc.id for doc in self.couch_docs),
+            (doc.parent_id for doc in self.sql_docs),
+        )
+
+        # should have one blob per parent
+        for parent_id in parent_ids:
+            db = get_db_alias_for_partitioned_doc(parent_id)
+            metas = list(BlobMeta.objects.using(db).filter(parent_id=parent_id))
+            self.assertEqual(len(metas), 1, metas)
+
+
+def resurrect_old_couch_blob_meta():
+
+    class BlobMeta(DocumentSchema):
+        id = StringProperty()
+        content_type = StringProperty()
+        content_length = IntegerProperty()
+        digest = StringProperty()
+
+    return BlobMeta
+
+
+OldCouchBlobMeta = resurrect_old_couch_blob_meta()
+
+
+@attr.s
+class CouchDoc(object):
+    """Container for items in TestMigrateBackend.couch_docs"""
+    class_ = attr.ib()
+    doc_type = attr.ib()
+    domain = attr.ib()
+    data = attr.ib()
+
+    @property
+    def id(self):
+        return self.data["_id"]
+
+
+@attr.s
+class SqlDoc(object):
+    """Container for items in TestMigrateBackend.sql_docs"""
+    obj = attr.ib()
+    domain = attr.ib()
+    parent_id = attr.ib()
+    type_code = attr.ib()
+    content_type = attr.ib()
+    content_length = attr.ib()


### PR DESCRIPTION
All the models (both Couch and SQL) affected by this migration should be using the new blob db API by now—if you know of any that do not, please let me know. I'd like to get this migration started soon since it is a prerequisite for migrating blobs out of Riak into Amazon S3. I'm still working on one more PR that migrates SQL forms to use the new blob db API. However, it will not be necessary to migrate existing form attachments into the `BlobMeta` table because they already exist in an easily query-able format in the shard dbs.

Reminder: the purpose of the `BlobMeta` table is to allow us to migrate from Riak to Amazon S3 in a more performant way than was previously possible. It also gives us a query-able set of blobs with which we can answer questions about how the blob db is being used at the domain and type code level.

For performance reasons this migration only writes blob metadata into the new `BlobMeta` table. It does not write any changes back to the Couch or SQL model from which the metadata is derived. This should not be a problem since the blob key is the only thing necessary to access the blob in the blobdb, and that can always be calculated from information on the Couch or SQL model.

@snopoke @emord 