### PR TITLE
Check for downgrade and non-trial subscriptions

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -18,13 +18,12 @@ hqDefine('accounting/js/confirm_plan', [
     var MORE_FEATURES = gettext("I need additional/custom features");
     var OTHER = gettext("Other");
 
-    var confirmPlanModel = function (isUpgrade, currentPlan, newPlan) {
+    var confirmPlanModel = function (isUpgrade, currentPlan) {
         'use strict';
         var self = {};
 
         self.isUpgrade = isUpgrade;
         self.currentPlan = currentPlan;
-        self.newPlan = newPlan;
 
         // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
         self.userAgreementSigned = ko.observable(!isUpgrade);
@@ -105,8 +104,7 @@ hqDefine('accounting/js/confirm_plan', [
     $(function () {
         var confirmPlan = confirmPlanModel(
             initialPageData.get('is_upgrade'),
-            initialPageData.get('current_plan'),
-            initialPageData.get('new_plan_name')
+            initialPageData.get('current_plan')
         );
 
         $('#confirm-plan-content').koApplyBindings(confirmPlan);

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1693,7 +1693,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
             )
             return False
 
-    def is_downgrade(self):
+    def is_downgrade_from_paid_plan(self):
         if self.current_subscription is None:
             return False
         elif self.current_subscription.is_trial:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1649,7 +1649,8 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
 
                 cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
                 if self.current_subscription is not None:
-                    if self.is_downgrade() and self.current_subscription.is_below_minimum_subscription:
+                    if self.is_downgrade_from_paid_plan() and \
+                            self.current_subscription.is_below_minimum_subscription:
                         self.current_subscription.update_subscription(
                             date_start=self.current_subscription.date_start,
                             date_end=self.current_subscription.date_start + datetime.timedelta(days=30)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1696,6 +1696,8 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
     def is_downgrade(self):
         if self.current_subscription is None:
             return False
+        elif self.current_subscription.is_trial:
+            return False
         else:
             return is_downgrade(
                 current_edition=self.current_subscription.plan_version.plan.edition,

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -8,7 +8,6 @@
 {% initial_page_data 'next_invoice_date' next_invoice_date %}
 {% initial_page_data 'current_plan' current_plan %}
 {% initial_page_data 'new_plan_edition' new_plan_edition %}
-{% initial_page_data 'new_plan_name' plan.name %}
 {% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
 {% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
 {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1753,7 +1753,7 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             next_subscription = self.current_subscription.next_subscription
 
             if is_saved:
-                if not request.user.is_superuser and not self.is_upgrade:
+                if self.billing_account_info_form.is_downgrade() and not request.user.is_superuser:
                     self.send_downgrade_email()
                 if next_subscription is not None:
                     # New subscription has been scheduled for the future


### PR DESCRIPTION
Check for downgrade and non-trial subscriptions _before_ sending the downgrading email.

`billing_account_info_form.is_downgrade()` is more accurate than `ConfirmSelectedPlanView.is_upgrade` because `self.current_subscription` is updated to the new subscription before the user reaches the ConfirmSelectedPlanView.