### PR TITLE
Split hqwebapps/js/select_2_ajax_widget based on select2 version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,6 @@ module.exports = {
         "space-in-parens": ["error", "never"],
         "space-infix-ops": ["error"],   // match flake8 E225
 
-        "eslint-dimagi/no-unblessed-new": ["error", ["Date", "Error", "RegExp", "Clipboard"]],
+        "eslint-dimagi/no-unblessed-new": ["error", ["Date", "Error", "Option", "RegExp", "Clipboard"]],
     }
 };

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -83,7 +83,7 @@ from corehq.apps.reminders.models import CaseReminderHandler
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.hqwebapp import crispy as hqcrispy
-from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax
+from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2AjaxV4
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.privileges import (
     REPORT_BUILDER_5,
@@ -512,7 +512,7 @@ USE_LOCATION_CHOICE = "user_location"
 USE_PARENT_LOCATION_CHOICE = 'user_parent_location'
 
 
-class CallCenterOwnerWidget(Select2Ajax):
+class CallCenterOwnerWidget(Select2AjaxV4):
 
     def set_domain(self, domain):
         self.domain = domain

--- a/corehq/apps/domain/static/domain/js/info_basic.js
+++ b/corehq/apps/domain/static/domain/js/info_basic.js
@@ -1,8 +1,8 @@
 hqDefine("domain/js/info_basic", [
     'jquery',
     'underscore',
-    'hqwebapp/js/select_2_ajax_widget_v3', // for call center case owner
-    'select2-3.5.2-legacy/select2',
+    'hqwebapp/js/select_2_ajax_widget_v4', // for call center case owner
+    'select2/dist/js/select2.full.min',
 ], function (
     $,
     _

--- a/corehq/apps/domain/static/domain/js/info_basic.js
+++ b/corehq/apps/domain/static/domain/js/info_basic.js
@@ -1,7 +1,7 @@
 hqDefine("domain/js/info_basic", [
     'jquery',
     'underscore',
-    'hqwebapp/js/select_2_ajax_widget', // for call center case owner
+    'hqwebapp/js/select_2_ajax_widget_v3', // for call center case owner
     'select2-3.5.2-legacy/select2',
 ], function (
     $,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -55,6 +55,7 @@ from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
     use_select2,
+    use_select2_v4,
     use_multiselect,
 )
 from corehq.apps.accounting.exceptions import (
@@ -349,7 +350,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
     page_title = ugettext_lazy("Basic")
 
     @method_decorator(domain_admin_required)
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -42,7 +42,7 @@ from corehq.apps.hqwebapp.widgets import (
     Select2MultipleChoiceWidget,
     DateRangePickerWidget,
     Select2,
-    Select2Ajax,
+    Select2AjaxV3,
 )
 from corehq.pillows import utils
 from couchexport.util import SerializableFunction
@@ -431,12 +431,12 @@ class DashboardFeedFilterForm(forms.Form):
     emwf_case_filter = forms.Field(
         label=ugettext_lazy("Groups or Users"),
         required=False,
-        widget=Select2Ajax(multiple=True),
+        widget=Select2AjaxV3(multiple=True),
     )
     emwf_form_filter = forms.Field(
         label=ugettext_lazy("Groups or Users"),
         required=False,
-        widget=Select2Ajax(multiple=True),
+        widget=Select2AjaxV3(multiple=True),
     )
     date_range = forms.ChoiceField(
         label=ugettext_lazy("Date Range"),

--- a/corehq/apps/export/templates/export/daily_saved_export_list.html
+++ b/corehq/apps/export/templates/export/daily_saved_export_list.html
@@ -7,7 +7,7 @@
 
 {% block js %}{{ block.super }}
     <script src="{% static 'clipboard/dist/clipboard.min.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/select_2_ajax_widget.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/select_2_ajax_widget_v3.js' %}"></script>
 {% endblock js%}
 
 {% block page_content %}

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -13,7 +13,7 @@
 
 {% block js %}{{ block.super }}
     {% include 'hqwebapp/includes/ui_element_js.html' %}
-    <script src="{% static 'hqwebapp/js/select_2_ajax_widget_v3.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/select_2_ajax_widget_v4.js' %}"></script>
     <script src="{% static 'groups/js/group_members.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -13,7 +13,7 @@
 
 {% block js %}{{ block.super }}
     {% include 'hqwebapp/includes/ui_element_js.html' %}
-    <script src="{% static 'hqwebapp/js/select_2_ajax_widget.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/select_2_ajax_widget_v3.js' %}"></script>
     <script src="{% static 'groups/js/group_members.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/groups/views.py
+++ b/corehq/apps/groups/views.py
@@ -150,7 +150,7 @@ def _update_group_membership(request, domain, group_id):
     if group.domain != domain:
         return HttpResponseForbidden()
 
-    selected_users = request.POST.get('selected_ids').split(',')
+    selected_users = request.POST.getlist('selected_ids')
 
     # check to make sure no users were deleted at time of making group
     all_users = CommCareUser.ids_by_domain(domain)

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -67,6 +67,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                     'jquery.rmi/jquery.rmi',
                     'jquery-ui/ui/sortable',
                     'select2-3.5.2-legacy/select2',
+                    'select2/dist/js/select2.full.min',
                 ];
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v3.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v3.js
@@ -1,9 +1,9 @@
-hqDefine("hqwebapp/js/select_2_ajax_widget", [
+hqDefine("hqwebapp/js/select_2_ajax_widget_v3", [
     'jquery',
-    'select2/dist/js/select2.full.min',
+    'select2-3.5.2-legacy/select2',
 ], function ($) {
     $(function () {
-        $(".hqwebapp-select2-ajax").each(function () {
+        $(".hqwebapp-select2-ajax-v3").each(function () {
             var $select = $(this),
                 data = $select.data();
             $select.select2({

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
@@ -1,0 +1,37 @@
+hqDefine("hqwebapp/js/select_2_ajax_widget_v4", [
+    'jquery',
+    'select2/dist/js/select2.full.min',
+], function ($) {
+    $(function () {
+        $(".hqwebapp-select2-ajax-v4").each(function () {
+            var $select = $(this),
+                htmlData = $select.data();
+            if (htmlData.initial) {
+                $select.append(new Option(htmlData.initial.text, htmlData.initial.id));
+            }
+            $select.select2({
+                multiple: htmlData.multiple,
+                escapeMarkup: function (m) { return m; },
+                ajax: {
+                    url: htmlData.endpoint,
+                    dataType: 'json',
+                    delay: 100,
+                    data: function (params) {
+                        return {
+                            q: params.term,
+                            page_limit: htmlData.pageSize,
+                            page: params.page
+                        };
+                    },
+                    processResults: function (data, params) {
+                        var more = (params.page || 1) * htmlData.pageSize < data.total;
+                        return {
+                            results: data.results,
+                            pagination: { more: more },
+                        };
+                    },
+                },
+            });
+        });
+    });
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
@@ -1,14 +1,13 @@
 hqDefine("hqwebapp/js/select_2_ajax_widget_v4", [
     'jquery',
+    'underscore',
     'select2/dist/js/select2.full.min',
-], function ($) {
+], function ($, _) {
     $(function () {
         $(".hqwebapp-select2-ajax-v4").each(function () {
             var $select = $(this),
                 htmlData = $select.data();
-            if (htmlData.initial) {
-                $select.append(new Option(htmlData.initial.text, htmlData.initial.id));
-            }
+
             $select.select2({
                 multiple: htmlData.multiple,
                 escapeMarkup: function (m) { return m; },
@@ -32,6 +31,17 @@ hqDefine("hqwebapp/js/select_2_ajax_widget_v4", [
                     },
                 },
             });
+
+            var initial = htmlData.initial;
+            if (initial) {
+                if (!_.isArray(initial)) {
+                    initial = [initial]
+                }
+                _.each(initial, function(result) {
+                    $select.append(new Option(result.text, result.id));
+                });
+                $select.val(_.pluck(initial, 'id')).trigger('change');
+            }
         });
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
@@ -32,15 +32,23 @@ hqDefine("hqwebapp/js/select_2_ajax_widget_v4", [
                 },
             });
 
+            // Select initial value if one was provided, which could be a single object,
+            // formatted as { id: 1, text: 'thing' }, or an array of such objects
             var initial = htmlData.initial;
             if (initial) {
                 if (!_.isArray(initial)) {
                     initial = [initial];
                 }
+
+                // Add a DOM option for each value, which select2 will pick up on change
                 _.each(initial, function (result) {
                     $select.append(new Option(result.text, result.id));
                 });
-                $select.val(_.pluck(initial, 'id')).trigger('change');
+
+                // Set the actual value; using an array works for both single and multiple selects
+                $select.val(_.pluck(initial, 'id'));
+
+                $select.trigger('change');
             }
         });
     });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget_v4.js
@@ -19,7 +19,7 @@ hqDefine("hqwebapp/js/select_2_ajax_widget_v4", [
                         return {
                             q: params.term,
                             page_limit: htmlData.pageSize,
-                            page: params.page
+                            page: params.page,
                         };
                     },
                     processResults: function (data, params) {
@@ -35,9 +35,9 @@ hqDefine("hqwebapp/js/select_2_ajax_widget_v4", [
             var initial = htmlData.initial;
             if (initial) {
                 if (!_.isArray(initial)) {
-                    initial = [initial]
+                    initial = [initial];
                 }
-                _.each(initial, function(result) {
+                _.each(initial, function (result) {
                     $select.append(new Option(result.text, result.id));
                 });
                 $select.val(_.pluck(initial, 'id')).trigger('change');

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -89,7 +89,7 @@ class Select2MultipleChoiceWidget(_Select2Mixin, forms.SelectMultiple):
     pass
 
 
-class Select2Ajax(forms.TextInput):
+class _Select2AjaxMixin():
     """
     A Select2 widget that loads its options asynchronously.
 
@@ -97,12 +97,6 @@ class Select2Ajax(forms.TextInput):
     The url is not specified in the form class definition because in most cases the url will be dependent on the
     domain of the request.
     """
-    def __init__(self, attrs=None, page_size=20, multiple=False):
-        self.page_size = page_size
-        self.multiple = multiple
-        self._initial = None
-        super(Select2Ajax, self).__init__(attrs)
-
     def set_url(self, url):
         self.url = url
 
@@ -119,6 +113,14 @@ class Select2Ajax(forms.TextInput):
             # if its a scalar
             return {"id": val, "text": val}
 
+
+class Select2AjaxV3(_Select2AjaxMixin, forms.TextInput):
+    def __init__(self, attrs=None, page_size=20, multiple=False):
+        self.page_size = page_size
+        self.multiple = multiple
+        self._initial = None
+        super(Select2AjaxV3, self).__init__(attrs)
+
     def render(self, name, value, attrs=None):
         attrs.update({
             'class': 'form-control hqwebapp-select2-ajax-v3',
@@ -127,7 +129,26 @@ class Select2Ajax(forms.TextInput):
             'data-page-size': self.page_size,
             'data-multiple': '1' if self.multiple else '0',
         })
-        output = super(Select2Ajax, self).render(name, value, attrs)
+        output = super(Select2AjaxV3, self).render(name, value, attrs)
+        return mark_safe(output)
+
+
+class Select2AjaxV4(_Select2AjaxMixin, forms.Select):
+    def __init__(self, attrs=None, page_size=20, multiple=False):
+        self.page_size = page_size
+        self.multiple = multiple
+        self._initial = None
+        super(Select2AjaxV4, self).__init__(attrs)
+
+    def render(self, name, value, attrs=None):
+        attrs.update({
+            'class': 'form-control hqwebapp-select2-ajax-v4',
+            'data-initial': json.dumps(self._initial if self._initial is not None else self._clean_initial(value)),
+            'data-endpoint': self.url,
+            'data-page-size': self.page_size,
+            'data-multiple': '1' if self.multiple else '0',
+        })
+        output = super(Select2AjaxV4, self).render(name, value, attrs)
         return mark_safe(output)
 
 

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -121,7 +121,7 @@ class Select2Ajax(forms.TextInput):
 
     def render(self, name, value, attrs=None):
         attrs.update({
-            'class': 'form-control hqwebapp-select2-ajax',
+            'class': 'form-control hqwebapp-select2-ajax-v3',
             'data-initial': json.dumps(self._initial if self._initial is not None else self._clean_initial(value)),
             'data-endpoint': self.url,
             'data-page-size': self.page_size,

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -14,7 +14,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import StrictButton
 
-from corehq.apps.hqwebapp.widgets import Select2Ajax
+from corehq.apps.hqwebapp.widgets import Select2AjaxV3
 from dimagi.utils.couch.database import iter_docs
 from memoized import memoized
 
@@ -524,7 +524,7 @@ class UsersAtLocationForm(forms.Form):
     selected_ids = forms.Field(
         label=ugettext_lazy("Workers at Location"),
         required=False,
-        widget=Select2Ajax(multiple=True),
+        widget=Select2AjaxV3(multiple=True),
     )
 
     def __init__(self, domain_object, location, *args, **kwargs):

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -7,7 +7,7 @@ hqDefine("locations/js/location", [
     'hqwebapp/js/alert_user',
     'analytix/js/google',
     'locations/js/location_drilldown',
-    'hqwebapp/js/select_2_ajax_widget',
+    'hqwebapp/js/select_2_ajax_widget_v3',
     'hqwebapp/js/widgets_v3',       // custom data fields use a .ko-select2
     'locations/js/widgets_main',
 ], function (

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -8,7 +8,7 @@ from crispy_forms import layout as crispy
 from crispy_forms.layout import Fieldset, Layout, Submit
 import datetime
 
-from corehq.apps.hqwebapp.widgets import Select2Ajax
+from corehq.apps.hqwebapp.widgets import Select2AjaxV3
 from dimagi.utils.django.fields import TrimmedCharField
 from django import forms
 from django.core.exceptions import ValidationError
@@ -651,7 +651,7 @@ class GroupMembershipForm(forms.Form):
     selected_ids = forms.Field(
         label=ugettext_lazy("Group Membership"),
         required=False,
-        widget=Select2Ajax(multiple=True),
+        widget=Select2AjaxV3(multiple=True),
     )
 
     def __init__(self, group_api_url, *args, **kwargs):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -8,7 +8,7 @@ from crispy_forms import layout as crispy
 from crispy_forms.layout import Fieldset, Layout, Submit
 import datetime
 
-from corehq.apps.hqwebapp.widgets import Select2AjaxV3
+from corehq.apps.hqwebapp.widgets import Select2AjaxV4
 from dimagi.utils.django.fields import TrimmedCharField
 from django import forms
 from django.core.exceptions import ValidationError
@@ -651,7 +651,7 @@ class GroupMembershipForm(forms.Form):
     selected_ids = forms.Field(
         label=ugettext_lazy("Group Membership"),
         required=False,
-        widget=Select2AjaxV3(multiple=True),
+        widget=Select2AjaxV4(multiple=True),
     )
 
     def __init__(self, group_api_url, *args, **kwargs):

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _, ugettext_noop
 from corehq.apps.reports.filters.api import MobileWorkersOptionsView
 from corehq.apps.hqwebapp.decorators import (
     use_multiselect,
-    use_select2,
+    use_select2_v4,
 )
 from django_prbac.utils import has_privilege
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
@@ -126,7 +126,7 @@ class BaseGroupsView(BaseUserSettingsView):
 
     @method_decorator(require_can_edit_commcare_users)
     @use_multiselect
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(BaseGroupsView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Similar to https://github.com/dimagi/commcare-hq/pull/21770, split this module into a v3 and a v4 version so I can upgrade pages one at a time.

Product note: this makes trivial changes to the look and feel of the select2 widgets on Groups > Edit Group Membership and Project Settings > Basic Info.

Marking don't merge just until I sanity test on staging.

@pr33thi / @millerdev 