### PR TITLE
Refactor get_property_map and deserialize external values

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -149,11 +149,11 @@ def get_addpatient_caseblock(case_type, owner, patient, repeater):
     property_map = get_property_map(repeater.openmrs_config.case_config)
 
     fields_to_update = {}
-    for prop, (jsonpath, value_map) in property_map.items():
+    for prop, (jsonpath, value_source) in property_map.items():
         matches = jsonpath.find(patient)
         if matches:
             patient_value = matches[0].value
-            new_value = value_map.get(patient_value, patient_value)
+            new_value = value_source.deserialize(patient_value)
             fields_to_update[prop] = new_value
 
     if fields_to_update:
@@ -175,12 +175,12 @@ def get_updatepatient_caseblock(case, patient, repeater):
     property_map = get_property_map(repeater.openmrs_config.case_config)
 
     fields_to_update = {}
-    for prop, (jsonpath, value_map) in property_map.items():
+    for prop, (jsonpath, value_source) in property_map.items():
         matches = jsonpath.find(patient)
         if matches:
             patient_value = matches[0].value
             case_value = case.get_case_property(prop)
-            new_value = value_map.get(patient_value, patient_value)
+            new_value = value_source.deserialize(patient_value)
             if case_value != new_value:
                 fields_to_update[prop] = new_value
 

--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -148,17 +148,17 @@ class WeightedPropertyPatientFinder(PatientFinder):
         def weights():
             for property_weight in self.property_weights:
                 prop = property_weight['case_property']
+                jsonpath, value_source = self._property_map[prop]
                 weight = property_weight['weight']
 
-                matches = self._property_map[prop].jsonpath.find(patient)
+                matches = jsonpath.find(patient)
                 for match in matches:
                     patient_value = match.value
-                    value_map = self._property_map[prop].value_map
                     case_value = case.get_case_property(prop)
                     match_type = property_weight['match_type']
                     match_params = property_weight['match_params']
                     match_function = partial(MATCH_FUNCTIONS[match_type], *match_params)
-                    is_equivalent = match_function(value_map.get(patient_value, patient_value), case_value)
+                    is_equivalent = match_function(value_source.deserialize(patient_value), case_value)
                     yield weight if is_equivalent else 0
 
         return sum(weights())

--- a/corehq/motech/openmrs/jsonpath.py
+++ b/corehq/motech/openmrs/jsonpath.py
@@ -38,3 +38,36 @@ class Cmp(JSONPath):
             other.op == self.op and
             other.operand == self.operand
         )
+
+    def __hash__(self):
+        return hash(str(self))
+
+
+class WhereNot(JSONPath):
+    """
+    Identical to JSONPath Where, but filters for only those nodes that
+    do *not* have a match on the right.
+
+    >>> jsonpath = WhereNot(Fields('spam'), Fields('spam'))
+    >>> jsonpath.find({"spam": {"spam": 1}})
+    []
+    >>> matches = jsonpath.find({"spam": 1})
+    >>> matches[0].value
+    1
+
+    """
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def find(self, data):
+        return [subdata for subdata in self.left.find(data) if not self.right.find(subdata)]
+
+    def __str__(self):
+        return '%s where not %s' % (self.left, self.right)
+
+    def __eq__(self, other):
+        return isinstance(other, WhereNot) and other.left == self.left and other.right == self.right
+
+    def __hash__(self):
+        return hash(str(self))

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -188,10 +188,10 @@ class OpenmrsConfig(DocumentSchema):
 # The `jsonpath` attribute is used for retrieving values from an
 # OpenMRS patient and the `value_map` attribute is for converting
 # OpenMRS concept UUIDs to CommCare property values, if necessary.
-JsonpathValuemap = namedtuple('JsonpathValuemap', ['jsonpath', 'value_map'])
+JsonpathValuesource = namedtuple('JsonpathValuesource', ['jsonpath', 'value_source'])
 
 
-def get_caseproperty_jsonpathvaluemap(jsonpath, value_source):
+def get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config):
     """
     Used for updating _property_map to map case properties to OpenMRS
     patient property-, attribute- and concept values.
@@ -200,37 +200,36 @@ def get_caseproperty_jsonpathvaluemap(jsonpath, value_source):
     do we find the OpenMRS value?"
 
     :param jsonpath: The path to a value in an OpenMRS patient JSON object
-    :param value_source: A case_config ValueSource instance
+    :param value_source_config: A case_config ValueSource instance
     :return: A single-item dictionary with the name of the case
-             property as key, and a JsonpathValuemap as value. If
-             value_source is a constant, then there is no corresponding
-             case property, so the function returns an empty dictionary
+             property as key, and a JsonpathValuesource as value. If
+             value_source_config is a ConstantString, then there is no
+             corresponding case property, so the function returns an
+             empty dictionary.
     """
