### PR TITLE
Search ancestor locations for OpenMRS UUID

### DIFF
--- a/corehq/motech/openmrs/handler.py
+++ b/corehq/motech/openmrs/handler.py
@@ -14,7 +14,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     UpdatePersonAttributeTask,
     UpdatePersonNameTask,
     UpdatePersonPropertiesTask,
-    get_openmrs_location_uuid,
+    get_ancestor_location_openmrs_uuid,
     get_patient,
 )
 from corehq.motech.openmrs.workflow import WorkflowTask, execute_workflow
@@ -184,7 +184,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
         """
         subtasks = []
         provider_uuid = getattr(self.openmrs_config, 'openmrs_provider', None)
-        location_uuid = get_openmrs_location_uuid(self.domain, self.info.case_id)
+        location_uuid = get_ancestor_location_openmrs_uuid(self.domain, self.info.case_id)
         self.info.form_question_values.update(self.form_question_values)
         for form_config in self.openmrs_config.form_configs:
             if form_config.xmlns == self.form_json['form']['@xmlns']:

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -84,10 +84,15 @@ def get_case_location_ancestor_repeaters(case):
     return []
 
 
-def get_openmrs_location_uuid(domain, case_id):
+def get_ancestor_location_openmrs_uuid(domain, case_id):
     case = CaseAccessors(domain).get_case(case_id)
-    location = get_case_location(case)
-    return location.metadata.get(LOCATION_OPENMRS_UUID) if location else None
+    case_location = get_case_location(case)
+    if not case_location:
+        return None
+    for location in reversed(case_location.get_ancestors(include_self=True)):
+        if location.metadata.get(LOCATION_OPENMRS_UUID):
+            return location.metadata[LOCATION_OPENMRS_UUID]
+    return None
 
 
 class CreatePersonAttributeTask(WorkflowTask):


### PR DESCRIPTION
This change enables requests to be sent to OpenMRS tagged with the OpenMRS location ID of a mobile worker's location's ancestor, instead of just the mobile worker's location. 

This is important for allowing CommCare location structures to be more flexible, but still sending the required data to OpenMRS.

Feature Flag: "Allow OpenMRS integration"