### PR TITLE
fix doctests in py3

### DIFF
--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -167,16 +167,16 @@ class XFormBuilder(object):
         """
         Builds a text node "id" parameter
 
-        >>> XFormBuilder.get_text_id('foo')
-        u'foo-label'
-        >>> XFormBuilder.get_text_id('foo', ['bar'])
-        u'bar/foo-label'
-        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'])
-        u'bar/baz/foo-label'
-        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1')
-        u'bar/baz/foo-choice1-label'
-        >>> XFormBuilder.get_text_id('foo', is_hint=True)
-        u'foo-hint'
+        >>> XFormBuilder.get_text_id('foo') if six.PY3 else XFormBuilder.get_text_id('foo').encode('utf-8')
+        'foo-label'
+        >>> XFormBuilder.get_text_id('foo', ['bar']) if six.PY3 else XFormBuilder.get_text_id('foo', ['bar']).encode('utf-8')
+        'bar/foo-label'
+        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz']) if six.PY3 else XFormBuilder.get_text_id('foo', ['bar', 'baz']).encode('utf-8')
+        'bar/baz/foo-label'
+        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1') if six.PY3 else XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1').encode('utf-8')
+        'bar/baz/foo-choice1-label'
+        >>> XFormBuilder.get_text_id('foo', is_hint=True) if six.PY3 else XFormBuilder.get_text_id('foo', is_hint=True).encode('utf-8')
+        'foo-hint'
 
         """
         text_id = []
@@ -193,12 +193,12 @@ class XFormBuilder(object):
         """
         Returns the reference to the data node of the given question
 
-        >>> XFormBuilder.get_data_ref('foo')
-        u'/data/foo'
-        >>> XFormBuilder.get_data_ref('foo', ['bar'])
-        u'/data/bar/foo'
-        >>> XFormBuilder.get_data_ref('foo', ['bar', 'baz'])
-        u'/data/bar/baz/foo'
+        >>> XFormBuilder.get_data_ref('foo') if six.PY3 else XFormBuilder.get_data_ref('foo').encode('utf-8')
+        '/data/foo'
+        >>> XFormBuilder.get_data_ref('foo', ['bar']) if six.PY3 else XFormBuilder.get_data_ref('foo', ['bar']).encode('utf-8')
+        '/data/bar/foo'
+        >>> XFormBuilder.get_data_ref('foo', ['bar', 'baz']) if six.PY3 else XFormBuilder.get_data_ref('foo', ['bar', 'baz']).encode('utf-8')
+        '/data/bar/baz/foo'
 
         """
         if groups is None:
@@ -210,10 +210,10 @@ class XFormBuilder(object):
         Return a namespaced parameter/tag name
 
         >>> xform = XFormBuilder()
-        >>> xform.get_namespaced('jr:constraintMsg')
-        u'{http://openrosa.org/javarosa}constraintMsg'
-        >>> xform.get_namespaced('constraint')
-        u'constraint'
+        >>> xform.get_namespaced('jr:constraintMsg') if six.PY3 else xform.get_namespaced('jr:constraintMsg').encode('utf-8')
+        '{http://openrosa.org/javarosa}constraintMsg'
+        >>> xform.get_namespaced('constraint') if six.PY3 else xform.get_namespaced('constraint').encode('utf-8')
+        'constraint'
 
         """
         has_namespace = re.compile(r'(\w+):(\w+)')

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -37,7 +37,7 @@ def b64_aes_encrypt(message):
 
     >>> settings.SECRET_KEY = 'xyzzy'
     >>> encrypted = b64_aes_encrypt('Around you is a forest.')
-    >>> encrypted == 'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I='
+    >>> encrypted == b'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I='
     True
 
     """
@@ -59,7 +59,7 @@ def b64_aes_decrypt(message):
 
     >>> settings.SECRET_KEY = 'xyzzy'
     >>> decrypted = b64_aes_decrypt(b'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I=')
-    >>> decrypted == 'Around you is a forest.'
+    >>> decrypted == b'Around you is a forest.'
     True
 
     """

--- a/custom/openclinica/utils.py
+++ b/custom/openclinica/utils.py
@@ -35,10 +35,10 @@ def quote_nan(value):
     """
     Returns value in single quotes if value is not a number
 
-    >>> quote_nan('foo')
-    u"'foo'"
-    >>> quote_nan('1')
-    u'1'
+    >>> quote_nan('foo') if six.PY3 else quote_nan('foo').encode('utf-8')
+    "'foo'"
+    >>> quote_nan('1') if six.PY3 else quote_nan('1').encode('utf-8')
+    '1'
 
     """
     try:
@@ -177,12 +177,12 @@ def mk_oc_username(cc_username):
 
     Strips off "@domain.name", replaces non-alphanumerics, and pads with "_" if less than 5 characters
 
-    >>> mk_oc_username('eric.idle@montypython.com')
-    u'eric_idle'
-    >>> mk_oc_username('eric')
-    u'eric_'
-    >>> mk_oc_username('I3#')
-    u'I3___'
+    >>> mk_oc_username('eric.idle@montypython.com') if six.PY3 else mk_oc_username('eric.idle@montypython.com').encode('utf-8')
+    'eric_idle'
+    >>> mk_oc_username('eric') if six.PY3 else mk_oc_username('eric').encode('utf-8')
+    'eric_'
+    >>> mk_oc_username('I3#') if six.PY3 else mk_oc_username('I3#').encode('utf-8')
+    'I3___'
 
     """
     username = cc_username.split('@')[0]
@@ -238,7 +238,7 @@ def oc_format_date(answer):
 
     """
     if isinstance(answer, datetime):
-        return answer.isoformat(sep=b' ')
+        return answer.isoformat(sep=' ' if six.PY3 else b' ')
     if isinstance(answer, (date, time)):
         return answer.isoformat()
     return answer


### PR DESCRIPTION
From https://github.com/dimagi/commcare-hq/pull/19116/

A lot of these involve encoding unicode into bytes in python2, so ```__repr__``` equals the value that's expected in the doctests.  I couldn't find a better way to make these tests work in both py2 and py3, but this does the trick and will be easy to clean up later.

@dimagi/py3 