### PR TITLE
Revert "skip specifying serializer for email tasks"

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -8,7 +8,7 @@ from dimagi.utils.logging import notify_exception
 import six
 
 
-@task(queue="email_queue",
+@task(serializer='pickle', queue="email_queue",
       bind=True, default_retry_delay=15 * 60, max_retries=10, acks_late=True)
 def send_mail_async(self, subject, message, from_email, recipient_list,
                     fail_silently=False, auth_user=None, auth_password=None,
@@ -48,7 +48,7 @@ def send_mail_async(self, subject, message, from_email, recipient_list,
         )
         self.retry(exc=e)
 
-@task(queue="email_queue",
+@task(serializer='pickle', queue="email_queue",
       bind=True, default_retry_delay=15 * 60, max_retries=10, acks_late=True)
 def send_html_email_async(self, subject, recipient, html_content,
                           text_content=None, cc=None,
@@ -77,7 +77,7 @@ def send_html_email_async(self, subject, recipient, html_content,
         self.retry(exc=e)
 
 
-@task(queue="email_queue",
+@task(serializer='pickle', queue="email_queue",
       bind=True, default_retry_delay=15 * 60, max_retries=10, acks_late=True)
 def mail_admins_async(self, subject, message, fail_silently=False, connection=None,
                       html_message=None):


### PR DESCRIPTION
This reverts commit 1a9d46c64cb8a3386340f3715e310f453ce630e1.

https://sentry.io/dimagi/commcarehq/issues/669432895/events/28992298191/