### PR TITLE
Releases changes followup

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4932,8 +4932,8 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         required=False
     )
 
-    @classmethod
-    def wrap(cls, data):
+    @staticmethod
+    def _scrap_old_conventions(data):
         should_save = False
         # scrape for old conventions and get rid of them
         if 'commcare_build' in data:
@@ -4966,14 +4966,19 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         if 'original_doc' in data:
             data['copy_history'] = [data.pop('original_doc')]
             should_save = True
+        return should_save
 
+    @classmethod
+    def wrap(cls, data, scrap_old_conventions=True):
+        if scrap_old_conventions:
+            should_save = cls._scrap_old_conventions(data)
         data["description"] = data.get('description') or data.get('short_description')
 
         self = super(ApplicationBase, cls).wrap(data)
         if not self.build_spec or self.build_spec.is_null():
             self.build_spec = get_default_build_spec()
 
-        if should_save:
+        if scrap_old_conventions and should_save:
             self.save()
 
         return self

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -98,7 +98,7 @@ def paginate_releases(request, domain, app_id):
         app_es = app_es.is_released()
     if build_comment:
         app_es = app_es.build_comment(build_comment)
-    results = app_es.run()
+    results = app_es.exclude_source().run()
     app_ids = results.doc_ids
     apps = get_docs(Application.get_db(), app_ids)
     for app in apps:

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -25,6 +25,7 @@ from django.views.decorators.cache import cache_control
 import ghdiff
 from couchdbkit import ResourceNotFound
 from dimagi.utils.web import json_response
+from dimagi.utils.couch.bulk import get_docs
 from phonelog.models import UserErrorEntry
 
 from corehq import privileges, toggles
@@ -97,8 +98,9 @@ def paginate_releases(request, domain, app_id):
         app_es = app_es.is_released()
     if build_comment:
         app_es = app_es.build_comment(build_comment)
-    apps = app_es.run()
-    saved_apps = [SavedAppBuild.wrap(app).to_saved_build_json(timezone) for app in apps.hits]
+    app_ids = app_es.get_ids()
+    apps = get_docs(Application.get_db(), app_ids)
+    saved_apps = [SavedAppBuild.wrap(app).to_saved_build_json(timezone) for app in apps]
 
     j2me_enabled_configs = CommCareBuildConfig.j2me_enabled_config_labels()
     for app in saved_apps:
@@ -116,12 +118,13 @@ def paginate_releases(request, domain, app_id):
         for app in saved_apps:
             app['num_errors'] = num_errors_dict.get(app['version'], 0)
 
-    num_pages = int(ceil(apps.total / limit))
+    total_apps = app_es.count()
+    num_pages = int(ceil(total_apps / limit))
 
     return json_response({
         'apps': saved_apps,
         'pagination': {
-            'total': apps.total,
+            'total': total_apps,
             'num_pages': num_pages,
             'current_page': page,
         }

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -100,7 +100,9 @@ def paginate_releases(request, domain, app_id):
         app_es = app_es.build_comment(build_comment)
     app_ids = app_es.get_ids()
     apps = get_docs(Application.get_db(), app_ids)
-    saved_apps = [SavedAppBuild.wrap(app).to_saved_build_json(timezone) for app in apps]
+    for app in apps:
+        app.pop('translations')
+    saved_apps = [SavedAppBuild.wrap(app, scrap_old_conventions=False).to_saved_build_json(timezone) for app in apps]
 
     j2me_enabled_configs = CommCareBuildConfig.j2me_enabled_config_labels()
     for app in saved_apps:

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -98,11 +98,13 @@ def paginate_releases(request, domain, app_id):
         app_es = app_es.is_released()
     if build_comment:
         app_es = app_es.build_comment(build_comment)
-    app_ids = app_es.get_ids()
+    results = app_es.run()
+    app_ids = results.doc_ids
     apps = get_docs(Application.get_db(), app_ids)
     for app in apps:
         app.pop('translations')
-    saved_apps = [SavedAppBuild.wrap(app, scrap_old_conventions=False).to_saved_build_json(timezone) for app in apps]
+    saved_apps = [SavedAppBuild.wrap(app, scrap_old_conventions=False).to_saved_build_json(timezone)
+                  for app in apps]
 
     j2me_enabled_configs = CommCareBuildConfig.j2me_enabled_config_labels()
     for app in saved_apps:
@@ -120,7 +122,7 @@ def paginate_releases(request, domain, app_id):
         for app in saved_apps:
             app['num_errors'] = num_errors_dict.get(app['version'], 0)
 
-    total_apps = app_es.count()
+    total_apps = results.total
     num_pages = int(ceil(total_apps / limit))
 
     return json_response({


### PR DESCRIPTION
Following up on changes done [here](https://github.com/dimagi/commcare-hq/pull/21506/files#diff-832a9c32f7b2d8f440fbbb812f09553dR85)

Noticed that fetching releases was taking quite a while for icds, [here](https://india.commcarehq.org/a/icds-cas/apps/view/f48503660b574a2bb43c808113732943/releases/json/?page=1&limit=5&only_show_released=false)
@orangejenny pointed out that it was including translations which was quite heavy for ICDS and that probably happened because translations are a part of the ES [doc](https://github.com/dimagi/commcare-hq/blob/master/corehq/pillows/mappings/app_mapping.py#L317). But looks like they are present in couch doc itself.

This PR addresses two things
1. Switch back to Couch DB for fetching docs. Fetching document from ES and then [wrapping it with a couch model](https://github.com/dimagi/commcare-hq/pull/21506/files#diff-832a9c32f7b2d8f440fbbb812f09553dR98) looks risky considering data can be different/outdated in es. Plus the wrap method was also updates the document if needed and in that case it would update the doc with details from the ES doc. This PR avoid update during the wrap when fetching releases, so should we revert to ES? But it still looks like the right change considering couch model wrapping ES data.
2. Avoids using translations when fetching the doc to avoid big ajax response. I initially was trying to work towards a wrapper which would only returns things in the ajax request that the releases page actually needs but that looked like a big fix that might break things. So just kept it the opposite for now to simply avoid things that are not used by the releases page for sure, starting with translations.
