### PR TITLE
Revert "Remove hiredis"

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -91,6 +91,7 @@ ghdiff==0.4
 graphviz==0.7
 greenlet==0.4.12
 gunicorn==19.9.0
+hiredis==0.2.0
 html5lib==1.0b8
 http-parser==0.8.3        # via restkit
 httpagentparser==1.7.8

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -75,6 +75,7 @@ gevent==1.2.2
 ghdiff==0.4
 greenlet==0.4.12
 gunicorn==19.9.0
+hiredis==0.2.0
 html5lib==1.0b8
 httpagentparser==1.7.8
 idna==2.7

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -79,6 +79,7 @@ gevent==1.2.2
 ghdiff==0.4
 greenlet==0.4.12
 gunicorn==19.9.0
+hiredis==0.2.0
 html5lib==1.0b8
 httpagentparser==1.7.8
 idna==2.7

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -95,6 +95,7 @@ quickcache==0.5.1
 zeep==1.6.0
 ethiopian-date-converter==0.1.5
 contextlib2==0.5.4
+hiredis==0.2.0
 xlwt==1.3.0
 django-prbac>=0.0.7
 html5lib==1.0b8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -73,6 +73,7 @@ gevent==1.2.2
 ghdiff==0.4
 greenlet==0.4.12
 gunicorn==19.9.0
+hiredis==0.2.0
 html5lib==1.0b8
 httpagentparser==1.7.8
 idna==2.7                 # via cryptography, email-validator

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -78,6 +78,7 @@ gevent==1.2.2
 ghdiff==0.4
 greenlet==0.4.12
 gunicorn==19.9.0
+hiredis==0.2.0
 html5lib==1.0b8
 httpagentparser==1.7.8
 idna==2.7

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -8,4 +8,3 @@ pycrypto
 restkit
 http-parser
 msgpack-python
-hiredis


### PR DESCRIPTION
Reverts dimagi/commcare-hq#21934

> Did anyone else also got this error `redis.exceptions.RedisError: Hiredis is not installed` while Executing task 'prime_version_static' during deploy. Had to install it through testing branch to make it deploy. is it a bug or i missed something.

Not sure where this came from

@Rohit25negi 