### PR TITLE
Cap display at 100 children per level

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
@@ -84,7 +84,7 @@
                 </a>
                 {% endwith %}
                 {% endif %}
-                
+
                 <div class="pull-right btn-group">
                     {% if case.edit_data.edit_form_id != None and not case.closed %}
                     {% with case.edit_data as data %}
@@ -100,7 +100,7 @@
                     </a>
                     {% endwith %}
                     {% endif %}
-                    
+
                     {% if show_view_buttons and case.case_id != current_case.case_id %}
                     <a class="btn btn-sm btn-default" href="{{ case.edit_data.view_url }}">
                         <i class="fa fa-eye"></i> {% trans "View" %}
@@ -123,6 +123,17 @@
                     <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
                 </div>
                 {% endif %}
+
+                {% if case.num_children > max_child_cases %}
+                <br style="line-height:0">
+                <span class="indenter" style="line-height:0; padding: 0 {{ case.edit_data.indent_px }}px"></span>
+                <div style="display:inline-block">
+                    {% blocktrans with case.num_children as num_children %}
+                    Displaying {{ max_child_cases }} of {{ num_children }} children
+                    {% endblocktrans %}
+                </div>
+                {% endif %}
+
             </td>
 
             {% for column in case.columns %}


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?282318

This just truncates the number of cases we display in the "Related Cases" widget.  This is because there's at least one project for which the case data page just doesn't load.  As-implemented, there's at least one db hit per child, not to mention that this view would quickly become unusable.

For testing, I set the limit at 3, here's what it looks like:
![image](https://user-images.githubusercontent.com/2367539/44928751-d6dd7400-ad26-11e8-9222-5d8c0ef94c43.png)
