### PR TITLE
use one consumer for metric gathering

### DIFF
--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -190,7 +190,10 @@ def get_pillow_json(pillow_config, consumer=None):
 
     if _is_kafka(checkpoint):
         # breaking composition boundaries so that we can use one Kafka connection
-        offsets = consumer.end_offsets(checkpoint.wrapped_sequence.keys())
+        offsets = {
+            "{},{}".format(tp.topic, tp.partition): offset
+            for tp, offset in consumer.end_offsets(checkpoint.wrapped_sequence.keys()).items()
+        }
     else:
         offsets = pillow.get_change_feed().get_latest_offsets_json()
 

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -9,6 +9,7 @@ import sys
 
 import simplejson
 from django.conf import settings
+from kafka import KafkaConsumer
 
 from dimagi.utils.chunked import chunked
 from dimagi.utils.modules import to_function
@@ -145,15 +146,29 @@ def safe_force_seq_int(seq, default=None):
         return default
 
 
+def _get_consumer():
+    return KafkaConsumer(
+        client_id='pillowtop_utils',
+        bootstrap_servers=settings.KAFKA_BROKERS,
+        request_timeout_ms=1000
+    )
+
+
 def get_all_pillows_json():
     pillow_configs = get_all_pillow_configs()
-    return [get_pillow_json(pillow_config) for pillow_config in pillow_configs]
+    consumer = _get_consumer()
+    return [get_pillow_json(pillow_config, consumer) for pillow_config in pillow_configs]
 
 
-def get_pillow_json(pillow_config):
+def get_pillow_json(pillow_config, consumer=None):
     assert isinstance(pillow_config, PillowConfig)
 
+    def _is_kafka(checkpoint):
+        return checkpoint.sequence_format == 'json'
+
     pillow = pillow_config.get_instance()
+    if consumer is None:
+        consumer = _get_consumer()
 
     checkpoint = pillow.get_checkpoint()
     timestamp = checkpoint.timestamp
@@ -172,11 +187,16 @@ def get_pillow_json(pillow_config):
         seconds_since_last = 0
         prettified_time_since_last = ''
         hours_since_last = None
-    offsets = pillow.get_change_feed().get_latest_offsets_json()
+
+    if _is_kafka(checkpoint):
+        # breaking composition boundaries so that we can use one Kafka connection
+        offsets = consumer.end_offsets(checkpoint.wrapped_sequence.keys())
+    else:
+        offsets = pillow.get_change_feed().get_latest_offsets_json()
 
     def _seq_to_int(checkpoint, seq):
         from pillowtop.models import kafka_seq_to_str
-        if checkpoint.sequence_format == 'json':
+        if _is_kafka(checkpoint):
             return json.loads(kafka_seq_to_str(seq))
         else:
             return force_seq_int(seq)


### PR DESCRIPTION
This should make the metrics stop failing. 

Currently it uses the pillows consumer, meaning that it creates a new connection for every pillow. 

This changes it to pass in a consumer so we're only using one consumer for all metrics.