### PR TITLE
return what is stored in case of pending state

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -293,7 +293,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         };
 
         self.goToPage = function (page) {
-            if(self.fetchState() == 'pending') {
+            if (self.fetchState() === 'pending') {
                 return self.savedApps();
             }
             self.fetchState('pending');

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -293,6 +293,9 @@ hqDefine('app_manager/js/releases/releases', function () {
         };
 
         self.goToPage = function (page) {
+            if(self.fetchState() == 'pending') {
+                return self.savedApps();
+            }
             self.fetchState('pending');
             $.ajax({
                 url: self.reverse("paginate_releases"),

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -294,7 +294,7 @@ hqDefine('app_manager/js/releases/releases', function () {
 
         self.goToPage = function (page) {
             if (self.fetchState() === 'pending') {
-                return self.savedApps();
+                return false;
             }
             self.fetchState('pending');
             $.ajax({


### PR DESCRIPTION
Noticed releases being requested twice on first page load.

Found these series of events
1. On page load [this](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js#L19-L18) loads releases by calling [this](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/static/app_manager/js/releases/releases.js#L295)
2. This eventually loads in html [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html#L223) and then calls the same method as above [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js#L22)
3. and now the first request finishes

The change here avoids the call again if the records are being fetched. Either we can just return what is loaded i.e `savedApps` as done in [first commit](https://github.com/dimagi/commcare-hq/pull/21976/commits/57c819bc958b56b2446611a5668ded18fc868e06). 
The duplicate request is also avoided if i use `return false` instead of retuning savedApps which probably is a better approach saying that the new request is aborted coz another is in place and hence i have updated that as the final change.
I am not sure what the best fix is if this is not reasonable.