### PR TITLE
[ICDS] Group ASR mobile UCR by age

### DIFF
--- a/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
@@ -15,7 +15,8 @@
     "description": "",
     "visible": false,
     "aggregation_columns": [
-      "owner_id"
+      "owner_id",
+      "age_group"
     ],
     "filters": [
       {
@@ -84,6 +85,18 @@
         "transform": {
           "type": "custom",
           "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Age Group",
+        "column_id": "age_group",
+        "type": "conditional_aggregation",
+        "whens": {
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 0 and 5": "0_to_5",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 6 and 11": "6_to_11",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 12 and 35": "12_to_35",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 36 and 59": "36_to_59",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 60 and 71": "60_to_71"
         }
       },
       {

--- a/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
@@ -1,0 +1,315 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-test",
+    "icds-sql",
+    "icds-cas",
+    "icds-cas-sandbox"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new",
+    "icds"
+  ],
+  "report_id": "static-asr_2_3_beneficiaries",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "ASR 2,3 - Beneficiaries (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "compare_as_string": false,
+        "datatype": "date",
+        "required": false,
+        "display": "Date of Birth",
+        "field": "dob",
+        "type": "date",
+        "slug": "dob"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "awc_id",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by AWW"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "supervisor_id",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Supervisor"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "block_id",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Block"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "district_id",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by District"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "state_id",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by State"
+      }
+    ],
+    "columns": [
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        },
+        "column_id": "owner_id",
+        "field": "owner_id",
+        "calculate_total": false,
+        "type": "field",
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "open_count",
+        "field": "open_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "open_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_st_count",
+        "field": "F_st_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_st_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_sc_count",
+        "field": "F_sc_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_sc_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_other_count",
+        "field": "F_other_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_other_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_minority_count",
+        "field": "F_minority_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_minority_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "F_disabled_count",
+        "field": "F_disabled_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "F_disabled_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_st_count",
+        "field": "M_st_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_st_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_sc_count",
+        "field": "M_sc_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_sc_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_other_count",
+        "field": "M_other_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_other_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_minority_count",
+        "field": "M_minority_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_minority_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "M_disabled_count",
+        "field": "M_disabled_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "M_disabled_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "disabled_movement_count",
+        "field": "disabled_movement_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "disabled_movement_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "disabled_mental_count",
+        "field": "disabled_mental_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "disabled_mental_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "disabled_seeing_count",
+        "field": "disabled_seeing_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "disabled_seeing_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "disabled_hearing_count",
+        "field": "disabled_hearing_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "disabled_hearing_count"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "disabled_speaking_count",
+        "field": "disabled_speaking_count",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "disabled_speaking_count"
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
@@ -23,290 +23,200 @@
     ],
     "filters": [
       {
-        "compare_as_string": false,
-        "datatype": "date",
-        "required": false,
         "display": "Date of Birth",
-        "field": "dob",
+        "slug": "dob",
         "type": "date",
-        "slug": "dob"
+        "field": "dob",
+        "datatype": "date"
       },
       {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
-        "type": "dynamic_choice_list",
-        "required": false,
+        "display": "Filter by AWW",
         "slug": "awc_id",
+        "type": "dynamic_choice_list",
         "field": "awc_id",
         "choice_provider": {
           "type": "location"
-        },
-        "display": "Filter by AWW"
+        }
       },
       {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
-        "type": "dynamic_choice_list",
-        "required": false,
+        "display": "Filter by Supervisor",
         "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
         "field": "supervisor_id",
         "choice_provider": {
           "type": "location"
-        },
-        "display": "Filter by Supervisor"
+        }
       },
       {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
-        "type": "dynamic_choice_list",
-        "required": false,
+        "display": "Filter by Block",
         "slug": "block_id",
+        "type": "dynamic_choice_list",
         "field": "block_id",
         "choice_provider": {
           "type": "location"
-        },
-        "display": "Filter by Block"
+        }
       },
       {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
-        "type": "dynamic_choice_list",
-        "required": false,
+        "display": "Filter by District",
         "slug": "district_id",
+        "type": "dynamic_choice_list",
         "field": "district_id",
         "choice_provider": {
           "type": "location"
-        },
-        "display": "Filter by District"
+        }
       },
       {
-        "compare_as_string": false,
-        "show_all": true,
-        "datatype": "string",
-        "type": "dynamic_choice_list",
-        "required": false,
+        "display": "Filter by State",
         "slug": "state_id",
+        "type": "dynamic_choice_list",
         "field": "state_id",
         "choice_provider": {
           "type": "location"
-        },
-        "display": "Filter by State"
+        }
       }
     ],
     "columns": [
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "transform": {
-          "type": "custom",
-          "custom_type": "owner_display"
-        },
-        "column_id": "owner_id",
-        "field": "owner_id",
-        "calculate_total": false,
-        "type": "field",
         "display": {
           "en": "Owner",
           "hin": "Owner"
         },
-        "aggregation": "simple"
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "open_count",
         "column_id": "open_count",
+        "type": "field",
         "field": "open_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "open_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_st_count",
         "column_id": "F_st_count",
+        "type": "field",
         "field": "F_st_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "F_st_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_sc_count",
         "column_id": "F_sc_count",
+        "type": "field",
         "field": "F_sc_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "F_sc_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_other_count",
         "column_id": "F_other_count",
+        "type": "field",
         "field": "F_other_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "F_other_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_minority_count",
         "column_id": "F_minority_count",
+        "type": "field",
         "field": "F_minority_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "F_minority_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "F_disabled_count",
         "column_id": "F_disabled_count",
+        "type": "field",
         "field": "F_disabled_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "F_disabled_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_st_count",
         "column_id": "M_st_count",
+        "type": "field",
         "field": "M_st_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "M_st_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_sc_count",
         "column_id": "M_sc_count",
+        "type": "field",
         "field": "M_sc_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "M_sc_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_other_count",
         "column_id": "M_other_count",
+        "type": "field",
         "field": "M_other_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "M_other_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_minority_count",
         "column_id": "M_minority_count",
+        "type": "field",
         "field": "M_minority_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "M_minority_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "M_disabled_count",
         "column_id": "M_disabled_count",
+        "type": "field",
         "field": "M_disabled_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "M_disabled_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "disabled_movement_count",
         "column_id": "disabled_movement_count",
+        "type": "field",
         "field": "disabled_movement_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "disabled_movement_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "disabled_mental_count",
         "column_id": "disabled_mental_count",
+        "type": "field",
         "field": "disabled_mental_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "disabled_mental_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "disabled_seeing_count",
         "column_id": "disabled_seeing_count",
+        "type": "field",
         "field": "disabled_seeing_count",
-        "transform": {},
-        "calculate_total": true,
-        "type": "field",
-        "display": "disabled_seeing_count"
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "disabled_hearing_count",
         "column_id": "disabled_hearing_count",
-        "field": "disabled_hearing_count",
-        "transform": {},
-        "calculate_total": true,
         "type": "field",
-        "display": "disabled_hearing_count"
+        "field": "disabled_hearing_count",
+        "aggregation": "sum",
+        "calculate_total": true
       },
       {
-        "sortable": false,
-        "description": null,
-        "format": "default",
-        "aggregation": "sum",
+        "display": "disabled_speaking_count",
         "column_id": "disabled_speaking_count",
-        "field": "disabled_speaking_count",
-        "transform": {},
-        "calculate_total": true,
         "type": "field",
-        "display": "disabled_speaking_count"
+        "field": "disabled_speaking_count",
+        "aggregation": "sum",
+        "calculate_total": true
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
@@ -1,16 +1,12 @@
 {
   "domains": [
-    "icds-dashboard-qa",
-    "reach-test",
-    "icds-test",
-    "icds-sql",
     "icds-cas",
-    "icds-cas-sandbox"
+    "icds-dashboard-qa",
+    "reach-test"
   ],
   "server_environment": [
     "softlayer",
-    "icds-new",
-    "icds"
+    "icds-new"
   ],
   "report_id": "static-asr_2_3_beneficiaries",
   "data_source_table": "static-person_cases_v2",

--- a/settings.py
+++ b/settings.py
@@ -1853,6 +1853,7 @@ STATIC_UCR_REPORTS = [
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_1_person_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2a_3_child_delivery_forms.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mpr_2a_person_cases.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mobile', 'asr_2_3_beneficiaries.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mobile', 'mpr_2a3_children_delivered.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mobile', 'mpr_2a_deaths.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'mobile', 'mpr_3_children_registered.json'),


### PR DESCRIPTION
:blowfish: :x: :blowfish: 
This is a continuation of the work I did in https://github.com/dimagi/commcare-hq/pull/21954

There's only ASR report that's repeated in the LS app, though it's a bit of a doozy.  The existing reports group dynamically based on age, though notably, they use `today() - 181`.  In this PR I switch that to use calendar months, which is in line with the spec.

The intervals are called:
"0_to_5", "6_to_11", "12_to_35", "36_to_59", and "60_to_71", indicating the inclusive ranges used, in months.

A dynamic version of this report is on india for testing.