### PR TITLE
Make breadcrumbs consistent on crud pages

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -4,19 +4,6 @@
 
 {% requirejs_main 'data_interfaces/js/list_automatic_update_rules' %}
 
-{% block title %}{{ current_page.title }}{% endblock %}
-
-{% block page_breadcrumbs %}
-    <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
-        <li>
-            <a href="{% url "data_interfaces_default" domain %}"><strong>{% trans "Data" %}</strong></a>
-        </li>
-        <li class="active">
-            {% trans "Automatically Close Cases" %}
-        </li>
-    </ol>
-{% endblock %}
-
 {% block pagination_header %}
     <div class="row">
         <div class="col-sm-8">

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -49,6 +49,7 @@ from corehq.apps.data_interfaces.dispatcher import (
 )
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.hqwebapp.decorators import use_typeahead, use_angular_js
+from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.const import SERVER_DATETIME_FORMAT
 from .dispatcher import require_form_management_privilege
 from .interfaces import FormManagementMode, BulkFormManagementInterface
@@ -114,7 +115,7 @@ class DataInterfaceSection(BaseDomainView):
         return reverse("data_interfaces_default", args=[self.domain])
 
 
-class CaseGroupListView(DataInterfaceSection, CRUDPaginatedViewMixin):
+class CaseGroupListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
     template_name = "data_interfaces/list_case_groups.html"
     urlname = 'case_group_list'
     page_title = ugettext_lazy("Case Groups")

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -299,7 +299,7 @@ class BaseProjectSettingsView(BaseDomainView):
     @property
     @memoized
     def section_url(self):
-        return reverse(EditMyProjectSettingsView.urlname, args=[self.domain])
+        return reverse(EditBasicProjectInfoView.urlname, args=[self.domain])
 
 
 class DefaultProjectSettingsView(BaseDomainView):

--- a/corehq/apps/hqadmin/views/utils.py
+++ b/corehq/apps/hqadmin/views/utils.py
@@ -47,7 +47,7 @@ def get_hqadmin_base_context(request):
 
 
 class BaseAdminSectionView(BaseSectionPageView):
-    section_name = ugettext_lazy("Admin Reports")
+    section_name = ugettext_lazy("Admin")
 
     @property
     def section_url(self):

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base_paginated_crud.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base_paginated_crud.html
@@ -1,4 +1,4 @@
-{% extends 'hqwebapp/two_column.html' %}
+{% extends 'hqwebapp/base_section.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}

--- a/corehq/apps/sms/templates/sms/manage_registration_invitations.html
+++ b/corehq/apps/sms/templates/sms/manage_registration_invitations.html
@@ -15,17 +15,6 @@
 </script>
 {% endblock %}
 
-{% block page_breadcrumbs %}
-    <ol id="hq-breadcrumbs" class="breadcrumb breadcrumb-hq-section">
-        <li><a href="{{ section.url }}"><strong>{{ section.page_name }}</strong></a></li>
-        {% for parent in current_page.parents %}
-            <li><a href="{{ parent.url }}">{{ parent.title }}</a></li>
-        {% endfor %}
-        <li class="active">{{ current_page.page_name }}</li>
-    </ol>
-{% endblock %}
-
-
 {% block page_content %}
 {% if sms_mobile_worker_registration_enabled %}
 <a href="#invitation-form"


### PR DESCRIPTION
From summit ux session. Adds breadcrumbs to a few pages that were missing them: keyword list, sms connectivity pages.

@Rohit25negi / @calellowitz 