-    if value_source['doc_type'] == 'ConstantString':
+    if value_source_config['doc_type'] == 'ConstantString':
         return {}
-    if value_source['doc_type'] == 'CaseProperty':
-        return {value_source['case_property']: JsonpathValuemap(jsonpath, {})}
-    if value_source['doc_type'] == 'CasePropertyMap':
-        value_map = {v: k for k, v in value_source['value_map'].items()}
-        return {value_source['case_property']: JsonpathValuemap(jsonpath, value_map)}
+    if value_source_config['doc_type'] in ('CaseProperty', 'CasePropertyMap'):
+        value_source = ValueSource.wrap(value_source_config)
+        return {value_source_config['case_property']: JsonpathValuesource(jsonpath, value_source)}
     raise ValueError(
         '"{}" is not a recognised ValueSource for setting OpenMRS patient values from CommCare case properties. '
-        'Please check your OpenMRS case config.'.format(value_source['doc_type'])
+        'Please check your OpenMRS case config.'.format(value_source_config['doc_type'])
     )
 
 
 def get_property_map(case_config):
     """
-    Returns a map of OpenMRS patient properties and attributes to case
-    properties.
+    Returns a map of case properties to OpenMRS patient properties and
+    attributes, and a ValueSource instance to deserialize them.
     """
     property_map = {}
 
-    for person_prop, value_source in case_config['person_properties'].items():
+    for person_prop, value_source_config in case_config['person_properties'].items():
         jsonpath = parse_jsonpath('person.' + person_prop)
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for attr_uuid, value_source in case_config['person_attributes'].items():
+    for attr_uuid, value_source_config in case_config['person_attributes'].items():
         # jsonpath_rw offers programmatic JSONPath expressions. For details on how to create JSONPath
         # expressions programmatically see the
         # `jsonpath_rw documentation <https://github.com/kennknowles/python-jsonpath-rw#programmatic-jsonpath>`__
@@ -250,17 +249,17 @@ def get_property_map(case_config):
             ),
             Fields('value')
         )
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for name_prop, value_source in case_config['person_preferred_name'].items():
+    for name_prop, value_source_config in case_config['person_preferred_name'].items():
         jsonpath = parse_jsonpath('person.preferredName.' + name_prop)
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for addr_prop, value_source in case_config['person_preferred_address'].items():
+    for addr_prop, value_source_config in case_config['person_preferred_address'].items():
         jsonpath = parse_jsonpath('person.preferredAddress.' + addr_prop)
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
-    for id_type_uuid, value_source in case_config['patient_identifiers'].items():
+    for id_type_uuid, value_source_config in case_config['patient_identifiers'].items():
         if id_type_uuid == 'uuid':
             jsonpath = parse_jsonpath('uuid')
         else:
@@ -277,6 +276,6 @@ def get_property_map(case_config):
                 ),
                 Fields('identifier')
             )
-        property_map.update(get_caseproperty_jsonpathvaluemap(jsonpath, value_source))
+        property_map.update(get_caseproperty_jsonpathvaluesource(jsonpath, value_source_config))
 
     return property_map

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -200,7 +200,7 @@ def get_property_map(case_config):
             jsonpath = parse_jsonpath('person.' + person_prop)
             property_map[value_source['case_property']] = (jsonpath, value_source)
 
-    for attr_uuid, value_source in case_config['person_attributes'].items():
+    for attr_type_uuid, value_source in case_config['person_attributes'].items():
         # jsonpath_rw offers programmatic JSONPath expressions. For details on how to create JSONPath
         # expressions programmatically see the
         # `jsonpath_rw documentation <https://github.com/kennknowles/python-jsonpath-rw#programmatic-jsonpath>`__
@@ -209,7 +209,7 @@ def get_property_map(case_config):
         # where a child matches *jsonpath2*. `Cmp` does a comparison in *jsonpath2*. It accepts a
         # comparison operator and a value. The JSONPath expression for matching simple attribute values is::
         #
-        #     (person.attributes[*] where attributeType.uuid eq attr_uuid).value
+        #     (person.attributes[*] where attributeType.uuid eq attr_type_uuid).value
         #
         # This extracts the person attribute values where their attribute type UUIDs match those configured in
         # case_config['person_attributes'].
@@ -219,18 +219,20 @@ def get_property_map(case_config):
         if 'case_property' in value_source:
             jsonpath = Union(
                 # Simple values: Return value if it has no children.
+                # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).(value where not *)
                 Child(
                     Where(
                         Child(Child(Fields('person'), Fields('attributes')), Slice()),
-                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_uuid)
+                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
                     ),
                     WhereNot(Fields('value'), Fields('*'))
                 ),
                 # Concept values: Return value.uuid if value.uuid exists:
