### PR TITLE
Allow overriding commcare UI translations on linked apps

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6563,6 +6563,7 @@ class LinkedApplication(Application):
     """
     # This is the id of the master application
     master = StringProperty()
+    linked_app_translations = DictProperty()
 
     @property
     @memoized
@@ -6584,6 +6585,10 @@ class LinkedApplication(Application):
             return get_latest_master_app_release(self.domain_link, self.master)
         else:
             raise ActionNotPermitted
+
+    def reapply_translations(self):
+        self.translations.update(self.linked_app_translations)
+        self.save()
 
 
 def import_app(app_id_or_source, domain, source_properties=None, validate_source_domain=None):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6563,7 +6563,10 @@ class LinkedApplication(Application):
     """
     # This is the id of the master application
     master = StringProperty()
-    linked_app_translations = DictProperty()
+
+    # The following properties will overwrite their corresponding values from
+    # the master app everytime the new master is pulled
+    linked_app_translations = DictProperty()  # corresponding property: translations
 
     @property
     @memoized

--- a/corehq/apps/app_manager/templates/app_manager/languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/languages.html
@@ -10,6 +10,7 @@
 {% registerurl "get_app_ui_translations" domain %}
 
 <div class="panel-group" id="language-settings-options">
+    {% if app.doc_type != "LinkedApplication" %}
     <div class="panel panel-appmanager">
       <div class="panel-heading">
         <h4 class="panel-title">
@@ -28,6 +29,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
 
     {% if not app.is_remote_app and app.get_doc_type == "Application" %}
       <div class="panel panel-appmanager">
@@ -72,6 +74,7 @@
       </div>
     {% endif %}
 
+    {% if app.doc_type != "LinkedApplication" %}
     <div class="panel panel-appmanager">
       <div class="panel-heading">
         <h4 class="panel-title">
@@ -90,5 +93,6 @@
         </div>
       </div>
     </div>
+    {% endif %}
 
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -166,6 +166,7 @@
     <ul class="nav nav-tabs sticky-tabs">
     {% if app.get_doc_type == 'LinkedApplication' %}
         <li><a href="#linked-app" data-toggle="tab">{% trans "Linked Application" %}</a></li>
+        <li><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
         <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
     {% else %}
         <li><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
@@ -204,11 +205,9 @@
                 </div>
             </div>
         {% endif %}
-        {% if app.get_doc_type != 'LinkedApplication' %}
-            <div class="tab-pane" id="languages">
-                {% include 'app_manager/languages.html' %}
-            </div>
-        {% endif %}
+        <div class="tab-pane" id="languages">
+            {% include 'app_manager/languages.html' %}
+        </div>
         <div class="tab-pane" id="actions">
             {% if app.get_doc_type != 'LinkedApplication' %}
                 {% if copy_app_form %}

--- a/corehq/apps/app_manager/views/translations.py
+++ b/corehq/apps/app_manager/views/translations.py
@@ -8,10 +8,6 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 
-from corehq.apps.app_manager.const import APP_TRANSLATION_UPLOAD_FAIL_MESSAGE
-from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
-    require_can_edit_apps
 from corehq.apps.app_manager.app_translations import (
     expected_bulk_app_sheet_headers,
     expected_bulk_app_sheet_rows,
@@ -19,6 +15,11 @@ from corehq.apps.app_manager.app_translations import (
     validate_bulk_app_translation_upload,
     read_uploaded_app_translation_file,
 )
+from corehq.apps.app_manager.const import APP_TRANSLATION_UPLOAD_FAIL_MESSAGE
+from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
+    require_can_edit_apps
+from corehq.apps.app_manager.models import LinkedApplication
 from corehq.apps.app_manager.ui_translations import process_ui_translation_upload, \
     build_ui_translation_download_file
 from corehq.util.workbook_json.excel import InvalidExcelFileException
@@ -53,6 +54,8 @@ def upload_bulk_ui_translations(request, domain, app_id):
             messages.error(request, message, extra_tags='html')
         else:
             # update translations only if there were no errors
+            if isinstance(app, LinkedApplication):
+                app.linked_app_translations = dict(trans_dict)
             app.translations = dict(trans_dict)
             app.save()
             success = True

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -342,6 +342,8 @@ def update_linked_app(app, user_id):
 
     app.domain_link.update_last_pull('app', user_id, model_details=AppLinkDetail(app_id=app._id))
 
+    app.reapply_translations()
+
 
 def clear_xmlns_app_id_cache(domain):
     from couchforms.analytics import get_all_xmlns_app_id_pairs_submitted_to_in_domain

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -342,6 +342,7 @@ def update_linked_app(app, user_id):
 
     app.domain_link.update_last_pull('app', user_id, model_details=AppLinkDetail(app_id=app._id))
 
+    # reapply linked application specific data
     app.reapply_translations()
 
 


### PR DESCRIPTION
Adds ability to add linked app specific translations. They must be uploaded via excel file. I wanted this to be as small and easy to reason about as possible, so I chose to add a linked app specific property that "reapplies" itself every time the linked app is updated. General workflow looks like:

1. Have linked app
2. Upload a translations file to the linked app
3. Make changes to master app
4. Pull the master app into the linked app
5. The translations that have been previously uploaded are reapplied to the update linked app