### PR TITLE
build_requirejs: include_directories

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -31,11 +31,25 @@ class Command(ResourceStaticCommand):
         with open(os.path.join(self.root_dir, 'staticfiles', 'hqwebapp', 'yaml', 'requirejs.yaml'), 'r') as f:
             config = yaml.load(f)
 
-            bundles = {}
-            all_modules = []
+            '''
+            The default strategy is to make one "bundle" for every corehq directory of js files.
+            Begin by gathering all corehq staticfiles directories into a dict like:
+                {
+                    'app_manager/js' => [
+                        'app_manager/js/app_view',
+                        'app_manager/js/add_ons',
+                        ...
+                    ],
+                    'app_manager/js/forms' => [
+                        'app_manager/js/forms/form_designer',
+                        ...
+                    ],
+                    ...
+                }
+            '''
             prefix = os.path.join(os.getcwd(), 'corehq')
-
-            # Gather all directories of static files
+            corehq_dirs = {}
+            all_js_files = []
             for finder in finders.get_finders():
                 if isinstance(finder, finders.AppDirectoriesFinder):
                     for path, storage in finder.list(['.*', '*~', '* *', '*.*ss', '*.png']):
@@ -43,10 +57,10 @@ class Command(ResourceStaticCommand):
                             continue
                         if path.endswith(".js"):
                             directory = re.sub(r'/[^/]*$', '', path)
-                            if directory not in bundles:
-                                bundles[directory] = []
-                            bundles[directory].append(path[:-3])
-                            all_modules.append(path[:-3])
+                            if directory not in corehq_dirs:
+                                corehq_dirs[directory] = []
+                            corehq_dirs[directory].append(path[:-3])
+                            all_js_files.append(path[:-3])
 
             # Go through customized bundles and expand any that include directories
             for module in config['modules']:
@@ -54,19 +68,19 @@ class Command(ResourceStaticCommand):
                     if 'include' not in module:
                         module['include'] = []
                     for directory in module.pop('include_directories'):
-                        if directory not in bundles:
+                        if directory not in corehq_dirs:
                             raise Exception("Could not find directory to include: {}".format(directory))
-                        module['include'] += bundles[directory]
+                        module['include'] += corehq_dirs[directory]
 
             # Add a bundle for each directory that doesn't already have a custom module defined
             customized_directories = {re.sub(r'/[^/]*$', '', m['name']): True for m in config['modules']}
-            for directory, inclusions in six.iteritems(bundles):
+            for directory, inclusions in six.iteritems(corehq_dirs):
                 if directory not in customized_directories and not directory.startswith("app_manager/js/vellum"):
                     # Add this module's config to build config
                     config['modules'].append({
                         'name': os.path.join(directory, 'bundle'),
                         'include': inclusions,
-                        'excludeShallow': [name for name in all_modules if name not in inclusions],
+                        'excludeShallow': [name for name in all_js_files if name not in inclusions],
                         'exclude': ['hqwebapp/js/common'],
                     })
 

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -48,7 +48,17 @@ class Command(ResourceStaticCommand):
                             bundles[directory].append(path[:-3])
                             all_modules.append(path[:-3])
 
-            # Add a bundle for each directory that doesn't already have a custom bundle defined
+            # Go through customized bundles and expand any that include directories
+            for module in config['modules']:
+                if 'include_directories' in module:
+                    if 'include' not in module:
+                        module['include'] = []
+                    for directory in module.pop('include_directories'):
+                        if directory not in bundles:
+                            raise Exception("Could not find directory to include: {}".format(directory))
+                        module['include'] += bundles[directory]
+
+            # Add a bundle for each directory that doesn't already have a custom module defined
             customized_directories = {re.sub(r'/[^/]*$', '', m['name']): True for m in config['modules']}
             for directory, inclusions in six.iteritems(bundles):
                 if directory not in customized_directories and not directory.startswith("app_manager/js/vellum"):

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -34,6 +34,8 @@ class Command(ResourceStaticCommand):
             bundles = {}
             all_modules = []
             prefix = os.path.join(os.getcwd(), 'corehq')
+
+            # Gather all directories of static files
             for finder in finders.get_finders():
                 if isinstance(finder, finders.AppDirectoriesFinder):
                     for path, storage in finder.list(['.*', '*~', '* *', '*.*ss', '*.png']):
@@ -46,9 +48,10 @@ class Command(ResourceStaticCommand):
                             bundles[directory].append(path[:-3])
                             all_modules.append(path[:-3])
 
-            customized = {re.sub(r'/[^/]*$', '', m['name']): True for m in config['modules']}
+            # Add a bundle for each directory that doesn't already have a custom bundle defined
+            customized_directories = {re.sub(r'/[^/]*$', '', m['name']): True for m in config['modules']}
             for directory, inclusions in six.iteritems(bundles):
-                if directory not in customized and not directory.startswith("app_manager/js/vellum"):
+                if directory not in customized_directories and not directory.startswith("app_manager/js/vellum"):
                     # Add this module's config to build config
                     config['modules'].append({
                         'name': os.path.join(directory, 'bundle'),
@@ -57,15 +60,18 @@ class Command(ResourceStaticCommand):
                         'exclude': ['hqwebapp/js/common'],
                     })
 
-            # Write .js files to staticfiles
+            # Write a no-op .js file to staticfiles for each bundle, because r.js needs an actual file to overwrite
             for module in config['modules']:
                 with open(os.path.join(self.root_dir, 'staticfiles', module['name'] + ".js"), 'w') as fout:
                     fout.write("define([], function() {});")
 
+            # Write final r.js config out as a .js file
             with open(os.path.join(self.root_dir, 'staticfiles', 'build.js'), 'w') as fout:
                 fout.write("({});".format(json.dumps(config, indent=4)))
 
+        # Run r.js
         call(["node", "bower_components/r.js/dist/r.js", "-o", "staticfiles/build.js"])
+
         filename = os.path.join(self.root_dir, 'staticfiles', 'hqwebapp', 'js', 'requirejs_config.js')
         resource_versions["hqwebapp/js/requirejs_config.js"] = self.get_hash(filename)
 


### PR DESCRIPTION
Allow bundle configs to include full directories, to avoid needing to make and maintain config like [this](https://github.com/dimagi/commcare-hq/pull/21269/commits/35e8231f939e36acd1ded1e9758e2e092ad2f718#diff-7c2ae1b50aacb5846194cb1bb4aa3d25R80)

@millerdev 
code buddies @jmtroth0 @gcapalbo 