### PR TITLE
Put update location over sms behind feature flag

### DIFF
--- a/corehq/apps/sms/tests/update_location_keyword_test.py
+++ b/corehq/apps/sms/tests/update_location_keyword_test.py
@@ -10,6 +10,7 @@ from corehq.apps.sms.messages import get_message
 from corehq.apps.sms.models import SMS
 from corehq.apps.sms.tests.util import setup_default_sms_test_backend, delete_domain_phone_numbers
 from corehq.apps.users.models import CommCareUser
+from corehq.util.test_utils import flag_enabled
 import corehq.apps.sms.messages as messages
 
 
@@ -23,6 +24,7 @@ def create_mobile_worker(domain, username, password, phone_number, save_vn=True)
     return user
 
 
+@flag_enabled('ALLOW_LOCATION_UPDATE_OVER_SMS')
 class UpdateLocationKeywordTest(TestCase, DomainSubscriptionMixin):
 
     def _get_last_outbound_message(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1237,6 +1237,13 @@ EMG_AND_REC_SMS_HANDLERS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+ALLOW_LOCATION_UPDATE_OVER_SMS = StaticToggle(
+    'allow_location_update_over_sms',
+    'Allow users to update their location over SMS.',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN]
+)
+
 ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
     'allow_user_defined_export_columns',
     'Add user defined columns to exports',


### PR DESCRIPTION
Now that HQ restricts data based on location, we shouldn't be allowing people to update their location via SMS to any location they want. I checked and this feature has actually never even been used (no one has invoked the "#UPDATE" keyword ever via SMS). So we can probably even just remove this update location via sms functionality altogether, unless product wants to keep it and find a way to make it more location-safe. In the meantime, I'm putting it behind a feature flag so it can't be used by everyone. I think this was built for ILS but as I said no one has ever used it.

@millerdev @gbova 