### PR TITLE
Skip cache when fetching user for write

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -60,7 +60,7 @@ def activate_new_user(form, is_domain_admin=True, domain=None, ip=None):
 
 def request_new_domain(request, form, is_new_user=True):
     now = datetime.utcnow()
-    current_user = CouchUser.from_django_user(request.user)
+    current_user = CouchUser.from_django_user(request.user, strict=True)
 
     dom_req = RegistrationRequest()
     if is_new_user:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1424,8 +1424,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         return couch_user
 
     @classmethod
-    def from_django_user(cls, django_user):
-        return cls.get_by_username(django_user.username)
+    def from_django_user(cls, django_user, strict=False):
+        return cls.get_by_username(django_user.username, strict=strict)
 
     @classmethod
     def create(cls, domain, username, password, email=None, uuid='', date='',


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/463254159/events/28856793114/?environment=production

There was a 500 error sometimes due to a document update conflict.  Hopefully this should take care of that.