### PR TITLE
Send changes to kafka in bulk

### DIFF
--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -27,15 +27,26 @@ class ChangeProducer(object):
         )
         return self._producer
 
-    def send_change(self, topic, change_meta):
+    def send_change(self, topic, change_meta, flush=False):
         message = change_meta.to_json()
         try:
             self.producer.send(topic, bytes(json.dumps(message)))
-            self.producer.flush()
+            if flush:
+                self.producer.flush()
         except Exception as e:
             _assert = soft_assert(notify_admins=True)
             _assert(False, 'Problem sending change to kafka {}: {} ({})'.format(
                 message, e, type(e)
+            ))
+            raise
+
+    def flush_changes(self, metadata=None):
+        try:
+            self.producer.flush()
+        except Exception as e:
+            _assert = soft_assert(notify_admins=True)
+            _assert(False, 'Problem flushing changes to kafka {}: {} ({})'.format(
+                metadata, e, type(e)
             ))
             raise
 

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -16,7 +16,7 @@ from corehq.form_processor.backends.sql.dbaccessors import (
 )
 from corehq.form_processor.backends.sql.update_strategy import SqlCaseUpdateStrategy
 from corehq.form_processor.change_publishers import (
-    publish_form_saved, publish_case_saved, publish_ledger_v2_saved)
+    publish_form_saved, publish_case_saved, publish_cases_saved, publish_ledgers_v2_saved)
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound, KafkaPublishingError
 from corehq.form_processor.interfaces.processor import CaseUpdateMetadata
 from corehq.form_processor.models import (
@@ -152,16 +152,12 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def publish_changes_to_kafka(processed_forms, cases, stock_result):
-        from corehq.apps.change_feed.producer import producer
-        publish_form_saved(processed_forms.submitted, flush=False)
-        cases = cases or []
-        for case in cases:
-            publish_case_saved(case, flush=False)
+        publish_form_saved(processed_forms.submitted)
+        if cases:
+            publish_cases_saved(cases)
 
         if stock_result:
-            for ledger in stock_result.models_to_save:
-                publish_ledger_v2_saved(ledger, flush=False)
-        producer.flush_changes(metadata={'domain': processed_forms.submitted.domain})
+            publish_ledgers_v2_saved(stock_result.models_to_save)
 
     @classmethod
     def apply_deprecation(cls, existing_xform, new_xform):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -161,7 +161,7 @@ class FormProcessorSQL(object):
         if stock_result:
             for ledger in stock_result.models_to_save:
                 publish_ledger_v2_saved(ledger, flush=False)
-        producer.flush(metadata={'domain': processed_forms.submitted.domain})
+        producer.flush_changes(metadata={'domain': processed_forms.submitted.domain})
 
     @classmethod
     def apply_deprecation(cls, existing_xform, new_xform):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -152,14 +152,16 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def publish_changes_to_kafka(processed_forms, cases, stock_result):
-        publish_form_saved(processed_forms.submitted)
+        from corehq.apps.change_feed.producer import producer
+        publish_form_saved(processed_forms.submitted, flush=False)
         cases = cases or []
         for case in cases:
-            publish_case_saved(case)
+            publish_case_saved(case, flush=False)
 
         if stock_result:
             for ledger in stock_result.models_to_save:
-                publish_ledger_v2_saved(ledger)
+                publish_ledger_v2_saved(ledger, flush=False)
+        producer.flush(metadata={'domain': processed_forms.submitted.domain})
 
     @classmethod
     def apply_deprecation(cls, existing_xform, new_xform):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -16,8 +16,7 @@ from corehq.form_processor.backends.sql.dbaccessors import (
 )
 from corehq.form_processor.backends.sql.update_strategy import SqlCaseUpdateStrategy
 from corehq.form_processor.change_publishers import (
-    publish_form_saved, publish_case_saved, publish_ledger_v2_saved,
-    republish_all_changes_for_form)
+    publish_form_saved, publish_case_saved, publish_ledger_v2_saved)
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound, KafkaPublishingError
 from corehq.form_processor.interfaces.processor import CaseUpdateMetadata
 from corehq.form_processor.models import (

--- a/corehq/form_processor/change_publishers.py
+++ b/corehq/form_processor/change_publishers.py
@@ -9,8 +9,8 @@ from corehq.form_processor.signals import sql_case_post_save
 from pillowtop.feed.interface import ChangeMeta
 
 
-def publish_form_saved(form, flush=True):
-    producer.send_change(topics.FORM_SQL, change_meta_from_sql_form(form), flush)
+def publish_form_saved(form):
+    producer.send_change(topics.FORM_SQL, change_meta_from_sql_form(form))
 
 
 def change_meta_from_sql_form(form):
@@ -36,12 +36,26 @@ def publish_form_deleted(domain, form_id):
     ))
 
 
