### PR TITLE
switch missing and not_started

### DIFF
--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -141,9 +141,9 @@ def get_task_status(task, is_multiple_download_task=False):
     elif is_ready:
         state = STATES.success
     elif task and _is_task_pending(task):
-        state = STATES.missing
-    elif progress.percent is None:
         state = STATES.not_started
+    elif progress.percent is None:
+        state = STATES.missing
     else:
         state = STATES.started
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?283916

We're skipping a lot of export rebuilds because ```rebuild_saved_export``` is exiting here:
https://github.com/dimagi/commcare-hq/blob/668524afaf9ab5b0e28bd8950c248ca0ce8a7b67/corehq/apps/export/tasks.py#L124-L125

I'm not sure how this was ever working, but I've confirmed that this change makes ```rebuild_saved_export``` execute the rebuild.