### PR TITLE
Put releases page back on couch

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -42,7 +42,7 @@ from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.util.timezones.utils import get_timezone_for_user
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_doc, get_latest_build_id, \
-    get_latest_released_app_version
+    get_latest_released_app_version, get_built_app_ids_for_app_id
 from corehq.apps.app_manager.models import BuildProfile
 from corehq.apps.app_manager.const import DEFAULT_FETCH_LIMIT
 from corehq.apps.users.models import CommCareUser
@@ -55,7 +55,6 @@ from corehq.apps.app_manager.views.download import source_files
 from corehq.apps.app_manager.views.settings import PromptSettingsUpdateView
 from corehq.apps.app_manager.views.utils import back_to_main, get_langs
 from corehq.apps.builds.models import CommCareBuildConfig
-from corehq.apps.es import AppES
 from corehq.apps.users.models import CouchUser
 import six
 
@@ -82,27 +81,30 @@ def paginate_releases(request, domain, app_id):
         limit = int(limit)
     except (TypeError, ValueError):
         limit = 10
+    skip = (page - 1) * limit
 
-    timezone = get_timezone_for_user(request.couch_user, domain)
+    tz = get_timezone_for_user(request.couch_user, domain)
 
-    app_es = (
-        AppES()
-        .start((page - 1) * limit)
-        .size(limit)
-        .sort('version', desc=True)
-        .domain(domain)
-        .is_build()
-        .app_id(app_id)
-    )
-    if only_show_released:
-        app_es = app_es.is_released()
-    if build_comment:
-        app_es = app_es.build_comment(build_comment)
-    results = app_es.exclude_source().run()
-    app_ids = results.doc_ids
-    apps = get_docs(Application.get_db(), app_ids)
-    saved_apps = [SavedAppBuild.wrap(app, scrap_old_conventions=False).releases_list_json(timezone)
-                  for app in apps]
+    start_build = {}
+    saved_apps = []
+    batch = [None]
+    while len(saved_apps) < skip + limit and len(batch):
+        batch = Application.get_db().view('app_manager/saved_app',
+            startkey=[domain, app_id, start_build],
+            endkey=[domain, app_id],
+            descending=True,
+            limit=limit,
+            wrapper=lambda x: SavedAppBuild.wrap(x['value'], scrap_old_conventions=False).releases_list_json(tz),
+        ).all()
+        if len(batch):
+            start_build = batch[-1]['version'] - 1
+        for app in batch:
+            # TODO: suck less if not searching, just skip
+            if not only_show_released or app['is_released']:
+                if not build_comment or build_comment.lower() in (app['build_comment'] or '').lower():
+                    saved_apps.append(app)
+
+    saved_apps = saved_apps[skip:skip + limit]
 
     j2me_enabled_configs = CommCareBuildConfig.j2me_enabled_config_labels()
     for app in saved_apps:
@@ -120,7 +122,7 @@ def paginate_releases(request, domain, app_id):
         for app in saved_apps:
             app['num_errors'] = num_errors_dict.get(app['version'], 0)
 
-    total_apps = results.total
+    total_apps = len(get_built_app_ids_for_app_id(domain, app_id))   # TODO: make accurate if searching
     num_pages = int(ceil(total_apps / limit))
 
     return json_response({


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?283502

Current ES issues are preventing users from making builds, because the builds list on the page is inaccurate, so HQ prevents you from creating a build.

@nickpell 