### PR TITLE
Customer Level Invoicing: Reminder Email and Block Downgrades

### DIFF
--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -171,20 +171,21 @@ class InvoiceTemplate(object):
             while len(items) > 0:
                 items_to_draw = items[12:]
                 items = items[:12]
-                self.draw_header()
-                self.draw_table(items)
-                self.canvas.showPage()
-                self.canvas.save()
+                if len(items) <= 4:
+                    self.draw_table_and_footer(items)
+                else:
+                    self.draw_header()
+                    self.draw_table(items)
+                    if len(items_to_draw) == 0:
+                        self.canvas.showPage()
+                        self.canvas.save()
+                        self.draw_totals_on_new_page()
+                    else:
+                        self.canvas.showPage()
+                        self.canvas.save()
                 items = items_to_draw
-            self.draw_totals_on_new_page()
         else:
-            self.draw_header()
-            if not self.is_wire or self.is_prepayment:
-                self.draw_table(self.items)
-            self.draw_totals(totals_x=inches(5.85), line_height=inches(0.25), subtotal_y=inches(3.5))
-            self.draw_footer()
-            self.canvas.showPage()
-            self.canvas.save()
+            self.draw_table_and_footer(self.items)
 
     def draw_logo(self):
         self.canvas.drawImage(self.logo_filename, inches(0.5), inches(2.5),
@@ -558,6 +559,15 @@ class InvoiceTemplate(object):
         ]), ParagraphStyle(''))
         payment_info2.wrapOn(self.canvas, width - inches(0.1), inches(0.9))
         payment_info2.drawOn(self.canvas, inches(0.6), inches(0.5))
+
+    def draw_table_and_footer(self, items):
+        self.draw_header()
+        if not self.is_wire or self.is_prepayment:
+            self.draw_table(items)
+        self.draw_totals(totals_x=inches(5.85), line_height=inches(0.25), subtotal_y=inches(3.5))
+        self.draw_footer()
+        self.canvas.showPage()
+        self.canvas.save()
 
     def draw_totals_on_new_page(self):
         self.canvas.setStrokeColor(STROKE_COLOR)

--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -171,18 +171,21 @@ class InvoiceTemplate(object):
             while len(items) > 0:
                 items_to_draw = items[12:]
                 items = items[:12]
-                if len(items) <= 4:
-                    self.draw_table_and_footer(items)
-                else:
-                    self.draw_header()
-                    self.draw_table(items)
-                    self.canvas.showPage()
-                    self.canvas.save()
-                    if len(items_to_draw) == 0:
-                        self.draw_totals_on_new_page()
+                self.draw_customer_invoice(items, items_to_draw)
                 items = items_to_draw
         else:
