### PR TITLE
Make the deactivated users show up in all reports.

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -126,12 +126,12 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
                 (self.get_static_options_size, self.get_static_options),
                 (self.get_groups_size, self.get_groups),
                 (self.get_locations_size, self.get_locations),
-                (self.get_active_users_size, self.get_active_users),
+                (self.get_all_users_size, self.get_all_users),
             ]
         else:
             return [
                 (self.get_locations_size, self.get_locations),
-                (self.get_active_users_size, self.get_active_users),
+                (self.get_all_users_size, self.get_all_users),
             ]
 
     def get_options(self):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -147,7 +147,7 @@ class EmwfUtils(object):
     def static_options(self):
         static_options = [("t__0", _("[Active Mobile Workers]"))]
 
-        types = ['DEMO_USER', 'ADMIN', 'WEB', 'UNKNOWN']
+        types = ['DEACTIVATED', 'DEMO_USER', 'ADMIN', 'WEB', 'UNKNOWN']
         if Domain.get_by_name(self.domain).commtrack_enabled:
             types.append('COMMTRACK')
         for t in types:


### PR DESCRIPTION
Note: I'm still looking for the usages of this everywhere to make sure this won't mess with anything.
Also, this is an intermediate PR, the final fix will be removing the SubmitHistoryUtils and other things that superclass the EMWF logic, because they now should be identical.

Update: Confirming that the reports affected are the ones listed in the original ticket as reports that should be affected: https://manage.dimagi.com/default.asp?282132