### PR TITLE
Add required questions to downgrading subscription modal

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -58,17 +58,15 @@ hqDefine('accounting/js/confirm_plan', [
             return self.newToolReason() === OTHER;
         });
         self.requiredQuestionsAnswered = ko.computed(function () {
-            if (self.downgradeReason() == null) {
+            if (!self.downgradeReason()) {
                 return false;
             }
-            var newToolNeeded =
-                self.downgradeReason() === SWITCH_TOOLS;
+            var newToolNeeded = self.downgradeReason() === SWITCH_TOOLS;
             var newToolAnswered = self.newTool() !== "";
-            var newToolReasonAnswered = (self.newToolReason() !== "" && self.newToolReason() !== OTHER) ||
-                (self.newToolReason() === OTHER && self.otherNewToolReason() !== "");
+            var newToolReasonAnswered = (self.newToolReason() && self.newToolReason() !== OTHER) ||
+                (self.otherNewToolReason() && self.newToolReason() === OTHER);
 
-            return (self.downgradeReason() !== "" && !newToolNeeded) ||
-                (newToolNeeded && newToolAnswered && newToolReasonAnswered);
+            return (self.downgradeReason() && !newToolNeeded) || (newToolNeeded && newToolAnswered && newToolReasonAnswered);
         });
 
         self.form = undefined;

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -17,8 +17,34 @@ hqDefine('accounting/js/confirm_plan', [
         self.currentPlan = currentPlan;
         self.newPlan = newPlan;
 
-        // If the user is upgrading, don't let them continue until they have agreed to the therms
+        // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
         self.userAgreementSigned = ko.observable(!isUpgrade);
+
+
+
+        self.downgradeReasonList = ko.observableArray([
+            "My project ended",
+            "The funding for my project ended",
+            "I don’t need the features of my paid plan anymore but I plan on continuing using CommCare",
+            "We are switching to a different mobile data collection tool",
+        ]);
+        self.newToolReasonList = ko.observableArray([
+            "For budget reason",
+            "I need more limited features",
+            "I need additional/custom features",
+            "Other",
+        ]);
+        self.downgradeReason = ko.observable("");
+        self.newToolReason = ko.observable("");
+        self.projectEnded = ko.computed(function () {
+            return self.downgradeReason() === "My project ended";
+        });
+        self.newToolNeeded = ko.computed(function () {
+            return self.downgradeReason() === "We are switching to a different mobile data collection tool";
+        });
+        self.otherSelected = ko.computed(function () {
+            return self.newToolReason() === "Other";
+        });
 
         self.form = undefined;
         self.openDowngradeModal = function (confirmPlanModel, e) {

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -20,8 +20,6 @@ hqDefine('accounting/js/confirm_plan', [
         // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
         self.userAgreementSigned = ko.observable(!isUpgrade);
 
-
-
         self.downgradeReasonList = ko.observableArray([
             "My project ended",
             "The funding for my project ended",
@@ -34,8 +32,13 @@ hqDefine('accounting/js/confirm_plan', [
             "I need additional/custom features",
             "Other",
         ]);
+
         self.downgradeReason = ko.observable("");
+        self.newTool = ko.observable("");
         self.newToolReason = ko.observable("");
+        self.otherNewToolReason = ko.observable("");
+        self.requiredQuestionsAnswered = ko.observable(false);
+
         self.projectEnded = ko.computed(function () {
             return self.downgradeReason() === "My project ended";
         });
@@ -44,6 +47,19 @@ hqDefine('accounting/js/confirm_plan', [
         });
         self.otherSelected = ko.computed(function () {
             return self.newToolReason() === "Other";
+        });
+        self.requiredQuestionsAnswered = ko.computed(function () {
+            if (self.downgradeReason() == null) {
+                return false;
+            }
+            var newToolNeeded =
+                self.downgradeReason() === "We are switching to a different mobile data collection tool";
+            var newToolAnswered = self.newTool() !== "";
+            var newToolReasonAnswered = (self.newToolReason() !== "" && self.newToolReason() !== "Other") ||
+                (self.newToolReason() === "Other" && self.otherNewToolReason() !== "");
+
+            return (self.downgradeReason() !== "" && !newToolNeeded) ||
+                (newToolNeeded && newToolAnswered && newToolReasonAnswered);
         });
 
         self.form = undefined;

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -9,14 +9,14 @@ hqDefine('accounting/js/confirm_plan', [
     _,
     initialPageData
 ) {
-    var PROJECT_ENDED = "My project ended";
-    var FUNDING_ENDED = "The funding for my project ended";
-    var CONTINUE_COMMCARE = "I don’t need the features of my paid plan anymore but I plan on continuing using CommCare";
-    var SWITCH_TOOLS = "We are switching to a different mobile data collection tool";
-    var BUDGET_REASONS = "For budget reasons";
-    var LIMITED_FEATURES = "I need more limited features";
-    var MORE_FEATURES = "I need additional/custom features";
-    var OTHER = "Other";
+    var PROJECT_ENDED = gettext("My project ended");
+    var FUNDING_ENDED = gettext("The funding for my project ended");
+    var CONTINUE_COMMCARE = gettext("I don’t need the features of my paid plan anymore but I plan on continuing using CommCare");
+    var SWITCH_TOOLS = gettext("We are switching to a different mobile data collection tool");
+    var BUDGET_REASONS = gettext("For budget reasons");
+    var LIMITED_FEATURES = gettext("I need more limited features");
+    var MORE_FEATURES = gettext("I need additional/custom features");
+    var OTHER = gettext("Other");
 
     var confirmPlanModel = function (isUpgrade, currentPlan, newPlan) {
         'use strict';

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -9,6 +9,15 @@ hqDefine('accounting/js/confirm_plan', [
     _,
     initialPageData
 ) {
+    var PROJECT_ENDED = "My project ended";
+    var FUNDING_ENDED = "The funding for my project ended";
+    var CONTINUE_COMMCARE = "I don’t need the features of my paid plan anymore but I plan on continuing using CommCare";
+    var SWITCH_TOOLS = "We are switching to a different mobile data collection tool";
+    var BUDGET_REASONS = "For budget reasons";
+    var LIMITED_FEATURES = "I need more limited features";
+    var MORE_FEATURES = "I need additional/custom features";
+    var OTHER = "Other";
+
     var confirmPlanModel = function (isUpgrade, currentPlan, newPlan) {
         'use strict';
         var self = {};
@@ -21,16 +30,16 @@ hqDefine('accounting/js/confirm_plan', [
         self.userAgreementSigned = ko.observable(!isUpgrade);
 
         self.downgradeReasonList = ko.observableArray([
-            "My project ended",
-            "The funding for my project ended",
-            "I don’t need the features of my paid plan anymore but I plan on continuing using CommCare",
-            "We are switching to a different mobile data collection tool",
+            PROJECT_ENDED,
+            FUNDING_ENDED,
+            CONTINUE_COMMCARE,
+            SWITCH_TOOLS,
         ]);
         self.newToolReasonList = ko.observableArray([
-            "For budget reason",
-            "I need more limited features",
-            "I need additional/custom features",
-            "Other",
+            BUDGET_REASONS,
+            LIMITED_FEATURES,
+            MORE_FEATURES,
+            OTHER,
         ]);
 
         self.downgradeReason = ko.observable("");
@@ -40,23 +49,23 @@ hqDefine('accounting/js/confirm_plan', [
         self.requiredQuestionsAnswered = ko.observable(false);
 
         self.projectEnded = ko.computed(function () {
-            return self.downgradeReason() === "My project ended";
+            return self.downgradeReason() === PROJECT_ENDED;
         });
         self.newToolNeeded = ko.computed(function () {
-            return self.downgradeReason() === "We are switching to a different mobile data collection tool";
+            return self.downgradeReason() === SWITCH_TOOLS;
         });
         self.otherSelected = ko.computed(function () {
-            return self.newToolReason() === "Other";
+            return self.newToolReason() === OTHER;
         });
         self.requiredQuestionsAnswered = ko.computed(function () {
             if (self.downgradeReason() == null) {
                 return false;
             }
             var newToolNeeded =
-                self.downgradeReason() === "We are switching to a different mobile data collection tool";
+                self.downgradeReason() === SWITCH_TOOLS;
             var newToolAnswered = self.newTool() !== "";
-            var newToolReasonAnswered = (self.newToolReason() !== "" && self.newToolReason() !== "Other") ||
-                (self.newToolReason() === "Other" && self.otherNewToolReason() !== "");
+            var newToolReasonAnswered = (self.newToolReason() !== "" && self.newToolReason() !== OTHER) ||
+                (self.newToolReason() === OTHER && self.otherNewToolReason() !== "");
 
             return (self.downgradeReason() !== "" && !newToolNeeded) ||
                 (newToolNeeded && newToolAnswered && newToolReasonAnswered);

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -57,25 +57,30 @@ hqDefine('accounting/js/confirm_plan', [
             }
         };
         self.submitDowngrade = function (pricingTable, e) {
-            var finish = function () {
-                if (self.form) {
-                    self.form.submit();
-                }
-            };
-
             var $button = $(e.currentTarget);
             $button.disableButton();
-            $.ajax({
-                method: "POST",
-                url: initialPageData.reverse('email_on_downgrade'),
-                data: {
-                    old_plan: self.currentPlan.name,
-                    new_plan: self.newPlan.name,
-                    note: $button.closest(".modal").find("textarea").val(),
-                },
-                success: finish,
-                error: finish,
-            });
+            if (self.form) {
+                var downgradeReason = "";
+                var selectedDowngradeOptions = document.getElementById("select-downgrade-reason").selectedOptions;
+                for (var i = 0; i < selectedDowngradeOptions.length; i++) {
+                    downgradeReason += selectedDowngradeOptions[i].value + ", ";
+                }
+                document.getElementById("downgrade-reason").value = downgradeReason;
+
+                var newToolReason = "";
+                var selectedNewToolOptions = document.getElementById("select-tool-reason").selectedOptions;
+                for (i = 0; i < selectedNewToolOptions.length; i++) {
+                    newToolReason += selectedNewToolOptions[i].value + "\n";
+                }
+                newToolReason += document.getElementById("text-tool-reason").value;
+                document.getElementById("new-tool-reason").value = newToolReason;
+
+                document.getElementById("will-project-restart").value = document.getElementById("select-project-restart").value;
+                document.getElementById("new-tool").value = document.getElementById("text-new-tool").value;
+                document.getElementById("feedback").value = document.getElementById("text-feedback").value;
+
+                self.form.submit();
+            }
         };
 
         return self;

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -29,18 +29,18 @@ hqDefine('accounting/js/confirm_plan', [
         // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
         self.userAgreementSigned = ko.observable(!isUpgrade);
 
-        self.downgradeReasonList = ko.observableArray([
+        self.downgradeReasonList = [
             PROJECT_ENDED,
             FUNDING_ENDED,
             CONTINUE_COMMCARE,
             SWITCH_TOOLS,
-        ]);
-        self.newToolReasonList = ko.observableArray([
+        ];
+        self.newToolReasonList = [
             BUDGET_REASONS,
             LIMITED_FEATURES,
             MORE_FEATURES,
             OTHER,
-        ]);
+        ];
 
         self.downgradeReason = ko.observable("");
         self.newTool = ko.observable("");

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -85,21 +85,13 @@ hqDefine('accounting/js/confirm_plan', [
             var $button = $(e.currentTarget);
             $button.disableButton();
             if (self.form) {
-                var downgradeReason = "";
-                var selectedDowngradeOptions = document.getElementById("select-downgrade-reason").selectedOptions;
-                for (var i = 0; i < selectedDowngradeOptions.length; i++) {
-                    downgradeReason += selectedDowngradeOptions[i].value + ", ";
+                if (self.otherSelected()) {
+                    document.getElementById("new-tool-reason").value = document.getElementById("text-tool-reason").value;
+                } else {
+                    document.getElementById("new-tool-reason").value = $("#select-tool-reason").val().join(", ");
                 }
-                document.getElementById("downgrade-reason").value = downgradeReason;
 
-                var newToolReason = "";
-                var selectedNewToolOptions = document.getElementById("select-tool-reason").selectedOptions;
-                for (i = 0; i < selectedNewToolOptions.length; i++) {
-                    newToolReason += selectedNewToolOptions[i].value + "\n";
-                }
-                newToolReason += document.getElementById("text-tool-reason").value;
-                document.getElementById("new-tool-reason").value = newToolReason;
-
+                document.getElementById("downgrade-reason").value = $("#select-downgrade-reason").val().join(", ");
                 document.getElementById("will-project-restart").value = document.getElementById("select-project-restart").value;
                 document.getElementById("new-tool").value = document.getElementById("text-new-tool").value;
                 document.getElementById("feedback").value = document.getElementById("text-feedback").value;

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1637,9 +1637,13 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                                     css_class="btn btn-default"),
                 StrictButton(_("Subscribe to Plan"),
                              type="submit",
+                             id='btn-subscribe-to-plan',
                              css_class='btn btn-success disable-on-submit-no-spinner '
                                        'add-spinner-on-click'),
             ),
+            crispy.Hidden(name="downgrade_email_note", value="", id="downgrade-email-note"),
+            crispy.Hidden(name="old_plan", value=current_subscription.plan_version.plan.edition),
+            crispy.Hidden(name="new_plan", value=plan_version.plan.edition)
         )
 
     def save(self, commit=True):

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -12,7 +12,7 @@ hqDefine("domain/js/confirm_billing_info", function () {
         $navigateForm.submit();
     });
 
-    document.getElementById('btn-subscribe-to-plan').onclick = function (e) {
+    document.getElementById('btn-subscribe-to-plan').onclick = function () {
         document.getElementById('downgrade-email-note').value = initialPageData.get("downgrade_email_note");
     };
 

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -12,6 +12,10 @@ hqDefine("domain/js/confirm_billing_info", function () {
         $navigateForm.submit();
     });
 
+    document.getElementById('btn-subscribe-to-plan').onclick = function (e) {
+        document.getElementById('downgrade-email-note').value = initialPageData.get("downgrade_email_note");
+    };
+
     Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
     var cardManager = new stripeCardManager.stripeCardManager({
         cards: initialPageData.get("cards"),

--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -14,6 +14,7 @@
     {% initial_page_data "plan" plan %}
     {% initial_page_data "cards" cards %}
     {% initial_page_data "stripe_public_key" stripe_public_key %}
+    {% initial_page_data "downgrade_email_note" downgrade_email_note %}
     {% registerurl "cards_view" domain %}
     <p class="lead">
         {% blocktrans with plan.name as p%}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -151,7 +151,7 @@
                     {% blocktrans %}
                         Could you indicate which new tool you’re using?
                     {% endblocktrans %}
-                    <textarea class="form-control" id="text-new-tool"></textarea>
+                    <textarea class="form-control" id="text-new-tool" data-bind="textInput: newTool"></textarea>
                     <br><br>
                     {% blocktrans %}
                         Why are you switching to a new tool?
@@ -163,7 +163,7 @@
                         {% blocktrans %}
                             Please specify
                         {% endblocktrans %}
-                        <textarea class="form-control" id="text-tool-reason"></textarea>
+                        <textarea class="form-control" id="text-tool-reason" data-bind="textInput: otherNewToolReason"></textarea>
                         <br><br>
                     </div>
                 </div>
@@ -174,7 +174,7 @@
                 <textarea class="form-control" id="text-feedback"></textarea>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade">{% trans "Continue" %}</button>
+                <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade, enable: requiredQuestionsAnswered">{% trans "Continue" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -88,6 +88,11 @@
     <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
         {% csrf_token %}
         <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
+        <input type="hidden" value="" name="downgrade_reason" id="downgrade-reason"/>
+        <input type="hidden" value="" name="will_project_restart" id="will-project-restart"/>
+        <input type="hidden" value="" name="new_tool" id="new-tool"/>
+        <input type="hidden" value="" name="new_tool_reason" id="new-tool-reason"/>
+        <input type="hidden" value="" name="feedback" id="feedback"/>
         <hr />
         <p>
             {% blocktrans %}
@@ -128,16 +133,16 @@
                 {% blocktrans %}
                     Why are you downgrading your subscription today?
                 {% endblocktrans %}
-                <select multiple="multiple" class="form-control" id="select_downgrade_reason" data-bind="value: downgradeReason, options: downgradeReasonList"></select>
+                <select multiple="multiple" class="form-control" id="select-downgrade-reason" data-bind="value: downgradeReason, options: downgradeReasonList"></select>
                 <br><br>
 
                 <div data-bind="visible: projectEnded">
                     {% blocktrans %}
                         Is there a chance your project may start again?
                     {% endblocktrans %}
-                    <select class="form-control" id="project-restart">
-                        <option value='true'>{% trans "Yes" %}</option>
-                        <option value='false'>{% trans "No" %}</option>
+                    <select class="form-control" id="select-project-restart">
+                        <option value='yes'>{% trans "Yes" %}</option>
+                        <option value='no' selected="selected">{% trans "No" %}</option>
                     </select>
                     <br><br>
                 </div>
@@ -151,22 +156,22 @@
                     {% blocktrans %}
                         Why are you switching to a new tool?
                     {% endblocktrans %}
-                    <select multiple="multiple" class="form-control" data-bind="options: newToolReasonList, value: newToolReason"></select>
+                    <select multiple="multiple" class="form-control" id="select-tool-reason" data-bind="options: newToolReasonList, value: newToolReason"></select>
                     <br><br>
-                </div>
 
-                <div data-bind="visible: otherSelected">
-                    {% blocktrans %}
-                        Please specify
-                    {% endblocktrans %}
-                    <textarea class="form-control"></textarea>
-                    <br><br>
+                    <div data-bind="visible: otherSelected">
+                        {% blocktrans %}
+                            Please specify
+                        {% endblocktrans %}
+                        <textarea class="form-control" id="text-tool-reason"></textarea>
+                        <br><br>
+                    </div>
                 </div>
 
                 {% blocktrans %}
                     Please let us know any other feedback you have
                 {% endblocktrans %}
-                <textarea class="form-control"></textarea>
+                <textarea class="form-control" id="text-feedback"></textarea>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade">{% trans "Continue" %}</button>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -120,14 +120,56 @@
             </div>
             <div class="modal-body">
                 {% blocktrans %}
-                    We'd love to make CommCare work better for you.
-                    Let us know what we can do to improve, or why you're downgrading.
+                    We’d love to make CommCare work better for you.
+                    Please help us, by answering these simple questions.
                 {% endblocktrans %}
+
                 <br><br>
+                {% blocktrans %}
+                    Why are you downgrading your subscription today?
+                {% endblocktrans %}
+                <select multiple="multiple" class="form-control" id="select_downgrade_reason" data-bind="value: downgradeReason, options: downgradeReasonList"></select>
+                <br><br>
+
+                <div data-bind="visible: projectEnded">
+                    {% blocktrans %}
+                        Is there a chance your project may start again?
+                    {% endblocktrans %}
+                    <select class="form-control" id="project-restart">
+                        <option value='true'>{% trans "Yes" %}</option>
+                        <option value='false'>{% trans "No" %}</option>
+                    </select>
+                    <br><br>
+                </div>
+
+                <div data-bind="visible: newToolNeeded">
+                    {% blocktrans %}
+                        Could you indicate which new tool you’re using?
+                    {% endblocktrans %}
+                    <textarea class="form-control" id="text-new-tool"></textarea>
+                    <br><br>
+                    {% blocktrans %}
+                        Why are you switching to a new tool?
+                    {% endblocktrans %}
+                    <select multiple="multiple" class="form-control" data-bind="options: newToolReasonList, value: newToolReason"></select>
+                    <br><br>
+                </div>
+
+                <div data-bind="visible: otherSelected">
+                    {% blocktrans %}
+                        Please specify
+                    {% endblocktrans %}
+                    <textarea class="form-control"></textarea>
+                    <br><br>
+                </div>
+
+                {% blocktrans %}
+                    Please let us know any other feedback you have
+                {% endblocktrans %}
                 <textarea class="form-control"></textarea>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade">{% trans "OK" %}</button>
+                <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade">{% trans "Continue" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1738,7 +1738,8 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     ) % (software_plan_name, downgrade_date)
                 )
             else:
-                self.send_downgrade_email()
+                if not request.user.is_superuser:
+                    self.send_downgrade_email()
                 if self.current_subscription.next_subscription is not None:
                     # New subscription has been scheduled for the future
                     current_subscription = self.current_subscription.plan_version.plan.edition

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1686,6 +1686,24 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
         return 'company_name' in self.request.POST
 
     @property
+    def downgrade_email_note(self):
+        if self.is_upgrade:
+            return None
+
+        downgrade_reason = self.request.POST.get('downgrade_reason')
+        will_project_restart = self.request.POST.get('will_project_restart')
+        new_tool = self.request.POST.get('new_tool')
+        new_tool_reason = self.request.POST.get('new_tool_reason')
+        feedback = self.request.POST.get('feedback')
+        if not downgrade_reason:
+            return None
+        return 'Why are you downgrading your subscription today?:\n' + downgrade_reason + '\n\n' +\
+               'Is there a chance your project may start again?:\n' + will_project_restart + '\n\n' +\
+               'Could you indicate which new tool you are using?\n' + new_tool + '\n\n' +\
+               'Why are you switching to a new tool?\n' + new_tool_reason + '\n\n' +\
+               'Additional feedback:\n' + feedback
+
+    @property
     @memoized
     def billing_account_info_form(self):
         if self.request.method == 'POST' and self.is_form_post:
@@ -1701,7 +1719,8 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
         return {
             'billing_account_info_form': self.billing_account_info_form,
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
-            'cards': self.payment_method.all_cards_serialized(self.account)
+            'cards': self.payment_method.all_cards_serialized(self.account),
+            'downgrade_email_note': self.downgrade_email_note
         }
 
     def post(self, request, *args, **kwargs):
@@ -1719,12 +1738,11 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     ) % (software_plan_name, downgrade_date)
                 )
             else:
+                self.send_downgrade_email()
                 if self.current_subscription.next_subscription is not None:
                     # New subscription has been scheduled for the future
                     current_subscription = self.current_subscription.plan_version.plan.edition
                     start_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
-                    # You have successfully scheduled your current Advanced Edition Plan
-                    # subscription to downgrade to the Pro Edition Plan on Sep 19, 2018.
                     message = _(
                         "You have successfully scheduled your current %s Edition Plan subscription to "
                         "downgrade to the %s Edition Plan on %s."
@@ -1738,6 +1756,26 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                 )
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
         return super(ConfirmBillingAccountInfoView, self).post(request, *args, **kwargs)
+
+    def send_downgrade_email(self):
+        message = '\n'.join([
+            '{user} is downgrading the subscription for {domain} from {old_plan} to {new_plan}',
+            '',
+            '{note}',
+        ]).format(
+            user=self.request.couch_user.username,
+            domain=self.request.domain,
+            old_plan=self.request.POST.get('old_plan', 'unknown'),
+            new_plan=self.request.POST.get('new_plan', 'unknown'),
+            note=self.request.POST.get('downgrade_email_note', 'none')
+        )
+
+        send_mail_async.delay(
+            '{}Subscription downgrade for {}'.format(
+                '[staging] ' if settings.SERVER_ENVIRONMENT == "staging" else "",
+                self.request.domain
+            ), message, settings.DEFAULT_FROM_EMAIL, [settings.GROWTH_EMAIL]
+        )
 
 
 class SubscriptionMixin(object):


### PR DESCRIPTION
This PR updates the Downgrading? modal that pops up when a user downgrades their subscription. Growth needs better data on why people downgrade.

Specs:
https://docs.google.com/document/d/1wdN02xuGMXuLPoQ3QJ16zm_WNNA2-u8yDl5kFxVGzCM/edit
https://docs.google.com/document/d/13U-VQSF5ODNd-3QbDgkeDekBTwroG6Fl6BEnwfsuSJg/edit

Review commit-by-commit