### PR TITLE
[ICDS] Add UCR report config that aggregates by age range

### DIFF
--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -861,7 +861,6 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                 {
                     'type': 'conditional_aggregation',
                     'display': 'age_range',
-                    'field': 'age_at_registration',
                     'column_id': 'age_range',
                     'whens': {
                         "age_at_registration between 0 and 6": "0-6",

--- a/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
@@ -18,164 +18,118 @@
     ],
     "filters": [
       {
-        "compare_as_string": false,
-        "datatype": "date",
-        "required": false,
+        "display": "Date Case Opened",
         "slug": "opened_on",
-        "field": "opened_on",
         "type": "date",
-        "display": "Date Case Opened"
+        "field": "opened_on",
+        "datatype": "date"
       },
       {
-        "compare_as_string": false,
-        "datatype": "integer",
-        "required": false,
+        "display": "Age at Registration Low Bound",
         "slug": "age_at_reg",
-        "field": "age_at_reg",
         "type": "numeric",
-        "display": "Age at Registration Low Bound"
+        "field": "age_at_reg",
+        "datatype": "integer"
       },
       {
-        "compare_as_string": false,
-        "datatype": "integer",
-        "required": false,
+        "display": "Age at Registration High Bound",
         "slug": "age_at_reg1",
-        "field": "age_at_reg",
         "type": "numeric",
-        "display": "Age at Registration High Bound"
+        "field": "age_at_reg",
+        "datatype": "integer"
       },
       {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
-        "choice_provider": {
-          "type": "location"
-        },
-        "required": false,
         "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
         "field": "awc_id",
-        "type": "dynamic_choice_list",
-        "slug": "awc_id"
-      },
-      {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
         "choice_provider": {
           "type": "location"
-        },
-        "required": false,
+        }
+      },
+      {
         "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
         "field": "supervisor_id",
-        "type": "dynamic_choice_list",
-        "slug": "supervisor_id"
-      },
-      {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
         "choice_provider": {
           "type": "location"
-        },
-        "required": false,
+        }
+      },
+      {
         "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
         "field": "block_id",
-        "type": "dynamic_choice_list",
-        "slug": "block_id"
-      },
-      {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
         "choice_provider": {
           "type": "location"
-        },
-        "required": false,
+        }
+      },
+      {
         "display": "Filter by District",
-        "field": "district_id",
+        "slug": "district_id",
         "type": "dynamic_choice_list",
-        "slug": "district_id"
-      },
-      {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
+        "field": "district_id",
         "choice_provider": {
           "type": "location"
-        },
-        "required": false,
+        }
+      },
+      {
         "display": "Filter by State",
-        "field": "state_id",
+        "slug": "state_id",
         "type": "dynamic_choice_list",
-        "slug": "state_id"
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
       }
     ],
     "columns": [
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "transform": {
-          "type": "custom",
-          "custom_type": "owner_display"
-        },
-        "column_id": "owner_id",
-        "field": "owner_id",
-        "calculate_total": false,
-        "type": "field",
         "display": {
           "en": "Owner",
           "hin": "Owner"
         },
-        "aggregation": "simple"
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_resident_count",
         "column_id": "F_resident_count",
+        "type": "field",
         "field": "F_resident_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "F_resident_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_resident_count",
         "column_id": "M_resident_count",
+        "type": "field",
         "field": "M_resident_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "M_resident_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_migrant_count",
         "column_id": "F_migrant_count",
-        "field": "F_migrant_count",
-        "transform": {},
-        "calculate_total": true,
         "type": "field",
-        "display": "F_migrant_count"
+        "field": "F_migrant_count",
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_migrant_count",
         "column_id": "M_migrant_count",
-        "field": "M_migrant_count",
-        "transform": {},
-        "calculate_total": true,
         "type": "field",
-        "display": "M_migrant_count"
+        "field": "M_migrant_count",
+        "aggregation": "sum",
+        "calculate_total": true
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
@@ -1,0 +1,184 @@
+{
+  "domains": [
+    "icds-cas",
+    "icds-dashboard-qa"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new"
+  ],
+  "report_id": "static-mobile_mpr_3_children_registered",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR 3 - Children Registered (Static)",
+    "description": "New children registered during month.  Displays person cases grouped by month opened, owner ID, and age group at time of registration",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "compare_as_string": false,
+        "datatype": "date",
+        "required": false,
+        "slug": "opened_on",
+        "field": "opened_on",
+        "type": "date",
+        "display": "Date Case Opened"
+      },
+      {
+        "compare_as_string": false,
+        "datatype": "integer",
+        "required": false,
+        "slug": "age_at_reg",
+        "field": "age_at_reg",
+        "type": "numeric",
+        "display": "Age at Registration Low Bound"
+      },
+      {
+        "compare_as_string": false,
+        "datatype": "integer",
+        "required": false,
+        "slug": "age_at_reg1",
+        "field": "age_at_reg",
+        "type": "numeric",
+        "display": "Age at Registration High Bound"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "choice_provider": {
+          "type": "location"
+        },
+        "required": false,
+        "display": "Filter by AWW",
+        "field": "awc_id",
+        "type": "dynamic_choice_list",
+        "slug": "awc_id"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "choice_provider": {
+          "type": "location"
+        },
+        "required": false,
+        "display": "Filter by Supervisor",
+        "field": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "slug": "supervisor_id"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "choice_provider": {
+          "type": "location"
+        },
+        "required": false,
+        "display": "Filter by Block",
+        "field": "block_id",
+        "type": "dynamic_choice_list",
+        "slug": "block_id"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "choice_provider": {
+          "type": "location"
+        },
+        "required": false,
+        "display": "Filter by District",
+        "field": "district_id",
+        "type": "dynamic_choice_list",
+        "slug": "district_id"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "choice_provider": {
+          "type": "location"
+        },
+        "required": false,
+        "display": "Filter by State",
+        "field": "state_id",
+        "type": "dynamic_choice_list",
+        "slug": "state_id"
+      }
+    ],
+    "columns": [
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        },
+        "column_id": "owner_id",
+        "field": "owner_id",
+        "calculate_total": false,
+        "type": "field",
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_resident_count",
+        "field": "F_resident_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_resident_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_resident_count",
+        "field": "M_resident_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_resident_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_migrant_count",
+        "field": "F_migrant_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_migrant_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_migrant_count",
+        "field": "M_migrant_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_migrant_count"
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
@@ -14,7 +14,9 @@
     "description": "New children registered during month.  Displays person cases grouped by month opened, owner ID, and age group at time of registration",
     "visible": false,
     "aggregation_columns": [
-      "owner_id"
+      "owner_id",
+      "month",
+      "age_group"
     ],
     "filters": [
       {
@@ -99,6 +101,22 @@
         "transform": {
           "type": "custom",
           "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "opened_on",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Age Group",
+        "column_id": "age_group",
+        "type": "conditional_aggregation",
+        "whens": {
+            "0 <= age_at_reg AND age_at_reg < 3": "under_3",
+            "3 <= age_at_reg AND age_at_reg <= 6": "over_3"
         }
       },
       {

--- a/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mobile_mpr_3_children_registered.json
@@ -25,17 +25,19 @@
         "datatype": "date"
       },
       {
-        "display": "Age at Registration Low Bound",
-        "slug": "age_at_reg",
-        "type": "numeric",
+        "slug": "age_at_registration_exists",
+        "type": "pre",
         "field": "age_at_reg",
+        "pre_operator": "!=",
+        "pre_value": "",
         "datatype": "integer"
       },
       {
-        "display": "Age at Registration High Bound",
-        "slug": "age_at_reg1",
-        "type": "numeric",
+        "slug": "age_at_registration_in_bounds",
+        "type": "pre",
         "field": "age_at_reg",
+        "pre_operator": "<=",
+        "pre_value": 6,
         "datatype": "integer"
       },
       {


### PR DESCRIPTION
https://trello.com/c/L93CRZVE/242-in-ucr-aggregate-across-columns-with-non-flat-values-and-or-dates

This report uses the `conditional_aggregation` column introduced in https://github.com/dimagi/commcare-hq/pull/21764.  A non-static version is live on the [testing domain](https://india.commcarehq.org/a/icds-cas/configurable_reports/reports/edit/59539f40d3d5d9cbd5e78bd0302c1755/)

Read commit-by-commit, since the first commit is a copy, the second is the result of a script, and the others are small.