### PR TITLE
replace UseIfRequested class with use_in kwarg

### DIFF
--- a/corehq/apps/api/fields.py
+++ b/corehq/apps/api/fields.py
@@ -19,6 +19,20 @@ def get_referenced_class(class_or_str):
         return class_or_str
 
 
+class AttributeOrCallable(object):
+
+    def __init__(self, attribute):
+        self.attribute = attribute
+
+    def __call__(self, v):
+        if isinstance(self.attribute, six.string_types):
+            accessor = lambda v: getattr(v, self.attribute)
+        else:
+            accessor = self.attribute
+
+        return accessor(v)
+
+
 class CallableApiField(ApiField):
     """
     A minor fix to Tastypie's ApiField to actually support callable attributes in general.
@@ -54,6 +68,7 @@ class ToManyDocumentsField(ApiField):
                                                    unique=unique,
                                                    readonly=readonly)
         self.to = to
+        self.attribute = AttributeOrCallable(attribute)
 
     @property
     def to_class(self):
@@ -101,6 +116,7 @@ class ToManyDictField(ApiField):
             use_in=use_in,
         )
         self.to = to
+        self.attribute = AttributeOrCallable(attribute)
 
     @property
     def to_class(self):
@@ -149,6 +165,7 @@ class ToManyListDictField(ApiField):
             use_in=use_in,
         )
         self.to = to
+        self.attribute = AttributeOrCallable(attribute)
 
     @property
     def to_class(self):

--- a/corehq/apps/api/fields.py
+++ b/corehq/apps/api/fields.py
@@ -207,6 +207,7 @@ class ToOneDocumentField(ApiField):
                                                    unique=unique,
                                                    readonly=readonly)
         self.to = to
+        self.attribute = AttributeOrCallable(attribute)
 
     @property
     def to_class(self):

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -9,7 +9,7 @@ from tastypie.exceptions import BadRequest
 
 from casexml.apps.case import xform as casexml_xform
 from corehq.apps.api.es import XFormES, CaseES, ElasticAPIQuerySet, es_search
-from corehq.apps.api.fields import ToManyDocumentsField, UseIfRequested, ToManyDictField, ToManyListDictField
+from corehq.apps.api.fields import ToManyDocumentsField, ToManyDictField, ToManyListDictField
 from corehq.apps.api.models import ESXFormInstance, ESCase
 from corehq.apps.api.resources import (
     CouchResourceMixin,
@@ -79,11 +79,9 @@ class XFormInstanceResource(SimpleSortableResourceMixin, HqBaseResource, DomainS
     def dehydrate_archived(self, bundle):
         return bundle.obj.is_archived
 
-    cases = UseIfRequested(
-        ToManyDocumentsField(
-            'corehq.apps.api.resources.v0_4.CommCareCaseResource',
-            attribute=lambda xform: casexml_xform.cases_referenced_by_xform(xform)
-        )
+    cases = ToManyDocumentsField(
+        'corehq.apps.api.resources.v0_4.CommCareCaseResource',
+        attribute=lambda xform: casexml_xform.cases_referenced_by_xform(xform)
     )
 
     attachments = fields.DictField(readonly=True, null=True)
@@ -223,28 +221,28 @@ class RepeaterResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourc
 
 
 class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResource, DomainSpecificResourceMixin):
-    xforms_by_name = UseIfRequested(ToManyListDictField(
+    xforms_by_name = ToManyListDictField(
         'corehq.apps.api.resources.v0_4.XFormInstanceResource',
-        attribute='xforms_by_name'
-    ))
-
-    xforms_by_xmlns = UseIfRequested(ToManyListDictField(
-        'corehq.apps.api.resources.v0_4.XFormInstanceResource',
-        attribute='xforms_by_xmlns'
-    ))
-
-    child_cases = UseIfRequested(
-        ToManyDictField(
-            'corehq.apps.api.resources.v0_4.CommCareCaseResource',
-            attribute='child_cases'
-        )
+        attribute='xforms_by_name',
+        use_in=(lambda bundle: bundle.request.GET.get('xforms_by_name__full', 'false').lower() == 'true'),
     )
 
-    parent_cases = UseIfRequested(
-        ToManyDictField(
-            'corehq.apps.api.resources.v0_4.CommCareCaseResource',
-            attribute='parent_cases'
-        )
+    xforms_by_xmlns = ToManyListDictField(
+        'corehq.apps.api.resources.v0_4.XFormInstanceResource',
+        attribute='xforms_by_xmlns',
+        use_in=(lambda bundle: bundle.request.GET.get('xforms_by_xmlns__full', 'false').lower() == 'true'),
+    )
+
+    child_cases = ToManyDictField(
+        'corehq.apps.api.resources.v0_4.CommCareCaseResource',
+        attribute='child_cases',
+        use_in=(lambda bundle: bundle.request.GET.get('child_cases__full', 'false').lower() == 'true'),
+    )
+
+    parent_cases = ToManyDictField(
+        'corehq.apps.api.resources.v0_4.CommCareCaseResource',
+        attribute='parent_cases',
+        use_in=(lambda bundle: bundle.request.GET.get('parent_cases__full', 'false').lower() == 'true'),
     )
 
     domain = fields.CharField(attribute='domain')

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -40,7 +40,7 @@ from corehq.apps.accounting.models import (
     SubscriptionAdjustment
 )
 from corehq.apps.api.es import ElasticAPIQuerySet
-from corehq.apps.api.fields import ToManyDocumentsField, ToOneDocumentField, UseIfRequested, ToManyDictField
+from corehq.apps.api.fields import ToManyDocumentsField, ToOneDocumentField, ToManyDictField
 from corehq.apps.api.resources import v0_4, v0_5
 from corehq.apps.api.util import get_obj, object_does_not_exist
 from corehq.apps.domain.models import Domain
@@ -1288,54 +1288,6 @@ class TestToOneDocumentField(TestCase):
         dehydrated_bundle = source_resource.full_dehydrate(bundle)
 
         self.assertEqual(dehydrated_bundle.data['other_model']['id'], 'bar')
-
-        
-class UseIfRequestedModel(object):
-
-    def __init__(self, id):
-        self.id = id
-
-
-class UseIfRequestedTestResource(Resource):
-    something = UseIfRequested(fields.CharField(attribute='id'))
-
-    def __init__(self, objs):
-        super(UseIfRequestedTestResource, self).__init__()
-        self.objs = objs
-
-    def obj_get_list(self):
-        return self.objs
-
-    def detail_uri_kwargs(self, bundle_or_obj):
-        return {
-            'pk': get_obj(bundle_or_obj).id
-        }
-
-    class Meta(object):
-        model_class = UseIfRequestedModel
-
-
-class TestUseIfRequested(TestCase):
-
-    def test_requested_use_in(self):
-        objs = [
-            UseIfRequestedModel(id='foo'),
-            UseIfRequestedModel(id='bar')
-        ]
-
-        test_resource = UseIfRequestedTestResource(objs)
-
-        bundle = test_resource.build_bundle(obj=objs[0])
-        dehydrated_bundle = test_resource.full_dehydrate(bundle)
-
-        self.assertFalse('id' in dehydrated_bundle.data)
-
-        bundle = test_resource.build_bundle(obj=objs[0])
-        bundle.request.GET['something__full'] = 'true'
-        dehydrated_bundle = test_resource.full_dehydrate(bundle)
-
-        self.assertTrue('something' in dehydrated_bundle.data)
-        self.assertEqual(dehydrated_bundle.data['something'], 'foo')
 
 
 class TestSingleSignOnResource(APIResourceTest):


### PR DESCRIPTION
Our implementation has issues in python3, so let's go with the tastypie-supported implementation.

See https://django-tastypie.readthedocs.io/en/latest/fields.html#ApiField.use_in