### PR TITLE
Stop looking up language code for users based on location

### DIFF
--- a/custom/icds/messaging/custom_content.py
+++ b/custom/icds/messaging/custom_content.py
@@ -153,7 +153,7 @@ def get_language_code_for_user(user):
 
 
 def render_content_for_user(user, template, context):
-    language_code = get_language_code_for_user(user)
+    language_code = user.memoized_usercase.get_language_code() or DEFAULT_LANGUAGE
     return render_message(language_code, template, context)
 
 
@@ -254,7 +254,6 @@ def validate_user_location_and_indicator(user, indicator_class):
 
 def run_indicator_for_user(user, indicator_class, language_code=None):
     validate_user_location_and_indicator(user, indicator_class)
-    language_code = language_code or get_language_code_for_user(user)
     indicator = indicator_class(user.domain, user)
     return indicator.get_messages(language_code=language_code)
 
@@ -265,7 +264,7 @@ def run_indicator_for_usercase(usercase, indicator_class):
 
     user = get_user_from_usercase(usercase)
     if user and user.location:
-        return run_indicator_for_user(user, indicator_class)
+        return run_indicator_for_user(user, indicator_class, language_code=usercase.get_language_code())
 
     return []
 

--- a/custom/icds/messaging/custom_content.py
+++ b/custom/icds/messaging/custom_content.py
@@ -152,7 +152,7 @@ def get_language_code_for_user(user):
     return get_language_code_for_state(state_code)
 
 
-def render_content_for_user(user, template, context):    
+def render_content_for_user(user, template, context):
     if user.memoized_usercase:
         language_code = user.memoized_usercase.get_language_code() or DEFAULT_LANGUAGE
     else:

--- a/custom/icds/messaging/custom_content.py
+++ b/custom/icds/messaging/custom_content.py
@@ -152,8 +152,12 @@ def get_language_code_for_user(user):
     return get_language_code_for_state(state_code)
 
 
-def render_content_for_user(user, template, context):
-    language_code = user.memoized_usercase.get_language_code() or DEFAULT_LANGUAGE
+def render_content_for_user(user, template, context):    
+    if user.memoized_usercase:
+        language_code = user.memoized_usercase.get_language_code() or DEFAULT_LANGUAGE
+    else:
+        language_code = DEFAULT_LANGUAGE
+
     return render_message(language_code, template, context)
 
 

--- a/custom/icds/tests/test_custom_content.py
+++ b/custom/icds/tests/test_custom_content.py
@@ -82,6 +82,10 @@ class CustomContentTest(BaseICDSTest):
         cls.user2 = CommCareUser.create(cls.domain, 'mobile-2', 'abc', location=cls.awc2)
         cls.user3 = CommCareUser.create(cls.domain, 'mobile-3', 'abc', location=cls.ls1)
 
+        cls.create_user_case(cls.user1)
+        cls.create_user_case(cls.user2)
+        cls.create_user_case(cls.user3)
+
         cls.create_basic_related_cases(cls.awc1.location_id)
         cls.red_child_health_case = cls.create_case(
             'child_health',
@@ -94,6 +98,14 @@ class CustomContentTest(BaseICDSTest):
 
         cls.migrated_case = cls.create_case('person', update={'migration_status': 'migrated'})
         cls.opted_out_case = cls.create_case('person', update={'registered_status': 'not_registered'})
+
+    @classmethod
+    def create_user_case(cls, user):
+        return cls.create_case(
+            'commcare-user',
+            owner_id=user.get_id,
+            update={'hq_user_id': user.get_id, 'external_id': user.get_id, 'language_code': ENGLISH},
+        )
 
     def test_run_indicator_for_usercase(self):
         with create_user_case(self.user1) as case:
@@ -173,8 +185,7 @@ class CustomContentTest(BaseICDSTest):
             []
         )
 
