### PR TITLE
retry fixture download on 502s caused by server slowness

### DIFF
--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -325,7 +325,7 @@ hqDefine("fixtures/js/lookup-manage", [
                         },
                         error: function (resp) {
                             if (resp.status === 502 && serverSlowRetries < 5){
-                                serverSlowRetries += 1
+                                serverSlowRetries += 1;
                                 setTimeout(poll, 2000);
                             }
                             else {

--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -304,7 +304,7 @@ hqDefine("fixtures/js/lookup-manage", [
 
         self.setupDownload = function (response) {
             var keep_polling = true;
-
+            var server_slow_retries = 0;
             function poll() {
                 if (keep_polling) {
                     $.ajax({
@@ -323,9 +323,15 @@ hqDefine("fixtures/js/lookup-manage", [
                                 setTimeout(poll, 2000);
                             }
                         },
-                        error: function () {
-                            self.downloadError();
-                            keep_polling = false;
+                        error: function (resp) {
+                            if (resp.status == 502 && server_slow_retries < 5){
+                                server_slow_retries += 1
+                                setTimeout(poll, 2000);
+                            }
+                            else {
+                                self.downloadError();
+                                keep_polling = false;
+                            }
                         },
                     });
                 }

--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -304,7 +304,7 @@ hqDefine("fixtures/js/lookup-manage", [
 
         self.setupDownload = function (response) {
             var keep_polling = true;
-            var server_slow_retries = 0;
+            var serverSlowRetries = 0;
             function poll() {
                 if (keep_polling) {
                     $.ajax({
@@ -324,8 +324,8 @@ hqDefine("fixtures/js/lookup-manage", [
                             }
                         },
                         error: function (resp) {
-                            if (resp.status == 502 && server_slow_retries < 5){
-                                server_slow_retries += 1
+                            if (resp.status == 502 && serverSlowRetries < 5){
+                                serverSlowRetries += 1
                                 setTimeout(poll, 2000);
                             }
                             else {

--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -293,7 +293,7 @@ hqDefine("fixtures/js/lookup-manage", [
                     },
                     dataType: 'json',
                     success: function (response) {
-                        self.setupDownload(response);
+                        self.setupDownload(response.download_url);
                     },
                     error: function (response) {
                         self.downloadError();
@@ -302,13 +302,13 @@ hqDefine("fixtures/js/lookup-manage", [
             }
         };
 
-        self.setupDownload = function (response) {
+        self.setupDownload = function (downloadUrl) {
             var keep_polling = true;
             var serverSlowRetries = 0;
             function poll() {
                 if (keep_polling) {
                     $.ajax({
-                        url: response.download_url,
+                        url: downloadUrl,
                         dataType: 'text',
                         success: function (resp) {
                             var progress = $("#download-progress");
@@ -324,7 +324,7 @@ hqDefine("fixtures/js/lookup-manage", [
                             }
                         },
                         error: function (resp) {
-                            if (resp.status == 502 && serverSlowRetries < 5){
+                            if (resp.status === 502 && serverSlowRetries < 5){
                                 serverSlowRetries += 1
                                 setTimeout(poll, 2000);
                             }


### PR DESCRIPTION
Attempting to address https://manage.dimagi.com/default.asp?283901#1535174

It has been difficult to download fixtures when the server is slow as the poll URL 502s. I noticed that on retrying the URL iit works okay. So, adding that retry logic to the poll. Hoping that this would address the transient failures. 
(We could also add a way for the user to retry the poll, but automatic retry as I did now was easiest.)

@proteusvacuum 