### PR TITLE
pickle emailed file attachments to support non-JSON serializable data

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import base64
 import datetime
+import pickle
 from decimal import Decimal
 import itertools
 from io import BytesIO
@@ -2229,11 +2232,13 @@ class BillingRecordBase(models.Model):
         context['can_view_statement'] = can_view_statement
         email_html = render_to_string(self.html_template, context)
         email_plaintext = render_to_string(self.text_template, context)
+        pickled_file_attachments = base64.b64encode(pickle.dumps([pdf_attachment])).decode('utf-8')
+
         send_html_email_async.delay(
             subject, contact_email, email_html,
             text_content=email_plaintext,
             email_from=email_from,
-            file_attachments=[pdf_attachment],
+            pickled_file_attachments=pickled_file_attachments,
             cc=cc_emails
         )
         self.emailed_to_list.extend([contact_email])

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import base64
 import calendar
 import hashlib
+import pickle
 import uuid
 from collections import defaultdict, namedtuple
 from datetime import datetime
@@ -813,10 +816,11 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
 
             for email in emails:
                 body = render_full_report_notification(None, content, email, self).content
+                pickled_file_attachments = base64.b64encode(pickle.dumps(excel_files)).decode('utf-8')
                 send_html_email_async.delay(
                     title, email, body,
                     email_from=settings.DEFAULT_FROM_EMAIL,
-                    file_attachments=excel_files)
+                    pickled_file_attachments=pickled_file_attachments)
 
     def remove_recipient(self, email):
         try:


### PR DESCRIPTION
Opening for tests - manually testing on staging right now.

Data flow:

python -> (pickled) bytes -> b64 encoded bytes -> unicode -> JSON in celery -> unicode -> b64 encoded bytes -> bytes -> python