### PR TITLE
switch "request" to "trigger"

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -131,7 +131,7 @@ FormplayerFrontend.reqres.setHandler('showSuccess', function(successMessage) {
 
 FormplayerFrontend.reqres.setHandler('handleNotification', function(notification) {
     if (notification.error){
-        FormplayerFrontend.request('showError', notification.message);
+        FormplayerFrontend.trigger('showError', notification.message);
     } else {
         FormplayerFrontend.request('showSuccess', notification.message);
     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -31,7 +31,7 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 // then parse the appId from the response.
                 if (urlObject.appId === undefined || urlObject.appId === null) {
                     if (menuResponse.appId === null || menuResponse.appId === undefined) {
-                        FormplayerFrontend.request('showError', "Response did not contain appId even though it was" +
+                        FormplayerFrontend.trigger('showError', "Response did not contain appId even though it was" +
                             "required. If this persists, please report an issue to CommCareHQ");
                         FormplayerFrontend.trigger("apps:list");
                         return;


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?282310

It seems we have a few ways of passing messages around. I'd love to spend more time at some point unifying that on one style, but for now at least I'll send all `showError` events to the right handler type

@orangejenny @gcapalbo 