### PR TITLE
Get latest offsets from the consumer instead of utility

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -9,8 +9,7 @@ from kafka.common import TopicPartition
 
 from corehq.apps.change_feed.data_sources import get_document_store
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
-from corehq.apps.change_feed.topics import get_multi_topic_offset, validate_offsets
-from memoized import memoized
+from corehq.apps.change_feed.topics import validate_offsets
 from dimagi.utils.logging import notify_error
 from pillowtop.checkpoints.manager import PillowCheckpointEventHandler
 from pillowtop.models import kafka_seq_to_str
@@ -38,6 +37,7 @@ class KafkaChangeFeed(ChangeFeed):
         self.strict = strict
         self.num_processes = num_processes
         self.process_num = process_num
+        self._consumer = None
 
     def __unicode__(self):
         return 'KafkaChangeFeed: topics: {}, client: {}'.format(self._topics, self._client_id)
@@ -45,11 +45,6 @@ class KafkaChangeFeed(ChangeFeed):
     @property
     def topics(self):
         return self._topics
-
-    @property
-    @memoized
-    def topic_and_partitions(self):
-        return list(self._get_partitioned_offsets(get_multi_topic_offset(self.topics)))
 
     def _get_single_topic_or_fail(self):
         if len(self._topics) != 1:
@@ -60,18 +55,15 @@ class KafkaChangeFeed(ChangeFeed):
         """
         Since must be a dictionary of topic partition offsets.
         """
+        timeout = float('inf') if forever else MIN_TIMEOUT
+        start_from_latest = since is None
+        reset = 'largest' if start_from_latest else 'smallest'
+        self._init_consumer(timeout, auto_offset_reset=reset)
+
         since = self._filter_offsets(since)
         # a special value of since=None will start from the end of the change stream
         if since is not None and (not isinstance(since, dict) or not since):
             raise ValueError("'since' must be None or a topic offset dictionary")
-
-        timeout = float('inf') if forever else MIN_TIMEOUT
-
-        start_from_latest = since is None
-
-        reset = 'largest' if start_from_latest else 'smallest'
-        consumer = self._get_consumer(timeout, auto_offset_reset=reset)
-        consumer.assign([TopicPartition(a, b) for a, b in self.topic_and_partitions])
 
         if not start_from_latest:
             if self.strict:
@@ -84,12 +76,12 @@ class KafkaChangeFeed(ChangeFeed):
 
             self._processed_topic_offsets = copy(since)
 
-            # this is how you tell the consumer to start from a certain point in the sequence
+            # Tell the consumer to start from offsets that were passed in
             for topic_partition, offset in since.items():
-                consumer.seek(TopicPartition(topic_partition[0], topic_partition[1]), int(offset))
+                self.consumer.seek(TopicPartition(topic_partition[0], topic_partition[1]), int(offset))
 
         try:
-            for message in consumer:
+            for message in self.consumer:
                 self._processed_topic_offsets[(message.topic, message.partition)] = message.offset
                 yield change_from_kafka_message(message)
         except StopIteration:
@@ -117,7 +109,7 @@ class KafkaChangeFeed(ChangeFeed):
         return copy(self._processed_topic_offsets)
 
     def get_latest_offsets(self):
-        return self._filter_offsets(get_multi_topic_offset(self.topics))
+        return self.consumer.end_offsets(self.consumer.assignment())
 
     def get_latest_offsets_json(self):
         return json.loads(kafka_seq_to_str(self.get_latest_offsets()))
@@ -125,7 +117,15 @@ class KafkaChangeFeed(ChangeFeed):
     def get_latest_offsets_as_checkpoint_value(self):
         return self.get_latest_offsets()
 
-    def _get_consumer(self, timeout, auto_offset_reset='smallest'):
+    @property
+    def consumer(self):
+        if self._consumer is None:
+            return self._init_consumer()
+        return self._consumer
+
+    def _init_consumer(self, timeout=MIN_TIMEOUT, auto_offset_reset='smallest'):
+        """Allow re-initing the consumer if necessary
+        """
         config = {
             'client_id': self._client_id,
             'bootstrap_servers': settings.KAFKA_BROKERS,
@@ -134,9 +134,15 @@ class KafkaChangeFeed(ChangeFeed):
             'enable_auto_commit': False,
             'api_version': settings.KAFKA_API_VERSION,
         }
-        return KafkaConsumer(
-            **config
-        )
+        self._consumer = KafkaConsumer(**config)
+
+        topic_partitions = []
+        for topic in self.topics:
+            for partition in self._consumer.partitions_for_topic(topic):
+                topic_partitions.append(TopicPartition(topic, partition))
+
+        self._consumer.assign(self._filter_partitions(topic_partitions))
+        return self._consumer
 
     def _filter_offsets(self, offsets):
         if offsets is None:
@@ -144,23 +150,17 @@ class KafkaChangeFeed(ChangeFeed):
 
         return {
             tp: offsets[tp]
-            for tp in self.topic_and_partitions
+            for tp in self.consumer.assignment()
             if tp in offsets
         }
 
-    def _get_partitioned_offsets(self, offsets):
-        topic_partitions = sorted(list(offsets))
+    def _filter_partitions(self, topic_partitions):
+        topic_partitions.sort()
 
-        partitioned_topic_partitions = [
+        return [
             topic_partitions[num::self.num_processes]
             for num in range(self.num_processes)
         ][self.process_num]
-
-        return {
-            tp: offset
-            for tp, offset in offsets.items()
-            if tp in partitioned_topic_partitions
-        }
 
 
 class KafkaCheckpointEventHandler(PillowCheckpointEventHandler):


### PR DESCRIPTION
Tried to make this change as small as possible, but it should almost stop all the errrors from ICDS's pillows.  because it removes an extra SimpleClient setup that happens in `get_multi_topic_offset`

I tried to make this change as small as possible. there's probably more improvements to be done and i plan on following up with more refactoring 