### PR TITLE
Split hqwebapps/js/widgets based on select2 version

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
@@ -1,8 +1,12 @@
+/**
+ * Temporary for select2 migration.
+ * This should only be referenced by hqwebapps/js/select2_v3 and hqwebapps/js/select2_v4
+ * All client code should depend on one of those two modules.
+ */
 hqDefine("hqwebapp/js/widgets", [
     'jquery',
-    'select2-3.5.2-legacy/select2',
 ], function ($) {
-    $(function () {
+    var init = function () {
         _.each($(".hqwebapp-autocomplete"), function (input) {
             var $input = $(input);
             $input.select2({
@@ -14,5 +18,9 @@ hqDefine("hqwebapp/js/widgets", [
         _.each($(".ko-select2"), function (element) {
             $(element).select2();
         });
-    });
+    };
+
+    return {
+        init: init,
+    };
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/widgets_v3.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/widgets_v3.js
@@ -1,0 +1,9 @@
+hqDefine("hqwebapp/js/widgets_v3", [
+    'jquery',
+    'hqwebapp/js/widgets',
+    'select2-3.5.2-legacy/select2',
+], function ($, hqWidgets) {
+    $(function () {
+        hqWidgets.init();
+    });
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/widgets_v4.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/widgets_v4.js
@@ -1,0 +1,9 @@
+hqDefine("hqwebapp/js/widgets_v4", [
+    'jquery',
+    'hqwebapp/js/widgets',
+    'select2/dist/js/select2.full.min',
+], function ($, hqWidgets) {
+    $(function () {
+        hqWidgets.init();
+    });
+});

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -8,7 +8,7 @@ hqDefine("locations/js/location", [
     'analytix/js/google',
     'locations/js/location_drilldown',
     'hqwebapp/js/select_2_ajax_widget',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/widgets_v3',       // custom data fields use a .ko-select2
     'locations/js/widgets_main',
 ], function (
     $,

--- a/corehq/apps/products/templates/products/manage/product.html
+++ b/corehq/apps/products/templates/products/manage/product.html
@@ -4,7 +4,10 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"</script>
+    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <!-- "Additional Information" uses a .ko-select2 -->
+    <!-- Uses v3 because BaseCommTrackManageView use_select2 -->
+    <script src="{% static 'hqwebapp/js/widgets_v3.js' %}"></script>
     <script src="{% static 'jquery-textchange/jquery.textchange.js' %}"></script>
     {% include 'hqwebapp/includes/ui_element_js.html' %}
 {% endblock %}

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -4,7 +4,7 @@ hqDefine("reports/js/edit_scheduled_report", [
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/multiselect_utils",
-    "hqwebapp/js/widgets",  // autocomplete widget for email recipient list
+    "hqwebapp/js/widgets_v4",  // autocomplete widget for email recipient list
 ], function (
     $,
     _,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -194,7 +194,7 @@ from corehq.form_processor.utils.xform import resave_form
 from corehq.apps.hqcase.utils import resave_case
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
-    use_select2,
+    use_select2_v4,
     use_datatables,
     use_multiselect,
 )
@@ -890,7 +890,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     template_name = 'reports/edit_scheduled_report.html'
 
     @use_multiselect
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(ScheduledReportsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
+++ b/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
@@ -3,7 +3,7 @@ hqDefine("smsbillables/js/smsbillables.rate_calc", [
     'knockout',
     'underscore',
     'hqwebapp/js/select2_handler',
-    'hqwebapp/js/widgets',  // the public sms page uses a .ko-select2 for country input
+    'hqwebapp/js/widgets_v3',  // the public sms page uses a .ko-select2 for country input
 ], function (
     $,
     ko,

--- a/corehq/apps/translations/templates/pull_resource.html
+++ b/corehq/apps/translations/templates/pull_resource.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "hqwebapp/js/widgets" %}
+{% requirejs_main "hqwebapp/js/widgets_v4" %}
 
 {% block page_content %}
     {% if not transifex_details_available %}

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -13,7 +13,7 @@ from django.contrib import messages
 from django.utils.decorators import method_decorator
 
 from corehq import toggles
-from corehq.apps.hqwebapp.decorators import use_select2
+from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.translations.forms import (
     ConvertTranslationsForm,
     PullResourceForm,
@@ -170,7 +170,7 @@ class PullResource(BaseTranslationsView):
     template_name = 'pull_resource.html'
     section_name = ugettext_noop("Translations")
 
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(PullResource, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -13,6 +13,7 @@
     {% endif %}
     <script src="{% static 'nic_compliance/js/encoder.js' %}"></script>
     <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/widgets_v3.js' %}"></script><!-- custom user data -->
     <script src="{% static 'users/js/edit_commcare_user.js' %}"></script>
 {% endblock %}
 

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -1,7 +1,7 @@
 hqDefine("repeaters/js/add_form_repeater", [
     'jquery',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/widgets',          // case repeaters use .ko-select2
+    'hqwebapp/js/widgets_v3',       // case repeaters ("Forward Cases") use .ko-select2
     'locations/js/widgets_main',    // openmrs repeaters use the LocationSelectWidget
 ], function (
     $,

--- a/custom/icds_reports/templates/icds_reports/icds_app/app_translations.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/app_translations.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/widgets" %}
+{% requirejs_main "hqwebapp/js/widgets_v4" %}
 
 {% block page_content %}
     {% if not transifex_details_available %}

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -32,7 +32,7 @@ from corehq.apps.locations.permissions import location_safe, user_can_access_loc
 from corehq.apps.locations.util import location_hierarchy_config
 from corehq.apps.hqwebapp.decorators import (
     use_daterangepicker,
-    use_select2,
+    use_select2_v4,
 )
 from corehq.apps.translations.views import ConvertTranslations, BaseTranslationsView
 from corehq.apps.users.decorators import require_permission
@@ -1608,7 +1608,7 @@ class AppTranslations(BaseTranslationsView):
     template_name = 'icds_reports/icds_app/app_translations.html'
     section_name = ugettext_lazy("Translations")
 
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(AppTranslations, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
[select2 needs upgrading](https://github.com/dimagi/commcare-hq/pull/21756#issuecomment-419252990). We have several widgets based on select2 (.ko-select2, .hqwebapp-autocomplete, hqwebapp/js/select2_handler.js, ...) that each need to be upgraded. It's difficult to migrate these widgets one at a time, because some pages depend on multiple widgets (a single page can't use multiple versions of select2 due to namespace and CSS issues).

This PR splits widgets.js into two versions: one that uses select2 v3 and one that uses select2 v4. The select2 calls in widgets.js are pretty basic, so they're already compatible with both v3 and v4 - which version a page uses depends on what *other* select2 dependencies the page has. The effect of this PR is just to make it explicit which select2 version is being used, both for readability and so that r.js can generate an accurate dependency tree.

@millerdev / @pr33thi 