### PR TITLE
modernize - use new range()

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -19,6 +19,7 @@ from couchexport.writers import (
     XlsLengthException,
     ZippedExportWriter,
 )
+from six.moves import range
 
 
 class ZippedExportWriterTests(SimpleTestCase):


### PR DESCRIPTION
This makes range return a generator instead of a list, consistent with its py3 interface.