### PR TITLE
replace assertItemsEqual

### DIFF
--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -265,7 +265,7 @@ class TestDumpLoadToggles(SimpleTestCase):
 
             for mocked_toggle in mocked_toggles.values():
                 loaded_toggle = Toggle.get(mocked_toggle.slug)
-                self.assertItemsEqual(mocked_toggle.enabled_users, loaded_toggle.enabled_users)
+                self.assertEqual(set(mocked_toggle.enabled_users), set(loaded_toggle.enabled_users))
 
 
 def _get_doc_counts_from_db(domain):


### PR DESCRIPTION
This function doesn't exist in py3.

From https://github.com/dimagi/commcare-hq/pull/19116

@dimagi/py3 