### PR TITLE
strucutre improvement

### DIFF
--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -13,6 +13,7 @@ from corehq.apps.app_manager.app_translations.const import MODULES_AND_FORMS_SHE
 
 Translation = namedtuple('Translation', 'key translation occurrences msgctxt')
 Unique_ID = namedtuple('UniqueID', 'type id')
+POFileInfo = namedtuple("POFileInfo", "name path")
 
 
 class AppTranslationsGenerator:
@@ -219,7 +220,7 @@ class PoFileGenerator(object):
                     po.append(entry)
             temp_file = tempfile.NamedTemporaryFile(delete=False)
             po.save(temp_file.name)
-            generated_files.append((file_name, temp_file.name))
+            generated_files.append(POFileInfo(file_name, temp_file.name))
         return generated_files
 
     def _cleanup(self):

--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -192,6 +192,7 @@ class AppTranslationsGenerator:
 
 class PoFileGenerator(object):
     def __init__(self, translations, metadata):
+        self._generated_files = list()  # list of tuples (filename, filepath)
         self.translations = translations
         self.metadata = metadata
 
@@ -202,7 +203,6 @@ class PoFileGenerator(object):
         self._cleanup()
 
     def generate_translation_files(self):
-        generated_files = []
         for file_name in self.translations:
             sheet_translations = self.translations[file_name]
             po = polib.POFile()
@@ -220,11 +220,11 @@ class PoFileGenerator(object):
                     po.append(entry)
             temp_file = tempfile.NamedTemporaryFile(delete=False)
             po.save(temp_file.name)
-            generated_files.append(POFileInfo(file_name, temp_file.name))
-        return generated_files
+            self._generated_files.append(POFileInfo(file_name, temp_file.name))
+        return self._generated_files
 
     def _cleanup(self):
-        for resource_name, filepath in self.generated_files:
+        for resource_name, filepath in self._generated_files:
             if os.path.exists(filepath):
                 os.remove(filepath)
         self.generated_files = []

--- a/corehq/apps/app_manager/tests/test_generators.py
+++ b/corehq/apps/app_manager/tests/test_generators.py
@@ -24,7 +24,8 @@ class TestPoFileGenerator(SimpleTestCase):
         }
         file_paths = []
         with PoFileGenerator(all_translations, {}) as po_file_generator:
-            for file_name, file_path in po_file_generator.generated_files:
+            generated_files = po_file_generator.generate_translation_files()
+            for file_name, file_path in generated_files:
                 file_paths.append(file_path)
                 list_of_translations = polib.pofile(file_path)
                 # assure translations
@@ -49,7 +50,8 @@ class TestPoFileGenerator(SimpleTestCase):
             'Language': 'hin',
         }
         with PoFileGenerator(all_translations, metadata) as po_file_generator:
-            for file_name, file_path in po_file_generator.generated_files:
+            generated_files = po_file_generator.generate_translation_files()
+            for file_name, file_path in generated_files:
                 # ensure meta data
                 with open(file_path, encoding='utf-8') as f:
                     file_content = f.read()

--- a/corehq/apps/app_manager/tests/test_generators.py
+++ b/corehq/apps/app_manager/tests/test_generators.py
@@ -22,9 +22,8 @@ class TestPoFileGenerator(SimpleTestCase):
             'sheet1': list(translations),
             'sheet2': list(translations),
         }
-        po_file_generator = PoFileGenerator(all_translations, {})
         file_paths = []
-        try:
+        with PoFileGenerator(all_translations, {}) as po_file_generator:
             for file_name, file_path in po_file_generator.generated_files:
                 file_paths.append(file_path)
                 list_of_translations = polib.pofile(file_path)
@@ -37,8 +36,7 @@ class TestPoFileGenerator(SimpleTestCase):
                 self.assertEqual(list_of_translations[1].msgstr, 'अलविदा')
                 self.assertEqual(list_of_translations[1].msgctxt, '0:occurrence-bye')
                 self.assertEqual(list_of_translations[1].occurrences, [('occurrence-bye', '')])
-        finally:
-            po_file_generator.cleanup()
+
         # assure files are cleaned
         for file_path in file_paths:
             self.assertFalse(os.path.exists(file_path))
@@ -50,8 +48,7 @@ class TestPoFileGenerator(SimpleTestCase):
             'Content-Type': 'text/plain; charset=utf-8',
             'Language': 'hin',
         }