-            self.draw_table_and_footer(self.items)
+            self.draw_table_with_header_and_footer(self.items)
+
+    def draw_customer_invoice(self, items, items_to_draw):
+        if len(items) <= 4:
+            self.draw_table_with_header_and_footer(items)
+        else:
+            self.draw_header()
+            self.draw_table(items)
+            self.canvas.showPage()
+            self.canvas.save()
+            if len(items_to_draw) == 0:
+                self.draw_totals_on_new_page()
 
     def draw_logo(self):
         self.canvas.drawImage(self.logo_filename, inches(0.5), inches(2.5),
@@ -557,7 +560,7 @@ class InvoiceTemplate(object):
         payment_info2.wrapOn(self.canvas, width - inches(0.1), inches(0.9))
         payment_info2.drawOn(self.canvas, inches(0.6), inches(0.5))
 
-    def draw_table_and_footer(self, items):
+    def draw_table_with_header_and_footer(self, items):
         self.draw_header()
         if not self.is_wire or self.is_prepayment:
             self.draw_table(items)

--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -176,13 +176,10 @@ class InvoiceTemplate(object):
                 else:
                     self.draw_header()
                     self.draw_table(items)
+                    self.canvas.showPage()
+                    self.canvas.save()
                     if len(items_to_draw) == 0:
-                        self.canvas.showPage()
-                        self.canvas.save()
                         self.draw_totals_on_new_page()
-                    else:
-                        self.canvas.showPage()
-                        self.canvas.save()
                 items = items_to_draw
         else:
             self.draw_table_and_footer(self.items)

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -677,9 +677,9 @@ class UserLineItemFactory(FeatureLineItemFactory):
 
     @property
     def unit_description(self):
-        quarterly_invoice = self.invoice.is_customer_invoice and \
+        periodic_invoice = self.invoice.is_customer_invoice and \
             self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
-        if self.num_excess_users > 0 or (quarterly_invoice and self.num_excess_users_over_period > 0):
+        if self.num_excess_users > 0 or (periodic_invoice and self.num_excess_users_over_period > 0):
             return ungettext(
                 "Per User fee exceeding monthly limit of %(monthly_limit)s user.",
                 "Per User fee exceeding monthly limit of %(monthly_limit)s users.",

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -678,7 +678,7 @@ class UserLineItemFactory(FeatureLineItemFactory):
     @property
     def unit_description(self):
         quarterly_invoice = self.invoice.is_customer_invoice and \
-                            self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
+            self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
         if self.num_excess_users > 0 or (quarterly_invoice and self.num_excess_users_over_period > 0):
             return ungettext(
                 "Per User fee exceeding monthly limit of %(monthly_limit)s user.",

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -677,9 +677,9 @@ class UserLineItemFactory(FeatureLineItemFactory):
 
     @property
     def unit_description(self):
-        periodic_invoice = self.invoice.is_customer_invoice and \
+        non_monthly_invoice = self.invoice.is_customer_invoice and \
             self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
-        if self.num_excess_users > 0 or (periodic_invoice and self.num_excess_users_over_period > 0):
+        if self.num_excess_users > 0 or (non_monthly_invoice and self.num_excess_users_over_period > 0):
             return ungettext(
                 "Per User fee exceeding monthly limit of %(monthly_limit)s user.",
                 "Per User fee exceeding monthly limit of %(monthly_limit)s users.",

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -677,7 +677,9 @@ class UserLineItemFactory(FeatureLineItemFactory):
 
     @property
     def unit_description(self):
-        if self.num_excess_users > 0:
+        quarterly_invoice = self.invoice.is_customer_invoice and \
+                            self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
+        if self.num_excess_users > 0 or (quarterly_invoice and self.num_excess_users_over_period > 0):
             return ungettext(
                 "Per User fee exceeding monthly limit of %(monthly_limit)s user.",
                 "Per User fee exceeding monthly limit of %(monthly_limit)s users.",

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1546,6 +1546,7 @@ class Subscription(models.Model):
                 DomainSubscriptionView.urlname, args=[self.subscriber.domain]),
             'base_url': get_site_domain(),
             'invoicing_contact_email': settings.INVOICING_CONTACT_EMAIL,
+            'sales_email': settings.REPORT_BUILDER_ADD_ON_EMAIL
         }
 
         if self.account.is_customer_billing_account:
@@ -1635,6 +1636,7 @@ class Subscription(models.Model):
                     USER_DATE_FORMAT),
                 'contacts': ', '.join(self._reminder_email_contacts(self.subscriber.domain)),
                 'dimagi_contact': email,
+                'accounts_email': settings.ACCOUNTS_EMAIL
             }
         else:
             domain = self.subscriber.domain

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1666,6 +1666,9 @@ class Subscription(models.Model):
                     )
                 )
             emails |= {billing_contact_email for billing_contact_email in billing_contact_emails}
+        if self.account.is_customer_billing_account:
+            enterprise_admin_emails = self.account.enterprise_admin_emails
+            emails |= {enterprise_admin_email for enterprise_admin_email in enterprise_admin_emails}
         return emails
 
     def set_billing_account_entry_point(self):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1754,6 +1754,13 @@ class Subscription(models.Model):
         else:
             return False
 
+    def user_can_change_subscription(self, user):
+        if not self.account.is_customer_billing_account:
+            return True
+        if user.is_superuser:
+            return True
+        return self.account.has_enterprise_admin(user.email)
+
 
 class InvoiceBaseManager(models.Manager):
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1851,8 +1851,8 @@ class Subscription(models.Model):
             return False
 
     def user_can_change_subscription(self, user):
-        if not self.account.is_customer_billing_account:
-            return True
+        if self.account.is_customer_billing_account:
+            return False
         if user.is_superuser:
             return True
         return self.account.has_enterprise_admin(user.email)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1540,6 +1540,7 @@ class Subscription(models.Model):
         context = {
             'domain': domain_name,
             'plan_name': plan_name,
+            'account': self.account.name,
             'ending_on': ending_on,
             'subscription_url': absolute_reverse(
                 DomainSubscriptionView.urlname, args=[self.subscriber.domain]),
@@ -1548,13 +1549,6 @@ class Subscription(models.Model):
         }
 
         if self.account.is_customer_billing_account:
