### PR TITLE
Downgrade select2 for Project Settings > Basic

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -83,7 +83,7 @@ from corehq.apps.reminders.models import CaseReminderHandler
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.hqwebapp import crispy as hqcrispy
-from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2AjaxV4
+from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2AjaxV3
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.privileges import (
     REPORT_BUILDER_5,
@@ -512,7 +512,7 @@ USE_LOCATION_CHOICE = "user_location"
 USE_PARENT_LOCATION_CHOICE = 'user_parent_location'
 
 
-class CallCenterOwnerWidget(Select2AjaxV4):
+class CallCenterOwnerWidget(Select2AjaxV3):
 
     def set_domain(self, domain):
         self.domain = domain

--- a/corehq/apps/domain/static/domain/js/info_basic.js
+++ b/corehq/apps/domain/static/domain/js/info_basic.js
@@ -1,8 +1,8 @@
 hqDefine("domain/js/info_basic", [
     'jquery',
     'underscore',
-    'hqwebapp/js/select_2_ajax_widget_v4', // for call center case owner
-    'select2/dist/js/select2.full.min',
+    'hqwebapp/js/select_2_ajax_widget_v3', // for call center case owner
+    'select2-3.5.2-legacy/select2',
 ], function (
     $,
     _

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -55,7 +55,6 @@ from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
     use_select2,
-    use_select2_v4,
     use_multiselect,
 )
 from corehq.apps.accounting.exceptions import (
@@ -350,7 +349,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
     page_title = ugettext_lazy("Basic")
 
     @method_decorator(domain_admin_required)
-    @use_select2_v4
+    @use_select2
     def dispatch(self, request, *args, **kwargs):
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
This undoes part of https://github.com/dimagi/commcare-hq/pull/21779: it's fine right now, but will have issues once https://github.com/dimagi/commcare-hq/pull/21756 is merged, because the basic info page will be using v4 but other pages in the domain app will be bundled with it and will still be on v3.

@pr33thi / @millerdev 