### PR TITLE
icds-new is dead, long live new icds

### DIFF
--- a/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/mobile/asr_2_3_beneficiaries.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-asr_2_3_beneficiaries",
   "data_source_table": "static-person_cases_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_10a_children_referred.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_10a_children_referred.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_10a_children_referred",
   "data_source_table": "static-person_cases_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_10b_pregnancies_referred.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_10b_pregnancies_referred.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_10b_pregnancies_referred",
   "data_source_table": "static-person_cases_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_11_awc_visits.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_11_awc_visits.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_11_awc_visits",
   "data_source_table": "static-visitorbook_forms",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_2a3_children_delivered.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_2a3_children_delivered.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_2a3_children_delivered",
   "data_source_table": "static-child_delivery_forms",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_2a_deaths.json
@@ -6,7 +6,6 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new",
     "icds"
   ],
   "report_id": "static-mpr_2a_deaths",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_3_children_registered.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_3_children_registered",
   "data_source_table": "static-person_cases_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_3i_pregnancies.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_3i_pregnancies.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_3i_pregnancies",
   "data_source_table": "static-person_cases_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_4a6_preschool_education.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_4a6_preschool_education.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_4a6_preschool_education",
   "data_source_table": "static-daily_feeding_forms",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_4b_iodized_salt.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_4b_iodized_salt.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_4b_iodized_salt",
   "data_source_table": "static-infrastructure_form",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_5_child_nutrition.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_5_child_nutrition.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_5_child_nutrition",
   "data_source_table": "static-child_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_5_pregnancy_nutrition.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_5_pregnancy_nutrition.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_5_pregnancy_nutrition",
   "data_source_table": "static-ccs_record_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_6ac_pse_attendance.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_6ac_pse_attendance.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_6ac_pse_attendance",
   "data_source_table": "static-child_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_6b_pse_attendance_per_year.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_6b_pse_attendance_per_year.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_6b_pse_attendance_per_year",
   "data_source_table": "static-child_cases_monthly_v2",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_7_growth_monitored.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_7_growth_monitored.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_7_growth_monitored",
   "data_source_table": "static-gm_forms",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_8_immunizations.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_8_immunizations.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_8_immunizations",
   "data_source_table": "static-tasks_cases",

--- a/custom/icds_reports/ucr/reports/mobile/mpr_9_vhnd.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_9_vhnd.json
@@ -6,7 +6,7 @@
   ],
   "server_environment": [
     "softlayer",
-    "icds-new"
+    "icds"
   ],
   "report_id": "static-mpr_9_vhnd",
   "data_source_table": "static-vhnd_form",


### PR DESCRIPTION
Switch environment references from `icds-new` to `icds` (as discussed [here](https://github.com/dimagi/commcare-hq/pull/21991#discussion_r221771985))