### PR TITLE
periodically check that no forms or cases are missing a domain

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -152,13 +152,13 @@ def clear_expired_sessions():
 def check_for_sql_cases_without_existing_domain():
     existing_domain_names = set(Domain.get_all_names())
 
-    case_domain_names = set()
+    missing_domains_with_cases = set()
     db_names = get_db_aliases_for_partitioned_query()
     for db_name in db_names:
-        case_domain_names |= set(CommCareCaseSQL.objects.using(db_name).values_list(
-            'domain', flat=True).distinct())
+        missing_domains_with_cases |= set(CommCareCaseSQL.objects.using(db_name).exclude(
+            domain__in=existing_domain_names,
+        ).values_list('domain', flat=True).distinct())
 
-    missing_domains_with_cases = case_domain_names - existing_domain_names
     if missing_domains_with_cases:
         mail_admins_async.delay(
             'There exist SQL cases with belonging to a missing domain',
@@ -174,13 +174,13 @@ def check_for_sql_cases_without_existing_domain():
 def check_for_sql_forms_without_existing_domain():
     existing_domain_names = set(Domain.get_all_names())
 
-    form_domain_names = set()
+    missing_domains_with_forms = set()
     db_names = get_db_aliases_for_partitioned_query()
     for db_name in db_names:
-        form_domain_names |= set(XFormInstanceSQL.objects.using(db_name).values_list(
-            'domain', flat=True).distinct())
+        missing_domains_with_forms |= set(XFormInstanceSQL.objects.using(db_name).exclude(
+            domain__in=existing_domain_names,
+        ).values_list('domain', flat=True).distinct())
 
-    missing_domains_with_forms = form_domain_names - existing_domain_names
     if missing_domains_with_forms:
         mail_admins_async.delay(
             'There exist SQL forms with belonging to a missing domain',

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -170,7 +170,7 @@ def check_for_sql_cases_without_existing_domain():
         )
 
 
-@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+@periodic_task(run_every=crontab(minute=0, hour=1), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def check_for_sql_forms_without_existing_domain():
     existing_domain_names = set(Domain.get_all_names())
 


### PR DESCRIPTION
This ensures that we are not at risk of a data breach if somebody creates a domain with the same name as one that we have deleted.

I only check SQL forms/cases because
 (1) new domains are SQL-domains by default so there shouldn't be a risk of a data breach, and
 (2) I don't know how (or if it's possible) to do this type of aggregation in couch.