### PR TITLE
Allow xform to ES pillow to be given custom pillow ID

### DIFF
--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -135,7 +135,6 @@ def transform_xform_for_elasticsearch(doc_dict):
 
 def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', num_processes=1,
                                       process_num=0, **kwargs):
-    assert pillow_id == 'XFormToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, XFORM_INDEX_INFO, topics.FORM_TOPICS)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),


### PR DESCRIPTION
@dimagi/scale-team This should allow adding more xform -> ES pillows as I noted in the recent email.

I had to revert https://github.com/dimagi/commcare-cloud/pull/2218/commits/c8a45d26e07b791569d7e8ef6a77de605d201a64 because we didn't support his before