-            subscriptions = self.account.subscription_set.filter(
-                plan_version=self.plan_version,
-                date_end=self.date_end,
-                is_active=True,
-                is_trial=False
-            )
-            domains = [subscription.subscriber.domain for subscription in subscriptions]
             subject = _(
                 "CommCare Alert: %(account_name)s's subscription to "
                 "%(plan_name)s ends %(ending_on)s"
@@ -1563,10 +1557,6 @@ class Subscription(models.Model):
                 'plan_name': plan_name,
                 'ending_on': ending_on,
             }
-            context.update({
-                'account': self.account.name,
-                'domains': ", ".join(domains)
-            })
         elif self.is_trial:
             subject = _("CommCare Alert: 30 day trial for '%(domain)s' "
                         "ends %(ending_on)s") % {
@@ -1636,16 +1626,10 @@ class Subscription(models.Model):
         email = self.account.dimagi_contact
         if self.account.is_customer_billing_account:
             account = self.account.name
-            subscriptions = self.account.subscription_set.filter(
-                plan_version=self.plan_version,
-                date_end=self.date_end,
-                is_active=True,
-                is_trial=False
-            )
-            domains = [subscription.subscriber.domain for subscription in subscriptions]
+            plan = self.plan_version.plan.edition
             context = {
                 'account': account,
-                'domains': ", ".join(domains),
+                'plan': plan,
                 'end_date': end_date,
                 'client_reminder_email_date': (self.date_end - datetime.timedelta(days=30)).strftime(
                     USER_DATE_FORMAT),

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.html
@@ -4,17 +4,14 @@
 <p>
     {% blocktrans %}
     Your {{ plan_name }} subscription ends soon! If you do not renew your subscription before then,
-    you will automatically be subscribed to the CommCare Community plan {{ ending_on }}
-    and lose access to all pay-only features on the following domains: {{ domains }}.
+    you will automatically be subscribed to the CommCare Community plan and
+    lose access to all pay-only features {{ ending_on }}
     {% endblocktrans %}
 </p>
 
 <p>
     {% blocktrans %}
-    To change or renew your subscription, please log into your project on
-    CommCare HQ and navigate to the
-    <a href="{{ subscription_url }}">subscription page</a> in your
-    project settings.
+    To change or renew your subscription, please reach out to <a href="mailto:accounts@dimagi.com">sales@dimagi.com</a>.
     {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+<p>{% blocktrans %}Dear {{ domain }} administrator,{% endblocktrans %}</p>
+
+<p>
+    {% blocktrans %}
+    Your {{ plan_name }} subscription ends soon! If you do not renew your subscription before then,
+    you will automatically be subscribed to the CommCare Community plan {{ ending_on }}
+    and lose access to all pay-only features on the following domains: {{ domains }}.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    To change or renew your subscription, please log into your project on
+    CommCare HQ and navigate to the
+    <a href="{{ subscription_url }}">subscription page</a> in your
+    project settings.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    If you have any questions, please don’t hesitate to contact {{ invoicing_contact_email }}.
+    Thank you for your use and support of CommCare.
+    {% endblocktrans %}
+</p>
+
+
+<p>
+    {% blocktrans %}
+    Best regards,
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}The CommCare HQ Team{% endblocktrans %}<br />
+    {{ base_url }}
+</p>

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.html
@@ -11,7 +11,7 @@
 
 <p>
     {% blocktrans %}
-    To change or renew your subscription, please reach out to <a href="mailto:accounts@dimagi.com">sales@dimagi.com</a>.
+    To change or renew your subscription, please reach out to {{ sales_email }}.
     {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.txt
@@ -5,7 +5,7 @@ Dear {{ account }} administrator,
 Your {{ plan_name }} subscription ends soon! If you do not renew your subscription before then, you will
 automatically be subscribed to the CommCare Community plan and lose access to all pay-only features {{ ending_on }}
 
-To change or renew your subscription, please reach out to sales@dimagi.com.
+To change or renew your subscription, please reach out to {{ sales_email }}.
 
 If you have any questions, please don’t hesitate to contact {{ invoicing_contact_email }}.
 Thank you for your use and support of CommCare.

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.txt
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% blocktrans %}
+Dear {{ account }} administrator,
+
+Your {{ plan_name }} subscription ends soon! If you do not renew your subscription before then,
+you will automatically be subscribed to the CommCare Community plan {{ ending_on }}
+and lose access to all pay-only features on the following domains: {{ domains }}.
+
+To change or renew your subscription, please log into your project on
+CommCare HQ and and navigate to the subscription page in your project
+settings: {{ subscription_url }}
+
+If you have any questions, please don’t hesitate to contact {{ invoicing_contact_email }}.
+Thank you for your use and support of CommCare.
+
+Best regards,
+
+The CommCare HQ Team
+{{ base_url }}
+{% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder.txt
@@ -2,13 +2,10 @@
 {% blocktrans %}
 Dear {{ account }} administrator,
 
-Your {{ plan_name }} subscription ends soon! If you do not renew your subscription before then,
-you will automatically be subscribed to the CommCare Community plan {{ ending_on }}
-and lose access to all pay-only features on the following domains: {{ domains }}.
+Your {{ plan_name }} subscription ends soon! If you do not renew your subscription before then, you will
+automatically be subscribed to the CommCare Community plan and lose access to all pay-only features {{ ending_on }}
 
-To change or renew your subscription, please log into your project on
-CommCare HQ and and navigate to the subscription page in your project
-settings: {{ subscription_url }}
+To change or renew your subscription, please reach out to sales@dimagi.com.
 
 If you have any questions, please don’t hesitate to contact {{ invoicing_contact_email }}.
 Thank you for your use and support of CommCare.

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
@@ -1,0 +1,18 @@
+<p>
+Dear {{ dimagi_contact }}
+</p>
+<p>
+You have been identified as the dimagi point of contact for {{ account }}.
+</p>
+<p>
+The following project spaces have subscriptions ending on {{ end_date }}: {{ domains }}.
+</p>
+<p>
+After {{ end_date }}, these subscriptions will automatically downgrade to the Community Plan. If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://confluence.dimagi.com/display/commcarehq/CommCare+HQ+Billing+-+Email+Templates#CommCareHQBilling-EmailTemplates-SubscriptionEnding">template</a> to follow up.
+</p>
+<p>
+Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).
+</p>
+<p>
+If you have any questions on this, please reach out to <a href="mailto:accounts@dimagi.com">accounts@dimagi.com</a>
+</p>

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
@@ -5,14 +5,14 @@ Dear {{ dimagi_contact }}
 You have been identified as the dimagi point of contact for {{ account }}.
 </p>
 <p>
-The following project spaces have subscriptions ending on {{ end_date }}: {{ domains }}.
+This account has a {{ plan }} subscription that is ending on {{ end_date }}. After that date, the subscription will automatically downgrade to the Community Plan.
 </p>
 <p>
-After {{ end_date }}, these subscriptions will automatically downgrade to the Community Plan. If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://confluence.dimagi.com/display/commcarehq/CommCare+HQ+Billing+-+Email+Templates#CommCareHQBilling-EmailTemplates-SubscriptionEnding">template</a> to follow up.
+If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://confluence.dimagi.com/display/commcarehq/CommCare+HQ+Billing+-+Email+Templates#CommCareHQBilling-EmailTemplates-SubscriptionEnding">template</a> to follow up.
 </p>
 <p>
 Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).
 </p>
 <p>
-If you have any questions on this, please reach out to <a href="mailto:accounts@dimagi.com">accounts@dimagi.com</a>
+If you have any questions on this, please reach out to <a href="mailto:accounts@dimagi.com">accounts@dimagi.com</a>.
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
@@ -14,5 +14,5 @@ If you haven't already, can you follow up with the partner to confirm they are a
 Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).
 </p>
 <p>