+                # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).value.uuid
                 Child(
                     Where(
                         Child(Child(Fields('person'), Fields('attributes')), Slice()),
-                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_uuid)
+                        Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
                     ),
                     Child(Fields('value'), Fields('uuid'))
                 )

--- a/corehq/motech/openmrs/tests/test_finders.py
+++ b/corehq/motech/openmrs/tests/test_finders.py
@@ -6,7 +6,7 @@ import doctest
 from django.test import SimpleTestCase
 
 from corehq.motech.openmrs.finders import PatientFinder, WeightedPropertyPatientFinder
-from corehq.motech.openmrs.openmrs_config import get_property_map
+from corehq.motech.openmrs.openmrs_config import get_property_map, OpenmrsCaseConfig
 import corehq.motech.openmrs.finders_utils
 
 
@@ -84,7 +84,7 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
     """
 
     def setUp(self):
-        self.case_config = {
+        self.case_config = OpenmrsCaseConfig.wrap({
             'patient_identifiers': {
                 'uuid': {'doc_type': 'CaseProperty', 'case_property': 'openmrs_uuid'},
                 'e2b97b70-1d5f-11e0-b929-000c29ad1d07': {'doc_type': 'CaseProperty', 'case_property': 'nid'}
@@ -116,7 +116,7 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
                     }
                 },
             },
-        }
+        })
         self.finder = WeightedPropertyPatientFinder.wrap({
             'doc_type': 'WeightedPropertyPatientFinder',
             'searchable_properties': ['last_name'],
@@ -141,10 +141,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_properties_jsonpath(self):
         for prop in ('sex', 'dob'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'sex': 'F',
@@ -153,10 +153,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_preferred_name_jsonpath(self):
         for prop in ('first_name', 'last_name'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'first_name': 'Mahapajapati',
@@ -165,10 +165,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_preferred_address_jsonpath(self):
         for prop in ('address_1', 'address_2'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'address_1': '56 Barnet Street',
@@ -177,10 +177,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_person_attributes_jsonpath(self):
         for prop in ('caste', 'class'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'caste': 'Buddhist',
@@ -189,10 +189,10 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
 
     def test_patient_identifiers_jsonpath(self):
         for prop in ('openmrs_uuid', 'nid'):
-            matches = self.finder._property_map[prop].jsonpath.find(PATIENT)
-            self.assertEqual(len(matches), 1, 'jsonpath "{}" did not uniquely match a patient value'.format(
-                self.finder._property_map[prop].jsonpath
-            ))
+            jsonpath, _ = self.finder._property_map[prop]
+            matches = jsonpath.find(PATIENT)
+            self.assertEqual(len(matches), 1,
+                             'jsonpath "{}" did not uniquely match a patient value'.format(jsonpath))
             patient_value = matches[0].value
             self.assertEqual(patient_value, {
                 'openmrs_uuid': '94c0e9c0-1bea-4467-b3c3-823e36c5adf5',

--- a/corehq/motech/openmrs/tests/test_jsonpath.py
+++ b/corehq/motech/openmrs/tests/test_jsonpath.py
@@ -1,30 +1,29 @@
 from __future__ import absolute_import
-
 from __future__ import unicode_literals
 import doctest
 from operator import gt, ge, eq
 
 from unittest import TestCase
-from jsonpath_rw import Child, Fields, Slice, Where, Root
+from jsonpath_rw import Child, Fields, Slice, Union, Where, Root
 
 import corehq.motech.openmrs.jsonpath
-from corehq.motech.openmrs.jsonpath import Cmp
-
-
-MENU = [
-    {"egg": 1, "bacon": 1},
-    {"egg": 1, "sausage": 1, "bacon": 1},
-    {"egg": 1, "spam": 1},
-    {"egg": 1, "bacon": 1, "spam": 1},
-    {"egg": 1, "bacon": 1, "sausage": 1, "spam": 1},
-    {"spam": 2, "bacon": 1, "sausage": 1},
-    {"spam": 4, "egg": 1, "bacon": 1},
-    {"spam": 4, "egg": 1},
-    {"spam": 10, "baked beans": 1}
-]
+from corehq.motech.openmrs.jsonpath import Cmp, WhereNot
 
 
 class CmpTests(TestCase):
+
+    menu = [
+        {"egg": 1, "bacon": 1},
+        {"egg": 1, "sausage": 1, "bacon": 1},
+        {"egg": 1, "spam": 1},
+        {"egg": 1, "bacon": 1, "spam": 1},
+        {"egg": 1, "bacon": 1, "sausage": 1, "spam": 1},
+        {"spam": 2, "bacon": 1, "sausage": 1},
+        {"spam": 4, "egg": 1, "bacon": 1},
+        {"spam": 4, "egg": 1},
+        {"spam": 10, "baked beans": 1}
+    ]
+
     def test_str(self):
         jsonpath = Cmp(Fields('spam'), gt, 0)
         self.assertEqual(str(jsonpath), 'spam gt 0')
@@ -40,7 +39,7 @@ class CmpTests(TestCase):
         self.assertNotEqual(jsonpath1, jsonpath2)
 
     def test_find_one(self):
-        max_spam = MENU[-1]
+        max_spam = self.menu[-1]
         jsonpath = Cmp(Fields('spam'), gt, 0)  # "spam gt 0"
         values = [match.value for match in jsonpath.find(max_spam)]
         self.assertEqual(values, [10])
@@ -48,7 +47,7 @@ class CmpTests(TestCase):
     def test_find_many(self):
         jsonpath = Cmp(Child(Slice(), Fields('spam')), gt, 0)  # "[*].spam gt 0"
         self.assertEqual(str(jsonpath), '[*].spam gt 0')
-        values = [match.value for match in jsonpath.find(MENU)]
+        values = [match.value for match in jsonpath.find(self.menu)]
         self.assertEqual(values, [1, 1, 1, 2, 4, 4, 10])
 
     def test_find_where(self):
@@ -57,13 +56,80 @@ class CmpTests(TestCase):
             Where(Slice(), Cmp(Fields('spam'), ge, 2)),
             Fields('bacon')
         )
-        matches = jsonpath.find(MENU)
+        matches = jsonpath.find(self.menu)
         self.assertEqual(len(matches), 2)  # There are two menu items with bacon where spam >= 2
 
     def test_cmp_list(self):
         jsonpath = Cmp(Root(), eq, 1)  # "[*] eq 1"
-        matches = jsonpath.find(MENU)
+        matches = jsonpath.find(self.menu)
         self.assertEqual(len(matches), 0)
+
+
+class WhereNotTests(TestCase):
+
+    patient = {
+        "display": "GAN203101 - Tara Devi",
+        "person": {
+            "display": "Tara Devi",
+            "attributes": [
+                {
+                    "display": "caste = janajati",
+                    "uuid": "e29c64b2-8978-4d9e-bc1d-8141a5708006",
+                    "value": "janajati",
+                    "attributeType": {
+                        "uuid": "c1f4239f-3f10-11e4-adec-0800271c1b75",
+                        "display": "caste"
+                    }
+                },
+                {
+                    "display": "General",
+                    "uuid": "18aa6e61-38a2-4852-8058-7d37645a4922",
+                    "value": {
+                        "uuid": "c1fc20ab-3f10-11e4-adec-0800271c1b75",
+                        "display": "General"
+                    },
+                    "attributeType": {
+                        "uuid": "c1f455e7-3f10-11e4-adec-0800271c1b75",
+                        "display": "class"
+                    }
+                }
+            ]
+        }
+    }
+
+    def get_jsonpath(self, attr_type_uuid):
+        return Union(
+            # Simple values: Return value if it has no children.
+            # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).(value where not *)
+            Child(
+                Where(
+                    Child(Child(Fields('person'), Fields('attributes')), Slice()),
+                    Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
+                ),
+                WhereNot(Fields('value'), Fields('*'))
+            ),
+            # Concept values: Return value.uuid if value.uuid exists:
+            # (person.attributes[*] where attributeType.uuid eq attr_type_uuid).value.uuid
+            Child(
+                Where(
+                    Child(Child(Fields('person'), Fields('attributes')), Slice()),
+                    Cmp(Child(Fields('attributeType'), Fields('uuid')), eq, attr_type_uuid)
+                ),
+                Child(Fields('value'), Fields('uuid'))
+            )
+        )
+
+    def test_where_not(self):
+        jsonpath = self.get_jsonpath("c1f4239f-3f10-11e4-adec-0800271c1b75")
+        matches = jsonpath.find(self.patient)
+        patient_value = matches[0].value
+        self.assertEqual(patient_value, "janajati")
+
+    def test_union(self):
+        jsonpath = self.get_jsonpath("c1f455e7-3f10-11e4-adec-0800271c1b75")
+        matches = jsonpath.find(self.patient)
+        patient_value = matches[0].value
+        self.assertEqual(patient_value, "c1fc20ab-3f10-11e4-adec-0800271c1b75")
 
 
 class DocTests(TestCase):


### PR DESCRIPTION
This is the final PR for importing data from the OpenMRS Atom feed.

It doesn't deal with the Atom feed specifically. It deals with deserializing external values. And it extends the code for fetching values from JSON-formatted OpenMRS patient details to support OpenMRS Concepts, which are user-defined data types where values are UUIDs.