-def publish_case_saved(case, send_post_save_signal=True, flush=True):
+def publish_case_saved(case, send_post_save_signal=True):
     """
     Publish the change to kafka and run case post-save signals.
     """
-    producer.send_change(topics.CASE_SQL, change_meta_from_sql_case(case), flush)
+    producer.send_change(topics.CASE_SQL, change_meta_from_sql_case(case))
     if send_post_save_signal:
+        sql_case_post_save.send(case.__class__, case=case)
+
+
+def publish_cases_saved(cases):
+    """
+    Publish the change to kafka and run case post-save signals.
+    """
+    for case in cases:
+        producer.send_change(topics.CASE_SQL, change_meta_from_sql_case(case), flush=False)
+
+    if cases:
+        producer.flush_changes(metadata={'domain': case[0].domain})
+
+    for case in cases:
         sql_case_post_save.send(case.__class__, case=case)
 
 
@@ -72,6 +86,16 @@ def publish_ledger_v2_saved(ledger_value, flush=True):
     producer.send_change(topics.LEDGER, change_meta_from_ledger_v2(
         ledger_value.ledger_reference, ledger_value.domain
     ), flush)
+
+
+def publish_ledgers_v2_saved(ledger_values):
+    for ledger_value in ledger_values:
+        producer.send_change(topics.LEDGER, change_meta_from_ledger_v2(
+            ledger_value.ledger_reference, ledger_value.domain
+        ))
+
+    if ledger_values:
+        producer.flush_changes(metadata={'domain': ledger_values[0].domain})
 
 
 def publish_ledger_v2_deleted(domain, case_id, section_id, entry_id):

--- a/corehq/form_processor/change_publishers.py
+++ b/corehq/form_processor/change_publishers.py
@@ -9,8 +9,8 @@ from corehq.form_processor.signals import sql_case_post_save
 from pillowtop.feed.interface import ChangeMeta
 
 
-def publish_form_saved(form):
-    producer.send_change(topics.FORM_SQL, change_meta_from_sql_form(form))
+def publish_form_saved(form, flush=True):
+    producer.send_change(topics.FORM_SQL, change_meta_from_sql_form(form), flush)
 
 
 def change_meta_from_sql_form(form):
@@ -36,11 +36,11 @@ def publish_form_deleted(domain, form_id):
     ))
 
 
-def publish_case_saved(case, send_post_save_signal=True):
+def publish_case_saved(case, send_post_save_signal=True, flush=True):
     """
     Publish the change to kafka and run case post-save signals.
     """
-    producer.send_change(topics.CASE_SQL, change_meta_from_sql_case(case))
+    producer.send_change(topics.CASE_SQL, change_meta_from_sql_case(case), flush)
     if send_post_save_signal:
         sql_case_post_save.send(case.__class__, case=case)
 
@@ -68,10 +68,10 @@ def publish_case_deleted(domain, case_id):
     ))
 
 
-def publish_ledger_v2_saved(ledger_value):
+def publish_ledger_v2_saved(ledger_value, flush=True):
     producer.send_change(topics.LEDGER, change_meta_from_ledger_v2(
         ledger_value.ledger_reference, ledger_value.domain
-    ))
+    ), flush)
 
 
 def publish_ledger_v2_deleted(domain, case_id, section_id, entry_id):

--- a/corehq/form_processor/change_publishers.py
+++ b/corehq/form_processor/change_publishers.py
@@ -9,18 +9,6 @@ from corehq.form_processor.signals import sql_case_post_save
 from pillowtop.feed.interface import ChangeMeta
 
 
-def republish_all_changes_for_form(domain, form_id):
-    """
-    Publishes all changes for the form and any touched cases/ledgers.
-
-    """
-    form = FormAccessors(domain=domain).get_form(form_id)
-    publish_form_saved(form)
-    for case in get_cases_from_form(domain, form):
-        publish_case_saved(case, send_post_save_signal=False)
-    _publish_ledgers_from_form(domain, form)
-
-
 def publish_form_saved(form):
     producer.send_change(topics.FORM_SQL, change_meta_from_sql_form(form))
 


### PR DESCRIPTION
@proteusvacuum @mkangia 

I haven't been able to nail down the exact cause of https://sentry.io/dimagi/commcarehq/issues/632397078/?environment=production

But this may help by keeping more messages in memory before sending. By bringing the flush into the processor, it should send them all at once which reduces the amount of times the `RecordAccumulator` is opened/closed
