### PR TITLE
Make the dot-menu allow for 7 inline dots

### DIFF
--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -365,7 +365,7 @@ body {
 
 .dot-menu-item {
     display: inline-block;
-    width: 15%;
+    width: 14%;
     margin: 0 auto;
     text-align: center;
     vertical-align: text-top;


### PR DESCRIPTION
Hi @calellowitz,
I have changed the width of the dot's in the dot-menu to make 7 dots from the AWC reports be inline.
Regards, Dawid.