### PR TITLE
Use total_seconds for pillow metrics to capture lag > 1 day

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -285,8 +285,8 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
         count = len(changes_chunk) * len(self.processors)
         datadog_counter('commcare.change_feed.changes.count', count, tags=tags)
 
-        max_change_lag = (datetime.utcnow() - changes_chunk[0].metadata.publish_timestamp).seconds
-        min_change_lag = (datetime.utcnow() - changes_chunk[-1].metadata.publish_timestamp).seconds
+        max_change_lag = (datetime.utcnow() - changes_chunk[0].metadata.publish_timestamp).total_seconds()
+        min_change_lag = (datetime.utcnow() - changes_chunk[-1].metadata.publish_timestamp).total_seconds()
         datadog_gauge('commcare.change_feed.chunked.min_change_lag', min_change_lag, tags=tags)
         datadog_gauge('commcare.change_feed.chunked.max_change_lag', max_change_lag, tags=tags)
 
@@ -339,7 +339,7 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
             count = 1 if processor else len(self.processors)
             datadog_counter(metric, value=count, tags=tags)
 
-            change_lag = (datetime.utcnow() - change.metadata.publish_timestamp).seconds
+            change_lag = (datetime.utcnow() - change.metadata.publish_timestamp).total_seconds()
             datadog_gauge('commcare.change_feed.change_lag', change_lag, tags=[
                 'pillow_name:{}'.format(self.get_name()),
                 _topic_for_ddog(change.topic),


### PR DESCRIPTION
https://docs.python.org/2/library/datetime.html

> and days, seconds and microseconds are then normalized so that the representation is unique, with
>
> 0 <= microseconds < 1000000
> 0 <= seconds < 3600*24 (the number of seconds in one day)
> -999999999 <= days <= 999999999