### PR TITLE
Load shared tags

### DIFF
--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -1,6 +1,7 @@
 {% extends "hqwebapp/base_page.html" %}
 {% load i18n %}
 {% load staticfiles %}
+{% load hq_shared_tags %}
 
 {% block title %}{% trans "Login to ICDS CAS" %}{% endblock title %}
 {% block title_context %} {% endblock %}


### PR DESCRIPTION
`CUSTOM_LANDING_TEMPLATE` needs to be changed to the login template to test these kinds of changes in the future @mkangia @orangejenny 

introduced here: https://github.com/dimagi/commcare-hq/pull/21211

going to hotfix to new servers
