### PR TITLE
delete all types of SQL forms when deleting a domain

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -141,10 +141,10 @@ def _delete_all_cases(domain_name):
 def _delete_all_forms(domain_name):
     logger.info('Deleting forms...')
     form_accessor = FormAccessors(domain_name)
-    form_ids = list(itertools.chain(
+    form_ids = list(itertools.chain(*[
         form_accessor.get_all_form_ids_in_domain(doc_type=doc_type)
         for doc_type in doc_type_to_state
-    ))
+    ]))
     for form_id_chunk in chunked(with_progress_bar(form_ids, stream=silence_during_tests()), 500):
         form_accessor.soft_delete_forms(list(form_id_chunk))
     logger.info('Deleting forms complete.')

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import itertools
 import logging
 from datetime import date
 
@@ -17,6 +18,7 @@ from corehq.apps.products.views import ProductFieldsView
 from corehq.apps.users.views.mobile import UserFieldsView
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
+from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.sql_db.util import get_db_alias_for_partitioned_doc
 from corehq.util.log import with_progress_bar
@@ -139,7 +141,10 @@ def _delete_all_cases(domain_name):
 def _delete_all_forms(domain_name):
     logger.info('Deleting forms...')
     form_accessor = FormAccessors(domain_name)
-    form_ids = form_accessor.get_all_form_ids_in_domain()
+    form_ids = list(itertools.chain(
+        form_accessor.get_all_form_ids_in_domain(doc_type=doc_type)
+        for doc_type in doc_type_to_state
+    ))
     for form_id_chunk in chunked(with_progress_bar(form_ids, stream=silence_during_tests()), 500):
         form_accessor.soft_delete_forms(list(form_id_chunk))
     logger.info('Deleting forms complete.')


### PR DESCRIPTION
Previously, we were only deleting XFormInstance.

@ctsims 