### PR TITLE
Fix autopay indicator

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
@@ -87,7 +87,6 @@ hqDefine("accounting/js/stripe_card_manager", [
 
         self.wrap = function (data) {
             ko.mapping.fromJS(data, mapping, self);
-            self.is_autopay(self.is_autopay() === 'True');
             self.url = baseUrl + card.token + '/';
         };
         self.wrap(card);


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?282067

`fromJS` does the right thing here, so `is_autopay` is already a boolean, not a "True"/"False" string.

@Rohit25negi @nickpell 