-If you have any questions on this, please reach out to <a href="mailto:accounts@dimagi.com">accounts@dimagi.com</a>.
+If you have any questions on this, please reach out to {{ accounts_email }}.
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.txt
@@ -2,10 +2,10 @@ Dear {{ dimagi_contact }}
 
 You have been identified as the dimagi point of contact for {{ account }}.
 
-The following project spaces have subscriptions ending on {{ end_date }}: {{ domains }}.
+This account has a {{ plan }} subscription that is ending on {{ end_date }}. After that date, the subscription will automatically downgrade to the Community Plan.
 
-After {{ end_date }}, these subscriptions will automatically downgrade to the Community Plan. If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email template to follow up.
+If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email template to follow up.
 
 Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).
 
-If you have any questions on this, please reach out to accounts@dimagi.com
+If you have any questions on this, please reach out to accounts@dimagi.com.

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.txt
@@ -8,4 +8,4 @@ If you haven't already, can you follow up with the partner to confirm they are a
 
 Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).
 
-If you have any questions on this, please reach out to accounts@dimagi.com.
+If you have any questions on this, please reach out to {{ accounts_email }}.

--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.txt
@@ -1,0 +1,11 @@
+Dear {{ dimagi_contact }}
+
+You have been identified as the dimagi point of contact for {{ account }}.
+
+The following project spaces have subscriptions ending on {{ end_date }}: {{ domains }}.
+
+After {{ end_date }}, these subscriptions will automatically downgrade to the Community Plan. If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email template to follow up.
+
+Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).
+
+If you have any questions on this, please reach out to accounts@dimagi.com

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -10,6 +10,7 @@
     {% initial_page_data "wire_email" user_email %}
     {% initial_page_data "plan" plan %}
     {% initial_page_data "can_purchase_credits" can_purchase_credits %}
