### PR TITLE
use caching to speed up loading the form settings page

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -498,6 +498,7 @@ def get_case_properties(app, case_types, defaults=(), include_parent_properties=
     return properties
 
 
+@quickcache(vary_on=['app.get_id'])
 def get_all_case_properties(app):
     return get_case_properties(app, app.get_case_types(), defaults=('name',), exclude_invalid_properties=True)
 

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -507,6 +507,7 @@ def get_all_case_properties_for_case_type(domain, case_type):
     return all_case_properties_by_domain(domain, [case_type]).get(case_type, [])
 
 
+@quickcache(vary_on=['app.get_id'])
 def get_usercase_properties(app):
     if is_usercase_in_use(app.domain):
         # TODO: add name here once it is fixed to concatenate first and last in form builder

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -30,7 +30,7 @@ from django.utils.translation import override, ugettext as _, ugettext
 from django.utils.translation import ugettext_lazy
 from couchdbkit.exceptions import BadValueError
 
-from corehq.apps.app_manager.app_schemas.case_properties import get_parent_type_map
+from corehq.apps.app_manager.app_schemas.case_properties import get_parent_type_map, get_all_case_properties
 from corehq.apps.app_manager.detail_screen import PropertyXpathGenerator
 from corehq.apps.linked_domain.applications import get_master_app_version, get_latest_master_app_release
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
@@ -5418,6 +5418,8 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
             domain_has_apps.clear(self.domain)
 
         LatestAppInfo(self.master_id, self.domain).clear_caches()
+
+        get_all_case_properties.clear(self)
 
         request = view_utils.get_request()
         user = getattr(request, 'couch_user', None)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -30,7 +30,11 @@ from django.utils.translation import override, ugettext as _, ugettext
 from django.utils.translation import ugettext_lazy
 from couchdbkit.exceptions import BadValueError
 
-from corehq.apps.app_manager.app_schemas.case_properties import get_parent_type_map, get_all_case_properties
+from corehq.apps.app_manager.app_schemas.case_properties import (
+    get_all_case_properties,
+    get_parent_type_map,
+    get_usercase_properties,
+)
 from corehq.apps.app_manager.detail_screen import PropertyXpathGenerator
 from corehq.apps.linked_domain.applications import get_master_app_version, get_latest_master_app_release
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5420,6 +5420,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         LatestAppInfo(self.master_id, self.domain).clear_caches()
 
         get_all_case_properties.clear(self)
+        get_usercase_properties.clear(self)
 
         request = view_utils.get_request()
         user = getattr(request, 'couch_user', None)


### PR DESCRIPTION
I found that these two functions take up most of the time when loading the form settings page for the L10K app.  Locally and on staging, caching makes a big difference in performance.