### PR TITLE
ewsghana: stop including legacy select2 script tags

### DIFF
--- a/custom/ewsghana/templates/ewsghana/base_template.html
+++ b/custom/ewsghana/templates/ewsghana/base_template.html
@@ -5,7 +5,6 @@
     <script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}'></script>
     <script src="{% static 'ewsghana/report_links.js' %}"></script>
     <script src="{% static 'hqwebapp/js/daterangepicker.config.js' %}"></script>
-    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
     <script src="{% static 'ewsghana/js/lib/canvg/canvg.min.js' %}"></script>
     <script src="{% static 'ewsghana/js/lib/canvg/rgbcolor.min.js' %}"></script>
     <script src="{% static 'ewsghana/js/lib/canvg/StackBlur.min.js' %}"></script>

--- a/custom/ewsghana/templates/ewsghana/dashboard_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/dashboard_print_report.html
@@ -4,14 +4,6 @@
 {% load i18n %}
 {% if show_time_notice %}{% endif %}
 
-{% block js %}
-    {% javascript_libraries underscore=True %}
-    <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
-    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-    {{ block.super }}
-{% endblock %}
-
 {% block js-inline %}
     {{ block.super }}
     <script>
@@ -37,8 +29,6 @@
 {% endblock %}
 
 {% block reportcontent %}
-    <link href="{% static 'nvd3/src/nv.d3.css' %}" rel="stylesheet">
-    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
     <style>
             button {
                 display: none !important;

--- a/custom/ewsghana/templates/ewsghana/facility_page_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/facility_page_print_report.html
@@ -4,15 +4,6 @@
 {% load i18n %}
 {% if show_time_notice %}{% endif %}
 
-{% block js %}
-    {% javascript_libraries underscore=True %}
-    <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
-    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-    <script src="{% static 'less/dist/less-1.3.1.min.js' %}"></script>
-    {{ block.super }}
-{% endblock %}
-
 {% block js-inline %}
     {{ block.super }}
     <script>
@@ -38,8 +29,6 @@
 {% endblock %}
 
 {% block reportcontent %}
-    <link href="{% static 'nvd3/src/nv.d3.css' %}" rel="stylesheet">
-    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
     <style>
         button {
             display: none !important;

--- a/custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html
@@ -4,14 +4,6 @@
 {% load i18n %}
 {% if show_time_notice %}{% endif %}
 
-{% block js %}
-    {% javascript_libraries underscore=True %}
-    <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
-    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-    {{ block.super }}
-{% endblock %}
-
 {% block js-inline %}
     {{ block.super }}
     <script>
@@ -37,8 +29,6 @@
 {% endblock %}
 
 {% block reportcontent %}
-    <link href="{% static 'nvd3/src/nv.d3.css' %}" rel="stylesheet">
-    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
     <link href="{% static 'bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet"/>
     <style>
         #report_table_non_reporting tbody {

--- a/custom/ewsghana/templates/ewsghana/stock_status_print_report.html
+++ b/custom/ewsghana/templates/ewsghana/stock_status_print_report.html
@@ -4,14 +4,6 @@
 {% load i18n %}
 {% if show_time_notice %}{% endif %}
 
-{% block js %}
-    {% javascript_libraries underscore=True %}
-    <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
-    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-    {{ block.super }}
-{% endblock %}
-
 {% block js-inline %}
     {{ block.super }}
     <script>
@@ -37,8 +29,6 @@
 {% endblock %}
 
 {% block reportcontent %}
-    <link href="{% static 'nvd3/src/nv.d3.css' %}" rel="stylesheet">
-    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
     <style>
             button {
                 display: none !important;


### PR DESCRIPTION
@pr33thi 

These reports all descend from ewsghana's [MultiReport](https://github.com/dimagi/commcare-hq/blob/master/custom/ewsghana/reports/__init__.py#L165) which descends from (GenericReportView)[https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/generic.py#L50] which uses `@use_select2` on dispatch (and also `@use_nvd3`, so I removed a couple of those, too).