-    @patch('custom.icds.messaging.custom_content.get_language_code_for_state')
-    def test_missed_cf_visit_to_aww(self, language_code_patch):
+    def test_missed_cf_visit_to_aww(self):
         c = CustomContent(custom_content_id='ICDS_MISSED_CF_VISIT_TO_AWW')
 
         schedule_instance = CaseTimedScheduleInstance(
@@ -184,14 +195,12 @@ class CustomContentTest(BaseICDSTest):
 
         c.set_context(schedule_instance=schedule_instance)
 
-        language_code_patch.return_value = ENGLISH
         self.assertEqual(
             c.get_list_of_messages(self.user1),
             ["AWC awc1 has not reported a visit during complementary feeding initiation period for Sam"],
         )
 
-    @patch('custom.icds.messaging.custom_content.get_language_code_for_state')
-    def test_missed_cf_visit_to_ls(self, language_code_patch):
+    def test_missed_cf_visit_to_ls(self):
         c = CustomContent(custom_content_id='ICDS_MISSED_CF_VISIT_TO_LS')
 
         schedule_instance = CaseTimedScheduleInstance(
@@ -201,14 +210,12 @@ class CustomContentTest(BaseICDSTest):
 
         c.set_context(schedule_instance=schedule_instance)
 
-        language_code_patch.return_value = ENGLISH
         self.assertEqual(
             c.get_list_of_messages(self.user3),
             ["AWC awc1 has not reported a visit during complementary feeding initiation period for Sam"],
         )
 
-    @patch('custom.icds.messaging.custom_content.get_language_code_for_state')
-    def test_missed_pnc_visit_to_ls(self, language_code_patch):
+    def test_missed_pnc_visit_to_ls(self):
         c = CustomContent(custom_content_id='ICDS_MISSED_PNC_VISIT_TO_LS')
 
         schedule_instance = CaseTimedScheduleInstance(
@@ -218,14 +225,12 @@ class CustomContentTest(BaseICDSTest):
 
         c.set_context(schedule_instance=schedule_instance)
 
-        language_code_patch.return_value = ENGLISH
         self.assertEqual(
             c.get_list_of_messages(self.user3),
             ["AWC awc1 has not reported a visit during the PNC within one week of delivery for Sam"],
         )
 
-    @patch('custom.icds.messaging.custom_content.get_language_code_for_state')
-    def test_child_illness_reported(self, language_code_patch):
+    def test_child_illness_reported(self):
         c = CustomContent(custom_content_id='ICDS_CHILD_ILLNESS_REPORTED')
 
         schedule_instance = CaseTimedScheduleInstance(
@@ -235,15 +240,13 @@ class CustomContentTest(BaseICDSTest):
 
         c.set_context(schedule_instance=schedule_instance)
 
-        language_code_patch.return_value = ENGLISH
         self.assertEqual(
             c.get_list_of_messages(self.user3),
             ["AWC awc1 has reported illness for the child Joe. Please ensure that AWW follows up with mother "
              "immediately"],
         )
 
-    @patch('custom.icds.messaging.custom_content.get_language_code_for_state')
-    def test_cf_visits_complete(self, language_code_patch):
+    def test_cf_visits_complete(self):
         c = CustomContent(custom_content_id='ICDS_CF_VISITS_COMPLETE')
 
         schedule_instance = CaseTimedScheduleInstance(
@@ -253,7 +256,6 @@ class CustomContentTest(BaseICDSTest):
 
         c.set_context(schedule_instance=schedule_instance)
 
-        language_code_patch.return_value = ENGLISH
         self.assertEqual(
             c.get_list_of_messages(self.user1),
             ["Congratulations! You've done all the Complementary Feeding  Visits for Sam"],


### PR DESCRIPTION
With this, language_code on the user case will be the only way to determine a user's language preference in all ICDS SMS alerts sent to users.

language_code is already the only way that we determine a beneficiary's language preference.

@millerdev @gbova 