### PR TITLE
Combine order_by_hierarchy and show_full_path

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -1273,9 +1273,9 @@ owner                | Select a possible case owner owner (user, group, or locat
 
 Location choice providers also support three additional configuration options:
 
-* "include_descendants" - Include descendant locations in the results. Defaults to `false`.
-* "show_full_path" - Display the full path to the location in the filter.  Defaults to `false`.
-* "order_by_hierarchy" - By default, locations show up in alphabetical order.  Set this to `true` to instead order by their position in the organization hierarchy.
+* "include_descendants" - Include descendants of the selected locations in the results. Defaults to `false`.
+* "show_full_path" - Display the full path to the location in the filter. Defaults to `false`.
+  The default behavior shows all locations as a flat alphabetical list.
 
 Example assuming "village" is a location ID, which is converted to names using the location `choice_provider`:
 ```json
@@ -1288,7 +1288,6 @@ Example assuming "village" is a location ID, which is converted to names using t
   "choice_provider": {
       "type": "location",
       "include_descendants": true,
-      "order_by_hierarchy": true,
       "show_full_path": true
   }
 }

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -229,12 +229,10 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         super(LocationChoiceProvider, self).__init__(report, filter_slug)
         self.include_descendants = False
         self.show_full_path = False
-        self.order_by_hierarchy = False
 
     def configure(self, spec):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)
         self.show_full_path = spec.get('show_full_path', self.show_full_path)
-        self.order_by_hierarchy = spec.get('order_by_hierarchy', self.order_by_hierarchy)
 
     def _locations_query(self, query_text, user):
         active_locations = SQLLocation.active_objects
@@ -249,7 +247,8 @@ class LocationChoiceProvider(ChainableChoiceProvider):
     def query(self, query_context):
         # todo: consider making this an extensions framework similar to custom expressions
         locations = self._locations_query(query_context.query, query_context.user)
-        if not self.order_by_hierarchy:
+        if not self.show_full_path:
+            # If the full path is displayed, order by hierarchy
             locations = locations.order_by('name')
 
         return self._locations_to_choices(
@@ -284,7 +283,7 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         return [Choice(SHOW_ALL_CHOICE, "[{}]".format(ugettext('Show All')))]
 
     def _locations_to_choices(self, locations):
-        cached_path_display = {}  # works best if self.order_by_hierarchy == True
+        cached_path_display = {}
 
         def display(loc):
             if self.show_full_path:

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -126,7 +126,7 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         choice_tuples = [
             (location.name, SearchableChoice(
                 location.location_id,
-                location.get_path_display(),
+                location.display_name,
                 searchable_text=[location.site_code, location.name]
             ))
             for location in six.itervalues(cls.locations)
@@ -137,7 +137,7 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         cls.choice_provider = LocationChoiceProvider(report, None)
         cls.choice_provider.configure({
             "include_descendants": False,
-            "show_full_path": True,
+            "show_full_path": False,
         })
         cls.static_choice_provider = StaticChoiceProvider(choices)
         cls.choice_query_context = partial(ChoiceQueryContext, user=cls.web_user)
@@ -177,7 +177,7 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
         scoped_choices = [
             SearchableChoice(
                 location.location_id,
-                location.get_path_display(),
+                location.display_name,
                 searchable_text=[location.site_code, location.name]
             )
             for location in [

--- a/custom/echis_reports/ucr/reports/hew_performance_by_health_post.json
+++ b/custom/echis_reports/ucr/reports/hew_performance_by_health_post.json
@@ -43,7 +43,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,
@@ -68,7 +67,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -84,7 +82,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -100,7 +97,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hew_performance_by_hew.json
+++ b/custom/echis_reports/ucr/reports/hew_performance_by_hew.json
@@ -43,7 +43,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,
@@ -68,7 +67,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -84,7 +82,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -100,7 +97,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hew_performance_by_submission_date.json
+++ b/custom/echis_reports/ucr/reports/hew_performance_by_submission_date.json
@@ -43,7 +43,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,
@@ -77,7 +76,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -93,7 +91,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -109,7 +106,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hew_performance_by_submission_date_all_forms.json
+++ b/custom/echis_reports/ucr/reports/hew_performance_by_submission_date_all_forms.json
@@ -39,7 +39,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,
@@ -73,7 +72,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -89,7 +87,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -105,7 +102,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hew_performance_report_focal_person.json
+++ b/custom/echis_reports/ucr/reports/hew_performance_report_focal_person.json
@@ -25,7 +25,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,
@@ -50,7 +49,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -66,7 +64,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,
@@ -82,7 +79,6 @@
         "choice_provider": {
           "include_descendants": false,
           "type": "string",
-          "order_by_hierarchy": false,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_4_child_illness_r3.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_4_child_illness_r3.json
@@ -22,7 +22,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_2_family_planning_r2.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_2_family_planning_r2.json
@@ -22,7 +22,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_3_immun_growth_r2.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_3_immun_growth_r2.json
@@ -22,7 +22,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_focal_person.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_focal_person.json
@@ -23,7 +23,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_focal_person_family_planning.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_focal_person_family_planning.json
@@ -24,7 +24,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_focal_person_immun_growth.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_focal_person_immun_growth.json
@@ -24,7 +24,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_r1.2.json
+++ b/custom/echis_reports/ucr/reports/hmis_monthly_mobile_job_aid_r1.2.json
@@ -21,7 +21,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/echis_reports/ucr/reports/ivr_weekly_mobile_job_aid.json
+++ b/custom/echis_reports/ucr/reports/ivr_weekly_mobile_job_aid.json
@@ -18,7 +18,6 @@
         "choice_provider": {
           "include_descendants": true,
           "type": "location",
-          "order_by_hierarchy": true,
           "show_full_path": false
         },
         "show_all": true,

--- a/custom/icds_reports/ucr/reports/mobile/mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_2a_deaths.json
@@ -41,7 +41,6 @@
         "choice_provider": {
           "type": "location",
           "include_descendants": true,
-          "order_by_hierarchy": true,
           "show_full_path": true
         }
       },
@@ -53,7 +52,6 @@
         "choice_provider": {
           "type": "location",
           "include_descendants": true,
-          "order_by_hierarchy": true,
           "show_full_path": true
         }
       },
@@ -65,7 +63,6 @@
         "choice_provider": {
           "type": "location",
           "include_descendants": true,
-          "order_by_hierarchy": true,
           "show_full_path": true
         }
       },
@@ -77,7 +74,6 @@
         "choice_provider": {
           "type": "location",
           "include_descendants": true,
-          "order_by_hierarchy": true,
           "show_full_path": true
         }
       },
@@ -89,7 +85,6 @@
         "choice_provider": {
           "type": "location",
           "include_descendants": true,
-          "order_by_hierarchy": true,
           "show_full_path": true
         }
       }


### PR DESCRIPTION
From this discussion: https://github.com/dimagi/commcare-hq/pull/21278#discussion_r204446458

It doesn't seem very sensible to show the full path and not order by hierarchy, or vice versa, so this combines the two into one setting.  This will change behavior for at least some ECHIS reports, so I'm waiting on feedback before merging.