### PR TITLE
next subscription

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1729,8 +1729,9 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
         if self.is_form_post and self.billing_account_info_form.is_valid():
             is_saved = self.billing_account_info_form.save()
             software_plan_name = DESC_BY_EDITION[self.selected_plan_version.plan.edition]['name']
+            next_subscription = self.current_subscription.next_subscription
             if not is_saved:
-                downgrade_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
+                downgrade_date = next_subscription.date_start.strftime(USER_DATE_FORMAT)
                 messages.error(
                     request, _(
                         "You have already scheduled a downgrade to the %s Software Plan on %s. If this is a "
@@ -1740,10 +1741,10 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             else:
                 if not request.user.is_superuser:
                     self.send_downgrade_email()
-                if self.current_subscription.next_subscription is not None:
+                if next_subscription is not None:
                     # New subscription has been scheduled for the future
                     current_subscription = self.current_subscription.plan_version.plan.edition
-                    start_date = self.current_subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT)
+                    start_date = next_subscription.date_start.strftime(USER_DATE_FORMAT)
                     message = _(
                         "You have successfully scheduled your current %s Edition Plan subscription to "
                         "downgrade to the %s Edition Plan on %s."

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1726,19 +1726,13 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:
             return self.async_response
+
         if self.is_form_post and self.billing_account_info_form.is_valid():
             is_saved = self.billing_account_info_form.save()
             software_plan_name = DESC_BY_EDITION[self.selected_plan_version.plan.edition]['name']
             next_subscription = self.current_subscription.next_subscription
-            if not is_saved:
-                downgrade_date = next_subscription.date_start.strftime(USER_DATE_FORMAT)
-                messages.error(
-                    request, _(
-                        "You have already scheduled a downgrade to the %s Software Plan on %s. If this is a "
-                        "mistake, please reach out to billing-support@dimagi.com."
-                    ) % (software_plan_name, downgrade_date)
-                )
-            else:
+
+            if is_saved:
                 if not request.user.is_superuser:
                     self.send_downgrade_email()
                 if next_subscription is not None:
@@ -1757,6 +1751,15 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
                     request, message
                 )
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
+
+            downgrade_date = next_subscription.date_start.strftime(USER_DATE_FORMAT)
+            messages.error(
+                request, _(
+                    "You have already scheduled a downgrade to the %s Software Plan on %s. If this is a "
+                    "mistake, please reach out to billing-support@dimagi.com."
+                ) % (software_plan_name, downgrade_date)
+            )
+
         return super(ConfirmBillingAccountInfoView, self).post(request, *args, **kwargs)
 
     def send_downgrade_email(self):


### PR DESCRIPTION
Turns out @nickpell was right and it's an infra thing as well as a new code thing! but this should make it a bit less fragile https://sentry.io/dimagi/commcarehq/issues/703401518/?environment=production

Basically, we were requesting the next subscription repeatedly and getting different results. I'm not sure if it was a cache fail or how Subscription fetches, but it might be worth an audit of other places it's requested too https://github.com/dimagi/commcare-hq/blob/d8c3ca2f4035564b5f4adba8b545ced86cb848a6/corehq/apps/accounting/models.py#L1147

The first commit is the actual change 🐟 

@proteusvacuum @emord @nickpell @gbova 