### PR TITLE
Make UI a little clearer for specifying Provider

### DIFF
--- a/corehq/motech/openmrs/README.md
+++ b/corehq/motech/openmrs/README.md
@@ -309,23 +309,24 @@ skew towards false negatives (Type I errors). In other words, it is much
 better not to choose a patient than to choose the wrong patient.
 
 
-Provider UUID
--------------
+Provider
+--------
 
 In OpenMRS, observations about a patient, like their height or their
 blood pressure, can be associated with a data provider. A "provider" is
 usually an OpenMRS user who can enter data.
 
 It is useful to label data from CommCare. OpenMRS Configuration has a
-field called "Provider UUID", and the value entered here is stored in
-OpenmrsConfig.openmrs_provider.
+field called "Provider's Person UUID", and the value entered here is
+stored in OpenmrsConfig.openmrs_provider.
 
 There are three different kinds of entities involved in setting up a
 provider in OpenMRS: A Person instance; a Provider instance; and a User
 instance.
 
-**NOTE**: The value that OpenMRS expects in the "Provider UUID" field is
-a **Person UUID**.
+**NOTE**: The value that OpenMRS expects in the "Provider's Person UUID"
+field is a **Person UUID**, not a **Provider UUID**. The distinction is
+not obvious in the OpenMRS interface.
 
 Use the following steps to create a provider for CommCare:
 
@@ -339,8 +340,8 @@ binary about it. You will have to decided whether CommCare is male or
 female. When you are done, click "Create Person".
 
 Make a note of the greyed UUID at the bottom of the next page. This is
-the value you will need for "Provider UUID" in the configuration for the
-OpenMRS Repeater.
+the value you will need for "Provider's Person UUID" in the
+configuration for the OpenMRS Repeater.
 
 Go back to the OpenMRS Administration page, choose "Manage Providers"
 and click "Add Provider". In the "Person" field, type the name of the

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -16,7 +16,7 @@ from six.moves import map
 
 
 class OpenmrsConfigForm(forms.Form):
-    openmrs_provider = forms.CharField(label=_('Provider UUID'), required=False)
+    openmrs_provider = forms.CharField(label=_("Provider's Person UUID"), required=False)
     case_config = JsonField(expected_type=dict)
     form_configs = JsonField(expected_type=list)
 


### PR DESCRIPTION
A small change to the UI to prompt integrators to use an OpenMRS Person UUID, and not an OpenMRS Provider UUID, to specify an OpenMRS Provider.

![image](https://user-images.githubusercontent.com/708421/45028066-d05f3d00-b043-11e8-895c-59ea9b6a8795.png)

This caught its second victim recently. Hopefully this change will make it a little less ambiguous.
