### PR TITLE
Fix cursor on project settings menu

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/navs.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/navs.less
@@ -59,6 +59,13 @@
   margin-bottom: 6px;
 }
 
+// Bootstrap's default is to use a pointer cursor for the whole nav, which causes elements
+// like menu section headers to look clickable. Items that are actually clickable are typically
+// links that already have the pointer cursor.
+.nav {
+  cursor: default;
+}
+
 .nav > li > a {
   color: @cc-brand-low;
 }


### PR DESCRIPTION
From summit: in the project settings (gear) menu, the user's name & menu's headers look clickable but they aren't.

@Rohit25negi / @proteusvacuum 