### PR TITLE
Split locations/js/widgets_main based on select2 version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,6 @@ module.exports = {
         "space-in-parens": ["error", "never"],
         "space-infix-ops": ["error"],   // match flake8 E225
 
-        "eslint-dimagi/no-unblessed-new": ["error", ["Date", "Error", "RegExp", "Clipboard"]],
+        "eslint-dimagi/no-unblessed-new": ["error", ["Date", "Error", "Option", "RegExp", "Clipboard"]],
     }
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -67,6 +67,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                     'jquery.rmi/jquery.rmi',
                     'jquery-ui/ui/sortable',
                     'select2-3.5.2-legacy/select2',
+                    'select2/dist/js/select2.full',
                 ];
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -67,7 +67,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                     'jquery.rmi/jquery.rmi',
                     'jquery-ui/ui/sortable',
                     'select2-3.5.2-legacy/select2',
-                    'select2/dist/js/select2.full',
+                    'select2/dist/js/select2.full.min',
                 ];
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -37,10 +37,10 @@ from .signals import location_edited
 from six.moves import filter
 
 
-class LocationSelectWidget(forms.Widget):
+class LocationSelectWidgetV3(forms.Widget):
 
     def __init__(self, domain, attrs=None, id='supply-point', multiselect=False, query_url=None):
-        super(LocationSelectWidget, self).__init__(attrs)
+        super(LocationSelectWidgetV3, self).__init__(attrs)
         self.domain = domain
         self.id = id
         self.multiselect = multiselect
@@ -55,7 +55,7 @@ class LocationSelectWidget(forms.Widget):
                          .filter(domain=self.domain, location_id__in=location_ids))
         initial_data = [{'id': loc.location_id, 'name': loc.get_path_display()} for loc in locations]
 
