### PR TITLE
Check row.data for length, not row

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -12,7 +12,13 @@ from mock import patch, Mock
 
 from couchexport.export import export_from_tables
 from couchexport.models import Format
-from couchexport.writers import ZippedExportWriter, CsvFileWriter, PythonDictWriter
+from couchexport.writers import (
+    MAX_XLS_COLUMNS,
+    CsvFileWriter,
+    PythonDictWriter,
+    XlsLengthException,
+    ZippedExportWriter,
+)
 
 
 class ZippedExportWriterTests(SimpleTestCase):
@@ -119,6 +125,28 @@ class Excel2007ExportWriterTests(SimpleTestCase):
             [b'row2\xe2\x80\x931', b'row2\xe2\x80\x932', b'row2\xe2\x80\x933'],
         ]
         tables = [[b'table\xe2\x80\x93title', table]]
+        export_from_tables(tables, file_, format_)
+
+
+class Excel2003ExportWriterTests(SimpleTestCase):
+
+    def test_data_length(self):
+        format_ = Format.XLS
+        file_ = io.BytesIO()
+        table = [
+            ['header{}'.format(i) for i in range(MAX_XLS_COLUMNS)],
+            ['row{}'.format(i) for i in range(MAX_XLS_COLUMNS)],
+        ]
+        tables = [['title', table]]
+
+        with self.assertRaises(XlsLengthException):
+            export_from_tables(tables, file_, format_)
+
+        table = [
+            ['header{}'.format(i) for i in range(MAX_XLS_COLUMNS - 1)],
+            ['row{}'.format(i) for i in range(MAX_XLS_COLUMNS - 1)],
+        ]
+        tables = [['title', table]]
         export_from_tables(tables, file_, format_)
 
 

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -26,8 +26,12 @@ from six.moves import zip
 from six.moves import map
 
 
+MAX_XLS_COLUMNS = 256
+
+
 class XlsLengthException(Exception):
     pass
+
 
 class UniqueHeaderGenerator(object):
 
@@ -431,10 +435,12 @@ class Excel2003ExportWriter(ExportWriter):
     def _write_row(self, sheet_index, row):
         row_index = self.table_indices[sheet_index]
         sheet = self.tables[sheet_index]
+
+        if hasattr(row, 'data') and len(row.data) >= MAX_XLS_COLUMNS:
+            raise XlsLengthException
+
         # have to deal with primary ids
         for i, val in enumerate(row):
-            if len(row) >= 256:
-                raise XlsLengthException
             sheet.write(row_index, i, six.text_type(val))
         self.table_indices[sheet_index] = row_index + 1
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?283120
https://sentry.io/dimagi/commcarehq/issues/687568766/

@pr33thi FYI. Not sure if you'd tested this and there were instances where `row` has a length?