### PR TITLE
Remove SimpleProducer

### DIFF
--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -20,14 +20,6 @@ def get_simple_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
     )
 
 
-def get_simple_kafka_client_or_none(client_id=GENERIC_KAFKA_CLIENT_ID):
-    try:
-        return get_simple_kafka_client(client_id)
-    except KafkaUnavailableError:
-        logging.warning('Ignoring missing kafka client during unit testing')
-        return None
-
-
 def get_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
     return KafkaClient(
         bootstrap_servers=settings.KAFKA_BROKERS,

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import data_sources
-from corehq.apps.change_feed.connection import get_simple_kafka_client_or_none
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from corehq.apps.domain.models import Domain
@@ -19,9 +18,8 @@ class KafkaProcessor(PillowProcessor):
     Processor that pushes changes to Kafka
     """
 
-    def __init__(self, kafka, data_source_type, data_source_name):
-        self._kafka = kafka
-        self._producer = ChangeProducer(self._kafka)
+    def __init__(self, data_source_type, data_source_name):
+        self._producer = ChangeProducer()
         self._data_source_type = data_source_type
         self._data_source_name = data_source_name
 
@@ -56,9 +54,8 @@ def get_application_db_kafka_pillow(pillow_id, **kwargs):
 
 
 def get_change_feed_pillow_for_db(pillow_id, couch_db):
-    kafka_client = get_simple_kafka_client_or_none()
     processor = KafkaProcessor(
-        kafka_client, data_source_type=data_sources.SOURCE_COUCH, data_source_name=couch_db.dbname
+        data_source_type=data_sources.SOURCE_COUCH, data_source_name=couch_db.dbname
     )
     change_feed = CouchChangeFeed(couch_db)
     checkpoint = PillowCheckpoint(pillow_id, change_feed.sequence_format)

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -31,6 +31,7 @@ class ChangeProducer(object):
         message = change_meta.to_json()
         try:
             self.producer.send(topic, bytes(json.dumps(message)))
+            self.producer.flush()
         except Exception as e:
             _assert = soft_assert(notify_admins=True)
             _assert(False, 'Problem sending change to kafka {}: {} ({})'.format(

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import json
 import time
-from django.conf import settings
 
 from corehq.util.soft_assert import soft_assert
 from kafka import SimpleProducer

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -3,11 +3,12 @@ from __future__ import absolute_import
 import json
 import time
 
-from corehq.util.soft_assert import soft_assert
-from kafka import SimpleProducer
+from django.conf import settings
+from kafka import KafkaProducer
 from kafka.common import LeaderNotAvailableError, FailedPayloadsError, KafkaUnavailableError
-from corehq.apps.change_feed.connection import get_simple_kafka_client
 from six.moves import range
+
+from corehq.util.soft_assert import soft_assert
 
 
 def send_to_kafka(producer, topic, change_meta):
@@ -44,30 +45,32 @@ def send_to_kafka(producer, topic, change_meta):
 class ChangeProducer(object):
 
     def __init__(self):
-        self._kafka = None
         self._producer = None
-        self._has_error = False
-
-    @property
-    def kafka(self):
-        if self._kafka is None:
-            self._kafka = get_simple_kafka_client(client_id='cchq-producer')
-        return self._kafka
 
     @property
     def producer(self):
         if self._producer is not None:
             return self._producer
 
-        self._producer = SimpleProducer(
-            self.kafka, async_send=False, req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
-            sync_fail_on_error=True
+        self._producer = KafkaProducer(
+            bootstrap_servers=settings.KAFKA_BROKERS,
+            api_version=settings.KAFKA_API_VERSION,
+            client_id="cchq-producer",
+            retries=3,
+            acks=1
         )
         return self._producer
 
     def send_change(self, topic, change_meta):
-        if self.producer:
-            send_to_kafka(self.producer, topic, change_meta)
+        message = change_meta.to_json()
+        try:
+            self.producer.send(topic, bytes(json.dumps(message)))
+        except Exception as e:
+            _assert = soft_assert(notify_admins=True)
+            _assert(False, 'Problem sending change to kafka {}: {} ({})'.format(
+                message, e, type(e)
+            ))
+            raise
 
 
 producer = ChangeProducer()

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -44,8 +44,8 @@ def send_to_kafka(producer, topic, change_meta):
 
 class ChangeProducer(object):
 
-    def __init__(self, kafka=None):
-        self._kafka = kafka
+    def __init__(self):
+        self._kafka = None
         self._producer = None
         self._has_error = False
 
@@ -62,7 +62,10 @@ class ChangeProducer(object):
 
     @property
     def producer(self):
-        if self._producer is None and not self._has_error:
+        if self._producer is not None:
+            return self._producer
+
+        if not self._has_error:
             if self.kafka is not None:
                 self._producer = SimpleProducer(
                     self._kafka, async_send=False, req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -1,45 +1,11 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 import json
-import time
 
 from django.conf import settings
 from kafka import KafkaProducer
-from kafka.common import LeaderNotAvailableError, FailedPayloadsError, KafkaUnavailableError
-from six.moves import range
 
 from corehq.util.soft_assert import soft_assert
-
-
-def send_to_kafka(producer, topic, change_meta):
-    def _send_to_kafka():
-        producer.send_messages(
-            bytes(topic),
-            bytes(json.dumps(change_meta.to_json())),
-        )
-
-    try:
-        tries = 3
-        for i in range(tries):
-            # try a few times because the python kafka libraries can trigger timeouts
-            # if they are idle for a while.
-            try:
-                _send_to_kafka()
-                break
-            except (FailedPayloadsError, KafkaUnavailableError, LeaderNotAvailableError):
-                if i == (tries - 1):
-                    # if it's the last try, fail hard
-                    raise
-    except LeaderNotAvailableError:
-        # kafka seems to be down. sleep a bit to avoid crazy amounts of error spam
-        time.sleep(15)
-        raise
-    except Exception as e:
-        _assert = soft_assert(notify_admins=True)
-        _assert(False, 'Problem sending change to kafka {}: {} ({})'.format(
-            change_meta.to_json(), e, type(e)
-        ))
-        raise
 
 
 class ChangeProducer(object):

--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -4,14 +4,11 @@ from copy import deepcopy
 import uuid
 
 from django.test import SimpleTestCase, TestCase
-from kafka import SimpleProducer
 from corehq.apps.change_feed import topics
-from corehq.apps.change_feed.connection import get_simple_kafka_client_or_none
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
 from corehq.apps.change_feed.exceptions import UnavailableKafkaOffset
-from corehq.apps.change_feed.producer import send_to_kafka
+from corehq.apps.change_feed.producer import producer
 from corehq.apps.change_feed.topics import get_multi_topic_first_available_offsets
-from memoized import memoized
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.feed.interface import ChangeMeta
 from pillowtop.pillow.interface import ConstructedPillow
@@ -116,12 +113,7 @@ class KafkaCheckpointTest(TestCase):
         self.assertEqual(feed.get_current_checkpoint_offsets(), current_kafka_offsets)
 
 
-@memoized
-def _get_producer():
-    return SimpleProducer(get_simple_kafka_client_or_none())
-
-
 def publish_stub_change(topic):
     meta = ChangeMeta(document_id=uuid.uuid4().hex, data_source_type='dummy-type', data_source_name='dummy-name')
-    send_to_kafka(_get_producer(), topic, meta)
+    producer.send_change(topic, meta)
     return meta

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -30,13 +30,12 @@ class ChangeFeedPillowTest(SimpleTestCase):
         # tests down the line to fail.
         # Specifically KafkaChangeFeedTest.test_multiple_topics_with_partial_checkpoint
         self._fake_couch.dbname = 'test_commcarehq'
-        with trap_extra_setup(KafkaUnavailableError):
-            self.consumer = KafkaConsumer(
-                topics.CASE,
-                bootstrap_servers=settings.KAFKA_BROKERS,
-                consumer_timeout_ms=100,
-                enable_auto_commit=False,
-            )
+        self.consumer = KafkaConsumer(
+            topics.CASE,
+            bootstrap_servers=settings.KAFKA_BROKERS,
+            consumer_timeout_ms=100,
+            enable_auto_commit=False,
+        )
         try:
             # This initialized the consumer listening from the latest offset
             next(self.consumer)

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -85,12 +85,6 @@ def get_topic_offset(topic):
     return get_multi_topic_offset([topic])
 
 
-def get_all_offsets():
-    """
-    :returns: A dict of offsets keyed by topic and parition"""
-    return get_multi_topic_offset(ALL)
-
-
 def get_multi_topic_offset(topics):
     """
     :returns: A dict of offsets keyed by topic and partition"""

--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -22,7 +22,7 @@ from soil import heartbeat
 from corehq.apps.hqadmin.escheck import check_es_cluster_health
 from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.apps.app_manager.models import Application
-from corehq.apps.change_feed.connection import get_simple_kafka_client_or_none
+from corehq.apps.change_feed.connection import get_kafka_client
 from corehq.apps.es import GroupES
 from corehq.blobs import CODES, get_blob_db
 from corehq.elastic import send_to_elasticsearch, refresh_elasticsearch_index
@@ -73,12 +73,14 @@ def check_rabbitmq():
 
 @change_log_level('kafka.client', logging.WARNING)
 def check_kafka():
-    client = get_simple_kafka_client_or_none()
-    if not client:
-        return ServiceStatus(False, "Could not connect to Kafka")
-    elif len(client.brokers) == 0:
+    try:
+        client = get_kafka_client()
+    except Exception as e:
+        return ServiceStatus(False, "Could not connect to Kafka: %s" % e)
+
+    if len(client.cluster.brokers()) == 0:
         return ServiceStatus(False, "No Kafka brokers found")
-    elif len(client.topics) == 0:
+    elif len(client.cluster.topics()) == 0:
         return ServiceStatus(False, "No Kafka topics found")
     else:
         return ServiceStatus(True, "Kafka seems to be in order")

--- a/corehq/apps/userreports/tests/test_location_data_source.py
+++ b/corehq/apps/userreports/tests/test_location_data_source.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import uuid
 from django.test import TestCase
-from kafka.common import KafkaUnavailableError
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import SQLLocation, LocationType
@@ -46,8 +45,7 @@ class TestLocationDataSource(TestCase):
 
         self.pillow = get_kafka_ucr_pillow()
         self.pillow.bootstrap(configs=[self.data_source_config])
-        with trap_extra_setup(KafkaUnavailableError):
-            self.pillow.get_change_feed().get_latest_offsets()
+        self.pillow.get_change_feed().get_latest_offsets()
 
     def tearDown(self):
         self.domain_obj.delete()

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import decimal
 import uuid
 from django.test import TestCase, SimpleTestCase, override_settings
-from kafka.common import KafkaUnavailableError
 from mock import patch, MagicMock
 from datetime import datetime, timedelta
 from six.moves import range
@@ -27,7 +26,7 @@ from corehq.apps.userreports.tests.utils import get_sample_data_source, get_samp
     doc_to_change, get_data_source_with_related_doc_type
 from corehq.apps.userreports.util import get_indicator_adapter, get_table_name
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.util.test_utils import softer_assert, trap_extra_setup
+from corehq.util.test_utils import softer_assert
 from corehq.util.context_managers import drop_connected_signals
 from pillow_retry.models import PillowError
 
@@ -247,8 +246,7 @@ class ProcessRelatedDocTypePillowTest(TestCase):
         self.adapter = get_indicator_adapter(self.config)
 
         self.pillow.bootstrap(configs=[self.config])
-        with trap_extra_setup(KafkaUnavailableError):
-            self.pillow.get_change_feed().get_latest_offsets()
+        self.pillow.get_change_feed().get_latest_offsets()
 
     def tearDown(self):
         self.config.delete()
@@ -317,8 +315,7 @@ class ReuseEvaluationContextTest(TestCase):
         self.pillow2 = get_kafka_ucr_pillow(topics=['case-sql'])
         self.pillow1.bootstrap(configs=[config1])
         self.pillow2.bootstrap(configs=self.configs)
-        with trap_extra_setup(KafkaUnavailableError):
-            self.pillow1.get_change_feed().get_latest_offsets()
+        self.pillow1.get_change_feed().get_latest_offsets()
 
     def tearDown(self):
         for adapter in self.adapters:
@@ -383,8 +380,7 @@ class AsyncIndicatorTest(TestCase):
         cls.adapter = get_indicator_adapter(cls.config)
 
         cls.pillow.bootstrap(configs=[cls.config])
-        with trap_extra_setup(KafkaUnavailableError):
-            cls.pillow.get_change_feed().get_latest_offsets()
+        cls.pillow.get_change_feed().get_latest_offsets()
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/ex-submodules/pillow_retry/tests/test_retry.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_retry.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.test import TestCase
 from fakecouch import FakeCouchDb
 from kafka import KafkaConsumer
-from kafka.common import KafkaUnavailableError
 from mock import MagicMock, patch
 
 from corehq.apps.change_feed import topics
@@ -49,14 +48,13 @@ class CouchPillowRetryProcessingTest(TestCase, TestMixin):
         super(CouchPillowRetryProcessingTest, self).setUp()
         self._fake_couch = FakeCouchDb()
         self._fake_couch.dbname = 'test_commcarehq'
-        with trap_extra_setup(KafkaUnavailableError):
-            self.consumer = KafkaConsumer(
-                topics.CASE,
-                client_id='test-consumer',
-                bootstrap_servers=settings.KAFKA_BROKERS,
-                consumer_timeout_ms=100,
-                enable_auto_commit=False,
-            )
+        self.consumer = KafkaConsumer(
+            topics.CASE,
+            client_id='test-consumer',
+            bootstrap_servers=settings.KAFKA_BROKERS,
+            consumer_timeout_ms=100,
+            enable_auto_commit=False,
+        )
         try:
             next(self.consumer)
         except StopIteration:


### PR DESCRIPTION
This uses `KafkaProducer` which will also handle retries for us. There are some cleanup commits in here too. 