### PR TITLE
Downgrade select2 for edit scheduled reports

### DIFF
--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -4,7 +4,7 @@ hqDefine("reports/js/edit_scheduled_report", [
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/multiselect_utils",
-    "hqwebapp/js/widgets_v4",  // autocomplete widget for email recipient list
+    "hqwebapp/js/widgets_v3",  // autocomplete widget for email recipient list
 ], function (
     $,
     _,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -194,7 +194,7 @@ from corehq.form_processor.utils.xform import resave_form
 from corehq.apps.hqcase.utils import resave_case
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
-    use_select2_v4,
+    use_select2,
     use_datatables,
     use_multiselect,
 )
@@ -890,7 +890,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     template_name = 'reports/edit_scheduled_report.html'
 
     @use_multiselect
-    @use_select2_v4
+    @use_select2
     def dispatch(self, request, *args, **kwargs):
         return super(ScheduledReportsView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?282766

Introduced in https://github.com/dimagi/commcare-hq/pull/21770

Seems new select2 doesn't support adding new choices in the same way the legacy version does.

@millerdev / @pr33thi 