### PR TITLE
Add ability to override logos for linked applications

### DIFF
--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -70,7 +70,11 @@ def _load_commcare_settings_layout(doc_type):
         section['title'] = ugettext_noop(section['title'])
         for i, key in enumerate(section['settings']):
             setting = settings.pop(key)
-            if doc_type == 'Application' or setting['type'] == 'hq':
+            if doc_type == 'Application':
+                section['settings'][i] = setting
+            elif doc_type != 'LinkedApplication' and setting['type'] == 'hq':
+                section['settings'][i] = setting
+            elif doc_type == 'LinkedApplication' and setting.get('supports_linked_app'):
                 section['settings'][i] = setting
             else:
                 section['settings'][i] = None
@@ -99,9 +103,7 @@ def get_custom_commcare_settings():
 
 @memoized
 def get_commcare_settings_layout(doc_type):
-    if doc_type == "LinkedApplication":
-        return {}
-    if doc_type in ['Application', 'RemoteApp']:
+    if doc_type in ['Application', 'RemoteApp', 'LinkedApplication']:
         return _load_commcare_settings_layout(doc_type)
     raise Exception("Unexpected doc_type received: %s" % doc_type)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6567,6 +6567,7 @@ class LinkedApplication(Application):
     # The following properties will overwrite their corresponding values from
     # the master app everytime the new master is pulled
     linked_app_translations = DictProperty()  # corresponding property: translations
+    linked_app_logo_refs = DictProperty()  # corresponding property: logo_refs
 
     @property
     @memoized
@@ -6589,8 +6590,9 @@ class LinkedApplication(Application):
         else:
             raise ActionNotPermitted
 
-    def reapply_translations(self):
+    def reapply_overrides(self):
         self.translations.update(self.linked_app_translations)
+        self.logo_refs.update(self.linked_app_logo_refs)
         self.save()
 
 

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -84,6 +84,7 @@
   id: "logo_android_home"
   widget: "image_uploader"
   privilege: "commcare_logo_uploader"
+  supports_linked_app: true
   force: true
 
 - name: "Login Logo"
@@ -91,6 +92,7 @@
   id: "logo_android_login"
   widget: "image_uploader"
   privilege: "commcare_logo_uploader"
+  supports_linked_app: true
   force: true
 
 - disabled: true

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -168,7 +168,6 @@
         <li><a href="#linked-app" data-toggle="tab">{% trans "Linked Application" %}</a></li>
         <li><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
         <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
-        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
     {% else %}
         <li><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
         {% if app.get_doc_type == 'Application' %}
@@ -176,8 +175,8 @@
         {% endif %}
         <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
         <li><a href="#add-ons" data-toggle="tab">{% trans "Add-ons" %}</a></li>
-        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
     {% endif %}
+      <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
     </ul>
     <div class="tab-content appmanager-tab-content">
         {% if app.get_doc_type == 'LinkedApplication' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -168,6 +168,7 @@
         <li><a href="#linked-app" data-toggle="tab">{% trans "Linked Application" %}</a></li>
         <li><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
         <li><a href="#actions" data-toggle="tab">{% trans "Actions" %}</a></li>
+        <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
     {% else %}
         <li><a href="#languages" data-toggle="tab">{% trans "Languages" %}</a></li>
         {% if app.get_doc_type == 'Application' %}

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -343,7 +343,7 @@ def update_linked_app(app, user_id):
     app.domain_link.update_last_pull('app', user_id, model_details=AppLinkDetail(app_id=app._id))
 
     # reapply linked application specific data
-    app.reapply_translations()
+    app.reapply_overrides()
 
 
 def clear_xmlns_app_id_cache(domain):

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -278,7 +278,8 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
 
     context['latest_commcare_version'] = get_commcare_versions(request.user)[-1]
 
-    if app and app.doc_type == 'Application' and has_privilege(request, privileges.COMMCARE_LOGO_UPLOADER):
+    if (app and app.doc_type in ('Application', 'LinkedApplication')
+            and has_privilege(request, privileges.COMMCARE_LOGO_UPLOADER)):
         uploader_slugs = list(ANDROID_LOGO_PROPERTY_MAPPING.keys())
         from corehq.apps.hqmedia.controller import MultimediaLogoUploadController
         from corehq.apps.hqmedia.views import ProcessLogoFileUploadView

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -373,6 +373,8 @@ class ProcessLogoFileUploadView(ProcessImageFileUploadView):
             ProcessLogoFileUploadView, self
         ).process_upload()
         self.app.logo_refs[self.filename] = ref['ref']
+        if self.app.doc_type == 'LinkedApplication':
+            self.app.linked_app_logo_refs[self.filename] = ref['ref']
         self.app.save()
         return ref
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -176,6 +176,56 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(self.linked_app.linked_app_translations, translations)
         self.assertEqual(self.linked_app.translations, translations)
 
+    def test_override_logo(self):
+        logo_refs = {
+            "hq_logo_android_home": {
+                "humanized_content_length": "45.4 KB",
+                "icon_class": "fa fa-picture-o",
+                "image_size": "448 X 332 Pixels",
+                "m_id": "e3c45dd61c5593fdc5d985f0b99f6199",
+                "media_type": "Image",
+                "path": "jr://file/commcare/logo/data/hq_logo_android_home.png",
+                "uid": "3b79a76a067baf6a23a0b6978b2fb352",
+                "updated": False,
+                "url": "/hq/multimedia/file/CommCareImage/e3c45dd61c5593fdc5d985f0b99f6199/"
+            },
+            "hq_logo_android_login": {
+                "humanized_content_length": "23.9 KB",
+                "icon_class": "fa fa-picture-o",
+                "image_size": "600 X 233 Pixels",
+                "m_id": "85dfa763344eea7b23f4d7fcd000db69",
+                "media_type": "Image",
+                "path": "jr://file/commcare/logo/data/hq_logo_android_login.png",
+                "uid": "595f99385362625eac8245c05f36f3d4",
+                "updated": False,
+                "url": "/hq/multimedia/file/CommCareImage/85dfa763344eea7b23f4d7fcd000db69/"
+            }
+        }
+
+        self.linked_app.master = self.plain_master_app.get_id
+
+        copy = self.plain_master_app.make_build()
+        copy.save()
+        self.addCleanup(copy.delete)
+
+        self.plain_master_app.save()  # increment version number
+        copy1 = self.plain_master_app.make_build()
+        copy1.is_released = True
+        copy1.save()
+        self.addCleanup(copy1.delete)
+
+        self.linked_app.linked_app_logo_refs = logo_refs
+        self.linked_app.save()
+        self.assertEqual(self.linked_app.logo_refs, {})
+
+        update_linked_app(self.linked_app, 'test_override_logos')
+        # fetch after update to get the new version
+        self.linked_app = LinkedApplication.get(self.linked_app._id)
+
+        self.assertEqual(self.plain_master_app.logo_refs, {})
+        self.assertEqual(self.linked_app.linked_app_logo_refs, logo_refs)
+        self.assertEqual(self.linked_app.logo_refs, logo_refs)
+
 
 class TestRemoteLinkedApps(BaseLinkedAppsTest):
 


### PR DESCRIPTION
Building off of https://github.com/dimagi/commcare-hq/pull/21898

I think there's a code smell here with all the `if doc_type == 'LinkedApplication'`. I'm not sure of the best way to deal with it though. Happy to listen to any feedback on that.