### PR TITLE
UCR Conditional Aggregations

### DIFF
--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -7,12 +7,13 @@ from django.utils.translation import ugettext as _
 from corehq.apps.userreports.reports.specs import PieChartSpec, \
     MultibarAggregateChartSpec, MultibarChartSpec, \
     FieldColumn, PercentageColumn, ExpandedColumn, AggregateDateColumn, \
-    OrderBySpec, LocationColumn, ExpressionColumn
+    OrderBySpec, LocationColumn, ExpressionColumn, ConditionalAggregationColumn
 
 
 class ReportColumnFactory(object):
     class_map = {
         'aggregate_date': AggregateDateColumn,
+        'conditional_aggregation': ConditionalAggregationColumn,
         'expanded': ExpandedColumn,
         'field': FieldColumn,
         'percent': PercentageColumn,

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -7,13 +7,15 @@ from django.utils.translation import ugettext as _
 from corehq.apps.userreports.reports.specs import PieChartSpec, \
     MultibarAggregateChartSpec, MultibarChartSpec, \
     FieldColumn, PercentageColumn, ExpandedColumn, AggregateDateColumn, \
-    OrderBySpec, LocationColumn, ExpressionColumn, ConditionalAggregationColumn
+    OrderBySpec, LocationColumn, ExpressionColumn, ConditionalAggregationColumn, \
+    SumWhenColumn
 
 
 class ReportColumnFactory(object):
     class_map = {
         'aggregate_date': AggregateDateColumn,
         'conditional_aggregation': ConditionalAggregationColumn,
+        'sum_when': SumWhenColumn,
         'expanded': ExpandedColumn,
         'field': FieldColumn,
         'percent': PercentageColumn,

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -31,6 +31,7 @@ from sqlagg.columns import (
     MonthColumn,
     NonzeroSumColumn,
     SimpleColumn,
+    SumWhen,
     YearColumn,
 )
 from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn
@@ -391,6 +392,28 @@ class ConditionalAggregationColumn(ReportColumn):
 
     def get_query_column_ids(self):
         return [self.column_id]
+
+
+class SumWhenColumn(ConditionalAggregationColumn):
+    type = TypeProperty("sum_when")
+    else_ = IntegerProperty()
+
+    def get_column_config(self, data_source_config, lang):
+        return ColumnConfig(columns=[
+            DatabaseColumn(
+                header=self.get_header(lang),
+                agg_column=SumWhen(
+                    whens=self.whens,
+                    else_=self.else_,
+                    alias=self.column_id,
+                ),
+                sortable=self.sortable,
+                data_slug=self.column_id,
+                format_fn=self.get_format_fn(),
+                help_text=self.description,
+                visible=self.visible,
+            )],
+        )
 
 
 class PercentageColumn(ReportColumn):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -7,6 +7,7 @@ import json
 from datetime import date
 from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
+from sqlalchemy import bindparam
 from corehq.apps.reports.datatables import DataTablesColumn
 from corehq.apps.userreports import const
 from corehq.apps.userreports.exceptions import InvalidQueryColumn
@@ -384,9 +385,8 @@ class ConditionalAggregationColumn(ReportColumn):
         )
 
     def get_whens(self):
-        transform_val = lambda val: "'{}'".format(val)
         return {
-            k: transform_val(v) for k, v in self.whens.items()
+            k: bindparam(None, v) for k, v in self.whens.items()
         }
 
     def get_query_column_ids(self):

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -843,3 +843,44 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
              ['MA', '7-12', 2],
              ['TN', '13+', 1]]
         )
+
+    def test_sum_when(self):
+        report_config = self._create_report(
+            aggregation_columns=[
+                'indicator_col_id_state',
+            ],
+            columns=[
+                {
+                    'type': 'field',
+                    'display': 'state',
+                    'field': 'indicator_col_id_state',
+                    'column_id': 'state',
+                    'aggregation': 'simple'
+                },
+                {
+                    'type': 'sum_when',
+                    'display': 'under_six_month_olds',
+                    'field': 'age_at_registration',
+                    'column_id': 'under_six_month_olds',
+                    'whens': {
+                        "age_at_registration < 6": 1,
+                    },
+                    'else_': 0
+                },
+                {
+                    'type': 'field',
+                    'display': 'report_column_display_number',
+                    'field': 'indicator_col_id_number',
+                    'column_id': 'report_column_col_id_number',
+                    'aggregation': 'sum'
+                }
+            ],
+            filters=None,
+        )
+        view = self._create_view(report_config)
+        self.assertItemsEqual(
+            view.export_table[0][1],
+            [['state', 'under_six_month_olds', 'report_column_display_number'],
+             ['MA', 2, 9],
+             ['TN', 0, 1]]
+        )

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -192,7 +192,7 @@ snowballstemmer==1.2.1    # via sphinx
 socketpool==0.5.3
 sphinx-rtd-theme==0.1.9
 sphinx==1.3.1
-sqlagg==0.10.2
+sqlagg==0.10.3
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.2.9
 sqlparse==0.2.4           # via django-debug-toolbar

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -153,7 +153,7 @@ sphinx-rtd-theme==0.3.0
 sphinx==1.7.2
 sphinxcontrib-django==0.3.1
 sphinxcontrib-websupport==1.1.0  # via sphinx
-sqlagg==0.10.2
+sqlagg==0.10.3
 sqlalchemy==1.2.9
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -162,7 +162,7 @@ singledispatch==3.4.0.3   # via tornado
 six==1.11.0
 smartypants==2.0.1
 socketpool==0.5.3
-sqlagg==0.10.2
+sqlagg==0.10.3
 sqlalchemy==1.2.9
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,7 +51,7 @@ numpy==1.7.1
 six==1.11.0
 socketpool==0.5.3
 markdown==2.2.1
-sqlagg==0.10.2
+sqlagg==0.10.3
 django-redis==4.2
 redis==2.10.5
 twilio==6.5.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -143,7 +143,7 @@ simplejson==3.11.1
 six==1.11.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
-sqlagg==0.10.2
+sqlagg==0.10.3
 sqlalchemy==1.2.9
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -152,7 +152,7 @@ simplejson==3.11.1
 six==1.11.0
 smartypants==2.0.1
 socketpool==0.5.3
-sqlagg==0.10.2
+sqlagg==0.10.3
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.2.9
 stripe==1.67.0


### PR DESCRIPTION
This adds as-yet-undocumented support for aggregating rows in a UCR Report by SQL conditional expressions.  The target use-case is the ICDS Mobile UCR v2 migration, which would benefit greatly from a subset of this.

For ICDS, we need to be able to group by age-group (0-6 months, 6-12 months, etcetera).  I'm also considering a more targeted approach here, because as-implemented, this is maybe overly powerful.  However, I've heard of very similar use cases, which don't fit quite so narrow a bucket - Emord has one which would be an extension of what's currently implemented.  Cody also mentioned wanting to group by age range as determined by `NOW() - dob_column`, which we may also want to do for ICDS at some point.

Right now I'm soliciting feedback on how to proceed.