### PR TITLE
Test ICDS login doesn't 500

### DIFF
--- a/custom/icds/tests/test_views.py
+++ b/custom/icds/tests/test_views.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+
+class TestViews(TestCase):
+    @override_settings(CUSTOM_LANDING_TEMPLATE='icds/login.html')
+    def test_custom_login(self):
+        response = self.client.get(reverse("login"), follow=False)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
@emord As requested, sorry that you had to handle the hotfix for https://github.com/dimagi/commcare-hq/pull/21754

Testing the general login page would have added some nice symmetry, but that throws errors about `STATICI18N_OUTPUT_DIR` that didn't seem worth digging into given that we're less likely to break the main login page.

code buddy @pr33thi 