### PR TITLE
Minor select2 upgrade in reports

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
@@ -5,10 +5,6 @@
 {% block view-tabs %}
 {% endblock %}
 
-{% block stylesheets %}{{ block.super }}
-    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-{% endblock %}
-
 {% block js %}{{ block.super }}
     <script src="{% static 'reports/js/hq_report.js' %}"></script>
     <script src="{% static 'reports/js/reports.util.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/partials/filters_js.html
+++ b/corehq/apps/reports/templates/reports/partials/filters_js.html
@@ -2,7 +2,6 @@
 
 {# This file may be compressed; it should contain only script tags #}
 
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 <script src="{% static 'reports/js/filters/button_group.js' %}"></script>
 <script src="{% static 'reports/js/filters/select2s.js' %}"></script>
 <script src="{% static 'reports/js/filters/phone_number.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -39,8 +39,6 @@
 {% block stylesheets %}
     {{ block.super }}
 
-    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-
     {% if less_debug %}
         <link type="text/less"
               rel="stylesheet"


### PR DESCRIPTION
Reports already include select2 3.5.2 via GenericReportView, which uses @use_select2, so remove these references to legacy 3.4.5.

@pr33thi 