### PR TITLE
change kafka logging

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1267,6 +1267,11 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        'kafka': {
+            'handlers': ['file'],
+            'level': 'ERROR',
+            'propogate': False,
+        },
     }
 }
 


### PR DESCRIPTION
this changes the location of the logging from the library from the default of stdout/wherever else to a file.

in particular it should stop these errors from being sent to sentry. https://sentry.io/dimagi/commcarehq/issues/681603859/events/30178183614/

@emord