### PR TITLE
Customer Billing QA

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2006,7 +2006,7 @@ class TriggerCustomerInvoiceForm(forms.Form):
                 return datetime.date(year, 1, 1), datetime.date(year, 12, 31)
             else:
                 raise InvoiceError(
-                    "Account %s is set to be invoiced yearly. You may only invoice on January 1"
+                    "%s is set to be invoiced yearly. You may only invoice on January 1"
                     % self.cleaned_data['customer_account']
                 )
         if account.invoicing_plan == InvoicingPlan.QUARTERLY:
@@ -2020,7 +2020,7 @@ class TriggerCustomerInvoiceForm(forms.Form):
                 return datetime.date(year, 10, 1), datetime.date(year, 12, 31)  # Quarter 4
             else:
                 raise InvoiceError(
-                    "Account %s is set to be invoiced quarterly. "
+                    "%s is set to be invoiced quarterly. "
                     "You may only invoice on April 1, July 1, October 1, or January 1."
                     % self.cleaned_data['customer_account']
                 )

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2248,11 +2248,15 @@ class AdjustBalanceForm(forms.Form):
             )
         elif method == CreditAdjustmentReason.TRANSFER:
             if self.invoice.is_customer_invoice:
+                subscription_invoice = None
+                customer_invoice = self.invoice
                 credit_line_balance = sum(
                     credit_line.balance
                     for credit_line in CreditLine.get_credits_for_customer_invoice(self.invoice)
                 )
             else:
+                subscription_invoice = self.invoice
+                customer_invoice = None
                 credit_line_balance = sum(
                     credit_line.balance
                     for credit_line in CreditLine.get_credits_for_invoice(self.invoice)
@@ -2263,7 +2267,8 @@ class AdjustBalanceForm(forms.Form):
             )
             CreditLine.add_credit(
                 -transfer_balance,
-                invoice=self.invoice,
+                invoice=subscription_invoice,
+                customer_invoice=customer_invoice,
                 **kwargs
             )
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2157,7 +2157,10 @@ class AdjustBalanceForm(forms.Form):
         self.helper.form_class = "form-horizontal"
         self.helper.label_class = 'col-sm-4 col-md-3'
         self.helper.field_class = 'col-sm-8 col-md-9'
