### PR TITLE
Include LinkedApplication in xforms_index

### DIFF
--- a/corehq/apps/app_manager/_design/views/xforms_index/map.js
+++ b/corehq/apps/app_manager/_design/views/xforms_index/map.js
@@ -6,7 +6,7 @@ function (doc) {
             "unique_id": form.unique_id
         });
     }
-    if (doc.doc_type === 'Application' && !doc.copy_of) {
+    if ((doc.doc_type === 'Application' || doc.doc_type === 'LinkedApplication') && !doc.copy_of) {
         if (doc.user_registration) {
             doEmit(doc.user_registration);
         }


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?283130

LinkedApplications aren't included in the xforms index, so looking up the form by ID fails.

