### PR TITLE
assert that ES is empty when deleting a domain

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -12,6 +12,7 @@ from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.utils import get_change_status
 from corehq.apps.custom_data_fields.dbaccessors import get_by_domain_and_type
 from corehq.apps.domain.utils import silence_during_tests
+from corehq.apps.es import AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES
 from corehq.apps.locations.views import LocationFieldsView
 from corehq.apps.products.views import ProductFieldsView
 from corehq.apps.users.views.mobile import UserFieldsView
@@ -162,6 +163,11 @@ def _delete_custom_data_fields(domain_name):
     logger.info('Deleting custom data fields complete.')
 
 
+def _assert_es_empty(domain_name):
+    for hqESQuery in [AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES]:
+        assert hqESQuery().domain(domain_name).run().total == 0, '%s contains data' % hqESQuery.index
+
+
 # We use raw queries instead of ORM because Django queryset delete needs to
 # fetch objects into memory to send signals and handle cascades. It makes deletion very slow
 # if we have a millions of rows in stock data tables.
@@ -232,6 +238,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('motech', 'RequestLog', 'domain'),
     ModelDeletion('couchforms', 'UnfinishedSubmissionStub', 'domain'),
     CustomDeletion('custom_data_fields', _delete_custom_data_fields),
+    CustomDeletion('es', _assert_es_empty),
 ]
 
 

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -12,7 +12,6 @@ from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.utils import get_change_status
 from corehq.apps.custom_data_fields.dbaccessors import get_by_domain_and_type
 from corehq.apps.domain.utils import silence_during_tests
-from corehq.apps.es import AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES
 from corehq.apps.locations.views import LocationFieldsView
 from corehq.apps.products.views import ProductFieldsView
 from corehq.apps.users.views.mobile import UserFieldsView
@@ -163,11 +162,6 @@ def _delete_custom_data_fields(domain_name):
     logger.info('Deleting custom data fields complete.')
 
 
-def _assert_es_empty(domain_name):
-    for hqESQuery in [AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES]:
-        assert hqESQuery().domain(domain_name).run().total == 0, '%s contains data' % hqESQuery.index
-
-
 # We use raw queries instead of ORM because Django queryset delete needs to
 # fetch objects into memory to send signals and handle cascades. It makes deletion very slow
 # if we have a millions of rows in stock data tables.
@@ -238,7 +232,6 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('motech', 'RequestLog', 'domain'),
     ModelDeletion('couchforms', 'UnfinishedSubmissionStub', 'domain'),
     CustomDeletion('custom_data_fields', _delete_custom_data_fields),
-    CustomDeletion('es', _assert_es_empty),
 ]
 
 

--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -42,9 +42,10 @@ class Command(BaseCommand):
                 print("\n\t\tDomain deletion cancelled.")
                 return
 
+        print("Deleting domain {}".format(domain_name))
+        domain.delete()
+
         for hqESQuery in [AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES]:
             assert hqESQuery().domain(domain_name).run().total == 0, '%s contains data' % hqESQuery.index
 
-        print("Deleting domain {}".format(domain_name))
-        domain.delete()
         print("Operation completed")

--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 
 from corehq.apps.domain.models import Domain
+from corehq.apps.es import AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES
 from six.moves import input
 
 
@@ -40,6 +41,10 @@ class Command(BaseCommand):
             if confirm != domain_name:
                 print("\n\t\tDomain deletion cancelled.")
                 return
+
+        for hqESQuery in [AppES, CaseES, CaseSearchES, DomainES, FormES, GroupES, LedgerES, UserES]:
+            assert hqESQuery().domain(domain_name).run().total == 0, '%s contains data' % hqESQuery.index
+
         print("Deleting domain {}".format(domain_name))
         domain.delete()
         print("Operation completed")


### PR DESCRIPTION
Adding this check because some previously deleted case data was still in ES for enikshay, and was not removed by deleting other cases.

We would want to know that data still is in ES, if it requires manual intervention to clear.