### PR TITLE
use similar pattern as iter_form_ids_by_xmlns to fetch case ids

### DIFF
--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -197,6 +197,10 @@ class CaseAccessorCouch(AbstractCaseAccessor):
         return get_case_ids_in_domain(domain, type=type)
 
     @staticmethod
+    def iter_case_ids_by_domain_and_type(domain, type_=None):
+        return get_case_ids_in_domain(domain, type=type_)
+
+    @staticmethod
     def get_case_ids_in_domain_by_owners(domain, owner_ids, closed=None):
         return get_case_ids_in_domain_by_owner(domain, owner_id__in=owner_ids, closed=closed)
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -990,6 +990,14 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         return CaseAccessorSQL._get_case_ids_in_domain(domain, owner_ids=owner_ids, is_closed=closed)
 
     @staticmethod
+    def iter_case_ids_by_domain_and_type(domain, type_):
+        from corehq.sql_db.util import run_query_across_partitioned_databases
+        q_expr = Q(domain=domain) & Q(type=type_)
+        for case_id in run_query_across_partitioned_databases(
+                CommCareCaseSQL, q_expr, values=['case_id']):
+            yield case_id
+
+    @staticmethod
     def save_case(case):
         transactions_to_save = case.get_live_tracked_models(CaseTransaction)
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -990,7 +990,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         return CaseAccessorSQL._get_case_ids_in_domain(domain, owner_ids=owner_ids, is_closed=closed)
 
     @staticmethod
-    def iter_case_ids_by_domain_and_type(domain, type_):
+    def iter_case_ids_by_domain_and_type(domain, type_=None):
         from corehq.sql_db.util import run_query_across_partitioned_databases
         q_expr = Q(domain=domain) & Q(type=type_)
         for case_id in run_query_across_partitioned_databases(

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -992,7 +992,9 @@ class CaseAccessorSQL(AbstractCaseAccessor):
     @staticmethod
     def iter_case_ids_by_domain_and_type(domain, type_=None):
         from corehq.sql_db.util import run_query_across_partitioned_databases
-        q_expr = Q(domain=domain) & Q(type=type_)
+        q_expr = Q(domain=domain) & Q(deleted=False)
+        if type_:
+            q_expr &= Q(type=type_)
         for case_id in run_query_across_partitioned_databases(
                 CommCareCaseSQL, q_expr, values=['case_id']):
             yield case_id

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -56,7 +56,7 @@ class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
 
     def iter_document_ids(self, last_id=None):
         # todo: support last_id
-        return iter(self.case_accessors.get_case_ids_in_domain(type=self.case_type))
+        return iter(self.case_accessors.iter_case_ids_by_domain_and_type(self.case_type))
 
     def iter_documents(self, ids):
         for wrapped_case in self.case_accessors.iter_cases(ids):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -208,7 +208,7 @@ class AbstractCaseAccessor(six.with_metaclass(ABCMeta)):
     def get_case_ids_in_domain(domain, type=None):
         raise NotImplementedError
 
-    @staticmethod
+    @abstractmethod
     def iter_case_ids_by_domain_and_type(domain, type_=None):
         raise NotImplementedError
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -208,6 +208,10 @@ class AbstractCaseAccessor(six.with_metaclass(ABCMeta)):
     def get_case_ids_in_domain(domain, type=None):
         raise NotImplementedError
 
+    @staticmethod
+    def iter_case_ids_by_domain_and_type(domain, type_=None):
+        raise NotImplementedError
+
     @abstractmethod
     def get_case_ids_in_domain_by_owners(domain, owner_ids):
         raise NotImplementedError
@@ -327,6 +331,9 @@ class CaseAccessors(object):
 
     def get_case_ids_in_domain(self, type=None):
         return self.db_accessor.get_case_ids_in_domain(self.domain, type)
+
+    def iter_case_ids_by_domain_and_type(self, type_=None):
+        return self.db_accessor.iter_case_ids_by_domain_and_type(self.domain, type_)
 
     def get_case_ids_by_owners(self, owner_ids, closed=None):
         """


### PR DESCRIPTION
For bigger domains like `egpaf-lesotho` the process to fetch all case ids was just not finishing. @snopoke suggested to use the process as we have when fetching forms since that seems more reliable.

For now, just added from where it was debugged when building a report. Should this be changed at all places?