-        return get_template('locations/manage/partials/autocomplete_select_widget.html').render({
+        return get_template('locations/manage/partials/autocomplete_select_widget_v3.html').render({
             'id': self.id,
             'name': name,
             'value': ','.join(loc.location_id for loc in locations),
@@ -637,7 +637,7 @@ class RelatedLocationForm(forms.Form):
         kwargs['initial'] = {'related_locations': ','.join(self.related_location_ids)}
         super(RelatedLocationForm, self).__init__(*args, **kwargs)
 
-        self.fields['related_locations'].widget = LocationSelectWidget(
+        self.fields['related_locations'].widget = LocationSelectWidgetV3(
             domain, id='id_related_locations', multiselect=True
         )
 

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -9,7 +9,7 @@ hqDefine("locations/js/location", [
     'locations/js/location_drilldown',
     'hqwebapp/js/select_2_ajax_widget',
     'hqwebapp/js/widgets_v3',       // custom data fields use a .ko-select2
-    'locations/js/widgets_main',
+    'locations/js/widgets_main_v3',
 ], function (
     $,
     ko,

--- a/corehq/apps/locations/static/locations/js/widgets_main_v3.js
+++ b/corehq/apps/locations/static/locations/js/widgets_main_v3.js
@@ -55,7 +55,7 @@ hqDefine("locations/js/widgets_main_v3", [
             });
         });
 
-        $(".locations-widget-primary").each(function () {
+        $(".locations-widget-primary-v3").each(function () {
             var $select = $(this),
                 $source = $('#' + $select.data("sourceCssId")),
                 value = $select.val();

--- a/corehq/apps/locations/static/locations/js/widgets_main_v3.js
+++ b/corehq/apps/locations/static/locations/js/widgets_main_v3.js
@@ -23,7 +23,7 @@ hqDefine("locations/js/widgets_main_v3", [
     }
 
     $(function () {
-        $(".locations-widget-autocomplete").each(function () {
+        $(".locations-widget-autocomplete-v3").each(function () {
             var $select = $(this),
                 options = $select.data();
             $select.select2({

--- a/corehq/apps/locations/static/locations/js/widgets_main_v3.js
+++ b/corehq/apps/locations/static/locations/js/widgets_main_v3.js
@@ -1,4 +1,4 @@
-hqDefine("locations/js/widgets_main", [
+hqDefine("locations/js/widgets_main_v3", [
     'jquery',
     'underscore',
     'select2-3.5.2-legacy/select2',

--- a/corehq/apps/locations/static/locations/js/widgets_main_v4.js
+++ b/corehq/apps/locations/static/locations/js/widgets_main_v4.js
@@ -1,0 +1,100 @@
+hqDefine("locations/js/widgets_main_v4", [
+    'jquery',
+    'underscore',
+    'select2/dist/js/select2.full.min',
+], function (
+    $,
+    _
+) {
+    // Update the options available to one select2 to be
+    // the selected values from another (multiselect) select2
+    function updateSelect2($source, $select) {
+        $select.find("option").remove();
+        _.each($source.select2('data'), function(result) {
+            $select.append(new Option(result.text || result.name, result.id));
+        });
+    }
+
+    $(function () {
+        $(".locations-widget-autocomplete-v4").each(function () {
+            var $select = $(this),
+                options = $select.data();
+            $select.select2({
+                multiple: options.multiselect,
+                allowClear: !options.multiselect,
+                placeholder: gettext("Select a Location"),
+                ajax: {
+                    url: options.queryUrl,
+                    dataType: 'json',
+                    delay: 500,
+                    data: function (params) {
+                        return {
+                            name: params.term,
+                            page: params.page,
+                        };
+                    },
+                    processResults: function (data, params) {
+                        var more = (params.page || 1) * 10 < data.total;
+                        return {
+                            results: data.results,
+                            pagination: { more: more },
+                        };
+                    },
+                },
+                templateResult: function (result) { return result.text || result.name; },
+                templateSelection: function (result) { return result.text || result.name; },
+            });
+
+            var initial = options.initialData;
+            if (initial) {
+                if (!_.isArray(initial)) {
+                    initial = [initial];
+                }
+                _.each(initial, function (result) {
+                    $select.append(new Option(result.name, result.id));
+                });
+                $select.val(_.pluck(initial, 'id')).trigger('change');
+            }
+
+            $select.trigger('select-ready');
+        });
+
+        $(".locations-widget-primary-v4").each(function () {
+            var $select = $(this),
+                $source = $('#' + $select.data("sourceCssId")),
+                value = $select.data("initial");
+
+            $select.select2({
+                allowClear: true,
+                placeholder: gettext("Choose a primary location"),
+            });
+
+            // This custom event is fired in autocomplete_select_widget.html
+            if ($source.hasClass("select2-hidden-accessible")) {
+                updateSelect2($source, $select);
+                $select.val(value).trigger("change");
+            } else {
+                $source.on('select-ready', function () {
+                    updateSelect2($source, $select);
+                    $select.val(value).trigger("change");
+                });
+            }
+
+            // Change options/value for css_id based on what's chosen for source_css_id
+            $source.on('change', function () {
+                updateSelect2($source, $select);
+                var sourceOptions = $source.select2('data'),
+                    newValue;
+                if (!sourceOptions.length) {
+                    newValue = null;
+                } else {
+                    newValue = $select.val();   // current value
+                    if (!_.contains(_.pluck(sourceOptions, 'id'), newValue)) {
+                        newValue = sourceOptions[0].id;
+                    }
+                }
+                $select.val(newValue).trigger('change');
+            });
+        });
+    });
+});

--- a/corehq/apps/locations/static/locations/js/widgets_main_v4.js
+++ b/corehq/apps/locations/static/locations/js/widgets_main_v4.js
@@ -10,7 +10,7 @@ hqDefine("locations/js/widgets_main_v4", [
     // the selected values from another (multiselect) select2
     function updateSelect2($source, $select) {
         $select.find("option").remove();
-        _.each($source.select2('data'), function(result) {
+        _.each($source.select2('data'), function (result) {
             $select.append(new Option(result.text || result.name, result.id));
         });
     }

--- a/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget_v3.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget_v3.html
@@ -1,6 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
-<input id="{{ id }}" type="hidden" class="locations-widget-autocomplete" name="{{ name }}" value="{{ value }}" style="width: 30em;"
+<input id="{{ id }}" type="hidden" class="locations-widget-autocomplete-v3" name="{{ name }}" value="{{ value }}" style="width: 30em;"
        data-multiselect="{% html_attr multiselect %}"
        data-query-url="{% html_attr query_url %}"
        data-initial-data="{% html_attr initial_data %}" />

--- a/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget_v4.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget_v4.html
@@ -1,0 +1,7 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+<select id="{{ id }}" class="locations-widget-autocomplete-v4 form-control" name="{{ name }}" value="{{ value }}" style="width: 30em;"
+       data-multiselect="{% html_attr multiselect %}"
+       data-query-url="{% html_attr query_url %}"
+       data-initial-data="{% html_attr initial_data %}">
+</select>

--- a/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
@@ -1,2 +1,0 @@
-<input class="locations-widget-primary" type="hidden" id="{{ css_id }}" name="{{ name }}" value="{{ value }}" style="width: 30em;"
-       data-css-id="{{ css_id }}" data-source-css-id="{{ source_css_id }}" />

--- a/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget_v3.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget_v3.html
@@ -1,0 +1,2 @@
+<input class="locations-widget-primary-v3" type="hidden" id="{{ css_id }}" name="{{ name }}" value="{{ value }}" style="width: 30em;"
+       data-css-id="{{ css_id }}" data-source-css-id="{{ source_css_id }}" />

--- a/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget_v4.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget_v4.html
@@ -1,0 +1,4 @@
+{% load hq_shared_tags %}
+
+<select class="locations-widget-primary-v4 form-control" id="{{ css_id }}" name="{{ name }}" style="width: 30em;"
+        data-initial="{% html_attr value %}" data-css-id="{{ css_id }}" data-source-css-id="{{ source_css_id }}"></select>

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -12,7 +12,7 @@ from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.forms import clean_password, NoAutocompleteMixin
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.utils import decode_password
-from corehq.apps.locations.forms import LocationSelectWidget
+from corehq.apps.locations.forms import LocationSelectWidgetV3
 from corehq.apps.programs.models import Program
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.forms import RoleForm
@@ -426,7 +426,7 @@ class AdminInvitesUserForm(RoleForm, _BaseForm, forms.Form):
         super(AdminInvitesUserForm, self).__init__(data=data, *args, **kwargs)
         if domain and domain.commtrack_enabled:
             self.fields['supply_point'] = forms.CharField(label='Supply Point', required=False,
-                                                          widget=LocationSelectWidget(domain.name),
+                                                          widget=LocationSelectWidgetV3(domain.name),
                                                           initial=location.location_id if location else '')
             self.fields['program'] = forms.ChoiceField(label="Program", choices=(), required=False)
             programs = Program.by_domain(domain.name, wrap=False)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -12,7 +12,7 @@ from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.forms import clean_password, NoAutocompleteMixin
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.utils import decode_password
-from corehq.apps.locations.forms import LocationSelectWidgetV3
+from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.apps.programs.models import Program
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.forms import RoleForm
@@ -426,8 +426,9 @@ class AdminInvitesUserForm(RoleForm, _BaseForm, forms.Form):
         super(AdminInvitesUserForm, self).__init__(data=data, *args, **kwargs)
         if domain and domain.commtrack_enabled:
             self.fields['supply_point'] = forms.CharField(label='Supply Point', required=False,
-                                                          widget=LocationSelectWidgetV3(domain.name),
-                                                          initial=location.location_id if location else '')
+                                                          widget=LocationSelectWidget(domain.name),
+                                                          initial=location.location_id if location else '',
+                                                          select2_version='v3')
             self.fields['program'] = forms.ChoiceField(label="Program", choices=(), required=False)
             programs = Program.by_domain(domain.name, wrap=False)
             choices = list((prog['_id'], prog['name']) for prog in programs)

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -28,7 +28,7 @@ from corehq.apps.reminders.util import DotExpandedDict, get_form_list
 from corehq.apps.groups.models import Group
 from corehq.apps.sms.models import Keyword
 from corehq.apps.smsforms.models import SQLXFormsSession
-from corehq.apps.locations.forms import LocationSelectWidgetV3
+from corehq.apps.locations.forms import LocationSelectWidget
 from corehq import toggles
 from corehq.util.timezones.conversions import UserTime
 from dimagi.utils.couch.database import iter_docs
@@ -2488,9 +2488,10 @@ class BroadcastForm(Form):
         self.fields['form_unique_id'].choices = form_choices(self.domain)
         self.fields['case_group_id'].choices = get_case_group_meta_in_domain(self.domain)
         self.fields['user_group_id'].choices = user_group_choices(self.domain)
-        self.fields['location_ids'].widget = LocationSelectWidgetV3(
+        self.fields['location_ids'].widget = LocationSelectWidget(
             self.domain,
             multiselect=True,
+            select2_version='v3',
         )
 
         self.helper = FormHelper()

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -28,7 +28,7 @@ from corehq.apps.reminders.util import DotExpandedDict, get_form_list
 from corehq.apps.groups.models import Group
 from corehq.apps.sms.models import Keyword
 from corehq.apps.smsforms.models import SQLXFormsSession
-from corehq.apps.locations.forms import LocationSelectWidget
+from corehq.apps.locations.forms import LocationSelectWidgetV3
 from corehq import toggles
 from corehq.util.timezones.conversions import UserTime
 from dimagi.utils.couch.database import iter_docs
@@ -2488,7 +2488,7 @@ class BroadcastForm(Form):
         self.fields['form_unique_id'].choices = form_choices(self.domain)
         self.fields['case_group_id'].choices = get_case_group_meta_in_domain(self.domain)
         self.fields['user_group_id'].choices = user_group_choices(self.domain)
-        self.fields['location_ids'].widget = LocationSelectWidget(
+        self.fields['location_ids'].widget = LocationSelectWidgetV3(
             self.domain,
             multiselect=True,
         )

--- a/corehq/apps/reminders/templates/reminders/broadcast.html
+++ b/corehq/apps/reminders/templates/reminders/broadcast.html
@@ -5,7 +5,7 @@
 
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'locations/js/widgets_main.js' %}"></script>
+    <script src="{% static 'locations/js/widgets_main_v3.js' %}"></script>
     <script src="{% static 'reminders/js/reminders.broadcast.ko.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -772,7 +772,7 @@ class AngularLocationSelectWidget(forms.Widget):
         """.format(validator='validate-location=""' if self.require else '')
 
 
-class PrimaryLocationWidget(forms.Widget):
+class PrimaryLocationWidgetV3(forms.Widget):
     """
     Options for this field are dynamically set in JS depending on what options are selected
     for 'assigned_locations'. This works in conjunction with LocationSelectWidgetV3.
@@ -783,12 +783,12 @@ class PrimaryLocationWidget(forms.Widget):
             css_id: css_id of primary_location field
             source_css_id: css_id of assigned_locations field
         """
-        super(PrimaryLocationWidget, self).__init__(attrs)
+        super(PrimaryLocationWidgetV3, self).__init__(attrs)
         self.css_id = css_id
         self.source_css_id = source_css_id
 
     def render(self, name, value, attrs=None):
-        return get_template('locations/manage/partials/drilldown_location_widget.html').render({
+        return get_template('locations/manage/partials/drilldown_location_widget_v3.html').render({
             'css_id': self.css_id,
             'source_css_id': self.source_css_id,
             'name': name,
@@ -819,7 +819,7 @@ class CommtrackUserForm(forms.Form):
         self.fields['assigned_locations'].widget = LocationSelectWidgetV3(
             self.domain, multiselect=True, id='id_assigned_locations'
         )
-        self.fields['primary_location'].widget = PrimaryLocationWidget(
+        self.fields['primary_location'].widget = PrimaryLocationWidgetV3(
             css_id='id_primary_location',
             source_css_id='id_assigned_locations'
         )

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -775,7 +775,7 @@ class AngularLocationSelectWidget(forms.Widget):
 class PrimaryLocationWidget(forms.Widget):
     """
     Options for this field are dynamically set in JS depending on what options are selected
-    for 'assigned_locations'. This works in conjunction with LocationSelectWidget.
+    for 'assigned_locations'. This works in conjunction with LocationSelectWidgetV3.
     """
     def __init__(self, css_id, source_css_id, attrs=None):
         """
@@ -813,10 +813,10 @@ class CommtrackUserForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        from corehq.apps.locations.forms import LocationSelectWidget
+        from corehq.apps.locations.forms import LocationSelectWidgetV3
         self.domain = kwargs.pop('domain', None)
         super(CommtrackUserForm, self).__init__(*args, **kwargs)
-        self.fields['assigned_locations'].widget = LocationSelectWidget(
+        self.fields['assigned_locations'].widget = LocationSelectWidgetV3(
             self.domain, multiselect=True, id='id_assigned_locations'
         )
         self.fields['primary_location'].widget = PrimaryLocationWidget(

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -772,23 +772,31 @@ class AngularLocationSelectWidget(forms.Widget):
         """.format(validator='validate-location=""' if self.require else '')
 
 
-class PrimaryLocationWidgetV3(forms.Widget):
+class PrimaryLocationWidget(forms.Widget):
     """
     Options for this field are dynamically set in JS depending on what options are selected
-    for 'assigned_locations'. This works in conjunction with LocationSelectWidgetV3.
+    for 'assigned_locations'. This works in conjunction with LocationSelectWidget.
     """
-    def __init__(self, css_id, source_css_id, attrs=None):
+    def __init__(self, css_id, source_css_id, attrs=None, select2_version=None):
         """
         args:
             css_id: css_id of primary_location field
             source_css_id: css_id of assigned_locations field
         """
-        super(PrimaryLocationWidgetV3, self).__init__(attrs)
+        super(PrimaryLocationWidget, self).__init__(attrs)
         self.css_id = css_id
         self.source_css_id = source_css_id
 
+        versioned_templates = {
+            'v3': 'locations/manage/partials/drilldown_location_widget_v3.html',
+            'v4': 'locations/manage/partials/drilldown_location_widget_v4.html',
+        }
+        if select2_version not in versioned_templates:
+            raise ValueError("select2_version must be in {}".format(", ".join(versioned_templates.keys())))
+        self.template = versioned_templates[select2_version]
+
     def render(self, name, value, attrs=None):
-        return get_template('locations/manage/partials/drilldown_location_widget_v3.html').render({
+        return get_template(self.template).render({
             'css_id': self.css_id,
             'source_css_id': self.source_css_id,
             'name': name,
@@ -813,15 +821,16 @@ class CommtrackUserForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        from corehq.apps.locations.forms import LocationSelectWidgetV3
+        from corehq.apps.locations.forms import LocationSelectWidget
         self.domain = kwargs.pop('domain', None)
         super(CommtrackUserForm, self).__init__(*args, **kwargs)
-        self.fields['assigned_locations'].widget = LocationSelectWidgetV3(
-            self.domain, multiselect=True, id='id_assigned_locations'
+        self.fields['assigned_locations'].widget = LocationSelectWidget(
+            self.domain, multiselect=True, id='id_assigned_locations', select2_version='v3'
         )
-        self.fields['primary_location'].widget = PrimaryLocationWidgetV3(
+        self.fields['primary_location'].widget = PrimaryLocationWidget(
             css_id='id_primary_location',
-            source_css_id='id_assigned_locations'
+            source_css_id='id_assigned_locations',
+            select2_version='v3'
         )
         if self.commtrack_enabled:
             programs = Program.by_domain(self.domain, wrap=False)

--- a/corehq/apps/users/templates/users/base_template.html
+++ b/corehq/apps/users/templates/users/base_template.html
@@ -3,5 +3,5 @@
 {% load hq_shared_tags %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static "locations/js/widgets_main.js" %}"></script>
+    <script src="{% static "locations/js/widgets_main_v3.js" %}"></script>
 {% endblock %}

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule_main.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule_main.js
@@ -1,7 +1,7 @@
 hqDefine("scheduling/js/create_schedule_main", [
     'scheduling/js/create_schedule.ko',
     'data_interfaces/js/make_read_only',
-    'locations/js/widgets_main',
+    'locations/js/widgets_main_v3',
 ], function () {
     // This page doesn't have any page-specific logic, it just depends on the modules above
 });

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from corehq.apps.locations.forms import LocationSelectWidget
+from corehq.apps.locations.forms import LocationSelectWidgetV3
 from corehq.motech.repeaters.dbaccessors import get_repeaters_by_domain
 from corehq.motech.repeaters.repeater_generators import RegisterGenerator
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
@@ -219,7 +219,7 @@ class OpenmrsRepeaterForm(CaseRepeaterForm):
 
     def __init__(self, *args, **kwargs):
         super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
-        self.fields['location_id'].widget = LocationSelectWidget(self.domain, id='id_location_id')
+        self.fields['location_id'].widget = LocationSelectWidgetV3(self.domain, id='id_location_id')
 
     def get_ordered_crispy_form_fields(self):
         fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from corehq.apps.locations.forms import LocationSelectWidgetV3
+from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.motech.repeaters.dbaccessors import get_repeaters_by_domain
 from corehq.motech.repeaters.repeater_generators import RegisterGenerator
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
@@ -219,7 +219,8 @@ class OpenmrsRepeaterForm(CaseRepeaterForm):
 
     def __init__(self, *args, **kwargs):
         super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
-        self.fields['location_id'].widget = LocationSelectWidgetV3(self.domain, id='id_location_id')
+        self.fields['location_id'].widget = LocationSelectWidget(self.domain, id='id_location_id',
+                                                                 select2_version='v4')
 
     def get_ordered_crispy_form_fields(self):
         fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -1,8 +1,8 @@
 hqDefine("repeaters/js/add_form_repeater", [
     'jquery',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/widgets_v3',       // case repeaters ("Forward Cases") use .ko-select2
-    'locations/js/widgets_main_v3',    // openmrs repeaters use the LocationSelectWidgetV3
+    'hqwebapp/js/widgets_v4',       // case repeaters ("Forward Cases") use .ko-select2
+    'locations/js/widgets_main_v4',    // openmrs repeaters use the LocationSelectWidget
 ], function (
     $,
     initialPageData

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -2,7 +2,7 @@ hqDefine("repeaters/js/add_form_repeater", [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/widgets_v3',       // case repeaters ("Forward Cases") use .ko-select2
-    'locations/js/widgets_main_v3',    // openmrs repeaters use the LocationSelectWidget
+    'locations/js/widgets_main_v3',    // openmrs repeaters use the LocationSelectWidgetV3
 ], function (
     $,
     initialPageData

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -2,7 +2,7 @@ hqDefine("repeaters/js/add_form_repeater", [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/widgets_v3',       // case repeaters ("Forward Cases") use .ko-select2
-    'locations/js/widgets_main',    // openmrs repeaters use the LocationSelectWidget
+    'locations/js/widgets_main_v3',    // openmrs repeaters use the LocationSelectWidget
 ], function (
     $,
     initialPageData

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -20,7 +20,7 @@ from dimagi.utils.post import simple_post
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views import BaseAdminProjectSettingsView, BaseProjectSettingsView
-from corehq.apps.hqwebapp.decorators import use_select2
+from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission
 from corehq.apps.users.models import Permissions
 
@@ -194,7 +194,7 @@ class AddCaseRepeaterView(AddRepeaterView):
     urlname = 'add_case_repeater'
     repeater_form_class = CaseRepeaterForm
 
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(AddCaseRepeaterView, self).dispatch(request, *args, **kwargs)
 

--- a/custom/ewsghana/forms.py
+++ b/custom/ewsghana/forms.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.urls import reverse
 from corehq.apps.reminders.forms import BroadcastForm
 from corehq.apps.reminders.models import (RECIPIENT_USER_GROUP, RECIPIENT_LOCATION)
-from corehq.apps.locations.forms import LocationSelectWidget
+from corehq.apps.locations.forms import LocationSelectWidgetV3
 from corehq.messaging.scheduling.forms import BroadcastForm as NewRemindersBroadcastForm
 from crispy_forms import layout as crispy
 from django import forms
@@ -137,7 +137,7 @@ class EWSUserSettings(forms.Form):
             del kwargs['domain']
         super(EWSUserSettings, self).__init__(*args, **kwargs)
         query_url = reverse('non_administrative_locations_for_select2', args=[domain])
-        self.fields['facility'].widget = LocationSelectWidget(domain=domain, id='facility', query_url=query_url)
+        self.fields['facility'].widget = LocationSelectWidgetV3(domain=domain, id='facility', query_url=query_url)
 
     def save(self, user, domain):
         ews_extension = EWSExtension.objects.get_or_create(user_id=user.get_id, domain=domain)[0]

--- a/custom/ewsghana/forms.py
+++ b/custom/ewsghana/forms.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.urls import reverse
 from corehq.apps.reminders.forms import BroadcastForm
 from corehq.apps.reminders.models import (RECIPIENT_USER_GROUP, RECIPIENT_LOCATION)
-from corehq.apps.locations.forms import LocationSelectWidgetV3
+from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.messaging.scheduling.forms import BroadcastForm as NewRemindersBroadcastForm
 from crispy_forms import layout as crispy
 from django import forms
@@ -137,7 +137,8 @@ class EWSUserSettings(forms.Form):
             del kwargs['domain']
         super(EWSUserSettings, self).__init__(*args, **kwargs)
         query_url = reverse('non_administrative_locations_for_select2', args=[domain])
-        self.fields['facility'].widget = LocationSelectWidgetV3(domain=domain, id='facility', query_url=query_url)
+        self.fields['facility'].widget = LocationSelectWidget(domain=domain, id='facility', query_url=query_url,
+                                                              select2_version='v3')
 
     def save(self, user, domain):
         ews_extension = EWSExtension.objects.get_or_create(user_id=user.get_id, domain=domain)[0]

--- a/custom/ewsghana/templates/ewsghana/user_extension.html
+++ b/custom/ewsghana/templates/ewsghana/user_extension.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static "locations/js/widgets_main.js" %}"></script>
+    <script src="{% static "locations/js/widgets_main_v3.js" %}"></script>
 {% endblock %}
 
 {% block page_content %}


### PR DESCRIPTION
Similar to https://github.com/dimagi/commcare-hq/pull/21770, split this module into a v3 and a v4 version so I can upgrade pages one at a time.

Product note: this makes trivial changes to the look and feel of the select2 widgets when adding or editing a repeater, see below.

Marking don't merge just until I sanity test on staging.

@pr33thi / @millerdev 

before
<img width="783" alt="screen shot 2018-09-07 at 9 27 11 pm" src="https://user-images.githubusercontent.com/1486591/45266803-fcf1cb00-b42e-11e8-87ad-b73df50a0887.png">

after
<img width="769" alt="screen shot 2018-09-07 at 9 25 04 pm" src="https://user-images.githubusercontent.com/1486591/45266804-01b67f00-b42f-11e8-8da2-4e7a65513c34.png">
