### PR TITLE
check if view is exempt first to reduce toggle check

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -317,11 +317,11 @@ def two_factor_check(view_func, api_key):
 
 
 def _two_factor_required(view_func, domain, couch_user):
-    if TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(couch_user.username):
-        return not getattr(view_func, 'two_factor_exempt', False)
+    exempt = getattr(view_func, 'two_factor_exempt', False)
+    if exempt:
+        return False
     return (
-        not getattr(view_func, 'two_factor_exempt', False)
-        and domain.two_factor_auth
+        (domain.two_factor_auth or TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(couch_user.username))
         and not couch_user.two_factor_disabled
     )
 


### PR DESCRIPTION
Was looking some errors on ICDS and noticed that we could avoid the toggle check altogether for exempt views.

There is a slight logic change since the superuser check didn't factor in `couch_user.two_factor_disabled`