### PR TITLE
Data cleaning: dropdowns for select questions

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -1,11 +1,13 @@
-/* global DOMPurify */
 hqDefine("hqwebapp/js/knockout_bindings.ko", [
     'jquery',
     'knockout',
+    'DOMPurify/dist/purify.min',
     'jquery-ui/ui/sortable',
+    'select2/dist/js/select2.full.min',
 ], function (
     $,
-    ko
+    ko,
+    DOMPurify
 ) {
     ko.bindingHandlers.hqbSubmitReady = {
         update: function (element, valueAccessor) {

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -602,6 +602,11 @@ def get_data_cleaning_data(form_data, instance):
                     'label': question.label,
                     'icon': question.icon,
                     'value': question.response,
+                    'type': question.type,
+                    'options': [{
+                        'id': option.value,
+                        'text': option.label,
+                    } for option in question.options],
                 }
                 ordered_question_values.append(value)
 

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -602,12 +602,15 @@ def get_data_cleaning_data(form_data, instance):
                     'label': question.label,
                     'icon': question.icon,
                     'value': question.response,
-                    'type': question.type,
                     'options': [{
                         'id': option.value,
                         'text': option.label,
                     } for option in question.options],
                 }
+                if question.type == 'MSelect':
+                    question_response_map[value].update({
+                        'multiple': True,
+                    })
                 ordered_question_values.append(value)
 
     _add_to_question_response_map(form_data)

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -303,7 +303,7 @@ hqDefine("reports/js/data_corrections", [
                     $input = $el.siblings("input");
                 $el.select2({
                     width: '100%',
-                    tags: true,     // TODO: this doesn't work for single selects: i see the box but can't type in it
+                    tags: true,
                 });
                 // TODO: add option for anything in value that isn't already in options
                 $el.val($input.val().split(" ")).trigger("change");

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -10,7 +10,12 @@
  *      Required:
  *          saveUrl
  *          properties: An object, where keys are the property name and values may be either strings or objects.
- *              If strings, they are assumed to be the property values. If objects, they should have a 'value' key
+ *              If strings, they are assumed to be the property values. If objects, they may include the properties
+ *                  value: Required. A string. Space-separated values if this is a multi-select (see below)
+ *                  options: Optional. A list of objects, each with a 'text' and 'id' key. If provided, a select
+ *                      box with a free text option will be displayed instead of a text box.
+ *                  multiple: Optional. If true (and options is provided), a multi-select box with a free text
+ *                      option will be displayed instead of a text box.
  *              with the property value and may then have arbitrary other properties to be used for display (see
  *              displayProperties below).
  *      Optional:
@@ -54,6 +59,8 @@ hqDefine("reports/js/data_corrections", [
         self.value = ko.observable(options.value || '');
         self.dirty = ko.observable(false);
         self.options = options.options || [];
+
+        // Account for select questions where the value is not one of the given options
         if (self.options.length && self.value()) {
             _.each(self.value().split(' '), function (value) {
                 if (!_.find(self.options, function (option) { return value === option.id })) {
@@ -63,8 +70,8 @@ hqDefine("reports/js/data_corrections", [
         }
         self.multiple = options.multiple === undefined ? false : options.multiple;
 
-        // TODO: comment this better
-        self.updateSelect = function (e) {
+        // Update hidden value for multiselects. See data_corrections_modal.html for context.
+        self.updateSpaceSeparatedValue = function (model, e) {
             var value = $(e.currentTarget).val();
             if (_.isArray(value)) {
                 value = value.join(" ");
@@ -307,14 +314,17 @@ hqDefine("reports/js/data_corrections", [
             });
             model = DataCorrectionsModel(options);
             $modal.koApplyBindings(model);
-            $modal.find("select").each(function() {
-                var $el = $(this),
-                    $input = $el.siblings("input");
+
+            $modal.find(".modal-body select").each(function() {
+                var $el = $(this);
                 $el.select2({
                     width: '100%',
                     tags: true,
                 });
-                $el.val($input.val().split(" ")).trigger("change");
+                if ($el.attr("multiple")) {
+                    var $input = $el.siblings("input");
+                    $el.val($input.val().split(" ")).trigger("change");
+                }
             });
         }
         return model;

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -54,6 +54,14 @@ hqDefine("reports/js/data_corrections", [
         self.value = ko.observable(options.value || '');
         self.dirty = ko.observable(false);
         self.options = options.options || [];
+        if (self.options.length && self.value()) {
+            _.each(self.value().split(' '), function (value) {
+                if (!_.find(self.options, function (option) { return value === option.id })) {
+                    self.options.unshift({id: value, text: value});
+                }
+            });
+        }
+        self.multiple = options.multiple === undefined ? false : options.multiple;
 
         // TODO: comment this better
         // TODO: make inputs actually hidden
@@ -308,7 +316,6 @@ hqDefine("reports/js/data_corrections", [
                     width: '100%',
                     tags: true,
                 });
-                // TODO: add option for anything in value that isn't already in options
                 $el.val($input.val().split(" ")).trigger("change");
             });
         }

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -30,6 +30,7 @@ hqDefine("reports/js/data_corrections", [
     "hqwebapp/js/assert_properties",
     "analytix/js/kissmetrix",
     "hqwebapp/js/components.ko",     // pagination
+    "select2/dist/js/select2.full.min",
 ], function (
     $,
     ko,
@@ -52,6 +53,15 @@ hqDefine("reports/js/data_corrections", [
         self.name = options.name;
         self.value = ko.observable(options.value || '');
         self.dirty = ko.observable(false);
+        self.options = options.options || [];
+
+        self.updateSelect = function (e) {
+            var value = $(e.currentTarget).val();
+            if (_.isArray(value)) {
+                value = value.join(" ");
+            }
+            self.value(value);
+        };
 
         return self;
     };
@@ -288,6 +298,16 @@ hqDefine("reports/js/data_corrections", [
             });
             model = new DataCorrectionsModel(options);
             $modal.koApplyBindings(model);
+            $modal.find("select").each(function() {
+                var $el = $(this),
+                    $input = $el.siblings("input");
+                $el.select2({
+                    width: '100%',
+                    tags: true,     // TODO: this doesn't work for single selects: i see the box but can't type in it
+                });
+                // TODO: add option for anything in value that isn't already in options
+                $el.val($input.val().split(" ")).trigger("change");
+            });
         }
         return model;
     };

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -55,6 +55,8 @@ hqDefine("reports/js/data_corrections", [
         self.dirty = ko.observable(false);
         self.options = options.options || [];
 
+        // TODO: comment this better
+        // TODO: make inputs actually hidden
         self.updateSelect = function (e) {
             var value = $(e.currentTarget).val();
             if (_.isArray(value)) {
@@ -296,8 +298,9 @@ hqDefine("reports/js/data_corrections", [
             $trigger.click(function () {
                 $modal.modal();
             });
-            model = new DataCorrectionsModel(options);
+            model = DataCorrectionsModel(options);
             $modal.koApplyBindings(model);
+            // TODO: make more knockout-y? new select2v4 binding?
             $modal.find("select").each(function() {
                 var $el = $(this),
                     $input = $el.siblings("input");

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -70,18 +70,29 @@ hqDefine("reports/js/data_corrections", [
                     }
                 });
             }
-            if (!self.multiple || !self.value()) {
+
+            // Single selects need to include a blank option for the allowClear and placeholder options to work
+            if (!self.multiple) {
                 self.options.unshift({id: '', text: ''});
             }
         }
 
         // Update hidden value for multiselects. See data_corrections_modal.html for context.
         self.updateSpaceSeparatedValue = function (model, e) {
-            var value = $(e.currentTarget).val();
-            if (_.isArray(value)) {
-                value = value.join(" ");
+            var newValue = $(e.currentTarget).val(),
+                oldValue = self.value(),
+                dirty = self.dirty();
+
+            if (_.isArray(newValue)) {
+                oldValue = oldValue.split(" ");
+                dirty = dirty || oldValue.length !== newValue.length ||
+                        oldValue.length !== _.intersection(oldValue, newValue).length;
+                newValue = newValue.join(" ");
+            } else {
+                dirty = dirty || oldValue !== newValue;
             }
-            self.value(value);
+            self.dirty(dirty);
+            self.value(newValue);
         };
 
         return self;

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -84,7 +84,7 @@ hqDefine("reports/js/data_corrections", [
                 dirty = self.dirty();
 
             if (_.isArray(newValue)) {
-                oldValue = oldValue.split(" ");
+                oldValue = oldValue ? oldValue.split(" ") : [];
                 dirty = dirty || oldValue.length !== newValue.length ||
                         oldValue.length !== _.intersection(oldValue, newValue).length;
                 newValue = newValue.join(" ");

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -314,32 +314,32 @@ hqDefine("reports/js/data_corrections", [
     var init = function ($trigger, $modal, options) {
         var model = undefined;
         if ($trigger.length && $modal.length) {
-            $trigger.click(function () {
-                $modal.modal();
-            });
             model = DataCorrectionsModel(options);
             $modal.koApplyBindings(model);
+            $trigger.click(function () {
+                $modal.modal();
 
-            $modal.find(".modal-body select").each(function () {
-                var $el = $(this),
-                    multiple = !!$el.attr("multiple"),
-                    select2Options = {
-                        width: '100%',
-                        tags: true,
-                    };
-                if (!multiple) {
-                    // Allow clearing in a single select, including adding a blank option
-                    // so placeholder and allowClear work properly
-                    select2Options = _.extend(select2Options, {
-                        allowClear: true,
-                        placeholder: gettext('Select a value'),
-                    });
-                }
-                $el.select2(select2Options);
-                if (multiple) {
-                    var $input = $el.siblings("input");
-                    $el.val($input.val().split(" ")).trigger("change");
-                }
+                $modal.find(".modal-body select").each(function () {
+                    var $el = $(this),
+                        multiple = !!$el.attr("multiple"),
+                        select2Options = {
+                            width: '100%',
+                            tags: true,
+                        };
+                    if (!multiple) {
+                        // Allow clearing in a single select, including adding a blank option
+                        // so placeholder and allowClear work properly
+                        select2Options = _.extend(select2Options, {
+                            allowClear: true,
+                            placeholder: gettext('Select a value'),
+                        });
+                    }
+                    $el.select2(select2Options);
+                    if (multiple) {
+                        var $input = $el.siblings("input");
+                        $el.val($input.val().split(" ")).trigger("change");
+                    }
+                });
             });
         }
         return model;

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -64,7 +64,6 @@ hqDefine("reports/js/data_corrections", [
         self.multiple = options.multiple === undefined ? false : options.multiple;
 
         // TODO: comment this better
-        // TODO: make inputs actually hidden
         self.updateSelect = function (e) {
             var value = $(e.currentTarget).val();
             if (_.isArray(value)) {
@@ -308,7 +307,6 @@ hqDefine("reports/js/data_corrections", [
             });
             model = DataCorrectionsModel(options);
             $modal.koApplyBindings(model);
-            // TODO: make more knockout-y? new select2v4 binding?
             $modal.find("select").each(function() {
                 var $el = $(this),
                     $input = $el.siblings("input");

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -88,11 +88,23 @@
                                             <i class="fa fa-pencil-square pull-left" data-bind="visible: dirty()"></i>
                                             <span data-bind="template: $root.propertyTemplate"></span>
                                         </label>
-                                        <div class="col-sm-6">
+                                        <div class="col-sm-6" data-bind="if: !options.length">
                                             <input type="text" class="form-control"
                                                    data-bind="value: value,
                                                               attr: { 'data-name': name },
                                                               event: { change: function() { this.dirty(true); } }" />
+                                        </div>
+                                        <div class="col-sm-6" data-bind="if: options.length">
+                                            <input type="text" class="form-control"
+                                                   data-bind="value: value,
+                                                              attr: { 'data-name': name }" />
+                                            <select class="form-control"
+                                                    data-bind="attr: { 'multiple': type === 'MSelect' },
+                                                               event: { change: function(model, e) { updateSelect(e); } }">
+                                                <!-- ko foreach: options -->
+                                                    <option data-bind="value: id, text: text"></option>
+                                                <!--/ko-->
+                                            </select>
                                         </div>
                                     </div>
                                 <!-- /ko -->

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -95,7 +95,7 @@
                                                               event: { change: function() { this.dirty(true); } }" />
                                         </div>
                                         <div class="col-sm-6" data-bind="if: options.length">
-                                            <input type="text" class="form-control"
+                                            <input type="hidden" class="form-control"
                                                    data-bind="value: value,
                                                               attr: { 'data-name': name }" />
                                             <select class="form-control"

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -6,7 +6,7 @@
 {% endcomment %}
 
 <!-- class='hide' keeps modal from showing until knockout initializes & removes the class -->
-<div class="hide modal fade data-corrections-modal" tabindex="-1"
+<div class="hide modal fade data-corrections-modal"
      data-bind="css: { 'full-screen-modal': isFullScreenModal(), 'hide': false },
                 event: { 'hidden.bs.modal': function() { $root.init(); }, 'shown.bs.modal': function() { $root.trackOpen(); } }">
     <div class="modal-dialog" data-bind="css: { 'modal-lg': isLargeModal() }">
@@ -99,11 +99,10 @@
                                                    data-bind="value: value,
                                                               attr: { 'data-name': name }" />
                                             <select class="form-control"
-                                                    data-bind="attr: { 'multiple': type === 'MSelect' },
+                                                    data-bind="foreach: options,
+                                                               attr: { 'multiple': type === 'MSelect' },
                                                                event: { change: function(model, e) { updateSelect(e); } }">
-                                                <!-- ko foreach: options -->
                                                     <option data-bind="value: id, text: text"></option>
-                                                <!--/ko-->
                                             </select>
                                         </div>
                                     </div>

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -100,7 +100,7 @@
                                                               attr: { 'data-name': name }" />
                                             <select class="form-control"
                                                     data-bind="foreach: options,
-                                                               attr: { 'multiple': type === 'MSelect' },
+                                                               attr: { 'multiple': multiple },
                                                                event: { change: function(model, e) { updateSelect(e); } }">
                                                     <option data-bind="value: id, text: text"></option>
                                             </select>

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -88,22 +88,41 @@
                                             <i class="fa fa-pencil-square pull-left" data-bind="visible: dirty()"></i>
                                             <span data-bind="template: $root.propertyTemplate"></span>
                                         </label>
-                                        <div class="col-sm-6" data-bind="if: !options.length">
-                                            <input type="text" class="form-control"
-                                                   data-bind="value: value,
-                                                              attr: { 'data-name': name },
-                                                              event: { change: function() { this.dirty(true); } }" />
-                                        </div>
-                                        <div class="col-sm-6" data-bind="if: options.length">
-                                            <input type="hidden" class="form-control"
-                                                   data-bind="value: value,
-                                                              attr: { 'data-name': name }" />
-                                            <select class="form-control"
-                                                    data-bind="foreach: options,
-                                                               attr: { 'multiple': multiple },
-                                                               event: { change: function(model, e) { updateSelect(e); } }">
-                                                    <option data-bind="value: id, text: text"></option>
-                                            </select>
+                                        <div class="col-sm-6">
+                                            <!-- ko ifnot: options.length -->
+                                                <input type="text" class="form-control"
+                                                       data-bind="value: value,
+                                                                  attr: { 'data-name': name },
+                                                                  event: { change: function() { this.dirty(true); } }" />
+                                            <!-- /ko -->
+                                            <!-- ko if: options.length -->
+                                                <!-- ko ifnot: multiple -->
+                                                    <select class="form-control"
+                                                            data-bind="foreach: options,
+                                                                       value: value,
+                                                                       attr: { 'data-name': name }">
+                                                            <option data-bind="value: id, text: text"></option>
+                                                    </select>
+                                                <!-- /ko -->
+                                                <!-- ko if: multiple -->
+                                                    {% comment %}
+                                                       Multiselect values are based on a space-separated string, because
+                                                       that's how form submissions work. Making this work with select2's
+                                                       comma-separated multiselect option is non-trivial, so instead we
+                                                       have a hidden input with a space-separated value that stays in sync
+                                                       with updates on the select2.
+                                                    {% endcomment %}
+                                                    <input type="hidden" class="form-control"
+                                                           data-bind="value: value,
+                                                                      attr: { 'data-name': name }" />
+                                                    <select class="form-control"
+                                                            multiple="multiple"
+                                                            data-bind="foreach: options,
+                                                                       event: { change: updateSpaceSeparatedValue }">
+                                                            <option data-bind="value: id, text: text"></option>
+                                                    </select>
+                                                <!-- /ko -->
+                                            <!-- /ko -->
                                         </div>
                                     </div>
                                 <!-- /ko -->

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -100,7 +100,8 @@
                                                     <select class="form-control"
                                                             data-bind="foreach: options,
                                                                        value: value,
-                                                                       attr: { 'data-name': name }">
+                                                                       attr: { 'data-name': name },
+                                                                       event: { change: function() { this.dirty(true); } }">
                                                             <option data-bind="value: id, text: text"></option>
                                                     </select>
                                                 <!-- /ko -->

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1270,6 +1270,7 @@ class CaseDataView(BaseProjectReportSectionView):
     http_method_names = ['get']
 
     @method_decorator(require_case_view_permission)
+    @use_select2_v4
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
         if not self.case_instance:
@@ -2038,6 +2039,7 @@ class FormDataView(BaseProjectReportSectionView):
     http_method_names = ['get']
 
     @method_decorator(require_form_view_permission)
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(FormDataView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
https://trello.com/c/8li42l6c/70-data-corrections-for-forms-dropdown-for-select-questions

This turns regular selects into dropdowns. It doesn't affect lookup-table-based selects.

<img width="636" alt="screen shot 2018-10-04 at 6 20 28 pm" src="https://user-images.githubusercontent.com/1486591/46506509-7dbf9f00-c802-11e8-85b5-d38c63151ecb.png">

[QA ticket](https://manage.dimagi.com/default.asp?283904)

@dannyroberts 