### PR TITLE
fix handling HTTPError in index_design_docs

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/sync_docs.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/sync_docs.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import logging
 from collections import namedtuple
+
+import six
 from requests.exceptions import HTTPError
 
 from django.conf import settings
@@ -43,7 +45,7 @@ def index_design_docs(db, docid, design_name, wait=True):
                 else:
                     list(db.view(view, limit=0, stale=settings.COUCH_STALE_QUERY))
             except HTTPError as e:
-                if 'timeout' not in e.message and e.status_int != 504:
+                if 'timeout' not in six.text_type(e) and e.response.status_code != 504:
                     raise
             else:
                 break


### PR DESCRIPTION
This PR does two things:

(1) Fixes this [sentry error](https://sentry.io/dimagi/commcarehq/issues/685903524/) due to differences in the interface of ```RequestFailed``` and ```HTTPError```.

(2) Replaces the deprecated ```e.message``` with ```six.text_type(e)```.