### PR TITLE
Task to poll OpenMRS Atom feed 

### DIFF
--- a/corehq/apps/locations/dbaccessors.py
+++ b/corehq/apps/locations/dbaccessors.py
@@ -71,6 +71,15 @@ def get_web_users_by_location(domain, location_id):
     return _cc_users_by_location(domain, location_id, user_class=WebUser)
 
 
+def get_commcare_users_by_location(domain, location_id):
+    from corehq.apps.users.models import CommCareUser
+    return _cc_users_by_location(domain, location_id, user_class=CommCareUser)
+
+
+def get_one_commcare_user_at_location(domain, location_id):
+    return get_commcare_users_by_location(domain, location_id).first()
+
+
 def get_users_location_ids(domain, user_ids):
     """Get the ids of the locations the users are assigned to"""
     result = (UserES()

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -149,11 +149,11 @@ def get_addpatient_caseblock(case_type, owner, patient, repeater):
     property_map = get_property_map(repeater.openmrs_config.case_config)
 
     fields_to_update = {}
-    for prop, (jsonpath, value_map) in property_map.items():
+    for prop, (jsonpath, value_source) in property_map.items():
         matches = jsonpath.find(patient)
         if matches:
             patient_value = matches[0].value
-            new_value = value_map.get(patient_value, patient_value)
+            new_value = value_source.deserialize(patient_value)
             fields_to_update[prop] = new_value
 
     if fields_to_update:
@@ -175,12 +175,12 @@ def get_updatepatient_caseblock(case, patient, repeater):
     property_map = get_property_map(repeater.openmrs_config.case_config)
 
     fields_to_update = {}
-    for prop, (jsonpath, value_map) in property_map.items():
+    for prop, (jsonpath, value_source) in property_map.items():
         matches = jsonpath.find(patient)
         if matches:
             patient_value = matches[0].value
             case_value = case.get_case_property(prop)
-            new_value = value_map.get(patient_value, patient_value)
+            new_value = value_source.deserialize(patient_value)
             if case_value != new_value:
                 fields_to_update[prop] = new_value
 

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -1,0 +1,261 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import re
+import uuid
+from collections import namedtuple
+from datetime import datetime
+
+import pytz
+from dateutil import parser as dateutil_parser
+from dateutil.tz import tzutc
+from lxml import etree
+from requests import RequestException
+
+from casexml.apps.case.mock import CaseBlock
+from corehq.apps.case_importer import util as importer_util
+from corehq.apps.case_importer.const import LookupErrors
+from corehq.apps.case_importer.util import EXTERNAL_ID
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.locations.dbaccessors import get_one_commcare_user_at_location
+from corehq.motech.openmrs.const import XMLNS_OPENMRS, OPENMRS_ATOM_FEED_DEVICE_ID
+from corehq.motech.openmrs.openmrs_config import get_property_map
+from corehq.motech.openmrs.repeater_helpers import get_patient_by_uuid
+from corehq.motech.requests import Requests
+from corehq.util.soft_assert import soft_assert
+
+
+UuidUpdatedAt = namedtuple('UuidUpdatedAt', 'uuid updated_at')
+_assert = soft_assert(['@'.join(('nhooper', 'dimagi.com'))])
+
+
+def get_patient_feed_xml(requests, page):
+    if not page:
+        # If this is the first time the patient feed is polled, just get
+        # the most recent changes. This shows updating patients
+        # successfully, but does not replay all OpenMRS changes.
+        page = 'recent'
+    patient_feed_url = '/ws/atomfeed/patient/' + page
+    resp = requests.get(patient_feed_url)
+    root = etree.fromstring(resp.content)
+    return root
+
+
+def get_timestamp(element, xpath='./atom:updated'):
+    """
+    Returns a datetime instance of the text at the given xpath.
+
+    >>> element = etree.XML('''<feed xmlns="http://www.w3.org/2005/Atom">
+    ...     <updated>2018-05-15T14:02:08Z</updated>
+    ... </feed>''')
+    >>> get_timestamp(element)
+    datetime.datetime(2018, 5, 15, 14, 2, 8, tzinfo=tzutc())
+
+    """
+    timestamp_elems = element.xpath(xpath, namespaces={'atom': 'http://www.w3.org/2005/Atom'})
+    if not timestamp_elems:
+        raise ValueError('XPath "{}" not found'.format(xpath))
+    if len(timestamp_elems) != 1:
+        raise ValueError('XPath "{}" matched multiple nodes'.format(xpath))
+    tzinfos = {'UTC': tzutc()}
+    return dateutil_parser.parse(timestamp_elems[0].text, tzinfos=tzinfos)
+
+
+def get_patient_uuid(element):
+    """
+    Extracts the UUID of a patient from an entry's "content" node.
+
+    >>> element = etree.XML('''<entry>
+    ...     <content type="application/vnd.atomfeed+xml">
+    ...         <![CDATA[/openmrs/ws/rest/v1/patient/e8aa08f6-86cd-42f9-8924-1b3ea021aeb4?v=full]]>
+    ...     </content>
+    ... </entry>''')
+    >>> get_patient_uuid(element) == 'e8aa08f6-86cd-42f9-8924-1b3ea021aeb4'
+    True
+
+    """
+    # "./*[local-name()='content']" ignores namespaces and matches all
+    # child nodes with tag name "content". This lets us traverse the
+    # feed regardless of whether the Atom namespace is explicitly given.
+    content = element.xpath("./*[local-name()='content']")
+    pattern = re.compile(r'/patient/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b')
+    if content and len(content) == 1:
+        cdata = content[0].text
+        matches = pattern.search(cdata)
+        if matches:
+            return matches.group(1)
+    raise ValueError('patient UUID not found')
+
+
+def get_updated_patients(repeater):
+    """
+    Iterates over a paginated atom feed, yields patients updated since
+    repeater.atom_feed_last_polled_at, and updates the repeater.
+    """
+    def has_new_entries_since(last_polled_at, element, xpath='./atom:updated'):
+        return not last_polled_at or get_timestamp(element, xpath) > last_polled_at
+
+    requests = Requests(
+        repeater.domain,
+        repeater.url,
+        repeater.username,
+        repeater.password
+    )
+    # The OpenMRS Atom Feed's timestamps are timezone-aware. So when we
+    # compare timestamps in has_new_entries_since(), this timestamp
+    # must also be timezone-aware. repeater.atom_feed_last_polled_at is
+    # set to a UTC timestamp (datetime.utcnow()), but the timezone gets
+    # dropped because it is stored as a jsonobject DateTimeProperty.
+    # This sets it as a UTC timestamp again:
+    last_polled_at = pytz.utc.localize(repeater.atom_feed_last_polled_at) \
+        if repeater.atom_feed_last_polled_at else None
+    page = repeater.atom_feed_last_page
+    try:
+        while True:
+            feed_xml = get_patient_feed_xml(requests, page)
+            if has_new_entries_since(last_polled_at, feed_xml):
+                for entry in feed_xml.xpath('./atom:entry', namespaces={'atom': 'http://www.w3.org/2005/Atom'}):
+                    if has_new_entries_since(last_polled_at, entry, './atom:published'):
+                        yield UuidUpdatedAt(
+                            get_patient_uuid(entry),
+                            get_timestamp(entry)
+                        )
+            next_page = feed_xml.xpath(
+                './atom:link[@rel="next-archive"]',
+                namespaces={'atom': 'http://www.w3.org/2005/Atom'}
+            )
+            if next_page:
+                href = next_page[0].get('href')
+                page = href.split('/')[-1]
+            else:
+                if not page:
+                    this_page = feed_xml.xpath(
+                        './atom:link[@rel="via"]',
+                        namespaces={'atom': 'http://www.w3.org/2005/Atom'}
+                    )
+                    href = this_page[0].get('href')
+                    page = href.split('/')[-1]
+                break
+    except RequestException:
+        # Don't update repeater if OpenMRS is offline
+        return
+    else:
+        repeater.atom_feed_last_polled_at = datetime.utcnow()
+        repeater.atom_feed_last_page = page
+        repeater.save()
+
+
+def get_addpatient_caseblock(case_type, owner, patient, repeater):
+    property_map = get_property_map(repeater.openmrs_config.case_config)
+
+    fields_to_update = {}
+    for prop, (jsonpath, value_map) in property_map.items():
+        matches = jsonpath.find(patient)
+        if matches:
+            patient_value = matches[0].value
+            new_value = value_map.get(patient_value, patient_value)
+            fields_to_update[prop] = new_value
+
+    if fields_to_update:
+        case_id = uuid.uuid4().hex
+        case_name = patient['person']['display']
+        return CaseBlock(
+            create=True,
+            case_id=case_id,
+            owner_id=owner.user_id,
+            user_id=owner.user_id,
+            case_type=case_type,
+            case_name=case_name,
+            external_id=patient['uuid'],
+            update=fields_to_update,
+        )
+
+
+def get_updatepatient_caseblock(case, patient, repeater):
+    property_map = get_property_map(repeater.openmrs_config.case_config)
+
+    fields_to_update = {}
+    for prop, (jsonpath, value_map) in property_map.items():
+        matches = jsonpath.find(patient)
+        if matches:
+            patient_value = matches[0].value
+            case_value = case.get_case_property(prop)
+            new_value = value_map.get(patient_value, patient_value)
+            if case_value != new_value:
+                fields_to_update[prop] = new_value
+
+    if fields_to_update:
+        case_name = patient['person']['display']
+        return CaseBlock(
+            create=False,
+            case_id=case.get_id,
+            case_name=case_name,
+            update=fields_to_update,
+        )
+
+
+def update_patient(repeater, patient_uuid, updated_at):
+    """
+    Fetch patient from OpenMRS, submit case update for all mapped case
+    properties.
+
+    .. NOTE:: OpenMRS UUID must be saved to "external_id" case property
+
+    """
+    _assert(
+        len(repeater.white_listed_case_types) == 1,
+        'Unable to update patients from OpenMRS unless a single case type is '
+        'specified. domain: "{}". repeater: "{}".'.format(
+            repeater.domain, repeater.get_id
+        )
+    )
+    case_type = repeater.white_listed_case_types[0]
+    requests = Requests(
+        repeater.domain,
+        repeater.url,
+        repeater.username,
+        repeater.password
+    )
+    patient = get_patient_by_uuid(requests, patient_uuid)
+    case, error = importer_util.lookup_case(
+        EXTERNAL_ID,
+        patient_uuid,
+        repeater.domain,
+        case_type=case_type,
+    )
+    if error == LookupErrors.NotFound:
+        owner = get_one_commcare_user_at_location(repeater.domain, repeater.location_id)
+        _assert(
+            owner,
+            'No users found at location "{}" to own patients added from '
+            'OpenMRS atom feed. domain: "{}". repeater: "{}".'.format(
+                repeater.location_id, repeater.domain, repeater.get_id
+            )
+        )
+        case_block = get_addpatient_caseblock(case_type, owner, patient, repeater)
+
+    else:
+        _assert(
+            error != LookupErrors.MultipleResults,
+            # Multiple cases matched to the same patient.
+            # Could be caused by:
+            # * The cases were given the same identifier value. It could
+            #   be user error, or case config assumed identifier was
+            #   unique but it wasn't.
+            # * PatientFinder matched badly.
+            # * Race condition where a patient was previously added to
+            #   both CommCare and OpenMRS.
+            'More than one case found matching unique OpenMRS UUID. '
+            'domain: "{}". case external_id: "{}". repeater: "{}".'.format(
+                repeater.domain, patient_uuid, repeater.get_id
+            )
+        )
+        case_block = get_updatepatient_caseblock(case, patient, repeater)
+
+    if case_block:
+        submit_case_blocks(
+            [case_block.as_string()],
+            repeater.domain,
+            xmlns=XMLNS_OPENMRS,
+            device_id=OPENMRS_ATOM_FEED_DEVICE_ID + repeater.get_id,
+        )

--- a/corehq/motech/openmrs/const.py
+++ b/corehq/motech/openmrs/const.py
@@ -27,6 +27,12 @@ OPENMRS_IMPORTER_DEVICE_ID_PREFIX = 'openmrs-importer-'
 # XMLNS to indicate that a form was imported from OpenMRS
 XMLNS_OPENMRS = 'http://commcarehq.org/openmrs-integration'
 
+OPENMRS_ATOM_FEED_POLL_INTERVAL = {'minute': '*/10'}
+
+# device_id for cases added/updated from OpenMRS Atom feed.
+# OpenmrsRepeater ID is appended to this.
+OPENMRS_ATOM_FEED_DEVICE_ID = 'openmrs-atomfeed-'
+
 # The Location property to store the OpenMRS location UUID in
 LOCATION_OPENMRS_UUID = 'openmrs_uuid'
 

--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -148,17 +148,17 @@ class WeightedPropertyPatientFinder(PatientFinder):
         def weights():
             for property_weight in self.property_weights:
                 prop = property_weight['case_property']
+                jsonpath, value_source = self._property_map[prop]
                 weight = property_weight['weight']
 
-                matches = self._property_map[prop].jsonpath.find(patient)
+                matches = jsonpath.find(patient)
                 for match in matches:
                     patient_value = match.value
-                    value_map = self._property_map[prop].value_map
                     case_value = case.get_case_property(prop)
                     match_type = property_weight['match_type']
                     match_params = property_weight['match_params']
                     match_function = partial(MATCH_FUNCTIONS[match_type], *match_params)
-                    is_equivalent = match_function(value_map.get(patient_value, patient_value), case_value)
+                    is_equivalent = match_function(value_source.deserialize(patient_value), case_value)
                     yield weight if is_equivalent else 0
 
         return sum(weights())

--- a/corehq/motech/openmrs/jsonpath.py
+++ b/corehq/motech/openmrs/jsonpath.py
@@ -38,3 +38,36 @@ class Cmp(JSONPath):
             other.op == self.op and
             other.operand == self.operand
         )
