### PR TITLE
stop querying for alert on every 500

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -491,19 +491,16 @@ def reverse_chevron(value):
 
 @register.simple_tag
 def maintenance_alert():
-    try:
-        alert = (MaintenanceAlert.objects
-                 .filter(active=True)
-                 .order_by('-modified'))[0]
-    except IndexError:
-        return ''
-    else:
+    alert = MaintenanceAlert.get_latest_alert()
+    if alert:
         return format_html(
             '<div class="alert alert-warning alert-maintenance" data-id="{}">{}{}</div>',
             alert.id,
             mark_safe('<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>'),
             mark_safe(alert.html),
         )
+    else:
+        return ''
 
 
 @register.simple_tag


### PR DESCRIPTION
When the server is struggling there are lots of 500s, each trying to load alert object. This PR caches and avoid hitting already struggling server. 

Here's an example [sentry](https://sentry.io/dimagi/commcarehq/issues/345623471/?query=maintenance_alert). This is probably not getting reported due to sentry rate limiting, but I saw many of these fly by in Django logs on ICDS today.