### PR TITLE
Fix edit form with attachments

### DIFF
--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import datetime
 import logging
 import uuid
+from lxml import etree
 
 import redis
 from couchdbkit.exceptions import ResourceNotFound
@@ -97,8 +98,10 @@ class FormProcessorCouch(object):
                     data = data[repeat_index]
             data[i.last()] = response
 
+        new_xml = etree.tostring(xml)
         new_form._deferred_blobs = None     # will be re-populated by apply_deprecation
         new_form.external_blobs.clear()     # will be re-populated by apply_deprecation
+        new_form.deferred_put_attachment(new_xml, "form.xml", content_type="text/xml")
         existing_form, new_form = apply_deprecation(existing_form, new_form)
         return (existing_form, new_form)
 

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -110,6 +110,11 @@ class FormProcessorSQL(object):
         new_form.user_id = user_id
         new_form.domain = existing_form.domain
         new_form.app_id = existing_form.app_id
+        cls.store_attachments(new_form, [Attachment(
+            name=ATTACHMENT_NAME,
+            raw_content=new_xml,
+            content_type='text/xml',
+        )])
 
         existing_form, new_form = apply_deprecation(existing_form, new_form)
         return (existing_form, new_form)

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -164,12 +164,7 @@ class FormProcessorInterface(object):
         existing_form = FormAccessors(xform.domain).get_with_attachments(xform.get_id)
         existing_form, new_form = self.processor.new_form_from_old(existing_form, xml,
                                                                    value_responses_map, user_id)
-        new_xml = etree.tostring(xml)
-        interface = FormProcessorInterface(xform.domain)
-        interface.store_attachments(new_form, [
-            Attachment(name=ATTACHMENT_NAME, raw_content=new_xml, content_type='text/xml')
-        ])
-        interface.save_processed_models([new_form, existing_form])
+        self.save_processed_models([new_form, existing_form])
 
         return errors
 


### PR DESCRIPTION
Attachments are lost if `FormProcessorSQL.store_attachments()` is called after `FormProcessorSQL.copy_attachments()`.