+
+    def __hash__(self):
+        return hash(str(self))
+
+
+class WhereNot(JSONPath):
+    """
+    Identical to JSONPath Where, but filters for only those nodes that
+    do *not* have a match on the right.
+
+    >>> jsonpath = WhereNot(Fields('spam'), Fields('spam'))
+    >>> jsonpath.find({"spam": {"spam": 1}})
+    []
+    >>> matches = jsonpath.find({"spam": 1})
+    >>> matches[0].value
+    1
+
+    """
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def find(self, data):
+        return [subdata for subdata in self.left.find(data) if not self.right.find(subdata)]
+
+    def __str__(self):
+        return '%s where not %s' % (self.left, self.right)
+
+    def __eq__(self, other):
+        return isinstance(other, WhereNot) and other.left == self.left and other.right == self.right
+
+    def __hash__(self):
+        return hash(str(self))

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -188,10 +188,10 @@ class OpenmrsConfig(DocumentSchema):
 # The `jsonpath` attribute is used for retrieving values from an
 # OpenMRS patient and the `value_map` attribute is for converting
 # OpenMRS concept UUIDs to CommCare property values, if necessary.
-JsonpathValuemap = namedtuple('JsonpathValuemap', ['jsonpath', 'value_map'])
+JsonpathValuesource = namedtuple('JsonpathValuesource', ['jsonpath', 'value_source'])
 
 
-def get_caseproperty_jsonpathvaluemap(jsonpath, value_source):
+def get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config):
     """
     Used for updating _property_map to map case properties to OpenMRS
     patient property-, attribute- and concept values.
@@ -200,37 +200,36 @@ def get_caseproperty_jsonpathvaluemap(jsonpath, value_source):
     do we find the OpenMRS value?"
 
     :param jsonpath: The path to a value in an OpenMRS patient JSON object
-    :param value_source: A case_config ValueSource instance
+    :param value_source_config: A case_config ValueSource instance
     :return: A single-item dictionary with the name of the case
-             property as key, and a JsonpathValuemap as value. If
-             value_source is a constant, then there is no corresponding
-             case property, so the function returns an empty dictionary
+             property as key, and a JsonpathValuesource as value. If
+             value_source_config is a ConstantString, then there is no
+             corresponding case property, so the function returns an
+             empty dictionary.
     """
