### PR TITLE
Remove two indexes from person_cases_v2

### DIFF
--- a/custom/icds_reports/ucr/data_sources/person_cases_v2.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v2.json
@@ -2794,12 +2794,6 @@
       {
         "column_ids": [
           "supervisor_id",
-          "owner_id"
-        ]
-      },
-      {
-        "column_ids": [
-          "supervisor_id",
           "opened_on"
         ]
       },
@@ -2813,12 +2807,6 @@
         "column_ids": [
           "awc_id",
           "dob"
-        ]
-      },
-      {
-        "column_ids": [
-          "awc_id",
-          "owner_id"
         ]
       },
       {


### PR DESCRIPTION
@dimagi/scale-team should remove some small amount of load from pgucr. Neither of these indexes should be very useful. were added from naively following PGhero