### PR TITLE
Update keyword functionality to use new framework

### DIFF
--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -20,13 +20,14 @@ from corehq.apps.reminders.models import (
     METHOD_SMS_SURVEY,
     REMINDER_TYPE_KEYWORD_INITIATED,
 )
-from corehq.apps.reminders.util import create_immediate_reminder
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.groups.models import Group
 from corehq.apps.formplayer_api.smsforms.api import current_question, TouchformsError
 from corehq.apps.app_manager.models import Form
 from corehq.form_processor.utils import is_commcarecase
+from corehq.messaging.scheduling.models import SMSContent, SMSSurveyContent
+from corehq.messaging.scheduling.scheduling_partitioned.models import ScheduleInstance
 from six.moves import filter
 
 
@@ -671,16 +672,34 @@ def process_survey_keyword_actions(verified_number, survey_keyword, text, msg):
         if contact is None:
             continue
 
-        if survey_keyword_action.action == KeywordAction.ACTION_SMS:
-            create_immediate_reminder(contact, METHOD_SMS, 
-                reminder_type=REMINDER_TYPE_KEYWORD_INITIATED,
-                message=survey_keyword_action.message_content,
-                case=case, logged_event=logged_event)
-        elif survey_keyword_action.action == KeywordAction.ACTION_SMS_SURVEY:
-            create_immediate_reminder(contact, METHOD_SMS_SURVEY,
-                reminder_type=REMINDER_TYPE_KEYWORD_INITIATED,
-                form_unique_id=survey_keyword_action.form_unique_id,
-                case=case, logged_event=logged_event)
+        # contact can be either a user, case, group, or location
+        if survey_keyword_action.action in (KeywordAction.ACTION_SMS, KeywordAction.ACTION_SMS_SURVEY):
+            if isinstance(contact, Group):
+                recipients = list(ScheduleInstance.expand_group(contact))
+            elif isinstance(contact, SQLLocation):
+                recipients = list(ScheduleInstance.expand_location_ids(contact.domain, [contact.location_id]))
+            else:
+                recipients = [contact]
+
+            if survey_keyword_action.action == KeywordAction.ACTION_SMS:
+                content = SMSContent(message={'*': survey_keyword_action.message_content})
+                content.set_context(case=case)
+            elif survey_keyword_action.action == KeywordAction.ACTION_SMS_SURVEY:
+                content = SMSSurveyContent(
+                    form_unique_id=survey_keyword_action.form_unique_id,
+                    expire_after=SQLXFormsSession.MAX_SESSION_LENGTH,
+                )
+                recipient_is_sender = survey_keyword_action.recipient == KeywordAction.RECIPIENT_SENDER
+                content.set_context(
+                    case=case,
+                    critical_section_already_acquired=recipient_is_sender,
+                )
+            else:
+                raise ValueError("Unexpected action %s" % survey_keyword_action.action)
+
+            for recipient in recipients:
+                content.send(recipient, logged_event)
+
         elif survey_keyword_action.action == KeywordAction.ACTION_STRUCTURED_SMS:
             res = handle_structured_sms(survey_keyword, survey_keyword_action,
                 sender, verified_number, text, send_response=True, msg=msg,

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -299,6 +299,11 @@ class Content(models.Model):
     # (i.e., this was scheduled content), this is the ScheduleInstance.
     schedule_instance = None
 
+    # Set to True if any necessary critical section locks have
+    # already been acquired. This is currently only used for SMSSurveyContent
+    # under certain circumstances.
+    critical_section_already_acquired = False
+
     class Meta(object):
         abstract = True
 
@@ -312,12 +317,14 @@ class Content(models.Model):
         """
         raise NotImplementedError()
 
-    def set_context(self, case=None, schedule_instance=None):
+    def set_context(self, case=None, schedule_instance=None, critical_section_already_acquired=False):
         if case:
             self.case = case
 
         if schedule_instance:
             self.schedule_instance = schedule_instance
+
+        self.critical_section_already_acquired = critical_section_already_acquired
 
     @staticmethod
     def get_workflow(logged_event):

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -176,6 +176,23 @@ class ScheduleInstance(PartitionedModel):
 
         return obj
 
+    @staticmethod
+    def expand_group(group):
+        if not isinstance(group, Group):
+            raise TypeError("Expected Group")
+
+        for user in group.get_users(is_active=True, only_commcare=False):
+            yield user
+
+    @staticmethod
+    def expand_location_ids(domain, location_ids):
+        user_ids = set()
+        for location_id in location_ids:
+            for user in get_all_users_by_location(domain, location_id):
+                if user.is_active and user.get_id not in user_ids:
+                    user_ids.add(user.get_id)
+                    yield user
+
     def _expand_recipient(self, recipient):
         if recipient is None:
             return
@@ -186,8 +203,7 @@ class ScheduleInstance(PartitionedModel):
             for case in case_group.get_cases():
                 yield case
         elif isinstance(recipient, Group):
-            group = recipient
-            for user in group.get_users(is_active=True, only_commcare=False):
+            for user in self.expand_group(recipient):
                 yield user
         elif isinstance(recipient, SQLLocation):
             location = recipient
@@ -211,12 +227,8 @@ class ScheduleInstance(PartitionedModel):
             else:
                 location_ids = [location.location_id]
 
-            user_ids = set()
-            for location_id in location_ids:
-                for user in get_all_users_by_location(self.domain, location_id):
-                    if user.is_active and user.get_id not in user_ids:
-                        user_ids.add(user.get_id)
-                        yield user
+            for user in self.expand_location_ids(self.domain, location_ids):
+                yield user
         else:
             raise UnknownRecipientType(recipient.__class__.__name__)
 


### PR DESCRIPTION
Keywords used to use the old reminders framework to deliver their content. This makes it so that they use the new framework to do so.

@gbova @millerdev 