-    if value_source['doc_type'] == 'ConstantString':
+    if value_source_config['doc_type'] == 'ConstantString':
         return {}
-    if value_source['doc_type'] == 'CaseProperty':
-        return {value_source['case_property']: JsonpathValuemap(jsonpath, {})}
-    if value_source['doc_type'] == 'CasePropertyMap':
-        value_map = {v: k for k, v in value_source['value_map'].items()}
-        return {value_source['case_property']: JsonpathValuemap(jsonpath, value_map)}
+    if value_source_config['doc_type'] in ('CaseProperty', 'CasePropertyMap'):
+        value_source = ValueSource.wrap(value_source_config)
+        return {value_source_config['case_property']: JsonpathValuesource(jsonpath, value_source)}
     raise ValueError(
         '"{}" is not a recognised ValueSource for setting OpenMRS patient values from CommCare case properties. '
-        'Please check your OpenMRS case config.'.format(value_source['doc_type'])
+        'Please check your OpenMRS case config.'.format(value_source_config['doc_type'])
     )
 
 
 def get_property_map(case_config):
     """
-    Returns a map of OpenMRS patient properties and attributes to case
-    properties.
+    Returns a map of case properties to OpenMRS patient properties and
+    attributes, and a ValueSource instance to deserialize them.
     """
     property_map = {}
 