-        po_file_generator = PoFileGenerator(all_translations, metadata)
-        try:
+        with PoFileGenerator(all_translations, metadata) as po_file_generator:
             for file_name, file_path in po_file_generator.generated_files:
                 # ensure meta data
                 with open(file_path, encoding='utf-8') as f:
@@ -59,5 +56,3 @@ class TestPoFileGenerator(SimpleTestCase):
                     self.assertIn("Language: hin", file_content)
                     self.assertIn("MIME-Version: 1.0", file_content)
                     self.assertIn("Content-Type: text/plain; charset=utf-8", file_content)
-        finally:
-            po_file_generator.cleanup()

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -98,14 +98,16 @@ class ConvertTranslations(BaseTranslationsView):
             )
         return translations
 
-    def _generate_po_file(self, worksheet):
+    def _generate_po_content(self, worksheet):
         """
         extract translations from worksheet and converts to a po file
         :return: list of files generated
         """
         translations = self._generate_translations_for_po(worksheet)
         with PoFileGenerator(translations, {}) as po_file_generator:
-            return po_file_generator.generated_files[0][1]
+            generated_file = po_file_generator.generated_files[0][1]
+            with open(generated_file, 'r', encoding="utf-8") as f:
+                return f.read()
 
     def _generate_excel_file(self):
         """
@@ -127,9 +129,7 @@ class ConvertTranslations(BaseTranslationsView):
     def _po_file_response(self):
         uploaded_file = self.convert_translation_form.cleaned_data.get('upload_file')
         worksheet = openpyxl.load_workbook(uploaded_file).worksheets[0]
-        generated_file = self._generate_po_file(worksheet)
-        with open(generated_file, 'r', encoding="utf-8") as f:
-            content = f.read()
+        content = self._generate_po_content(worksheet)
         response = HttpResponse(content, content_type="text/html; charset=utf-8")
         response['Content-Disposition'] = safe_filename_header(worksheet.title, 'po')
         return response

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -101,7 +101,8 @@ class ConvertTranslations(BaseTranslationsView):
     def _generate_po_content(self, worksheet):
         """
         extract translations from worksheet and converts to a po file
-        :return: list of files generated
+
+        :return: content of file generated
         """
         translations = self._generate_translations_for_po(worksheet)
         with PoFileGenerator(translations, {}) as po_file_generator:

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -107,7 +107,7 @@ class ConvertTranslations(BaseTranslationsView):
         translations = self._generate_translations_for_po(worksheet)
         with PoFileGenerator(translations, {}) as po_file_generator:
             generated_files = po_file_generator.generate_translation_files()
-            with open(generated_files[0].file_path, 'r', encoding="utf-8") as f:
+            with open(generated_files[0].path, 'r', encoding="utf-8") as f:
                 return f.read()
 
     def _generate_excel_file(self):

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -106,7 +106,7 @@ class ConvertTranslations(BaseTranslationsView):
         translations = self._generate_translations_for_po(worksheet)
         with PoFileGenerator(translations, {}) as po_file_generator:
             generated_files = po_file_generator.generate_translation_files()
-            with open(generated_files[0][1], 'r', encoding="utf-8") as f:
+            with open(generated_files[0].file_path, 'r', encoding="utf-8") as f:
                 return f.read()
 
     def _generate_excel_file(self):

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -105,8 +105,8 @@ class ConvertTranslations(BaseTranslationsView):
         """
         translations = self._generate_translations_for_po(worksheet)
         with PoFileGenerator(translations, {}) as po_file_generator:
-            generated_file = po_file_generator.generated_files[0][1]
-            with open(generated_file, 'r', encoding="utf-8") as f:
+            generated_files = po_file_generator.generate_translation_files()
+            with open(generated_files[0][1], 'r', encoding="utf-8") as f:
                 return f.read()
 
     def _generate_excel_file(self):

--- a/custom/icds/translations/integrations/transifex.py
+++ b/custom/icds/translations/integrations/transifex.py
@@ -55,7 +55,8 @@ class Transifex(object):
             self.key_lang, self.source_lang, self.lang_prefix,
             self.exclude_if_default, self.use_version_postfix)
         with PoFileGenerator(app_trans_generator.translations, app_trans_generator.metadata) as po_file_generator:
-            return self._send_files_to_transifex(po_file_generator.generated_files)
+            generated_files = po_file_generator.generate_translation_files()
+            return self._send_files_to_transifex(generated_files)
 
     @property
     @memoized

--- a/custom/icds/translations/integrations/transifex.py
+++ b/custom/icds/translations/integrations/transifex.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from django.conf import settings
 from memoized import memoized
 
