### PR TITLE
Show case and form ids when support toggle is enabled

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/import_history.js
+++ b/corehq/apps/case_importer/static/case_importer/js/import_history.js
@@ -24,6 +24,14 @@ hqDefine('case_importer/js/import_history', [
             return initialPageData.reverse('case_importer_upload_file_download', self.upload_id);
         };
 
+        self.formIdsUrl = function () {
+            return initialPageData.reverse('case_importer_upload_form_ids', self.upload_id);
+        };
+
+        self.caseIdsUrl = function () {
+            return initialPageData.reverse('case_importer_upload_case_ids', self.upload_id);
+        };
+
         return self;
     };
 

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -8,6 +8,8 @@
 {% block page_content %}
     {% registerurl 'case_importer_uploads' domain %}
     {% registerurl 'case_importer_upload_file_download' domain '---' %}
+    {% registerurl 'case_importer_upload_form_ids' domain '---' %}
+    {% registerurl 'case_importer_upload_case_ids' domain '---' %}
     {% registerurl 'case_importer_update_upload_comment' domain '---' %}
 
     {% include 'case_importer/partials/help_message.html' %}

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 <!--ko if: state() == states.SUCCESS && !_.isEmpty(case_uploads())-->
 <table class="table table-striped">
     <tr>
@@ -8,6 +9,11 @@
         <th class="col-md-4">{% trans "Details" %}</th>
         <th class="col-md-3">{% trans "Comment" %}</th>
         <th class="col-md-2">{% trans "File" %}</th>
+        {% if request|toggle_enabled:"SUPPORT" %}
+            <th>Form IDs</th>
+            <th>Case IDs</th>
+        {% endif %}
+
     </tr>
     <!--ko foreach: case_uploads-->
     <tr>
@@ -82,6 +88,18 @@
             <!--/ko-->
             <!--/ko-->
         </td>
+        {% if request|toggle_enabled:"SUPPORT" %}
+            <td>
+                <a data-bind="attr: {href: formIdsUrl()}" target="_blank">
+                    <i class="fa fa-download"></i>
+                </a>
+            </td>
+            <td>
+                <a data-bind="attr: {href: caseIdsUrl()}" target="_blank">
+                    <i class="fa fa-download"></i>
+                </a>
+            </td>
+        {% endif %}
     </tr>
     <!--/ko-->
 </table>


### PR DESCRIPTION
I've used these hidden links a few times in the last interrupt cycle, and it seems like no one knows about them. Putting them behind the support toggle.
FYI @karmuno 



FF: Support only