### PR TITLE
don't re-publish changes from duplicate forms

### DIFF
--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -153,16 +153,7 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def publish_changes_to_kafka(processed_forms, cases, stock_result):
-        # todo: form deprecations?
         publish_form_saved(processed_forms.submitted)
-        if processed_forms.submitted.is_duplicate:
-            # for duplicate forms, also publish changes for the original form since the fact that
-            # we're getting a duplicate indicates that we may not have fully processed/published it
-            # the first time
-            republish_all_changes_for_form(
-                processed_forms.submitted.domain, processed_forms.submitted.orig_id
-            )
-
         cases = cases or []
         for case in cases:
             publish_case_saved(case)

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -17,90 +17,6 @@ from pillowtop.processors.sample import TestProcessor
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
-@use_sql_backend
-class KafkaPublishingSQLTest(TestCase):
-
-    domain = 'sql-kafka-publishing-test'
-
-    def setUp(self):
-        super(KafkaPublishingSQLTest, self).setUp()
-        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
-        self.form_accessors = FormAccessors(domain=self.domain)
-        self.processor = TestProcessor()
-        self.case_pillow = ConstructedPillow(
-            name='test-kafka-case-feed',
-            checkpoint=None,
-            change_feed=KafkaChangeFeed(topics=[topics.CASE, topics.CASE_SQL], client_id='test-kafka-case-feed'),
-            processor=self.processor
-        )
-        self.ledger_pillow = ConstructedPillow(
-            name='test-kafka-ledger-feed',
-            checkpoint=None,
-            change_feed=KafkaChangeFeed(topics=[topics.LEDGER], client_id='test-kafka-ledger-feed'),
-            processor=self.processor
-        )
-
-    def test_duplicate_case_published(self):
-        # this test only runs on sql because it's handling a sql-specific edge case where duplicate
-        # form submissions should cause cases to be resubmitted.
-        # see: http://manage.dimagi.com/default.asp?228463 for context
-        case_id = uuid.uuid4().hex
-        form_xml = get_simple_form_xml(uuid.uuid4().hex, case_id)
-        submit_form_locally(form_xml, domain=self.domain)
-        self.assertEqual(1, len(CaseAccessors(self.domain).get_case_ids_in_domain()))
-
-        with process_pillow_changes(self.case_pillow):
-            with process_pillow_changes('DefaultChangeFeedPillow'):
-                dupe_form = submit_form_locally(form_xml, domain=self.domain).xform
-                self.assertTrue(dupe_form.is_duplicate)
-
-        # check the case was republished
-        self.assertEqual(1, len(self.processor.changes_seen))
-        case_meta = self.processor.changes_seen[0].metadata
-        self.assertEqual(case_id, case_meta.document_id)
-        self.assertEqual(self.domain, case_meta.domain)
-
-    def test_duplicate_ledger_published(self):
-        # this test also only runs on the sql backend for reasons described in test_duplicate_case_published
-        # setup products and case
-        product_a = make_product(self.domain, 'A Product', 'prodcode_a')
-        product_b = make_product(self.domain, 'B Product', 'prodcode_b')
-        case_id = uuid.uuid4().hex
-        form_xml = get_simple_form_xml(uuid.uuid4().hex, case_id)
-        submit_form_locally(form_xml, domain=self.domain)
-
-        # submit ledger data
-        balances = (
-            (product_a._id, 100),
-            (product_b._id, 50),
-        )
-        ledger_blocks = [
-            get_single_balance_block(case_id, prod_id, balance)
-            for prod_id, balance in balances
-        ]
-        form = submit_case_blocks(ledger_blocks, self.domain)[0]
-
-        # submit duplicate
-        with process_pillow_changes(self.ledger_pillow):
-            with process_pillow_changes('DefaultChangeFeedPillow'):
-                dupe_form = submit_form_locally(form.get_xml(), domain=self.domain).xform
-                self.assertTrue(dupe_form.is_duplicate)
-
-        # confirm republished
-        ledger_meta_a = self.processor.changes_seen[0].metadata
-        ledger_meta_b = self.processor.changes_seen[1].metadata
-        format_id = lambda product_id: '{}/{}/{}'.format(case_id, 'stock', product_id)
-        expected_ids = {format_id(product_a._id), format_id(product_b._id)}
-        for meta in [ledger_meta_a, ledger_meta_b]:
-            self.assertTrue(meta.document_id in expected_ids)
-            expected_ids.remove(meta.document_id)
-            self.assertEqual(self.domain, meta.domain)
-
-        # cleanup
-        product_a.delete()
-        product_b.delete()
-
-
 class KafkaPublishingTest(TestCase):
 
     domain = 'kafka-publishing-test'
@@ -141,34 +57,6 @@ class KafkaPublishingTest(TestCase):
         change_meta = self.processor.changes_seen[0].metadata
         self.assertEqual(form.form_id, change_meta.document_id)
         self.assertEqual(self.domain, change_meta.domain)
-
-    def test_duplicate_form_published(self):
-        form_id = uuid.uuid4().hex
-        form_xml = get_simple_form_xml(form_id)
-        orig_form = submit_form_locally(form_xml, domain=self.domain).xform
-        self.assertEqual(form_id, orig_form.form_id)
-        self.assertEqual(1, len(self.form_accessors.get_all_form_ids_in_domain()))
-
-        with process_pillow_changes(self.form_pillow):
-            with process_pillow_changes('DefaultChangeFeedPillow'):
-                # post an exact duplicate
-                dupe_form = submit_form_locally(form_xml, domain=self.domain).xform
-                self.assertTrue(dupe_form.is_duplicate)
-                self.assertNotEqual(form_id, dupe_form.form_id)
-                if should_use_sql_backend(self.domain):
-                    self.assertEqual(form_id, dupe_form.orig_id)
-
-        # make sure changes made it to kafka
-        dupe_form_meta = self.processor.changes_seen[0].metadata
-        self.assertEqual(dupe_form.form_id, dupe_form_meta.document_id)
-        self.assertEqual(dupe_form.domain, dupe_form.domain)
-        if should_use_sql_backend(self.domain):
-            # sql domains also republish the original form to ensure that if the server crashed
-            # in the processing of the form the first time that it is still sent to kafka
-            orig_form_meta = self.processor.changes_seen[1].metadata
-            self.assertEqual(orig_form.form_id, orig_form_meta.document_id)
-            self.assertEqual(self.domain, orig_form_meta.domain)
-            self.assertEqual(dupe_form.domain, dupe_form.domain)
 
     def test_form_soft_deletions(self):
         form = create_and_save_a_form(self.domain)


### PR DESCRIPTION
This is already handled by the form re-processing queue.

Just noticed this while looking at a sentry issue. This should also reduce the load on kafka / pillows, especially during / after outages.