### PR TITLE
Only have one kafka client per process

### DIFF
--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -6,9 +6,14 @@ from kafka.common import KafkaUnavailableError
 import logging
 
 
+_kafka_client = None
+
+
 def get_kafka_client():
-    # todo: we may want to make this more configurable
-    return KafkaClient(settings.KAFKA_BROKERS)
+    global _kafka_client
+    if _kafka_client is None:
+        _kafka_client = KafkaClient(settings.KAFKA_BROKERS)
+    return _kafka_client
 
 
 def get_kafka_client_or_none():


### PR DESCRIPTION
@dimagi/scale-team lots of errors coming in overnight about failed payloads. went through the stack trace and I think we try to make a new kafka connection everytime we need topics. this will keep one around per process/thread. I think this may help network issues