-    for person_prop, value_source in case_config['person_properties'].items():
+    for person_prop, value_source_config in case_config['person_properties'].items():
         jsonpath = parse_jsonpath('person.' + person_prop)
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for attr_uuid, value_source in case_config['person_attributes'].items():
+    for attr_uuid, value_source_config in case_config['person_attributes'].items():
         # jsonpath_rw offers programmatic JSONPath expressions. For details on how to create JSONPath
         # expressions programmatically see the
         # `jsonpath_rw documentation <https://github.com/kennknowles/python-jsonpath-rw#programmatic-jsonpath>`__
@@ -250,17 +249,17 @@ def get_property_map(case_config):
             ),
             Fields('value')
         )
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for name_prop, value_source in case_config['person_preferred_name'].items():
+    for name_prop, value_source_config in case_config['person_preferred_name'].items():
         jsonpath = parse_jsonpath('person.preferredName.' + name_prop)
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for addr_prop, value_source in case_config['person_preferred_address'].items():
+    for addr_prop, value_source_config in case_config['person_preferred_address'].items():
         jsonpath = parse_jsonpath('person.preferredAddress.' + addr_prop)
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for id_type_uuid, value_source in case_config['patient_identifiers'].items():
+    for id_type_uuid, value_source_config in case_config['patient_identifiers'].items():
         if id_type_uuid == 'uuid':
             jsonpath = parse_jsonpath('uuid')
         else:
@@ -277,6 +276,6 @@ def get_property_map(case_config):
                 ),
                 Fields('identifier')
             )
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
     return property_map

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -200,7 +200,7 @@ def get_property_map(case_config):
             jsonpath = parse_jsonpath('person.' + person_prop)
             property_map[value_source['case_property']] = (jsonpath, value_source)
 
