### PR TITLE
Add metrics to case list and submit history apply buttons

### DIFF
--- a/corehq/apps/reports/static/reports/js/case_list.js
+++ b/corehq/apps/reports/static/reports/js/case_list.js
@@ -4,6 +4,11 @@ hqDefine("reports/js/case_list", ['jquery', 'analytix/js/kissmetrix'], function 
             $(document).on('click', 'td.case-name-link', function () {
                 kissAnalytics.track.event("Clicked Case Name in Case List Report");
             });
+            $(document).on('click', 'button#apply-filters', function () {
+                kissAnalytics.track.event("Clicked Apply", _.object(
+                    _.pluck($('#paramSelectorForm').serializeArray(), 'name'),
+                    _.pluck($('#paramSelectorForm').serializeArray(), 'value')));
+            });
         }
     });
 });

--- a/corehq/apps/reports/static/reports/js/submit_history.js
+++ b/corehq/apps/reports/static/reports/js/submit_history.js
@@ -4,6 +4,11 @@ hqDefine("reports/js/submit_history", ['jquery', 'analytix/js/kissmetrix'], func
             $(document).on('click', 'td.view-form-link', function () {
                 kissAnalytics.track.event("Clicked View Form in Submit History Report");
             });
+            $(document).on('click', 'button#apply-filters', function () {
+                kissAnalytics.track.event("Clicked Apply", _.object(
+                    _.pluck($('#paramSelectorForm').serializeArray(), 'name'),
+                    _.pluck($('#paramSelectorForm').serializeArray(), 'value')));
+            });
         }
     });
 });


### PR DESCRIPTION
For submit history, this is returned:
![screen shot 2018-10-09 at 11 22 30 am](https://user-images.githubusercontent.com/35747290/46679841-c934cd00-cbb5-11e8-8848-1b7363627dfd.png)

For case list, this is returned: 
![screen shot 2018-10-09 at 11 22 42 am](https://user-images.githubusercontent.com/35747290/46679862-d5b92580-cbb5-11e8-8b61-19237d9302a4.png)
^^where t__`number` is referring to the `number`s specified [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/models.py#L76-L82)
