### PR TITLE
Change pre-filled signup text from "Email" to "Professional Email"

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -35,7 +35,7 @@ class RegisterWebUserForm(forms.Form):
     # Not inheriting from other forms to de-obfuscate the role of this form.
 
     full_name = forms.CharField(label=_("Full Name"))
-    email = forms.CharField(label=_("Email"))
+    email = forms.CharField(label=_("Professional Email"))
     password = forms.CharField(
         label=_("Create Password"),
         widget=forms.PasswordInput(),


### PR DESCRIPTION
https://trello.com/c/TyZW1241/148-change-pre-filled-text-on-hq-signup-from-email-to-professional-email

<img width="483" alt="screen shot 2018-10-04 at 3 19 21 pm" src="https://user-images.githubusercontent.com/15271571/46497572-f1ed4900-c7e8-11e8-8d08-23c042fb2fbc.png">