-        self.helper.form_action = reverse('invoice_summary', args=[self.invoice.id])
+        if invoice.is_customer_invoice:
+            self.helper.form_action = reverse('customer_invoice_summary', args=[self.invoice.id])
+        else:
+            self.helper.form_action = reverse('invoice_summary', args=[self.invoice.id])
         self.helper.layout = crispy.Layout(
             crispy.Div(
                 crispy.Field(
@@ -2218,28 +2221,42 @@ class AdjustBalanceForm(forms.Form):
     def adjust_balance(self, web_user=None):
         method = self.cleaned_data['method']
         kwargs = {
-            'account': self.invoice.subscription.account,
+            'account': self.invoice.account if self.invoice.is_customer_invoice
+            else self.invoice.subscription.account,
             'note': self.cleaned_data['note'],
             'reason': method,
-            'subscription': self.invoice.subscription,
+            'subscription': None if self.invoice.is_customer_invoice else self.invoice.subscription,
             'web_user': web_user,
         }
         if method == CreditAdjustmentReason.MANUAL:
-            CreditLine.add_credit(
-                -self.amount,
-                invoice=self.invoice,
-                **kwargs
-            )
+            if self.invoice.is_customer_invoice:
+                CreditLine.add_credit(
+                    -self.amount,
+                    customer_invoice=self.invoice,
+                    **kwargs
+                )
+            else:
+                CreditLine.add_credit(
+                    -self.amount,
+                    invoice=self.invoice,
+                    **kwargs
+                )
             CreditLine.add_credit(
                 self.amount,
                 permit_inactive=True,
                 **kwargs
             )
         elif method == CreditAdjustmentReason.TRANSFER:
-            credit_line_balance = sum(
-                credit_line.balance
-                for credit_line in CreditLine.get_credits_for_invoice(self.invoice)
-            )
+            if self.invoice.is_customer_invoice:
+                credit_line_balance = sum(
+                    credit_line.balance
+                    for credit_line in CreditLine.get_credits_for_customer_invoice(self.invoice)
+                )
+            else:
+                credit_line_balance = sum(
+                    credit_line.balance
+                    for credit_line in CreditLine.get_credits_for_invoice(self.invoice)
+                )
             transfer_balance = (
                 min(self.amount, credit_line_balance)
                 if credit_line_balance > 0 else min(0, self.amount)

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2006,7 +2006,8 @@ class TriggerCustomerInvoiceForm(forms.Form):
                 return datetime.date(year, 1, 1), datetime.date(year, 12, 31)
             else:
                 raise InvoiceError(
-                    "%s is set to be invoiced yearly. You may only invoice on January 1"
+                    "%s is set to be invoiced yearly, and you may not invoice in this month. "
+                    "You must select December in the year for which you are triggering an annual invoice."
                     % self.cleaned_data['customer_account']
                 )
         if account.invoicing_plan == InvoicingPlan.QUARTERLY:
@@ -2020,8 +2021,8 @@ class TriggerCustomerInvoiceForm(forms.Form):
                 return datetime.date(year, 10, 1), datetime.date(year, 12, 31)  # Quarter 4
             else:
                 raise InvoiceError(
-                    "%s is set to be invoiced quarterly. "
-                    "You may only invoice on April 1, July 1, October 1, or January 1."
+                    "%s is set to be invoiced quarterly, and you may not invoice in this month. "
+                    "You must select the last month of a quarter to trigger a quarterly invoice."
                     % self.cleaned_data['customer_account']
                 )
         else:

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2221,8 +2221,8 @@ class AdjustBalanceForm(forms.Form):
     def adjust_balance(self, web_user=None):
         method = self.cleaned_data['method']
         kwargs = {
-            'account': self.invoice.account if self.invoice.is_customer_invoice
-            else self.invoice.subscription.account,
+            'account': (self.invoice.account if self.invoice.is_customer_invoice
+                        else self.invoice.subscription.account),
             'note': self.cleaned_data['note'],
             'reason': method,
             'subscription': None if self.invoice.is_customer_invoice else self.invoice.subscription,

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -936,6 +936,8 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
         'corehq.apps.accounting.interface.IsHiddenFilter',
     ]
 
+    account = None
+
     @property
     def headers(self):
         header = DataTablesHeader(
@@ -1161,6 +1163,9 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
             'month': statement_start.strftime("%B"),
             'rows': self.rows,
         })
+
+    def filter_by_account(self, account):
+        self.account = account
 
 
 def _get_domain_from_payment_record(payment_record):

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -246,7 +246,7 @@ class DomainInvoiceFactory(object):
 
 class DomainWireInvoiceFactory(object):
 
-    def __init__(self, domain, date_start=None, date_end=None, contact_emails=None):
+    def __init__(self, domain, date_start=None, date_end=None, contact_emails=None, account=None):
         self.date_start = date_start
         self.date_end = date_end
         self.contact_emails = contact_emails
@@ -254,22 +254,25 @@ class DomainWireInvoiceFactory(object):
         self.logged_throttle_error = False
         if self.domain is None:
             raise InvoiceError("Domain '{}' is not a valid domain on HQ!".format(self.domain))
+        self.account = account
 
     @transaction.atomic
     def create_wire_invoice(self, balance):
 
         # Gather relevant invoices
-        invoices = Invoice.objects.filter(
-            subscription__subscriber__domain=self.domain,
-            is_hidden=False,
-            date_paid__exact=None,
-        ).order_by('-date_start')
-
-        BillingAccount.get_or_create_account_by_domain(
-            self.domain.name,
-            created_by=self.__class__.__name__,
-            entry_point=EntryPoint.SELF_STARTED,
-        )[0]
+        if self.account and self.account.is_customer_billing_account:
+            invoices = CustomerInvoice.objects.filter(account=self.account)
+        else:
+            invoices = Invoice.objects.filter(
+                subscription__subscriber__domain=self.domain,
+                is_hidden=False,
+                date_paid__exact=None
+            ).order_by('-date_start')
+            self.account = BillingAccount.get_or_create_account_by_domain(
+                self.domain.name,
+                created_by=self.__class__.__name__,
+                entry_point=EntryPoint.SELF_STARTED
+            )[0]
 
         # If no start date supplied, default earliest start date of unpaid invoices
         if self.date_start:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3182,7 +3182,7 @@ class CreditLine(ValidateModelMixin, models.Model):
     @classmethod
     def add_credit(cls, amount, account=None, subscription=None,
                    is_product=False, feature_type=None, payment_record=None,
-                   invoice=None, line_item=None, related_credit=None,
+                   invoice=None, customer_invoice=None, line_item=None, related_credit=None,
                    note=None, reason=None, web_user=None, permit_inactive=False):
         if account is None and subscription is None:
             raise CreditLineError(
@@ -3231,7 +3231,7 @@ class CreditLine(ValidateModelMixin, models.Model):
             is_new = True
         credit_line.adjust_credit_balance(amount, is_new=is_new, note=note,
                                           payment_record=payment_record,
-                                          invoice=invoice, line_item=line_item,
+                                          invoice=invoice, customer_invoice=customer_invoice, line_item=line_item,
                                           related_credit=related_credit,
                                           reason=reason, web_user=web_user)
         return credit_line

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2630,6 +2630,7 @@ class CustomerBillingRecord(BillingRecordBase):
         payment_status = (_("Paid")
                           if self.invoice.is_paid or self.invoice.balance == 0
                           else _("Payment Required"))
+        # Random domain, because all subscriptions on a customer account link to the same Enterprise Dashboard
         domain = self.invoice.subscriptions.first().subscriber.domain
         context.update({
             'account_name': self.invoice.account.name,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2636,7 +2636,7 @@ class CustomerBillingRecord(BillingRecordBase):
             'account_name': self.invoice.account.name,
             'date_due': self.invoice.date_due,
             'is_small_invoice': is_small_invoice,
-            'total_balance': self.invoice.balance,
+            'total_balance': '{:.2f}'.format(self.invoice.balance),
             'is_total_balance_due': self.invoice.balance >= SMALL_INVOICE_THRESHOLD,
             'payment_status': payment_status,
             'statements_url': absolute_reverse(

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2600,6 +2600,9 @@ class CustomerBillingRecord(BillingRecordBase):
     INVOICE_AUTOPAY_HTML_TEMPLATE = 'accounting/email/invoice_autopayment.html'
     INVOICE_AUTOPAY_TEXT_TEMPLATE = 'accounting/email/invoice_autopayment.txt'
 
+    INVOICE_HTML_TEMPLATE = 'accounting/email/customer_invoice.html'
+    INVOICE_TEXT_TEMPLATE = 'accounting/email/customer_invoice.txt'
+
     class Meta(object):
         app_label = 'accounting'
 
@@ -2621,18 +2624,22 @@ class CustomerBillingRecord(BillingRecordBase):
         return not self.invoice.is_hidden
 
     def email_context(self):
+        from corehq.apps.accounting.views import EnterpriseBillingStatementsView
         context = super(CustomerBillingRecord, self).email_context()
         is_small_invoice = self.invoice.balance < SMALL_INVOICE_THRESHOLD
         payment_status = (_("Paid")
                           if self.invoice.is_paid or self.invoice.balance == 0
                           else _("Payment Required"))
+        domain = self.invoice.subscriptions.first().subscriber.domain
         context.update({
-            # 'plan_name': self.invoice.subscription.plan_version.plan.name,
+            'account_name': self.invoice.account.name,
             'date_due': self.invoice.date_due,
             'is_small_invoice': is_small_invoice,
             'total_balance': self.invoice.balance,
             'is_total_balance_due': self.invoice.balance >= SMALL_INVOICE_THRESHOLD,
             'payment_status': payment_status,
+            'statements_url': absolute_reverse(
+                EnterpriseBillingStatementsView.urlname, args=[domain]),
         })
         if self.invoice.account.auto_pay_enabled:
             try:
@@ -2798,9 +2805,9 @@ class CustomerBillingRecord(BillingRecordBase):
 
     def email_subject(self):
         month_name = self.invoice.date_start.strftime("%B")
-        return "Your %(month)s CommCare Billing Statement for Customer Account %(account)s" % {
+        return "Your %(month)s CommCare Billing Statement for Customer Account %(account_name)s" % {
             'month': month_name,
-            'account': self.invoice.account,
+            'account_name': self.invoice.account.name,
         }
 
     def email_from(self):

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -33,7 +33,7 @@ from corehq.apps.accounting.exceptions import (
     CreditLineError,
     InvoiceError,
 )
-from corehq.apps.accounting.invoicing import DomainInvoiceFactory
+from corehq.apps.accounting.invoicing import DomainInvoiceFactory, CustomerAccountInvoiceFactory
 from corehq.apps.accounting.models import (
     BillingAccount,
     CreditLine,
@@ -51,7 +51,8 @@ from corehq.apps.accounting.models import (
     SubscriptionType,
     WirePrepaymentBillingRecord,
     WirePrepaymentInvoice,
-    DomainUserHistory
+    DomainUserHistory,
+    InvoicingPlan
 )
 from corehq.apps.accounting.payment_handlers import AutoPayInvoicePaymentHandler
 from corehq.apps.accounting.utils import (
@@ -233,6 +234,38 @@ def generate_invoices(based_on_date=None):
             invoice_factory.create_invoices()
             log_accounting_info("Sent invoices for domain %s" % domain.name)
         except CreditLineError as e:
+            log_accounting_error(
+                "There was an error utilizing credits for "
+                "domain %s: %s" % (domain.name, e),
+                show_stack_trace=True,
+            )
+        except InvoiceError as e:
+            log_accounting_error(
+                "Could not create invoice for domain %s: %s" % (domain.name, e),
+                show_stack_trace=True,
+            )
+        except Exception as e:
+            log_accounting_error(
+                "Error occurred while creating invoice for "
+                "domain %s: %s" % (domain.name, e),
+                show_stack_trace=True,
+            )
+    all_customer_billing_accounts = BillingAccount.objects.filter(is_customer_billing_account=True)
+    for account in all_customer_billing_accounts:
+        try:
+            if account.invoicing_plan == InvoicingPlan.QUARTERLY:
+                customer_invoice_start = invoice_start - relativedelta(months=2)
+            elif account.invoicing_plan == InvoicingPlan.YEARLY:
+                customer_invoice_start = invoice_start - relativedelta(months=11)
+            else:
+                customer_invoice_start = invoice_start
+            invoice_factory = CustomerAccountInvoiceFactory(
+                account=account,
+                date_start=customer_invoice_start,
+                date_end=invoice_end
+            )
+            invoice_factory.create_invoice()
+        except CreditLineError as E:
             log_accounting_error(
                 "There was an error utilizing credits for "
                 "domain %s: %s" % (domain.name, e),

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -265,7 +265,7 @@ def generate_invoices(based_on_date=None):
                 date_end=invoice_end
             )
             invoice_factory.create_invoice()
-        except CreditLineError as E:
+        except CreditLineError as e:
             log_accounting_error(
                 "There was an error utilizing credits for "
                 "domain %s: %s" % (domain.name, e),

--- a/corehq/apps/accounting/templates/accounting/email/customer_invoice.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_invoice.html
@@ -243,7 +243,7 @@
 
 <p>
     {% blocktrans %}
-    Best Regards,<br />
+    Best regards,<br />
     The CommCare HQ Team<br />
     www.commcarehq.org
     {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/customer_invoice.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_invoice.html
@@ -1,0 +1,258 @@
+{% load i18n %}
+
+<p>{{ greeting }}</p>
+
+<p>
+    {% blocktrans %}
+    Your {{ month_name }} Billing Statement is now available for Customer Account {{ account_name }}.
+    {% endblocktrans %}
+</p>
+
+<table cellpadding="2">
+    <tr>
+        <th align="right">
+            {% trans 'Statement No.' %}:
+        </th>
+        <td>
+            {{ statement_number }}
+        </td>
+    </tr>
+    <tr>
+        <th align="right">
+            {% trans 'Account' %}:
+        </th>
+        <td>
+            {{ account_name }}
+        </td>
+    </tr>
+    <tr>
+        <th align="right">
+            {% trans 'Status' %}:
+        </th>
+        <td>
+            {{ payment_status }}
+        </td>
+    </tr>
+    <tr>
+        <th align="right">
+            {% trans 'Amount Due this Month' %}:
+        </th>
+        <td>
+            {{ amount_due }}
+        </td>
+    </tr>
+    <tr>
+        <th align="right">
+            {% trans 'Total Balance' %}:
+        </th>
+        <td>
+            {{ total_balance }}
+        </td>
+    </tr>
+    {% if total_balance > 0 %}
+    <tr>
+        <th align="right">
+            {% trans 'Payment Due Date' %}:
+        </th>
+        <td>
+            {{ date_due }}
+        </td>
+    </tr>
+    {% endif %}
+
+    {% if credits.subscription %}
+    <tr>
+        <th align="right">
+            <span style="text-decoration:underline;">{% trans 'Subscription Credits Remaining' %}</span>
+        </th>
+    </tr>
+    {% endif %}
+    {% if credits.subscription.product %}
+    <tr>
+        <th align="right">
+            {% trans 'Plan Credits' %}:
+        </th>
+        <td>
+            {{ credits.subscription.product.amount }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if credits.subscription.user %}
+    <tr>
+        <th align="right">
+            {% trans 'User Credits' %}:
+        </th>
+        <td>
+            {{ credits.subscription.user.amount }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if credits.subscription.sms %}
+    <tr>
+        <th align="right">
+            {% trans 'SMS Credits' %}:
+        </th>
+        <td>
+            {{ credits.subscription.sms.amount }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if credits.subscription.general %}
+    <tr>
+        <th align="right">
+            {% trans 'General Credits' %}:
+        </th>
+        <td>
+            {{ credits.subscription.general.amount }}
+        </td>
+    </tr>
+    {% endif %}
+
+    {% if credits.account %}
+    <tr>
+        <th align="right">
+            <span style="text-decoration:underline;">{% trans 'Account Credits Remaining' %}</span>
+        </th>
+    </tr>
+    {% endif %}
+    {% if credits.account.product %}
+    <tr>
+        <th align="right">
+            {% trans 'Plan Credits' %}:
+        </th>
+        <td>
+            {{ credits.account.product.amount }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if credits.account.user %}
+    <tr>
+        <th align="right">
+            {% trans 'User Credits' %}:
+        </th>
+        <td>
+            {{ credits.account.user.amount }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if credits.account.sms %}
+    <tr>
+        <th align="right">
+            {% trans 'SMS Credits' %}:
+        </th>
+        <td>
+            {{ credits.account.sms.amount }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if credits.account.general %}
+    <tr>
+        <th align="right">
+            {% trans 'General Credits' %}:
+        </th>
+        <td>
+            {{ credits.account.general.amount }}
+        </td>
+    </tr>
+    {% endif %}
+</table>
+
+{% if is_total_balance_due %}
+    <p>
+        {% if is_small_invoice %}
+            {% blocktrans %}
+            Please note that the due date for this {{ month_name }} payment has been
+            postponed, as the amount due this month is less than $100. However as
+            your total balance is now beyond $100, please note that you have to pay
+            your balance within the next 30 days.
+            {% endblocktrans %}
+        {% else  %}
+            {% blocktrans %}
+            Your total balance is now beyond $100, please note that you have to pay
+            your balance within the next 30 days.
+            {% endblocktrans %}
+        {% endif %}
+    </p>
+
+    <p>
+        {% if can_view_statement %}
+            {% blocktrans %}
+            To view the full billing statement, log into your project space on
+            CommCareHQ and navigate to <a href="{{ statements_url }}">
+            Billing Statements</a>.
+            {% endblocktrans %}
+        {% else %}
+            {% blocktrans %}
+            Your project's administrator can view the full billing statement by
+            logging into your project space on CommCareHQ and navigating to
+            <a href="{{ statements_url }}">Billing Statements</a>.
+            {% endblocktrans %}
+        {% endif %}
+    </p>
+
+    <p>
+        {% blocktrans %}
+        You can pay this bill by credit card or by wire:
+        <ul>
+            <li>
+                To pay by credit card, please go to your
+                <a href="{{ statements_url }}">Billing Statements</a> page, click
+                on the green "Make Payment" button in front of your unpaid
+                invoice(s), and fill in the amount you want to pay as well as your
+                credit card details.
+            </li>
+            <li>
+                To pay by wire, find Dimagi's bank account details on your invoice.
+                Please include the invoice number in your wire payment and make
+                sure to send an email to {{ accounts_email }} after you have made
+                the payment, mentioning the date of the payment, the amount, the
+                invoice number, and the project space.
+            </li>
+        </ul>
+        {% endblocktrans %}
+    </p>
+{% else %}
+    <p>
+        {% if total_balance > 0 %}
+        {% blocktrans %}
+            Please note that the due date for this payment has been postponed, as
+            the amount due this month is less than $100.  You will start receiving
+            reminder emails for payments once your total balance reaches $100.
+        {% endblocktrans %}
+        {% endif %}
+
+        {% if can_view_statement %}
+            {% blocktrans %}
+            To view and pay invoices, you can log into your project space on
+            CommCareHQ and navigate to <a href="{{ statements_url }}">Billing Statements</a>.
+            {% endblocktrans %}
+        {% else %}
+            {% blocktrans %}
+            To view and pay invoices, your project's administrator can log into your project space on
+            CommCareHQ and navigate to <a href="{{ statements_url }}">Billing Statements</a>.
+            {% endblocktrans %}
+        {% endif %}
+    </p>
+{% endif %}
+
+<p>
+    {% blocktrans %}
+    Thank you for using {{ plan_name }}. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    Best Regards,<br />
+    The CommCare HQ Team<br />
+    www.commcarehq.org
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    Statement From:
+    CommCare HQ and the corporation Dimagi, Inc.
+    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    {% endblocktrans %}
+</p>

--- a/corehq/apps/accounting/templates/accounting/email/customer_invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_invoice.txt
@@ -1,0 +1,88 @@
+{% load i18n %}
+{% blocktrans %}
+{{ greeting }}
+
+Your {{ month_name }} Billing Statement is now available for Customer Account {{ account_name }}.
+
+Statement No.: {{ statement_number }}
+Account: {{ account_name }}
+Status: {{ payment_status }}
+Amount Due this Month: {{ amount_due }}
+Total Balance: {{ total_balance }}
+{% endblocktrans %}
+{% if total_balance > 0 %}
+{% blocktrans %}
+    Payment Due Date: {{ date_due }}
+{% endblocktrans %}
+{% endif  %}
+
+{% if is_total_balance_due %}
+    {% if is_small_invoice %}
+        {% blocktrans %}
+        Please note that the due date for this {{ month_name }} payment has been
+        postponed, as the amount due this month is less than $100. However as
+        your total balance is now beyond $100, please note that you have to pay
+        your balance within the next 30 days.
+        {% endblocktrans %}
+    {% endif %}
+
+
+    {% if can_view_statement %}
+        {% blocktrans %}
+        To view the full billing statement, log into your project space on
+        CommCareHQ and navigate to Billing Statements at {{ statements_url }}
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans %}
+        Your project's administrator can view the full billing statement by
+        logging into your project space on CommCareHQ and navigating to
+        Billing Statements at {{ statements_url }}
+        {% endblocktrans %}
+    {% endif %}
+
+    {% blocktrans %}
+    To pay this bill, you can either choose a credit card or wire payment:
+        - To pay by credit card, please go to your Billing Statements page, click
+          on the green "Make Payment" button in front of your unpaid invoice(s),
+          and fill in the amount you want to pay as well as your credit card
+          details.
+        - To pay by wire, find Dimagi's bank account details on your invoice.
+          Please include the invoice number in your wire payment and make sure to
+          send an email to {{ accounts_email }} after you have made the payment,
+          mentioning the date of the payment, the amount, the invoice number, and
+          the project space.
+    {% endblocktrans %}
+{% else %}
+    {% if total_balance > 0 %}
+    {% blocktrans %}
+        Please note that the due date for this payment has been postponed, as
+        the amount due this month is less than $100.  You will start receiving
+        reminder emails for payments once your total balance reaches $100.
+    {% endblocktrans %}
+    {% endif  %}
+
+    {% if can_view_statement %}
+        {% blocktrans %}
+        To view and pay invoices, you can log into your project space on
+        CommCareHQ and navigate to Billing Statements at {{ statements_url }}
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans %}
+        To view and pay invoices, your project's administrator can log into your project space on
+        CommCareHQ and navigate to Billing Statements at {{ statements_url }}
+        {% endblocktrans %}
+    {% endif %}
+{% endif %}
+
+{% blocktrans %}
+Thank you for using {{ plan_name }}. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
+
+Best Regards,
+The CommCare HQ Team
+www.commcarehq.org
+
+
+Statement From:
+CommCare HQ and the corporation Dimagi, Inc.
+585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+{% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/customer_invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_invoice.txt
@@ -77,7 +77,7 @@ Total Balance: {{ total_balance }}
 {% blocktrans %}
 Thank you for using {{ plan_name }}. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
 
-Best Regards,
+Best regards,
 The CommCare HQ Team
 www.commcarehq.org
 

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -5,7 +5,7 @@ from django.core import mail
 from corehq.apps.accounting.tests.test_invoicing import BaseInvoiceTestCase
 from corehq.apps.accounting import utils, tasks
 from corehq.apps.accounting.invoicing import DomainWireInvoiceFactory
-from corehq.apps.accounting.models import Invoice
+from corehq.apps.accounting.models import Invoice, CustomerInvoice
 
 
 class TestWireInvoice(BaseInvoiceTestCase):
@@ -25,6 +25,38 @@ class TestWireInvoice(BaseInvoiceTestCase):
         factory = DomainWireInvoiceFactory(
             self.domain_name,
             contact_emails=[self.dimagi_user],
+        )
+        balance = Decimal(100)
+
+        mail.outbox = []
+        wi = factory.create_wire_invoice(balance)
+
+        self.assertEqual(wi.balance, balance)
+        self.assertEqual(wi.domain, self.domain.name)
+        self.assertEqual(len(mail.outbox), 1)
+
+
+class TestCustomerAccountWireInvoice(BaseInvoiceTestCase):
+
+    def setUp(self):
+        super(TestCustomerAccountWireInvoice, self).setUp()
+        self.account.is_customer_billing_account = True
+        self.account.save()
+
+        invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        tasks.generate_invoices(invoice_date)
+
+        invoice_date = utils.months_from_date(self.subscription.date_start, 3)
+        tasks.generate_invoices(invoice_date)
+
+        self.invoices = CustomerInvoice.objects.all()
+        self.domain_name = self.invoices.first().subscriptions.first().subscriber.domain
+
+    def test_factory(self):
+        factory = DomainWireInvoiceFactory(
+            self.domain_name,
+            contact_emails=[self.dimagi_user],
+            account=self.account
         )
         balance = Decimal(100)
 

--- a/corehq/apps/accounting/urls.py
+++ b/corehq/apps/accounting/urls.py
@@ -27,7 +27,8 @@ from corehq.apps.accounting.views import (
     enterprise_dashboard_total,
     enterprise_settings,
     edit_enterprise_settings,
-    CustomerInvoicePdfView
+    CustomerInvoicePdfView,
+    EnterpriseBillingStatementsView
 )
 
 
@@ -74,4 +75,6 @@ domain_specific = [
         name='enterprise_dashboard_total'),
     url(r'^settings/$', enterprise_settings, name='enterprise_settings'),
     url(r'^settings/edit/$', edit_enterprise_settings, name='edit_enterprise_settings'),
+    url(r'^billing_statements/$', EnterpriseBillingStatementsView.as_view(),
+        name=EnterpriseBillingStatementsView.urlname),
 ]

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -1287,7 +1287,8 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
 
     @property
     def invoices(self):
-        invoices = CustomerInvoice.objects.filter(account=self.account)
+        account = self.account or _get_account_or_404(self.request, self.request.domain)
+        invoices = CustomerInvoice.objects.filter(account=account)
         if not self.show_hidden:
             invoices = invoices.filter(is_hidden=False)
         if self.show_unpaid:
@@ -1309,8 +1310,9 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
         Returns the total balance of unpaid, unhidden invoices.
         Doesn't take into account the view settings on the page.
         """
+        account = self.account or _get_account_or_404(self.request, self.request.domain)
         invoices = (CustomerInvoice.objects
-                    .filter(account=self.account)
+                    .filter(account=account)
                     .filter(date_paid__exact=None)
                     .filter(is_hidden=False))
         return invoices.aggregate(
@@ -1414,6 +1416,4 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
         return self.paginate_crud_response
 
     def dispatch(self, request, *args, **kwargs):
-        if self.account is None:
-            raise Http404()
         return super(EnterpriseBillingStatementsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -410,8 +410,12 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
     def invoice_context(self):
         subscriber_domain = self.subscription.subscriber.domain
 
-        invoice_report = InvoiceInterface(self.request)
-        invoice_report.filter_by_subscription(self.subscription)
+        if self.subscription.account.is_customer_billing_account:
+            invoice_report = CustomerInvoiceInterface(self.request)
+            invoice_report.filter_by_account(self.subscription.account)
+        else:
+            invoice_report = InvoiceInterface(self.request)
+            invoice_report.filter_by_subscription(self.subscription)
         # Tied to InvoiceInterface.
         encoded_params = urlencode({'subscriber': subscriber_domain})
         invoice_report_url = "{}?{}".format(invoice_report.get_url(), encoded_params)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -1418,6 +1418,3 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
 
     def post(self, *args, **kwargs):
         return self.paginate_crud_response
-
-    def dispatch(self, request, *args, **kwargs):
-        return super(EnterpriseBillingStatementsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -971,7 +971,7 @@ class CustomerInvoiceSummaryView(InvoiceSummaryViewBase):
     def page_context(self):
         context = super(CustomerInvoiceSummaryView, self).page_context
         context.update({
-            'adjustment_balance_form': self.adjust_balance_form,
+            'adjust_balance_form': self.adjust_balance_form,
             'adjustment_list': self.adjustment_list
         })
         return context

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -8,6 +8,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.paginator import Paginator
+from django.db.models import Sum
 from django.forms.forms import NON_FIELD_ERRORS
 from django.forms.utils import ErrorList
 from django.urls import reverse
@@ -21,7 +22,7 @@ from django.http import (
 )
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from django.views.decorators.http import require_POST
 from django.views.generic import View
 
@@ -30,12 +31,21 @@ from dimagi.utils.couch.cache.cache_core import get_redis_client
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.domain.decorators import login_and_domain_required, require_superuser
+from corehq.apps.domain.views import (
+    BillingStatementPdfView,
+    PAYMENT_ERROR_MESSAGES,
+    InvoiceStripePaymentView,
+    WireInvoiceView,
+    BulkStripePaymentView,
+    DomainAccountingSettings
+)
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
     use_select2,
     use_jquery_ui,
     use_multiselect,
 )
+from corehq.const import USER_DATE_FORMAT
 
 import csv342 as csv
 from memoized import memoized
@@ -77,14 +87,17 @@ from corehq.apps.accounting.async_handlers import (
     SoftwarePlanAsyncHandler,
 )
 from corehq.apps.accounting.models import (
-    Invoice, WireInvoice, CustomerInvoice, BillingAccount, CreditLine, Subscription,
+    Invoice, WireInvoice, CustomerInvoice, BillingAccount, CreditLine, Subscription, CustomerBillingRecord,
     SoftwarePlanVersion, SoftwarePlan, CreditAdjustment, DefaultProductPlan, StripePaymentMethod, InvoicePdf
 )
 from corehq.apps.accounting.tasks import email_enterprise_report
 from corehq.apps.accounting.utils import (
     fmt_feature_rate_dict, fmt_product_rate_dict,
     has_subscription_already_ended,
-    log_accounting_error)
+    log_accounting_error,
+    quantize_accounting_decimal,
+    get_customer_cards
+)
 from corehq.apps.hqwebapp.views import BaseSectionPageView, CRUDPaginatedViewMixin
 from corehq import privileges
 from django_prbac.decorators import requires_privilege_raise404
@@ -1240,3 +1253,167 @@ def edit_enterprise_settings(request, domain):
         return enterprise_settings(request, domain)
 
     return HttpResponseRedirect(reverse('enterprise_settings', args=[domain]))
+
+
+class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMixin):
+    template_name = 'domain/billing_statements.html'
+    urlname = 'enterprise_billing_statements'
+    page_title = ugettext_lazy("Billing Statements")
+
+    limit_text = ugettext_lazy("statements per page")
+    empty_notification = ugettext_lazy("No Billing Statements match the current criteria.")
+    loading_message = ugettext_lazy("Loading statements...")
+
+    @property
+    def parameters(self):
+        return self.request.POST if self.request.method == 'POST' else self.request.GET
+
+    @property
+    def stripe_cards(self):
+        return get_customer_cards(self.request.user.username, self.domain)
+
+    @property
+    def show_hidden(self):
+        if not self.request.user.is_superuser:
+            return False
+        return bool(self.request.POST.get('additionalData[show_hidden]'))
+
+    @property
+    def show_unpaid(self):
+        try:
+            return json.loads(self.request.POST.get('additionalData[show_unpaid]'))
+        except TypeError:
+            return False
+
+    @property
+    def invoices(self):
+        invoices = CustomerInvoice.objects.filter(account=self.account)
+        if not self.show_hidden:
+            invoices = invoices.filter(is_hidden=False)
+        if self.show_unpaid:
+            invoices = invoices.filter(date_paid__exact=None)
+        return invoices.order_by('-date_start', '-date_end')
+
+    @property
+    def total(self):
+        return self.paginated_invoices.count
+
+    @property
+    @memoized
+    def paginated_invoices(self):
+        return Paginator(self.invoices, self.limit)
+
+    @property
+    def total_balance(self):
+        """
+        Returns the total balance of unpaid, unhidden invoices.
+        Doesn't take into account the view settings on the page.
+        """
+        invoices = (CustomerInvoice.objects
+                    .filter(account=self.account)
+                    .filter(date_paid__exact=None)
+                    .filter(is_hidden=False))
+        return invoices.aggregate(
+            total_balance=Sum('balance')
+        ).get('total_balance') or 0.00
+
+    @property
+    def column_names(self):
+        return [
+            _("Statement No."),
+            _("Billing Period"),
+            _("Date Due"),
+            _("Payment Status"),
+            _("PDF"),
+        ]
+
+    @property
+    def page_context(self):
+        pagination_context = self.pagination_context
+        pagination_context.update({
+            'stripe_options': {
+                'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
+                'stripe_cards': self.stripe_cards,
+            },
+            'payment_error_messages': PAYMENT_ERROR_MESSAGES,
+            'payment_urls': {
+                'process_invoice_payment_url': reverse(
+                    InvoiceStripePaymentView.urlname,
+                    args=[self.domain],
+                ),
+                'process_bulk_payment_url': reverse(
+                    BulkStripePaymentView.urlname,
+                    args=[self.domain],
+                ),
+                'process_wire_invoice_url': reverse(
+                    WireInvoiceView.urlname,
+                    args=[self.domain],
+                ),
+            },
+            'total_balance': self.total_balance,
+            'show_plan': False
+        })
+        return pagination_context
+
+    @property
+    def can_pay_invoices(self):
+        return self.request.couch_user.is_domain_admin(self.domain)
+
+    @property
+    def paginated_list(self):
+        for invoice in self.paginated_invoices.page(self.page).object_list:
+            try:
+                last_billing_record = CustomerBillingRecord.objects.filter(
+                    invoice=invoice
+                ).latest('date_created')
+                if invoice.is_paid:
+                    payment_status = (_("Paid on %s.")
+                                      % invoice.date_paid.strftime(USER_DATE_FORMAT))
+                    payment_class = "label label-default"
+                else:
+                    payment_status = _("Not Paid")
+                    payment_class = "label label-danger"
+                date_due = (
+                    (invoice.date_due.strftime(USER_DATE_FORMAT)
+                     if not invoice.is_paid else _("Already Paid"))
+                    if invoice.date_due else _("None")
+                )
+                yield {
+                    'itemData': {
+                        'id': invoice.id,
+                        'invoice_number': invoice.invoice_number,
+                        'start': invoice.date_start.strftime(USER_DATE_FORMAT),
+                        'end': invoice.date_end.strftime(USER_DATE_FORMAT),
+                        'plan': None,
+                        'payment_status': payment_status,
+                        'payment_class': payment_class,
+                        'date_due': date_due,
+                        'pdfUrl': reverse(
+                            BillingStatementPdfView.urlname,
+                            args=[self.domain, last_billing_record.pdf_data_id]
+                        ),
+                        'canMakePayment': (not invoice.is_paid
+                                           and self.can_pay_invoices),
+                        'balance': "%s" % quantize_accounting_decimal(invoice.balance),
+                    },
+                    'template': 'statement-row-template',
+                }
+            except CustomerBillingRecord.DoesNotExist:
+                log_accounting_error(
+                    "An invoice was generated for %(invoice_id)d "
+                    "(domain: %(domain)s), but no billing record!" % {
+                        'invoice_id': invoice.id,
+                        'domain': self.domain,
+                    }
+                )
+
+    def refresh_item(self, item_id):
+        pass
+
+    def post(self, *args, **kwargs):
+        return self.paginate_crud_response
+
+    def dispatch(self, request, *args, **kwargs):
+        if self.account is None:
+            raise Http404()
+        return super(EnterpriseBillingStatementsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/domain/templates/domain/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/billing_statements.html
@@ -11,6 +11,7 @@
     {% initial_page_data 'payment_error_messages' payment_error_messages %}
     {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}
     {% initial_page_data 'total_balance' total_balance %}
+    {% initial_page_data 'show_plan' show_plan %}
 
     <div id="currentBalanceSection">
         <h2>{% trans 'Total Due:' %}
@@ -62,7 +63,9 @@
 {% block pagination_templates %}
     <script type="text/html" id="statement-row-template">
         <td class="col-sm-2" data-bind="text: invoice_number"></td>
-        <td class="col-sm-2" data-bind="text: plan.name"></td>
+        {% if show_plan %}
+            <td class="col-sm-2" data-bind="text: plan.name"></td>
+        {% endif %}
         <td class="col-sm-3">
             <span data-bind="text: start"></span> - <span data-bind="text: end"></span>
         </td>

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -92,7 +92,7 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan, SoftwarePlanEdition, BillingAccount,
     BillingAccountType,
     Invoice, BillingRecord, InvoicePdf, PaymentMethodType,
-    EntryPoint, WireInvoice,
+    EntryPoint, WireInvoice, CustomerInvoice,
     StripePaymentMethod, LastPayment,
     UNLIMITED_FEATURE_USAGE, MINIMUM_SUBSCRIPTION_LENGTH
 )
@@ -882,6 +882,7 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
                 ),
             },
             'total_balance': self.total_balance,
+            'show_plan': True
         })
         return pagination_context
 
@@ -1152,24 +1153,37 @@ class BillingStatementPdfView(View):
                     pk=invoice_pdf.invoice_id,
                     domain=domain
                 )
+            elif invoice_pdf.is_customer:
+                invoice = CustomerInvoice.objects.get(
+                    pk=invoice_pdf.invoice_id
+                )
             else:
                 invoice = Invoice.objects.get(
                     pk=invoice_pdf.invoice_id,
                     subscription__subscriber__domain=domain
                 )
-        except (Invoice.DoesNotExist, WireInvoice.DoesNotExist):
+        except (Invoice.DoesNotExist, WireInvoice.DoesNotExist, CustomerInvoice.DoesNotExist):
             raise Http404()
 
-        if invoice.is_wire:
-            edition = 'Bulk'
+        if invoice.is_customer_invoice:
+            from corehq.apps.accounting.views import _get_account_or_404
+            account = _get_account_or_404(request, domain)
+            filename = "%(pdf_id)s_%(account)s_%(filename)s" % {
+                'pdf_id': invoice_pdf._id,
+                'account': account,
+                'filename': invoice_pdf.get_filename(invoice)
+            }
         else:
-            edition = DESC_BY_EDITION[invoice.subscription.plan_version.plan.edition]['name']
-        filename = "%(pdf_id)s_%(domain)s_%(edition)s_%(filename)s" % {
-            'pdf_id': invoice_pdf._id,
-            'domain': domain,
-            'edition': edition,
-            'filename': invoice_pdf.get_filename(invoice),
-        }
+            if invoice.is_wire:
+                edition = 'Bulk'
+            else:
+                edition = DESC_BY_EDITION[invoice.subscription.plan_version.plan.edition]['name']
+            filename = "%(pdf_id)s_%(domain)s_%(edition)s_%(filename)s" % {
+                'pdf_id': invoice_pdf._id,
+                'domain': domain,
+                'edition': edition,
+                'filename': invoice_pdf.get_filename(invoice),
+            }
         try:
             data = invoice_pdf.get_data(invoice)
             response = HttpResponse(data, content_type='application/pdf')

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1119,9 +1119,11 @@ class WireInvoiceView(View):
         return super(WireInvoiceView, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
+        from corehq.apps.accounting.views import _get_account_or_404
         emails = request.POST.get('emails', []).split()
         balance = Decimal(request.POST.get('customPaymentAmount', 0))
-        wire_invoice_factory = DomainWireInvoiceFactory(request.domain, contact_emails=emails)
+        account = _get_account_or_404(request, request.domain)
+        wire_invoice_factory = DomainWireInvoiceFactory(request.domain, contact_emails=emails, account=account)
         try:
             wire_invoice_factory.create_wire_invoice(balance)
         except Exception as e:

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1350,6 +1350,10 @@ class EnterpriseSettingsTab(UITab):
                 'title': _('Enterprise Settings'),
                 'url': reverse('enterprise_settings', args=[self.domain]),
             },
+            {
+                'title': _('Billing Statements'),
+                'url': reverse('enterprise_billing_statements', args=[self.domain])
+            }
         ]))
         return items
 


### PR DESCRIPTION
Original Specs and QA tickets:
https://docs.google.com/document/d/1wdN02xuGMXuLPoQ3QJ16zm_WNNA2-u8yDl5kFxVGzCM/edit
https://manage.dimagi.com/default.asp?282068
https://manage.dimagi.com/default.asp?282080
https://manage.dimagi.com/default.asp?282076
http://manage.dimagi.com/default.asp?282086
https://manage.dimagi.com/default.asp?281922
https://manage.dimagi.com/default.asp?281923
https://manage.dimagi.com/default.asp?282083


I added a Billing Statements page on the Enterprise Dashboard, where a user can pay off invoices by wire or credit card:
<img width="1438" alt="enterprise dashboard - billing statements" src="https://user-images.githubusercontent.com/15271571/46172933-dcb96d00-c272-11e8-9216-e9e61f26440c.png">

The email for customer invoices looks a little different. `Billing Statements` links to the Enterprise Dashboard page above. The account is listed in the email, and neither domain nor plan are listed:
<img width="1105" alt="enterprise customer invoice email" src="https://user-images.githubusercontent.com/15271571/46172972-fbb7ff00-c272-11e8-83b1-9193003b50ea.png">

I also added customer invoices to the subscriptions page. Any subscription that is associated with a customer account will show all the customer invoices for that account. As in the Customer Invoices search page, there is no Subscription or Project Space field:
<img width="1440" alt="cusotmer invoices on subscriptions page" src="https://user-images.githubusercontent.com/15271571/46174402-e8a72e00-c276-11e8-8980-2a1f4feb40ed.png">
