### PR TITLE
delete es cases

### DIFF
--- a/corehq/apps/es/management/commands/relog_deleted_cases.py
+++ b/corehq/apps/es/management/commands/relog_deleted_cases.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.es import CaseES
+from corehq.apps.hqcase.utils import resave_case
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+
+from corehq.util.log import with_progress_bar
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **kwargs):
+        case_ids_and_domains = self._get_saved_deleted_case_ids()
+
+        for case_ids_and_domains in with_progress_bar(case_ids_and_domains):
+            for case_id, domain in case_ids_and_domains:
+                case = CaseAccessors(domain).get_case(case_id)
+                resave_case(domain, case)
+
+    @staticmethod
+    def _get_saved_deleted_case_ids():
+        return set(
+            CaseES().set_query(
+                {
+                    "term": {
+                        "doc_type": "CommCareCase-Deleted"
+                    }
+                }
+            ).values_list("_id", "domain"))

--- a/corehq/apps/es/management/commands/relog_deleted_cases.py
+++ b/corehq/apps/es/management/commands/relog_deleted_cases.py
@@ -23,11 +23,10 @@ class Command(BaseCommand):
 
     @staticmethod
     def _get_saved_deleted_case_ids():
-        return set(
-            CaseES().set_query(
-                {
-                    "term": {
-                        "doc_type": "CommCareCase-Deleted"
-                    }
+        return CaseES().set_query(
+            {
+                "term": {
+                    "doc_type": "CommCareCase-Deleted"
                 }
-            ).values_list("_id", "domain"))
+            }
+        ).values_list("_id", "domain")

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -43,7 +43,7 @@ class ElasticProcessor(PillowProcessor):
         if doc is None or (self.doc_filter_fn and self.doc_filter_fn(doc)):
             return
 
-        if doc.doc_type is not None and doc.doc_type.endswith("-Deleted"):
+        if doc.get('doc_type') is not None and doc['doc_type'].endswith("-Deleted"):
             self._delete_doc_if_exists(change.id)
             return
 

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -11,6 +11,9 @@ from pillowtop.logger import pillow_logging
 from .interface import PillowProcessor
 
 
+from corehq.apps.change_feed.document_types import is_deletion
+
+
 def identity(x):
     return x
 
@@ -38,6 +41,10 @@ class ElasticProcessor(PillowProcessor):
 
         ensure_document_exists(change)
         ensure_matched_revisions(change, doc)
+
+        if is_deletion(doc):
+            self._delete_doc_if_exists(change.id)
+            return
 
         if doc is None or (self.doc_filter_fn and self.doc_filter_fn(doc)):
             return

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -5,7 +5,6 @@ import time
 
 from elasticsearch.exceptions import RequestError, ConnectionError, NotFoundError, ConflictError
 
-from pillowtop.dao.exceptions import DocumentNotFoundError
 from pillowtop.utils import ensure_matched_revisions, ensure_document_exists
 from pillowtop.exceptions import PillowtopIndexingError
 from pillowtop.logger import pillow_logging

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -17,6 +17,7 @@ from corehq.apps.change_feed.document_types import is_deletion
 def identity(x):
     return x
 
+
 RETRY_INTERVAL = 2  # seconds, exponentially increasing
 MAX_RETRIES = 4  # exponential factor threshold for alerts
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?283408

Thanks farid for recommending that I look at the scale of the bad data. Turns out some of the earliest "deleted" cases in ES are from 2016, so this isn't a new bug, just likely is more visible with higher traffic and a more delayed CaseToElasticsearch pillow. 

**Context** 📖 The narrative that I'm telling myself right now is that these are caused by dropped messages. If there were other messages logged before deletion that were not dropped, but that are processed after the doc is deleted in postgres or couch, the deleted object would be saved to ES.

**Fixing old cases** 💊 Relogging all of the broken cases to kafka should delete them, since it's handled by the [change publisher](https://github.com/dimagi/commcare-hq/blob/master/corehq/form_processor/change_publishers.py#L68) a635d80d39.

**Handling future cases** 🛡 I also want to add the extra safeguard in b278ca5 so that we will never save a deleted case to ES, since that looks real bad. This isn't a 100% fix though. We can still lose messages in which case we might not update the case to the latest state

@proteusvacuum @emord 