### PR TITLE
Make breadcrumbs consistent in data dictionary

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -1,20 +1,8 @@
-{% extends "hqwebapp/two_column.html" %}
+{% extends "hqwebapp/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
+
 {% requirejs_main "data_dictionary/js/data_dictionary" %}
-
-{% block title %}{% trans "Data Dictionary" %}{% endblock %}\
-
-{% block page_breadcrumbs %}
-    <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
-        <li>
-            <a href="{% url 'data_interfaces_default' domain %}"><strong>{% trans "Data" %}</strong></a>
-        </li>
-        <li>
-            <a href="{% url 'data_dictionary' domain %}">{% trans "Data Dictionary" %}</a>
-        </li>
-    </ol>
-{% endblock %}
 
 {% block page_navigation %}
     <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/import_data_dict.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/import_data_dict.html
@@ -7,20 +7,6 @@
     <script src="{% static 'hqwebapp/js/bulk_upload_file.js' %}"></script>
 {% endblock %}
 
-{% block page_breadcrumbs %}
-    <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
-        <li>
-            <a href="{% url 'data_interfaces_default' domain %}"><strong>{% trans "Data" %}</strong></a>
-        </li>
-        <li>
-            <a href="{% url 'data_dictionary' domain %}">{% trans "Data Dictionary" %}</a>
-        </li>
-        <li>
-            <a href="{% url 'upload_data_dict' domain %}">{% trans "Upload Data Dictionary" %}</a>
-        </li>
-    </ol>
-{% endblock %}
-
 {% block page_content %}
     {% include "hqwebapp/partials/bulk_upload.html" %}
 {% endblock %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/import_data_dict.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/import_data_dict.html
@@ -3,9 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/bulk_upload_file.js' %}"></script>
-{% endblock %}
+{% requirejs_main 'hqwebapp/js/bulk_upload_file' %}
 
 {% block page_content %}
     {% include "hqwebapp/partials/bulk_upload.html" %}

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -152,7 +152,7 @@ class ExportDataDictionaryView(View):
 
 
 class DataDictionaryView(BaseProjectDataView):
-    section_name = _("Data Dictionary")
+    page_title = _("Data Dictionary")
     template_name = "data_dictionary/base.html"
     urlname = 'data_dictionary'
 
@@ -170,14 +170,9 @@ class DataDictionaryView(BaseProjectDataView):
         })
         return main_context
 
-    @property
-    @memoized
-    def section_url(self):
-        return reverse(DataDictionaryView.urlname, args=[self.domain])
-
 
 class UploadDataDictionaryView(BaseProjectDataView):
-    section_name = _("Data Dictionary")
+    page_title = _("Upload Data Dictionary")
     template_name = "data_dictionary/import_data_dict.html"
     urlname = 'upload_data_dict'
 
@@ -186,6 +181,13 @@ class UploadDataDictionaryView(BaseProjectDataView):
     @method_decorator(toggles.DATA_DICTIONARY.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         return super(UploadDataDictionaryView, self).dispatch(request, *args, **kwargs)
+
+    @property
+    def parent_pages(self):
+        return [{
+            'title': DataDictionaryView.page_title,
+            'url': reverse(DataDictionaryView.urlname, args=(self.domain,)),
+        }]
 
     @property
     def page_context(self):


### PR DESCRIPTION
From summit ux session. Use standard breadcrumb code. Makes last breadcrumb (current page) not a link, and fixes page title on upload page.

@Rohit25negi / @calellowitz 