-from corehq.apps.app_manager.app_translations.generators import TransifexPOFileGenerator
+from corehq.apps.app_manager.app_translations.generators import AppTranslationsGenerator, PoFileGenerator
 from corehq.apps.app_manager.app_translations.parser import TranslationsParser
 from custom.icds.translations.integrations.client import TransifexApiClient
 
@@ -26,35 +26,36 @@ class Transifex(object):
         :param lang_prefix: prefix if other than "default_"
         :param resource_slugs: resource slugs
         :param is_source_file: upload as source language file(True) or translation(False)
+        :param exclude_if_default: ignore translation if its same as the source lang when pushing target langs
         :param use_version_postfix: use version number at the end of resource slugs
         :param update_resource: update resource file
         """
         if version:
             version = int(version)
         self.version = version
+        self.domain = domain
+        self.app_id = app_id
         self.key_lang = "en"  # the lang in which the string keys are, should be english
         self.lang_prefix = lang_prefix
         self.project_slug = project_slug
         self._resource_slugs = resource_slugs
         self.is_source_file = is_source_file
+        self.exclude_if_default = exclude_if_default
         self.source_lang = source_lang
         self.lock_translations = lock_translations
         self.use_version_postfix = use_version_postfix
         self.update_resource = update_resource
-        self.transifex_po_file_generator = TransifexPOFileGenerator(domain, app_id, version, self.key_lang,
-                                                                    source_lang, lang_prefix, exclude_if_default,
-                                                                    use_version_postfix)
 
     def send_translation_files(self):
         """
-        submit files to transifex for performing translations
+        submit translation files to transifex
         """
-        try:
-            self.transifex_po_file_generator.generate_translation_files()
-            file_uploads = self._send_files_to_transifex()
-        finally:
-            self._cleanup()
-        return file_uploads
+        app_trans_generator = AppTranslationsGenerator(
+            self.domain, self.app_id, self.version,
+            self.key_lang, self.source_lang, self.lang_prefix,
+            self.exclude_if_default, self.use_version_postfix)
+        with PoFileGenerator(app_trans_generator.translations, app_trans_generator.metadata) as po_file_generator:
+            return self._send_files_to_transifex(po_file_generator.generated_files)
 
     @property
     @memoized
@@ -70,9 +71,9 @@ class Transifex(object):
         else:
             raise Exception(_("Transifex account details not available on this environment."))
 
-    def _send_files_to_transifex(self):
+    def _send_files_to_transifex(self, generated_files):
         file_uploads = {}
-        for resource_name, path_to_file in self.transifex_po_file_generator.generated_files:
+        for resource_name, path_to_file in generated_files:
             if self.is_source_file:
                 response = self.client.upload_resource(
                     path_to_file,
@@ -90,9 +91,6 @@ class Transifex(object):
             else:
                 file_uploads[resource_name] = "{}: {}".format(response.status_code, response.content)
         return file_uploads
-
-    def _cleanup(self):
-        self.transifex_po_file_generator.cleanup()
 
     @property
     @memoized
@@ -116,6 +114,7 @@ class Transifex(object):
     def get_translations(self):
         """
         pull translations from transifex
+
         :return: dict of resource_slug mapped to POEntry objects
         """
         if self.version and self.use_version_postfix:


### PR DESCRIPTION
Follow up on https://github.com/dimagi/commcare-hq/pull/21516

Basically picked from these two feedbacks
https://github.com/dimagi/commcare-hq/pull/21516#pullrequestreview-149742103 by Daniel
https://github.com/dimagi/commcare-hq/pull/21516#discussion_r213485235 by Ethan

Changes made, also in the commit message
- make PoFileGenerator behave as a context manager
- revert TransifexPoFileGenerator to have a method that does the major task[was not needed and was removed eventually]
- rename TransifexPoFileGenerator to AppTranslationsGenerator

Why?
Context manager was definitely the way to go. Got all clean up code at one place.
I reverted the change i made earlier for TransfiexPoFileGenerator, specifically [here](https://github.com/dimagi/commcare-hq/pull/21723/files#diff-389860842dade5566b99beb0b7021f2eR192) and thought of bringing all its operations in a single method as suggested by Ethan.
After the changes the functionality broke. so then i made `Transifex` co-ordinate directly with `PoFileGenerator` and renamed `TransfiexPoFileGenerator` as `AppTranslationsGenerator` as it was now just generating the content for the translations files.

Thanks for suggesting this.