### PR TITLE
Add check for location id

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -576,7 +576,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
         self.set_role(domain, role)
         if project.commtrack_enabled:
             self.get_domain_membership(domain).program_id = program_id
-        if project.uses_locations:
+        if project.uses_locations and location_id:
             self.set_location(domain, location_id)
         self.save()
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?282782
This threw a bug when a web user is invited without having the location set (original pr: https://github.com/dimagi/commcare-hq/pull/21352)

code buddy @orangejenny 
@esoergel 
fyi @sravfeyn 
