### PR TITLE
add check for any UCR tables belonging to a missing domain

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -12,6 +12,7 @@ from celery.task import periodic_task
 
 from django.conf import settings
 from django.core.management import call_command
+from django.db import connections
 
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.models import Domain
@@ -21,6 +22,7 @@ from corehq.apps.cleanup.management.commands.fix_xforms_with_undefined_xmlns imp
     parse_log_message, ERROR_SAVING, SET_XMLNS, MULTI_MATCH, \
     CANT_MATCH, FORM_HAS_UNDEFINED_XMLNS
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL, FormAccessorSQL, doc_type_to_state
+from corehq.sql_db.connections import ConnectionManager, UCR_ENGINE_ID
 from io import open
 
 
@@ -213,3 +215,28 @@ def check_for_elasticsearch_data_without_existing_domain():
         mail_admins_async.delay(
             'All data in ES belongs to valid domains', ''
         )
+
+
+@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+def check_for_ucr_tables_without_existing_domain():
+    all_domain_names = Domain.get_all_names()
+
+    connection_name = ConnectionManager().get_django_db_alias(UCR_ENGINE_ID)
+    table_names = connections[connection_name].introspection.table_names()
+    ucr_table_names = [name for name in table_names if name.startswith('config_report')]
+
+    missing_domains_to_tables = defaultdict(list)
+
+    for ucr_table_name in ucr_table_names:
+        table_domain = ucr_table_name.split('_')[2]
+        if table_domain not in all_domain_names:
+            missing_domains_to_tables[table_domain].append(ucr_table_name)
+
+    if missing_domains_to_tables:
+        for missing_domain in missing_domains_to_tables:
+            mail_admins_async.delay(
+                'Missing domain "%s" has remaining UCR tables' % missing_domain,
+                six.text_type(missing_domains_to_tables[missing_domain])
+            )
+    elif _is_monday():
+        mail_admins_async.delay('All UCR tables belong to valid domains', '')

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -153,6 +153,10 @@ def _get_all_domains_that_have_ever_had_subscriptions():
     return Subscription.visible_and_suppressed_objects.values_list('subscriber__domain', flat=True).distinct()
 
 
+def _is_monday():
+    return datetime.utcnow().isoweekday() == 1
+
+
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def check_for_sql_cases_without_existing_domain():
     missing_domains_with_cases = set()
@@ -165,7 +169,7 @@ def check_for_sql_cases_without_existing_domain():
             'There exist SQL cases belonging to a missing domain',
             six.text_type(missing_domains_with_cases)
         )
-    elif datetime.utcnow().isoweekday() == 1:
+    elif _is_monday():
         mail_admins_async.delay(
             'All SQL cases belong to valid domains', ''
         )
@@ -184,7 +188,7 @@ def check_for_sql_forms_without_existing_domain():
             'There exist SQL forms belonging to a missing domain',
             six.text_type(missing_domains_with_forms)
         )
-    elif datetime.utcnow().isoweekday() == 1:
+    elif _is_monday():
         mail_admins_async.delay(
             'All SQL forms belong to valid domains', ''
         )
@@ -205,7 +209,7 @@ def check_for_elasticsearch_data_without_existing_domain():
                         query.index, count, domain_name
                     ), ''
                 )
-    if not issue_found and datetime.utcnow().isoweekday() == 1:
+    if not issue_found and _is_monday():
         mail_admins_async.delay(
             'All data in ES belongs to valid domains', ''
         )


### PR DESCRIPTION
🐡 or 🏢 

@emord Would it be possible to do something like this for the UCR ES backend?