### PR TITLE
gracefully handle null task ids

### DIFF
--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -146,6 +146,8 @@ class DownloadBase(object):
     @property
     def task(self):
         from soil.util import get_task
+        if not self.task_id:
+            return None
         return get_task(self.task_id)
 
     def get_progress(self):

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -140,7 +140,7 @@ def get_task_status(task, is_multiple_download_task=False):
             context_error = "%s: %s" % (type(task.result).__name__, task.result)
     elif is_ready:
         state = STATES.success
-    elif _is_task_pending(task):
+    elif task and _is_task_pending(task):
         state = STATES.missing
     elif progress.percent is None:
         state = STATES.not_started

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -40,7 +40,10 @@ def get_task_progress(task):
     error = False
     error_message = ''
     try:
-        info = task.info
+        if not task:
+            info = None
+        else:
+            info = task.info
     except (TypeError, NotImplementedError):
         current = total = percent = None
         logging.exception("No celery result backend?")

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -100,7 +100,11 @@ def get_task_status(task, is_multiple_download_task=False):
     context_error = None
     is_ready = False
     failed = False
-    if is_multiple_download_task:
+    if not task:
+        progress = get_task_progress(None)
+        context_result = False
+        context_error = []
+    elif is_multiple_download_task:
         if task.ready():
             context_result, context_error = _get_download_context_multiple_tasks(task)
         progress = get_multiple_task_progress(task)
@@ -124,7 +128,7 @@ def get_task_status(task, is_multiple_download_task=False):
     def progress_complete():
         return (
             getattr(settings, 'CELERY_ALWAYS_EAGER', False) or
-            progress.percent == 100 and
+            progress and progress.percent == 100 and
             not progress.error
         )
 


### PR DESCRIPTION
Alternative to https://github.com/dimagi/commcare-hq/pull/21674

Fixes a bug when ```AsyncResult(None)``` is called in celery 4.x.