+    {% initial_page_data "can_change_subscription" can_change_subscription %}
     {% registerurl "domain_credits_payment" domain %}
     {% registerurl "domain_wire_payment" domain %}
 
@@ -37,21 +38,23 @@
                             {% endblocktrans %}
                             </div>
                         {% endif %}
-                        {% if plan.is_annual_plan %}
-                        <form action="{% url 'annual_plan_request_quote' domain %}">
-                            <div style="margin-top:10px;">
-                                <label class="control-label">{% trans "Got questions about your plan?" %}</label>
-                                <button class="btn btn-primary btn-lg">
-                                    {% trans 'Talk to Sales' %}
-                                </button>
-                            </div>
-                        </form>
-                        {% else %}
-                            <p>
-                                <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
-                                    {% trans "Change Plan" %}
-                                </a>
-                            </p>
+                        {% if can_change_subscription %}
+                            {% if plan.is_annual_plan %}
+                            <form action="{% url 'annual_plan_request_quote' domain %}">
+                                <div style="margin-top:10px;">
+                                    <label class="control-label">{% trans "Got questions about your plan?" %}</label>
+                                    <button class="btn btn-primary btn-lg">
+                                        {% trans 'Talk to Sales' %}
+                                    </button>
+                                </div>
+                            </form>
+                            {% else %}
+                                <p>
+                                    <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
+                                        {% trans "Change Plan" %}
+                                    </a>
+                                </p>
+                            {% endif %}
                         {% endif %}
 
                         {% if plan.is_trial %}

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -705,6 +705,14 @@ class DomainSubscriptionView(DomainAccountingSettings):
         return list(map(_get_feature_info, plan_version.feature_rates.all()))
 
     @property
+    def can_change_subscription(self):
+        if not self.account.is_customer_billing_account:
+            return True
+        if self.request.user.is_superuser:
+            return True
+        return self.account.has_enterprise_admin(self.request.user.email)
+
+    @property
     def page_context(self):
         return {
             'plan': self.plan,
@@ -718,7 +726,8 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'show_account_credits': any(
                 feature['account_credit'].get('is_visible')
                 for feature in self.plan.get('features')
-            )
+            ),
+            'can_change_subscription': self.can_change_subscription
         }
 
 


### PR DESCRIPTION
- [x] Block web users from downgrading subscriptions for customer accounts
    There is no "Change Plan" button when a self-service webuser (who is not an enterprise admin) accesses the Current Subscription page. If they do manage to send a request to upgrade or downgrade the plan, they will see the error message in the screenshot below.
- [x] Update the "Subscription Ending in X Days" email
    https://docs.google.com/document/d/19hk1Ga8KkGvOqd5rDYHi5D5WccVIe0pYMUPlbAmECN0/edit
- [x] Reduce the number of pages per invoice


Link to original spec:
https://docs.google.com/document/d/1wdN02xuGMXuLPoQ3QJ16zm_WNNA2-u8yDl5kFxVGzCM/edit

Screenshot:
<img width="1387" alt="screen shot 2018-10-10 at 6 44 51 pm" src="https://user-images.githubusercontent.com/15271571/46770522-c6250400-ccbd-11e8-9fc8-573e5125a9aa.png">
