### PR TITLE
Pillow bootstrap

### DIFF
--- a/corehq/apps/userreports/data_source_providers.py
+++ b/corehq/apps/userreports/data_source_providers.py
@@ -3,6 +3,8 @@ from abc import ABCMeta, abstractmethod
 from corehq.apps.userreports.models import DataSourceConfiguration, StaticDataSourceConfiguration
 import six
 
+from corehq.apps.userreports.util import get_data_source_configurations
+
 
 class DataSourceProvider(six.with_metaclass(ABCMeta, object)):
     @abstractmethod
@@ -13,7 +15,7 @@ class DataSourceProvider(six.with_metaclass(ABCMeta, object)):
 class DynamicDataSourceProvider(DataSourceProvider):
 
     def get_data_sources(self):
-        return [config for config in DataSourceConfiguration.all() if not config.is_deactivated]
+        return get_data_source_configurations()
 
 
 class StaticDataSourceProvider(DataSourceProvider):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -122,9 +122,9 @@ class ConfigurableReportTableManagerMixin(object):
             # not waiting on a reset and has not been bootstrapped for the bootstrap_interval
             or (not self.reset_initiated_at and (
                 datetime.utcnow() - self.last_bootstrapped > timedelta(seconds=self.bootstrap_interval)))
-            # waiting on a reset and request was initiated 5 mins before
+            # waiting on a reset and request was initiated 2 mins before
             or (self.reset_initiated_at and
-                (datetime.utcnow() - self.reset_initiated_at > timedelta(minutes=5)))
+                (datetime.utcnow() - self.reset_initiated_at > timedelta(minutes=2)))
         )
 
     def bootstrap_if_needed(self):


### PR DESCRIPTION
[Spec](https://docs.google.com/document/d/1SuXES-FHZTRyL-e6QdEgsoxDcbsYUngPXDww2ydKCyk/edit)

1. Add DD notification for tracking time taken by UCR pillows for bootstrap
2. An attempt to reduce bootstrap time by fetching all configs asynchronously and then fetch them after a 2-minute delay. Also fetch only once instead of once for each pillow instance. Begin just with get report configs which takes around 44 secs to load `1720` configs
```
In [2]: from corehq.util.timer import TimingContext

In [3]: with TimingContext("fetch_confs") as timing_fetch_confs:
   ...:     configs = [config for config in DataSourceConfiguration.all() if not config.is_deactivated]
   ...:

In [4]: timing_fetch_confs.duration
Out[4]: 44.13952994346619

In [5]: len(configs)
Out[5]: 1720
```
This can be then further extended to [other things](https://github.com/dimagi/commcare-hq/blob/2d60bf36b3d6d7de08650f47a6c79488bed41b22/corehq/apps/userreports/pillow.py#L145-L155)

Best review
🐟 / 🐟 

@czue thoughts?