### PR TITLE
avoid line-too-long errors in commcare-version admin report

### DIFF
--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -8,6 +8,8 @@ max_requests = 240
 max_requests_jitter = int(max_requests * 0.5)
 # defaults to 30 sec, setting to 5 minutes to fight `GreenletExit`s
 graceful_timeout = 5*60
+# defaults to 4094, increasing to avoid https://manage.dimagi.com/default.asp?283517#1532884
+limit_request_line = 4500
 
 
 def post_fork(server, worker):


### PR DESCRIPTION
@mkangia @esoergel 
https://manage.dimagi.com/default.asp?283517#edit_0_283517