### PR TITLE
switch MISSING and NOT_STARTED in case importer

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/import_history.js
+++ b/corehq/apps/case_importer/static/case_importer/js/import_history.js
@@ -47,7 +47,7 @@ hqDefine('case_importer/js/import_history', [
             FAILED: 3,
         };
         self.case_uploads = ko.observableArray(null);
-        self.state = ko.observable(self.states.NOT_STARTED);
+        self.state = ko.observable(self.states.MISSING);
         var uploadIdsInDataMatchCurrent = function (data) {
             return _.chain(self.case_uploads()).pluck('upload_id').isEqual(_(data).pluck('upload_id')).value();
         };
@@ -80,7 +80,7 @@ hqDefine('case_importer/js/import_history', [
             }
         };
         self.fetchCaseUploads = function () {
-            if (self.state() === self.states.NOT_STARTED) {
+            if (self.state() === self.states.MISSING) {
                 // only show spinner on first fetch
                 self.state(self.states.STARTED);
             }
@@ -93,7 +93,7 @@ hqDefine('case_importer/js/import_history', [
 
                 var anyInProgress = _.any(self.case_uploads(), function (caseUpload) {
                     return caseUpload.task_status().state === self.states.STARTED ||
-                            caseUpload.task_status().state === self.states.NOT_STARTED;
+                            caseUpload.task_status().state === self.states.MISSING;
                 });
                 if (anyInProgress) {
                     _.delay(self.fetchCaseUploads, 5000);

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -29,7 +29,7 @@
             <!--ko if: task_status().state == $root.states.FAILED-->
             <span class="label label-danger">{% trans "Failed" %}</span>
             <!--/ko-->
-            <!--ko if: task_status().state == $root.states.NOT_STARTED-->
+            <!--ko if: task_status().state == $root.states.MISSING-->
             {% trans "Waiting to start" %}
             <!--/ko-->
             <!--ko if: task_status().state == $root.states.NOT_STARTED-->

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -32,7 +32,7 @@
             <!--ko if: task_status().state == $root.states.NOT_STARTED-->
             {% trans "Waiting to start" %}
             <!--/ko-->
-            <!--ko if: task_status().state == $root.states.MISSING-->
+            <!--ko if: task_status().state == $root.states.NOT_STARTED-->
             {% trans "Info no longer available" %}
             <!--/ko-->
             <!--ko if: task_status().state == $root.states.STARTED-->

--- a/corehq/apps/case_importer/tracking/task_status.py
+++ b/corehq/apps/case_importer/tracking/task_status.py
@@ -13,7 +13,7 @@ class TaskStatus(jsonobject.StrictJsonObject):
     result = jsonobject.ObjectProperty(lambda: TaskStatusResult)
 
     def is_finished(self):
-        return self.state not in (STATES.not_started, STATES.started)
+        return self.state not in (STATES.missing, STATES.started)
 
 
 class TaskStatusProgress(jsonobject.StrictJsonObject):


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?284115

This preserves the behavior of the task status in the case importer before https://github.com/dimagi/commcare-hq/pull/22036 was merged to fix an issue with saved exports.  I don't understand why the saved exports bug only emerged recently, and why the case importer was not affected by the earlier bug, but in any case this restores the status tracking for the case importer.  I've confirmed on staging that this fixes the issue.