-    for attr_uuid, value_source in case_config['person_attributes'].items():
+    for attr_type_uuid, value_source in case_config['person_attributes'].items():
         # jsonpath_rw offers programmatic JSONPath expressions. For details on how to create JSONPath
         # expressions programmatically see the
         # `jsonpath_rw documentation <https://github.com/kennknowles/python-jsonpath-rw#programmatic-jsonpath>`__
@@ -209,7 +209,7 @@ def get_property_map(case_config):
         # where a child matches *jsonpath2*. `Cmp` does a comparison in *jsonpath2*. It accepts a
         # comparison operator and a value. The JSONPath expression for matching simple attribute values is::
         #
-        #     (person.attributes[*] where attributeType.uuid eq attr_uuid).value
+        #     (person.attributes[*] where attributeType.uuid eq attr_type_uuid).value
         #
         # This extracts the person attribute values where their attribute type UUIDs match those configured in
         # case_config['person_attributes'].
@@ -219,18 +219,20 @@ def get_property_map(case_config):
         if 'case_property' in value_source:
             jsonpath = Union(
                 # Simple values: Return value if it has no children.
+                # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).(value where not *)
                 Child(
                     Where(
                         Child(Child(Fields('person'), Fields('attributes')), Slice()),
-                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_uuid)
+                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
                     ),
                     WhereNot(Fields('value'), Fields('*'))
                 ),
                 # Concept values: Return value.uuid if value.uuid exists:
+                # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).value.uuid
                 Child(
                     Where(
                         Child(Child(Fields('person'), Fields('attributes')), Slice()),
-                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_uuid)
+                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
                     ),
                     Child(Fields('value'), Fields('uuid'))
                 )

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -564,11 +564,11 @@ def create_patient(requests, info, case_config):
     }
     person = {}
     if name:
-        person['names'] = [serialize(name)]
+        person['names'] = [name]
     if address:
-        person['addresses'] = [serialize(address)]
+        person['addresses'] = [address]
     if properties:
-        person.update(serialize(properties))
+        person.update(properties)
     if person:
         identifiers = [
             {'identifierType': patient_identifier_type, 'identifier': value_source.get_value(info)}

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
 
-from couchdbkit.ext.django.schema import SchemaProperty, StringProperty
+from couchdbkit.ext.django.schema import SchemaProperty, StringProperty, DateTimeProperty, BooleanProperty
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 
@@ -37,6 +37,15 @@ class OpenmrsRepeater(CaseRepeater):
 
     location_id = StringProperty(default='')
     openmrs_config = SchemaProperty(OpenmrsConfig)
+
+    # self.white_listed_case_types must have exactly one case type set
+    # for Atom feed integration to add cases for OpenMRS patients.
+    # self.location_id must be set to determine their case owner. The
+    # owner is set to the first CommCareUser instance found at that
+    # location.
+    atom_feed_enabled = BooleanProperty(default=False)
+    atom_feed_last_polled_at = DateTimeProperty(default=None)
+    atom_feed_last_page = StringProperty(default=None)
 
     def __eq__(self, other):
         return (

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -21,18 +21,21 @@ from corehq.apps.case_importer import util as importer_util
 from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.case_importer.util import EXTERNAL_ID
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.apps.locations.dbaccessors import get_all_users_by_location
+from corehq.apps.locations.dbaccessors import get_one_commcare_user_at_location
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.users.models import CommCareUser
+from corehq.motech.openmrs.atom_feed import get_updated_patients, update_patient
 from corehq.motech.openmrs.const import (
-    IMPORT_FREQUENCY_MONTHLY,
     IMPORT_FREQUENCY_WEEKLY,
+    IMPORT_FREQUENCY_MONTHLY,
+    OPENMRS_ATOM_FEED_POLL_INTERVAL,
     OPENMRS_IMPORTER_DEVICE_ID_PREFIX,
     XMLNS_OPENMRS,
 )
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.models import POSIX_MILLISECONDS
+from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.requests import Requests
 from corehq.motech.utils import b64_aes_decrypt
 from toggle.shortcuts import find_domains_with_toggle_enabled
@@ -123,12 +126,6 @@ def get_updatepatient_caseblock(case, patient, importer):
     )
 
 
-def get_commcare_users_by_location(domain_name, location_id):
-    for user in get_all_users_by_location(domain_name, location_id):
-        if user.is_commcare_user():
-            yield user
-
-
 def import_patients_of_owner(requests, importer, domain_name, owner, location=None):
     openmrs_patients = get_openmrs_patients(requests, importer, location)
     case_blocks = []
@@ -215,9 +212,8 @@ def import_patients_to_domain(domain_name, force=False):
                 locations = SQLLocation.objects.filter(domain=domain_name, location_type=location_type)
             for location in locations:
                 # Assign cases to the first user in the location, not to the location itself
-                try:
-                    owner = next(get_commcare_users_by_location(domain_name, location.location_id))
-                except StopIteration:
+                owner = get_one_commcare_user_at_location(domain_name, location.location_id)
+                if not owner:
                     logger.error(
                         'Project space "{domain}" at location "{location}" has no user to own cases imported from '
                         'OpenMRS Importer "{importer}"'.format(
@@ -258,9 +254,24 @@ def import_patients():
         import_patients_to_domain(domain_name)
 
 
-@task(serializer='pickle', queue='background_queue')
+@task(queue='background_queue')
+def poll_openmrs_atom_feeds(domain_name):
+    for repeater in OpenmrsRepeater.by_domain(domain_name):
+        if repeater.atom_feed_enabled and not repeater.paused:
+            updated_patients = get_updated_patients(repeater)
+            for patient_uuid, updated_at in updated_patients:
+                update_patient(repeater, patient_uuid, updated_at)
+
+
+@periodic_task(
+    serializer='pickle',
+    run_every=crontab(**OPENMRS_ATOM_FEED_POLL_INTERVAL),
+    queue='background_queue'
+)
 def track_changes():
     """
     Uses the OpenMRS Atom Feed to track changes
     """
-    pass
+    domains = find_domains_with_toggle_enabled(toggles.OPENMRS_INTEGRATION)
+    for domain in domains:
+        poll_openmrs_atom_feeds.delay(domain)

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -1,0 +1,95 @@
+# encoding: utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import doctest
+import re
+from datetime import datetime
+
+from dateutil.tz import tzutc, tzoffset
+from django.test import SimpleTestCase
+from lxml import etree
+
+import corehq.motech.openmrs.atom_feed
+from corehq.motech.openmrs.atom_feed import get_timestamp, get_patient_uuid
+
+
+class GetTimestampTests(SimpleTestCase):
+
+    def setUp(self):
+        self.feed_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Patient AOP</title>
+  <updated>2018-05-15T14:02:08Z</updated>
+  <entry>
+    <title>Patient</title>
+    <updated>2018-04-26T10:56:10Z</updated>
+  </entry>
+</feed>
+"""
+
+    def test_no_node(self):
+        xml = re.sub(r'<updated.*</updated>', b'', self.feed_xml)
+        feed_elem = etree.XML(xml)
+        with self.assertRaisesRegex(ValueError, r'^XPath "./atom:updated" not found$'):
+            get_timestamp(feed_elem)
+
+    def test_xpath(self):
+        feed_elem = etree.XML(self.feed_xml)
+        # "*[local-name()='foo']" ignores namespaces and matches all nodes with tag "foo":
+        timestamp = get_timestamp(feed_elem, "./*[local-name()='entry']/*[local-name()='updated']")
+        self.assertEqual(timestamp, datetime(2018, 4, 26, 10, 56, 10, tzinfo=tzutc()))
+
+    def test_bad_date(self):
+        xml = re.sub(r'2018-05-15T14:02:08Z', b'Nevermore', self.feed_xml)
+        feed_elem = etree.XML(xml)
+        with self.assertRaisesRegex(ValueError, r'^Unknown string format$'):
+            get_timestamp(feed_elem)
+
+    def test_timezone(self):
+        xml = re.sub(r'2018-05-15T14:02:08Z', b'2018-05-15T14:02:08+0500', self.feed_xml)
+        feed_elem = etree.XML(xml)
+        timestamp = get_timestamp(feed_elem)
+        self.assertEqual(timestamp, datetime(2018, 5, 15, 14, 2, 8, tzinfo=tzoffset(None, 5 * 60 * 60)))
+
+
+class GetPatientUuidTests(SimpleTestCase):
+
+    def setUp(self):
+        self.feed_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Patient AOP</title>
+  <entry>
+    <title>Patient</title>
+    <content type="application/vnd.atomfeed+xml">
+      <![CDATA[/openmrs/ws/rest/v1/patient/e8aa08f6-86cd-42f9-8924-1b3ea021aeb4?v=full]]>
+    </content>
+  </entry>
+</feed>
+"""
+
+    def test_no_content_node(self):
+        xml = re.sub(r'<content.*</content>', b'', self.feed_xml, flags=re.DOTALL)
+        feed_elem = etree.XML(xml)
+        entry_elem = next(e for e in feed_elem if e.tag.endswith('entry'))
+        with self.assertRaisesRegex(ValueError, r'^patient UUID not found$'):
+            get_patient_uuid(entry_elem)
+
+    def test_bad_cdata(self):
+        xml = re.sub(r'e8aa08f6-86cd-42f9-8924-1b3ea021aeb4', b'mary-mallon', self.feed_xml)
+        feed_elem = etree.XML(xml)
+        entry_elem = next(e for e in feed_elem if e.tag.endswith('entry'))
+        with self.assertRaisesRegex(ValueError, r'^patient UUID not found$'):
+            get_patient_uuid(entry_elem)
+
+    def test_success(self):
+        feed_elem = etree.XML(self.feed_xml)
+        entry_elem = next(e for e in feed_elem if e.tag.endswith('entry'))
+        patient_uuid = get_patient_uuid(entry_elem)
+        self.assertEqual(patient_uuid, 'e8aa08f6-86cd-42f9-8924-1b3ea021aeb4')
+
+
+class DocTests(SimpleTestCase):
+    def test_doctests(self):
+        results = doctest.testmod(corehq.motech.openmrs.atom_feed)
+        self.assertEqual(results.failed, 0)

--- a/corehq/motech/openmrs/tests/test_finders.py
+++ b/corehq/motech/openmrs/tests/test_finders.py
@@ -6,7 +6,7 @@ import doctest
 from django.test import SimpleTestCase
 
 from corehq.motech.openmrs.finders import PatientFinder, WeightedPropertyPatientFinder
-from corehq.motech.openmrs.openmrs_config import get_property_map
+from corehq.motech.openmrs.openmrs_config import get_property_map, OpenmrsCaseConfig
 import corehq.motech.openmrs.finders_utils
 
 
@@ -84,7 +84,7 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
     """
 
     def setUp(self):
-        self.case_config = {
+        self.case_config = OpenmrsCaseConfig.wrap({
             'patient_identifiers': {
                 'uuid': {'doc_type': 'CaseProperty', 'case_property': 'openmrs_uuid'},
                 'e2b97b70-1d5f-11e0-b929-000c29ad1d07': {'doc_type': 'CaseProperty', 'case_property': 'nid'}
@@ -116,7 +116,7 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
                     }
                 },
             },
-        }
+        })
         self.finder = WeightedPropertyPatientFinder.wrap({
             'doc_type': 'WeightedPropertyPatientFinder',
             'searchable_properties': ['last_name'],
@@ -141,10 +141,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_properties_jsonpath(self):
         for prop in ('sex', 'dob'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'sex': 'F',
@@ -153,10 +153,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_preferred_name_jsonpath(self):
         for prop in ('first_name', 'last_name'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'first_name': 'Mahapajapati',
@@ -165,10 +165,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_preferred_address_jsonpath(self):
         for prop in ('address_1', 'address_2'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'address_1': '56 Barnet Street',
@@ -177,10 +177,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_attributes_jsonpath(self):
         for prop in ('caste', 'class'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'caste': 'Buddhist',
@@ -189,10 +189,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_patient_identifiers_jsonpath(self):
         for prop in ('openmrs_uuid', 'nid'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'openmrs_uuid': '94c0e9c0-1bea-4467-b3c3-823e36c5adf5',

--- a/corehq/motech/openmrs/tests/test_jsonpath.py
+++ b/corehq/motech/openmrs/tests/test_jsonpath.py
@@ -1,30 +1,29 @@
 from __future__ import absolute_import
-
 from __future__ import unicode_literals
 import doctest
 from operator import gt, ge, eq
 
 from unittest import TestCase
-from jsonpath_rw import Child, Fields, Slice, Where, Root
+from jsonpath_rw import Child, Fields, Slice, Union, Where, Root
 
 import corehq.motech.openmrs.jsonpath
-from corehq.motech.openmrs.jsonpath import Cmp
-
-
-MENU = [
-    {"egg": 1, "bacon": 1},
-    {"egg": 1, "sausage": 1, "bacon": 1},
-    {"egg": 1, "spam": 1},
-    {"egg": 1, "bacon": 1, "spam": 1},
-    {"egg": 1, "bacon": 1, "sausage": 1, "spam": 1},
-    {"spam": 2, "bacon": 1, "sausage": 1},
-    {"spam": 4, "egg": 1, "bacon": 1},
-    {"spam": 4, "egg": 1},
-    {"spam": 10, "baked beans": 1}
-]
+from corehq.motech.openmrs.jsonpath import Cmp, WhereNot
 
 
 class CmpTests(TestCase):
+
+    menu = [
+        {"egg": 1, "bacon": 1},
+        {"egg": 1, "sausage": 1, "bacon": 1},
+        {"egg": 1, "spam": 1},
+        {"egg": 1, "bacon": 1, "spam": 1},
+        {"egg": 1, "bacon": 1, "sausage": 1, "spam": 1},
+        {"spam": 2, "bacon": 1, "sausage": 1},
+        {"spam": 4, "egg": 1, "bacon": 1},
+        {"spam": 4, "egg": 1},
+        {"spam": 10, "baked beans": 1}
+    ]
+
     def test_str(self):
         jsonpath = Cmp(Fields('spam'), gt, 0)
         self.assertEqual(str(jsonpath), 'spam gt 0')
@@ -40,7 +39,7 @@ class CmpTests(TestCase):
         self.assertNotEqual(jsonpath1, jsonpath2)
 
     def test_find_one(self):
-        max_spam = MENU[-1]
+        max_spam = self.menu[-1]
         jsonpath = Cmp(Fields('spam'), gt, 0)  # "spam gt 0"
         values = [match.value for match in jsonpath.find(max_spam)]
         self.assertEqual(values, [10])
@@ -48,7 +47,7 @@ class CmpTests(TestCase):
     def test_find_many(self):
         jsonpath = Cmp(Child(Slice(), Fields('spam')), gt, 0)  # "[*].spam gt 0"
         self.assertEqual(str(jsonpath), '[*].spam gt 0')
-        values = [match.value for match in jsonpath.find(MENU)]
+        values = [match.value for match in jsonpath.find(self.menu)]
         self.assertEqual(values, [1, 1, 1, 2, 4, 4, 10])
 
     def test_find_where(self):
@@ -57,13 +56,80 @@ class CmpTests(TestCase):
             Where(Slice(), Cmp(Fields('spam'), ge, 2)),
             Fields('bacon')
         )
-        matches = jsonpath.find(MENU)
+        matches = jsonpath.find(self.menu)
         self.assertEqual(len(matches), 2)  # There are two menu items with bacon where spam >= 2
 
     def test_cmp_list(self):
         jsonpath = Cmp(Root(), eq, 1)  # "[*] eq 1"
-        matches = jsonpath.find(MENU)
+        matches = jsonpath.find(self.menu)
         self.assertEqual(len(matches), 0)
+
+
+class WhereNotTests(TestCase):
+
+    patient = {
+        "display": "GAN203101 - Tara Devi",
+        "person": {
+            "display": "Tara Devi",
+            "attributes": [
+                {
+                    "display": "caste = janajati",
+                    "uuid": "e29c64b2-8978-4d9e-bc1d-8141a5708006",
+                    "value": "janajati",
+                    "attributeType": {
+                        "uuid": "c1f4239f-3f10-11e4-adec-0800271c1b75",
+                        "display": "caste"
+                    }
+                },
+                {
+                    "display": "General",
+                    "uuid": "18aa6e61-38a2-4852-8058-7d37645a4922",
+                    "value": {
+                        "uuid": "c1fc20ab-3f10-11e4-adec-0800271c1b75",
+                        "display": "General"
+                    },
+                    "attributeType": {
+                        "uuid": "c1f455e7-3f10-11e4-adec-0800271c1b75",
+                        "display": "class"
+                    }
+                }
+            ]
+        }
+    }
+
+    def get_jsonpath(self, attr_type_uuid):
+        return Union(
+            # Simple values: Return value if it has no children.
+            # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).(value where not *)
+            Child(
+                Where(
+                    Child(Child(Fields('person'), Fields('attributes')), Slice()),
+                    Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
+                ),
+                WhereNot(Fields('value'), Fields('*'))
+            ),
+            # Concept values: Return value.uuid if value.uuid exists:
+            # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).value.uuid
+            Child(
+                Where(
+                    Child(Child(Fields('person'), Fields('attributes')), Slice()),
+                    Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
+                ),
+                Child(Fields('value'), Fields('uuid'))
+            )
+        )
+
+    def test_where_not(self):
+        jsonpath = self.get_jsonpath("c1f4239f-3f10-11e4-adec-0800271c1b75")
+        matches = jsonpath.find(self.patient)
+        patient_value = matches[0].value
+        self.assertEqual(patient_value, "janajati")
+
+    def test_union(self):
+        jsonpath = self.get_jsonpath("c1f455e7-3f10-11e4-adec-0800271c1b75")
+        matches = jsonpath.find(self.patient)
+        patient_value = matches[0].value
+        self.assertEqual(patient_value, "c1fc20ab-3f10-11e4-adec-0800271c1b75")
 
 
 class DocTests(TestCase):

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -223,6 +223,7 @@ class AddOpenmrsRepeaterView(AddCaseRepeaterView):
     def set_repeater_attr(self, repeater, cleaned_data):
         repeater = super(AddOpenmrsRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
         repeater.location_id = self.add_repeater_form.cleaned_data['location_id']
+        repeater.atom_feed_enabled = self.add_repeater_form.cleaned_data['atom_feed_enabled']
         return repeater
 
 

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-
 from __future__ import unicode_literals
+
 import json
 from base64 import b64decode, b64encode
 


### PR DESCRIPTION
This is a task that runs frequently (every 10 minutes; often enough for updates to appear to be "live"). It polls an Atom feed exposed by OpenMRS. The feed lists the UUIDs of OpenMRS patients who have been created or whose details have changed.

The task then fetches the details of the patients, and updates or creates the corresponding CommCare case with those details.

OpenMRS servers are assigned a location. New cases are assigned an owner based on that location; the owner will be the first mobile worker in that location. The idea is that integrators will set the location to that of a supervisor, who can then distribute patient cases among CHWs.

Feature flag: `openmrs_integration` / "Enable OpenMRS integration"
