### PR TITLE
Add ddtrace to requirements

### DIFF
--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -11,6 +11,7 @@ uWSGI==2.0.11.2
 ipython==5.2.2
 ndg-httpsclient
 pyasn1
+ddtrace==0.9.2
 
 # ssl issue
 # https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification-in-python-2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -30,6 +30,7 @@ csiphash==0.0.5
 csv342==1.0.0
 cython==0.27.3
 datadog==0.15.0
+ddtrace==0.9.2
 decorator==4.0.11
 defusedxml==0.4.1
 diff-match-patch==20120106
@@ -105,6 +106,7 @@ markdown==2.2.1
 markupsafe==1.0
 mock==2.0.0
 monotonic==1.5            # via eventlet
+msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1
 newrelic==4.4.1.104
 numpy==1.7.1
@@ -178,6 +180,7 @@ user-agents==1.1.0
 uwsgi==2.0.11.2
 wcwidth==0.1.7            # via prompt-toolkit
 werkzeug==0.11.15
+wrapt==1.10.11            # via ddtrace
 xhtml2pdf==0.0.6
 xlrd==1.0.0
 xlwt==1.3.0

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -2,7 +2,6 @@
 architect
 # https://github.com/django-nose/django-nose/pull/228
 django-nose
-ddtrace
 feedparser
 pycrypto
 restkit

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -6,4 +6,3 @@ feedparser
 pycrypto
 restkit
 http-parser
-msgpack-python


### PR DESCRIPTION
Installing `ddtrace` is the first step in setting up [APM for webworkers](https://manage.dimagi.com/default.asp?284131)

Running `make requirements` with `ddtrace` in `requirements.in` also added in `wrapt` and `msgpack-python`.

@emord 
code buddy @jmtroth0 
